### PR TITLE
Integrate mship workflow into bundled skills (finishing, worktrees, writing-plans, executing-plans)

### DIFF
--- a/docs/superpowers/plans/2026-04-17-mship-skill-integration.md
+++ b/docs/superpowers/plans/2026-04-17-mship-skill-integration.md
@@ -1,0 +1,411 @@
+# mship-skill workflow integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-mship-skill-integration-design.md`
+
+**Goal:** Replace direct git/gh commands with mship verbs in four bundled skills (`finishing-a-development-branch`, `using-git-worktrees`, `writing-plans`, `executing-plans`) so agents following them route through mship's state-managing commands.
+
+**Architecture:** Surgical edits to markdown files. No tests beyond a markdown-parse check + a post-install round-trip smoke. Structure and wording preserved outside the conflict sites per the spec's decision log.
+
+**Tech Stack:** Markdown. `python -c "import mistune; ..."` for parse validation.
+
+---
+
+## File Structure
+
+| File | Responsibility | Status |
+|---|---|---|
+| `src/mship/skills/finishing-a-development-branch/SKILL.md` | 5 inline edits: option label, Option 1 note, Option 2 fence, Option 4 fence, Step 5 body + table cell | modify |
+| `src/mship/skills/using-git-worktrees/SKILL.md` | Top-of-skill callout + comment above line 97 + Example Workflow (lines 180-192) refresh | modify |
+| `src/mship/skills/writing-plans/SKILL.md` | Extend Step 5 commit example to pair with `mship journal` | modify |
+| `src/mship/skills/executing-plans/SKILL.md` | Add mship flow note to Step 3; promote Remember bullet to Step 1 sub-item | modify |
+
+No test files change (skills are markdown). No code changes.
+
+---
+
+## Task 1: `finishing-a-development-branch` — five surgical sites
+
+**File:** `src/mship/skills/finishing-a-development-branch/SKILL.md`
+
+- [ ] **Step 1.1: Update Option 2's label (line 57)**
+
+Change:
+
+```markdown
+2. Push and create a Pull Request
+```
+
+To:
+
+```markdown
+2. Finish the task and open a Pull Request
+```
+
+- [ ] **Step 1.2: Prepend mship-close note to Option 1 "Merge Locally" (before line 70)**
+
+Insert the following italic note immediately after the `#### Option 1: Merge Locally` heading (line 68), before the existing fenced bash block:
+
+```markdown
+*In a mothership workspace, run `mship close` after the local merge to update state and clean up the worktree.*
+
+```
+
+(Blank line after the note, before the existing code fence.)
+
+- [ ] **Step 1.3: Replace Option 2's fenced block (lines 91-104)**
+
+Replace the existing fenced bash (from ``` ```bash ``` on line 91 through the closing ``` on line 104) with:
+
+````markdown
+```bash
+# Write the PR body to a file (or pass inline via --body "...")
+cat > /tmp/pr-body.md <<'EOF'
+## Summary
+<2-3 bullets of what changed>
+
+## Test plan
+- [ ] <verification steps>
+EOF
+
+# Finish the task: pushes the branch, opens the PR, stamps state.
+mship finish --body-file /tmp/pr-body.md
+```
+````
+
+- [ ] **Step 1.4: Replace Option 4's fenced block (lines 128-132)**
+
+Replace the fenced bash block inside "If confirmed:":
+
+````markdown
+```bash
+mship close --abandon
+```
+````
+
+- [ ] **Step 1.5: Replace Step 5 "Cleanup Worktree" body (lines 136-148)**
+
+Replace the whole section body (the "Check if in worktree" paragraph + both fenced blocks) between the `### Step 5: Cleanup Worktree` heading (line 136) and the next heading (`## Quick Reference`, line 152) with:
+
+```markdown
+**For Options 1, 2, 4:**
+
+*In a mothership workspace, worktree cleanup is handled by `mship close` (run after merge for Option 1; run after merge notification for Option 2). No manual `git worktree remove` needed.*
+
+**For Option 3:** Keep worktree.
+```
+
+- [ ] **Step 1.6: Update Quick Reference table cell (line 159)**
+
+In the row for `4. Discard`, change the "Cleanup Branch" cell from `✓ (force)` to `✓ (via close --abandon)`. The row becomes:
+
+```markdown
+| 4. Discard | - | - | - | ✓ (via close --abandon) |
+```
+
+- [ ] **Step 1.7: Markdown parse validation**
+
+Run:
+
+```bash
+uv run python -c "
+import mistune, pathlib
+p = pathlib.Path('src/mship/skills/finishing-a-development-branch/SKILL.md')
+html = mistune.html(p.read_text())
+assert '<h2' in html and '<code>' in html, 'lost structure'
+print(f'OK — {len(html)} chars rendered')
+"
+```
+
+Expected: `OK — <N> chars rendered`.
+
+- [ ] **Step 1.8: Commit**
+
+```bash
+git add src/mship/skills/finishing-a-development-branch/SKILL.md
+git commit -m "docs(skill/finishing): route Options 2 and 4 through mship verbs"
+```
+
+---
+
+## Task 2: `using-git-worktrees` — top callout + inline comment + example refresh
+
+**File:** `src/mship/skills/using-git-worktrees/SKILL.md`
+
+- [ ] **Step 2.1: Add top-of-skill "In a mothership workspace" callout**
+
+Insert the following new section between `## Overview` (ends at line 14) and `## Directory Selection Process` (line 16). The new section goes on lines 15–19 of the edited file (roughly):
+
+```markdown
+## In a mothership workspace
+
+If a `mothership.yaml` is present at any ancestor directory, use `mship spawn '<description>'` instead of the steps below. `mship spawn` creates the worktree, registers it in workspace state, runs per-repo `task setup`, and (where configured) symlinks heavy directories. The Directory Selection, Safety Verification, and Creation Steps sections below apply only when you're not spawning a mship task (e.g., quick read-only exploration or a non-mship repo).
+
+```
+
+(Blank line before the next heading.)
+
+- [ ] **Step 2.2: Add non-mship comment above `git worktree add` fence (around line 96)**
+
+Immediately before the `### 2. Create Worktree` fenced block, insert a single sentence (one blank line before and after if needed):
+
+```markdown
+*For non-mship workflows, create the worktree directly:*
+```
+
+Then the existing fenced block starting with `# Determine full path` and containing `git worktree add "$path" -b "$BRANCH_NAME"` stays unchanged.
+
+- [ ] **Step 2.3: Replace the Example Workflow block (lines 180-192)**
+
+Replace the content between `## Example Workflow` (line 178) and `## Red Flags` (line 194) with:
+
+````markdown
+## Example Workflow
+
+```
+You: I'm using the using-git-worktrees skill to set up an isolated workspace.
+
+[Detect: mothership.yaml found at /abs/workspace — routing through mship spawn]
+[Run: mship spawn "implement auth middleware" --repos auth-service]
+[mship creates worktree at .worktrees/feat/implement-auth-middleware, runs task setup]
+[Run: mship test (baseline check)]
+
+Worktree ready at /abs/workspace/.worktrees/feat/implement-auth-middleware
+Tests passing (47 tests, 0 failures)
+Ready to implement auth middleware
+```
+````
+
+- [ ] **Step 2.4: Markdown parse validation**
+
+```bash
+uv run python -c "
+import mistune, pathlib
+p = pathlib.Path('src/mship/skills/using-git-worktrees/SKILL.md')
+html = mistune.html(p.read_text())
+assert '<h2' in html and '<code>' in html, 'lost structure'
+assert 'mship spawn' in html, 'callout missing'
+print(f'OK — {len(html)} chars rendered')
+"
+```
+
+Expected: `OK — <N> chars rendered`.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/mship/skills/using-git-worktrees/SKILL.md
+git commit -m "docs(skill/worktrees): mship spawn callout + non-mship fallback framing"
+```
+
+---
+
+## Task 3: `writing-plans` — pair commit example with `mship journal`
+
+**File:** `src/mship/skills/writing-plans/SKILL.md`
+
+- [ ] **Step 3.1: Extend Step 5 commit example (lines 98-103)**
+
+Current content:
+
+````markdown
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/path/test.py src/path/file.py
+git commit -m "feat: add specific feature"
+```
+````
+
+Replace with:
+
+````markdown
+- [ ] **Step 5: Commit (pair with `mship journal` in a mothership workspace)**
+
+```bash
+git add tests/path/test.py src/path/file.py
+git commit -m "feat: add specific feature"
+# In a mothership workspace, also record the step in the journal:
+mship journal "implemented specific feature; tests passing" --action committed
+```
+
+Pair the commit with a `mship journal` entry so other sessions can reconstruct progress without reading every commit diff.
+````
+
+- [ ] **Step 3.2: Markdown parse validation**
+
+```bash
+uv run python -c "
+import mistune, pathlib
+p = pathlib.Path('src/mship/skills/writing-plans/SKILL.md')
+html = mistune.html(p.read_text())
+assert 'mship journal' in html, 'journal pairing missing'
+print(f'OK — {len(html)} chars rendered')
+"
+```
+
+Expected: `OK — <N> chars rendered`.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add src/mship/skills/writing-plans/SKILL.md
+git commit -m "docs(skill/plans): pair commit example with mship journal entry"
+```
+
+---
+
+## Task 4: `executing-plans` — mship flow note + promote Remember bullet
+
+**File:** `src/mship/skills/executing-plans/SKILL.md`
+
+- [ ] **Step 4.1: Extend Step 3 "Complete Development" (around lines 32-37)**
+
+After the existing three bullets under `### Step 3: Complete Development`, append one more italic line:
+
+```markdown
+- **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
+- Follow that skill to verify tests, present options, execute choice
+
+*In a mothership workspace, `finishing-a-development-branch` routes through `mship finish --body-file <path>` (see that skill's Option 2).*
+```
+
+(Blank line between the last bullet and the italic note.)
+
+- [ ] **Step 4.2: Promote the mship bullet to Step 1 (lines 18-23 and 63-69)**
+
+Current Step 1:
+
+```markdown
+### Step 1: Load and Review Plan
+1. Read plan file
+2. Review critically - identify any questions or concerns about the plan
+3. If concerns: Raise them with your human partner before starting
+4. If no concerns: Create TodoWrite and proceed
+```
+
+Replace with:
+
+```markdown
+### Step 1: Load and Review Plan
+1. Read plan file
+2. Review critically — identify any questions or concerns about the plan
+3. If concerns: Raise them with your human partner before starting
+4. **If this is a mothership workspace** (`mothership.yaml` at any ancestor): verify `mship status` shows an active task BEFORE starting. No active task → stop and tell the user to `mship spawn "<description>"` first. Then `cd` into `task.worktrees.<repo>` and do all work and commits there. The mship pre-commit hook refuses commits from outside the worktree, so "just commit on main" is both wrong and blocked.
+5. If no concerns: Create TodoWrite and proceed
+```
+
+Also remove the duplicated mship bullet from the "Remember" list at lines 64-69. The whole bullet starting with `- **If this is a mothership workspace**` through `both wrong and blocked.` goes away.
+
+- [ ] **Step 4.3: Markdown parse validation**
+
+```bash
+uv run python -c "
+import mistune, pathlib
+p = pathlib.Path('src/mship/skills/executing-plans/SKILL.md')
+html = mistune.html(p.read_text())
+# Confirm Step 1 now contains the mship bullet
+import re
+step1_match = re.search(r'Load and Review Plan.*?(?=Step 2|## )', html, re.DOTALL)
+assert step1_match and 'mship status' in step1_match.group(0), 'mship bullet not in Step 1'
+# And that only ONE mship bullet remains total
+assert html.count('mship spawn \"&lt;description&gt;\"') + html.count('mship spawn &quot;&lt;description&gt;&quot;') <= 2, 'duplication not removed'
+print(f'OK — {len(html)} chars rendered')
+"
+```
+
+Expected: `OK — <N> chars rendered`.
+
+(The duplication assertion tolerates both HTML-entity forms that `mistune` may emit for the quoted string.)
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add src/mship/skills/executing-plans/SKILL.md
+git commit -m "docs(skill/executing): surface mship gate in Step 1; note finish flow"
+```
+
+---
+
+## Task 5: Install round-trip smoke
+
+- [ ] **Step 5.1: Rebuild + reinstall the tool from this worktree**
+
+```bash
+uv tool install --reinstall --from . mothership 2>&1 | tail -3
+mship skill install --force 2>&1 | tail -10
+```
+
+Expected: `claude: 15 skills installed → ~/.claude/skills/` (with some `refreshed` lines if prior install existed).
+
+- [ ] **Step 5.2: Spot-check each edited skill via its installed path**
+
+```bash
+echo "--- finishing-a-development-branch ---"
+grep -n "mship finish --body-file\|mship close --abandon" ~/.claude/skills/finishing-a-development-branch/SKILL.md | head -5
+
+echo "--- using-git-worktrees ---"
+grep -n "In a mothership workspace\|mship spawn" ~/.claude/skills/using-git-worktrees/SKILL.md | head -5
+
+echo "--- writing-plans ---"
+grep -n "mship journal" ~/.claude/skills/writing-plans/SKILL.md | head -3
+
+echo "--- executing-plans ---"
+grep -n "mship status\|finishing-a-development-branch.*mship finish" ~/.claude/skills/executing-plans/SKILL.md | head -5
+```
+
+Expected: each skill shows its mship mentions via the installed symlink.
+
+- [ ] **Step 5.3: No commit needed (verification only).**
+
+---
+
+## Task 6: Finish
+
+- [ ] **Step 6.1: Spec coverage check**
+
+| Spec site | Task/step |
+|---|---|
+| 1.1 Option 2 label | 1.1 |
+| 1.2 Option 1 mship-close note | 1.2 |
+| 1.3 Option 2 fenced block | 1.3 |
+| 1.4 Option 4 fenced block | 1.4 |
+| 1.5 Step 5 body + table cell | 1.5, 1.6 |
+| 2.1 Top-of-skill callout | 2.1 |
+| 2.2 Line 97 non-mship comment | 2.2 |
+| 2.3 Example Workflow refresh | 2.3 |
+| 3.1 Commit example with journal | 3.1 |
+| 4.1 Step 3 finish-flow note | 4.1 |
+| 4.2 Promote mship bullet + remove duplicate | 4.2 |
+
+- [ ] **Step 6.2: Full test suite (sanity — no code changed so this should be pure no-op green)**
+
+```bash
+uv run pytest -x -q 2>&1 | tail -3
+```
+
+Expected: all pass (no new tests, no changed Python).
+
+- [ ] **Step 6.3: Finish via `mship finish --body-file -` (dogfood the flow the skills now describe)**
+
+```bash
+mship finish --body-file - <<'EOF'
+## Summary
+
+Surgical edits to four bundled skills so agents following them route through mship verbs instead of direct git/gh:
+
+- **`finishing-a-development-branch`** — Option 2 now says `mship finish --body-file`; Option 4 says `mship close --abandon`; Step 5 notes that `mship close` cleans up the worktree (no manual `git worktree remove`).
+- **`using-git-worktrees`** — Top-of-skill callout routes mship users to `mship spawn`; the `git worktree add` fence is flagged as the non-mship fallback; Example Workflow demonstrates the mship path.
+- **`writing-plans`** — Step 5 commit example now pairs `git commit` with `mship journal --action committed`, showing plan authors the expected mship-plan pattern.
+- **`executing-plans`** — Step 1 now surfaces the mship-workspace check before execution; Step 3 notes that the finish skill routes through `mship finish --body-file`.
+
+Wording and structure preserved per the spec's "keep most as-is" directive. Ten other bundled skills are unchanged. No code changes; install round-trip smoke validates the edits flow through to `~/.claude/skills/`.
+
+## Test plan
+
+- [x] Markdown parse via `mistune.html()` for each edited file — all render without structural loss.
+- [x] Install round-trip: `uv tool install --reinstall --from . mothership` then `mship skill install --force`; each skill's symlink target reflects the edits.
+- [x] Full pytest (no code changed, pure sanity) green.
+EOF
+```

--- a/docs/superpowers/specs/2026-04-17-mship-skill-integration-design.md
+++ b/docs/superpowers/specs/2026-04-17-mship-skill-integration-design.md
@@ -1,0 +1,158 @@
+# mship-skill workflow integration — Design
+
+## Context
+
+Mship ships a bundle of skills (installed via `mship skill install` into `~/.claude/skills/` and `~/.agents/skills/mothership/`). Most are generic methodology skills inherited from upstream `obra/superpowers`; they apply equally to any workflow. A few prescribe concrete git/gh commands that directly conflict with mship's state-managing verbs — agents following those skills bypass `mship finish`'s audit gate, leave `finished_at` unstamped, and skip the state reconciliation that mship exists to provide.
+
+Audit of the 15 bundled skills in this session found exactly four with mship-workflow touch points:
+
+| Skill | Current conflict | Severity |
+|---|---|---|
+| `finishing-a-development-branch` | Option 2 teaches `git push -u origin <branch>` + `gh pr create --title "…" --body "…"`; Option 4 teaches `git branch -D`; Step 5 teaches `git worktree remove` | High — routes agents around `mship finish`/`mship close` |
+| `using-git-worktrees` | Line 97 teaches `git worktree add "$path" -b "$BRANCH"` directly | High — routes around `mship spawn` |
+| `executing-plans` | Partially mship-aware already (line 64-69 "Remember" bullet); finish-skill reference at line 34-37 doesn't note the mship flow | Low — polish |
+| `writing-plans` | Illustrative `git commit -m "feat: …"` at line 102 is a plan template, not a workflow prescription — but benefits from showing the `mship journal` pairing authors should encode into mship plans | Very low — enhancement |
+
+Ten other skills (`test-driven-development`, `systematic-debugging`, `verification-before-completion`, `writing-skills`, `brainstorming`, `requesting-code-review`, `receiving-code-review`, `dispatching-parallel-agents`, `using-superpowers`, `subagent-driven-development`, `working-with-mothership`) have no mship conflicts and stay untouched.
+
+## Goal
+
+An agent following any bundled skill in a mship workspace produces a flow that goes through mship's verbs (`spawn`, `finish --body-file`, `close`, `journal`) — the commands that update `.mothership/state.yaml`, trigger audit/reconcile gates, and preserve worktree isolation. No direct `git push -u origin` / `gh pr create` / `git worktree add` / `git branch -D` / `git worktree remove` in the canonical path.
+
+Wording and structure of each skill are preserved per the "keep most of the skills as-is" directive; edits are surgical at the conflict sites, with one top-of-skill callout for `using-git-worktrees` where pure inline substitution would trivialize entire sections (decision 1 below).
+
+## Anti-goals
+
+- **No structural rewrites.** Headings, step numbers, option lists, table layouts preserved. Skills remain recognizable as the superpowers originals.
+- **No conditional forks** (`if mship, else generic` branches scattered in prose). The mship-installed copies assume mship — they're distributed *by* mship.
+- **No change to generic-methodology skills.** Ten of the fifteen stay byte-identical.
+- **No upstream contribution to `obra/superpowers`.** These edits apply to the mship-bundled copies only; the upstream repo keeps its own versions.
+- **No new skill.** `working-with-mothership` already fills the mship-overview role; we don't need an `mship-pr-flow` or similar.
+- **No frontmatter / description changes.** Skill discovery triggers stay intact.
+
+## Edit catalog
+
+### Skill 1 — `finishing-a-development-branch` (five sites)
+
+**Site 1.1 — Option label (line 57).** Soften Option 2's title to match mship's verb.
+- From: `2. Push and create a Pull Request`
+- To:   `2. Finish the task and open a Pull Request`
+
+**Site 1.2 — Option 1 "Merge Locally" (lines 70-85).** Keep the existing commands; prepend a one-line note:
+> *In a mothership workspace, run `mship close` after the local merge to update state and clean up the worktree.*
+
+**Site 1.3 — Option 2 "Push and Create PR" (lines 91-104).** Replace the fenced block:
+
+```bash
+# Write the PR body to a file (or pass inline via --body "...")
+cat > /tmp/pr-body.md <<'EOF'
+## Summary
+<2-3 bullets of what changed>
+
+## Test plan
+- [ ] <verification steps>
+EOF
+
+# Finish the task: pushes the branch, opens the PR, stamps state.
+mship finish --body-file /tmp/pr-body.md
+```
+
+**Site 1.4 — Option 4 "Discard" (lines 128-132).** Replace the fenced block:
+
+```bash
+mship close --abandon
+```
+
+**Site 1.5 — Step 5 "Cleanup Worktree" (lines 136-148).** Replace the body:
+
+> *In a mothership workspace, worktree cleanup is handled by `mship close` (run after merge for Option 1; run after merge notification for Option 2). No manual `git worktree remove` needed.*
+
+Plus: Quick Reference table cell for Option 4 "Cleanup Branch" becomes `✓ (via close --abandon)`.
+
+### Skill 2 — `using-git-worktrees` (A+: top callout + inline substitution)
+
+**Site 2.1 — Top-of-skill callout.** Insert after the `## Overview` section, before `## Directory Selection Process`:
+
+```markdown
+## In a mothership workspace
+
+If a `mothership.yaml` is present at any ancestor directory, use `mship spawn '<description>'` instead of the steps below. `mship spawn` creates the worktree, registers it in workspace state, runs per-repo `task setup`, and (where configured) symlinks heavy directories. The Directory Selection, Safety Verification, and Creation Steps sections below apply only when you're not spawning a mship task (e.g., quick read-only exploration or a non-mship repo).
+```
+
+**Site 2.2 — Line 97 fenced block.** Leave the `git worktree add` command as-is (the callout above directs mship users elsewhere). Add a `# For non-mship workflows:` comment immediately above the fenced block to reinforce that the snippet is the fallback path, not the primary one.
+
+**Site 2.3 — Example Workflow (lines 180-192).** Replace the example bash with a mship-first variant:
+
+```
+You: I'm using the using-git-worktrees skill to set up an isolated workspace.
+
+[Detect: mothership.yaml found at /abs/workspace — routing through mship spawn]
+[Run: mship spawn "implement auth middleware" --repos auth-service]
+[mship creates worktree at .worktrees/feat/implement-auth-middleware, runs task setup]
+[Run: mship test (baseline check)]
+
+Worktree ready at /abs/workspace/.worktrees/feat/implement-auth-middleware
+Tests passing (47 tests, 0 failures)
+Ready to implement auth middleware
+```
+
+### Skill 3 — `writing-plans` (one mship-journal flavor site)
+
+**Site 3.1 — Task template commit step (lines 98-103).** Extend the existing example to pair the commit with a `mship journal` entry, showing plan authors the expected pattern for mship-workspace plans:
+
+From:
+```bash
+git add tests/path/test.py src/path/file.py
+git commit -m "feat: add specific feature"
+```
+
+To:
+```bash
+git add tests/path/test.py src/path/file.py
+git commit -m "feat: add specific feature"
+# In a mothership workspace, also record the step in the journal:
+mship journal "implemented specific feature; tests passing" --action committed
+```
+
+Single-sentence note appended to the step caption: *"Pair the commit with a `mship journal` entry so other sessions can reconstruct progress without reading every commit diff."*
+
+### Skill 4 — `executing-plans` (two polish sites)
+
+**Site 4.1 — Step 3 "Complete Development" (lines 32-37).** Extend the existing reference to `finishing-a-development-branch` with a one-liner noting mship's route:
+
+> *In a mothership workspace, `finishing-a-development-branch` routes through `mship finish --body-file <path>` (see that skill's Option 2).*
+
+**Site 4.2 — Promote existing mship bullet from "Remember" list to a dedicated Step 1 subsection.** The current bullet at lines 64-69 is a closing reminder; it should be read before execution begins. Move (don't duplicate) it under `## Step 1: Load and Review Plan` as a numbered sub-item:
+
+```markdown
+### Step 1: Load and Review Plan
+
+1. Read plan file
+2. Review critically — identify any questions or concerns about the plan
+3. If concerns: Raise them with your human partner before starting
+4. **If this is a mothership workspace** (`mothership.yaml` at any ancestor): verify `mship status` shows an active task BEFORE starting. No active task → stop and tell the user to `mship spawn "<description>"` first. Then `cd` into `task.worktrees.<repo>` and do all work and commits there. The mship pre-commit hook refuses commits from outside the worktree, so "just commit on main" is both wrong and blocked.
+5. If no concerns: Create TodoWrite and proceed
+```
+
+Remove the same bullet from the "Remember" list at lines 63-69 to avoid duplication.
+
+## Testing
+
+No unit tests (skills are markdown):
+
+- **Rendering check.** `python -c "import mistune; mistune.html(open(path).read())"` for each edited file — no parse errors.
+- **Cross-reference check.** Every `[link](...)` in the edited files resolves to an existing skill in the bundle.
+- **Dogfood.** Next `mship finish` + `mship close` in this session exercises Skill 1's updated Option 2 flow; the manual smoke validates no regressions.
+- **Install round-trip.** `uv tool install --reinstall --from . mothership` → `mship skill install --only claude --force` → `head -10 ~/.claude/skills/finishing-a-development-branch/SKILL.md` shows the mship flow.
+
+No golden-file test for exact prose; the edit catalog above describes each change precisely enough for PR-time review.
+
+## Decisions log
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | For `using-git-worktrees`, use A+ (top callout + inline) instead of pure surgical substitution | Pure substitution trivializes the skill's entire Directory Selection + Safety Verification sections. The callout cleanly routes mship users to `mship spawn` while preserving the skill's generic content as-is below. |
+| 2 | Keep `writing-plans` in scope despite low conflict | The `git commit` example is illustrative for plan authors, not a workflow prescription. Adding the `mship journal` pairing turns the example into a demonstration of the expected mship plan-authoring pattern — very low cost, nonzero value. |
+| 3 | Replace Step 5 of `finishing-a-development-branch` with prose, not code | Worktree cleanup in mship happens as a side effect of `mship close`; users don't run a separate command. Prose conveys that better than a fenced code block. |
+| 4 | No conditional forks in prose ("if mship, else"); mship-installed copies assume mship | The skills are distributed by mship; their audience is mship users. Branching makes the prose noisier and doesn't serve anyone. `using-git-worktrees`'s callout is the one exception — it's a short preamble, not a branch scattered through the skill. |
+| 5 | Leave ten other skills untouched | No mship conflicts in their current text. Editing them for prose consistency would be gratuitous and risks drift from upstream superpowers. |

--- a/src/mship/skills/executing-plans/SKILL.md
+++ b/src/mship/skills/executing-plans/SKILL.md
@@ -17,9 +17,10 @@ Load plan, review critically, execute all tasks, report when complete.
 
 ### Step 1: Load and Review Plan
 1. Read plan file
-2. Review critically - identify any questions or concerns about the plan
+2. Review critically — identify any questions or concerns about the plan
 3. If concerns: Raise them with your human partner before starting
-4. If no concerns: Create TodoWrite and proceed
+4. **If this is a mothership workspace** (`mothership.yaml` at any ancestor): verify `mship status` shows an active task BEFORE starting. No active task → stop and tell the user to `mship spawn "<description>"` first. Then `cd` into `task.worktrees.<repo>` and do all work and commits there. The mship pre-commit hook refuses commits from outside the worktree, so "just commit on main" is both wrong and blocked.
+5. If no concerns: Create TodoWrite and proceed
 
 ### Step 2: Execute Tasks
 
@@ -35,6 +36,8 @@ After all tasks complete and verified:
 - Announce: "I'm using the finishing-a-development-branch skill to complete this work."
 - **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
 - Follow that skill to verify tests, present options, execute choice
+
+*In a mothership workspace, `finishing-a-development-branch` routes through `mship finish --body-file <path>` (see that skill's Option 2).*
 
 ## When to Stop and Ask for Help
 
@@ -61,12 +64,6 @@ After all tasks complete and verified:
 - Reference skills when plan says to
 - Stop when blocked, don't guess
 - Never start implementation on main/master branch without explicit user consent
-- **If this is a mothership workspace** (`mothership.yaml` at any ancestor): verify
-  `mship status` shows an active task BEFORE starting. No active task → stop and
-  tell the user to `mship spawn "<description>"` first. Then `cd` into
-  `task.worktrees.<repo>` and do all work and commits there. The mship pre-commit
-  hook refuses commits from outside the worktree, so "just commit on main" is
-  both wrong and blocked.
 
 ## Integration
 

--- a/src/mship/skills/finishing-a-development-branch/SKILL.md
+++ b/src/mship/skills/finishing-a-development-branch/SKILL.md
@@ -67,7 +67,7 @@ Which option?
 
 #### Option 1: Merge Locally
 
-*In a mothership workspace, run `mship close` after the local merge to update state and clean up the worktree.*
+*In a mothership workspace, run `mship close` after this block. It records the merge in state and cleans up the worktree. Safe to run even after `git branch -d` — `mship close` tolerates an already-deleted branch.*
 
 ```bash
 # Switch to base branch
@@ -137,7 +137,7 @@ Then: Cleanup worktree (Step 5)
 
 **For Options 1, 2, 4:**
 
-*In a mothership workspace, worktree cleanup is handled by `mship close` (run after merge for Option 1; run after merge notification for Option 2). No manual `git worktree remove` needed.*
+*In a mothership workspace, worktree cleanup is handled by `mship close`. Run it after the local merge (Option 1) or after the PR merges on GitHub (Option 2 — check via `mship reconcile` or `gh pr view`). No manual `git worktree remove` needed.*
 
 **For Option 3:** Keep worktree.
 

--- a/src/mship/skills/finishing-a-development-branch/SKILL.md
+++ b/src/mship/skills/finishing-a-development-branch/SKILL.md
@@ -54,7 +54,7 @@ Present exactly these 4 options:
 Implementation complete. What would you like to do?
 
 1. Merge back to <base-branch> locally
-2. Push and create a Pull Request
+2. Finish the task and open a Pull Request
 3. Keep the branch as-is (I'll handle it later)
 4. Discard this work
 
@@ -66,6 +66,8 @@ Which option?
 ### Step 4: Execute Choice
 
 #### Option 1: Merge Locally
+
+*In a mothership workspace, run `mship close` after the local merge to update state and clean up the worktree.*
 
 ```bash
 # Switch to base branch
@@ -89,18 +91,17 @@ Then: Cleanup worktree (Step 5)
 #### Option 2: Push and Create PR
 
 ```bash
-# Push branch
-git push -u origin <feature-branch>
-
-# Create PR
-gh pr create --title "<title>" --body "$(cat <<'EOF'
+# Write the PR body to a file (or pass inline via --body "...")
+cat > /tmp/pr-body.md <<'EOF'
 ## Summary
 <2-3 bullets of what changed>
 
-## Test Plan
+## Test plan
 - [ ] <verification steps>
 EOF
-)"
+
+# Finish the task: pushes the branch, opens the PR, stamps state.
+mship finish --body-file /tmp/pr-body.md
 ```
 
 Then: Cleanup worktree (Step 5)
@@ -127,8 +128,7 @@ Wait for exact confirmation.
 
 If confirmed:
 ```bash
-git checkout <base-branch>
-git branch -D <feature-branch>
+mship close --abandon
 ```
 
 Then: Cleanup worktree (Step 5)
@@ -137,15 +137,7 @@ Then: Cleanup worktree (Step 5)
 
 **For Options 1, 2, 4:**
 
-Check if in worktree:
-```bash
-git worktree list | grep $(git branch --show-current)
-```
-
-If yes:
-```bash
-git worktree remove <worktree-path>
-```
+*In a mothership workspace, worktree cleanup is handled by `mship close` (run after merge for Option 1; run after merge notification for Option 2). No manual `git worktree remove` needed.*
 
 **For Option 3:** Keep worktree.
 
@@ -156,7 +148,7 @@ git worktree remove <worktree-path>
 | 1. Merge locally | ✓ | - | - | ✓ |
 | 2. Create PR | - | ✓ | ✓ | - |
 | 3. Keep as-is | - | - | ✓ | - |
-| 4. Discard | - | - | - | ✓ (force) |
+| 4. Discard | - | - | - | ✓ (via close --abandon) |
 
 ## Common Mistakes
 

--- a/src/mship/skills/using-git-worktrees/SKILL.md
+++ b/src/mship/skills/using-git-worktrees/SKILL.md
@@ -13,6 +13,10 @@ Git worktrees create isolated workspaces sharing the same repository, allowing w
 
 **Announce at start:** "I'm using the using-git-worktrees skill to set up an isolated workspace."
 
+## In a mothership workspace
+
+If a `mothership.yaml` is present at any ancestor directory, use `mship spawn '<description>'` instead of the steps below. `mship spawn` creates the worktree, registers it in workspace state, runs per-repo `task setup`, and (where configured) symlinks heavy directories. The Directory Selection, Safety Verification, and Creation Steps sections below apply only when you're not spawning a mship task (e.g., quick read-only exploration or a non-mship repo).
+
 ## Directory Selection Process
 
 Follow this priority order:
@@ -81,6 +85,8 @@ project=$(basename "$(git rev-parse --show-toplevel)")
 ```
 
 ### 2. Create Worktree
+
+*For non-mship workflows, create the worktree directly:*
 
 ```bash
 # Determine full path
@@ -180,15 +186,14 @@ Ready to implement <feature-name>
 ```
 You: I'm using the using-git-worktrees skill to set up an isolated workspace.
 
-[Check .worktrees/ - exists]
-[Verify ignored - git check-ignore confirms .worktrees/ is ignored]
-[Create worktree: git worktree add .worktrees/auth -b feature/auth]
-[Run npm install]
-[Run npm test - 47 passing]
+[Detect: mothership.yaml found at /abs/workspace — routing through mship spawn]
+[Run: mship spawn "implement auth middleware" --repos auth-service]
+[mship creates worktree at .worktrees/feat/implement-auth-middleware, runs task setup]
+[Run: mship test (baseline check)]
 
-Worktree ready at /Users/jesse/myproject/.worktrees/auth
+Worktree ready at /abs/workspace/.worktrees/feat/implement-auth-middleware
 Tests passing (47 tests, 0 failures)
-Ready to implement auth feature
+Ready to implement auth middleware
 ```
 
 ## Red Flags

--- a/src/mship/skills/using-git-worktrees/SKILL.md
+++ b/src/mship/skills/using-git-worktrees/SKILL.md
@@ -220,4 +220,4 @@ Ready to implement auth middleware
 - Any skill needing isolated workspace
 
 **Pairs with:**
-- **finishing-a-development-branch** - REQUIRED for cleanup after work complete
+- **finishing-a-development-branch** - REQUIRED for cleanup after work complete (uses `mship close` in mothership workspaces; manual `git worktree remove` otherwise)

--- a/src/mship/skills/writing-plans/SKILL.md
+++ b/src/mship/skills/writing-plans/SKILL.md
@@ -95,12 +95,16 @@ def function(input):
 Run: `pytest tests/path/test.py::test_name -v`
 Expected: PASS
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Commit (pair with `mship journal` in a mothership workspace)**
 
 ```bash
 git add tests/path/test.py src/path/file.py
 git commit -m "feat: add specific feature"
+# In a mothership workspace, also record the step in the journal:
+mship journal "implemented specific feature; tests passing" --action committed
 ```
+
+Pair the commit with a `mship journal` entry so other sessions can reconstruct progress without reading every commit diff.
 ````
 
 ## No Placeholders


### PR DESCRIPTION
## Summary

Surgical edits to four bundled skills so agents following them route through mship verbs instead of direct git/gh:

- **`finishing-a-development-branch`** — Option 2 now says `mship finish --body-file`; Option 4 says `mship close --abandon`; Step 5 notes that `mship close` cleans up the worktree (no manual `git worktree remove`). Option 1 gains a sequencing note for `mship close` after the local merge.
- **`using-git-worktrees`** — Top-of-skill callout routes mship users to `mship spawn`; the `git worktree add` fence is framed as the non-mship fallback; Example Workflow demonstrates the mship path; Integration section clarifies that cleanup uses `mship close` in mothership workspaces.
- **`writing-plans`** — Step 5 commit example now pairs `git commit` with `mship journal --action committed`, with a trailing paragraph explaining why plan authors should encode the pairing.
- **`executing-plans`** — Mship-workspace check promoted from the "Remember" list into Step 1 item 4 (read before execution, not after); Step 3 notes that the finish skill routes through `mship finish --body-file`.

Wording and structure preserved per the spec's "keep most as-is" directive. Ten other bundled skills are unchanged. No code changes.

## Test plan

- [x] `mistune.html()` parse check for each edited file during implementation.
- [x] Install round-trip: `uv tool install --reinstall --from . mothership` + `mship skill install --force`; each skill's symlink resolves to the new content.
- [x] Spot-check: `grep` against `~/.claude/skills/<skill>/SKILL.md` finds each mship mention.
- [x] Full pytest green (805 passed, no code changed — pure sanity).

## Methodology

Shipped through the skill flow: `brainstorming` → `writing-plans` → `subagent-driven-development`. Two review loops surfaced real prose issues fixed in follow-up commits (Option 1 sequencing ambiguity; Integration section wording).
