### PR TITLE
mship run shows prefixed live stdout and stderr

### DIFF
--- a/docs/superpowers/plans/2026-04-18-mship-run-live-output.md
+++ b/docs/superpowers/plans/2026-04-18-mship-run-live-output.md
@@ -872,7 +872,7 @@ Expected: all green.
 
 - [ ] **Step 4.4: Run full test suite (excluding known-flaky)**
 
-Run: `pytest tests/ --ignore=tests/core/view/test_web_port.py 2>&1 | tail -20`
+Run: `pytest tests/ 2>&1 | tail -20`
 Expected: a passing summary. No regressions in existing tests.
 
 - [ ] **Step 4.5: Commit**
@@ -986,7 +986,7 @@ rm -rf /tmp/run-stream-smoke /tmp/run-stream-smoke.out
 
 ```bash
 cd /home/bailey/development/repos/mothership/.worktrees/feat/mship-run-shows-prefixed-live-stdout-and-stderr
-pytest tests/ --ignore=tests/core/view/test_web_port.py 2>&1 | tail -5
+pytest tests/ 2>&1 | tail -5
 ```
 
 Expected: green summary.

--- a/docs/superpowers/plans/2026-04-18-mship-run-live-output.md
+++ b/docs/superpowers/plans/2026-04-18-mship-run-live-output.md
@@ -1,0 +1,1046 @@
+# `mship run` Live Prefixed Output Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `mship run` stream every service's stdout and stderr to our stdout in real time, prefixed with the repo name, matching docker-compose convention.
+
+**Architecture:** A new `StreamPrinter` helper holds per-repo colors + shared stdout lock. Drain threads read subprocess PIPEs line-by-line and hand each line to the printer. The executor wires both the foreground `run` branch (previously capture-and-discard) and the background `run` branch (previously unread PIPEs) through this path, scoped to `canonical_task == "run"`.
+
+**Tech Stack:** Python 3.14, `subprocess.Popen`, `threading.Thread`, stdlib `sys.stdout` + raw ANSI escape codes (no Rich dependency in the new helper).
+
+**Reference spec:** `docs/superpowers/specs/2026-04-18-mship-run-live-output-design.md`
+
+---
+
+## File structure
+
+**New files:**
+- `src/mship/util/stream_printer.py` — `StreamPrinter` class, `drain_to_printer()` helper, color palette + ANSI helper. One module, one responsibility: prefix service output and serialize writes.
+- `tests/util/test_stream_printer.py` — unit tests for `StreamPrinter` and the ANSI/color helpers.
+- `tests/util/test_shell_streaming.py` — unit tests for `drain_to_printer()` against a fake `Popen`.
+- `tests/core/test_executor_run_streaming.py` — integration tests with real `Popen` subprocesses through the full executor.
+
+**Modified files:**
+- `src/mship/core/executor.py` — `execute()` constructs a `StreamPrinter` when `canonical_task == "run"`; `_execute_one` routes both foreground and background `run` through `Popen` + `drain_to_printer`.
+
+**Unchanged files (expected to stay green):**
+- `src/mship/cli/exec.py` — CLI `run_cmd` wait-loop, signal forwarding, kill-group logic is all reused unchanged.
+- `src/mship/util/shell.py` — `run_streaming`, `run`, `run_task` stay as-is. The new helpers go in a sibling module so `shell.py` keeps its single responsibility (subprocess plumbing, no display logic).
+
+**Task ordering rationale:** Task 1 (StreamPrinter) is pure and testable without subprocesses. Task 2 (drain_to_printer) depends on Task 1 and can be tested with a fake Popen. Task 3 wires the executor end-to-end. Task 4 runs real subprocesses through the whole stack. Task 5 manual smoke + PR.
+
+---
+
+## Task 1: StreamPrinter module
+
+**Files:**
+- Create: `src/mship/util/stream_printer.py`
+- Create: `tests/util/test_stream_printer.py`
+
+**Context:** Pure module. `StreamPrinter` formats and prints prefixed lines under a shared lock. Color is applied via raw ANSI when attached to a TTY, skipped otherwise. Width is computed at construction from the longest repo name in the run.
+
+- [ ] **Step 1.1: Write failing tests**
+
+Write `tests/util/test_stream_printer.py`:
+
+```python
+import io
+import re
+import sys
+import threading
+
+import pytest
+
+from mship.util.stream_printer import StreamPrinter, _assign_colors
+
+
+def _drain_capsys(capsys):
+    """Read the combined captured text. Works under capsys and capfd."""
+    return capsys.readouterr().out
+
+
+def test_write_pads_repo_to_longest_width(capsys):
+    p = StreamPrinter(repos=["api", "worker"], use_color=False)
+    p.write("api", "hello\n")
+    p.write("worker", "world\n")
+    out = _drain_capsys(capsys)
+    assert "api     | hello\n" in out     # 3 chars + 3 pad + "  | "
+    assert "worker  | world\n" in out     # 6 chars + 0 pad + "  | "
+
+
+def test_write_with_single_repo(capsys):
+    p = StreamPrinter(repos=["only"], use_color=False)
+    p.write("only", "line\n")
+    out = _drain_capsys(capsys)
+    assert "only  | line\n" in out
+
+
+def test_write_empty_repo_list(capsys):
+    """Edge case: width=0 still produces a parseable prefix."""
+    p = StreamPrinter(repos=[], use_color=False)
+    p.write("x", "z\n")
+    out = _drain_capsys(capsys)
+    assert "x  | z\n" in out
+
+
+def test_write_strips_trailing_newlines_but_keeps_inner(capsys):
+    p = StreamPrinter(repos=["api"], use_color=False)
+    p.write("api", "line1\n")
+    p.write("api", "line2")          # no trailing newline
+    p.write("api", "line3\r\n")      # CRLF
+    out = _drain_capsys(capsys)
+    assert "api  | line1\n" in out
+    assert "api  | line2\n" in out
+    assert "api  | line3\n" in out
+
+
+def test_use_color_true_adds_ansi(capsys):
+    p = StreamPrinter(repos=["api"], use_color=True)
+    p.write("api", "hello\n")
+    out = _drain_capsys(capsys)
+    assert "\x1b[" in out             # ANSI CSI present
+    assert "hello" in out
+
+
+def test_use_color_false_no_ansi(capsys):
+    p = StreamPrinter(repos=["api"], use_color=False)
+    p.write("api", "hello\n")
+    out = _drain_capsys(capsys)
+    assert "\x1b[" not in out
+
+
+def test_use_color_auto_detects_isatty(capsys, monkeypatch):
+    """When use_color is unset, default to sys.stdout.isatty()."""
+    # capsys makes stdout non-tty; auto-detection should disable color.
+    p = StreamPrinter(repos=["api"])
+    p.write("api", "hello\n")
+    out = _drain_capsys(capsys)
+    assert "\x1b[" not in out
+
+
+def test_assign_colors_deterministic():
+    """Same repo list in any order produces the same repo->color mapping."""
+    c1 = _assign_colors(["b", "a", "c"])
+    c2 = _assign_colors(["a", "c", "b"])
+    assert c1 == c2
+    # Three repos → three distinct colors
+    assert len({c1["a"], c1["b"], c1["c"]}) == 3
+
+
+def test_assign_colors_cycles_palette_beyond_six_repos():
+    """Palette is 6 colors; 8 repos should cycle without crashing."""
+    repos = [f"r{i}" for i in range(8)]
+    colors = _assign_colors(repos)
+    assert len(colors) == 8
+    assert all(isinstance(c, str) for c in colors.values())
+
+
+def test_thread_safety_no_line_tearing(capsys):
+    """10 threads × 100 writes each = 1000 lines. Every captured line
+    must match the valid prefix pattern; no mid-line interleaving."""
+    p = StreamPrinter(repos=["api", "worker"], use_color=False)
+
+    def _writer(repo, n):
+        for i in range(n):
+            p.write(repo, f"line-{i}-{repo}\n")
+
+    threads = [
+        threading.Thread(target=_writer, args=("api", 500)),
+        threading.Thread(target=_writer, args=("worker", 500)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    out = _drain_capsys(capsys)
+    pattern = re.compile(r"^(api|worker)\s*\| line-\d+-(api|worker)$")
+    non_empty = [ln for ln in out.splitlines() if ln]
+    assert len(non_empty) == 1000
+    for ln in non_empty:
+        m = pattern.match(ln)
+        assert m is not None, f"line did not match: {ln!r}"
+        # repo name in prefix must match repo name in content
+        assert m.group(1) == m.group(2), f"prefix/content mismatch: {ln!r}"
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+Run: `pytest tests/util/test_stream_printer.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'mship.util.stream_printer'`.
+
+- [ ] **Step 1.3: Create the module**
+
+Write `src/mship/util/stream_printer.py`:
+
+```python
+"""Line-prefixed, thread-safe printer for `mship run` service output.
+
+Constructed once per `mship run` invocation. Drain threads (one per
+service's stdout and stderr PIPE) call `write()` with each line as it
+arrives. The printer pads the repo name to a fixed width, applies an
+ANSI color when attached to a TTY, acquires a lock, and writes to
+stdout so that lines from parallel services never tear.
+
+This module intentionally has no Rich dependency: it emits raw ANSI
+escape codes so the output is deterministic and easy to test.
+"""
+from __future__ import annotations
+
+import sys
+import threading
+
+
+# Fixed palette, cycled in sorted-repo order for deterministic coloring.
+_PALETTE = ("36", "32", "33", "35", "34", "31")  # cyan, green, yellow, magenta, blue, red
+
+
+def _assign_colors(repos: list[str]) -> dict[str, str]:
+    """Return {repo: ansi_color_code} cycling _PALETTE in sorted order."""
+    return {
+        repo: _PALETTE[i % len(_PALETTE)]
+        for i, repo in enumerate(sorted(repos))
+    }
+
+
+def _colorize(text: str, ansi_code: str) -> str:
+    """Wrap `text` in an ANSI SGR escape sequence."""
+    return f"\x1b[{ansi_code}m{text}\x1b[0m"
+
+
+class StreamPrinter:
+    """Thread-safe line-prefixed printer for multi-service output."""
+
+    def __init__(self, repos: list[str], use_color: bool | None = None) -> None:
+        self._width = max((len(r) for r in repos), default=0)
+        self._colors = _assign_colors(repos)
+        self._use_color = (
+            sys.stdout.isatty() if use_color is None else use_color
+        )
+        self._lock = threading.Lock()
+
+    def write(self, repo: str, line: str) -> None:
+        # Normalise trailing whitespace: strip any \r\n combinations and
+        # re-add exactly one \n so the output is consistent regardless of
+        # what the child process emits.
+        content = line.rstrip("\r\n")
+        prefix = f"{repo:<{self._width}}  | "
+        if self._use_color and repo in self._colors:
+            prefix = _colorize(prefix, self._colors[repo])
+        with self._lock:
+            sys.stdout.write(f"{prefix}{content}\n")
+            sys.stdout.flush()
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+Run: `pytest tests/util/test_stream_printer.py -v`
+Expected: all 10 tests pass.
+
+- [ ] **Step 1.5: Commit (pair with `mship journal`)**
+
+```bash
+git add src/mship/util/stream_printer.py tests/util/test_stream_printer.py
+git commit -m "feat(util): StreamPrinter — thread-safe prefixed line printer"
+mship journal "StreamPrinter with per-repo color, width padding, thread-safe writes; 10 unit tests" --action committed
+```
+
+---
+
+## Task 2: `drain_to_printer` helper
+
+**Files:**
+- Modify: `src/mship/util/stream_printer.py`
+- Create: `tests/util/test_shell_streaming.py`
+
+**Context:** `drain_to_printer(proc, repo, printer)` spawns two daemon threads that call `proc.stdout.readline()` and `proc.stderr.readline()` in a loop, feeding each line into the printer. Returns the threads so callers can `join()` them after `proc.wait()`.
+
+- [ ] **Step 2.1: Write failing tests**
+
+Write `tests/util/test_shell_streaming.py`:
+
+```python
+import io
+import threading
+import time
+
+import pytest
+
+from mship.util.stream_printer import StreamPrinter, drain_to_printer
+
+
+class _FakePopen:
+    """Minimal Popen-shaped object for drain tests."""
+    def __init__(self, stdout_text: str = "", stderr_text: str = ""):
+        self.stdout = io.StringIO(stdout_text) if stdout_text else None
+        self.stderr = io.StringIO(stderr_text) if stderr_text else None
+
+
+def test_drain_prints_stdout_lines(capsys):
+    printer = StreamPrinter(repos=["api"], use_color=False)
+    proc = _FakePopen(stdout_text="line1\nline2\n")
+    threads = drain_to_printer(proc, "api", printer)
+    for t in threads:
+        t.join(timeout=1.0)
+    out = capsys.readouterr().out
+    assert "api  | line1\n" in out
+    assert "api  | line2\n" in out
+
+
+def test_drain_prints_stderr_lines(capsys):
+    printer = StreamPrinter(repos=["api"], use_color=False)
+    proc = _FakePopen(stderr_text="err-line\n")
+    threads = drain_to_printer(proc, "api", printer)
+    for t in threads:
+        t.join(timeout=1.0)
+    out = capsys.readouterr().out
+    assert "api  | err-line\n" in out
+
+
+def test_drain_handles_none_streams(capsys):
+    """If proc.stdout or proc.stderr is None, drain should not error."""
+    printer = StreamPrinter(repos=["api"], use_color=False)
+    proc = _FakePopen()  # both streams None
+    threads = drain_to_printer(proc, "api", printer)
+    for t in threads:
+        t.join(timeout=1.0)
+    # No output, no exceptions
+    assert capsys.readouterr().out == ""
+
+
+def test_drain_prefixes_are_correct_for_multiple_repos(capsys):
+    """Two separate drain invocations writing to same printer — both
+    lines appear with correct prefixes, no tearing."""
+    printer = StreamPrinter(repos=["api", "worker"], use_color=False)
+    p1 = _FakePopen(stdout_text="hello from api\n")
+    p2 = _FakePopen(stdout_text="hello from worker\n")
+    threads = drain_to_printer(p1, "api", printer) + drain_to_printer(p2, "worker", printer)
+    for t in threads:
+        t.join(timeout=1.0)
+    out = capsys.readouterr().out
+    assert "api     | hello from api\n" in out
+    assert "worker  | hello from worker\n" in out
+
+
+def test_drain_returns_two_threads():
+    printer = StreamPrinter(repos=["api"], use_color=False)
+    proc = _FakePopen(stdout_text="a\n", stderr_text="b\n")
+    threads = drain_to_printer(proc, "api", printer)
+    assert len(threads) == 2
+    for t in threads:
+        t.join(timeout=1.0)
+
+
+def test_drain_threads_are_daemons():
+    printer = StreamPrinter(repos=["api"], use_color=False)
+    proc = _FakePopen(stdout_text="a\n")
+    threads = drain_to_printer(proc, "api", printer)
+    for t in threads:
+        assert t.daemon is True
+        t.join(timeout=1.0)
+```
+
+- [ ] **Step 2.2: Run tests to verify they fail**
+
+Run: `pytest tests/util/test_shell_streaming.py -v`
+Expected: FAIL with `ImportError: cannot import name 'drain_to_printer' from 'mship.util.stream_printer'`.
+
+- [ ] **Step 2.3: Add `drain_to_printer` to the module**
+
+Append to `src/mship/util/stream_printer.py`:
+
+```python
+def drain_to_printer(
+    proc,
+    repo: str,
+    printer: StreamPrinter,
+) -> list[threading.Thread]:
+    """Start daemon threads that read proc.stdout and proc.stderr and
+    feed every line to `printer`. Returns the threads so the caller can
+    join() them after proc.wait() if it wants to ensure all output has
+    flushed before continuing.
+
+    If either stream is None (e.g. caller didn't request a PIPE) the
+    corresponding thread exits immediately without error.
+    """
+    def _drain(stream):
+        if stream is None:
+            return
+        try:
+            for line in iter(stream.readline, ""):
+                printer.write(repo, line)
+        except Exception:
+            # Reading from a closed/broken stream: exit cleanly. The
+            # main thread will observe the process exit via proc.wait().
+            pass
+        finally:
+            try:
+                stream.close()
+            except Exception:
+                pass
+
+    threads = [
+        threading.Thread(target=_drain, args=(proc.stdout,), daemon=True),
+        threading.Thread(target=_drain, args=(proc.stderr,), daemon=True),
+    ]
+    for t in threads:
+        t.start()
+    return threads
+```
+
+- [ ] **Step 2.4: Run tests to verify they pass**
+
+Run: `pytest tests/util/test_shell_streaming.py -v`
+Expected: 6 passed.
+
+Run: `pytest tests/util/ -v`
+Expected: all tests in tests/util/ still pass (including the existing `test_shell.py` tests).
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/mship/util/stream_printer.py tests/util/test_shell_streaming.py
+git commit -m "feat(util): drain_to_printer — daemon threads relay Popen output"
+mship journal "drain_to_printer helper + 6 unit tests for Popen-shaped streams" --action committed
+```
+
+---
+
+## Task 3: Wire executor — foreground and background `run` both stream
+
+**Files:**
+- Modify: `src/mship/core/executor.py`
+
+**Context:** The executor has two paths in `_execute_one` that need to change when `canonical_task == "run"`:
+
+1. **Background (`start_mode == "background"` AND canonical is `run`)** — already uses `Popen` via `run_streaming`. Add one line: attach `drain_to_printer` so output actually appears.
+2. **Foreground (anything else with canonical `run`)** — currently calls `run_task()` which uses `subprocess.run(capture_output=True)`. Swap to `Popen` via `run_streaming`, attach drain threads, wait for completion, join drain threads.
+
+In `execute()`, construct the `StreamPrinter` once per call when the canonical task is `run`. Hold as `self._printer` so `_execute_one` can reach it. For non-`run` tasks, leave `self._printer = None`.
+
+No test in this task — existing tests stay green; Task 4 adds new integration tests.
+
+- [ ] **Step 3.1: Run existing executor tests to establish baseline**
+
+Run: `pytest tests/core/test_executor.py -v`
+Expected: all tests pass. Record the pass count for after-comparison.
+
+- [ ] **Step 3.2: Modify the executor**
+
+Edit `src/mship/core/executor.py`:
+
+Add two imports near the top (after the existing `from mship.util.shell import ...` line):
+
+```python
+from mship.util.stream_printer import StreamPrinter, drain_to_printer
+```
+
+In the `RepoExecutor` class, extend `__init__` to initialise `self._printer`:
+
+Find:
+```python
+    def __init__(
+        self,
+        config: WorkspaceConfig,
+        graph: DependencyGraph,
+        state_manager: StateManager,
+        shell: ShellRunner,
+        healthcheck,  # HealthcheckRunner
+    ) -> None:
+        self._config = config
+        self._graph = graph
+        self._state_manager = state_manager
+        self._shell = shell
+        self._healthcheck = healthcheck
+```
+
+Append after `self._healthcheck = healthcheck`:
+
+```python
+        self._printer: StreamPrinter | None = None
+```
+
+Replace the existing `_execute_one` method with:
+
+```python
+    def _execute_one(
+        self,
+        repo_name: str,
+        canonical_task: str,
+        task_slug: str | None,
+    ) -> tuple[RepoResult, object | None]:
+        """Execute a single repo's task. Thread-safe.
+
+        Returns (RepoResult, background_process_or_None).
+        """
+        actual_name = self.resolve_task_name(repo_name, canonical_task)
+        env_runner = self.resolve_env_runner(repo_name)
+        upstream_env = self.resolve_upstream_env(repo_name, task_slug)
+        cwd = self._resolve_cwd(repo_name, task_slug)
+        repo_config = self._config.repos[repo_name]
+
+        if repo_config.start_mode == "background" and canonical_task == "run":
+            # Launch as background subprocess, don't wait
+            command = self._shell.build_command(
+                f"task {actual_name}", env_runner
+            )
+            popen = self._shell.run_streaming(command, cwd=cwd)
+            # Drain stdout/stderr to the shared printer. Threads are daemon
+            # and die naturally when the PIPEs close at process exit.
+            if self._printer is not None:
+                drain_to_printer(popen, repo_name, self._printer)
+            return (
+                RepoResult(
+                    repo=repo_name,
+                    task_name=actual_name,
+                    shell_result=ShellResult(returncode=0, stdout="", stderr=""),
+                    background_pid=popen.pid,
+                ),
+                popen,
+            )
+
+        if canonical_task == "run":
+            # Foreground `run` task: stream output live via Popen + drain
+            # threads, then wait for completion. This replaces the old
+            # capture-and-never-print behavior of run_task().
+            command = self._shell.build_command(
+                f"task {actual_name}", env_runner
+            )
+            _start = _time.monotonic()
+            popen = self._shell.run_streaming(command, cwd=cwd)
+            threads: list = []
+            if self._printer is not None:
+                threads = drain_to_printer(popen, repo_name, self._printer)
+            returncode = popen.wait()
+            for t in threads:
+                t.join(timeout=1.0)
+            _elapsed_ms = int((_time.monotonic() - _start) * 1000)
+            return (
+                RepoResult(
+                    repo=repo_name,
+                    task_name=actual_name,
+                    # Output already streamed to stdout; the ShellResult
+                    # carries only the returncode for downstream logic.
+                    shell_result=ShellResult(returncode=returncode, stdout="", stderr=""),
+                    duration_ms=_elapsed_ms,
+                ),
+                None,
+            )
+
+        # Non-run tasks (setup, test, ...) keep the capture-and-return path.
+        _start = _time.monotonic()
+        shell_result = self._shell.run_task(
+            task_name=canonical_task,
+            actual_task_name=actual_name,
+            cwd=cwd,
+            env_runner=env_runner,
+            env=upstream_env or None,
+        )
+        _elapsed_ms = int((_time.monotonic() - _start) * 1000)
+
+        return (
+            RepoResult(
+                repo=repo_name,
+                task_name=actual_name,
+                shell_result=shell_result,
+                duration_ms=_elapsed_ms,
+            ),
+            None,
+        )
+```
+
+Note: the background branch's `ShellResult(returncode=0, ...)` is unchanged from the existing code — we trust Popen spawned successfully. The foreground `run` branch's `upstream_env` is not threaded through `run_streaming`; see Step 3.3 for why this is OK for v1.
+
+Replace the existing `execute()` method to construct the printer:
+
+Find the start of `execute`:
+```python
+    def execute(
+        self,
+        canonical_task: str,
+        repos: list[str],
+        run_all: bool = False,
+        task_slug: str | None = None,
+    ) -> ExecutionResult:
+        tiers = self._graph.topo_tiers(repos)
+        result = ExecutionResult()
+```
+
+Insert a new block immediately after `result = ExecutionResult()`:
+
+```python
+        if canonical_task == "run":
+            self._printer = StreamPrinter(repos=sorted(set(repos)))
+        else:
+            self._printer = None
+```
+
+(The rest of `execute()` stays unchanged.)
+
+- [ ] **Step 3.3: Handle upstream_env in foreground-run path**
+
+`run_streaming(command, cwd)` today does not accept an `env` argument. Foreground `run` tasks have `upstream_env` set when the repo has `depends_on` with worktree paths. To keep the foreground run path equivalent to the previous capture-output path, either:
+
+1. Thread `env` through `run_streaming`, or
+2. Inline the Popen call in the executor (bypassing `run_streaming`) with env wired in.
+
+Choose option 1 — it's a tiny change and keeps `run_streaming` honest.
+
+Edit `src/mship/util/shell.py`. Change the signature of `run_streaming`:
+
+Find:
+```python
+    def run_streaming(self, command: str, cwd: Path) -> subprocess.Popen:
+        """Run a command with stdout/stderr streaming (for logs, run).
+
+        Launches the subprocess in its own process group so signal delivery
+        can reach the whole tree (including grandchildren) on termination.
+        """
+        kwargs = dict(
+            shell=True,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if os.name == "nt":
+            kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            kwargs["start_new_session"] = True
+        return subprocess.Popen(command, **kwargs)
+```
+
+Replace with:
+```python
+    def run_streaming(
+        self,
+        command: str,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.Popen:
+        """Run a command with stdout/stderr streaming (for logs, run).
+
+        Launches the subprocess in its own process group so signal delivery
+        can reach the whole tree (including grandchildren) on termination.
+        """
+        run_env = None
+        if env:
+            run_env = {**os.environ, **env}
+        kwargs = dict(
+            shell=True,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=run_env,
+        )
+        if os.name == "nt":
+            kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            kwargs["start_new_session"] = True
+        return subprocess.Popen(command, **kwargs)
+```
+
+Then update the foreground-run branch in `_execute_one` (Step 3.2) to pass `env`:
+
+Find (inside the `if canonical_task == "run":` branch you just wrote):
+```python
+            popen = self._shell.run_streaming(command, cwd=cwd)
+```
+
+Replace with:
+```python
+            popen = self._shell.run_streaming(command, cwd=cwd, env=upstream_env or None)
+```
+
+(Do NOT change the background-run branch. Background tasks don't use upstream_env today, and changing that is out of scope.)
+
+- [ ] **Step 3.4: Run the existing executor tests**
+
+Run: `pytest tests/core/test_executor.py tests/util/test_shell.py -v`
+Expected: all existing tests still pass. The executor change only affects `canonical_task == "run"` paths; setup/test/other tasks unaffected. The `run_streaming` signature change is additive (env defaults to None).
+
+If any test fails, fix the mismatch. Candidates for breakage:
+- A test that passes positional args to `run_streaming` — unlikely, but check.
+- A test that mocks `subprocess.Popen` and asserts on the kwarg dict — it will now also see `env=None` added. Update the assertion to not require an exact-match dict.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add src/mship/core/executor.py src/mship/util/shell.py
+git commit -m "feat(executor): stream run-task output via StreamPrinter"
+mship journal "executor wires foreground + background run through drain_to_printer; run_streaming gets env kwarg" --action committed
+```
+
+---
+
+## Task 4: Integration test with real subprocesses
+
+**Files:**
+- Create: `tests/core/test_executor_run_streaming.py`
+
+**Context:** End-to-end test that runs real `sh -c '...'` subprocesses through the full executor and asserts the streamed output appears in pytest's `capsys`. This is the test that catches regressions in the integration wiring between executor, StreamPrinter, and drain threads.
+
+- [ ] **Step 4.1: Write the test file**
+
+Write `tests/core/test_executor_run_streaming.py`:
+
+```python
+"""Integration tests for `canonical_task == "run"` streaming.
+
+These spin up real subprocesses and assert on captured stdout. They
+use shell.run_streaming via the real executor — no mocks on the
+subprocess layer.
+"""
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mship.core.config import RepoConfig, WorkspaceConfig
+from mship.core.executor import RepoExecutor
+from mship.core.graph import DependencyGraph
+from mship.util.shell import ShellRunner
+
+
+def _build_executor(tmp_path: Path, repo_commands: dict[str, str]) -> RepoExecutor:
+    """Build a real RepoExecutor over a minimal config. Each repo's `run`
+    task is set to an inline shell command — no Taskfile indirection.
+    repo_commands maps repo name to the shell command string to run."""
+    repos: dict[str, RepoConfig] = {}
+    for name, cmd in repo_commands.items():
+        repo_dir = tmp_path / name
+        repo_dir.mkdir()
+        repos[name] = RepoConfig(
+            path=repo_dir,
+            type="service",
+            tasks={"run": cmd},
+            start_mode="foreground",
+        )
+    config = WorkspaceConfig(workspace="t", repos=repos)
+    graph = DependencyGraph(config)
+    state_mgr = MagicMock()
+    state_mgr.load.return_value = MagicMock(tasks={})
+
+    class _Shell(ShellRunner):
+        """Override build_command so we don't need `task` CLI installed.
+        The test sends raw shell strings through run / run_streaming."""
+        def build_command(self, command: str, env_runner: str | None = None) -> str:
+            # command is "task <actual-name>" where actual-name is the raw
+            # command we stashed in tasks["run"]. Strip the `task ` prefix
+            # and execute the command directly.
+            if command.startswith("task "):
+                return command[len("task "):]
+            return command
+
+    return RepoExecutor(
+        config=config,
+        graph=graph,
+        state_manager=state_mgr,
+        shell=_Shell(),
+        healthcheck=MagicMock(wait=lambda *a, **kw: MagicMock(ready=True, message="")),
+    )
+
+
+def test_foreground_run_streams_stdout_and_stderr(capsys, tmp_path):
+    ex = _build_executor(tmp_path, {
+        "api": "sh -c 'echo hello; echo world >&2; exit 0'",
+    })
+    result = ex.execute("run", repos=["api"])
+    out = capsys.readouterr().out
+    assert "api  | hello" in out
+    assert "api  | world" in out
+    assert result.success is True
+
+
+def test_foreground_run_nonzero_returncode_still_streams(capsys, tmp_path):
+    ex = _build_executor(tmp_path, {
+        "api": "sh -c 'echo oops; exit 2'",
+    })
+    result = ex.execute("run", repos=["api"])
+    out = capsys.readouterr().out
+    assert "api  | oops" in out
+    assert result.success is False
+    assert result.results[0].shell_result.returncode == 2
+
+
+def test_two_parallel_services_both_visible(capsys, tmp_path):
+    ex = _build_executor(tmp_path, {
+        "api":    "sh -c 'echo from-api; sleep 0.05; echo api-done'",
+        "worker": "sh -c 'echo from-worker; sleep 0.05; echo worker-done'",
+    })
+    result = ex.execute("run", repos=["api", "worker"])
+    out = capsys.readouterr().out
+    assert "api     | from-api" in out
+    assert "api     | api-done" in out
+    assert "worker  | from-worker" in out
+    assert "worker  | worker-done" in out
+    assert result.success is True
+
+
+def test_background_run_streams_output(capsys, tmp_path):
+    """`start_mode: background` services also get their output relayed."""
+    repo_dir = tmp_path / "bg"
+    repo_dir.mkdir()
+    config = WorkspaceConfig(
+        workspace="t",
+        repos={
+            "bg": RepoConfig(
+                path=repo_dir,
+                type="service",
+                tasks={"run": "sh -c 'echo bg-hello; sleep 0.1'"},
+                start_mode="background",
+            ),
+        },
+    )
+    graph = DependencyGraph(config)
+    state_mgr = MagicMock()
+    state_mgr.load.return_value = MagicMock(tasks={})
+
+    class _Shell(ShellRunner):
+        def build_command(self, command: str, env_runner: str | None = None) -> str:
+            return command[len("task "):] if command.startswith("task ") else command
+
+    ex = RepoExecutor(
+        config=config,
+        graph=graph,
+        state_manager=state_mgr,
+        shell=_Shell(),
+        healthcheck=MagicMock(wait=lambda *a, **kw: MagicMock(ready=True, message="")),
+    )
+    result = ex.execute("run", repos=["bg"])
+    # Background subprocess is still alive here; wait for it to finish so
+    # drain threads fully relay the output before we assert.
+    for proc in result.background_processes:
+        proc.wait(timeout=2)
+    # Give drain threads a moment to flush.
+    import time as _t
+    _t.sleep(0.1)
+    out = capsys.readouterr().out
+    assert "bg  | bg-hello" in out
+
+
+def test_non_run_task_does_not_stream(capsys, tmp_path):
+    """Setup/test/etc stay on the capture path — output should NOT appear
+    on our stdout via the printer."""
+    repo_dir = tmp_path / "r"
+    repo_dir.mkdir()
+    config = WorkspaceConfig(
+        workspace="t",
+        repos={
+            "r": RepoConfig(
+                path=repo_dir,
+                type="service",
+                tasks={"setup": "echo setup-output"},
+                start_mode="foreground",
+            ),
+        },
+    )
+    graph = DependencyGraph(config)
+    state_mgr = MagicMock()
+    state_mgr.load.return_value = MagicMock(tasks={})
+
+    class _Shell(ShellRunner):
+        def build_command(self, command: str, env_runner: str | None = None) -> str:
+            return command[len("task "):] if command.startswith("task ") else command
+
+    ex = RepoExecutor(
+        config=config,
+        graph=graph,
+        state_manager=state_mgr,
+        shell=_Shell(),
+        healthcheck=MagicMock(wait=lambda *a, **kw: MagicMock(ready=True, message="")),
+    )
+    ex.execute("setup", repos=["r"])
+    out = capsys.readouterr().out
+    # setup-output should NOT appear as a prefixed line — setup uses
+    # capture path, returning the string in ShellResult.stdout instead.
+    assert "r  | setup-output" not in out
+```
+
+- [ ] **Step 4.2: Run integration tests**
+
+Run: `pytest tests/core/test_executor_run_streaming.py -v`
+Expected: 5 passed.
+
+If any test fails with a config shape issue (e.g., `RepoConfig` requires fields you didn't provide), inspect `src/mship/core/config.py` for the required defaults and fix the test fixture. Don't work around by modifying the executor — the config shape is the source of truth.
+
+- [ ] **Step 4.3: Run the full executor test subdir**
+
+Run: `pytest tests/core/test_executor.py tests/core/test_executor_run_streaming.py -v`
+Expected: all green.
+
+- [ ] **Step 4.4: Run full test suite (excluding known-flaky)**
+
+Run: `pytest tests/ --ignore=tests/core/view/test_web_port.py 2>&1 | tail -20`
+Expected: a passing summary. No regressions in existing tests.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add tests/core/test_executor_run_streaming.py
+git commit -m "test(executor): integration tests for run streaming"
+mship journal "5 integration tests covering foreground + background + parallel + non-run" --action committed
+```
+
+---
+
+## Task 5: Manual smoke + finish PR
+
+**Files:**
+- None (verification only)
+
+**Context:** Exercise the feature end-to-end with real `task` CLI commands and two repos.
+
+- [ ] **Step 5.1: Reinstall tool, build scratch workspace**
+
+```bash
+cd /home/bailey/development/repos/mothership/.worktrees/feat/mship-run-shows-prefixed-live-stdout-and-stderr
+uv tool install --reinstall --from . mothership
+rm -rf /tmp/run-stream-smoke
+mkdir -p /tmp/run-stream-smoke
+cd /tmp/run-stream-smoke
+
+cat > mothership.yaml <<'EOF'
+workspace: run-stream-smoke
+repos:
+  api:
+    path: ./api
+    type: service
+  worker:
+    path: ./worker
+    type: service
+EOF
+
+mkdir -p api worker
+for r in api worker; do
+  cat > "$r/Taskfile.yml" <<EOF
+version: '3'
+tasks:
+  run:
+    cmds:
+      - for i in 1 2 3 4 5; do echo "[$r] line \$i"; sleep 0.2; done
+      - echo "$r done" >&2
+EOF
+done
+mkdir -p .mothership
+```
+
+- [ ] **Step 5.2: Interleaved foreground streaming**
+
+```bash
+cd /tmp/run-stream-smoke
+mship run 2>&1 | tee /tmp/run-stream-smoke.out
+```
+
+Expected:
+- Lines from both `api` and `worker` interleave in real time (not a burst at the end).
+- Each line is prefixed: `api     | [api] line 1`, `worker  | [worker] line 1`, etc.
+- The stderr line ("api done", "worker done") also appears prefixed.
+- Exit 0 at the end.
+- With the `| tee` pipe, ANSI colors should NOT appear (non-TTY destination).
+
+- [ ] **Step 5.3: TTY smoke (color on)**
+
+```bash
+cd /tmp/run-stream-smoke
+mship run
+```
+
+Expected:
+- Same lines, now with color per-repo prefix (cyan for api, green for worker — whichever the deterministic palette assignment produces in sorted order).
+- Exit 0 at the end.
+
+- [ ] **Step 5.4: Non-zero exit propagates**
+
+Edit api/Taskfile.yml run task to exit 1 at the end:
+
+```bash
+cd /tmp/run-stream-smoke
+cat > api/Taskfile.yml <<'EOF'
+version: '3'
+tasks:
+  run:
+    cmds:
+      - echo "api starting"
+      - echo "api oopsing" >&2
+      - exit 1
+EOF
+
+mship run; echo "EXIT: $?"
+```
+
+Expected:
+- `api  | api starting` and `api  | api oopsing` appear (merged stderr with same prefix).
+- `worker` output also appears.
+- `api: failed to start` summary line (existing CLI behavior).
+- `EXIT: 1`.
+
+- [ ] **Step 5.5: Cleanup**
+
+```bash
+rm -rf /tmp/run-stream-smoke /tmp/run-stream-smoke.out
+```
+
+- [ ] **Step 5.6: Full pytest final check**
+
+```bash
+cd /home/bailey/development/repos/mothership/.worktrees/feat/mship-run-shows-prefixed-live-stdout-and-stderr
+pytest tests/ --ignore=tests/core/view/test_web_port.py 2>&1 | tail -5
+```
+
+Expected: green summary.
+
+- [ ] **Step 5.7: Open PR**
+
+```bash
+cat > /tmp/run-stream-body.md <<'EOF'
+## Summary
+
+`mship run` now streams every service's stdout and stderr to our stdout in real time, prefixed with the repo name. Both foreground and background services were previously silent (foreground: captured-and-never-printed; background: unread PIPEs could fill up and block the child). Both paths now flow through a shared `StreamPrinter` + per-service drain threads.
+
+Prefix format matches docker-compose: `<repo-padded>  | <line>`, per-repo color when stdout is a TTY, bare text when piped.
+
+## Scope
+
+- Only `canonical_task == "run"` streams. `test`, `setup`, and other tasks keep the capture-and-return path (their output is structured and consumed programmatically).
+- Stdout and stderr share the same prefix (matches docker-compose; keeps the split-on-pipe rule clean).
+- No new CLI flags. TTY auto-detection for color.
+
+## New files
+
+- `src/mship/util/stream_printer.py` — `StreamPrinter` class + `drain_to_printer` helper. Single responsibility, no Rich dependency (raw ANSI).
+
+## Modified files
+
+- `src/mship/core/executor.py` — `execute()` constructs the printer when `canonical_task == "run"`; `_execute_one` routes both foreground and background `run` through `Popen` + drain threads.
+- `src/mship/util/shell.py` — `run_streaming` gains an optional `env=` kwarg (so foreground `run` can pass `upstream_env` through).
+
+## Test plan
+
+- [x] `tests/util/test_stream_printer.py`: 10 unit tests (width, color, auto-TTY-detect, palette determinism, thread-safety under 1000 interleaved writes).
+- [x] `tests/util/test_shell_streaming.py`: 6 unit tests for `drain_to_printer` with a fake Popen (stdout, stderr, None streams, multi-repo, return shape, daemon flag).
+- [x] `tests/core/test_executor_run_streaming.py`: 5 integration tests with real subprocesses (single foreground, non-zero exit, parallel tier, background, non-run isolation).
+- [x] Existing `tests/core/test_executor.py` still green — unchanged tasks (setup, test, etc.) unaffected.
+- [x] Manual smoke in a scratch workspace: two services, interleaved prefixed output visible in real time; ANSI present on TTY, absent on `| tee`; non-zero exit propagates with inline error visible.
+
+Fixes the reported adoption blocker: `mship run` no longer looks broken when services fail to start.
+EOF
+
+mship finish --body-file /tmp/run-stream-body.md
+```
+
+Expected: PR URL returned.
+
+---
+
+## Done when
+
+- [x] `StreamPrinter` renders `<repo-padded>  | <content>` lines thread-safely; ANSI applied when `use_color=True` (auto when TTY).
+- [x] `drain_to_printer` spawns daemon threads that read Popen PIPEs and feed the printer; works with None streams.
+- [x] Executor foreground `run`: `Popen` + drain + wait + join — output appears live, returncode propagates to `ShellResult`.
+- [x] Executor background `run`: `Popen` + drain (threads continue after `_execute_one` returns).
+- [x] Non-`run` canonical tasks (setup, test, ...) unchanged — still use `run_task` capture path.
+- [x] `run_streaming` accepts `env=` kwarg so foreground `run` can pass `upstream_env`.
+- [x] All existing tests pass; 21 new tests pass (10 + 6 + 5).
+- [x] Manual smoke confirms interleaved live output, color on TTY, no color when piped, non-zero exit visible.

--- a/docs/superpowers/specs/2026-04-18-mship-run-live-output-design.md
+++ b/docs/superpowers/specs/2026-04-18-mship-run-live-output-design.md
@@ -1,0 +1,263 @@
+# `mship run` — live prefixed stdout/stderr — Design
+
+## Context
+
+`mship run` starts services across repos but the user never sees their output. Two silent bugs in the current implementation:
+
+1. **Background services** (`start_mode: background`): `ShellRunner.run_streaming` spawns `subprocess.Popen(stdout=PIPE, stderr=PIPE)` but nothing drains the PIPEs. Service output is invisible to the user AND the PIPE buffer can fill up, at which point the child blocks on its next write.
+2. **Foreground services** (default `start_mode`): `ShellRunner.run_task` calls `subprocess.run(capture_output=True)`. Output is captured into a `ShellResult` that the CLI never prints. Even on failure, the CLI prints only `"<repo>: failed to start"` — not the actual stderr.
+
+Either way, the user is left guessing why a service didn't come up. This is the single largest adoption blocker for `mship run` in multi-service workspaces.
+
+## Goal
+
+Make `mship run` stream every subprocess's stdout and stderr to our stdout in real time, prefixed with the repo name so lines from parallel services stay disambiguated. Match the docker-compose convention: `<repo-padded>  | <line>`, per-repo color when attached to a TTY, no color when piped. Apply to both `foreground` and `background` services.
+
+## Success criterion
+
+Given a two-repo workspace where each repo's `run` task prints to stdout and stderr, `mship run` produces output like:
+
+```
+api     | Server listening on :8080
+api     | [GET /health] 200 ok
+worker  | Starting queue consumer
+worker  | ERROR: connection refused
+api     | [GET /items] 200 ok
+```
+
+- Lines from both services interleave as they are produced (no multi-second batching).
+- Prefix width is consistent — longest repo name sets the column.
+- Per-repo color when `stdout.isatty()`; bare text when piped or redirected.
+- `[GET /items]` and similar bracketed content in the service's own output is NOT confused with the prefix (prefix is always at line start, ends with `|`, content starts after).
+- Ctrl-C terminates all services and exits cleanly.
+- A service that exits non-zero: its final error output is already visible inline; the CLI's "failed to start" summary stays as today (no duplication).
+
+## Anti-goals
+
+- **No file persistence.** Not writing to `.mothership/logs/<repo>.log`. `mship logs` today delegates to the user's own Taskfile `logs` task — that contract stays.
+- **No change to `test`, `setup`, or any other canonical task.** Only `canonical_task == "run"` switches to streaming. Other tasks still use `run_task` (capture-and-return) because their output is structured and consumed programmatically.
+- **No distinct stderr prefix.** Stdout and stderr share the same prefix. Distinguishing them (e.g., `api ERR|`) adds visual noise and breaks the clean `<repo>|` regex split. Content-level markers (log levels, `Error:`) are the service's job.
+- **No JSON output mode.** Streaming is for humans and agents reading the terminal. `mship context`/`dispatch` cover the structured output need.
+- **No per-line timestamps.** The service can include its own. Adding ours adds column width and clutters short lines.
+- **No rate-limit / throttle.** If a service floods stdout, we relay it verbatim. Users can pipe to `| head` or `| grep` as normal.
+- **No change to `mship run` flags.** No new `--prefix`, `--no-color`, `--log-file`. TTY auto-detection covers color. YAGNI.
+
+## Why prefix format `<repo>  | <line>` (option A from brainstorming)
+
+Agents consuming `mship run` output need to split lines into `(repo, content)` reliably. Three candidates considered:
+
+| Format | Parse risk for content containing… |
+|---|---|
+| `<repo>  \| <line>` | Pipe `\|` is rare in program output — split on first `\|` is near-unambiguous. |
+| `[<repo>] <line>` | Brackets appear in Python tracebacks, JSON-ish formats. Greedy regex false-positives if not line-anchored. |
+| `<repo>: <line>` | Colons are everywhere (timestamps, URLs, `Error:`). Splitting on first `:` breaks constantly. |
+
+Pipe wins. It's also the docker-compose default, which means agents trained on docker-compose output parse it already.
+
+## Architecture
+
+### New helper — `src/mship/util/shell.py::StreamPrinter`
+
+A thread-safe line printer scoped to a single `mship run` invocation.
+
+```python
+class StreamPrinter:
+    """Prefix-and-print service output line-by-line.
+
+    Constructed once per `mship run`; passed into each subprocess's
+    drain threads. All writes go through the lock so lines never tear
+    across services in the final stdout.
+    """
+
+    def __init__(self, repos: list[str], use_color: bool | None = None):
+        self._width = max((len(r) for r in repos), default=0)
+        self._colors = _assign_colors(repos)
+        self._use_color = sys.stdout.isatty() if use_color is None else use_color
+        self._lock = threading.Lock()
+
+    def write(self, repo: str, line: str) -> None:
+        prefix = f"{repo:<{self._width}}  | "
+        if self._use_color and repo in self._colors:
+            prefix = _colorize(prefix, self._colors[repo])
+        with self._lock:
+            sys.stdout.write(f"{prefix}{line.rstrip()}\n")
+            sys.stdout.flush()
+```
+
+- `_assign_colors(repos)` returns `dict[str, str]` with a deterministic color per repo drawn from a fixed palette (`cyan`, `green`, `yellow`, `magenta`, `blue`, `red`) cycling in sorted-repo order. Determinism matters: re-running `mship run` with the same repo list produces the same color scheme.
+- `_colorize(text, color)` wraps with ANSI escape codes (no Rich dependency in this helper — keeps it testable as a pure function with simple string output).
+- `use_color=None` means "auto-detect"; explicit `True/False` is for tests.
+- Output goes to `sys.stdout.write` + `flush()` rather than `print()` so we control newline handling ourselves (the service's line already ended with `\n`; we `rstrip` it and add exactly one `\n`).
+
+### New helper — `src/mship/util/shell.py::drain_to_printer`
+
+```python
+def drain_to_printer(
+    proc: subprocess.Popen,
+    repo: str,
+    printer: StreamPrinter,
+) -> list[threading.Thread]:
+    """Start daemon threads that read proc.stdout and proc.stderr line by
+    line and push each line through `printer`. Returns the threads so
+    callers can join() them after proc.wait() if they want to ensure all
+    output is flushed before continuing.
+    """
+    def _drain(stream):
+        if stream is None:
+            return
+        try:
+            for line in iter(stream.readline, ""):
+                printer.write(repo, line)
+        finally:
+            try:
+                stream.close()
+            except Exception:
+                pass
+
+    threads = [
+        threading.Thread(target=_drain, args=(proc.stdout,), daemon=True),
+        threading.Thread(target=_drain, args=(proc.stderr,), daemon=True),
+    ]
+    for t in threads:
+        t.start()
+    return threads
+```
+
+Stdout and stderr share the same prefix — no visual differentiation. Threads are daemons so they won't block process exit if a service's PIPE is slow to close.
+
+### Executor integration — `src/mship/core/executor.py`
+
+**`_execute_one` when `canonical_task == "run"`:** switch from `run_task()` (capture-output) to `Popen`+drain for BOTH `start_mode` branches.
+
+Foreground `run` (new):
+
+```python
+if canonical_task == "run" and repo_config.start_mode != "background":
+    command = self._shell.build_command(f"task {actual_name}", env_runner)
+    popen = self._shell.run_streaming(command, cwd=cwd)
+    threads = drain_to_printer(popen, repo_name, self._printer)
+    returncode = popen.wait()
+    for t in threads:
+        t.join(timeout=1.0)
+    return (
+        RepoResult(
+            repo=repo_name,
+            task_name=actual_name,
+            shell_result=ShellResult(returncode=returncode, stdout="", stderr=""),
+        ),
+        None,
+    )
+```
+
+Background `run` (existing code, plus one new line):
+
+```python
+if repo_config.start_mode == "background" and canonical_task == "run":
+    command = self._shell.build_command(f"task {actual_name}", env_runner)
+    popen = self._shell.run_streaming(command, cwd=cwd)
+    drain_to_printer(popen, repo_name, self._printer)   # new
+    return (
+        RepoResult(
+            repo=repo_name,
+            task_name=actual_name,
+            shell_result=ShellResult(returncode=0, stdout="", stderr=""),
+            background_pid=popen.pid,
+        ),
+        popen,
+    )
+```
+
+Drain threads for background processes are not joined — they run until the PIPE closes when the background service exits, after which `readline()` returns empty and the thread dies naturally.
+
+**`execute()` constructs the printer once per call** when the canonical task is `run`:
+
+```python
+def execute(self, canonical_task: str, repos: list[str], ...) -> ExecutionResult:
+    if canonical_task == "run":
+        self._printer = StreamPrinter(repos=sorted(set(repos)))
+    else:
+        self._printer = None
+    ...
+```
+
+`self._printer` is an instance attribute because `_execute_one` needs access. Cleared to `None` for non-run tasks so any accidental use fails loudly.
+
+**All other canonical tasks** (`setup`, `test`, anything else) go through the existing `run_task()` capture path. Their output continues to be captured in `ShellResult.stdout`/`stderr` and consumed programmatically by the CLI (test diffs, setup warnings).
+
+### CLI — `src/mship/cli/exec.py::run_cmd`
+
+No changes. The existing wait-loop, signal forwarding, and kill-group logic work unchanged. The drain threads are invisible to this layer.
+
+## Data flow
+
+Per `mship run` invocation:
+
+1. CLI `run_cmd` → `executor.execute("run", repos=[api, worker])`.
+2. `execute()` constructs `StreamPrinter(repos=["api", "worker"])`. Width = 6 (`worker`). Colors: `api=cyan`, `worker=green` (sorted-order palette assignment).
+3. Topo tiers processed in order. For each repo:
+   - Foreground service: `Popen` spawned. Two drain threads start. `proc.wait()` blocks. Every line the service writes to stdout or stderr appears on our stdout as `api     | <line>` within milliseconds. On exit, PIPEs close, threads finish, `proc.wait()` returns, `_execute_one` joins threads (1s timeout, belt-and-suspenders) and returns.
+   - Background service: same Popen + drain, but `_execute_one` returns immediately. Drain threads keep running. CLI's outer loop will `proc.wait()` after signal forwarding is set up.
+4. When all foregrounds complete: `ExecutionResult` returned to CLI. If all succeeded and no background procs remain, CLI prints `"All services started"`. If background procs are alive, CLI waits on them (existing code) while drain threads continue relaying output.
+5. Ctrl-C: existing signal handler sends SIGINT to process groups. Services die, PIPEs close, drain threads exit via empty-readline, main thread proceeds through kill sequence. Clean exit.
+
+## Error handling
+
+- **Service exits non-zero (foreground):** `shell_result.returncode = <nonzero>`. `ExecutionResult.success = False`. CLI prints `"<repo>: failed to start"` as today. The actual error output appeared inline via streaming BEFORE the summary line — no duplication needed.
+- **Service crashes mid-run (background):** `proc.wait()` returns non-zero later. Existing CLI logic: other backgrounds killed, exit 1. Drain threads already relayed whatever output was produced before the crash.
+- **Drain thread dies unexpectedly (e.g., I/O error):** the thread is daemon, so it doesn't block process exit. Output after the failure is lost but the main loop proceeds. Low-risk, acceptable.
+- **PIPE fills up:** eliminated. Both PIPEs are drained in parallel by threads, so neither can block the child's writes.
+- **Line-tearing between services:** eliminated. `StreamPrinter._lock` serializes the final `sys.stdout.write` call.
+- **Partial lines at process exit:** if a service exits mid-line (no trailing `\n`), `readline()` returns the partial content; we strip+print it. Minor cosmetic edge case, not worth special handling.
+- **`sys.stdout.isatty()` called inside a test:** tests using `capsys` or redirecting stdout will see `isatty() == False` → no color. That's what we want for deterministic assertions.
+- **Existing `ShellResult` consumers:** a grep of the codebase for `.stdout` reads on `run` task results finds one usage in `executor.py` (healthcheck formatting). That path receives `shell_result.stdout = ""` for `run` tasks now; healthcheck reads its own message separately. Other `.stdout` reads are on non-`run` tasks (`test`, `setup`) which are unchanged. No downstream breakage.
+
+## Testing
+
+### Unit — `tests/util/test_stream_printer.py` (new)
+
+- `StreamPrinter(repos=["api", "worker"]).write("api", "hello\n")` → captured stdout is `"api     | hello\n"` (with 2-space pad after name; width=6 from "worker" + 2 spaces).
+- Width padding with single repo: `StreamPrinter(repos=["only"])` → prefix `"only  | "`.
+- Width padding with empty list: `StreamPrinter(repos=[])` — width=0, prefix just `"<repo>  | "` (repo name still appears because it's the key). Edge case for safety; `mship run` won't hit it.
+- Color enabled: `use_color=True` → prefix wrapped with ANSI escape codes (assert `\033[` present). `use_color=False` → no escape codes.
+- Color auto-detect: construct in test with stdout redirected (capsys) → `isatty()==False` → no color.
+- Color determinism: same repo list in any order produces the same repo→color mapping (colors assigned by sorted order).
+- Thread safety: 10 threads × 100 writes each = 1000 lines. After `join()`, every captured line starts with a valid prefix (no mid-line split). Use a regex to assert every non-empty captured line matches `^<repo-padded>  | <content>$`.
+
+### Unit — `tests/util/test_shell_streaming.py` (new)
+
+- `drain_to_printer(fake_proc, "api", printer)` with `fake_proc.stdout = io.StringIO("line1\nline2\n")` and `fake_proc.stderr = io.StringIO("err\n")`: after joining both threads, captured stdout contains exactly three lines all prefixed `api | ...`, lines 1 and 2 from stdout in order, "err" appears once (order relative to stdout is non-deterministic due to threading — assert presence only).
+- `stream = None` on one side (rare but possible if caller misuses) → thread exits quickly, no error.
+- `readline()` raising on a closed stream mid-drain → caught, thread exits.
+
+### Integration — `tests/core/test_executor_run_streaming.py` (new)
+
+- Build a real `Executor` with a real `ShellRunner` and fake `GitRunner` / `DependencyGraph`. Config has two repos with `tasks.run` pointing to a shell command that writes to stdout and stderr: `sh -c 'echo hello; echo world >&2'`. `start_mode: foreground`.
+- `executor.execute("run", repos=["api", "worker"])` with `capsys` capturing stdout.
+- Assert:
+  - captured stdout contains `"api"` prefix appearing at least twice (hello + world).
+  - captured stdout contains `"worker"` prefix appearing at least twice.
+  - All lines start at column 0 (no pre-prefix garbage).
+- Repeat with `start_mode: background`: spawn the Popen, manually drain-then-kill (or have the command `sleep 0.2 && exit 0` so it exits on its own), assert same output appeared.
+- Non-zero exit: `sh -c 'echo oops; exit 2'` → output captured in capsys, `result.success == False`, `result.results[0].shell_result.returncode == 2`.
+
+### Regression — `tests/core/test_executor.py` (existing)
+
+- Tests that exercise `setup`, `test`, and other canonical tasks still use the capture path and still read `shell_result.stdout` / `shell_result.stderr`. No changes required, but run the file to confirm no breakage.
+
+### Manual smoke
+
+- Scratch workspace with two repos, each with a `Taskfile.yml` run task that echoes a few lines over a couple of seconds then exits. Run `mship run`; confirm prefixed lines interleave. Ctrl-C the run; confirm clean exit. Re-run with `mship run | cat` (non-TTY stdout); confirm no ANSI escapes in the output. Finally, a background-mode repo: confirm its output also appears live while the foreground services run.
+
+## Decisions log
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Scope to `canonical_task == "run"` only | Other tasks (`test`, `setup`) return structured results that mship consumes. Streaming would require parallel capture which complicates the executor for no user benefit. |
+| 2 | Pipe separator `<repo>  \| <line>`, not brackets or colon | Brackets false-match content (tracebacks, JSON). Colons match everywhere (URLs, timestamps). Pipe is rare in tool output and matches docker-compose convention. |
+| 3 | Stdout + stderr share the same prefix | Visual distinction adds width overhead and breaks the clean split-on-pipe rule. Log level is a content-level concern. Docker-compose also merges. |
+| 4 | Color per-repo via raw ANSI, not Rich | `StreamPrinter` is a tiny pure module — no reason to pull Rich into shell.py. Raw ANSI escapes are deterministic, 6 lines of code, and test-friendly (just check for `\033[` or its absence). |
+| 5 | TTY auto-detection via `sys.stdout.isatty()`, no flag | `--color=always/never/auto` is a classic bikeshed. Auto covers 99% of cases; piped output is automatically clean. Can add a flag later if a real user needs it. |
+| 6 | No file persistence | `.mothership/logs/<repo>.log` would be useful but out of scope. The user's Taskfile `logs` task is the existing persistence contract. Adding ours creates ambiguity. |
+| 7 | `StreamPrinter` constructed once per `execute()` call, held as `self._printer` | Ensures the same width/colors apply across all tiers of a single `mship run`. Scoping to the call (not singleton) keeps tests isolated. |
+| 8 | Drain threads are daemons | Don't block process exit if a background service's PIPE is slow to close. Acceptable loss: at most a few lines of late output during shutdown. |
+| 9 | Foreground `_execute_one` joins drain threads with 1s timeout | Belt-and-suspenders: ensure any buffered output is flushed before the `RepoResult` is returned. 1s is well past any realistic drain time; beyond that, accept loss. |

--- a/src/mship/core/executor.py
+++ b/src/mship/core/executor.py
@@ -9,6 +9,7 @@ from mship.core.graph import DependencyGraph
 from mship.core.healthcheck import HealthcheckResult
 from mship.core.state import StateManager, TestResult
 from mship.util.shell import ShellRunner, ShellResult
+from mship.util.stream_printer import StreamPrinter, drain_to_printer
 
 
 @dataclass
@@ -58,6 +59,7 @@ class RepoExecutor:
         self._state_manager = state_manager
         self._shell = shell
         self._healthcheck = healthcheck
+        self._printer: StreamPrinter | None = None
 
     def resolve_task_name(self, repo_name: str, canonical: str) -> str:
         repo = self._config.repos[repo_name]
@@ -135,8 +137,10 @@ class RepoExecutor:
                 f"task {actual_name}", env_runner
             )
             popen = self._shell.run_streaming(command, cwd=cwd)
-            # Mark as "success" — we launched it. If it crashes later, that's
-            # surfaced via Ctrl-C or process exit observation.
+            # Drain stdout/stderr to the shared printer. Threads are daemon
+            # and die naturally when the PIPEs close at process exit.
+            if self._printer is not None:
+                drain_to_printer(popen, repo_name, self._printer)
             return (
                 RepoResult(
                     repo=repo_name,
@@ -147,6 +151,35 @@ class RepoExecutor:
                 popen,
             )
 
+        if canonical_task == "run":
+            # Foreground `run` task: stream output live via Popen + drain
+            # threads, then wait for completion. This replaces the old
+            # capture-and-never-print behavior of run_task().
+            command = self._shell.build_command(
+                f"task {actual_name}", env_runner
+            )
+            _start = _time.monotonic()
+            popen = self._shell.run_streaming(command, cwd=cwd, env=upstream_env or None)
+            threads: list = []
+            if self._printer is not None:
+                threads = drain_to_printer(popen, repo_name, self._printer)
+            returncode = popen.wait()
+            for t in threads:
+                t.join(timeout=1.0)
+            _elapsed_ms = int((_time.monotonic() - _start) * 1000)
+            return (
+                RepoResult(
+                    repo=repo_name,
+                    task_name=actual_name,
+                    # Output already streamed to stdout; the ShellResult
+                    # carries only the returncode for downstream logic.
+                    shell_result=ShellResult(returncode=returncode, stdout="", stderr=""),
+                    duration_ms=_elapsed_ms,
+                ),
+                None,
+            )
+
+        # Non-run tasks (setup, test, ...) keep the capture-and-return path.
         _start = _time.monotonic()
         shell_result = self._shell.run_task(
             task_name=canonical_task,
@@ -176,6 +209,11 @@ class RepoExecutor:
     ) -> ExecutionResult:
         tiers = self._graph.topo_tiers(repos)
         result = ExecutionResult()
+
+        if canonical_task == "run":
+            self._printer = StreamPrinter(repos=sorted(set(repos)))
+        else:
+            self._printer = None
 
         for tier in tiers:
             tier_results: list[RepoResult] = []

--- a/src/mship/util/shell.py
+++ b/src/mship/util/shell.py
@@ -50,18 +50,27 @@ class ShellRunner:
         command = self.build_command(f"task {actual_task_name}", env_runner)
         return self.run(command, cwd, env=env)
 
-    def run_streaming(self, command: str, cwd: Path) -> subprocess.Popen:
+    def run_streaming(
+        self,
+        command: str,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.Popen:
         """Run a command with stdout/stderr streaming (for logs, run).
 
         Launches the subprocess in its own process group so signal delivery
         can reach the whole tree (including grandchildren) on termination.
         """
+        run_env = None
+        if env:
+            run_env = {**os.environ, **env}
         kwargs = dict(
             shell=True,
             cwd=cwd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            env=run_env,
         )
         if os.name == "nt":
             kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP

--- a/src/mship/util/stream_printer.py
+++ b/src/mship/util/stream_printer.py
@@ -1,0 +1,56 @@
+"""Line-prefixed, thread-safe printer for `mship run` service output.
+
+Constructed once per `mship run` invocation. Drain threads (one per
+service's stdout and stderr PIPE) call `write()` with each line as it
+arrives. The printer pads the repo name to a fixed width, applies an
+ANSI color when attached to a TTY, acquires a lock, and writes to
+stdout so that lines from parallel services never tear.
+
+This module intentionally has no Rich dependency: it emits raw ANSI
+escape codes so the output is deterministic and easy to test.
+"""
+from __future__ import annotations
+
+import sys
+import threading
+
+
+# Fixed palette, cycled in sorted-repo order for deterministic coloring.
+_PALETTE = ("36", "32", "33", "35", "34", "31")  # cyan, green, yellow, magenta, blue, red
+
+
+def _assign_colors(repos: list[str]) -> dict[str, str]:
+    """Return {repo: ansi_color_code} cycling _PALETTE in sorted order."""
+    return {
+        repo: _PALETTE[i % len(_PALETTE)]
+        for i, repo in enumerate(sorted(repos))
+    }
+
+
+def _colorize(text: str, ansi_code: str) -> str:
+    """Wrap `text` in an ANSI SGR escape sequence."""
+    return f"\x1b[{ansi_code}m{text}\x1b[0m"
+
+
+class StreamPrinter:
+    """Thread-safe line-prefixed printer for multi-service output."""
+
+    def __init__(self, repos: list[str], use_color: bool | None = None) -> None:
+        self._width = max((len(r) for r in repos), default=0)
+        self._colors = _assign_colors(repos)
+        self._use_color = (
+            sys.stdout.isatty() if use_color is None else use_color
+        )
+        self._lock = threading.Lock()
+
+    def write(self, repo: str, line: str) -> None:
+        # Normalise trailing whitespace: strip any \r\n combinations and
+        # re-add exactly one \n so the output is consistent regardless of
+        # what the child process emits.
+        content = line.rstrip("\r\n")
+        prefix = f"{repo:<{self._width}}  | "
+        if self._use_color and repo in self._colors:
+            prefix = _colorize(prefix, self._colors[repo])
+        with self._lock:
+            sys.stdout.write(f"{prefix}{content}\n")
+            sys.stdout.flush()

--- a/src/mship/util/stream_printer.py
+++ b/src/mship/util/stream_printer.py
@@ -54,3 +54,41 @@ class StreamPrinter:
         with self._lock:
             sys.stdout.write(f"{prefix}{content}\n")
             sys.stdout.flush()
+
+
+def drain_to_printer(
+    proc,
+    repo: str,
+    printer: StreamPrinter,
+) -> list[threading.Thread]:
+    """Start daemon threads that read proc.stdout and proc.stderr and
+    feed every line to `printer`. Returns the threads so the caller can
+    join() them after proc.wait() if it wants to ensure all output has
+    flushed before continuing.
+
+    If either stream is None (e.g. caller didn't request a PIPE) the
+    corresponding thread exits immediately without error.
+    """
+    def _drain(stream):
+        if stream is None:
+            return
+        try:
+            for line in iter(stream.readline, ""):
+                printer.write(repo, line)
+        except Exception:
+            # Reading from a closed/broken stream: exit cleanly. The
+            # main thread will observe the process exit via proc.wait().
+            pass
+        finally:
+            try:
+                stream.close()
+            except Exception:
+                pass
+
+    threads = [
+        threading.Thread(target=_drain, args=(proc.stdout,), daemon=True),
+        threading.Thread(target=_drain, args=(proc.stderr,), daemon=True),
+    ]
+    for t in threads:
+        t.start()
+    return threads

--- a/src/mship/util/stream_printer.py
+++ b/src/mship/util/stream_printer.py
@@ -73,7 +73,13 @@ def drain_to_printer(
         if stream is None:
             return
         try:
-            for line in iter(stream.readline, ""):
+            while True:
+                line = stream.readline()
+                # Real TextIO.readline returns str; "" signals EOF. A mock
+                # or broken stream may return a non-str — exit the loop so
+                # the thread can never infinite-spin on MagicMock returns.
+                if not isinstance(line, str) or line == "":
+                    break
                 printer.write(repo, line)
         except Exception:
             # Reading from a closed/broken stream: exit cleanly. The

--- a/tests/cli/test_exec.py
+++ b/tests/cli/test_exec.py
@@ -34,6 +34,16 @@ def configured_exec_app(workspace: Path):
 
     mock_shell = MagicMock(spec=ShellRunner)
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok\n", stderr="")
+    # Foreground `run` now goes through run_streaming + Popen.wait() (Task 3).
+    # Return a Popen-shaped mock with None PIPEs so drain threads exit
+    # immediately and wait() returns a real int returncode.
+    popen_mock = MagicMock()
+    popen_mock.pid = 12345
+    popen_mock.stdout = None
+    popen_mock.stderr = None
+    popen_mock.wait.return_value = 0
+    popen_mock.poll.return_value = 0
+    mock_shell.run_streaming.return_value = popen_mock
     container.shell.override(mock_shell)
 
     yield workspace, mock_shell
@@ -94,13 +104,22 @@ def test_mship_run_works_without_active_task(workspace: Path):
     mock_shell = MagicMock(spec=ShellRunner)
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok\n", stderr="")
     mock_shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    # Foreground `run` now goes through run_streaming + Popen.wait() (Task 3).
+    popen_mock = MagicMock()
+    popen_mock.pid = 54321
+    popen_mock.stdout = None
+    popen_mock.stderr = None
+    popen_mock.wait.return_value = 0
+    popen_mock.poll.return_value = 0
+    mock_shell.run_streaming.return_value = popen_mock
     container.shell.override(mock_shell)
 
     try:
         result = runner.invoke(app, ["run", "--repos", "shared"])
         assert result.exit_code == 0, result.output
-        # Executor invoked for the filtered repo
-        assert mock_shell.run_task.called
+        # Executor invoked for the filtered repo. Task 3 changed foreground
+        # `run` to go through run_streaming (was run_task).
+        assert mock_shell.run_streaming.called
     finally:
         container.shell.reset_override()
         container.config_path.reset_override()

--- a/tests/core/test_executor.py
+++ b/tests/core/test_executor.py
@@ -443,6 +443,8 @@ repos:
     # Mock streaming: returns a Popen-like object
     popen_mock = MagicMock()
     popen_mock.pid = 12345
+    popen_mock.stdout = None  # prevent drain threads from looping on mock data
+    popen_mock.stderr = None
     mock_shell.run_streaming.return_value = popen_mock
 
     executor = RepoExecutor(config, graph, state_mgr, mock_shell, healthcheck=MagicMock())
@@ -455,8 +457,8 @@ repos:
     mock_shell.run_streaming.assert_called_once()
 
 
-def test_foreground_start_mode_uses_run_task(workspace: Path):
-    """Default start_mode is foreground — uses run_task."""
+def test_foreground_start_mode_uses_run_streaming(workspace: Path):
+    """Default start_mode is foreground — foreground run uses run_streaming + wait."""
     config = ConfigLoader.load(workspace / "mothership.yaml")
     graph = DependencyGraph(config)
     state_dir = workspace / ".mothership"
@@ -464,12 +466,22 @@ def test_foreground_start_mode_uses_run_task(workspace: Path):
     state_mgr = StateManager(state_dir)
 
     mock_shell = MagicMock(spec=ShellRunner)
-    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    popen_mock = MagicMock()
+    popen_mock.pid = 9999
+    popen_mock.stdout = None  # disable drain threads
+    popen_mock.stderr = None
+    popen_mock.wait.return_value = 0
+    mock_shell.run_streaming.return_value = popen_mock
 
     executor = RepoExecutor(config, graph, state_mgr, mock_shell, healthcheck=MagicMock())
-    executor.execute("run", repos=["shared"])
-    mock_shell.run_task.assert_called_once()
-    mock_shell.run_streaming.assert_not_called()
+    result = executor.execute("run", repos=["shared"])
+    # run_task should NOT be called for foreground run
+    mock_shell.run_task.assert_not_called()
+    # run_streaming SHOULD have been called
+    mock_shell.run_streaming.assert_called_once()
+    # popen.wait() should have been called to block until completion
+    popen_mock.wait.assert_called_once()
+    assert result.success
 
 
 def test_background_returns_in_execution_result(workspace: Path):
@@ -494,6 +506,8 @@ repos:
     mock_shell = MagicMock(spec=ShellRunner)
     popen_mock = MagicMock()
     popen_mock.pid = 12345
+    popen_mock.stdout = None
+    popen_mock.stderr = None
     mock_shell.run_streaming.return_value = popen_mock
 
     executor = RepoExecutor(config, graph, state_mgr, mock_shell, healthcheck=MagicMock())
@@ -525,6 +539,8 @@ repos:
     mock_shell = MagicMock(spec=ShellRunner)
     popen_mock = MagicMock()
     popen_mock.pid = 55555
+    popen_mock.stdout = None
+    popen_mock.stderr = None
     mock_shell.run_streaming.return_value = popen_mock
 
     executor = RepoExecutor(config, graph, state_mgr, mock_shell, healthcheck=MagicMock())
@@ -600,6 +616,8 @@ repos:
     mock_shell = MagicMock(spec=ShellRunner)
     popen_mock = MagicMock()
     popen_mock.pid = 12345
+    popen_mock.stdout = None
+    popen_mock.stderr = None
     mock_shell.run_streaming.return_value = popen_mock
 
     from mship.core.healthcheck import HealthcheckRunner
@@ -643,6 +661,8 @@ repos:
     mock_shell = MagicMock(spec=ShellRunner)
     popen_mock = MagicMock()
     popen_mock.pid = 12345
+    popen_mock.stdout = None
+    popen_mock.stderr = None
     mock_shell.run_streaming.return_value = popen_mock
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
 

--- a/tests/core/test_executor_run_streaming.py
+++ b/tests/core/test_executor_run_streaming.py
@@ -4,6 +4,7 @@ These spin up real subprocesses and assert on captured stdout. They
 use shell.run_streaming via the real executor — no mocks on the
 subprocess layer.
 """
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -14,11 +15,22 @@ from mship.core.executor import RepoExecutor
 from mship.core.graph import DependencyGraph
 from mship.util.shell import ShellRunner
 
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="Integration tests use /bin/sh; skip on Windows.",
+)
 
-def _build_executor(tmp_path: Path, repo_commands: dict[str, str]) -> RepoExecutor:
-    """Build a real RepoExecutor over a minimal config. Each repo's `run`
-    task is set to an inline shell command — no Taskfile indirection.
-    repo_commands maps repo name to the shell command string to run."""
+
+def _build_executor(
+    tmp_path: Path,
+    repo_commands: dict[str, str],
+    *,
+    start_mode: str = "foreground",
+    task_key: str = "run",
+) -> RepoExecutor:
+    """Build a real RepoExecutor over a minimal config. Each repo's
+    task_key task is set to an inline shell command — no Taskfile
+    indirection. repo_commands maps repo name to the shell command string."""
     repos: dict[str, RepoConfig] = {}
     for name, cmd in repo_commands.items():
         repo_dir = tmp_path / name
@@ -26,8 +38,8 @@ def _build_executor(tmp_path: Path, repo_commands: dict[str, str]) -> RepoExecut
         repos[name] = RepoConfig(
             path=repo_dir,
             type="service",
-            tasks={"run": cmd},
-            start_mode="foreground",
+            tasks={task_key: cmd},
+            start_mode=start_mode,
         )
     config = WorkspaceConfig(workspace="t", repos=repos)
     graph = DependencyGraph(config)
@@ -92,33 +104,10 @@ def test_two_parallel_services_both_visible(capsys, tmp_path):
 
 def test_background_run_streams_output(capsys, tmp_path):
     """`start_mode: background` services also get their output relayed."""
-    repo_dir = tmp_path / "bg"
-    repo_dir.mkdir()
-    config = WorkspaceConfig(
-        workspace="t",
-        repos={
-            "bg": RepoConfig(
-                path=repo_dir,
-                type="service",
-                tasks={"run": "sh -c 'echo bg-hello; sleep 0.1'"},
-                start_mode="background",
-            ),
-        },
-    )
-    graph = DependencyGraph(config)
-    state_mgr = MagicMock()
-    state_mgr.load.return_value = MagicMock(tasks={})
-
-    class _Shell(ShellRunner):
-        def build_command(self, command: str, env_runner: str | None = None) -> str:
-            return command[len("task "):] if command.startswith("task ") else command
-
-    ex = RepoExecutor(
-        config=config,
-        graph=graph,
-        state_manager=state_mgr,
-        shell=_Shell(),
-        healthcheck=MagicMock(wait=lambda *a, **kw: MagicMock(ready=True, message="")),
+    ex = _build_executor(
+        tmp_path,
+        {"bg": "sh -c 'echo bg-hello; sleep 0.1'"},
+        start_mode="background",
     )
     result = ex.execute("run", repos=["bg"])
     # Background subprocess is still alive here; wait for it to finish so
@@ -135,33 +124,10 @@ def test_background_run_streams_output(capsys, tmp_path):
 def test_non_run_task_does_not_stream(capsys, tmp_path):
     """Setup/test/etc stay on the capture path — output should NOT appear
     on our stdout via the printer."""
-    repo_dir = tmp_path / "r"
-    repo_dir.mkdir()
-    config = WorkspaceConfig(
-        workspace="t",
-        repos={
-            "r": RepoConfig(
-                path=repo_dir,
-                type="service",
-                tasks={"setup": "echo setup-output"},
-                start_mode="foreground",
-            ),
-        },
-    )
-    graph = DependencyGraph(config)
-    state_mgr = MagicMock()
-    state_mgr.load.return_value = MagicMock(tasks={})
-
-    class _Shell(ShellRunner):
-        def build_command(self, command: str, env_runner: str | None = None) -> str:
-            return command[len("task "):] if command.startswith("task ") else command
-
-    ex = RepoExecutor(
-        config=config,
-        graph=graph,
-        state_manager=state_mgr,
-        shell=_Shell(),
-        healthcheck=MagicMock(wait=lambda *a, **kw: MagicMock(ready=True, message="")),
+    ex = _build_executor(
+        tmp_path,
+        {"r": "echo setup-output"},
+        task_key="setup",
     )
     ex.execute("setup", repos=["r"])
     out = capsys.readouterr().out

--- a/tests/core/test_executor_run_streaming.py
+++ b/tests/core/test_executor_run_streaming.py
@@ -1,0 +1,170 @@
+"""Integration tests for `canonical_task == "run"` streaming.
+
+These spin up real subprocesses and assert on captured stdout. They
+use shell.run_streaming via the real executor — no mocks on the
+subprocess layer.
+"""
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mship.core.config import RepoConfig, WorkspaceConfig
+from mship.core.executor import RepoExecutor
+from mship.core.graph import DependencyGraph
+from mship.util.shell import ShellRunner
+
+
+def _build_executor(tmp_path: Path, repo_commands: dict[str, str]) -> RepoExecutor:
+    """Build a real RepoExecutor over a minimal config. Each repo's `run`
+    task is set to an inline shell command — no Taskfile indirection.
+    repo_commands maps repo name to the shell command string to run."""
+    repos: dict[str, RepoConfig] = {}
+    for name, cmd in repo_commands.items():
+        repo_dir = tmp_path / name
+        repo_dir.mkdir()
+        repos[name] = RepoConfig(
+            path=repo_dir,
+            type="service",
+            tasks={"run": cmd},
+            start_mode="foreground",
+        )
+    config = WorkspaceConfig(workspace="t", repos=repos)
+    graph = DependencyGraph(config)
+    state_mgr = MagicMock()
+    state_mgr.load.return_value = MagicMock(tasks={})
+
+    class _Shell(ShellRunner):
+        """Override build_command so we don't need `task` CLI installed.
+        The test sends raw shell strings through run / run_streaming."""
+        def build_command(self, command: str, env_runner: str | None = None) -> str:
+            # command is "task <actual-name>" where actual-name is the raw
+            # command we stashed in tasks["run"]. Strip the `task ` prefix
+            # and execute the command directly.
+            if command.startswith("task "):
+                return command[len("task "):]
+            return command
+
+    return RepoExecutor(
+        config=config,
+        graph=graph,
+        state_manager=state_mgr,
+        shell=_Shell(),
+        healthcheck=MagicMock(wait=lambda *a, **kw: MagicMock(ready=True, message="")),
+    )
+
+
+def test_foreground_run_streams_stdout_and_stderr(capsys, tmp_path):
+    ex = _build_executor(tmp_path, {
+        "api": "sh -c 'echo hello; echo world >&2; exit 0'",
+    })
+    result = ex.execute("run", repos=["api"])
+    out = capsys.readouterr().out
+    assert "api  | hello" in out
+    assert "api  | world" in out
+    assert result.success is True
+
+
+def test_foreground_run_nonzero_returncode_still_streams(capsys, tmp_path):
+    ex = _build_executor(tmp_path, {
+        "api": "sh -c 'echo oops; exit 2'",
+    })
+    result = ex.execute("run", repos=["api"])
+    out = capsys.readouterr().out
+    assert "api  | oops" in out
+    assert result.success is False
+    assert result.results[0].shell_result.returncode == 2
+
+
+def test_two_parallel_services_both_visible(capsys, tmp_path):
+    ex = _build_executor(tmp_path, {
+        "api":    "sh -c 'echo from-api; sleep 0.05; echo api-done'",
+        "worker": "sh -c 'echo from-worker; sleep 0.05; echo worker-done'",
+    })
+    result = ex.execute("run", repos=["api", "worker"])
+    out = capsys.readouterr().out
+    assert "api     | from-api" in out
+    assert "api     | api-done" in out
+    assert "worker  | from-worker" in out
+    assert "worker  | worker-done" in out
+    assert result.success is True
+
+
+def test_background_run_streams_output(capsys, tmp_path):
+    """`start_mode: background` services also get their output relayed."""
+    repo_dir = tmp_path / "bg"
+    repo_dir.mkdir()
+    config = WorkspaceConfig(
+        workspace="t",
+        repos={
+            "bg": RepoConfig(
+                path=repo_dir,
+                type="service",
+                tasks={"run": "sh -c 'echo bg-hello; sleep 0.1'"},
+                start_mode="background",
+            ),
+        },
+    )
+    graph = DependencyGraph(config)
+    state_mgr = MagicMock()
+    state_mgr.load.return_value = MagicMock(tasks={})
+
+    class _Shell(ShellRunner):
+        def build_command(self, command: str, env_runner: str | None = None) -> str:
+            return command[len("task "):] if command.startswith("task ") else command
+
+    ex = RepoExecutor(
+        config=config,
+        graph=graph,
+        state_manager=state_mgr,
+        shell=_Shell(),
+        healthcheck=MagicMock(wait=lambda *a, **kw: MagicMock(ready=True, message="")),
+    )
+    result = ex.execute("run", repos=["bg"])
+    # Background subprocess is still alive here; wait for it to finish so
+    # drain threads fully relay the output before we assert.
+    for proc in result.background_processes:
+        proc.wait(timeout=2)
+    # Give drain threads a moment to flush.
+    import time as _t
+    _t.sleep(0.1)
+    out = capsys.readouterr().out
+    assert "bg  | bg-hello" in out
+
+
+def test_non_run_task_does_not_stream(capsys, tmp_path):
+    """Setup/test/etc stay on the capture path — output should NOT appear
+    on our stdout via the printer."""
+    repo_dir = tmp_path / "r"
+    repo_dir.mkdir()
+    config = WorkspaceConfig(
+        workspace="t",
+        repos={
+            "r": RepoConfig(
+                path=repo_dir,
+                type="service",
+                tasks={"setup": "echo setup-output"},
+                start_mode="foreground",
+            ),
+        },
+    )
+    graph = DependencyGraph(config)
+    state_mgr = MagicMock()
+    state_mgr.load.return_value = MagicMock(tasks={})
+
+    class _Shell(ShellRunner):
+        def build_command(self, command: str, env_runner: str | None = None) -> str:
+            return command[len("task "):] if command.startswith("task ") else command
+
+    ex = RepoExecutor(
+        config=config,
+        graph=graph,
+        state_manager=state_mgr,
+        shell=_Shell(),
+        healthcheck=MagicMock(wait=lambda *a, **kw: MagicMock(ready=True, message="")),
+    )
+    ex.execute("setup", repos=["r"])
+    out = capsys.readouterr().out
+    # setup-output should NOT appear as a prefixed line — setup uses
+    # capture path, returning the string in ShellResult.stdout instead.
+    assert "r  | setup-output" not in out

--- a/tests/util/test_shell_streaming.py
+++ b/tests/util/test_shell_streaming.py
@@ -1,0 +1,78 @@
+import io
+import threading
+import time
+
+import pytest
+
+from mship.util.stream_printer import StreamPrinter, drain_to_printer
+
+
+class _FakePopen:
+    """Minimal Popen-shaped object for drain tests."""
+    def __init__(self, stdout_text: str = "", stderr_text: str = ""):
+        self.stdout = io.StringIO(stdout_text) if stdout_text else None
+        self.stderr = io.StringIO(stderr_text) if stderr_text else None
+
+
+def test_drain_prints_stdout_lines(capsys):
+    printer = StreamPrinter(repos=["api"], use_color=False)
+    proc = _FakePopen(stdout_text="line1\nline2\n")
+    threads = drain_to_printer(proc, "api", printer)
+    for t in threads:
+        t.join(timeout=1.0)
+    out = capsys.readouterr().out
+    assert "api  | line1\n" in out
+    assert "api  | line2\n" in out
+
+
+def test_drain_prints_stderr_lines(capsys):
+    printer = StreamPrinter(repos=["api"], use_color=False)
+    proc = _FakePopen(stderr_text="err-line\n")
+    threads = drain_to_printer(proc, "api", printer)
+    for t in threads:
+        t.join(timeout=1.0)
+    out = capsys.readouterr().out
+    assert "api  | err-line\n" in out
+
+
+def test_drain_handles_none_streams(capsys):
+    """If proc.stdout or proc.stderr is None, drain should not error."""
+    printer = StreamPrinter(repos=["api"], use_color=False)
+    proc = _FakePopen()  # both streams None
+    threads = drain_to_printer(proc, "api", printer)
+    for t in threads:
+        t.join(timeout=1.0)
+    # No output, no exceptions
+    assert capsys.readouterr().out == ""
+
+
+def test_drain_prefixes_are_correct_for_multiple_repos(capsys):
+    """Two separate drain invocations writing to same printer — both
+    lines appear with correct prefixes, no tearing."""
+    printer = StreamPrinter(repos=["api", "worker"], use_color=False)
+    p1 = _FakePopen(stdout_text="hello from api\n")
+    p2 = _FakePopen(stdout_text="hello from worker\n")
+    threads = drain_to_printer(p1, "api", printer) + drain_to_printer(p2, "worker", printer)
+    for t in threads:
+        t.join(timeout=1.0)
+    out = capsys.readouterr().out
+    assert "api     | hello from api\n" in out
+    assert "worker  | hello from worker\n" in out
+
+
+def test_drain_returns_two_threads():
+    printer = StreamPrinter(repos=["api"], use_color=False)
+    proc = _FakePopen(stdout_text="a\n", stderr_text="b\n")
+    threads = drain_to_printer(proc, "api", printer)
+    assert len(threads) == 2
+    for t in threads:
+        t.join(timeout=1.0)
+
+
+def test_drain_threads_are_daemons():
+    printer = StreamPrinter(repos=["api"], use_color=False)
+    proc = _FakePopen(stdout_text="a\n")
+    threads = drain_to_printer(proc, "api", printer)
+    for t in threads:
+        assert t.daemon is True
+        t.join(timeout=1.0)

--- a/tests/util/test_stream_printer.py
+++ b/tests/util/test_stream_printer.py
@@ -37,7 +37,7 @@ def test_write_empty_repo_list(capsys):
     assert "x  | z\n" in out
 
 
-def test_write_strips_trailing_newlines_but_keeps_inner(capsys):
+def test_write_strips_trailing_newlines(capsys):
     p = StreamPrinter(repos=["api"], use_color=False)
     p.write("api", "line1\n")
     p.write("api", "line2")          # no trailing newline

--- a/tests/util/test_stream_printer.py
+++ b/tests/util/test_stream_printer.py
@@ -1,0 +1,118 @@
+import io
+import re
+import sys
+import threading
+
+import pytest
+
+from mship.util.stream_printer import StreamPrinter, _assign_colors
+
+
+def _drain_capsys(capsys):
+    """Read the combined captured text. Works under capsys and capfd."""
+    return capsys.readouterr().out
+
+
+def test_write_pads_repo_to_longest_width(capsys):
+    p = StreamPrinter(repos=["api", "worker"], use_color=False)
+    p.write("api", "hello\n")
+    p.write("worker", "world\n")
+    out = _drain_capsys(capsys)
+    assert "api     | hello\n" in out     # 3 chars + 3 pad + "  | "
+    assert "worker  | world\n" in out     # 6 chars + 0 pad + "  | "
+
+
+def test_write_with_single_repo(capsys):
+    p = StreamPrinter(repos=["only"], use_color=False)
+    p.write("only", "line\n")
+    out = _drain_capsys(capsys)
+    assert "only  | line\n" in out
+
+
+def test_write_empty_repo_list(capsys):
+    """Edge case: width=0 still produces a parseable prefix."""
+    p = StreamPrinter(repos=[], use_color=False)
+    p.write("x", "z\n")
+    out = _drain_capsys(capsys)
+    assert "x  | z\n" in out
+
+
+def test_write_strips_trailing_newlines_but_keeps_inner(capsys):
+    p = StreamPrinter(repos=["api"], use_color=False)
+    p.write("api", "line1\n")
+    p.write("api", "line2")          # no trailing newline
+    p.write("api", "line3\r\n")      # CRLF
+    out = _drain_capsys(capsys)
+    assert "api  | line1\n" in out
+    assert "api  | line2\n" in out
+    assert "api  | line3\n" in out
+
+
+def test_use_color_true_adds_ansi(capsys):
+    p = StreamPrinter(repos=["api"], use_color=True)
+    p.write("api", "hello\n")
+    out = _drain_capsys(capsys)
+    assert "\x1b[" in out             # ANSI CSI present
+    assert "hello" in out
+
+
+def test_use_color_false_no_ansi(capsys):
+    p = StreamPrinter(repos=["api"], use_color=False)
+    p.write("api", "hello\n")
+    out = _drain_capsys(capsys)
+    assert "\x1b[" not in out
+
+
+def test_use_color_auto_detects_isatty(capsys, monkeypatch):
+    """When use_color is unset, default to sys.stdout.isatty()."""
+    # capsys makes stdout non-tty; auto-detection should disable color.
+    p = StreamPrinter(repos=["api"])
+    p.write("api", "hello\n")
+    out = _drain_capsys(capsys)
+    assert "\x1b[" not in out
+
+
+def test_assign_colors_deterministic():
+    """Same repo list in any order produces the same repo->color mapping."""
+    c1 = _assign_colors(["b", "a", "c"])
+    c2 = _assign_colors(["a", "c", "b"])
+    assert c1 == c2
+    # Three repos → three distinct colors
+    assert len({c1["a"], c1["b"], c1["c"]}) == 3
+
+
+def test_assign_colors_cycles_palette_beyond_six_repos():
+    """Palette is 6 colors; 8 repos should cycle without crashing."""
+    repos = [f"r{i}" for i in range(8)]
+    colors = _assign_colors(repos)
+    assert len(colors) == 8
+    assert all(isinstance(c, str) for c in colors.values())
+
+
+def test_thread_safety_no_line_tearing(capsys):
+    """10 threads × 100 writes each = 1000 lines. Every captured line
+    must match the valid prefix pattern; no mid-line interleaving."""
+    p = StreamPrinter(repos=["api", "worker"], use_color=False)
+
+    def _writer(repo, n):
+        for i in range(n):
+            p.write(repo, f"line-{i}-{repo}\n")
+
+    threads = [
+        threading.Thread(target=_writer, args=("api", 500)),
+        threading.Thread(target=_writer, args=("worker", 500)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    out = _drain_capsys(capsys)
+    pattern = re.compile(r"^(api|worker)\s*\| line-\d+-(api|worker)$")
+    non_empty = [ln for ln in out.splitlines() if ln]
+    assert len(non_empty) == 1000
+    for ln in non_empty:
+        m = pattern.match(ln)
+        assert m is not None, f"line did not match: {ln!r}"
+        # repo name in prefix must match repo name in content
+        assert m.group(1) == m.group(2), f"prefix/content mismatch: {ln!r}"


### PR DESCRIPTION
## Summary

`mship run` now streams every service's stdout and stderr to our stdout in real time, prefixed with the repo name. Both foreground and background services were previously silent (foreground: captured-and-never-printed; background: unread PIPEs could fill up and block the child). Both paths now flow through a shared `StreamPrinter` + per-service drain threads.

Prefix format matches docker-compose: `<repo-padded>  | <line>`, per-repo color when stdout is a TTY, bare text when piped.

## Scope

- Only `canonical_task == "run"` streams. `test`, `setup`, and other tasks keep the capture-and-return path (their output is structured and consumed programmatically).
- Stdout and stderr share the same prefix (matches docker-compose; keeps the split-on-pipe rule clean).
- No new CLI flags. TTY auto-detection for color.

## Bug fix: test suite memory leak

While verifying, discovered the streaming path caused pytest OOM on constrained hardware. Root cause: `drain_to_printer`'s `iter(stream.readline, "")` infinite-loops when `stream` is a MagicMock — `readline()` returns MagicMock, never equal to `""`. Leaked daemon threads wrote millions of MagicMock reprs into capsys buffers.

Fix: switch to `while True` + `isinstance(line, str)` break. Zero behavior change in production (real `TextIO.readline` always returns `str`). Defensive against future mock/stub mistakes. Also updated two test fixtures in `tests/cli/test_exec.py` that relied on Task 3 not-yet-wired `run_streaming` mocks.

Confirmed full suite passes at 130 MB peak RSS (was hitting 7 GB before the fix).

## New files

- `src/mship/util/stream_printer.py` — `StreamPrinter` class + `drain_to_printer` helper. Single responsibility, no Rich dependency (raw ANSI).

## Modified files

- `src/mship/core/executor.py` — `execute()` constructs the printer when `canonical_task == "run"`; `_execute_one` routes both foreground and background `run` through `Popen` + drain threads.
- `src/mship/util/shell.py` — `run_streaming` gains an optional `env=` kwarg (so foreground `run` can pass `upstream_env` through).
- `tests/cli/test_exec.py` — two fixtures updated to mock `run_streaming` as well as `run_task` (Task 3 regression catch).

## Test plan

- [x] `tests/util/test_stream_printer.py`: 10 unit tests (width, color, auto-TTY-detect, palette determinism, thread-safety under 1000 interleaved writes).
- [x] `tests/util/test_shell_streaming.py`: 6 unit tests for `drain_to_printer` with a fake Popen (stdout, stderr, None streams, multi-repo, return shape, daemon flag).
- [x] `tests/core/test_executor_run_streaming.py`: 5 integration tests with real subprocesses (single foreground, non-zero exit, parallel tier, background, non-run isolation). Windows-skip at module level.
- [x] Full suite (`pytest tests/`): 864 passed, 130 MB peak RSS. No `--ignore` flags.
- [x] Manual smoke: two services with real subprocesses produce interleaved prefixed output; non-zero exit propagates with inline error visible; piped output has no ANSI.

Fixes the reported adoption blocker: `mship run` no longer looks broken when services fail to start.
