### PR TITLE
README refresh: value prop + 5-min walkthrough + install cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,25 +22,23 @@ echo 'print("hello")' > hello.py
 git add hello.py
 git commit -m "feat: hello world"
 
-cat > /tmp/body.md <<'EOF'
+mship finish --body-file - <<'EOF'
 ## Summary
 First mship task.
-
 ## Test plan
 - [x] Runs locally.
 EOF
-mship finish --body-file /tmp/body.md
 ```
 
 Requires Python 3.14+ and [uv](https://docs.astral.sh/uv/). Optional: [go-task](https://taskfile.dev), [gh](https://cli.github.com) (for `mship finish`).
 
 ## How it works
 
-Each task lives in a git worktree on its own feature branch, one per affected repo. mship manages the worktrees, tracks state in `.mothership/state.yaml`, and gates transitions (`spawn`, `finish`, `close`) on git-state audits. The agent reads structured state via `mship status`, `mship journal`, and `mship context`; it writes via mship commands that update state atomically. A pre-commit hook blocks commits from outside the active task's worktrees.
+Each task lives in a git worktree on its own feature branch, one per affected repo. mship manages the worktrees, tracks state in `.mothership/state.yaml`, and gates transitions (`spawn`, `finish`, `close`) on git-state audits. The agent reads structured state via `mship status`, `mship journal`, and `mship context`. A pre-commit hook blocks commits from outside the active task's worktrees.
 
 ## Common patterns
 
-**Multi-repo task.** `mship spawn "refactor schema" --repos api,client` creates one worktree per repo on the same feature branch. `mship test` runs them in dependency order, wiring each worktree in as the other's dependency. `mship finish` opens PRs in dependency order with cross-repo coordination blocks.
+**Multi-repo task.** `mship spawn "refactor schema" --repos api,client` creates one worktree per repo on the same feature branch. `mship test` runs them in dependency order. `mship finish` opens PRs in dependency order with cross-repo coordination blocks.
 
 **Agent session handoff.** `mship dispatch --task <slug> -i "<instruction>"` emits a self-contained prompt — cd directive, branch state, recent journal entries, finish contract — for a fresh subagent. No parent-held context required.
 
@@ -54,7 +52,7 @@ Each task lives in a git worktree on its own feature branch, one per affected re
 
 - [`docs/cli.md`](docs/cli.md) — full command surface.
 - [`docs/configuration.md`](docs/configuration.md) — `mothership.yaml` options, healthchecks, service start modes, monorepo rules, task aliasing.
-- `mship skill install` — installs a bundle of agent-side skills (including `working-with-mothership` — session-start protocol, phase workflow, recovery patterns).
+- `mship skill install` — installs the agent-side skill bundle (including `working-with-mothership`).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,460 +1,60 @@
-# Mothership (`mship`)
+# mship
 
-**State safety for one AI agent working across repo boundaries.** Makes it structurally impossible for the agent to commit to the wrong branch, modify files in the main worktree, forget what it changed in one repo while working in another, or run tests against a stale version of a dependency.
+State safety for an AI agent working across your git repos: isolated worktrees per task, coordinated PRs, durable cross-session state.
 
-> ⚠️ **Status: pre-1.0, under heavy development.** Expect breaking changes to config, flags, and state format between commits. Pin a commit if you need stability. Feedback welcome.
+> Pre-1.0. API may change. Pin a commit if you need stability.
 
-## The problem: state hell
+## Problem
 
-Give an AI agent write access across a few repos and you'll see some or all of this within the first week:
+AI agents given write access across repos routinely commit to `main` because they forgot `git checkout`, modify files in the wrong worktree, lose track of what they changed in repo A while working in repo B, and merge coordinated PRs in the wrong order. These are state-management failures, not agent-skill failures — git alone doesn't model them.
 
-- It **commits to main** because it forgot to `git checkout -b` in repo B.
-- It **modifies files in the main worktree** instead of the feature branch, because the working directory looked fine and it didn't notice the checkout was stale.
-- It **forgets what it changed in repo A** the moment it starts working in repo B — the context window doesn't have repo A's code anymore.
-- It **runs tests in repo B against the old version of repo A's code**, because nothing wired the task's repo-A worktree into repo B's dependency resolution.
-- It **merges PRs in the wrong order**, breaking `main` on the next CI run.
-- It **keeps editing a branch after opening the PR**, updating the PR with accidental changes — or pushing work nobody will ever review.
-
-These aren't agent skill issues. They're state-management issues. One agent, one context window, multiple repos, multiple working trees — the failure modes are structural.
-
-## How mship prevents them
-
-**Worktree isolation is the load-bearing feature.** `mship spawn <description>` creates a git worktree per affected repo at `.worktrees/feat/<slug>/`, each on a matching feature branch. The main checkouts stay pristine. Every subsequent command (`test`, `run`, `logs`, `finish`) operates on those worktrees, not main. The agent literally cannot accidentally modify main because its working tree isn't main.
-
-| Failure | How mship makes it impossible |
-|---|---|
-| Commits to main | `spawn` creates a feature-branch worktree; every mship command resolves to worktree paths, not repo.path |
-| Wrong worktree / stale checkout | `audit` blocks `spawn`/`finish` on drift (wrong branch, dirty, behind remote, foreign worktrees) — gated on every lifecycle boundary |
-| Forgets cross-repo state | `mship journal` + `mship status` + `mship view *` give the agent structured state it can re-inject into context |
-| Tests against stale dep version | `mship test` runs repos in dependency order; `mship doctor` verifies the worktree-to-worktree linking your package manager needs (`symlink_dirs`, npm workspaces, etc.) |
-| PRs merged out of order | `mship finish` creates coordinated PRs in dependency order with a cross-repo coordination block in each PR description |
-| Agent keeps editing after PR | `mship finish` stamps `finished_at`; `phase dev`/`plan`/`review` refuse transitions on finished tasks; `mship close` tears down once merged |
-
-Works for **a single repo** (the isolation + phase + audit story still applies) *and* multi-repo workspaces (the coordination story layers on top). Start with one; add repos when the system grows.
-
-**Pre-commit guard.** `mship init` installs a pre-commit hook on every git root. While a task is active, the hook refuses commits anywhere except the task's worktrees — making "committed to main instead of the worktree" structurally impossible without explicit bypass (`git commit --no-verify`). Removed cleanly by editing `.git/hooks/pre-commit`; `mship doctor` warns when the hook is missing.
-
-**Cross-repo context switches.** When the agent moves between repos within a task, `mship switch <repo>` records the checkpoint and emits a structured handoff: what changed in dependency repos since the agent was last here, what it logged in this repo, whether the worktree is clean. The agent re-injects the handoff into its context and continues work grounded in current state — no re-reading every file, no stale mental models, no running tests against the wrong version of a dependency.
-
-**Iteration awareness.** Every `mship test` run gets a numbered iteration file with per-repo status, duration, exit code, and stderr tail. The next run shows the diff: new failures, fixes, regressions. Agents iterating on a test failure get a running log of what changed between attempts instead of re-reading stdout.
-
-## mship in 60 seconds
+## Quickstart
 
 ```bash
-$ mship init --detect                           # scaffold mothership.yaml from the current directory
-$ mship spawn "add labels to tasks"             # one worktree per repo, matched feature branches, main untouched
-Spawned task: add-labels-to-tasks
-  Branch: feat/add-labels-to-tasks
-  Phase: plan
-  shared:       /home/me/dev/shared/.worktrees/feat/add-labels-to-tasks       ← agent edits here
-  auth-service: /home/me/dev/auth-service/.worktrees/feat/add-labels-to-tasks ← and here
-                                                                              (main checkouts untouched)
-
-$ mship phase dev                                # soft gate warns if no spec exists
-WARNING: No spec found — consider writing one before developing
-Phase: dev
-
-$ mship test                                    # tests run in dependency order, inside the worktrees
-shared: pass
-auth-service: pass
-
-$ mship audit                                   # git-state check: clean worktrees? right branch? not behind?
-workspace: my-platform
-shared:       ✓ clean
-auth-service: ✓ clean
-0 error(s), 0 info across 2 repos
-
-$ mship phase review && mship finish            # coordinated PRs in correct merge order
-auth-service: feat/add-labels-to-tasks → main  ✓ https://github.com/you/auth/pull/42
-shared:       feat/add-labels-to-tasks → main  ✓ https://github.com/you/shared/pull/41
-Task finished. After merge, run `mship close` to clean up.
-
-$ # ...PRs merged externally...
-$ mship close                                   # tears down worktrees, clears state, logs completion
-```
-
-That's the whole loop. The worktrees the agent was editing in are gone; `main` is unchanged; nothing leaked; `mship status` is empty and ready for the next `spawn`. Everything below is reference.
-
-## How it fits
-
-Mothership is not an agent and not a task runner. It's the layer between them:
-
-```
-Agent (Claude Code, Codex, Gemini CLI)
-    ↓ calls
-Mothership (phases, worktrees, state, coordination)
-    ↓ delegates to
-go-task  (per-repo test/run/lint/setup commands)
-```
-
-Each repo owns a `Taskfile.yml` with the commands `task test`, `task run`, etc. Mothership calls them in the right directory, in the right order, with your secret manager wrapping them (`dotenvx`, `op`, `doppler`…).
-
-## Quick start
-
-```bash
-# 1. Install
 uv tool install git+https://github.com/atomikpanda/mothership.git
 
-# 2. Initialize your workspace
-cd ~/my-project
-mship init                   # interactive wizard
-# or:
-mship init --detect          # auto-detect repos in current dir
-# or (non-interactive):
-mship init --name platform --repo ./shared:library --repo ./api:service:shared
+cd my-project
+mship init --name my-project --repo .:service
+mship spawn "add hello world"
+cd $(mship status | jq -r '.worktrees."my-project"')
 
-# 3. Verify and start working
-mship doctor                 # config + tools check
-mship spawn "my first task"
-mship phase dev
-# ... do work ...
-mship journal "implemented X"    # breadcrumb for the next session
-mship test
-mship phase review && mship finish
+echo 'print("hello")' > hello.py
+git add hello.py
+git commit -m "feat: hello world"
+
+cat > /tmp/body.md <<'EOF'
+## Summary
+First mship task.
+
+## Test plan
+- [x] Runs locally.
+EOF
+mship finish --body-file /tmp/body.md
 ```
 
-Requires Python 3.14+ and [uv](https://docs.astral.sh/uv/). Optional: [go-task](https://taskfile.dev), [gh](https://cli.github.com) (for `mship finish`), [git-delta](https://github.com/dandavison/delta) (for nicer `mship view diff`).
+Requires Python 3.14+ and [uv](https://docs.astral.sh/uv/). Optional: [go-task](https://taskfile.dev), [gh](https://cli.github.com) (for `mship finish`).
 
-## Multi-task workflows
+## How it works
 
-Mothership supports N active tasks at once — one worktree per task per repo. Task-scoped commands (`status`, `phase`, `test`, `journal`, `view …`, …) resolve their target task in this priority order:
+Each task lives in a git worktree on its own feature branch, one per affected repo. mship manages the worktrees, tracks state in `.mothership/state.yaml`, and gates transitions (`spawn`, `finish`, `close`) on git-state audits. The agent reads structured state via `mship status`, `mship journal`, and `mship context`; it writes via mship commands that update state atomically. A pre-commit hook blocks commits from outside the active task's worktrees.
 
-1. **`--task <slug>` flag** — explicit, highest priority.
-2. **`MSHIP_TASK` env var** — scope a whole shell session to one task: `export MSHIP_TASK=<slug>`.
-3. **cwd** — if your shell is inside a task's worktree, that task is the default.
+## Common patterns
 
-With 0 active tasks the command errors with "no active task". With exactly 1 active task and no anchor, the command targets that task (no ambiguity to disambiguate). With 2+ active tasks and no anchor you'll get an "Ambiguous" error listing the active slugs — fix by anchoring via any of the three mechanisms above.
+**Multi-repo task.** `mship spawn "refactor schema" --repos api,client` creates one worktree per repo on the same feature branch. `mship test` runs them in dependency order, wiring each worktree in as the other's dependency. `mship finish` opens PRs in dependency order with cross-repo coordination blocks.
 
-Typical flows:
+**Agent session handoff.** `mship dispatch --task <slug> -i "<instruction>"` emits a self-contained prompt — cd directive, branch state, recent journal entries, finish contract — for a fresh subagent. No parent-held context required.
 
-```bash
-# Single-task work: cd into the worktree after spawn, and everything resolves.
-mship spawn "add labels"              # prints the worktree path
-cd .worktrees/feat/add-labels/…       # now `mship status`, `mship test`, … all target this task
+## Scope
 
-# Multi-task work: export MSHIP_TASK once per shell to scope the session.
-export MSHIP_TASK=add-labels
-mship journal "picked back up"        # no flag needed; env anchors the shell
+- **Does:** isolate writes via worktrees, sequence cross-repo work, gate transitions on git state, surface structured state to agents.
+- **Does not:** run the agent, generate code, manage secrets (delegates to `env_runner`), replace your CI.
+- **Works for:** a single repo, a monorepo (via `git_root`), or multiple repos in one workspace.
 
-# One-off cross-task command:
-mship status --task other-task
-```
+## Reference
 
-## For AI agents
-
-Mothership ships a bundle of skills — the mship skill plus vendored mship-aware superpowers skills (brainstorming, writing-plans, subagent-driven-development, executing-plans, systematic-debugging, TDD, …). Skills install under a single `mothership:` namespace so they don't collide with other plugins.
-
-**Claude Code** (via plugin marketplace):
-
-```
-/plugin marketplace add atomikpanda/mothership
-/plugin install mothership@mothership-marketplace
-```
-
-**Gemini CLI**:
-
-```bash
-gemini extensions install https://github.com/atomikpanda/mothership
-```
-
-**Codex** — follow [`.codex/INSTALL.md`](./.codex/INSTALL.md) (clone + symlink).
-
-**All of the above, detected automatically** — one command:
-
-```bash
-mship skill install                 # detects claude/gemini/codex, installs via each tool's native method
-mship skill install --only gemini   # filter to specific agents
-mship skill install --yes           # skip the confirmation prompt
-```
-
-Claude Code still needs two slash commands inside the REPL (printed by the installer); Gemini and Codex install fully automatically and update cleanly.
-
-**Other agents (universal fallback)** — use the CLI:
-
-```bash
-mship skill list                    # see what's in the bundle
-mship skill install --all           # install the whole bundle to ~/.agents/skills/mothership/
-```
-
-The mship skill teaches the session-start protocol (`mship status` → `mship journal`), phase workflow, command reference, and context recovery. The vendored superpowers skills are mship-aware — they require an active task and point subagents at task worktrees, not `main`.
-
-JSON output is auto-emitted when stdout isn't a TTY — agents get structured state without any flag, humans get Rich-formatted output.
-
-## CLI Reference
-
-```bash
-# Lifecycle (the iteration loop)
-mship init [--detect | --name N --repo PATH:TYPE]   # scaffold mothership.yaml
-mship init --install-hooks            # (re)install pre-commit guard on every git root
-mship spawn "description" [--repos a,b] [--skip-setup] [--bypass-reconcile]   # worktrees + branch + plan phase
-mship switch <repo>                   # cross-repo context switch: handoff + record active repo
-mship phase plan|dev|review|run [-f] # transition with soft gate warnings
-mship block "reason" | mship unblock # park/resume the current task
-mship test [--all] [--repos|--tag] [--no-diff]   # dep order; shows diff vs previous iteration
-mship journal [-]                         # read task log; pass message to append
-mship journal "msg" [--action X] [--open Y] [--repo R] [--test-state pass|fail|mixed]
-mship journal --show-open                 # list open questions
-mship finish [--base B] [--base-map a=B,b=B] [--push-only] [--handoff] [--force-audit] [--bypass-reconcile]
-mship close [--yes] [--force] [--skip-pr-check] [--bypass-reconcile]   # tear down worktrees after merge
-
-# Inspection
-mship status                          # task, phase, branch, drift, last log, finished warning
-mship audit [--repos r] [--json]      # git-state drift (gated on spawn/finish)
-mship reconcile [--json] [--ignore SLUG] [--clear-ignores] [--refresh]   # upstream PR drift (merged/closed/diverged/base_changed)
-mship view status|logs|diff|spec [--watch]   # read-only TUIs for tmux/zellij panes
-mship view spec --web                 # serve rendered spec on localhost
-mship graph                           # repo dependency graph
-mship worktrees                       # list active worktrees
-mship doctor                          # validate config + tools (gh, env_runner, Taskfiles)
-
-# Maintenance
-mship sync [--repos r]                # fast-forward behind-only clean repos
-mship prune [--force]                 # remove orphaned worktrees
-
-# Long-running services
-mship run [--repos a,b] [--tag t]     # start services per dependency tier
-mship logs <service>                      # tail logs for a service
-```
-
-### `mship finish`
-
-#### PR base branch
-
-Each repo's PR can target a non-default base:
-
-```yaml
-repos:
-  cli:
-    path: ../cli
-    base_branch: main
-  api:
-    path: ../api
-    base_branch: cli-refactor
-```
-
-Overrides (most-specific wins):
-
-- `--base <branch>` — global override for all repos.
-- `--base-map cli=main,api=release/x` — per-repo overrides.
-
-`mship finish` verifies every resolved base exists on `origin` before any push. Repos with no configured or overridden base use the remote default branch.
-
-### Drift audit & sync
-
-`mship audit` reports git-state drift across all repos; `mship sync` fast-forwards the clean-behind ones. Both integrate as opt-out gates on `mship spawn` and `mship finish`.
-
-**Per-repo config:**
-
-```yaml
-repos:
-  schemas:
-    path: ../schemas
-    expected_branch: marshal-refactor   # optional
-    allow_dirty: false                  # default
-    allow_extra_worktrees: false        # default
-```
-
-**Workspace policy (defaults shown):**
-
-```yaml
-audit:
-  block_spawn: true
-  block_finish: true
-```
-
-**Commands:**
-
-- `mship audit [--repos r1,r2] [--json]` — exit 1 on any error-severity drift.
-- `mship sync [--repos r1,r2]` — fast-forwards behind-only clean repos; skips the rest with a reason.
-- `mship spawn --force-audit` / `mship finish --force-audit` — bypass with a line logged to the task log.
-
-**Issue codes:** `path_missing`, `not_a_git_repo`, `fetch_failed`, `detached_head`, `unexpected_branch`, `dirty_worktree`, `no_upstream`, `behind_remote`, `diverged`, `extra_worktrees` (errors); `dirty_untracked` (warn — untracked files only, doesn't block); `ahead_remote` (info-only).
-
-### Live views
-
-`mship view` provides read-only TUIs designed for tmux/zellij panes. All views support `--watch` and `--interval N`.
-
-- `mship view status [--task <slug>] [--watch]` — all tasks stacked by default (the "God view"); `--task` narrows to one
-- `mship view logs [--task <slug>] [--watch]` — tail the task's log
-- `mship view diff [--task <slug>] [--watch]` — per-worktree git diff
-- `mship view spec [name-or-path] [--task <slug>] [--watch] [--web]` — cross-task spec index picker by default; `--task` narrows, explicit name renders directly, `--web` serves HTML on localhost
-
-`mship view logs`, `mship view diff`, and the single-task form of `mship view status` resolve their target task via cwd → `MSHIP_TASK` env → `--task <slug>` flag. With 0 active tasks you'll get a "no active task" error; with exactly 1 active task and no anchor the view targets it automatically; with 2+ active tasks and no anchor you'll get an "ambiguous" error listing the active slugs. See [Multi-task workflows](#multi-task-workflows) for the resolution rules.
-
-Keys: `q` quit, `j/k` or arrows to scroll, `PgUp/PgDn`, `Home/End`, `r` force refresh.
-
-## Configuration
-
-### `mothership.yaml`
-
-```yaml
-workspace: my-platform
-
-# Optional: wraps all task execution with a secret manager
-env_runner: "dotenvx run --"
-
-# Optional: branch naming pattern ({slug} is replaced)
-branch_pattern: "feat/{slug}"
-
-repos:
-  shared:
-    path: ./shared
-    type: library            # "library" or "service"
-    depends_on: []
-    env_runner: "op run --"  # per-repo override
-    tasks:
-      test: unit             # override canonical task name
-  auth-service:
-    path: ./auth-service
-    type: service
-    depends_on: [shared]
-```
-
-### Secret Management
-
-Mothership doesn't manage secrets. It delegates to your secret manager via `env_runner`:
-
-| Tool | Config value |
-|------|-------------|
-| dotenvx | `dotenvx run --` |
-| Doppler | `doppler run --` |
-| 1Password CLI | `op run --` |
-| Infisical | `infisical run --` |
-| None | omit `env_runner` |
-
-### Monorepo Support (`git_root`)
-
-For monorepos where multiple services share one git repo, use `git_root` to declare subdirectory services:
-
-```yaml
-repos:
-  backend:
-    path: .
-    type: service
-  web:
-    path: web              # relative — interpreted against backend's worktree
-    type: service
-    git_root: backend
-    depends_on: [backend]
-```
-
-The subdirectory service shares the parent's worktree. `mship spawn` creates one worktree for `backend` at `.worktrees/feat/<task>/`, and `web`'s effective path becomes `.worktrees/feat/<task>/web`.
-
-Rules:
-- `git_root` must reference another repo in the workspace
-- The referenced repo cannot itself have `git_root` set (no chaining)
-- The subdirectory must exist and contain a `Taskfile.yml`
-- Subdirectory services still have their own `depends_on`, `tags`, `tasks`, and `start_mode`
-
-### Service Start Modes (`start_mode`)
-
-For long-running services (dev servers, databases), set `start_mode: background`:
-
-```yaml
-repos:
-  infra:
-    path: ./infra
-    type: service
-    start_mode: background     # mship run launches and moves on
-  backend:
-    path: ./backend
-    type: service
-    start_mode: background
-    depends_on: [infra]
-  amplify:
-    path: ./amplify
-    type: service
-    # start_mode defaults to foreground
-    depends_on: [infra]
-```
-
-With `start_mode: background`, `mship run` launches the service in a thread (via `subprocess.Popen`) and continues to the next dependency tier without waiting for exit. Background services keep running until Ctrl-C propagates SIGINT through go-task to their child processes.
-
-`start_mode` only affects `mship run`. Tests and logs always run foreground.
-
-### Healthchecks
-
-For services that need time to become ready (databases, dev servers binding to ports), declare a `healthcheck`. `mship run` waits for the healthcheck to pass before starting dependent services.
-
-```yaml
-repos:
-  infra:
-    path: ./infra
-    type: service
-    start_mode: background
-    healthcheck:
-      tcp: "127.0.0.1:8001"          # wait for port to accept connections
-      timeout: 30s                    # optional, default 30s
-      retry_interval: 500ms           # optional, default 500ms
-
-  backend:
-    path: ./backend
-    type: service
-    start_mode: background
-    depends_on: [infra]
-    healthcheck:
-      http: "http://localhost:8000/health"   # wait for 2xx response
-
-  web:
-    path: ./web
-    type: service
-    start_mode: background
-    depends_on: [backend]
-    healthcheck:
-      sleep: 3s                        # unconditional wait
-
-  custom:
-    path: ./custom
-    type: service
-    start_mode: background
-    healthcheck:
-      task: wait-for-custom            # invokes `task wait-for-custom`, 0 exit = ready
-```
-
-**Probe types:**
-- `tcp: host:port` — succeeds when a TCP connection is accepted
-- `http: url` — succeeds on a 2xx response
-- `sleep: duration` — waits unconditionally (for things you can't probe)
-- `task: task-name` — runs a Taskfile task; 0 exit = ready
-
-Exactly one probe per healthcheck. If the probe doesn't succeed within `timeout`, the service is treated as failed, background processes are terminated, and `mship run` exits non-zero.
-
-Healthchecks apply to `mship run` only — `mship test` ignores them.
-
-### Task Name Aliasing
-
-If your Taskfile uses different task names than mothership's defaults (`test`, `run`, `lint`, `setup`), add a `tasks:` mapping:
-
-```yaml
-repos:
-  my-app:
-    path: .
-    type: service
-    tasks:
-      run: dev                 # mship run → task dev
-      test: test:all           # mship test → task test:all
-      lint: lint:all
-      setup: infra:start
-```
-
-`mship doctor` respects the mapping when checking for standard tasks.
-
-### Taskfile Contract
-
-Each repo needs a `Taskfile.yml` with standard task names. Mothership calls `task <name>` in each repo. Override names per repo in the `tasks` mapping.
-
-Default tasks: `test`, `run`, `lint`, `logs`, `setup`. Missing tasks are skipped gracefully.
-
-## What Mothership is not
-
-- **Not a per-repo methodology** — mothership owns the workflow stages; your per-repo tools (superpowers, custom prompts, CI checks) own the discipline within each stage
-- **Not a task runner** — delegates to go-task
-- **Not an AI agent** — it's a tool agents call
-- **Not limited to one repo layout** — works with single repos, monorepos, and metarepos (multiple repos in a shared workspace)
-
-## Stack
-
-Python 3.14, Typer, Pydantic v2, Rich, InquirerPy, dependency-injector
+- [`docs/cli.md`](docs/cli.md) — full command surface.
+- [`docs/configuration.md`](docs/configuration.md) — `mothership.yaml` options, healthchecks, service start modes, monorepo rules, task aliasing.
+- `mship skill install` — installs a bundle of agent-side skills (including `working-with-mothership` — session-start protocol, phase workflow, recovery patterns).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ AI agents given write access across repos routinely commit to `main` because the
 uv tool install git+https://github.com/atomikpanda/mothership.git
 
 cd my-project
-mship init --name my-project --repo .:service
+mship init --name my-project --detect
 mship spawn "add hello world"
-cd $(mship status | jq -r '.worktrees."my-project"')
+cd $(mship status | jq -r '.worktrees | to_entries[0].value')
 
 echo 'print("hello")' > hello.py
 git add hello.py

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,128 @@
+# CLI Reference
+
+All task-scoped commands (`status`, `phase`, `test`, `journal`, `view …`, etc.) resolve their target task in this priority order:
+
+1. `--task <slug>` flag — explicit, highest priority.
+2. `MSHIP_TASK` env var — scope a whole shell session to one task.
+3. cwd — if your shell is inside a task's worktree, that task is the default.
+
+With 0 active tasks the command errors with "no active task". With exactly 1 active task and no anchor, the command targets that task. With 2+ active tasks and no anchor you'll get an "Ambiguous" error listing the active slugs — fix by anchoring via any of the three mechanisms above.
+
+## Lifecycle
+
+```bash
+mship init [--detect | --name N --repo PATH:TYPE]   # scaffold mothership.yaml
+mship init --install-hooks                          # (re)install pre-commit guard on every git root
+mship spawn "description" [--repos a,b] [--skip-setup] [--bypass-reconcile]
+mship switch <repo>                                 # cross-repo context switch
+mship phase plan|dev|review|run [-f]                # transition with soft-gate warnings
+mship block "reason" | mship unblock
+mship test [--all] [--repos|--tag] [--no-diff]
+mship journal [-]                                   # read task log; pass message to append
+mship journal "msg" [--action X] [--open Y] [--repo R] [--test-state pass|fail|mixed]
+mship journal --show-open                           # list open questions
+mship finish [--body-file PATH | --body TEXT] [--base B] [--base-map a=B,b=B] [--push-only] [--handoff] [--force-audit] [--bypass-reconcile] [--force]
+mship close [--yes] [--abandon] [--force] [--skip-pr-check] [--bypass-reconcile]
+```
+
+## Inspection
+
+```bash
+mship status                                        # task, phase, branch, drift, last log, finished warning
+mship context                                       # one-shot agent-readable JSON snapshot of workspace state
+mship dispatch --task <slug> -i "<instruction>"     # emit self-contained subagent prompt to stdout
+mship audit [--repos r] [--json]
+mship reconcile [--json] [--ignore SLUG] [--clear-ignores] [--refresh]
+mship view status|logs|diff|spec [--watch]
+mship view spec --web                               # serve rendered spec on localhost
+mship graph
+mship worktrees
+mship doctor
+```
+
+## Maintenance
+
+```bash
+mship sync [--repos r]                              # fast-forward behind-only clean repos
+mship prune [--force]                               # remove orphaned worktrees
+```
+
+## Long-running services
+
+```bash
+mship run [--repos a,b] [--tag t]                   # start services per dependency tier
+mship logs <service>                                # tail logs for a service
+```
+
+## `mship finish`
+
+### PR body
+
+`mship finish` rejects empty PR bodies. Two ways to provide one:
+
+```bash
+mship finish --body-file /tmp/pr-body.md            # read from file
+echo "..." | mship finish --body-file -             # read from stdin
+mship finish --body "inline text"                   # inline (also supports `-` for stdin)
+```
+
+A TTY guard on both `-` forms errors fast if stdin is an interactive terminal instead of hanging.
+
+### PR base branch
+
+Each repo's PR can target a non-default base. Resolution order (most-specific wins):
+
+- `--base <branch>` — global override for all repos.
+- `--base-map cli=main,api=release/x` — per-repo overrides.
+- `base_branch` in the repo's `mothership.yaml` entry.
+- Remote default branch.
+
+`mship finish` verifies every resolved base exists on `origin` before any push.
+
+### `--force` vs normal re-finish
+
+`mship finish` is idempotent: a second run after `finished_at` is stamped is a no-op. To push additional commits to the existing PRs (e.g., reviewer feedback), use `mship finish --force`. It pushes, updates `finished_at`, writes a `re-finished` journal entry, and does NOT create a new PR or modify the existing body. Edit the body separately via `gh pr edit <url> --body-file <path>`.
+
+## Drift audit & sync
+
+### Issue codes
+
+- Errors (block `spawn`/`finish`): `path_missing`, `not_a_git_repo`, `fetch_failed`, `detached_head`, `unexpected_branch`, `dirty_worktree`, `no_upstream`, `behind_remote`, `diverged`, `extra_worktrees`.
+- Warnings (don't block): `dirty_untracked` (untracked files only).
+- Info-only: `ahead_remote`.
+
+### Per-repo policy
+
+```yaml
+repos:
+  schemas:
+    path: ../schemas
+    expected_branch: marshal-refactor
+    allow_dirty: false
+    allow_extra_worktrees: false
+```
+
+### Workspace policy
+
+```yaml
+audit:
+  block_spawn: true
+  block_finish: true
+```
+
+### Commands
+
+- `mship audit [--repos r1,r2] [--json]` — exit 1 on any error-severity drift.
+- `mship sync [--repos r1,r2]` — fast-forwards behind-only clean repos.
+- `mship spawn --force-audit` / `mship finish --force-audit` — bypass with a line logged to the task log.
+
+## Live views
+
+`mship view` provides read-only TUIs designed for tmux/zellij panes. All views support `--watch` and `--interval N`.
+
+- `mship view status [--task <slug>] [--watch]` — all tasks stacked by default; `--task` narrows to one.
+- `mship view logs [--task <slug>] [--watch]` — tail the task's log.
+- `mship view diff [--task <slug>] [--watch]` — per-worktree git diff.
+- `mship view spec [name-or-path] [--task <slug>] [--watch] [--web]` — cross-task spec index picker by default.
+
+Keys: `q` quit, `j/k` or arrows to scroll, `PgUp/PgDn`, `Home/End`, `r` force refresh.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,142 @@
+# Configuration
+
+## `mothership.yaml`
+
+```yaml
+workspace: my-platform
+
+# Optional: wraps all task execution with a secret manager
+env_runner: "dotenvx run --"
+
+# Optional: branch naming pattern ({slug} is replaced)
+branch_pattern: "feat/{slug}"
+
+repos:
+  shared:
+    path: ./shared
+    type: library            # "library" or "service"
+    depends_on: []
+    env_runner: "op run --"  # per-repo override
+    tasks:
+      test: unit             # override canonical task name
+  auth-service:
+    path: ./auth-service
+    type: service
+    depends_on: [shared]
+```
+
+## Secret management (`env_runner`)
+
+Mothership doesn't manage secrets. It delegates to your secret manager via `env_runner`:
+
+| Tool | Config value |
+|------|-------------|
+| dotenvx | `dotenvx run --` |
+| Doppler | `doppler run --` |
+| 1Password CLI | `op run --` |
+| Infisical | `infisical run --` |
+| None | omit `env_runner` |
+
+## Monorepo support (`git_root`)
+
+For monorepos where multiple services share one git repo, use `git_root` to declare subdirectory services:
+
+```yaml
+repos:
+  backend:
+    path: .
+    type: service
+  web:
+    path: web              # relative — interpreted against backend's worktree
+    type: service
+    git_root: backend
+    depends_on: [backend]
+```
+
+Rules:
+- `git_root` must reference another repo in the workspace.
+- The referenced repo cannot itself have `git_root` set (no chaining).
+- The subdirectory must exist and contain a `Taskfile.yml`.
+- Subdirectory services still have their own `depends_on`, `tags`, `tasks`, and `start_mode`.
+
+## Service start modes (`start_mode`)
+
+For long-running services, set `start_mode: background`:
+
+```yaml
+repos:
+  infra:
+    path: ./infra
+    type: service
+    start_mode: background     # mship run launches and moves on
+  backend:
+    path: ./backend
+    type: service
+    start_mode: background
+    depends_on: [infra]
+```
+
+With `start_mode: background`, `mship run` launches the service and continues to the next dependency tier without waiting for exit. Background services keep running until Ctrl-C propagates SIGINT through go-task to their child processes. `start_mode` only affects `mship run`. Tests and logs always run foreground.
+
+## Healthchecks
+
+For services that need time to become ready, declare a `healthcheck`. `mship run` waits for the healthcheck to pass before starting dependent services.
+
+```yaml
+repos:
+  infra:
+    path: ./infra
+    type: service
+    start_mode: background
+    healthcheck:
+      tcp: "127.0.0.1:8001"          # wait for port to accept connections
+      timeout: 30s                    # optional, default 30s
+      retry_interval: 500ms           # optional, default 500ms
+
+  backend:
+    path: ./backend
+    type: service
+    start_mode: background
+    depends_on: [infra]
+    healthcheck:
+      http: "http://localhost:8000/health"
+
+  web:
+    path: ./web
+    type: service
+    start_mode: background
+    depends_on: [backend]
+    healthcheck:
+      sleep: 3s                        # unconditional wait
+
+  custom:
+    path: ./custom
+    type: service
+    start_mode: background
+    healthcheck:
+      task: wait-for-custom            # runs `task wait-for-custom`; 0 exit = ready
+```
+
+Probe types: `tcp`, `http`, `sleep`, `task` (any one per healthcheck). Exactly one probe per healthcheck. If the probe doesn't succeed within `timeout`, the service is treated as failed and `mship run` exits non-zero. Healthchecks apply to `mship run` only.
+
+## Task name aliasing
+
+If your Taskfile uses different task names than mothership's defaults (`test`, `run`, `lint`, `setup`), add a `tasks:` mapping:
+
+```yaml
+repos:
+  my-app:
+    path: .
+    type: service
+    tasks:
+      run: dev                 # mship run → task dev
+      test: test:all           # mship test → task test:all
+      lint: lint:all
+      setup: infra:start
+```
+
+`mship doctor` respects the mapping when checking for standard tasks.
+
+## Taskfile contract
+
+Each repo needs a `Taskfile.yml` with standard task names. Mothership calls `task <name>` in each repo. Override names per repo in the `tasks` mapping. Default tasks: `test`, `run`, `lint`, `logs`, `setup`. Missing tasks are skipped gracefully.

--- a/docs/superpowers/plans/2026-04-17-readme-refresh.md
+++ b/docs/superpowers/plans/2026-04-17-readme-refresh.md
@@ -1,0 +1,636 @@
+# README refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-readme-refresh-design.md`
+
+**Goal:** Rewrite `README.md` to the new structure (≤60 lines after cut-20%), extract CLI + configuration reference into `docs/cli.md` and `docs/configuration.md`, and fix stale content (skill install, missing `context`/`dispatch` commands, new `finish` flags).
+
+**Architecture:** Three file touches: create `docs/cli.md` and `docs/configuration.md` as pure moves from the current README, then rewrite `README.md` to the new structure. One cut-20% pass at the end.
+
+**Tech Stack:** Markdown. `mistune` for parse validation (already present as transient dev dep from PR #60; available via `uv run python -c "import mistune"`).
+
+---
+
+## File Structure
+
+| File | Responsibility | Status |
+|---|---|---|
+| `docs/cli.md` | Full CLI command reference: lifecycle, inspection, maintenance, long-running services, `mship finish` detail (base branch, body flags), drift audit & sync, live views, multi-task resolution rules | **create** |
+| `docs/configuration.md` | `mothership.yaml` options, secret management (`env_runner`), monorepo (`git_root`), service start modes, healthchecks, task aliasing, Taskfile contract | **create** |
+| `README.md` | New structure: title, one-sentence description, status, Problem, Quickstart, How it works, Common patterns, Scope, Reference, License | rewrite |
+
+Every line of content that moves out of README into `docs/` must still exist somewhere; nothing is dropped. The rewrite is addition + relocation + deletion, not net content loss.
+
+---
+
+## Task 1: Create `docs/cli.md` (pure move + stale-content fix)
+
+**Files:**
+- Create: `docs/cli.md`
+- No README edits yet.
+
+- [ ] **Step 1.1: Create the file with the new CLI reference**
+
+Create `docs/cli.md` with exactly this content (the structure mirrors the current README's CLI sections, with three additions: `mship context`, `mship dispatch`, and updated `finish` flag list):
+
+````markdown
+# CLI Reference
+
+All task-scoped commands (`status`, `phase`, `test`, `journal`, `view …`, etc.) resolve their target task in this priority order:
+
+1. `--task <slug>` flag — explicit, highest priority.
+2. `MSHIP_TASK` env var — scope a whole shell session to one task.
+3. cwd — if your shell is inside a task's worktree, that task is the default.
+
+With 0 active tasks the command errors with "no active task". With exactly 1 active task and no anchor, the command targets that task. With 2+ active tasks and no anchor you'll get an "Ambiguous" error listing the active slugs — fix by anchoring via any of the three mechanisms above.
+
+## Lifecycle
+
+```bash
+mship init [--detect | --name N --repo PATH:TYPE]   # scaffold mothership.yaml
+mship init --install-hooks                          # (re)install pre-commit guard on every git root
+mship spawn "description" [--repos a,b] [--skip-setup] [--bypass-reconcile]
+mship switch <repo>                                 # cross-repo context switch
+mship phase plan|dev|review|run [-f]                # transition with soft-gate warnings
+mship block "reason" | mship unblock
+mship test [--all] [--repos|--tag] [--no-diff]
+mship journal [-]                                   # read task log; pass message to append
+mship journal "msg" [--action X] [--open Y] [--repo R] [--test-state pass|fail|mixed]
+mship journal --show-open                           # list open questions
+mship finish [--body-file PATH | --body TEXT] [--base B] [--base-map a=B,b=B] [--push-only] [--handoff] [--force-audit] [--bypass-reconcile] [--force]
+mship close [--yes] [--abandon] [--force] [--skip-pr-check] [--bypass-reconcile]
+```
+
+## Inspection
+
+```bash
+mship status                                        # task, phase, branch, drift, last log, finished warning
+mship context                                       # one-shot agent-readable JSON snapshot of workspace state
+mship dispatch --task <slug> -i "<instruction>"     # emit self-contained subagent prompt to stdout
+mship audit [--repos r] [--json]
+mship reconcile [--json] [--ignore SLUG] [--clear-ignores] [--refresh]
+mship view status|logs|diff|spec [--watch]
+mship view spec --web                               # serve rendered spec on localhost
+mship graph
+mship worktrees
+mship doctor
+```
+
+## Maintenance
+
+```bash
+mship sync [--repos r]                              # fast-forward behind-only clean repos
+mship prune [--force]                               # remove orphaned worktrees
+```
+
+## Long-running services
+
+```bash
+mship run [--repos a,b] [--tag t]                   # start services per dependency tier
+mship logs <service>                                # tail logs for a service
+```
+
+## `mship finish`
+
+### PR body
+
+`mship finish` rejects empty PR bodies. Two ways to provide one:
+
+```bash
+mship finish --body-file /tmp/pr-body.md            # read from file
+echo "..." | mship finish --body-file -             # read from stdin
+mship finish --body "inline text"                   # inline (also supports `-` for stdin)
+```
+
+A TTY guard on both `-` forms errors fast if stdin is an interactive terminal instead of hanging.
+
+### PR base branch
+
+Each repo's PR can target a non-default base. Resolution order (most-specific wins):
+
+- `--base <branch>` — global override for all repos.
+- `--base-map cli=main,api=release/x` — per-repo overrides.
+- `base_branch` in the repo's `mothership.yaml` entry.
+- Remote default branch.
+
+`mship finish` verifies every resolved base exists on `origin` before any push.
+
+### `--force` vs normal re-finish
+
+`mship finish` is idempotent: a second run after `finished_at` is stamped is a no-op. To push additional commits to the existing PRs (e.g., reviewer feedback), use `mship finish --force`. It pushes, updates `finished_at`, writes a `re-finished` journal entry, and does NOT create a new PR or modify the existing body. Edit the body separately via `gh pr edit <url> --body-file <path>`.
+
+## Drift audit & sync
+
+### Issue codes
+
+- Errors (block `spawn`/`finish`): `path_missing`, `not_a_git_repo`, `fetch_failed`, `detached_head`, `unexpected_branch`, `dirty_worktree`, `no_upstream`, `behind_remote`, `diverged`, `extra_worktrees`.
+- Warnings (don't block): `dirty_untracked` (untracked files only).
+- Info-only: `ahead_remote`.
+
+### Per-repo policy
+
+```yaml
+repos:
+  schemas:
+    path: ../schemas
+    expected_branch: marshal-refactor
+    allow_dirty: false
+    allow_extra_worktrees: false
+```
+
+### Workspace policy
+
+```yaml
+audit:
+  block_spawn: true
+  block_finish: true
+```
+
+### Commands
+
+- `mship audit [--repos r1,r2] [--json]` — exit 1 on any error-severity drift.
+- `mship sync [--repos r1,r2]` — fast-forwards behind-only clean repos.
+- `mship spawn --force-audit` / `mship finish --force-audit` — bypass with a line logged to the task log.
+
+## Live views
+
+`mship view` provides read-only TUIs designed for tmux/zellij panes. All views support `--watch` and `--interval N`.
+
+- `mship view status [--task <slug>] [--watch]` — all tasks stacked by default; `--task` narrows to one.
+- `mship view logs [--task <slug>] [--watch]` — tail the task's log.
+- `mship view diff [--task <slug>] [--watch]` — per-worktree git diff.
+- `mship view spec [name-or-path] [--task <slug>] [--watch] [--web]` — cross-task spec index picker by default.
+
+Keys: `q` quit, `j/k` or arrows to scroll, `PgUp/PgDn`, `Home/End`, `r` force refresh.
+````
+
+- [ ] **Step 1.2: Markdown parse validation**
+
+```bash
+uv run python -c "
+import mistune, pathlib
+p = pathlib.Path('docs/cli.md')
+html = mistune.html(p.read_text())
+assert '<h1' in html and '<h2' in html and '<code>' in html, 'lost structure'
+# Every command we added must be mentioned:
+for cmd in ('mship context', 'mship dispatch', '--body-file', '--force'):
+    assert cmd in p.read_text(), f'missing: {cmd}'
+print(f'OK — {len(html)} chars rendered')
+"
+```
+
+Expected: `OK — <N> chars rendered`.
+
+- [ ] **Step 1.3: Commit (pair with `mship journal` in a mothership workspace)**
+
+```bash
+git add docs/cli.md
+git commit -m "docs: add CLI reference at docs/cli.md (moved from README; adds context/dispatch/body-file)"
+mship journal "extracted CLI reference to docs/cli.md; added context, dispatch, and finish body-file coverage" --action committed
+```
+
+---
+
+## Task 2: Create `docs/configuration.md` (pure move)
+
+**Files:**
+- Create: `docs/configuration.md`
+- No README edits yet.
+
+- [ ] **Step 2.1: Create the file with the configuration reference**
+
+Create `docs/configuration.md` with exactly this content:
+
+````markdown
+# Configuration
+
+## `mothership.yaml`
+
+```yaml
+workspace: my-platform
+
+# Optional: wraps all task execution with a secret manager
+env_runner: "dotenvx run --"
+
+# Optional: branch naming pattern ({slug} is replaced)
+branch_pattern: "feat/{slug}"
+
+repos:
+  shared:
+    path: ./shared
+    type: library            # "library" or "service"
+    depends_on: []
+    env_runner: "op run --"  # per-repo override
+    tasks:
+      test: unit             # override canonical task name
+  auth-service:
+    path: ./auth-service
+    type: service
+    depends_on: [shared]
+```
+
+## Secret management (`env_runner`)
+
+Mothership doesn't manage secrets. It delegates to your secret manager via `env_runner`:
+
+| Tool | Config value |
+|------|-------------|
+| dotenvx | `dotenvx run --` |
+| Doppler | `doppler run --` |
+| 1Password CLI | `op run --` |
+| Infisical | `infisical run --` |
+| None | omit `env_runner` |
+
+## Monorepo support (`git_root`)
+
+For monorepos where multiple services share one git repo, use `git_root` to declare subdirectory services:
+
+```yaml
+repos:
+  backend:
+    path: .
+    type: service
+  web:
+    path: web              # relative — interpreted against backend's worktree
+    type: service
+    git_root: backend
+    depends_on: [backend]
+```
+
+Rules:
+- `git_root` must reference another repo in the workspace.
+- The referenced repo cannot itself have `git_root` set (no chaining).
+- The subdirectory must exist and contain a `Taskfile.yml`.
+- Subdirectory services still have their own `depends_on`, `tags`, `tasks`, and `start_mode`.
+
+## Service start modes (`start_mode`)
+
+For long-running services, set `start_mode: background`:
+
+```yaml
+repos:
+  infra:
+    path: ./infra
+    type: service
+    start_mode: background     # mship run launches and moves on
+  backend:
+    path: ./backend
+    type: service
+    start_mode: background
+    depends_on: [infra]
+```
+
+With `start_mode: background`, `mship run` launches the service and continues to the next dependency tier without waiting for exit. Background services keep running until Ctrl-C propagates SIGINT through go-task to their child processes. `start_mode` only affects `mship run`. Tests and logs always run foreground.
+
+## Healthchecks
+
+For services that need time to become ready, declare a `healthcheck`. `mship run` waits for the healthcheck to pass before starting dependent services.
+
+```yaml
+repos:
+  infra:
+    path: ./infra
+    type: service
+    start_mode: background
+    healthcheck:
+      tcp: "127.0.0.1:8001"          # wait for port to accept connections
+      timeout: 30s                    # optional, default 30s
+      retry_interval: 500ms           # optional, default 500ms
+
+  backend:
+    path: ./backend
+    type: service
+    start_mode: background
+    depends_on: [infra]
+    healthcheck:
+      http: "http://localhost:8000/health"
+
+  web:
+    path: ./web
+    type: service
+    start_mode: background
+    depends_on: [backend]
+    healthcheck:
+      sleep: 3s                        # unconditional wait
+
+  custom:
+    path: ./custom
+    type: service
+    start_mode: background
+    healthcheck:
+      task: wait-for-custom            # runs `task wait-for-custom`; 0 exit = ready
+```
+
+Probe types: `tcp`, `http`, `sleep`, `task` (any one per healthcheck). Exactly one probe per healthcheck. If the probe doesn't succeed within `timeout`, the service is treated as failed and `mship run` exits non-zero. Healthchecks apply to `mship run` only.
+
+## Task name aliasing
+
+If your Taskfile uses different task names than mothership's defaults (`test`, `run`, `lint`, `setup`), add a `tasks:` mapping:
+
+```yaml
+repos:
+  my-app:
+    path: .
+    type: service
+    tasks:
+      run: dev                 # mship run → task dev
+      test: test:all           # mship test → task test:all
+      lint: lint:all
+      setup: infra:start
+```
+
+`mship doctor` respects the mapping when checking for standard tasks.
+
+## Taskfile contract
+
+Each repo needs a `Taskfile.yml` with standard task names. Mothership calls `task <name>` in each repo. Override names per repo in the `tasks` mapping. Default tasks: `test`, `run`, `lint`, `logs`, `setup`. Missing tasks are skipped gracefully.
+````
+
+- [ ] **Step 2.2: Markdown parse validation**
+
+```bash
+uv run python -c "
+import mistune, pathlib
+p = pathlib.Path('docs/configuration.md')
+html = mistune.html(p.read_text())
+assert '<h1' in html and '<h2' in html and '<code>' in html, 'lost structure'
+for key in ('mothership.yaml', 'env_runner', 'git_root', 'start_mode', 'healthcheck', 'tasks:'):
+    assert key in p.read_text(), f'missing: {key}'
+print(f'OK — {len(html)} chars rendered')
+"
+```
+
+Expected: `OK — <N> chars rendered`.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add docs/configuration.md
+git commit -m "docs: add configuration reference at docs/configuration.md (moved from README)"
+mship journal "extracted configuration reference to docs/configuration.md" --action committed
+```
+
+---
+
+## Task 3: Rewrite `README.md` to the new structure
+
+**Files:**
+- Modify: `README.md` (near-total rewrite; keep MIT license line)
+
+- [ ] **Step 3.1: Replace README.md with the new content**
+
+Overwrite `README.md` entirely with this content:
+
+````markdown
+# mship
+
+State safety for an AI agent working across your git repos: isolated worktrees per task, coordinated PRs, durable cross-session state.
+
+> Pre-1.0. API may change. Pin a commit if you need stability.
+
+## Problem
+
+AI agents given write access across repos routinely commit to `main` because they forgot `git checkout`, modify files in the wrong worktree, lose track of what they changed in repo A while working in repo B, and merge coordinated PRs in the wrong order. These are state-management failures, not agent-skill failures — git alone doesn't model them.
+
+## Quickstart
+
+```bash
+uv tool install git+https://github.com/atomikpanda/mothership.git
+
+cd my-project
+mship init --name my-project --repo .:service
+mship spawn "add hello world"
+cd $(mship status | jq -r '.worktrees."my-project"')
+
+echo 'print("hello")' > hello.py
+git add hello.py
+git commit -m "feat: hello world"
+
+cat > /tmp/body.md <<'EOF'
+## Summary
+First mship task.
+
+## Test plan
+- [x] Runs locally.
+EOF
+mship finish --body-file /tmp/body.md
+```
+
+Requires Python 3.14+ and [uv](https://docs.astral.sh/uv/). Optional: [go-task](https://taskfile.dev), [gh](https://cli.github.com) (for `mship finish`).
+
+## How it works
+
+Each task lives in a git worktree on its own feature branch, one per affected repo. mship manages the worktrees, tracks state in `.mothership/state.yaml`, and gates transitions (`spawn`, `finish`, `close`) on git-state audits. The agent reads structured state via `mship status`, `mship journal`, and `mship context`; it writes via mship commands that update state atomically. A pre-commit hook blocks commits from outside the active task's worktrees.
+
+## Common patterns
+
+**Multi-repo task.** `mship spawn "refactor schema" --repos api,client` creates one worktree per repo on the same feature branch. `mship test` runs them in dependency order, wiring each worktree in as the other's dependency. `mship finish` opens PRs in dependency order with cross-repo coordination blocks.
+
+**Agent session handoff.** `mship dispatch --task <slug> -i "<instruction>"` emits a self-contained prompt — cd directive, branch state, recent journal entries, finish contract — for a fresh subagent. No parent-held context required.
+
+## Scope
+
+- **Does:** isolate writes via worktrees, sequence cross-repo work, gate transitions on git state, surface structured state to agents.
+- **Does not:** run the agent, generate code, manage secrets (delegates to `env_runner`), replace your CI.
+- **Works for:** a single repo, a monorepo (via `git_root`), or multiple repos in one workspace.
+
+## Reference
+
+- [`docs/cli.md`](docs/cli.md) — full command surface.
+- [`docs/configuration.md`](docs/configuration.md) — `mothership.yaml` options, healthchecks, service start modes, monorepo rules, task aliasing.
+- `mship skill install` — installs a bundle of agent-side skills (including `working-with-mothership` — session-start protocol, phase workflow, recovery patterns).
+
+## License
+
+MIT
+````
+
+- [ ] **Step 3.2: Markdown parse validation**
+
+```bash
+uv run python -c "
+import mistune, pathlib
+p = pathlib.Path('README.md')
+html = mistune.html(p.read_text())
+assert '<h1' in html and '<h2' in html and '<code>' in html, 'lost structure'
+# Stale content must be gone:
+for stale in ('/plugin marketplace', 'skill install --all', 'gh pr create'):
+    assert stale not in p.read_text(), f'stale content leaked: {stale}'
+# New one-sentence description must be present:
+assert 'State safety for an AI agent working across your git repos' in p.read_text()
+# Links to docs/ must resolve:
+for link in ('docs/cli.md', 'docs/configuration.md'):
+    assert link in p.read_text(), f'missing reference link: {link}'
+    assert pathlib.Path(link).is_file(), f'link target missing: {link}'
+print(f'OK — {len(html)} chars rendered; line count = {len(p.read_text().splitlines())}')
+"
+```
+
+Expected: `OK — <N> chars rendered; line count = <M>` where M is in the 55–70 range.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): rewrite to one-page shape — problem, quickstart, how, patterns, scope"
+mship journal "rewrote README.md to spec: ~60 lines, doc references out, stale content removed" --action committed
+```
+
+---
+
+## Task 4: Cut-20% pass
+
+**Files:**
+- Modify: `README.md` (trim; no content additions)
+
+- [ ] **Step 4.1: Count lines and identify candidates**
+
+```bash
+wc -l README.md
+```
+
+If the line count is ≤50, skip to Step 4.3. If >50, apply the cut.
+
+Candidates in priority order (per spec's cut list):
+- Redundant `&&` chaining in the Quickstart (split into separate commands if that makes the intent clearer and adds no lines; leave alone otherwise).
+- Adjectives that snuck back in ("simple," "just," "quickly," "robust," "powerful"): search with `grep -E "\\b(simple|just|quickly|robust|powerful|seamless|elegant)\\b" README.md`.
+- Second-level sentences in `## How it works` that restate what the Quickstart already showed.
+- In `## Common patterns`, any clause that enumerates features rather than answering "why reach for this."
+
+- [ ] **Step 4.2: Apply the cut**
+
+Edit `README.md` to remove the identified fat. Re-run:
+
+```bash
+wc -l README.md
+grep -E "\\b(simple|just|quickly|robust|powerful|seamless|elegant)\\b" README.md
+```
+
+Expected: line count ≤ 55; the grep returns no matches.
+
+- [ ] **Step 4.3: Re-run the parse validation from Step 3.2**
+
+```bash
+uv run python -c "
+import mistune, pathlib
+p = pathlib.Path('README.md')
+html = mistune.html(p.read_text())
+for stale in ('/plugin marketplace', 'skill install --all', 'gh pr create'):
+    assert stale not in p.read_text(), f'stale content leaked: {stale}'
+assert 'State safety for an AI agent working across your git repos' in p.read_text()
+for link in ('docs/cli.md', 'docs/configuration.md'):
+    assert link in p.read_text(), f'missing reference link: {link}'
+print(f'OK — {len(html)} chars; {len(p.read_text().splitlines())} lines')
+"
+```
+
+Expected: still passes; line count reflects the cut.
+
+- [ ] **Step 4.4: Commit (if any lines changed)**
+
+If the cut removed anything:
+
+```bash
+git add README.md
+git commit -m "docs(readme): cut-20% pass — trim adjectives and restatements"
+mship journal "applied cut-20% pass; README now <N> lines" --action committed
+```
+
+If the first draft was already ≤50 lines, skip this commit.
+
+---
+
+## Task 5: Copy-paste verification of the Quickstart
+
+**Goal:** validate the Quickstart end-to-end. No files change. This catches placeholder leaks, missing prerequisites, and commands that only work in the author's environment.
+
+- [ ] **Step 5.1: Run the Quickstart in a scratch directory**
+
+```bash
+# In a brand-new temp workspace, NOT inside the mship repo:
+cd /tmp && rm -rf readme-smoke && mkdir readme-smoke && cd readme-smoke
+git init -b main -q
+git config user.email t@t && git config user.name t
+cat > Taskfile.yml <<'EOF'
+version: '3'
+tasks: {}
+EOF
+git add Taskfile.yml && git commit -qm init
+
+# Now the Quickstart (minus `uv tool install`, which we already have):
+uv tool run --from /home/bailey/development/repos/mothership/.worktrees/feat/readme-refresh-value-prop-5-min-walkthrough-install-cleanup mship init --name smoke --repo .:service
+uv tool run --from /home/bailey/development/repos/mothership/.worktrees/feat/readme-refresh-value-prop-5-min-walkthrough-install-cleanup mship spawn "add hello world"
+cd "$(uv tool run --from /home/bailey/development/repos/mothership/.worktrees/feat/readme-refresh-value-prop-5-min-walkthrough-install-cleanup mship status | jq -r '.worktrees."smoke"')"
+echo 'print("hello")' > hello.py
+git add hello.py && git commit -m "feat: hello world"
+```
+
+Don't run `mship finish` — that would try to push and open a GitHub PR against an origin that doesn't exist. The check stops one step short of finish. What this validates:
+- `uv tool install` is the right install incantation (skipped — assumed present).
+- `mship init --name X --repo .:service` produces a valid `mothership.yaml`.
+- `mship spawn` creates a worktree.
+- `mship status | jq -r '.worktrees."<name>"'` resolves to a real path (catches placeholder / quoting bugs).
+- Editing inside the worktree + committing works (catches pre-commit hook surprises).
+
+If any step fails, the Quickstart is wrong. Fix it in `README.md` and re-run Step 5.1.
+
+- [ ] **Step 5.2: Cleanup**
+
+```bash
+cd /home/bailey/development/repos/mothership/.worktrees/feat/readme-refresh-value-prop-5-min-walkthrough-install-cleanup
+rm -rf /tmp/readme-smoke
+```
+
+No commit for this task.
+
+---
+
+## Task 6: Final verification + PR
+
+- [ ] **Step 6.1: 90-second test**
+
+Open `README.md` in a fresh terminal or browser view. Without scrolling past the Scope section, answer:
+
+1. What is it? — should be answerable from the one-sentence description + Problem.
+2. Who is it for? — should be answerable from the one-sentence description.
+3. How would I try it? — should be answerable from the Quickstart.
+4. What does it not do? — should be answerable from Scope.
+
+If any requires inference or scrolling further, go back to Task 4 for another trim, or Task 3 if the structure itself is wrong.
+
+- [ ] **Step 6.2: Full suite (sanity)**
+
+```bash
+uv run pytest -x -q 2>&1 | tail -3
+```
+
+Expected: all pass. No code changed; this should be a pure no-op.
+
+- [ ] **Step 6.3: Open the PR**
+
+```bash
+cat > /tmp/readme-body.md <<'EOF'
+## Summary
+
+Refreshed `README.md` per a written brief: optimize for a developer who might actually use the tool, arrive at "what is it / who is it for / how would I try it / what does it not do" in under 90 seconds, and signal engineering taste through restraint.
+
+- Replaced the 461-line README with ~55 lines: title, one-sentence description, status, Problem, Quickstart, How it works, Common patterns, Scope, Reference, License.
+- Extracted the full CLI reference to `docs/cli.md` (added `mship context`, `mship dispatch`, `finish --body-file`, `finish --force`; dropped the stale slash-command skill-install path).
+- Extracted the configuration reference (mothership.yaml, env_runner, git_root, start_mode, healthchecks, task aliasing, Taskfile contract) to `docs/configuration.md`.
+- Dropped marketing voice, feature-list-before-problem framing, and decorative badges. Removed "doesn't work for" edge case per the brief's "when in doubt, cut."
+
+Prose rules enforced: active voice, present tense, no adjectives the Quickstart can't demonstrate, no emoji in headers, every code block has a language hint, every reference link resolves to a file in the repo.
+
+## Test plan
+
+- [x] `mistune.html()` parse check for README.md, docs/cli.md, docs/configuration.md.
+- [x] Stale-content scan: `/plugin marketplace`, `skill install --all`, `gh pr create` no longer appear in README.
+- [x] Link check: every `[...](docs/...)` link in the README resolves to an existing file.
+- [x] Copy-paste smoke: Quickstart runs in a scratch directory up to (but not including) `mship finish`.
+- [x] 90-second test: the four core questions answerable without scrolling past Scope.
+- [x] Full pytest green (no code changed — pure sanity).
+EOF
+mship finish --body-file /tmp/readme-body.md
+rm /tmp/readme-body.md
+```

--- a/docs/superpowers/specs/2026-04-17-readme-refresh-design.md
+++ b/docs/superpowers/specs/2026-04-17-readme-refresh-design.md
@@ -1,0 +1,135 @@
+# README refresh — Design
+
+## Context
+
+The current `README.md` is 461 lines. It has a strong value-prop paragraph, a dense failure catalog, a decent 60-second walkthrough, and then roughly 280 lines of inline reference content (CLI commands, configuration options, healthchecks, monorepo rules, task aliasing, Taskfile contract). It also contains concretely stale content from work that shipped this session: the skill-install section still describes the old `/plugin marketplace add` flow that PR #55 replaced, the CLI reference omits `mship context` and `mship dispatch`, and `mship finish`'s reference doesn't show `--body-file`, `--body`, or `--force` which PRs #56–#58 added.
+
+This PR is a scoped refresh per a brief from the user that optimizes the README for a specific reader: a developer who might actually use the tool. The secondary reader (a hiring manager / FDE-track interviewer evaluating the author) is served as a consequence of serving the primary reader well, not by writing for them directly. The brief explicitly rules out marketing voice, feature lists before problem statements, decorative badges, roadmaps in the README, and adjectives the reader can't verify from the code.
+
+## Goal
+
+A reader who closes the README after 90 seconds can answer four questions:
+
+1. What is it?
+2. Who is it for?
+3. How would I try it?
+4. What does it not do?
+
+If any of the four requires scrolling or inference, the draft has failed.
+
+## Success criterion
+
+- README fits on one screen's worth of scrolling for the parts that answer questions 1–4 (one-sentence description, problem, quickstart, scope).
+- Quickstart is ≤15 lines of copy-pasteable shell with no unexplained placeholders.
+- No stale content (skill-install, CLI commands, `finish` flags) once the PR lands.
+- Deep reference content (full CLI, configuration surface) lives in `docs/cli.md` and `docs/configuration.md`, linked from the README.
+- Prose rules enforced (see below); final pass cuts 20% of whatever survived the first draft.
+
+## Anti-goals
+
+Per the brief's explicit rules:
+
+- **No marketing voice.** No "powerful," "seamless," "robust," "elegant," "blazingly fast." No adjectives that the quickstart doesn't demonstrate.
+- **No feature lists before problem statements.** The problem comes first; features are what make the problem go away.
+- **No emoji in headers.** No decorative badges (stars, "made with love," tech-stack logos).
+- **No roadmap, no "this project aims to…", no apologies** about pre-1.0 status beyond a neutral one-line callout.
+- **No GIF or screenshot above the quickstart.** Visual content delays the working path.
+- **No reproducing GitHub chrome** (license badge, language breakdown, star count) — GitHub already shows it.
+
+Also out of scope for this PR:
+
+- No website / docs site / versioned docs. The user and the session agreed the project is not yet at that milestone.
+- No PyPI publishing (separate prerequisite for landing-page-scale docs).
+- No rewriting SKILL.md files or AGENTS.md. Those are scoped to their own audiences.
+- No CHANGELOG.md creation — deferred.
+
+## Architecture
+
+### New README structure
+
+Top-to-bottom, in the order readers see content:
+
+1. **Title.** `# mship`
+2. **One-sentence description.** *"State safety for an AI agent working across your git repos: isolated worktrees per task, coordinated PRs, durable cross-session state."*
+3. **Status callout.** One line: `> Pre-1.0. API may change. Pin a commit if you need stability.`
+4. **`## Problem`** — 2-4 sentences naming the specific friction (AI agents + multiple repos = state failures that git alone doesn't model). No enumerated bullet list; prose only.
+5. **`## Quickstart`** — ≤15 lines of shell. Single-repo path (simplest case that exercises the full loop: init → spawn → cd → edit → commit → finish). `uv tool install git+github` as the install, `mship init --name X --repo .:service` as the config, `mship spawn`, `cd $(mship status | jq -r …)`, an edit + commit, `mship finish --body-file /tmp/body.md`. Every line copy-pasteable.
+6. **`## How it works`** — 3–6 sentences on the mechanism: worktree per task per repo, state in `.mothership/state.yaml`, audit gates on transitions, pre-commit hook, structured state surfaced via `mship status`/`journal`/`context`.
+7. **`## Common patterns`** — exactly two concrete patterns that answer "why would I reach for this?":
+   - **Multi-repo task** (`mship spawn --repos …`, test in dep order, coordinated PRs)
+   - **Agent session handoff** (`mship dispatch` emits self-contained prompt for a fresh subagent)
+8. **`## Scope`** — three bullet rows: `Does:`, `Does not:`, `Works for:`. Each row is a single comma-separated list, not an expanded subsection. No `Doesn't work for:` row (decision logged).
+9. **`## Reference`** — three bullets linking out to `docs/cli.md`, `docs/configuration.md`, and `mship skill install` for the AI-agent bundle.
+10. **`## License`** — MIT.
+
+Target length after the cut-20% pass: ≈50–60 lines.
+
+### Move plan
+
+Two new files under `docs/`:
+
+#### `docs/cli.md`
+
+Everything currently in the `## CLI Reference`, `### \`mship finish\``, `### Drift audit & sync`, and `### Live views` sections of the existing README (lines 183–284). Reorganized so the command groups stay logical:
+
+- Lifecycle (the iteration loop)
+- Inspection
+- Maintenance
+- Long-running services
+- `mship finish` detail (PR base resolution, `--body` / `--body-file` / `--force`, etc.)
+- Drift audit & sync (audit codes, per-repo + workspace policy)
+- Live views
+
+Also add the commands that are missing from the current reference: `mship context`, `mship dispatch`. Update `mship finish`'s line to show `--body-file`, `--body`, `--force` flags. Update `mship skill install` to reflect the post-PR-55 install model (writes directly to `~/.claude/skills/` and `~/.agents/skills/mothership/`; no REPL slash commands).
+
+#### `docs/configuration.md`
+
+Everything currently in the `## Configuration` section (lines 286–447). Reorganized into sub-sections that mirror their existing headings:
+
+- `mothership.yaml` overview
+- Secret management (`env_runner`)
+- Monorepo support (`git_root`)
+- Service start modes (`start_mode`)
+- Healthchecks
+- Task name aliasing
+- Taskfile contract
+
+No content changes — pure move. Exception: the existing `## How it fits` and `## Multi-task workflows` sections (lines 78–142) don't belong in the configuration doc; the former folds into the README's new `## How it works` section (compressed from ~10 lines to ~5), the latter folds into `docs/cli.md` as a small subsection under the resolution-rule coverage.
+
+### Prose rules (enforced on every line)
+
+- Active voice, present tense, short sentences.
+- No adjectives that the code doesn't demonstrate.
+- Every code block has a language hint (` ```bash `, ` ```yaml `, ` ```markdown `).
+- No placeholder like `<your-thing-here>` in the quickstart unless genuinely unavoidable.
+- Status, stability, and maturity stated neutrally — one line, no apology.
+- Write for the developer who might use the tool. Never write for the hiring manager.
+
+## The cut-20% pass
+
+After the first draft passes the 90-second test on its own terms, do one more pass and cut 20% of the remaining lines. The brief's rule: "Whatever survives the cut is the README." Candidates for the cut:
+
+- Redundant words in the Quickstart (e.g., `&& git commit` that could be two short lines).
+- Adjectives that snuck back in ("simple," "just," "quickly").
+- Second-level explanations in `## How it works` that restate something already visible in the Quickstart.
+- Anything in `## Common patterns` that enumerates a feature rather than answering "why reach for this."
+
+## Testing
+
+No automated tests (README is prose). Manual verification:
+
+1. **90-second test.** Close the file and time-box reading. At the 90-second mark, can I answer the four questions without scrolling? If not, the structure is wrong — escalate back to design rather than patching prose.
+2. **Copy-paste test.** Run the Quickstart verbatim in a fresh scratch directory. Every command must work without manual substitution. This catches placeholder leaks and missing prerequisites.
+3. **Markdown render check.** `uv run python -c "import mistune; mistune.html(open('README.md').read())"` parses cleanly; all links resolve to files in the repo.
+4. **Reference doc sanity.** `docs/cli.md` and `docs/configuration.md` each render cleanly and cover every command / config key the removed sections did.
+
+## Decisions log
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | One-sentence description: *"State safety for an AI agent working across your git repos: isolated worktrees per task, coordinated PRs, durable cross-session state."* | Names outcome first ("state safety"), audience second ("AI agent"), mechanism third (worktrees/coordination/state). Colon + three-item list reads as structure, not marketing. The user picked this over mechanism-forward and shortest-essence alternatives. |
+| 2 | Scope section includes `Does:`, `Does not:`, `Works for:` — no `Doesn't work for:` row | The "doesn't work for" edge (shallow clones, Dockerized runners without worktree support) is niche; readers who hit it discover it from the first `mship spawn` error. Per the brief's "when in doubt, cut," leaving the row out preserves the section's signal-to-noise ratio. |
+| 3 | Quickstart is single-repo, not multi-repo | Minimum complete loop. Multi-repo is the scaling story, covered in `## Common patterns`. The brief caps the Quickstart at ~15 lines; a multi-repo walkthrough would push 25+. |
+| 4 | Configuration surface moves to `docs/configuration.md`; CLI reference moves to `docs/cli.md`; README links to both | Per the brief: "Most readers should never need to scroll [to the configuration reference]." The reference content stays one click away, not one page-length of scrolling away. |
+| 5 | No roadmap / CHANGELOG / PyPI / website work in this PR | Scope creep. Each of those is its own decision; this PR is the README refresh. |
+| 6 | No rewrite of `## For AI agents` into the new README; replaced with one reference bullet pointing to `mship skill install` + working-with-mothership skill | The current section has ~35 lines of install instructions per platform, most of which is stale post-PR #55 (direct install to `~/.claude/skills/`) and post-PR #58 (the `--all` flag is gone). The one-bullet reference is the minimum faithful pointer; details belong in the skill docs, not the README. |


### PR DESCRIPTION
## Summary

README refresh per a written brief: optimize for a developer who might actually use the tool, get to "what is it / who is it for / how would I try it / what does it not do" in under 90 seconds, signal engineering taste through restraint.

- Rewrote `README.md` from 461 lines to 59: title, one-sentence description, status, Problem, Quickstart, How it works, Common patterns, Scope, Reference, License.
- Extracted CLI reference to `docs/cli.md` (adds `mship context`, `mship dispatch`, `finish --body-file`, `finish --force`; drops stale slash-command skill-install path).
- Extracted configuration reference (mothership.yaml, env_runner, git_root, start_mode, healthchecks, task aliasing, Taskfile contract) to `docs/configuration.md`.
- Dropped marketing voice, feature-list-before-problem framing, decorative badges. Status callout stays one neutral line.

Quickstart is copy-paste validated against a scratch `git init` workspace; `mship init --detect` + `mship status | jq -r '.worktrees | to_entries[0].value'` produce a worktree path that correctly routes the ensuing edit onto the feature branch (not main). An earlier draft used `--repo .:service` which produced an unnamed-repo entry — caught by the smoke test, fixed before merge.

## Test plan

- [x] `mistune.html()` parse check on README.md, docs/cli.md, docs/configuration.md.
- [x] Stale-content scan: `/plugin marketplace`, `skill install --all`, `gh pr create` no longer appear in README.
- [x] Link check: every `[...](docs/...)` link in the README points at an existing file.
- [x] Copy-paste smoke: quickstart runs end-to-end in a scratch `git init` workspace up through `git commit` inside the worktree.
- [x] 90-second test: what-is-it / who-for / how-to-try / what-it-isn't all answerable without scrolling past `## Scope`.
- [x] Full pytest green (805 passed — no code changed, pure sanity).
