### PR TITLE
fix #8 auto link pr to issues in task

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -498,13 +498,43 @@ def register(app: typer.Typer, get_container):
                 output.error(f"{repo_name}: {e}")
                 raise typer.Exit(code=1)
 
+            # Build the PR body — appends `Closes #N` for any GitHub issue
+            # references in the task description, log entries, or commit subjects.
+            from mship.core.issue_refs import append_closes_footer, extract_issue_refs
+            texts: list[str] = [task.description]
+            try:
+                entries = container.log_manager().read(task.slug)
+                for e in entries:
+                    if e.message:
+                        texts.append(e.message)
+                    if e.action:
+                        texts.append(e.action)
+                    if e.open_question:
+                        texts.append(e.open_question)
+            except Exception:
+                pass
+            try:
+                eff_base = effective_bases[repo_name] or "HEAD"
+                import shlex as _shlex
+                subjects_res = shell.run(
+                    f"git log --format=%s origin/{_shlex.quote(eff_base)}..{_shlex.quote(task.branch)}",
+                    cwd=repo_path,
+                )
+                if subjects_res.returncode == 0:
+                    for line in subjects_res.stdout.splitlines():
+                        if line.strip():
+                            texts.append(line)
+            except Exception:
+                pass
+            pr_body = append_closes_footer(task.description, extract_issue_refs(texts))
+
             # Create PR
             try:
                 pr_url = pr_mgr.create_pr(
                     repo_path=repo_path,
                     branch=task.branch,
                     title=task.description,
-                    body=task.description,
+                    body=pr_body,
                     base=effective_bases[repo_name],
                 )
             except RuntimeError as e:

--- a/src/mship/core/issue_refs.py
+++ b/src/mship/core/issue_refs.py
@@ -1,0 +1,44 @@
+"""Extract GitHub issue references (`#N`) from free text."""
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+
+_ISSUE_REF = re.compile(r"(?<![A-Za-z0-9_#])#(\d+)\b")
+
+
+def extract_issue_refs(texts: Iterable[str]) -> list[int]:
+    """Return unique, ascending-sorted issue numbers referenced across `texts`.
+
+    Matches `#N` where N is one or more digits, not preceded by an identifier
+    character. Handles `(#3)`, `, #3`, `Closes #3`, but NOT `abc#3` (anchor-link
+    style) or `##3` (escaped markdown heading). Empty input returns `[]`.
+    """
+    found: set[int] = set()
+    for t in texts:
+        if not t:
+            continue
+        for match in _ISSUE_REF.finditer(t):
+            try:
+                found.add(int(match.group(1)))
+            except ValueError:
+                continue
+    return sorted(found)
+
+
+def append_closes_footer(body: str, refs: list[int]) -> str:
+    """Append a `Closes #A, #B` footer to `body`. No-op when `refs` is empty.
+
+    Uses `Closes` for output consistency (GitHub also accepts `Fixes`/`Resolves`).
+    """
+    if not refs:
+        return body
+    refs_str = ", ".join(f"#{n}" for n in refs)
+    separator = "" if body.endswith("\n\n") else ("\n" if body.endswith("\n") else "\n\n")
+    if separator == "\n":
+        separator = "\n"  # keep one newline; we'll add another below
+        return f"{body}\nCloses {refs_str}"
+    if separator == "":
+        return f"{body}Closes {refs_str}"
+    return f"{body}{separator}Closes {refs_str}"

--- a/tests/core/test_issue_refs.py
+++ b/tests/core/test_issue_refs.py
@@ -1,0 +1,63 @@
+from mship.core.issue_refs import append_closes_footer, extract_issue_refs
+
+
+def test_extract_empty_returns_empty():
+    assert extract_issue_refs([]) == []
+    assert extract_issue_refs(["", None]) == []  # type: ignore[list-item]
+
+
+def test_extract_single_ref():
+    assert extract_issue_refs(["fix #3 audit check"]) == [3]
+
+
+def test_extract_multiple_refs_deduped_and_sorted():
+    refs = extract_issue_refs([
+        "fix #8 auto link",
+        "also closes #3 and #12",
+        "mentions #8 again",
+    ])
+    assert refs == [3, 8, 12]
+
+
+def test_extract_ignores_identifier_prefix():
+    """`abc#3` is an anchor-link-ish pattern, not an issue ref."""
+    assert extract_issue_refs(["see section abc#3 for details"]) == []
+
+
+def test_extract_ignores_double_hash():
+    """`##3` is a markdown heading hint, not an issue ref."""
+    assert extract_issue_refs(["##3 some heading"]) == []
+
+
+def test_extract_allows_parens_and_punctuation():
+    assert extract_issue_refs(["fix (#3) and closes #7, also #12."]) == [3, 7, 12]
+
+
+def test_extract_ignores_bare_hash():
+    assert extract_issue_refs(["C# is a language", "# heading"]) == []
+
+
+def test_extract_scans_across_multiple_texts():
+    refs = extract_issue_refs(["desc mentions #3", "log says #8", "commit: fix #12"])
+    assert refs == [3, 8, 12]
+
+
+def test_append_closes_footer_empty_refs_is_noop():
+    assert append_closes_footer("some body", []) == "some body"
+
+
+def test_append_closes_footer_single_ref():
+    assert append_closes_footer("body", [3]) == "body\n\nCloses #3"
+
+
+def test_append_closes_footer_multiple_refs():
+    assert append_closes_footer("body", [3, 7]) == "body\n\nCloses #3, #7"
+
+
+def test_append_closes_footer_handles_trailing_newline():
+    # Input with a single trailing newline gets a blank-line separator
+    assert append_closes_footer("body\n", [3]) == "body\n\nCloses #3"
+
+
+def test_append_closes_footer_handles_double_trailing_newline():
+    assert append_closes_footer("body\n\n", [3]) == "body\n\nCloses #3"

--- a/tests/test_finish_integration.py
+++ b/tests/test_finish_integration.py
@@ -549,3 +549,91 @@ def test_finish_still_blocks_other_audit_errors(finish_workspace):
     result = runner.invoke(app, ["finish"])
     assert result.exit_code != 0
     assert "dirty_worktree" in result.output
+
+
+def test_finish_auto_links_issue_refs_in_description(finish_workspace):
+    """Regression for #8: task description containing `#N` should produce PR body with `Closes #N`."""
+    workspace, mock_shell = finish_workspace
+
+    result = runner.invoke(app, ["spawn", "fix #42 something important", "--repos", "shared", "--force-audit"])
+    assert result.exit_code == 0, result.output
+
+    captured_body: list[str] = []
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "git status --porcelain" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "symbolic-ref --short HEAD" in cmd:
+            return ShellResult(returncode=0, stdout="feat/fix-42-something-important\n", stderr="")
+        if "git fetch" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
+            return ShellResult(returncode=0, stdout="origin/feat/fix-42-something-important\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
+        if "rev-list --count" in cmd:
+            return ShellResult(returncode=0, stdout="0\n", stderr="")
+        if "git worktree list" in cmd:
+            return ShellResult(returncode=0, stdout="worktree /tmp/shared\n", stderr="")
+        if "git ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc\trefs/heads/main\n", stderr="")
+        if "git log --format=%s" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            # Extract --body from the command
+            import shlex as _shlex
+            tokens = _shlex.split(cmd)
+            if "--body" in tokens:
+                idx = tokens.index("--body")
+                captured_body.append(tokens[idx + 1])
+            return ShellResult(returncode=0, stdout="https://x/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell.run.side_effect = mock_run
+
+    result = runner.invoke(app, ["finish"])
+    assert result.exit_code == 0, result.output
+    assert captured_body, "expected gh pr create to be invoked"
+    assert "Closes #42" in captured_body[0]
+
+
+def test_finish_pr_body_unchanged_when_no_issue_refs(finish_workspace):
+    """Task description without `#N` → PR body is just the description."""
+    workspace, mock_shell = finish_workspace
+
+    result = runner.invoke(app, ["spawn", "ordinary task description", "--repos", "shared", "--force-audit"])
+    assert result.exit_code == 0, result.output
+
+    captured_body: list[str] = []
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
+        if "rev-list --count" in cmd:
+            return ShellResult(returncode=0, stdout="0\n", stderr="")
+        if "git log --format=%s" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            import shlex as _shlex
+            tokens = _shlex.split(cmd)
+            if "--body" in tokens:
+                idx = tokens.index("--body")
+                captured_body.append(tokens[idx + 1])
+            return ShellResult(returncode=0, stdout="https://x/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell.run.side_effect = mock_run
+
+    result = runner.invoke(app, ["finish", "--force-audit"])
+    assert result.exit_code == 0, result.output
+    assert captured_body
+    assert "Closes" not in captured_body[0]
+    assert captured_body[0] == "ordinary task description"


### PR DESCRIPTION
mship finish now scans task.description, mship log entries, and commit subjects on the task branch for GitHub issue references like `#42`. Unique refs are appended to the PR body as a `Closes #A, #B` footer.

New `core/issue_refs.py` module with `extract_issue_refs()` + `append_closes_footer()` helpers, unit tests, and integration tests verifying the footer appears when refs exist and not otherwise.

Closes #8