### PR TITLE
enrich precommit hook refusal with recovery commands

### DIFF
--- a/src/mship/cli/internal.py
+++ b/src/mship/cli/internal.py
@@ -79,6 +79,8 @@ def register(app: typer.Typer, get_container):
             raise typer.Exit(code=0)
 
         # No match — reject with list of active worktrees.
+        import shlex
+        import subprocess
         import sys
         sys.stderr.write(
             f"\u26d4 mship: refusing commit — {tl} is not a registered worktree.\n"
@@ -86,8 +88,39 @@ def register(app: typer.Typer, get_container):
         )
         for slug, wt in registered:
             sys.stderr.write(f"     {wt} ({slug})\n")
+
+        # If the rejected toplevel has uncommitted changes, it's almost
+        # certainly a misrouted-edit situation (absolute paths in a tool call
+        # bypassed the user's cwd). Show exact recovery commands per worktree.
+        has_changes = False
+        try:
+            probe = subprocess.run(
+                ["git", "-C", str(tl), "status", "--porcelain"],
+                capture_output=True, text=True, check=False, timeout=5,
+            )
+            has_changes = probe.returncode == 0 and bool(probe.stdout.strip())
+        except (subprocess.SubprocessError, OSError):
+            pass
+
+        if has_changes:
+            q_tl = shlex.quote(str(tl))
+            sys.stderr.write(
+                f"\n   {tl} has uncommitted changes — looks like edits landed here\n"
+                f"   instead of the worktree. To move them:\n"
+            )
+            for slug, wt in registered:
+                q_wt = shlex.quote(str(wt))
+                sys.stderr.write(
+                    f"     git -C {q_tl} stash push -u -m {slug}-misrouted\n"
+                    f"     cd {q_wt} && git stash pop\n"
+                )
+            if len(registered) > 1:
+                sys.stderr.write(
+                    "   (pick the worktree the edits belong to — don't run both)\n"
+                )
+
         sys.stderr.write(
-            f"   cd into one of those, or use `git commit --no-verify` to override.\n"
+            "\n   cd into a worktree, or use `git commit --no-verify` to override.\n"
         )
         raise typer.Exit(code=1)
 

--- a/tests/cli/test_check_commit.py
+++ b/tests/cli/test_check_commit.py
@@ -105,6 +105,143 @@ def test_check_commit_wrong_toplevel_exits_one_with_paths(tmp_path):
         container.state_manager.reset()
 
 
+def _git(args: list[str], cwd: Path) -> None:
+    import subprocess
+    subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True,
+        env={
+            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+            "PATH": "/usr/bin:/bin",
+        },
+    )
+
+
+def test_check_commit_dirty_toplevel_shows_recovery_commands(tmp_path):
+    """When the rejected path has uncommitted changes, show per-worktree
+    `git -C ... stash push` / `cd ... && git stash pop` lines so the user
+    can move misrouted edits to the correct worktree."""
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(tmp_path / ".mothership")
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    (tmp_path / ".mothership").mkdir()
+
+    wt = tmp_path / "wt-cli"
+    wt.mkdir()
+    task = Task(
+        slug="my-task", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["cli"], branch="feat/my-task",
+        worktrees={"cli": wt},
+    )
+    _seed(tmp_path / ".mothership", task)
+
+    # Real git repo at `wrong` with a modified-but-uncommitted file.
+    wrong = tmp_path / "main-checkout"
+    wrong.mkdir()
+    _git(["init", "-q"], cwd=wrong)
+    (wrong / "file.txt").write_text("hello\n")
+    _git(["add", "file.txt"], cwd=wrong)
+    _git(["commit", "-q", "-m", "init"], cwd=wrong)
+    (wrong / "file.txt").write_text("dirty\n")
+
+    try:
+        result = runner.invoke(app, ["_check-commit", str(wrong)])
+        assert result.exit_code == 1
+        out = result.output
+        # Recovery block must name the slug, reference the main-checkout path,
+        # and name the worktree destination.
+        assert "uncommitted changes" in out
+        assert "my-task-misrouted" in out
+        assert f"git -C {wrong}" in out or f"git -C {wrong.as_posix()}" in out
+        assert str(wt) in out
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+
+
+def test_check_commit_clean_toplevel_no_recovery_block(tmp_path):
+    """Clean rejected path → no recovery block (avoids noise when the user
+    just forgot to cd, not an actual misroute)."""
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(tmp_path / ".mothership")
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    (tmp_path / ".mothership").mkdir()
+
+    wt = tmp_path / "wt-cli"
+    wt.mkdir()
+    task = Task(
+        slug="t", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["cli"], branch="feat/t",
+        worktrees={"cli": wt},
+    )
+    _seed(tmp_path / ".mothership", task)
+
+    wrong = tmp_path / "main-checkout"
+    wrong.mkdir()
+    _git(["init", "-q"], cwd=wrong)
+    (wrong / "file.txt").write_text("hello\n")
+    _git(["add", "file.txt"], cwd=wrong)
+    _git(["commit", "-q", "-m", "init"], cwd=wrong)
+    # Deliberately leave the tree clean.
+
+    try:
+        result = runner.invoke(app, ["_check-commit", str(wrong)])
+        assert result.exit_code == 1
+        out = result.output
+        assert "uncommitted changes" not in out
+        assert "stash push" not in out
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+
+
+def test_check_commit_multi_worktree_recovery_warns_pick_one(tmp_path):
+    """With >1 active worktree, the recovery block still prints per-worktree
+    commands but adds a 'pick one' note so the user doesn't run both."""
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(tmp_path / ".mothership")
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    (tmp_path / ".mothership").mkdir()
+
+    wt_cli = tmp_path / "wt-cli"
+    wt_api = tmp_path / "wt-api"
+    wt_cli.mkdir(); wt_api.mkdir()
+    task = Task(
+        slug="multi", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["cli", "api"], branch="feat/multi",
+        worktrees={"cli": wt_cli, "api": wt_api},
+    )
+    _seed(tmp_path / ".mothership", task)
+
+    wrong = tmp_path / "main-checkout"
+    wrong.mkdir()
+    _git(["init", "-q"], cwd=wrong)
+    (wrong / "f").write_text("x")
+    _git(["add", "f"], cwd=wrong)
+    _git(["commit", "-q", "-m", "i"], cwd=wrong)
+    (wrong / "f").write_text("y")
+
+    try:
+        result = runner.invoke(app, ["_check-commit", str(wrong)])
+        assert result.exit_code == 1
+        out = result.output
+        assert "pick the worktree" in out
+        assert str(wt_cli) in out
+        assert str(wt_api) in out
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+
+
 def test_check_commit_fails_open_on_corrupt_state(tmp_path):
     container.config_path.override(tmp_path / "mothership.yaml")
     container.state_dir.override(tmp_path / ".mothership")


### PR DESCRIPTION
## Summary

`_check-commit` (invoked by the installed pre-commit hook) already refuses `git commit` from outside a registered worktree while a task is active. Until now the message just said *where* the worktrees are; recovering from a misroute — moving the accidentally-main-checkout edits to the correct worktree — meant hand-crafting a `stash push` / `stash pop` dance across two directories, which is easy to botch.

This change adds the two specific commands to the refusal message, per active worktree:

```
⛔ mship: refusing commit — /path/to/main is not a registered worktree.
   Active task worktrees:
     /path/to/.worktrees/feat/my-task (my-task)

   /path/to/main has uncommitted changes — looks like edits landed here
   instead of the worktree. To move them:
     git -C /path/to/main stash push -u -m my-task-misrouted
     cd /path/to/.worktrees/feat/my-task && git stash pop

   cd into a worktree, or use `git commit --no-verify` to override.
```

Guardrails:

- the recovery block only prints when the rejected toplevel actually has uncommitted changes (`git status --porcelain` non-empty). Clean paths stay as before — no noise when the user just forgot to `cd`.
- multi-worktree tasks print one `stash push` / `stash pop` pair per worktree plus a "pick the worktree the edits belong to — don't run both" warning.
- `shlex.quote` is applied to both paths so paths-with-spaces don't break the copy-paste.
- `git status --porcelain` is called with a 5s timeout and exceptions are caught — a hook that takes forever or crashes on a weird filesystem would be worse than no recovery hint at all.

This is option **A** from issue #46. Options B (status-time detection), C (file-overlap check), and D (a `mship rescue` verb) are deferred — A is the cheapest, highest-hit-rate fix.

## Test plan

- [x] Three new tests in `tests/cli/test_check_commit.py` (pattern copies the existing `wrong_toplevel` test):
  - `test_check_commit_dirty_toplevel_shows_recovery_commands` — dirty git repo at the rejected path; asserts the `stash push`, `-misrouted` marker, and worktree destination all appear.
  - `test_check_commit_clean_toplevel_no_recovery_block` — clean git repo; asserts `"uncommitted changes"` and `"stash push"` do *not* appear.
  - `test_check_commit_multi_worktree_recovery_warns_pick_one` — two worktrees; asserts both are listed and the `"pick the worktree"` note is present.
- [x] Existing 5 `_check-commit` tests unchanged and still pass.
- [x] Full suite: 725 passing (previously 722; +3 new tests).
- [x] Dogfooded by writing this PR — edits landed in the right worktree (for once).

## Notes

- The pre-commit hook body in `src/mship/core/hooks.py` is unchanged. Only the refusal output from `_check-commit` changes, so existing installations pick up the enriched message automatically next time they `git commit` from the wrong place.
- Doesn't attempt to *execute* the recovery — destructive-ish, user should see and run the commands themselves. Consistent with how the existing `--no-verify` escape hatch is surfaced.

Closes #46
