### PR TITLE
fix finish audit no_upstream false positive

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -315,6 +315,14 @@ def register(app: typer.Typer, get_container):
             known = frozenset()
         report = audit_repos(config, shell, names=task.affected_repos, known_worktree_paths=known)
 
+        # finish is what creates the upstream via `git push -u` — so while the
+        # task is still unfinished, `no_upstream` on the task's own branch is a
+        # false positive that would block every first-time finish. Filter it
+        # out of the gate's report; standalone `mship audit` still reports it.
+        if task.finished_at is None:
+            from mship.core.repo_state import without_no_upstream_on_task_branch
+            report = without_no_upstream_on_task_branch(report, task.branch)
+
         def _log_bypass(codes: list[str]) -> None:
             container.log_manager().append(
                 task.slug, f"BYPASSED AUDIT: finish — {', '.join(codes)}"

--- a/src/mship/core/repo_state.py
+++ b/src/mship/core/repo_state.py
@@ -56,6 +56,41 @@ class AuditReport:
 
 
 # ---------------------------------------------------------------------------
+# Report filters
+# ---------------------------------------------------------------------------
+
+
+def without_no_upstream_on_task_branch(
+    report: AuditReport, task_branch: str
+) -> AuditReport:
+    """Return a copy of `report` with `no_upstream` issues stripped from repos
+    currently on `task_branch`.
+
+    Used by `mship finish` before invoking its audit gate: a first-time finish
+    on a feature branch always has no upstream yet — finish itself is what
+    creates it via `git push -u`. Letting that false positive block finish
+    would force every user to pass `--force-audit` on every task.
+
+    Other audit errors (dirty, diverged, unexpected_branch, etc.) are
+    unchanged. `mship audit` run standalone still reports `no_upstream`.
+    """
+    new_repos: list[RepoAudit] = []
+    for r in report.repos:
+        if r.current_branch == task_branch:
+            filtered = tuple(i for i in r.issues if i.code != "no_upstream")
+            if len(filtered) != len(r.issues):
+                new_repos.append(RepoAudit(
+                    name=r.name,
+                    path=r.path,
+                    current_branch=r.current_branch,
+                    issues=filtered,
+                ))
+                continue
+        new_repos.append(r)
+    return AuditReport(repos=tuple(new_repos))
+
+
+# ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/core/test_repo_state.py
+++ b/tests/core/test_repo_state.py
@@ -232,6 +232,43 @@ def test_audit_no_upstream(audit_workspace):
     assert "no_upstream" in _issue_codes(rep, "cli")
 
 
+def test_without_no_upstream_strips_from_matching_branch():
+    from pathlib import Path as _P
+    from mship.core.repo_state import (
+        AuditReport, Issue, RepoAudit, without_no_upstream_on_task_branch,
+    )
+
+    r = RepoAudit(
+        name="cli", path=_P("/abs/cli"), current_branch="feat/t",
+        issues=(
+            Issue("no_upstream", "error", "no upstream"),
+            Issue("dirty_worktree", "error", "1 file"),
+        ),
+    )
+    report = AuditReport(repos=(r,))
+    filtered = without_no_upstream_on_task_branch(report, "feat/t")
+    (only,) = filtered.repos
+    codes = {i.code for i in only.issues}
+    assert "no_upstream" not in codes
+    assert "dirty_worktree" in codes  # other issues untouched
+
+
+def test_without_no_upstream_ignores_other_branches():
+    from pathlib import Path as _P
+    from mship.core.repo_state import (
+        AuditReport, Issue, RepoAudit, without_no_upstream_on_task_branch,
+    )
+
+    r = RepoAudit(
+        name="cli", path=_P("/abs/cli"), current_branch="main",
+        issues=(Issue("no_upstream", "error", "no upstream"),),
+    )
+    report = AuditReport(repos=(r,))
+    filtered = without_no_upstream_on_task_branch(report, "feat/t")
+    (only,) = filtered.repos
+    assert any(i.code == "no_upstream" for i in only.issues)
+
+
 def test_audit_extra_worktrees(audit_workspace):
     cfg, shell = _load(audit_workspace)
     clone = audit_workspace / "cli"

--- a/tests/test_finish_integration.py
+++ b/tests/test_finish_integration.py
@@ -468,3 +468,84 @@ def test_finish_push_only_rejects_base_flags(finish_workspace):
     result = runner.invoke(app, ["finish", "--push-only", "--base", "main"])
     assert result.exit_code != 0
     assert "push-only" in result.output.lower()
+
+
+def test_finish_suppresses_no_upstream_for_task_branch(finish_workspace):
+    """Regression for #6: finish must succeed when the only audit error is
+    `no_upstream` on the task's own branch — finish itself creates the upstream."""
+    workspace, mock_shell = finish_workspace
+
+    # Spawn without audit gate interference (the repo has no origin configured
+    # in the fixture, so audit would fire no_upstream at spawn time too).
+    result = runner.invoke(app, ["spawn", "noupstream fix", "--repos", "shared", "--force-audit"])
+    assert result.exit_code == 0, result.output
+
+    # Mock shell to simulate a clean worktree on the task branch with no
+    # upstream configured. The key: when finish audits, `no_upstream` fires on
+    # feat/noupstream-fix. The fix under test removes it from the gate.
+    def mock_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "git status --porcelain" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "git fetch" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "symbolic-ref --short HEAD" in cmd:
+            return ShellResult(returncode=0, stdout="feat/noupstream-fix\n", stderr="")
+        if "git rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
+            # No upstream -> non-zero -> audit emits no_upstream
+            return ShellResult(returncode=128, stdout="", stderr="no upstream")
+        if "git rev-parse --git-common-dir" in cmd:
+            return ShellResult(returncode=0, stdout=".git\n", stderr="")
+        if "git worktree list" in cmd:
+            return ShellResult(returncode=0, stdout="worktree /tmp/shared\n", stderr="")
+        if "git rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
+        if "git rev-list --count" in cmd:
+            return ShellResult(returncode=0, stdout="0\n", stderr="")
+        if "git ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc\trefs/heads/main\n", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://x/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell.run.side_effect = mock_run
+
+    # NO --force-audit — this is the whole point of the fix.
+    result = runner.invoke(app, ["finish"])
+    assert result.exit_code == 0, result.output
+    assert "BYPASSED AUDIT" not in result.output
+
+
+def test_finish_still_blocks_other_audit_errors(finish_workspace):
+    """The fix must only suppress no_upstream; dirty_worktree etc. still block."""
+    workspace, mock_shell = finish_workspace
+
+    result = runner.invoke(app, ["spawn", "still blocks", "--repos", "shared", "--force-audit"])
+    assert result.exit_code == 0
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "git status --porcelain" in cmd:
+            # Dirty worktree → still blocks
+            return ShellResult(returncode=0, stdout=" M foo.py\n", stderr="")
+        if "git fetch" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "symbolic-ref --short HEAD" in cmd:
+            return ShellResult(returncode=0, stdout="feat/still-blocks\n", stderr="")
+        if "git rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
+            return ShellResult(returncode=128, stdout="", stderr="")
+        if "git rev-parse --git-common-dir" in cmd:
+            return ShellResult(returncode=0, stdout=".git\n", stderr="")
+        if "git worktree list" in cmd:
+            return ShellResult(returncode=0, stdout="worktree /tmp/shared\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell.run.side_effect = mock_run
+
+    result = runner.invoke(app, ["finish"])
+    assert result.exit_code != 0
+    assert "dirty_worktree" in result.output


### PR DESCRIPTION
Suppresses the `no_upstream` false positive that `mship finish` audited on every first-time finish — the gate refused because the feature branch had no upstream yet, even though finish itself was about to create it. New `without_no_upstream_on_task_branch` helper strips the issue from the gate's view of the report; standalone `mship audit` still reports it. Other audit errors still block.

Closes #6