### PR TITLE
fix superpowers subagent prompts for worktree discipline

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -61,6 +61,12 @@ After all tasks complete and verified:
 - Reference skills when plan says to
 - Stop when blocked, don't guess
 - Never start implementation on main/master branch without explicit user consent
+- **If this is a mothership workspace** (`mothership.yaml` at any ancestor): verify
+  `mship status` shows an active task BEFORE starting. No active task → stop and
+  tell the user to `mship spawn "<description>"` first. Then `cd` into
+  `task.worktrees.<repo>` and do all work and commits there. The mship pre-commit
+  hook refuses commits from outside the worktree, so "just commit on main" is
+  both wrong and blocked.
 
 ## Integration
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -11,6 +11,15 @@ Execute plan by dispatching fresh subagent per task, with two-stage review after
 
 **Core principle:** Fresh subagent per task + two-stage review (spec then quality) = high quality, fast iteration
 
+**If this is a mothership workspace** (i.e. there's a `mothership.yaml` at the
+repo root or any ancestor): before dispatching ANY implementer subagent, verify
+there is an active mship task with a worktree. Run `mship status`. If
+`current_task` is null, stop — tell the user to `mship spawn "<description>"`
+first, then pass the worktree path (from `task.worktrees.<repo>`) as `Work from:`
+in every implementer prompt. Subagents work and commit inside that worktree,
+never on `main`. This is what keeps worktree isolation intact across the whole
+plan execution. See `./implementer-prompt.md` for the full pre-dispatch checklist.
+
 ## When to Use
 
 ```dot

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -2,6 +2,22 @@
 
 Use this template when dispatching an implementer subagent.
 
+**IMPORTANT — before dispatching:** Check whether this is a mothership workspace
+(a `mothership.yaml` exists at the repo root or any ancestor). If yes:
+
+1. There MUST be an active mship task before you dispatch implementer subagents.
+   Run `mship status` — if `current_task` is null, refuse to dispatch and tell
+   the user to `mship spawn "<description>"` first.
+2. The subagent MUST work in the task's worktree, not the main checkout. Set
+   `Work from:` below to the worktree path from `mship status`
+   (`tasks.<slug>.worktrees.<repo>`). Never point it at the main repo root.
+3. The subagent MUST commit on the task's feature branch (inside the worktree).
+   The mship pre-commit hook will refuse commits from the main checkout, but
+   the prompt should say this explicitly so the subagent doesn't waste a cycle.
+
+If this is NOT a mothership workspace, point `Work from:` at the repo root and
+proceed as before.
+
 ```
 Task tool (general-purpose):
   description: "Implement Task N: [task name]"
@@ -32,11 +48,27 @@ Task tool (general-purpose):
     1. Implement exactly what the task specifies
     2. Write tests (following TDD if task says to)
     3. Verify implementation works
-    4. Commit your work
+    4. Commit your work on the current feature branch (see "Where to work" below)
     5. Self-review (see below)
     6. Report back
 
-    Work from: [directory]
+    ## Where to work
+
+    Work from: [worktree path for this task, NOT the main repo root]
+
+    **If this is a mothership workspace (the controller set `Work from:` to a
+    path inside `.worktrees/`):**
+    - Stay inside that directory for ALL edits and commits. `cd` there at the
+      start if your shell isn't already in it.
+    - The worktree is checked out on the task's feature branch (e.g.
+      `feat/<task-slug>`). `git status` should show that branch, not `main`.
+    - **Never commit to `main`.** If you find yourself on `main`, stop and
+      report back as `BLOCKED` — the controller set up the wrong directory.
+      The mship pre-commit hook will refuse anyway, but don't waste a cycle.
+    - Don't run `git checkout -b` yourself. The branch already exists.
+
+    **If this is NOT a mothership workspace:** work from the given directory
+    and follow the project's conventional branching.
 
     **While you work:** If you encounter something unexpected or unclear, **ask questions**.
     It's always OK to pause and clarify. Don't guess or make assumptions.


### PR DESCRIPTION
Teaches the vendored superpowers skills (`subagent-driven-development/implementer-prompt.md` + its SKILL.md, and `executing-plans/SKILL.md`) to detect a mothership workspace, require an active `mship` task before dispatching implementer subagents, pass the worktree path as `Work from:`, and tell subagents never to commit on `main`.

Closes #1