### PR TITLE
allow finish --force to push commits to existing PR

### DIFF
--- a/skills/working-with-mothership/SKILL.md
+++ b/skills/working-with-mothership/SKILL.md
@@ -84,7 +84,7 @@ mship block "reason" | mship unblock
 mship test [--all] [--repos|--tag] [--no-diff]
 mship journal "msg" [--action X] [--open Y] [--repo R] [--test-state pass|fail|mixed]
 mship journal --show-open                 # what am I blocked on across this task?
-mship finish [--base B] [--base-map ...] [--push-only] [--handoff] [--force-audit] [--body-file F | --body TEXT]
+mship finish [--base B] [--base-map ...] [--push-only] [--handoff] [--force-audit] [--body-file F | --body TEXT] [--force]
 mship close [--yes] [--abandon] [--force] [--skip-pr-check]
 ```
 
@@ -107,6 +107,8 @@ If you don't, your edits in the shell affect the main checkout, not the feature 
 **`finish`:** PR base resolves as `--base-map` entry > `--base` > `repo.base_branch` in config > gh default. Every base is verified on origin before any push; empty branches and missing bases fail fast with no partial state.
 
 **`finish` PR body — write a real one.** By default the PR body is just the task description plus a `Closes #N` footer for any issue refs found in the description, journal, and commit subjects. That's a placeholder, not a body. For agent-driven finishes, pass `--body-file <path>` (or `--body '<inline>'`, or `--body -` for stdin) with a real Summary and Test plan. Empty bodies are rejected — that's deliberate. If you forgot at finish time, follow up immediately with `gh pr edit <url> --body-file <path>`. A bare task-description PR is treated as incomplete.
+
+**`finish --force` — push post-finish commits to existing PRs.** After `finish` once, normal `finish` re-runs are idempotent no-ops. If reviewer feedback or on-device testing requires new commits, make them in the worktree, then run `mship finish --force` to push them to the existing PR(s). Updates `finished_at`, adds a `re-finished` journal entry, and does **not** create a new PR or touch the existing PR body. Without `--force`, finish warns when the worktree has commits past `origin/<branch>` so you don't silently lose work — but it won't push. To update a PR body after re-push, use `gh pr edit <url> --body-file <path>` separately (`--force` and `--body-file` are mutually exclusive).
 
 **`close` gates (in order):**
 1. **Requires `finish` first.** Refuses if `task.finished_at is None` unless `--abandon` is passed.

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -426,6 +426,12 @@ def register(app: typer.Typer, get_container):
                  "Recommended for agents: write a Summary + Test plan rather than "
                  "letting finish fall back to the task description.",
         ),
+        force: bool = typer.Option(
+            False, "--force", "-f",
+            help="Push new commits to an already-finished task's existing PR(s). "
+                 "Updates finished_at and appends a `re-finished` journal entry. "
+                 "Does not touch the PR body — use `gh pr edit` for that.",
+        ),
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),
     ):
         """Create PRs across repos in dependency order."""
@@ -439,6 +445,16 @@ def register(app: typer.Typer, get_container):
 
         if push_only and (handoff or base is not None or base_map is not None):
             output.error("--push-only is incompatible with --handoff/--base/--base-map")
+            raise typer.Exit(code=1)
+
+        if force and handoff:
+            output.error("--force is incompatible with --handoff")
+            raise typer.Exit(code=1)
+        if force and (body is not None or body_file is not None):
+            output.error(
+                "--force doesn't touch PR bodies — use `gh pr edit <url> --body-file <path>` "
+                "to update an existing PR body"
+            )
             raise typer.Exit(code=1)
 
         # --- Resolve PR body source ---
@@ -646,12 +662,63 @@ def register(app: typer.Typer, get_container):
             raise typer.Exit(code=1)
 
         pr_list: list[dict] = []
+        repushed_repos: list[str] = []  # repos where --force re-pushed commits
+
+        # --- Detect post-finish unpushed commits when NOT in --force mode ---
+        # Without this, `finish` on an already-finished task with new commits
+        # silently succeeds but pushes nothing, training users to reach for
+        # direct `git push`. Warn loudly and point at --force.
+        if not force and not push_only and not handoff:
+            stale_repos: list[tuple[str, int]] = []
+            for repo_name in task.pr_urls:
+                wt = task.worktrees.get(repo_name)
+                if wt is None:
+                    continue
+                wt_path = Path(wt)
+                if not wt_path.exists():
+                    continue
+                # count_commits_ahead(base=branch, branch=branch) counts commits
+                # on the local branch past origin's copy of that branch.
+                n = pr_mgr.count_commits_ahead(wt_path, task.branch, task.branch)
+                if n > 0:
+                    stale_repos.append((repo_name, n))
+            if stale_repos:
+                output.warning("Task has unpushed commits since last finish:")
+                for repo_name, n in stale_repos:
+                    output.warning(f"  {repo_name}: {n} commits past origin/{task.branch}")
+                output.warning("Pass `--force` to push them to the existing PR(s).")
 
         for i, repo_name in enumerate(ordered, 1):
-            # Skip if PR already created (idempotent re-run)
-            if repo_name in task.pr_urls:
+            # Skip if PR already created (idempotent re-run), unless --force.
+            if repo_name in task.pr_urls and not force:
                 if output.is_tty:
                     output.print(f"  {repo_name}: already has PR {task.pr_urls[repo_name]}")
+                pr_list.append({
+                    "repo": repo_name,
+                    "url": task.pr_urls[repo_name],
+                    "order": i,
+                    "base": effective_bases.get(repo_name),
+                })
+                continue
+            if repo_name in task.pr_urls and force:
+                # Re-push only: branch already exists on origin, new commits
+                # attach to the existing PR. Don't touch gh; don't rebuild body.
+                repo_config = config.repos[repo_name]
+                repo_path = repo_config.path
+                if repo_name in task.worktrees:
+                    wt_path = Path(task.worktrees[repo_name])
+                    if wt_path.exists():
+                        repo_path = wt_path
+                try:
+                    pr_mgr.push_branch(repo_path, task.branch)
+                except RuntimeError as e:
+                    output.error(f"{repo_name}: {e}")
+                    raise typer.Exit(code=1)
+                repushed_repos.append(repo_name)
+                if output.is_tty:
+                    output.print(
+                        f"  {repo_name}: {task.branch} re-pushed to {task.pr_urls[repo_name]}"
+                    )
                 pr_list.append({
                     "repo": repo_name,
                     "url": task.pr_urls[repo_name],
@@ -734,8 +801,9 @@ def register(app: typer.Typer, get_container):
                 output.print(f"  {repo_name}: {task.branch} → {base_label}  ✓ {pr_url}")
             pr_list[-1]["base"] = effective_bases[repo_name]
 
-        # Update PRs with coordination blocks (multi-repo only)
-        if len(pr_list) > 1:
+        # Update PRs with coordination blocks (multi-repo only). Skip under
+        # --force re-push so we don't clobber a user's manual PR-body edits.
+        if len(pr_list) > 1 and not force:
             for pr_info in pr_list:
                 block = pr_mgr.build_coordination_block(
                     task.slug, pr_list, current_repo=pr_info["repo"]
@@ -745,17 +813,26 @@ def register(app: typer.Typer, get_container):
                     new_body = existing_body + block
                     pr_mgr.update_pr_body(pr_info["url"], new_body)
 
-        # Log PR URLs
+        # Log PR URLs + re-finished entries
         log_mgr = container.log_manager()
         for pr_info in pr_list:
-            log_mgr.append(
-                t.slug,
-                f"PR created for {pr_info['repo']}: {pr_info['url']}",
-            )
+            if pr_info["repo"] in repushed_repos:
+                log_mgr.append(
+                    t.slug,
+                    f"re-finished: pushed new commits to {pr_info['repo']}/{task.branch}",
+                    repo=pr_info["repo"],
+                    action="re-finished",
+                )
+            elif pr_info["repo"] not in task.pr_urls or pr_info["url"] != task.pr_urls.get(pr_info["repo"]):
+                # Newly-created PR this run
+                log_mgr.append(
+                    t.slug,
+                    f"PR created for {pr_info['repo']}: {pr_info['url']}",
+                )
 
-        # Stamp finished_at on successful PR creation.
+        # Stamp finished_at on successful PR creation OR on --force re-push.
         from datetime import datetime as _dt, timezone as _tz
-        if task.finished_at is None:
+        if task.finished_at is None or force:
             now = _dt.now(_tz.utc)
 
             def _stamp_finished(s):
@@ -766,14 +843,20 @@ def register(app: typer.Typer, get_container):
 
         if output.is_tty:
             output.print("")
-            output.success(f"Created {len(pr_list)} PR(s) for task: {task.slug}")
-            if len(pr_list) > 1:
+            if repushed_repos:
+                output.success(
+                    f"Re-pushed {len(repushed_repos)} PR(s) for task: {task.slug}"
+                )
+            else:
+                output.success(f"Created {len(pr_list)} PR(s) for task: {task.slug}")
+            if len(pr_list) > 1 and not force:
                 output.print("Merge in dependency order as shown in each PR description.")
             output.print("[green]Task finished.[/green] After merge, run `mship close` to clean up.")
         else:
             output.json({
                 "task": task.slug,
                 "prs": pr_list,
+                "re_pushed": repushed_repos,
                 "finished_at": task.finished_at.isoformat(),
             })
             output.print("Task finished. After merge, run `mship close` to clean up.")

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -7,7 +7,7 @@ import pytest
 from typer.testing import CliRunner
 
 from mship.cli import app, container
-from mship.core.state import StateManager
+from mship.core.state import StateManager, Task, WorkspaceState
 from mship.util.shell import ShellResult, ShellRunner
 
 runner = CliRunner()
@@ -477,6 +477,142 @@ def test_finish_gh_not_available(configured_git_app: Path):
     assert result.exit_code != 0 or "gh" in result.output.lower()
 
     cli_container.shell.reset_override()
+
+
+def _make_finished_task_with_existing_pr(
+    configured_git_app: Path,
+    *,
+    slug: str = "t",
+    ahead_of_origin: int = 0,
+) -> StateManager:
+    """Seed a task that's already gone through `finish` once (has PR url + finished_at).
+
+    `ahead_of_origin` configures what the mocked git rev-list returns for
+    `origin/<branch>..<branch>` when this task's branch is queried — i.e. how
+    many post-finish commits the worktree has that haven't been pushed yet.
+    """
+    from datetime import datetime, timezone
+    sm = StateManager(configured_git_app / ".mothership")
+    state = WorkspaceState(
+        tasks={slug: Task(
+            slug=slug, description="d", phase="review",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch=f"feat/{slug}",
+            worktrees={"shared": configured_git_app / "shared"},
+            pr_urls={"shared": "https://github.com/o/r/pull/99"},
+            finished_at=datetime.now(timezone.utc),
+        )},
+    )
+    sm.save(state)
+    return sm
+
+
+def _finish_force_shell_factory(*, ahead_count: int):
+    """Shell side_effect for finish-force tests.
+
+    Captures any `git push` or `gh pr create` so tests can assert what ran.
+    `ahead_count` applies ONLY to `origin/<X>..<X>` queries (the unpushed-
+    commits probe); all other rev-list-count probes (audit: `@{u}..HEAD`,
+    finish's preflight) still return 0 to keep the audit gate happy.
+    """
+    import re
+    same_branch_ahead = re.compile(r"origin/([^.\s'\"]+)\.\.\1")
+
+    captured: dict[str, list[str]] = {"push": [], "pr_create": []}
+
+    def run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "symbolic-ref" in cmd:
+            return ShellResult(returncode=0, stdout="main\n", stderr="")
+        if "fetch" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
+            return ShellResult(returncode=0, stdout="origin/main\n", stderr="")
+        if "rev-list --count" in cmd:
+            if same_branch_ahead.search(cmd):
+                return ShellResult(returncode=0, stdout=f"{ahead_count}\n", stderr="")
+            return ShellResult(returncode=0, stdout="0\n", stderr="")
+        if "status --porcelain" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "worktree list" in cmd:
+            return ShellResult(returncode=0, stdout="worktree /tmp/fake\n", stderr="")
+        if "ls-remote --heads" in cmd:
+            return ShellResult(returncode=0, stdout="abc refs/heads/main\n", stderr="")
+        if "git push" in cmd:
+            captured["push"].append(cmd)
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            captured["pr_create"].append(cmd)
+            return ShellResult(returncode=0, stdout="https://x/pr/new\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    return run, captured
+
+
+def test_finish_force_repushes_to_existing_pr(configured_git_app: Path):
+    """--force on an already-finished task with new commits: pushes, does NOT
+    create a new PR, updates finished_at, adds a re-finished journal entry."""
+    from mship.cli import container as cli_container
+
+    sm = _make_finished_task_with_existing_pr(configured_git_app, slug="rp", ahead_of_origin=2)
+    before = sm.load().tasks["rp"].finished_at
+
+    run, captured = _finish_force_shell_factory(ahead_count=2)
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = run
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    cli_container.shell.override(mock_shell)
+    try:
+        import time
+        time.sleep(0.01)  # ensure a new finished_at timestamp differs from `before`
+        result = runner.invoke(app, ["finish", "--force", "--task", "rp"])
+        assert result.exit_code == 0, result.output
+        assert len(captured["push"]) == 1, f"expected one push, got {captured['push']}"
+        assert captured["pr_create"] == [], "should NOT create a new PR under --force"
+
+        state = sm.load()
+        assert state.tasks["rp"].finished_at > before, "finished_at must be re-stamped"
+    finally:
+        cli_container.shell.reset_override()
+
+
+def test_finish_without_force_warns_about_unpushed_commits(configured_git_app: Path):
+    """Without --force on a finished task with local commits ahead of origin:
+    the user gets a warning pointing at --force, and no push happens."""
+    from mship.cli import container as cli_container
+
+    sm = _make_finished_task_with_existing_pr(configured_git_app, slug="warn")
+    run, captured = _finish_force_shell_factory(ahead_count=3)
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = run
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    cli_container.shell.override(mock_shell)
+    try:
+        result = runner.invoke(app, ["finish", "--task", "warn"])
+        assert result.exit_code == 0, result.output
+        assert "unpushed commits" in result.output
+        assert "--force" in result.output
+        assert "3 commits" in result.output
+        assert captured["push"] == [], "no push without --force"
+    finally:
+        cli_container.shell.reset_override()
+
+
+def test_finish_force_incompatible_with_body_file(configured_git_app: Path):
+    _make_finished_task_with_existing_pr(configured_git_app, slug="bf")
+    result = runner.invoke(
+        app, ["finish", "--force", "--task", "bf", "--body", "hi"]
+    )
+    assert result.exit_code != 0
+    assert "gh pr edit" in result.output
+
+
+def test_finish_force_incompatible_with_handoff(configured_git_app: Path):
+    _make_finished_task_with_existing_pr(configured_git_app, slug="ho")
+    result = runner.invoke(app, ["finish", "--force", "--task", "ho", "--handoff"])
+    assert result.exit_code != 0
+    assert "handoff" in result.output.lower()
 
 
 def test_spawn_skip_setup_flag(configured_git_app: Path):


### PR DESCRIPTION
## Summary

`mship finish` was idempotent: after a task's `finish` once, re-running on the same task silently did nothing, even when the worktree had new commits. Users (me, many times in a single day) routinely fell back to raw `git push` to attach follow-up commits to an open PR — which bypasses mship's state tracking, audit gate, and journal entirely.

This PR wires up `mship finish --force` per option **A** of issue #34.

**With `--force`:**
- Re-pushes `task.branch` to `origin` for every repo that already has a `pr_urls` entry. `git push -u origin <branch>` attaches new commits to the existing remote branch, and therefore to the existing PR.
- Does **not** call `gh pr create` (we'd get "already exists" and a noisy error).
- Does **not** rewrite PR bodies — specifically, the multi-repo coordination block is NOT re-appended, so manual PR-body edits survive the re-push.
- Stamps a fresh `finished_at` timestamp on the task.
- Appends a `re-finished` journal entry per re-pushed repo, so the task log shows the review-cycle iteration.

**Without `--force`:** finish now warns loudly when the worktree has commits past `origin/<branch>` on any repo with an existing PR, instead of the old silent no-op. The warning points at `--force`:

```
⚠ Task has unpushed commits since last finish:
    shared: 3 commits past origin/feat/my-task
Pass `--force` to push them to the existing PR(s).
```

The silent no-op was the actual bug. Without the warning, the user has no signal that their commits didn't go anywhere.

## Flag interactions

- `--force` + `--handoff` → rejected. Handoff generates a CI manifest, no PR work.
- `--force` + `--body` / `--body-file` → rejected with a message pointing at `gh pr edit <url> --body-file <path>`. Reasoning: re-push is mostly a commit-tracking operation; mixing a body rewrite in is ambiguous with the coordination-block skip above. Cleaner as a separate explicit step.
- `--force` + `--push-only` → compatible (both operate on the push side; neither hits gh).
- `--force` + `--bypass-reconcile` → compatible (reconcile gate still applies unless bypassed).

## Skill update

`skills/working-with-mothership/SKILL.md` gains a paragraph on `--force` under the `finish` section, mirroring the `--body-file` guidance from PR #44. Ensures the next agent touching a finished task knows what to do instead of reaching for `git push`.

## Why not a separate `mship update-pr` verb (option B from #34)

Semantic cleanliness argument for B: "finish is terminal; update-pr is mid-review iteration." Real argument against: two ways to do nearly the same thing. `--force` matches the existing `mship finish --force-audit` ergonomic, fits the shortest path for agents ("same command I already used, one more flag"), and the re-finished journal entry is enough state to distinguish the phases in the log. If the semantic pain becomes real we can always add the verb later; it's additive.

## Test plan

- [x] Four new tests in `tests/cli/test_worktree.py`:
  - `test_finish_force_repushes_to_existing_pr` — mock shell captures all `git push` / `gh pr create` calls. With `--force` and `ahead_count=2`: exactly one push is issued, `gh pr create` is NOT called, `finished_at` is re-stamped to a new timestamp.
  - `test_finish_without_force_warns_about_unpushed_commits` — same seed, no `--force`, `ahead_count=3`: exit 0, output contains `"unpushed commits"`, `"--force"`, and `"3 commits"`; no push issued.
  - `test_finish_force_incompatible_with_body_file` — combination rejected, output points at `gh pr edit`.
  - `test_finish_force_incompatible_with_handoff` — rejected with handoff name in output.
- [x] The shell mock carefully distinguishes between `origin/<X>..<X>` (unpushed-commits probe — returns `ahead_count`) and all other rev-list-count queries (returns 0), so the audit gate's `diverged`/`dirty_worktree` probes stay clean.
- [x] Existing 14 finish + close tests unchanged; all still pass.
- [x] Full suite: 726 passing (previously 722; +4 new tests).
- [x] Dogfooded — this PR was created by the spawn → commit → `mship finish --body-file` flow.

## Follow-ups (out of scope)

- If `--force-audit` → `--bypass-audit` rename happens per the Bypass-flag-naming memory, `finish --force` might deserve renaming too (e.g. `--bypass-finished` or `--repush`). Left alone for now because the issue explicitly specified `--force` and it matches the existing `close --force` ergonomic.
- Updating PR bodies under `--force` is rejected today; a future enhancement could allow it if we work out the coordination-block merge semantics.

Closes #34
