### PR TITLE
Audit: split severity for dirty_worktree — untracked → warn, modified → error (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ audit:
 - `mship sync [--repos r1,r2]` — fast-forwards behind-only clean repos; skips the rest with a reason.
 - `mship spawn --force-audit` / `mship finish --force-audit` — bypass with a line logged to the task log.
 
-**Issue codes:** `path_missing`, `not_a_git_repo`, `fetch_failed`, `detached_head`, `unexpected_branch`, `dirty_worktree`, `no_upstream`, `behind_remote`, `diverged`, `extra_worktrees` (errors); `ahead_remote` (info-only).
+**Issue codes:** `path_missing`, `not_a_git_repo`, `fetch_failed`, `detached_head`, `unexpected_branch`, `dirty_worktree`, `no_upstream`, `behind_remote`, `diverged`, `extra_worktrees` (errors); `dirty_untracked` (warn — untracked files only, doesn't block); `ahead_remote` (info-only).
 
 ### Live views
 

--- a/docs/superpowers/plans/2026-04-17-audit-severity-split.md
+++ b/docs/superpowers/plans/2026-04-17-audit-severity-split.md
@@ -1,0 +1,397 @@
+# Audit Severity Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-audit-severity-split-design.md`
+
+**Goal:** Stop blocking spawn/finish on untracked-only dirt while keeping the gate's teeth for tracked-modified dirt.
+
+**Architecture:** Extend `Severity = Literal["error", "warn", "info"]`. Rewrite `_probe_dirty` in `src/mship/core/repo_state.py` to return `tuple[Issue, ...]`, classifying lines from `git status --porcelain` as `dirty_worktree` (error, tracked-modified) or `dirty_untracked` (warn, untracked-only). Add a yellow ⚠ display lane in `src/mship/cli/audit.py`. Existing `has_errors` gate logic stays unchanged — by construction, warn issues never trip it.
+
+**Tech Stack:** Python 3.14, pytest, dataclasses.
+
+---
+
+## File Structure
+
+| File | Responsibility | Status |
+|---|---|---|
+| `src/mship/core/repo_state.py` | Extend `Severity` literal; rewrite `_probe_dirty` to classify and return tuple; update caller `_audit_one` to splice tuple into issues | modify |
+| `src/mship/cli/audit.py` | Add `[yellow]⚠[/yellow]` display lane and `warn(s)` footer counter | modify |
+| `tests/core/test_repo_state.py` | New unit tests for classification (untracked-only, modified-only, mixed); migrate existing untracked-fixture tests | modify |
+| `tests/cli/test_audit.py` | Migrate existing untracked-fixture tests; add yellow-lane display test | modify |
+| `tests/cli/test_sync.py` | Migrate untracked-fixture test (`test_sync_dirty_nonzero`) | modify |
+| `tests/core/test_audit_gate.py` | Add gate-behavior test: warn-only audit doesn't block | modify |
+| `tests/test_integration.py`, `tests/test_finish_integration.py` | Migrate untracked-fixture assertions | modify |
+
+---
+
+## Task 1: Extend Severity literal and rewrite the dirty probe (TDD)
+
+**Files:**
+- Modify: `src/mship/core/repo_state.py`
+- Test: `tests/core/test_repo_state.py`
+
+- [ ] **Step 1.1: Write failing tests for the new probe behavior**
+
+Append to `tests/core/test_repo_state.py`:
+
+```python
+# --- _probe_dirty classification (issue #35) ---
+
+def test_probe_dirty_untracked_only_emits_warn(audit_workspace):
+    cfg, shell = _load(audit_workspace)
+    (audit_workspace / "cli" / "new.txt").write_text("hi\n")  # untracked
+    rep = audit_repos(cfg, shell, names=["cli"])
+    cli = next(r for r in rep.repos if r.name == "cli")
+    codes = {(i.code, i.severity) for i in cli.issues}
+    assert ("dirty_untracked", "warn") in codes
+    assert not any(c == "dirty_worktree" for c, _ in codes)
+    assert cli.has_errors is False
+
+
+def test_probe_dirty_modified_tracked_emits_error(audit_workspace):
+    cfg, shell = _load(audit_workspace)
+    # README.md is a tracked file in the audit_workspace fixture
+    (audit_workspace / "cli" / "README.md").write_text("modified content\n")
+    rep = audit_repos(cfg, shell, names=["cli"])
+    cli = next(r for r in rep.repos if r.name == "cli")
+    codes = {(i.code, i.severity) for i in cli.issues}
+    assert ("dirty_worktree", "error") in codes
+    assert cli.has_errors is True
+
+
+def test_probe_dirty_mixed_emits_both(audit_workspace):
+    cfg, shell = _load(audit_workspace)
+    (audit_workspace / "cli" / "README.md").write_text("modified\n")  # tracked-modified
+    (audit_workspace / "cli" / "new.txt").write_text("hi\n")          # untracked
+    rep = audit_repos(cfg, shell, names=["cli"])
+    cli = next(r for r in rep.repos if r.name == "cli")
+    codes = {(i.code, i.severity) for i in cli.issues}
+    assert ("dirty_worktree", "error") in codes
+    assert ("dirty_untracked", "warn") in codes
+    assert cli.has_errors is True
+```
+
+Run: `uv run pytest tests/core/test_repo_state.py -k probe_dirty -v`
+Expected: 3 FAIL — `dirty_untracked` doesn't exist yet; everything currently fires as `dirty_worktree` error.
+
+- [ ] **Step 1.2: Extend the Severity literal and rewrite `_probe_dirty`**
+
+In `src/mship/core/repo_state.py`, change line 9:
+
+```python
+Severity = Literal["error", "warn", "info"]
+```
+
+Replace the `_probe_dirty` function (currently at lines 241-261) with:
+
+```python
+def _probe_dirty(
+    shell,
+    root_path: Path,
+    subdir: Path | None,
+    allow_dirty: bool,
+) -> tuple[Issue, ...]:
+    if allow_dirty:
+        return ()
+    cmd = "git status --porcelain"
+    if subdir is not None:
+        cmd += f" -- {shlex.quote(str(subdir))}"
+    rc, out, _ = _sh_out(shell, cmd, root_path)
+    if rc != 0:
+        return ()
+    untracked = 0
+    modified = 0
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        # Porcelain v1: first 2 chars are the status code. "??" is untracked;
+        # anything else (M, A, D, R, C, U, plus staged/unstaged combos) is
+        # tracked-modified content.
+        if line.startswith("??"):
+            untracked += 1
+        else:
+            modified += 1
+    issues: list[Issue] = []
+    if modified:
+        issues.append(Issue(
+            "dirty_worktree", "error",
+            f"{modified} modified tracked file" + ("s" if modified != 1 else ""),
+        ))
+    if untracked:
+        issues.append(Issue(
+            "dirty_untracked", "warn",
+            f"{untracked} untracked file" + ("s" if untracked != 1 else ""),
+        ))
+    return tuple(issues)
+```
+
+- [ ] **Step 1.3: Update `_audit_one` (the only caller) to splice the tuple**
+
+Find the call site:
+
+```bash
+grep -n "_probe_dirty" src/mship/core/repo_state.py
+```
+
+Replace the conditional-append (`if dirty_issue: issues.append(dirty_issue)`) with `issues.extend(...)`:
+
+```python
+issues.extend(_probe_dirty(shell, root_path, subdir, allow_dirty))
+```
+
+- [ ] **Step 1.4: Run the new probe tests**
+
+Run: `uv run pytest tests/core/test_repo_state.py -k probe_dirty -v`
+Expected: 3 PASS
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/mship/core/repo_state.py tests/core/test_repo_state.py
+git commit -m "feat(audit): split dirty_worktree into modified (error) + untracked (warn)"
+```
+
+---
+
+## Task 2: Add yellow ⚠ display lane to `mship audit`
+
+**Files:**
+- Modify: `src/mship/cli/audit.py`
+- Test: `tests/cli/test_audit.py`
+
+- [ ] **Step 2.1: Write failing test for the warn display**
+
+Append to `tests/cli/test_audit.py`:
+
+```python
+def test_audit_warn_displays_yellow_lane(audit_workspace):
+    _override(audit_workspace)
+    try:
+        (audit_workspace / "cli" / "new.txt").write_text("hi\n")  # untracked → warn
+        result = runner.invoke(app, ["audit"])
+        assert result.exit_code == 0, result.output  # warn does NOT block
+        assert "dirty_untracked" in result.output
+        assert "warn(s)" in result.output  # footer counter includes warn
+    finally:
+        _reset()
+```
+
+Run: `uv run pytest tests/cli/test_audit.py::test_audit_warn_displays_yellow_lane -v`
+Expected: FAIL — the CLI doesn't render a warn lane yet, and exit code will be 1 (current behavior treats untracked as error).
+
+- [ ] **Step 2.2: Add the warn lane in `src/mship/cli/audit.py`**
+
+Replace the existing for-loop body (currently lines 53-59) with:
+
+```python
+                for i in r.issues:
+                    if i.severity == "error":
+                        err_count += 1
+                        output.print(f"  [red]✗[/red] {i.code}: {i.message}")
+                    elif i.severity == "warn":
+                        warn_count += 1
+                        output.print(f"  [yellow]⚠[/yellow] {i.code}: {i.message}")
+                    else:
+                        info_count += 1
+                        output.print(f"  [blue]ⓘ[/blue] {i.code}: {i.message}")
+```
+
+Initialize `warn_count = 0` near the existing `err_count = 0` and `info_count = 0` (currently lines 45-46). Update the footer (currently line 61):
+
+```python
+        output.print(f"{err_count} error(s), {warn_count} warn(s), {info_count} info across {len(report.repos)} repos")
+```
+
+- [ ] **Step 2.3: Run the new display test**
+
+Run: `uv run pytest tests/cli/test_audit.py::test_audit_warn_displays_yellow_lane -v`
+Expected: PASS
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add src/mship/cli/audit.py tests/cli/test_audit.py
+git commit -m "feat(audit): yellow warn display lane for dirty_untracked"
+```
+
+---
+
+## Task 3: Migrate existing tests that asserted untracked-as-error
+
+**Files:**
+- Modify: `tests/core/test_repo_state.py`, `tests/cli/test_audit.py`, `tests/cli/test_sync.py`, `tests/test_integration.py`, `tests/test_finish_integration.py`
+
+These tests pre-date the split and use a fixture that creates `new.txt` (untracked). Under the new semantics, untracked → warn, not error. Each one needs either (a) test setup updated to modify a tracked file (when the intent is "dirty blocks"), or (b) assertions updated to expect warn-not-error semantics (when the intent is "dirty surfaces").
+
+- [ ] **Step 3.1: Migrate `tests/core/test_repo_state.py::test_audit_dirty_worktree`**
+
+This test creates an untracked file and asserts `dirty_worktree`. Intent: verify the probe surfaces dirt. Best migration: switch the setup to modify a tracked file so the assertion (and the test name) stay valid:
+
+Replace lines 169-173 with:
+
+```python
+def test_audit_dirty_worktree(audit_workspace):
+    cfg, shell = _load(audit_workspace)
+    (audit_workspace / "cli" / "README.md").write_text("modified\n")  # tracked-modified
+    rep = audit_repos(cfg, shell, names=["cli"])
+    assert "dirty_worktree" in _issue_codes(rep, "cli")
+```
+
+- [ ] **Step 3.2: Migrate `tests/core/test_repo_state.py::test_audit_allow_dirty_suppresses`**
+
+Replace the setup line (currently line 182):
+
+```python
+    (audit_workspace / "cli" / "README.md").write_text("modified\n")
+```
+
+- [ ] **Step 3.3: Migrate `tests/core/test_repo_state.py` lines 444 and 519-520**
+
+Inspect those tests with:
+
+```bash
+sed -n '430,450p;510,525p' tests/core/test_repo_state.py
+```
+
+For each test that creates an untracked file (`.write_text(...)` of a *new* path) and asserts `"dirty_worktree" in codes`, replace the setup to modify a tracked file (e.g., the existing `README.md` in each repo) so the existing assertion holds. If a test's intent is "untracked-only behavior" rather than "tracked-dirty surfaces," update the assertion to `dirty_untracked` instead.
+
+- [ ] **Step 3.4: Migrate `tests/cli/test_audit.py::test_audit_dirty_exits_one`**
+
+Replace lines 31-39 with:
+
+```python
+def test_audit_modified_tracked_exits_one(audit_workspace):
+    _override(audit_workspace)
+    try:
+        (audit_workspace / "cli" / "README.md").write_text("modified\n")  # tracked-modified
+        result = runner.invoke(app, ["audit"])
+        assert result.exit_code == 1
+        assert "dirty_worktree" in result.output
+    finally:
+        _reset()
+```
+
+- [ ] **Step 3.5: Migrate `tests/cli/test_audit.py::test_audit_json_shape`**
+
+Replace the setup line (currently line 45):
+
+```python
+        (audit_workspace / "cli" / "README.md").write_text("modified\n")
+```
+
+- [ ] **Step 3.6: Migrate `tests/cli/test_sync.py::test_sync_dirty_nonzero`**
+
+Currently (lines 21-32) creates untracked file and expects exit 1. Replace setup line (currently line 25):
+
+```python
+        (audit_workspace / "cli" / "README.md").write_text("modified\n")
+```
+
+- [ ] **Step 3.7: Migrate `tests/test_integration.py:121` and `tests/test_finish_integration.py:309, 551`**
+
+For each, find the `.write_text(...)` setup line that creates the dirty condition. If it creates a new path (untracked), change the path to an existing tracked file (`README.md` or similar). Confirm with:
+
+```bash
+grep -n "write_text" tests/test_integration.py | head
+grep -n "write_text" tests/test_finish_integration.py | head
+```
+
+The fix per occurrence: switch the path to an existing tracked file in the same repo.
+
+- [ ] **Step 3.8: Run all migrated test files**
+
+```bash
+uv run pytest tests/core/test_repo_state.py tests/cli/test_audit.py tests/cli/test_sync.py tests/test_integration.py tests/test_finish_integration.py -v
+```
+
+Expected: all PASS. If any fail, the migration in that test missed a setup detail — re-read it and fix.
+
+- [ ] **Step 3.9: Commit**
+
+```bash
+git add tests/
+git commit -m "test(audit): migrate untracked-fixture tests to use tracked-modified setup"
+```
+
+---
+
+## Task 4: Gate-behavior regression test
+
+**Files:**
+- Modify: `tests/core/test_audit_gate.py`
+
+- [ ] **Step 4.1: Write a test confirming warn-only audit doesn't block**
+
+Append to `tests/core/test_audit_gate.py`:
+
+```python
+def test_gate_does_not_block_when_only_warn_issues():
+    """A repo audit with only `dirty_untracked` (warn) must not trip the gate."""
+    from mship.core.repo_state import RepoAudit, AuditReport, Issue
+    from pathlib import Path
+
+    audit = RepoAudit(
+        name="cli", path=Path("/abs"), current_branch="main",
+        issues=(Issue("dirty_untracked", "warn", "1 untracked file"),),
+    )
+    report = AuditReport(repos=(audit,))
+    assert report.has_errors is False
+```
+
+Run: `uv run pytest tests/core/test_audit_gate.py::test_gate_does_not_block_when_only_warn_issues -v`
+Expected: PASS (no implementation change — this is a regression guard)
+
+- [ ] **Step 4.2: Commit**
+
+```bash
+git add tests/core/test_audit_gate.py
+git commit -m "test(audit_gate): regression — warn-only audit doesn't block"
+```
+
+---
+
+## Task 5: Full verification + PR
+
+- [ ] **Step 5.1: Full test suite**
+
+```bash
+uv run pytest -x -q
+```
+
+Expected: all pass. If any test outside the migrated set fails, it's likely also using the untracked-fixture pattern — search and migrate per Task 3.
+
+- [ ] **Step 5.2: Spec coverage check**
+
+Each spec section ↔ task:
+- ✅ Type extension (`Severity` literal) — Task 1.2
+- ✅ Probe split returning tuple — Task 1.2
+- ✅ Two-issue emission for mixed dirt — Task 1.1 / 1.2
+- ✅ CLI yellow ⚠ lane + footer counter — Task 2
+- ✅ Gate behavior unchanged (`has_errors` not tripped by warn) — Tasks 1.1, 4.1
+- ✅ Test surface migration — Task 3
+- ✅ JSON schema absorbs `"warn"` without version bump — Task 1.2 (no schema change needed; Task 3.5 verifies via `test_audit_json_shape` migration)
+
+- [ ] **Step 5.3: Open the PR via `mship finish` with a real body**
+
+```bash
+mship finish --body-file - <<'EOF'
+## Summary
+
+- Split `dirty_worktree` into `dirty_worktree` (error, modified-tracked) + `dirty_untracked` (warn, untracked).
+- Added `"warn"` to the `Severity` literal (matches `CheckResult.status` convention).
+- `mship audit` gains a yellow ⚠ display lane.
+- Spawn/finish gate (`has_errors`) unchanged — warn issues don't block.
+
+Closes #35.
+
+## Test plan
+
+- [x] New unit tests: untracked-only → warn, modified-only → error, mixed → both.
+- [x] CLI display: warn lane prints yellow ⚠ and the footer counter shows `warn(s)`.
+- [x] Gate regression: warn-only audit does NOT trip `has_errors`.
+- [x] Migrated all pre-existing tests that used the untracked-fixture pattern.
+- [x] Full pytest green.
+EOF
+```

--- a/docs/superpowers/specs/2026-04-17-audit-severity-split-design.md
+++ b/docs/superpowers/specs/2026-04-17-audit-severity-split-design.md
@@ -1,0 +1,98 @@
+# Audit severity split — Design
+
+## Context
+
+`mship audit` today emits a single `dirty_worktree` issue at severity `error` whenever `git status --porcelain` produces any output. Untracked files (e.g. `.claude/`, `.codex/`, editor swaps) trip this gate just as readily as modified tracked files, even though the two have very different consequences:
+
+- **Untracked new files** (`??` in porcelain): typically tool/IDE state. Don't affect what's on the branch; don't block any subsequent operation.
+- **Modified tracked files**: real uncommitted work that could be lost if the user later resets, switches branches, or runs an `--abandon`.
+
+Because `mship spawn` / `finish` block on any audit error, users hit `--force-audit` reflexively for the untracked case, training them to ignore the gate altogether. That defeats the gate for the case it actually exists to protect.
+
+This is GitHub issue #35.
+
+## Goal
+
+Stop blocking spawn/finish on untracked-only dirt. Keep the gate's teeth for tracked-modified dirt.
+
+## Non-goals
+
+- Workspace-config `audit.ignore_paths` list (issue #35 Option B). Composes cleanly with this fix later but adds config surface that's not needed to address the reported pain.
+- Restructuring the audit issue taxonomy beyond adding one new code.
+
+## Architecture
+
+### Type extension
+
+```python
+# src/mship/core/repo_state.py
+Severity = Literal["error", "warn", "info"]   # was: ["error", "info"]
+```
+
+`"warn"` is already the canonical third-tier name in this codebase — `CheckResult.status` in `core/doctor.py` uses `"pass" | "warn" | "fail"`. No new vocabulary.
+
+### Probe split
+
+`_probe_dirty()` returns `tuple[Issue, ...]` instead of `Issue | None`. Walks each line of `git status --porcelain`, classifies by the leading two-character status, and emits up to two issues:
+
+| Porcelain prefix | Class | Issue |
+|---|---|---|
+| `??` | untracked | `Issue("dirty_untracked", "warn", "<n> untracked file(s)")` |
+| anything else (`M `, ` M`, `A `, `MM`, `D `, `R `, `C `, `U `, ...) | modified-tracked | `Issue("dirty_worktree", "error", "<n> modified tracked file(s)")` |
+
+When both classes of dirt exist, both issues fire. `Issue` ordering: error first, then warn (purely cosmetic for human display; JSON consumers shouldn't depend on order).
+
+### Gate behavior — unchanged by design
+
+- `RepoAudit.has_errors` keeps its `severity == "error"` check (already correct: warn issues don't trip it).
+- `AuditReport.has_errors` aggregates across repos via `has_errors` — same.
+- `audit_gate.py` blocks spawn/finish on `has_errors`. Warn flows through to user output but doesn't block.
+- `--bypass-audit` (and the existing `--force-audit` alias) still work for the rare case where modified-tracked content legitimately needs an override.
+
+### CLI display
+
+`src/mship/cli/audit.py` adds a yellow ⚠ lane between the existing red ✗ (error) and blue ⓘ (info):
+
+```
+  [yellow]⚠[/yellow] {code}: {message}
+```
+
+Footer counter becomes `"{err} error(s), {warn} warn(s), {info} info across N repos"`.
+
+### Output schemas
+
+JSON output (`mship audit --json`) carries the `severity` field per issue, so the existing schema accommodates `"warn"` without a version bump. Consumers that filtered on `severity == "error"` keep their current semantics.
+
+## Testing
+
+In `tests/core/test_repo_state.py` (new cases):
+
+- **Untracked-only dirt** → `_probe_dirty` returns one `Issue("dirty_untracked", "warn", ...)`; `has_errors == False`.
+- **Modified-only dirt** → returns one `Issue("dirty_worktree", "error", ...)`; `has_errors == True`.
+- **Mixed dirt** (one modified, one untracked) → returns both issues; `has_errors == True`.
+- **Clean** → returns empty tuple.
+
+In `tests/cli/test_audit.py` (revisions):
+
+- Any existing test that asserted "untracked file produces a `dirty_worktree` error" gets re-targeted to assert `dirty_untracked` warn.
+- Add a test confirming the yellow ⚠ display lane fires for warn issues.
+
+In `tests/core/test_audit_gate.py`:
+
+- Confirm a repo audit with only `dirty_untracked` does NOT block spawn/finish (gate sees `has_errors == False`).
+- Confirm a repo audit with `dirty_worktree` DOES block (regression guard on the unchanged gate behavior).
+
+## Migration / compatibility
+
+- **No state migration.** No on-disk format changes.
+- **JSON consumers** that switch on `code == "dirty_worktree"` keep working — that code still exists for the modified case. Consumers gain an additional `code == "dirty_untracked"` warn-tier signal.
+- **Workflow muscle memory:** users who reach for `--force-audit` to clear untracked-only dirt will find they no longer need it. The flag itself is unchanged.
+
+## Decisions log
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Two distinct issue codes (`dirty_worktree` error + `dirty_untracked` warn) instead of one code with conditional severity | Agents reading audit JSON can distinguish without parsing the `message` string; mirrors how `audit` already separates `behind_remote`, `diverged`, etc. into distinct codes. |
+| 2 | `"warn"` (not `"warning"`) for the new severity | Matches the existing `CheckResult.status` convention in `core/doctor.py`. |
+| 3 | `_probe_dirty` returns a tuple, not a list of one optional issue | Lets the mixed-dirt case emit both issues atomically without caller-side stitching. |
+| 4 | Defer Option B (config-level `audit.ignore_paths`) | Severity split alone resolves the reported pain (untracked-only no longer blocks). The config approach is additive and worth its own design decision. |

--- a/src/mship/cli/audit.py
+++ b/src/mship/cli/audit.py
@@ -43,6 +43,7 @@ def register(app: typer.Typer, get_container):
         output.print(f"[bold]workspace:[/bold] {config.workspace}")
         output.print("")
         err_count = 0
+        warn_count = 0
         info_count = 0
         for r in report.repos:
             branch_suffix = f" ({r.current_branch})" if r.current_branch else ""
@@ -54,9 +55,12 @@ def register(app: typer.Typer, get_container):
                     if i.severity == "error":
                         err_count += 1
                         output.print(f"  [red]✗[/red] {i.code}: {i.message}")
+                    elif i.severity == "warn":
+                        warn_count += 1
+                        output.print(f"  [yellow]⚠[/yellow] {i.code}: {i.message}")
                     else:
                         info_count += 1
                         output.print(f"  [blue]ⓘ[/blue] {i.code}: {i.message}")
             output.print("")
-        output.print(f"{err_count} error(s), {info_count} info across {len(report.repos)} repos")
+        output.print(f"{err_count} error(s), {warn_count} warn(s), {info_count} info across {len(report.repos)} repos")
         raise typer.Exit(code=1 if report.has_errors else 0)

--- a/src/mship/core/repo_state.py
+++ b/src/mship/core/repo_state.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Literal
 
-Severity = Literal["error", "info"]
+Severity = Literal["error", "warn", "info"]
 
 
 @dataclass(frozen=True)
@@ -243,22 +243,39 @@ def _probe_dirty(
     root_path: Path,
     subdir: Path | None,
     allow_dirty: bool,
-) -> Issue | None:
+) -> tuple[Issue, ...]:
     if allow_dirty:
-        return None
+        return ()
     cmd = "git status --porcelain"
     if subdir is not None:
         cmd += f" -- {shlex.quote(str(subdir))}"
     rc, out, _ = _sh_out(shell, cmd, root_path)
     if rc != 0:
-        return None
-    lines = [ln for ln in out.splitlines() if ln.strip()]
-    if lines:
-        return Issue(
+        return ()
+    untracked = 0
+    modified = 0
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        # Porcelain v1: first 2 chars are the status code. "??" is untracked;
+        # anything else (M, A, D, R, C, U, plus staged/unstaged combos) is
+        # tracked-modified content.
+        if line.startswith("??"):
+            untracked += 1
+        else:
+            modified += 1
+    issues: list[Issue] = []
+    if modified:
+        issues.append(Issue(
             "dirty_worktree", "error",
-            f"{len(lines)} uncommitted change" + ("s" if len(lines) != 1 else ""),
-        )
-    return None
+            f"{modified} modified tracked file" + ("s" if modified != 1 else ""),
+        ))
+    if untracked:
+        issues.append(Issue(
+            "dirty_untracked", "warn",
+            f"{untracked} untracked file" + ("s" if untracked != 1 else ""),
+        ))
+    return tuple(issues)
 
 
 # ---------------------------------------------------------------------------
@@ -328,9 +345,7 @@ def audit_repos(
             subdir: Path | None = None
             if m_cfg.git_root is not None:
                 subdir = m_cfg.path  # relative path within the parent
-            di = _probe_dirty(shell, root_path, subdir, m_cfg.allow_dirty)
-            if di is not None:
-                per_repo_issues[m].append(di)
+            per_repo_issues[m].extend(_probe_dirty(shell, root_path, subdir, m_cfg.allow_dirty))
 
     repos = tuple(
         RepoAudit(

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -128,7 +128,7 @@ mship graph
 mship worktrees
 ```
 
-**`audit` issue codes** (errors unless noted): `path_missing`, `not_a_git_repo`, `fetch_failed`, `detached_head`, `unexpected_branch`, `dirty_worktree`, `no_upstream`, `behind_remote`, `diverged`, `extra_worktrees`; `ahead_remote` (info-only).
+**`audit` issue codes** (errors unless noted): `path_missing`, `not_a_git_repo`, `fetch_failed`, `detached_head`, `unexpected_branch`, `dirty_worktree`, `no_upstream`, `behind_remote`, `diverged`, `extra_worktrees`; `dirty_untracked` (warn — untracked files only, doesn't block); `ahead_remote` (info-only).
 
 **`audit` is automatically gated on `spawn` and `finish`** — any error blocks unless `--force-audit` (which writes a `BYPASSED AUDIT` entry to the task log). Opt out at the workspace level via `audit: {block_spawn: false, block_finish: false}` in `mothership.yaml`.
 

--- a/tests/cli/test_audit.py
+++ b/tests/cli/test_audit.py
@@ -28,10 +28,10 @@ def test_audit_clean_exits_zero(audit_workspace):
         _reset()
 
 
-def test_audit_dirty_exits_one(audit_workspace):
+def test_audit_modified_tracked_exits_one(audit_workspace):
     _override(audit_workspace)
     try:
-        (audit_workspace / "cli" / "x.txt").write_text("x")
+        (audit_workspace / "cli" / "README.md").write_text("modified\n")
         result = runner.invoke(app, ["audit"])
         assert result.exit_code == 1
         assert "dirty_worktree" in result.output
@@ -42,7 +42,7 @@ def test_audit_dirty_exits_one(audit_workspace):
 def test_audit_json_shape(audit_workspace):
     _override(audit_workspace)
     try:
-        (audit_workspace / "cli" / "x.txt").write_text("x")
+        (audit_workspace / "cli" / "README.md").write_text("modified\n")
         result = runner.invoke(app, ["audit", "--json"])
         assert result.exit_code == 1
         payload = json.loads(result.output)

--- a/tests/cli/test_audit.py
+++ b/tests/cli/test_audit.py
@@ -137,3 +137,15 @@ def test_audit_still_flags_foreign_worktree(audit_workspace):
         assert "mship prune" in result.output
     finally:
         _reset()
+
+
+def test_audit_warn_displays_yellow_lane(audit_workspace):
+    _override(audit_workspace)
+    try:
+        (audit_workspace / "cli" / "new.txt").write_text("hi\n")  # untracked → warn
+        result = runner.invoke(app, ["audit"])
+        assert result.exit_code == 0, result.output  # warn does NOT block
+        assert "dirty_untracked" in result.output
+        assert "warn(s)" in result.output  # footer counter includes warn
+    finally:
+        _reset()

--- a/tests/cli/test_sync.py
+++ b/tests/cli/test_sync.py
@@ -23,7 +23,7 @@ def test_sync_dirty_nonzero(audit_workspace):
     container.config_path.override(audit_workspace / "mothership.yaml")
     container.state_dir.override(audit_workspace / ".mothership")
     try:
-        (audit_workspace / "cli" / "x.txt").write_text("x")
+        (audit_workspace / "cli" / "README.md").write_text("modified\n")
         result = runner.invoke(app, ["sync"])
         assert result.exit_code == 1
         assert "dirty_worktree" in result.output

--- a/tests/core/test_audit_gate.py
+++ b/tests/core/test_audit_gate.py
@@ -85,3 +85,16 @@ def test_collect_known_worktree_paths_no_tasks():
     state = _FakeState({})
     result = collect_known_worktree_paths(_FakeStateMgr(state))
     assert result == frozenset()
+
+
+def test_gate_does_not_block_when_only_warn_issues():
+    """A repo audit with only `dirty_untracked` (warn) must not trip the gate."""
+    from mship.core.repo_state import RepoAudit, AuditReport, Issue
+    from pathlib import Path
+
+    audit = RepoAudit(
+        name="cli", path=Path("/abs"), current_branch="main",
+        issues=(Issue("dirty_untracked", "warn", "1 untracked file"),),
+    )
+    report = AuditReport(repos=(audit,))
+    assert report.has_errors is False

--- a/tests/core/test_audit_gate.py
+++ b/tests/core/test_audit_gate.py
@@ -89,9 +89,6 @@ def test_collect_known_worktree_paths_no_tasks():
 
 def test_gate_does_not_block_when_only_warn_issues():
     """A repo audit with only `dirty_untracked` (warn) must not trip the gate."""
-    from mship.core.repo_state import RepoAudit, AuditReport, Issue
-    from pathlib import Path
-
     audit = RepoAudit(
         name="cli", path=Path("/abs"), current_branch="main",
         issues=(Issue("dirty_untracked", "warn", "1 untracked file"),),

--- a/tests/core/test_repo_state.py
+++ b/tests/core/test_repo_state.py
@@ -168,7 +168,7 @@ def test_audit_expected_branch_passes_when_root_path_is_a_worktree(audit_workspa
 
 def test_audit_dirty_worktree(audit_workspace):
     cfg, shell = _load(audit_workspace)
-    (audit_workspace / "cli" / "new.txt").write_text("hi\n")
+    (audit_workspace / "cli" / "README.md").write_text("modified\n")
     rep = audit_repos(cfg, shell, names=["cli"])
     assert "dirty_worktree" in _issue_codes(rep, "cli")
 
@@ -179,7 +179,7 @@ def test_audit_allow_dirty_suppresses(audit_workspace):
     data["repos"]["cli"]["allow_dirty"] = True
     cfg_path.write_text(yaml.safe_dump(data))
     cfg, shell = _load(audit_workspace)
-    (audit_workspace / "cli" / "new.txt").write_text("hi\n")
+    (audit_workspace / "cli" / "README.md").write_text("modified\n")
     rep = audit_repos(cfg, shell, names=["cli"])
     assert "dirty_worktree" not in _issue_codes(rep, "cli")
 
@@ -435,7 +435,7 @@ def test_audit_local_only_still_detects_dirty(audit_workspace):
     from mship.core.repo_state import audit_repos
     from mship.util.shell import ShellRunner
 
-    (audit_workspace / "cli" / "new.txt").write_text("x\n")
+    (audit_workspace / "cli" / "README.md").write_text("modified\n")
 
     cfg = ConfigLoader.load(audit_workspace / "mothership.yaml")
     shell = ShellRunner()
@@ -499,7 +499,7 @@ def test_audit_monorepo_one_fetch_per_root(tmp_path):
     }))
 
     # Dirty pkg-a only — branch/fetch state is clean
-    (mono / "pkg-a" / "dirty.txt").write_text("x")
+    (mono / "pkg-a" / "Taskfile.yml").write_text("version: '3'\ntasks: {modified: true}\n")
 
     cfg, shell = _load(tmp_path)
     # Wrap shell to count fetch calls

--- a/tests/core/test_repo_state.py
+++ b/tests/core/test_repo_state.py
@@ -179,9 +179,12 @@ def test_audit_allow_dirty_suppresses(audit_workspace):
     data["repos"]["cli"]["allow_dirty"] = True
     cfg_path.write_text(yaml.safe_dump(data))
     cfg, shell = _load(audit_workspace)
-    (audit_workspace / "cli" / "README.md").write_text("modified\n")
+    (audit_workspace / "cli" / "README.md").write_text("modified\n")  # tracked-modified
+    (audit_workspace / "cli" / "new.txt").write_text("hi\n")          # untracked
     rep = audit_repos(cfg, shell, names=["cli"])
-    assert "dirty_worktree" not in _issue_codes(rep, "cli")
+    codes = _issue_codes(rep, "cli")
+    assert "dirty_worktree" not in codes
+    assert "dirty_untracked" not in codes  # allow_dirty suppresses both tiers
 
 
 def test_audit_ahead_remote_is_info(audit_workspace):

--- a/tests/core/test_repo_state.py
+++ b/tests/core/test_repo_state.py
@@ -518,3 +518,39 @@ def test_audit_monorepo_one_fetch_per_root(tmp_path):
     pkg_b_codes = _issue_codes(rep, "pkg_b")
     assert "dirty_worktree" in pkg_a_codes
     assert "dirty_worktree" not in pkg_b_codes
+
+
+# --- _probe_dirty classification (issue #35) ---
+
+def test_probe_dirty_untracked_only_emits_warn(audit_workspace):
+    cfg, shell = _load(audit_workspace)
+    (audit_workspace / "cli" / "new.txt").write_text("hi\n")  # untracked
+    rep = audit_repos(cfg, shell, names=["cli"])
+    cli = next(r for r in rep.repos if r.name == "cli")
+    codes = {(i.code, i.severity) for i in cli.issues}
+    assert ("dirty_untracked", "warn") in codes
+    assert not any(c == "dirty_worktree" for c, _ in codes)
+    assert cli.has_errors is False
+
+
+def test_probe_dirty_modified_tracked_emits_error(audit_workspace):
+    cfg, shell = _load(audit_workspace)
+    # README.md is a tracked file in the audit_workspace fixture
+    (audit_workspace / "cli" / "README.md").write_text("modified content\n")
+    rep = audit_repos(cfg, shell, names=["cli"])
+    cli = next(r for r in rep.repos if r.name == "cli")
+    codes = {(i.code, i.severity) for i in cli.issues}
+    assert ("dirty_worktree", "error") in codes
+    assert cli.has_errors is True
+
+
+def test_probe_dirty_mixed_emits_both(audit_workspace):
+    cfg, shell = _load(audit_workspace)
+    (audit_workspace / "cli" / "README.md").write_text("modified\n")  # tracked-modified
+    (audit_workspace / "cli" / "new.txt").write_text("hi\n")          # untracked
+    rep = audit_repos(cfg, shell, names=["cli"])
+    cli = next(r for r in rep.repos if r.name == "cli")
+    codes = {(i.code, i.severity) for i in cli.issues}
+    assert ("dirty_worktree", "error") in codes
+    assert ("dirty_untracked", "warn") in codes
+    assert cli.has_errors is True

--- a/tests/core/test_repo_sync.py
+++ b/tests/core/test_repo_sync.py
@@ -49,7 +49,7 @@ def test_sync_behind_repo_fast_forwards(audit_workspace):
 
 def test_sync_dirty_skipped(audit_workspace):
     cfg, shell = _load(audit_workspace)
-    (audit_workspace / "cli" / "x.txt").write_text("x")
+    (audit_workspace / "cli" / "README.md").write_text("modified\n")  # tracked-modified
     report = audit_repos(cfg, shell)
     out = sync_repos(report, cfg, shell)
     r = _result_for(out, "cli")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -115,7 +115,7 @@ def test_spawn_blocks_when_affected_repo_is_dirty(audit_workspace):
     container.state_dir.override(state_dir)
     container.log_manager.reset()
     try:
-        (audit_workspace / "cli" / "x.txt").write_text("x")
+        (audit_workspace / "cli" / "README.md").write_text("modified\n")
         result = runner.invoke(app, ["spawn", "dirty test", "--repos", "cli"])
         assert result.exit_code == 1
         assert "dirty_worktree" in result.output
@@ -132,7 +132,7 @@ def test_spawn_force_audit_bypasses_and_logs(audit_workspace):
     container.state_dir.override(state_dir)
     container.log_manager.reset()
     try:
-        (audit_workspace / "cli" / "x.txt").write_text("x")
+        (audit_workspace / "cli" / "README.md").write_text("modified\n")
         result = runner.invoke(app, ["spawn", "force test", "--repos", "cli", "--force-audit"])
         assert result.exit_code == 0, result.output
 


### PR DESCRIPTION
## Summary

- Split `dirty_worktree` into `dirty_worktree` (error, modified-tracked) + `dirty_untracked` (warn, untracked).
- Added `"warn"` to the `Severity` literal (matches `CheckResult.status` convention).
- `mship audit` gains a yellow ⚠ display lane.
- Spawn/finish gate (`has_errors`) unchanged — warn issues don't block.
- README + working-with-mothership skill updated to document the new tier.

Closes #35.

## Test plan

- [x] New unit tests: untracked-only → warn, modified-only → error, mixed → both.
- [x] CLI display: warn lane prints yellow ⚠ and the footer counter shows `warn(s)`.
- [x] Gate regression: warn-only audit does NOT trip `has_errors`.
- [x] Migrated all pre-existing tests that used the untracked-fixture pattern (9 tests across 6 files).
- [x] `allow_dirty: true` suppresses both tiers — explicit assertion added.
- [x] Full pytest green (767 passed).

Closes #35