### PR TITLE
silent fallback for unknown mship internal commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 ]
 
 [project.scripts]
-mship = "mship.cli:app"
+mship = "mship.cli:run"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -81,6 +81,32 @@ from mship.cli import layout as _layout_mod
 from mship.cli import internal as _internal_mod
 from mship.cli import reconcile as _reconcile_mod
 
+def _should_silent_exit(argv: list[str]) -> bool:
+    """True if argv is invoking an unknown `_`-prefixed internal command.
+
+    Stale git hooks from older mship versions invoke renamed internals like
+    `mship _log-commit`. They're wrapped in `|| true` in the hook body, so
+    the hook itself is fine with a nonzero exit — but typer prints a 6-line
+    usage error, which is noise on every single commit until the user runs
+    `mship init --install-hooks`. Swallow it.
+    """
+    if len(argv) < 2:
+        return False
+    cmd = argv[1]
+    if not cmd.startswith("_"):
+        return False
+    known = {c.name for c in app.registered_commands if c.name}
+    return cmd not in known
+
+
+def run() -> None:
+    """Entry point wrapper — see `_should_silent_exit`."""
+    import sys
+    if _should_silent_exit(sys.argv):
+        sys.exit(0)
+    app()
+
+
 _status_mod.register(app, get_container)
 _phase_mod.register(app, get_container)
 _worktree_mod.register(app, get_container)

--- a/tests/cli/test_unknown_internal.py
+++ b/tests/cli/test_unknown_internal.py
@@ -1,0 +1,36 @@
+"""Silent fallback for unknown `_`-prefixed internal commands (issue #38)."""
+import pytest
+
+from mship.cli import _should_silent_exit
+
+
+class TestShouldSilentExit:
+    def test_unknown_underscore_command_triggers_silent_exit(self):
+        assert _should_silent_exit(["mship", "_log-commit"]) is True
+
+    def test_known_underscore_command_does_not(self):
+        # _check-commit / _post-checkout / _journal-commit are registered
+        assert _should_silent_exit(["mship", "_check-commit", "/tmp"]) is False
+        assert _should_silent_exit(["mship", "_journal-commit"]) is False
+        assert _should_silent_exit(["mship", "_post-checkout", "a", "b"]) is False
+
+    def test_non_underscore_unknown_command_does_not(self):
+        """Unknown non-prefixed commands keep their normal error behavior —
+        those are user-facing typos, not hook-renamed internals."""
+        assert _should_silent_exit(["mship", "doesnotexist"]) is False
+        assert _should_silent_exit(["mship", "klose"]) is False
+
+    def test_known_public_command_does_not(self):
+        assert _should_silent_exit(["mship", "status"]) is False
+        assert _should_silent_exit(["mship", "close"]) is False
+
+    def test_no_subcommand_does_not(self):
+        assert _should_silent_exit(["mship"]) is False
+        assert _should_silent_exit([]) is False
+
+    def test_only_underscore_no_name_does_not_match_any_known(self):
+        # A bare `_` isn't registered; treat as unknown internal → silent.
+        assert _should_silent_exit(["mship", "_"]) is True
+
+    def test_underscore_with_extra_args_still_matches(self):
+        assert _should_silent_exit(["mship", "_old-renamed-thing", "arg1", "arg2"]) is True


### PR DESCRIPTION
## Summary

When `mship log` was renamed to `mship journal`, the post-commit hook body was updated (it now calls `_journal-commit`), but existing installations still have the old `_log-commit` hook wired into `.git/hooks/post-commit`. Every `git commit` in those installations prints this:

```
Usage: mship [OPTIONS] COMMAND [ARGS]...
Try 'mship --help' for help.
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ No such command '_log-commit'. Did you mean '_journal-commit',               │
│ '_check-commit'?                                                             │
╰──────────────────────────────────────────────────────────────────────────────╯
```

The hook itself is fine — it's wrapped in `|| true` — but the 6-line typer error shows on every commit, forever, until the user runs `mship init --install-hooks`. That's a noise floor high enough to desensitize users to real mship output.

This PR implements the "long-term" fix from issue #38: have the mship entry point silently no-op on any unknown `_`-prefixed command. Observable effect for stale-hook installations: the error simply goes away, starting with the first commit after the upgrade.

## Design

- `src/mship/cli/__init__.py` gains a `run()` wrapper and a pure `_should_silent_exit(argv)` helper.
- `_should_silent_exit` returns `True` only when argv[1] starts with `_` AND isn't a registered command name (looked up via `app.registered_commands`).
- `run()` calls `sys.exit(0)` in that case; otherwise invokes the typer app as before.
- `pyproject.toml`'s `[project.scripts]` entry moves from `mship.cli:app` → `mship.cli:run` so the wrapper is what gets installed.

Non-underscore unknown commands (typos like `mship klsoe`) keep their normal "did you mean" error — only hook-called internals get the silent treatment.

This pairs with the short-/medium-term fixes suggested in #38 (`mship doctor` detection, auto-heal of stale hook blocks). Those are still worth doing as follow-ups, since they'd also catch drift on the pre-commit + post-checkout hooks. But the silent-fallback alone eliminates the user-visible symptom immediately for everyone with stale hooks — no doctor-run required.

## Test plan

- [x] New `tests/cli/test_unknown_internal.py` — 7 unit tests covering:
  - unknown `_`-prefixed name → silent exit
  - known `_`-prefixed names (`_check-commit`, `_journal-commit`, `_post-checkout`) → normal dispatch
  - unknown non-underscore name → normal dispatch (preserves typo errors)
  - known public name → normal dispatch
  - empty / no-subcommand argv → normal dispatch
  - `_` + extra args → silent exit
- [x] Full suite: 729 passing (previously 722; +7 new tests).
- [x] Manual smoke:
  ```
  $ uv run mship _log-commit
  (exit 0, no output)

  $ uv run mship _check-commit /nonexistent
  ⛔ mship: refusing commit — /nonexistent is not a registered worktree.
     ...
  (exit 1, full output as before)

  $ uv run mship _some-old-hook-name
  (exit 0, no output)

  $ uv run mship klsoe
  Usage: mship [OPTIONS] COMMAND [ARGS]...
  Try 'mship --help' for help.
  ...
  (exit 2, normal typo error)
  ```
- [x] Dogfooded — the commit created for this PR landed without the `_log-commit` noise (visible in earlier commits in this session).

Closes #38
