### PR TITLE
add pr body support to finish and document it

### DIFF
--- a/skills/working-with-mothership/SKILL.md
+++ b/skills/working-with-mothership/SKILL.md
@@ -84,7 +84,7 @@ mship block "reason" | mship unblock
 mship test [--all] [--repos|--tag] [--no-diff]
 mship journal "msg" [--action X] [--open Y] [--repo R] [--test-state pass|fail|mixed]
 mship journal --show-open                 # what am I blocked on across this task?
-mship finish [--base B] [--base-map ...] [--push-only] [--handoff] [--force-audit]
+mship finish [--base B] [--base-map ...] [--push-only] [--handoff] [--force-audit] [--body-file F | --body TEXT]
 mship close [--yes] [--abandon] [--force] [--skip-pr-check]
 ```
 
@@ -105,6 +105,8 @@ If you don't, your edits in the shell affect the main checkout, not the feature 
 **Always log structured.** `--action` makes session resume actually work. `--open` flags blockers you'll come back to. `--show-open` lists them. The `repo` field is auto-inferred from `mship switch`'s active repo.
 
 **`finish`:** PR base resolves as `--base-map` entry > `--base` > `repo.base_branch` in config > gh default. Every base is verified on origin before any push; empty branches and missing bases fail fast with no partial state.
+
+**`finish` PR body — write a real one.** By default the PR body is just the task description plus a `Closes #N` footer for any issue refs found in the description, journal, and commit subjects. That's a placeholder, not a body. For agent-driven finishes, pass `--body-file <path>` (or `--body '<inline>'`, or `--body -` for stdin) with a real Summary and Test plan. Empty bodies are rejected — that's deliberate. If you forgot at finish time, follow up immediately with `gh pr edit <url> --body-file <path>`. A bare task-description PR is treated as incomplete.
 
 **`close` gates (in order):**
 1. **Requires `finish` first.** Refuses if `task.finished_at is None` unless `--abandon` is passed.
@@ -296,6 +298,7 @@ Then `mship test --tag mobile` runs both.
 - **Don't merge PRs out of order** — the coordination block in each PR description shows the correct order.
 - **Don't ignore healthcheck failures** — if `mship run` reports a service didn't become ready, the dependent services won't work either.
 - **Don't run `mship finish` with failing tests** — run `mship test` first.
+- **Don't ship a PR with a placeholder body.** If you didn't pass `--body-file`/`--body` to `mship finish`, the PR body is just the task description — not a Summary + Test plan. Follow up with `gh pr edit <url> --body-file <path>` before declaring done. Reviewers (human or agent) need to know what changed and how it was verified.
 - **Don't paste test output into `mship journal`** — after every `mship test`, mship auto-logs a structured entry with iteration, test_state, and action. The iteration file under `.mothership/test-runs/` has stderr for failures.
 - **Don't keep editing a worktree after `mship finish`** — once `finish` stamps the task as done, phase transitions are blocked (except `run`). If you need to make changes, open a new task with `mship spawn`.
 - **Don't manually edit `.mothership/state.yaml`** — use the CLI commands instead.

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -416,6 +416,16 @@ def register(app: typer.Typer, get_container):
         force_audit: bool = typer.Option(False, "--force-audit", help="Bypass audit gate for this finish"),
         push_only: bool = typer.Option(False, "--push-only", help="Push branches only; skip gh pr create"),
         bypass_reconcile: bool = typer.Option(False, "--bypass-reconcile", help="Skip upstream PR drift check for this finish"),
+        body: Optional[str] = typer.Option(
+            None, "--body",
+            help="Inline PR body. Use '-' to read from stdin. Mutually exclusive with --body-file.",
+        ),
+        body_file: Optional[str] = typer.Option(
+            None, "--body-file",
+            help="Read PR body from this file. Mutually exclusive with --body. "
+                 "Recommended for agents: write a Summary + Test plan rather than "
+                 "letting finish fall back to the task description.",
+        ),
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),
     ):
         """Create PRs across repos in dependency order."""
@@ -429,6 +439,33 @@ def register(app: typer.Typer, get_container):
 
         if push_only and (handoff or base is not None or base_map is not None):
             output.error("--push-only is incompatible with --handoff/--base/--base-map")
+            raise typer.Exit(code=1)
+
+        # --- Resolve PR body source ---
+        if body is not None and body_file is not None:
+            output.error("--body and --body-file are mutually exclusive")
+            raise typer.Exit(code=1)
+        if (body is not None or body_file is not None) and (push_only or handoff):
+            output.error("--body/--body-file has no effect with --push-only or --handoff")
+            raise typer.Exit(code=1)
+        custom_body: Optional[str] = None
+        if body is not None:
+            if body == "-":
+                import sys as _sys
+                custom_body = _sys.stdin.read()
+            else:
+                custom_body = body
+        elif body_file is not None:
+            try:
+                custom_body = Path(body_file).read_text()
+            except OSError as e:
+                output.error(f"Could not read --body-file {body_file!r}: {e}")
+                raise typer.Exit(code=1)
+        if custom_body is not None and not custom_body.strip():
+            output.error(
+                "PR body is empty. Write a Summary + Test plan, or omit --body/--body-file "
+                "to fall back to the task description."
+            )
             raise typer.Exit(code=1)
         state_mgr = container.state_manager()
         state = state_mgr.load()
@@ -667,7 +704,8 @@ def register(app: typer.Typer, get_container):
                             texts.append(line)
             except Exception:
                 pass
-            pr_body = append_closes_footer(task.description, extract_issue_refs(texts))
+            pr_body_base = custom_body if custom_body is not None else task.description
+            pr_body = append_closes_footer(pr_body_base, extract_issue_refs(texts))
 
             # Create PR
             try:

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -392,6 +392,77 @@ def test_finish_creates_prs(configured_git_app: Path):
     cli_container.shell.reset_override()
 
 
+def test_finish_body_file_passed_to_gh_pr_create(configured_git_app: Path):
+    """--body-file contents must land in the gh pr create invocation."""
+    from mship.cli import container as cli_container
+
+    runner.invoke(app, ["spawn", "body test", "--repos", "shared"])
+
+    body_path = configured_git_app / "body.md"
+    body_path.write_text(
+        "## Summary\n- added thing\n\n## Test plan\n- [ ] verify thing\n"
+    )
+
+    captured: dict[str, str] = {}
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            captured["create_cmd"] = cmd
+            return ShellResult(returncode=0, stdout="https://x/pr/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = mock_run
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    cli_container.shell.override(mock_shell)
+    try:
+        result = runner.invoke(
+            app, ["finish", "--task", "body-test", "--body-file", str(body_path)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "create_cmd" in captured
+        # The body ends up shlex-quoted; check the content leaked through verbatim.
+        assert "## Summary" in captured["create_cmd"]
+        assert "- added thing" in captured["create_cmd"]
+        assert "## Test plan" in captured["create_cmd"]
+    finally:
+        cli_container.shell.reset_override()
+
+
+def test_finish_body_and_body_file_mutually_exclusive(configured_git_app: Path):
+    runner.invoke(app, ["spawn", "mutex test", "--repos", "shared"])
+    result = runner.invoke(
+        app, ["finish", "--task", "mutex-test", "--body", "x", "--body-file", "/tmp/y"]
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+def test_finish_rejects_empty_body_file(configured_git_app: Path, tmp_path: Path):
+    runner.invoke(app, ["spawn", "empty body test", "--repos", "shared"])
+    empty = tmp_path / "empty.md"
+    empty.write_text("   \n\n")
+    result = runner.invoke(
+        app, ["finish", "--task", "empty-body-test", "--body-file", str(empty)]
+    )
+    assert result.exit_code != 0
+    assert "empty" in result.output.lower()
+
+
+def test_finish_body_incompatible_with_push_only(configured_git_app: Path):
+    runner.invoke(app, ["spawn", "po mutex test", "--repos", "shared"])
+    result = runner.invoke(
+        app,
+        ["finish", "--task", "po-mutex-test", "--push-only", "--body", "x"],
+    )
+    assert result.exit_code != 0
+    assert "no effect" in result.output.lower() or "push-only" in result.output.lower()
+
+
 def test_finish_gh_not_available(configured_git_app: Path):
     from mship.cli import container as cli_container
 


### PR DESCRIPTION
## Summary

`mship finish` previously built a PR body of just the task description plus a
`Closes #N` footer — enough to link issues, but not enough for a reviewer to
see what changed or how it was verified. Agents (and humans in a hurry) were
landing PRs with placeholder bodies.

This change:

- adds `--body <text>` (use `-` for stdin) and `--body-file <path>` to
  `mship finish`, mutually exclusive, both incompatible with `--push-only`
  and `--handoff` (no PR is created in those modes).
- rejects empty bodies so the flag can't accidentally degrade to the old
  placeholder.
- updates the `working-with-mothership` skill to spell out that the default
  body is a placeholder, point at `--body-file` as the right tool, and add a
  pitfalls bullet about the `gh pr edit` follow-up when you forgot.

The body content is still merged with the existing `append_closes_footer`
helper, so `Closes #N` references found in the description, journal, or
commit subjects still get appended automatically. Multi-repo coordination
blocks are still appended afterward unchanged.

This PR is itself produced via `mship finish --body-file`, so the body
you're reading is generated by the new code path.

## Test plan

- [x] 4 new tests in `tests/cli/test_worktree.py`:
  - `test_finish_body_file_passed_to_gh_pr_create` — captures the
    `gh pr create` shell command and asserts the file's content
    (`## Summary`, `## Test plan`, body bullets) leaks through verbatim.
  - `test_finish_body_and_body_file_mutually_exclusive` — exits non-zero
    with "mutually exclusive" in the output.
  - `test_finish_rejects_empty_body_file` — whitespace-only body file is
    refused with an "empty" error.
  - `test_finish_body_incompatible_with_push_only` — refuses the
    combination.
- [x] Existing finish + close suite still green (15/15 close, 6/6 finish).
- [x] Full repo suite green (722 passed).
- [x] Manual: this PR.

## Notes

- The `_log-commit` post-commit hook error visible during commits is a
  separate pre-existing bug (the command was renamed to `_journal-commit`).
  Filing a follow-up.
- During this work I twice fell into the "edit absolute paths into the main
  checkout while cwd is the worktree" footgun the AGENTS.md / mship pre-commit
  hook are designed to catch. The hook caught me on `git commit`; I had to
  stash from the main checkout and re-apply in the worktree both times.
  Worth thinking about whether mship can detect this pattern earlier
  (e.g., during a periodic state check, or via an FS-watch) — separate issue.
