### PR TITLE
Add Tier-2 context fields: drift, main_checkout_clean, last_workspace_fetch_at (#50 follow-up)

### DIFF
--- a/src/mship/cli/context.py
+++ b/src/mship/cli/context.py
@@ -11,6 +11,7 @@ import typer
 
 from mship.cli.output import Output
 from mship.core.context import build_context
+from mship.core.reconcile.cache import ReconcileCache
 
 
 def register(app: typer.Typer, get_container):
@@ -18,10 +19,13 @@ def register(app: typer.Typer, get_container):
     def context():
         """Emit a JSON snapshot of workspace state for agent consumption."""
         container = get_container()
+        state_dir = container.state_dir()
         payload = build_context(
             state=container.state_manager().load(),
             config=container.config(),
             log_manager=container.log_manager(),
             cwd=Path.cwd(),
+            state_dir=state_dir,
+            cache=ReconcileCache(state_dir),
         )
         Output().json(payload)

--- a/src/mship/cli/sync.py
+++ b/src/mship/cli/sync.py
@@ -13,6 +13,7 @@ def register(app: typer.Typer, get_container):
         """Fast-forward repos that audit cleanly and are behind origin."""
         from mship.core.repo_state import audit_repos
         from mship.core.repo_sync import sync_repos
+        from mship.core.workspace_meta import write_last_sync_at
 
         container = get_container()
         output = Output()
@@ -36,6 +37,7 @@ def register(app: typer.Typer, get_container):
             raise typer.Exit(code=1)
 
         out = sync_repos(report, config, shell)
+        write_last_sync_at(container.state_dir())
         for r in out.results:
             if r.status == "up_to_date":
                 output.print(f"  {r.name}: up to date")

--- a/src/mship/core/context.py
+++ b/src/mship/core/context.py
@@ -4,26 +4,30 @@ A pure function `build_context()` aggregates state, log, and git probes into one
 JSON-shaped dict so an agent can recover its full top-of-turn picture in a
 single tool call. See GitHub issue #50.
 
-Tier-1 fields only (no network, no `gh` calls). Drift / main-checkout-clean /
-last-workspace-fetch are deferred to follow-ups.
+Drift is read from the existing reconcile cache only — `mship context` never
+fetches. Stale or absent → `"unknown"` for that task.
 """
 from __future__ import annotations
 
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Optional
 
 from mship.core.config import WorkspaceConfig
 from mship.core.log import LogManager
+from mship.core.reconcile.cache import ReconcileCache
 from mship.core.state import Task, WorkspaceState
+from mship.core.workspace_meta import read_last_sync_at
 
 
 SCHEMA_VERSION = "1"
 
 
 GitCounter = Callable[[Path, str], Optional[int]]
+DirtyCheck = Callable[[Path], Optional[bool]]
 
 
 def _git_count_default(wt_path: Path, ref_spec: str) -> Optional[int]:
@@ -44,6 +48,29 @@ def _git_count_default(wt_path: Path, ref_spec: str) -> Optional[int]:
         return int(r.stdout.strip())
     except ValueError:
         return None
+
+
+def _dirty_check_default(repo_path: Path) -> Optional[bool]:
+    """True if `git status --porcelain` shows any output, False if clean.
+
+    Returns None when the path isn't a git checkout or git errors out — keeps
+    the field informative without lying about state we couldn't observe.
+    """
+    if not repo_path.is_dir():
+        return None
+    try:
+        r = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=str(repo_path),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if r.returncode != 0:
+        return None
+    return bool(r.stdout.strip())
 
 
 def _last_test_summary(task: Task) -> tuple[Optional[str], int]:
@@ -110,10 +137,52 @@ def _binary_matches_editable_install() -> Optional[bool]:
         return False
 
 
+def _drift_for_task(slug: str, cache: Optional[ReconcileCache]) -> str:
+    if cache is None:
+        return "unknown"
+    payload = cache.read()
+    if payload is None:
+        return "unknown"
+    raw = payload.results.get(slug)
+    if not isinstance(raw, dict):
+        return "unknown"
+    state = raw.get("state")
+    return state if isinstance(state, str) else "unknown"
+
+
+def _last_drift_check_at(cache: Optional[ReconcileCache]) -> Optional[str]:
+    if cache is None:
+        return None
+    payload = cache.read()
+    if payload is None:
+        return None
+    return datetime.fromtimestamp(payload.fetched_at, tz=timezone.utc).isoformat()
+
+
+def _main_checkout_clean(
+    config: WorkspaceConfig,
+    dirty_check: DirtyCheck,
+) -> dict[str, Optional[bool]]:
+    """Per-repo cleanliness of the main checkout (the path declared in mothership.yaml).
+
+    Skips repos with `git_root` set — they share a checkout with their parent,
+    so checking the parent already covers them and a separate entry would
+    misleadingly report the parent's status under each child's key.
+    """
+    out: dict[str, Optional[bool]] = {}
+    for name, repo in config.repos.items():
+        if repo.git_root is not None:
+            continue
+        dirty = dirty_check(repo.path)
+        out[name] = (not dirty) if dirty is not None else None
+    return out
+
+
 def _task_payload(
     task: Task,
     log_manager: LogManager,
     git_count: GitCounter,
+    cache: Optional[ReconcileCache],
 ) -> dict[str, Any]:
     last_test_state, last_test_iteration = _last_test_summary(task)
 
@@ -141,6 +210,7 @@ def _task_payload(
         "last_test_state": last_test_state,
         "last_test_iteration": last_test_iteration,
         "last_log_entry_at": _last_log_at(log_manager, task.slug),
+        "drift": _drift_for_task(task.slug, cache),
     }
 
 
@@ -149,29 +219,36 @@ def build_context(
     config: WorkspaceConfig,
     log_manager: LogManager,
     cwd: Path,
+    state_dir: Path,
     *,
+    cache: Optional[ReconcileCache] = None,
     git_count: GitCounter = _git_count_default,
+    dirty_check: DirtyCheck = _dirty_check_default,
     binary_check: Callable[[], Optional[bool]] = _binary_matches_editable_install,
 ) -> dict[str, Any]:
     """Assemble the agent-readable workspace context payload.
 
-    `git_count` and `binary_check` are injection points for tests; production
-    callers leave them at the defaults.
+    `cache`, `git_count`, `dirty_check`, and `binary_check` are injection points
+    for tests; production callers leave them at the defaults (with the CLI
+    constructing a real `ReconcileCache(state_dir)`).
     """
-    del config  # reserved for Tier-2 fields (main_checkout_clean, etc.)
-
     active_tasks = [
-        _task_payload(task, log_manager, git_count)
+        _task_payload(task, log_manager, git_count, cache)
         for task in state.tasks.values()
         if task.finished_at is None
     ]
 
     cwd_task, cwd_repo = _cwd_match(state, cwd)
 
+    last_sync = read_last_sync_at(state_dir)
+
     return {
         "schema_version": SCHEMA_VERSION,
         "active_tasks": active_tasks,
         "cwd_matches_task": cwd_task,
         "cwd_matches_repo": cwd_repo,
+        "main_checkout_clean": _main_checkout_clean(config, dirty_check),
         "mship_binary_matches_editable_install": binary_check(),
+        "last_workspace_fetch_at": last_sync.isoformat() if last_sync else None,
+        "last_drift_check_at": _last_drift_check_at(cache),
     }

--- a/src/mship/core/workspace_meta.py
+++ b/src/mship/core/workspace_meta.py
@@ -1,0 +1,55 @@
+"""Tiny key/value store for workspace-level metadata that doesn't fit in state.yaml.
+
+Currently holds only `last_sync_at` (written by `mship sync`, read by
+`mship context`). Kept as a separate JSON file so a corrupt write here can
+never wedge `state.yaml`.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+META_FILENAME = "workspace_meta.json"
+
+
+def _path(state_dir: Path) -> Path:
+    return Path(state_dir) / META_FILENAME
+
+
+def _read_raw(state_dir: Path) -> dict:
+    p = _path(state_dir)
+    if not p.is_file():
+        return {}
+    try:
+        data = json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_raw(state_dir: Path, data: dict) -> None:
+    Path(state_dir).mkdir(parents=True, exist_ok=True)
+    p = _path(state_dir)
+    tmp = p.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True))
+    tmp.replace(p)
+
+
+def read_last_sync_at(state_dir: Path) -> Optional[datetime]:
+    raw = _read_raw(state_dir).get("last_sync_at")
+    if not isinstance(raw, str):
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def write_last_sync_at(state_dir: Path, when: Optional[datetime] = None) -> None:
+    when = when or datetime.now(timezone.utc)
+    data = _read_raw(state_dir)
+    data["last_sync_at"] = when.isoformat()
+    _write_raw(state_dir, data)

--- a/tests/cli/test_context.py
+++ b/tests/cli/test_context.py
@@ -60,6 +60,10 @@ def test_context_emits_valid_json(tmp_path: Path):
             assert task["base_branch"] == "main"
             assert task["phase"] == "dev"
             assert task["finished_at"] is None
+            assert task["drift"] == "unknown"  # no reconcile cache present
+        assert data["main_checkout_clean"] == {}  # config has no repos
+        assert data["last_workspace_fetch_at"] is None
+        assert data["last_drift_check_at"] is None
     finally:
         _reset_container()
 

--- a/tests/cli/test_sync.py
+++ b/tests/cli/test_sync.py
@@ -1,6 +1,7 @@
 from typer.testing import CliRunner
 
 from mship.cli import app, container
+from mship.core.workspace_meta import read_last_sync_at
 
 runner = CliRunner()
 
@@ -26,6 +27,21 @@ def test_sync_dirty_nonzero(audit_workspace):
         result = runner.invoke(app, ["sync"])
         assert result.exit_code == 1
         assert "dirty_worktree" in result.output
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+
+
+def test_sync_records_last_workspace_fetch_at(audit_workspace):
+    state_dir = audit_workspace / ".mothership"
+    container.config_path.override(audit_workspace / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    try:
+        assert read_last_sync_at(state_dir) is None
+        result = runner.invoke(app, ["sync"])
+        assert result.exit_code == 0, result.output
+        assert read_last_sync_at(state_dir) is not None
     finally:
         container.config_path.reset_override()
         container.state_dir.reset_override()

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1,6 +1,7 @@
 """Tests for the pure `build_context` builder (no CLI, no real git)."""
 from __future__ import annotations
 
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -10,7 +11,9 @@ import pytest
 from mship.core.config import WorkspaceConfig, RepoConfig
 from mship.core.context import SCHEMA_VERSION, build_context
 from mship.core.log import LogManager
+from mship.core.reconcile.cache import CachePayload, ReconcileCache
 from mship.core.state import Task, TestResult, WorkspaceState
+from mship.core.workspace_meta import write_last_sync_at
 
 
 def _config(tmp_path: Path) -> WorkspaceConfig:
@@ -50,10 +53,15 @@ def _no_binary_check() -> Optional[bool]:
     return None
 
 
-def _build(state, config, log_manager, cwd, **kw):
+def _build(state, config, log_manager, cwd, state_dir=None, **kw):
     kw.setdefault("git_count", lambda *_: None)
     kw.setdefault("binary_check", _no_binary_check)
-    return build_context(state, config, log_manager, cwd, **kw)
+    kw.setdefault("dirty_check", lambda _p: None)
+    return build_context(
+        state, config, log_manager, cwd,
+        state_dir=state_dir if state_dir is not None else cwd,
+        **kw,
+    )
 
 
 def test_empty_state_returns_no_active_tasks(tmp_path: Path):
@@ -191,3 +199,131 @@ def test_most_recent_test_result_wins(tmp_path: Path):
     )})
     out = _build(state, _config(tmp_path), log_mgr, tmp_path)
     assert out["active_tasks"][0]["last_test_state"] == "fail"
+
+
+# --- Tier 2: drift, main_checkout_clean, fetch/drift timestamps -----------
+
+
+def test_drift_unknown_when_no_cache(tmp_path: Path):
+    log_mgr = LogManager(tmp_path / "logs")
+    state = WorkspaceState(tasks={"u": _task("u")})
+    out = _build(state, _config(tmp_path), log_mgr, tmp_path)
+    assert out["active_tasks"][0]["drift"] == "unknown"
+    assert out["last_drift_check_at"] is None
+
+
+def test_drift_read_from_cache(tmp_path: Path):
+    log_mgr = LogManager(tmp_path / "logs")
+    state = WorkspaceState(tasks={"a": _task("a"), "b": _task("b")})
+
+    cache = ReconcileCache(tmp_path)
+    fetched = time.time()
+    cache.write(CachePayload(
+        fetched_at=fetched, ttl_seconds=300,
+        results={
+            "a": {"state": "merged", "pr_url": None, "pr_number": None,
+                  "base": None, "merge_commit": None, "updated_at": None},
+            # 'b' deliberately absent -> "unknown"
+        },
+        ignored=[],
+    ))
+
+    out = _build(state, _config(tmp_path), log_mgr, tmp_path,
+                 state_dir=tmp_path, cache=cache)
+    by_slug = {t["slug"]: t for t in out["active_tasks"]}
+    assert by_slug["a"]["drift"] == "merged"
+    assert by_slug["b"]["drift"] == "unknown"
+    assert out["last_drift_check_at"] is not None
+
+
+def test_drift_unknown_when_cache_entry_malformed(tmp_path: Path):
+    log_mgr = LogManager(tmp_path / "logs")
+    state = WorkspaceState(tasks={"x": _task("x")})
+
+    cache = ReconcileCache(tmp_path)
+    cache.write(CachePayload(
+        fetched_at=time.time(), ttl_seconds=300,
+        results={"x": {"not_a_state_field": "junk"}},
+        ignored=[],
+    ))
+
+    out = _build(state, _config(tmp_path), log_mgr, tmp_path,
+                 state_dir=tmp_path, cache=cache)
+    assert out["active_tasks"][0]["drift"] == "unknown"
+
+
+def test_main_checkout_clean_dispatches_per_repo(tmp_path: Path):
+    log_mgr = LogManager(tmp_path / "logs")
+    cfg = _config(tmp_path)
+    seen: list[Path] = []
+
+    def dirty(p: Path) -> Optional[bool]:
+        seen.append(p)
+        return False  # clean
+
+    out = _build(
+        WorkspaceState(), cfg, log_mgr, tmp_path,
+        dirty_check=dirty,
+    )
+    assert out["main_checkout_clean"] == {"repo": True}
+    assert seen == [cfg.repos["repo"].path]
+
+
+def test_main_checkout_clean_reports_dirty(tmp_path: Path):
+    log_mgr = LogManager(tmp_path / "logs")
+    out = _build(
+        WorkspaceState(), _config(tmp_path), log_mgr, tmp_path,
+        dirty_check=lambda _p: True,
+    )
+    assert out["main_checkout_clean"] == {"repo": False}
+
+
+def test_main_checkout_clean_unknown_on_error(tmp_path: Path):
+    log_mgr = LogManager(tmp_path / "logs")
+    out = _build(
+        WorkspaceState(), _config(tmp_path), log_mgr, tmp_path,
+        dirty_check=lambda _p: None,
+    )
+    assert out["main_checkout_clean"] == {"repo": None}
+
+
+def test_main_checkout_clean_skips_git_root_children(tmp_path: Path):
+    """Repos with `git_root` set share their parent's checkout — don't double-report."""
+    log_mgr = LogManager(tmp_path / "logs")
+
+    parent_dir = tmp_path / "mono"
+    parent_dir.mkdir()
+    (parent_dir / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    child_dir = parent_dir / "pkg"
+    child_dir.mkdir()
+    (child_dir / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+
+    cfg = WorkspaceConfig(
+        workspace="t",
+        repos={
+            "mono": RepoConfig(path=parent_dir, type="service"),
+            "pkg": RepoConfig(path=child_dir, type="library", git_root="mono"),
+        },
+    )
+
+    out = _build(
+        WorkspaceState(), cfg, log_mgr, tmp_path,
+        dirty_check=lambda _p: False,
+    )
+    assert out["main_checkout_clean"] == {"mono": True}
+    assert "pkg" not in out["main_checkout_clean"]
+
+
+def test_last_workspace_fetch_at_null_when_unset(tmp_path: Path):
+    log_mgr = LogManager(tmp_path / "logs")
+    out = _build(WorkspaceState(), _config(tmp_path), log_mgr, tmp_path)
+    assert out["last_workspace_fetch_at"] is None
+
+
+def test_last_workspace_fetch_at_round_trips(tmp_path: Path):
+    log_mgr = LogManager(tmp_path / "logs")
+    when = datetime(2026, 4, 17, 12, 0, tzinfo=timezone.utc)
+    write_last_sync_at(tmp_path, when)
+    out = _build(WorkspaceState(), _config(tmp_path), log_mgr, tmp_path,
+                 state_dir=tmp_path)
+    assert out["last_workspace_fetch_at"] == when.isoformat()


### PR DESCRIPTION
Add Tier-2 context fields: drift, main_checkout_clean, last_workspace_fetch_at (#50 follow-up)

Closes #50