### PR TITLE
spawn skips setup when task binary missing and doctor surfaces it

### DIFF
--- a/docs/superpowers/plans/2026-04-18-spawn-skip-setup-when-task-missing.md
+++ b/docs/superpowers/plans/2026-04-18-spawn-skip-setup-when-task-missing.md
@@ -1,0 +1,515 @@
+# Spawn Skip Setup When `task` Missing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `mship spawn` silently skips the per-repo setup task when the `task` binary is not on PATH; `mship doctor` surfaces the missing binary as a `warn`-status check so the signal lives in one predictable place.
+
+**Architecture:** Guard the setup `run_task` call in `WorktreeManager.spawn` behind `shutil.which("task") is not None` (two call-sites: git_root branch and normal-repo branch). Add a new `go-task` check to `Doctor.diagnose` that mirrors the existing `gh` pattern (`pass` when found, `warn` when missing). No new config keys, no caching.
+
+**Tech Stack:** Python 3.14, `shutil.which`, existing Pydantic-based config, pytest + `monkeypatch`.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-18-spawn-skip-setup-when-task-missing-design.md`
+**Closes:** #51
+
+---
+
+## File structure
+
+**Modified files:**
+- `src/mship/core/worktree.py` — add `import shutil` if missing; guard the two setup `run_task` calls with `shutil.which("task") is not None`.
+- `src/mship/core/doctor.py` — add `import shutil`; add a new `go-task` check near the existing `gh` block.
+- `tests/core/test_worktree.py` — add a new skip-behavior test; update 2 existing tests to monkeypatch `shutil.which` so they still exercise the setup path on machines without `task` installed.
+- `tests/core/test_doctor.py` — add 2 new tests for `go-task` pass/warn.
+
+**Unchanged files:**
+- `src/mship/util/shell.py` — `run_task` stays identical. The guard lives at the caller.
+- Other `run_task` callers (executor, healthcheck task probes) — out of scope per spec decision 1.
+
+**Task ordering rationale:** Task 1 is the spawn guard — self-contained, touches one production file and one test file. Task 2 is the doctor check — similar shape, different file. Task 3 verifies end-to-end and opens the PR.
+
+---
+
+## Task 1: Guard `WorktreeManager.spawn` setup calls on `shutil.which("task")`
+
+**Files:**
+- Modify: `src/mship/core/worktree.py`
+- Modify: `tests/core/test_worktree.py`
+
+**Context:** The setup block exists twice in `WorktreeManager.spawn` — once inside the `git_root` sub-branch (around line 222) and once inside the normal-repo branch (around line 257). Both wrap an identical `if not skip_setup:` guard. Extend each guard with `and shutil.which("task") is not None`. When the binary isn't on PATH, the setup call is skipped silently.
+
+- [ ] **Step 1.1: Write failing test for the skip behavior**
+
+Append to `tests/core/test_worktree.py` (bottom of file):
+
+```python
+def test_spawn_skips_setup_when_task_binary_missing(worktree_deps, monkeypatch):
+    """When `task` binary isn't on PATH, spawn skips the setup run_task
+    call silently — no warning appended, no mock invocation.
+    """
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    monkeypatch.setattr(
+        "mship.core.worktree.shutil.which",
+        lambda name: None if name == "task" else "/usr/bin/" + name,
+    )
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    result = mgr.spawn("task-missing-smoke", repos=["shared"])
+
+    # No setup warning about missing task binary
+    assert not any("setup failed" in w for w in result.setup_warnings)
+    # run_task was NOT called for setup (the guard short-circuits before the call)
+    assert not any(
+        call.kwargs.get("task_name") == "setup"
+        for call in shell.run_task.call_args_list
+    )
+```
+
+- [ ] **Step 1.2: Update existing `test_spawn_runs_setup_task` to monkeypatch `shutil.which`**
+
+Existing test at `tests/core/test_worktree.py:111`:
+
+```python
+def test_spawn_runs_setup_task(worktree_deps):
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("with setup", repos=["shared"])
+    shell.run_task.assert_called()
+```
+
+Replace with:
+
+```python
+def test_spawn_runs_setup_task(worktree_deps, monkeypatch):
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    monkeypatch.setattr(
+        "mship.core.worktree.shutil.which",
+        lambda name: "/usr/local/bin/task" if name == "task" else None,
+    )
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("with setup", repos=["shared"])
+    shell.run_task.assert_called()
+```
+
+- [ ] **Step 1.3: Update existing `test_spawn_collects_setup_warnings_on_failure` to monkeypatch `shutil.which`**
+
+Existing test at `tests/core/test_worktree.py:217`:
+
+```python
+def test_spawn_collects_setup_warnings_on_failure(worktree_deps):
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    # Make setup return non-zero
+    shell.run_task.return_value = ShellResult(
+        returncode=1, stdout="", stderr="setup task not found"
+    )
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    result = mgr.spawn("warning test", repos=["shared"])
+    assert len(result.setup_warnings) == 1
+    assert "shared" in result.setup_warnings[0]
+    assert "setup" in result.setup_warnings[0].lower()
+```
+
+Replace with:
+
+```python
+def test_spawn_collects_setup_warnings_on_failure(worktree_deps, monkeypatch):
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    monkeypatch.setattr(
+        "mship.core.worktree.shutil.which",
+        lambda name: "/usr/local/bin/task" if name == "task" else None,
+    )
+    # Make setup return non-zero
+    shell.run_task.return_value = ShellResult(
+        returncode=1, stdout="", stderr="setup task not found"
+    )
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    result = mgr.spawn("warning test", repos=["shared"])
+    assert len(result.setup_warnings) == 1
+    assert "shared" in result.setup_warnings[0]
+    assert "setup" in result.setup_warnings[0].lower()
+```
+
+- [ ] **Step 1.4: Run the three tests to verify expected state**
+
+Run: `pytest tests/core/test_worktree.py::test_spawn_skips_setup_when_task_binary_missing tests/core/test_worktree.py::test_spawn_runs_setup_task tests/core/test_worktree.py::test_spawn_collects_setup_warnings_on_failure -v`
+
+Expected:
+- `test_spawn_skips_setup_when_task_binary_missing` — **FAIL** (production guard doesn't exist yet; mock returns None for "task" but the spawn still calls run_task).
+- `test_spawn_runs_setup_task` — **PASS** (production doesn't check shutil.which, so run_task is still called; the added monkeypatch is a no-op for now).
+- `test_spawn_collects_setup_warnings_on_failure` — **PASS** (same reason).
+
+- [ ] **Step 1.5: Add the production guard in `worktree.py`**
+
+Edit `src/mship/core/worktree.py`.
+
+Add `import shutil` at the top of the module if it's not already there. Existing imports:
+
+```python
+import shutil
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+```
+
+(Verify — `shutil` is already used for `shutil.copy2` in the `_copy_bind_files` method, so the import is almost certainly present. Add only if the file doesn't have it.)
+
+Find the first setup block (inside the `git_root` branch — the one after the symlink + bind_file extends, ending with the `continue`):
+
+```python
+                if not skip_setup:
+                    actual_setup = repo_config.tasks.get("setup", "setup")
+                    setup_result = self._shell.run_task(
+                        task_name="setup",
+                        actual_task_name=actual_setup,
+                        cwd=effective,
+                        env_runner=repo_config.env_runner or self._config.env_runner,
+                    )
+                    if setup_result.returncode != 0:
+                        setup_warnings.append(
+                            f"{repo_name}: setup failed (task '{actual_setup}') — "
+                            f"{setup_result.stderr.strip()[:200]}"
+                        )
+```
+
+Replace with:
+
+```python
+                if not skip_setup and shutil.which("task") is not None:
+                    actual_setup = repo_config.tasks.get("setup", "setup")
+                    setup_result = self._shell.run_task(
+                        task_name="setup",
+                        actual_task_name=actual_setup,
+                        cwd=effective,
+                        env_runner=repo_config.env_runner or self._config.env_runner,
+                    )
+                    if setup_result.returncode != 0:
+                        setup_warnings.append(
+                            f"{repo_name}: setup failed (task '{actual_setup}') — "
+                            f"{setup_result.stderr.strip()[:200]}"
+                        )
+```
+
+Find the second setup block (inside the normal-repo branch, ending just before `base_branch = workspace_default_branch_from_config(...)`):
+
+```python
+            if not skip_setup:
+                actual_setup = repo_config.tasks.get("setup", "setup")
+                setup_result = self._shell.run_task(
+                    task_name="setup",
+                    actual_task_name=actual_setup,
+                    cwd=wt_path,
+                    env_runner=repo_config.env_runner or self._config.env_runner,
+                )
+                if setup_result.returncode != 0:
+                    setup_warnings.append(
+                        f"{repo_name}: setup failed (task '{actual_setup}') — "
+                        f"{setup_result.stderr.strip()[:200]}"
+                    )
+```
+
+Replace with:
+
+```python
+            if not skip_setup and shutil.which("task") is not None:
+                actual_setup = repo_config.tasks.get("setup", "setup")
+                setup_result = self._shell.run_task(
+                    task_name="setup",
+                    actual_task_name=actual_setup,
+                    cwd=wt_path,
+                    env_runner=repo_config.env_runner or self._config.env_runner,
+                )
+                if setup_result.returncode != 0:
+                    setup_warnings.append(
+                        f"{repo_name}: setup failed (task '{actual_setup}') — "
+                        f"{setup_result.stderr.strip()[:200]}"
+                    )
+```
+
+- [ ] **Step 1.6: Re-run the three tests to verify they all pass**
+
+Run: `pytest tests/core/test_worktree.py::test_spawn_skips_setup_when_task_binary_missing tests/core/test_worktree.py::test_spawn_runs_setup_task tests/core/test_worktree.py::test_spawn_collects_setup_warnings_on_failure -v`
+
+Expected: 3 passed.
+
+- [ ] **Step 1.7: Run the full worktree test file**
+
+Run: `pytest tests/core/test_worktree.py -v`
+
+Expected: all tests pass. If a different test relies on `shell.run_task` being called for setup and fails due to the new guard (because the test environment lacks `task`), update it by adding a `monkeypatch.setattr("mship.core.worktree.shutil.which", lambda name: "/usr/local/bin/task" if name == "task" else None)` block at the top.
+
+- [ ] **Step 1.8: Commit**
+
+```bash
+git add src/mship/core/worktree.py tests/core/test_worktree.py
+git commit -m "feat(worktree): skip setup silently when task binary missing"
+mship journal "spawn now gates setup on shutil.which('task'); existing setup tests updated with monkeypatch" --action committed
+```
+
+---
+
+## Task 2: `mship doctor` surfaces `go-task` as a check
+
+**Files:**
+- Modify: `src/mship/core/doctor.py`
+- Modify: `tests/core/test_doctor.py`
+
+**Context:** Doctor today reports on `gh`, `env_runner`, and other tools. Add a `go-task` row that always fires: `pass` when `shutil.which("task")` returns a path, `warn` when it returns None. Message for the warn case points at https://taskfile.dev and explains the consequence ("mship will skip per-repo setup on spawn").
+
+- [ ] **Step 2.1: Write failing tests**
+
+Append to `tests/core/test_doctor.py` (bottom of the file):
+
+```python
+def test_doctor_go_task_pass_when_binary_present(workspace: Path, monkeypatch):
+    monkeypatch.setattr(
+        "mship.core.doctor.shutil.which",
+        lambda name: "/usr/local/bin/task" if name == "task" else None,
+    )
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    from mship.core.doctor import DoctorChecker
+    shell = MagicMock(spec=ShellRunner)
+    shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    report = DoctorChecker(config, shell).diagnose()
+    go_task_checks = [c for c in report.checks if c.name == "go-task"]
+    assert len(go_task_checks) == 1
+    assert go_task_checks[0].status == "pass"
+    assert "go-task found" in go_task_checks[0].message
+
+
+def test_doctor_go_task_warn_when_binary_missing(workspace: Path, monkeypatch):
+    monkeypatch.setattr(
+        "mship.core.doctor.shutil.which",
+        lambda name: None,
+    )
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    from mship.core.doctor import DoctorChecker
+    shell = MagicMock(spec=ShellRunner)
+    shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    report = DoctorChecker(config, shell).diagnose()
+    go_task_checks = [c for c in report.checks if c.name == "go-task"]
+    assert len(go_task_checks) == 1
+    assert go_task_checks[0].status == "warn"
+    assert "not installed" in go_task_checks[0].message
+    assert "https://taskfile.dev" in go_task_checks[0].message
+    assert "skip per-repo setup on spawn" in go_task_checks[0].message
+```
+
+- [ ] **Step 2.2: Run tests to verify they fail**
+
+Run: `pytest tests/core/test_doctor.py::test_doctor_go_task_pass_when_binary_present tests/core/test_doctor.py::test_doctor_go_task_warn_when_binary_missing -v`
+
+Expected: both FAIL with `assert len(go_task_checks) == 1` (no such check yet) — `len` will be 0.
+
+- [ ] **Step 2.3: Add the `go-task` check to `Doctor.diagnose`**
+
+Edit `src/mship/core/doctor.py`.
+
+Add `import shutil` at the top of the module. The existing imports are:
+
+```python
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+```
+
+Add `import shutil` immediately after `import os`:
+
+```python
+import os
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+```
+
+Find the `gh` check in `diagnose()` (around line 220):
+
+```python
+        # gh CLI
+        gh_result = self._shell.run("gh auth status", cwd=Path("."))
+        if gh_result.returncode == 0:
+            report.checks.append(CheckResult(name="gh", status="pass", message="authenticated"))
+        elif gh_result.returncode == 127:
+            report.checks.append(CheckResult(name="gh", status="warn", message="gh CLI not installed (optional — needed for mship finish)"))
+        else:
+            report.checks.append(CheckResult(name="gh", status="warn", message="gh CLI not authenticated (run gh auth login)"))
+```
+
+Immediately after that block (before the `# Dev-mode trap:` comment), insert:
+
+```python
+        # go-task binary — signals whether spawn will run per-repo setup tasks
+        if shutil.which("task") is not None:
+            report.checks.append(CheckResult(
+                name="go-task",
+                status="pass",
+                message="go-task found",
+            ))
+        else:
+            report.checks.append(CheckResult(
+                name="go-task",
+                status="warn",
+                message=(
+                    "go-task not installed (https://taskfile.dev); "
+                    "mship will skip per-repo setup on spawn"
+                ),
+            ))
+```
+
+- [ ] **Step 2.4: Run tests to verify they pass**
+
+Run: `pytest tests/core/test_doctor.py -v`
+
+Expected: all tests pass (the 2 new + existing).
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/mship/core/doctor.py tests/core/test_doctor.py
+git commit -m "feat(doctor): add go-task binary check (pass/warn)"
+mship journal "mship doctor now reports go-task binary presence; signals missing binary via warn row" --action committed
+```
+
+---
+
+## Task 3: Manual smoke + finish PR
+
+**Files:**
+- None (verification only).
+
+**Context:** Exercise the change end-to-end in a scratch workspace, with and without `task` on PATH.
+
+- [ ] **Step 3.1: Reinstall tool**
+
+```bash
+cd /home/bailey/development/repos/mothership/.worktrees/feat/spawn-skips-setup-when-task-binary-missing-and-doctor-surfaces-it
+uv tool install --reinstall --from . mothership
+```
+
+- [ ] **Step 3.2: Build scratch workspace**
+
+```bash
+rm -rf /tmp/task-missing-smoke
+mkdir -p /tmp/task-missing-smoke
+cd /tmp/task-missing-smoke
+
+cat > mothership.yaml <<'EOF'
+workspace: task-missing-smoke
+repos:
+  svc:
+    path: ./svc
+    type: service
+EOF
+
+mkdir -p svc .mothership
+git -C svc init -q
+git -C svc commit --allow-empty -m "init" -q
+git -C svc remote add origin /tmp/task-missing-smoke/fake-remote 2>/dev/null || true
+```
+
+- [ ] **Step 3.3: Smoke — spawn (this machine doesn't have `task` installed, so this exercises the no-task path)**
+
+First confirm task isn't on PATH:
+
+```bash
+which task; echo "task which-exit: $?"
+```
+
+Expected: empty output, `which-exit: 1` (not found). If task IS installed on this machine, skip Steps 3.3–3.4 and rely on the unit-test coverage; Step 3.5 below is the task-present smoke.
+
+With task confirmed missing:
+
+```bash
+cd /tmp/task-missing-smoke
+mship spawn "smoke-no-task" 2>&1 | tail -20
+```
+
+Expected: the `setup_warnings` array in the JSON output does NOT contain `"task: not found"` or `"setup failed"`. Before the fix, it did.
+
+Cleanup the spawned task so the next smoke runs cleanly:
+
+```bash
+mship close --yes --abandon --task smoke-no-task 2>&1 | tail -3
+```
+
+- [ ] **Step 3.4: Smoke — doctor reports the missing binary**
+
+```bash
+mship doctor 2>&1 | grep -i go-task
+```
+
+Expected: one line matching `warn   go-task   go-task not installed (https://taskfile.dev); mship will skip per-repo setup on spawn`.
+
+- [ ] **Step 3.5: Smoke — doctor with `task` on PATH (only run if task IS installed locally)**
+
+```bash
+which task && mship doctor 2>&1 | grep -i go-task
+```
+
+If `task` is installed: expect `pass   go-task   go-task found`.
+If not installed: the pass case is covered by the unit test in Task 2; note the skip and proceed.
+
+- [ ] **Step 3.6: Cleanup**
+
+```bash
+rm -rf /tmp/task-missing-smoke
+```
+
+- [ ] **Step 3.7: Full pytest final check**
+
+```bash
+cd /home/bailey/development/repos/mothership/.worktrees/feat/spawn-skips-setup-when-task-binary-missing-and-doctor-surfaces-it
+pytest tests/ 2>&1 | tail -3
+```
+
+Expected: 870+ passed.
+
+- [ ] **Step 3.8: Open PR**
+
+Write this body to `/tmp/task-missing-body.md`:
+
+```markdown
+## Summary
+
+Closes #51. `mship spawn` no longer prints `"mothership: setup failed (task 'setup') — /bin/sh: 1: task: not found"` on every invocation when go-task isn't installed. Instead:
+
+- **`mship spawn`** silently skips the setup call when `shutil.which("task")` returns None.
+- **`mship doctor`** surfaces the missing binary as a `warn`-status check (`go-task not installed (https://taskfile.dev); mship will skip per-repo setup on spawn`).
+
+Previously, a session with three spawns produced three identical warnings. Now the signal lives in one predictable place (doctor) and appears exactly as many times as the user runs `mship doctor`.
+
+## Scope
+
+- Only the spawn-setup `run_task` invocation is gated. Other `run_task` callers (`mship run`, `mship test`, healthcheck task probes) still surface "task: not found" if the user tries to use those commands — those are one-time actionable errors, not repeated noise.
+- No new config key, no caching, no TTL.
+- Doctor's new check always fires (pass/warn), matching the existing `gh` pattern.
+
+## Changes
+
+- `src/mship/core/worktree.py` — `if not skip_setup:` guard extended with `and shutil.which("task") is not None` at the two setup call-sites (git_root branch and normal-repo branch).
+- `src/mship/core/doctor.py` — new `go-task` check added near the existing `gh` block.
+
+## Test plan
+
+- [x] `tests/core/test_worktree.py`: 1 new test (`test_spawn_skips_setup_when_task_binary_missing`). 2 existing tests (`test_spawn_runs_setup_task`, `test_spawn_collects_setup_warnings_on_failure`) updated to monkeypatch `shutil.which` so they still exercise the setup path on machines without go-task.
+- [x] `tests/core/test_doctor.py`: 2 new tests for the `go-task` pass and warn cases.
+- [x] Full suite: 870+ passed.
+- [x] Manual smoke: spawn in a go-task-less environment produces no setup warning; doctor surfaces the missing binary.
+```
+
+Then:
+
+```bash
+cd /home/bailey/development/repos/mothership/.worktrees/feat/spawn-skips-setup-when-task-binary-missing-and-doctor-surfaces-it
+mship finish --body-file /tmp/task-missing-body.md
+```
+
+Expected: PR URL returned.
+
+---
+
+## Done when
+
+- [x] `WorktreeManager.spawn` skips setup silently when `shutil.which("task")` is None (both branches).
+- [x] `Doctor.diagnose` emits a `go-task` `CheckResult` — `pass` when binary found, `warn` with messaging otherwise.
+- [x] No other `run_task` callers changed.
+- [x] All existing `test_worktree.py` and `test_doctor.py` tests pass. 3 tests updated (one new, two monkeypatched); 2 tests added for doctor.
+- [x] Full pytest green (870+).
+- [x] Manual smoke: spawn clean without task on PATH; doctor shows the warn row.

--- a/docs/superpowers/specs/2026-04-18-spawn-skip-setup-when-task-missing-design.md
+++ b/docs/superpowers/specs/2026-04-18-spawn-skip-setup-when-task-missing-design.md
@@ -1,0 +1,221 @@
+# Spawn skips setup when `task` binary missing, doctor surfaces it — Design
+
+## Context
+
+Every `mship spawn` in an environment without [go-task](https://taskfile.dev) installed prints:
+
+```
+mothership: setup failed (task 'setup') — /bin/sh: 1: task: not found
+```
+
+This is a once-per-workspace configuration issue — the user hasn't installed go-task, or doesn't intend to use it — but it fires on every spawn until addressed. In a session with three spawns, that's three identical warnings that never change meaning. Repeated-identical-warnings desensitize both humans and agents to real signal: a noisy floor trains readers to skim past output, and then the signal the tool actually wants to convey gets skipped too.
+
+The issue (#51) lays out three options: (A) state-cached probe with TTL, (B) short-circuit when `shutil.which("task")` is None, (C) new config key `audit.run_setup_on_spawn`. Option B matches today's semantics best — no new surface area, no cached state to invalidate, no config opt-in. The only piece missing from B is an informational surface: `mship doctor` should report the missing binary, so the signal is visible exactly once per `doctor` invocation rather than hidden entirely.
+
+## Goal
+
+`mship spawn` silently skips the per-repo setup invocation when the `task` binary is not on PATH. `mship doctor` gains a `go-task` check that reports `pass` when the binary is present and `warn` when it isn't, surfacing the missing binary as actionable guidance instead of as spam on every spawn.
+
+## Success criterion
+
+On a machine without go-task installed:
+
+```
+$ mship spawn "tiny task"
+Task spawned. Repos: …. Branch: feat/tiny-task
+```
+
+No `setup_warnings` entry related to the missing `task` binary. Output is clean.
+
+```
+$ mship doctor
+…
+warn   go-task            go-task not installed (https://taskfile.dev); mship will skip per-repo setup on spawn
+…
+```
+
+On a machine with go-task installed, `mship spawn` runs setup as today (possibly producing legitimate per-repo setup failures, which are still warned about). `mship doctor` emits `pass   go-task   go-task found`.
+
+## Anti-goals
+
+- **No caching in `.mothership/state.yaml`.** Issue Option A. Introduces invalidation and TTL decisions we don't need — `shutil.which` is cheap (pure PATH scan, microseconds).
+- **No new config key.** Issue Option C. Users shouldn't have to opt out of noisy default behavior; fixing the default is better.
+- **No broadening to other `run_task` callers.** `mship run` / `mship test` / healthcheck task probes still surface their own "task: not found" errors when the user tries to use those commands. That's a one-time, actionable signal — not repeated noise. This design is narrowly scoped to the spawn-setup invocation.
+- **No mechanism to restore the old per-spawn warning.** The signal moves to `mship doctor`. Users who disagree can reopen the issue; there is no flag to reinstate the old behavior in this change.
+- **No change to what "setup" means** when the binary IS installed. Existing setup-task-fails warnings (permission errors, bad taskfile syntax, etc.) continue to surface exactly as today.
+
+## Architecture
+
+### `src/mship/core/worktree.py::WorktreeManager.spawn`
+
+Two touchpoints — the `git_root` subdirectory branch and the normal-repo branch — each currently read:
+
+```python
+if not skip_setup:
+    actual_setup = repo_config.tasks.get("setup", "setup")
+    setup_result = self._shell.run_task(
+        task_name="setup",
+        actual_task_name=actual_setup,
+        cwd=<wt_path>,
+        env_runner=repo_config.env_runner or self._config.env_runner,
+    )
+    if setup_result.returncode != 0:
+        setup_warnings.append(
+            f"{repo_name}: setup failed (task '{actual_setup}') — "
+            f"{setup_result.stderr.strip()[:200]}"
+        )
+```
+
+Replace the guard in both places:
+
+```python
+if not skip_setup and shutil.which("task") is not None:
+    actual_setup = repo_config.tasks.get("setup", "setup")
+    setup_result = self._shell.run_task(
+        task_name="setup",
+        actual_task_name=actual_setup,
+        cwd=<wt_path>,
+        env_runner=repo_config.env_runner or self._config.env_runner,
+    )
+    if setup_result.returncode != 0:
+        setup_warnings.append(
+            f"{repo_name}: setup failed (task '{actual_setup}') — "
+            f"{setup_result.stderr.strip()[:200]}"
+        )
+```
+
+Add `import shutil` at the top of the module if not already imported.
+
+`shutil.which("task")` is checked on every repo iteration rather than once-per-spawn. This is intentional and cheap: it keeps the logic local to the setup block, avoids a top-of-spawn variable that would be stale if PATH changed mid-spawn (extremely rare, but free to be correct), and matches the pattern of other one-shot probes in the codebase.
+
+### `src/mship/core/doctor.py::Doctor.diagnose`
+
+Add a new check near the existing `gh` check (around line 220, between `gh CLI` and `Dev-mode trap`). The check is always-on — it emits a row whether the binary is present or missing, matching the `gh` pattern:
+
+```python
+# go-task binary
+if shutil.which("task") is not None:
+    report.checks.append(CheckResult(
+        name="go-task",
+        status="pass",
+        message="go-task found",
+    ))
+else:
+    report.checks.append(CheckResult(
+        name="go-task",
+        status="warn",
+        message=(
+            "go-task not installed (https://taskfile.dev); "
+            "mship will skip per-repo setup on spawn"
+        ),
+    ))
+```
+
+`shutil` is already imported at module top (line 1: `import os`; line 2 imports a different module — verify and add `import shutil` if missing).
+
+The check appears in every `mship doctor` run. Workspace-level doctor runs and `mship init`'s embedded doctor pass both inherit it.
+
+## Data flow
+
+**`mship spawn` in an environment without `task`:**
+
+1. CLI `spawn` → `WorktreeManager.spawn(...)`.
+2. Per-repo loop: worktree created, symlinks + bind_files copied.
+3. `if not skip_setup and shutil.which("task") is not None:` evaluates `shutil.which("task")` → returns `None` → guard fails → setup block skipped → no `run_task` invocation, no warning appended.
+4. `SpawnResult.setup_warnings` for this repo is empty (modulo unrelated symlink/bind warnings).
+
+**`mship spawn` with `task` installed:**
+
+1. Same flow; `shutil.which("task")` returns a path → guard passes → existing setup path runs unchanged. A legitimate non-zero return from the user's setup task still produces the existing warning.
+
+**`mship doctor`:**
+
+1. Existing checks run.
+2. `go-task` block: `shutil.which("task")` probes PATH; emits `pass` or `warn` row with the appropriate message.
+3. Report returned with one additional row compared to today.
+
+## Error handling
+
+- **`shutil.which` raises** (effectively impossible — it's a pure PATH-scan over `os.environ["PATH"]`) → let it propagate. The caller's exception-handling layer is the right place to deal with an impossible condition, not this code.
+- **`task` appears mid-session** (user installs it between spawns) → next `spawn` re-probes and runs setup. No stale cache.
+- **`task` disappears mid-session** (PATH mutation) → next spawn silently skips setup. Doctor, if run, reports `warn`. Current behavior would have logged `task: not found` per spawn; new behavior is silent. Acceptable — the user is actively modifying their environment; they know what they did.
+- **Non-existent `setup` task in a user's `Taskfile.yml`** — outside the scope of this change. `task setup` fails with a non-127 returncode; the existing warning path still fires. This change only touches the 127/task-not-on-PATH case.
+
+## Testing
+
+### Unit — `tests/core/test_worktree.py` (extend existing)
+
+1. **Setup skipped when `task` missing** — use `monkeypatch.setattr("mship.core.worktree.shutil.which", lambda name: None)`. Run `spawn(...)` against a mock shell with a config that has a `setup` task defined. Assert:
+   - `result.setup_warnings` contains no entry matching `"setup failed"`.
+   - `mock_shell.run_task` was never called with `task_name="setup"` (tracks the skip).
+
+2. **Setup runs normally when `task` present** — `monkeypatch.setattr("mship.core.worktree.shutil.which", lambda name: "/usr/local/bin/task")`. Same config. Run `spawn(...)`. Assert:
+   - `mock_shell.run_task` was called once per repo with `task_name="setup"`.
+   - When mock returns `returncode=0`, no warning.
+   - When mock returns `returncode=1, stderr="broken"`, warning contains `"setup failed (task 'setup') — broken"` (verifies the existing warning path still fires for real setup failures).
+
+3. **`skip_setup=True` bypasses the check** — regression guard. `monkeypatch.setattr("mship.core.worktree.shutil.which", lambda name: "/usr/local/bin/task")`. Run `spawn(..., skip_setup=True)`. Assert `run_task` not called. (The new guard is `and`-ed onto `not skip_setup`, so this path stays clean.)
+
+### Unit — `tests/core/test_doctor.py` (extend existing)
+
+1. **`go-task` pass when binary present** — `monkeypatch.setattr("mship.core.doctor.shutil.which", lambda name: "/usr/local/bin/task" if name == "task" else None)`. Run doctor. Assert the report contains a `CheckResult` with `name="go-task"`, `status="pass"`, `message="go-task found"`.
+
+2. **`go-task` warn when binary missing** — `monkeypatch.setattr("mship.core.doctor.shutil.which", lambda name: None)`. Run doctor. Assert a `CheckResult` with `name="go-task"`, `status="warn"`, message contains `"not installed"` and `"https://taskfile.dev"`.
+
+3. **Mixed PATH** — `shutil.which` returns a path for some binaries and None for others; the `task` check should depend only on `task`'s presence. Uses the same monkeypatch pattern with a dict lookup.
+
+### Integration / regression
+
+- All existing `test_worktree.py` tests continue to pass. Tests that previously expected a `"setup failed (task 'setup') — …"` warning either mock `shutil.which` to return a path (preserving the old path) or pre-install the mock behavior described above.
+- All existing `test_doctor.py` tests continue to pass. The new check is additive.
+- Full `pytest tests/` stays green.
+
+### Manual smoke
+
+In an environment without go-task installed (e.g., `PATH=/usr/bin:/bin` for a single invocation):
+
+```bash
+cd /tmp
+rm -rf spawn-smoke && mkdir -p spawn-smoke && cd spawn-smoke
+cat > mothership.yaml <<'EOF'
+workspace: spawn-smoke
+repos:
+  svc:
+    path: ./svc
+    type: service
+EOF
+mkdir svc .mothership
+git -C svc init -q
+git -C svc commit --allow-empty -m "init"
+git -C svc remote add origin /tmp/spawn-smoke/fake
+
+PATH=/usr/bin:/bin mship spawn "test" 2>&1
+```
+
+Expect no `setup_warnings` entry about `task: not found`.
+
+```bash
+PATH=/usr/bin:/bin mship doctor 2>&1 | grep go-task
+```
+
+Expect `warn   go-task            go-task not installed …`.
+
+Then with `task` installed (`PATH=$PATH`):
+
+```bash
+mship doctor 2>&1 | grep go-task
+```
+
+Expect `pass   go-task   go-task found`.
+
+## Decisions log
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Scope to spawn-setup only, not all `run_task` callers | The reported pain is repeated-identical warnings on every spawn. `mship run` / `mship test` / healthcheck task probes also use `run_task`, but a user who invokes those without task installed gets a one-time actionable error — that's legitimate signal, not noise. Hiding those would mask real config problems. |
+| 2 | `shutil.which` per repo, not per spawn call | Cheap probe, keeps logic local to the guard. Avoids a top-of-spawn variable that could drift if PATH changed mid-spawn (rare but free to get right). |
+| 3 | Doctor row is always-on (pass + warn), not warn-only | Matches the existing `gh` check pattern. Users reading doctor output don't have to infer from silence whether a check was skipped or passed. One extra line on the happy path is cheap. |
+| 4 | No new config key to restore old warning behavior | Adding a flag to opt back into noise is a worse design than fixing the default. If a user genuinely wants the warning, they can rely on `mship doctor` — which is the correct surface. |
+| 5 | No caching in `.mothership/state.yaml` with TTL (issue's Option A) | `shutil.which` is microseconds; caching buys nothing measurable and adds invalidation complexity (TTL choice, reset on `mship doctor`, interaction with `uv tool install --reinstall`). |
+| 6 | Message phrasing: `"go-task not installed (https://taskfile.dev); mship will skip per-repo setup on spawn"` | Names the upstream source (actionable — user can install it), and states the consequence (so the user understands why doctor is surfacing this: setup will be skipped). |
+| 7 | No change to the existing "setup failed (task 'setup') — …" warning for non-127 returncodes | Real setup failures (bad Taskfile syntax, permission errors) still need to surface. The scope boundary is tight: only the "task binary not on PATH" case silences. |

--- a/src/mship/core/doctor.py
+++ b/src/mship/core/doctor.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -224,6 +225,23 @@ class DoctorChecker:
             report.checks.append(CheckResult(name="gh", status="warn", message="gh CLI not installed (optional — needed for mship finish)"))
         else:
             report.checks.append(CheckResult(name="gh", status="warn", message="gh CLI not authenticated (run gh auth login)"))
+
+        # go-task binary — signals whether spawn will run per-repo setup tasks
+        if shutil.which("task") is not None:
+            report.checks.append(CheckResult(
+                name="go-task",
+                status="pass",
+                message="go-task found",
+            ))
+        else:
+            report.checks.append(CheckResult(
+                name="go-task",
+                status="warn",
+                message=(
+                    "go-task not installed (https://taskfile.dev); "
+                    "mship will skip per-repo setup on spawn"
+                ),
+            ))
 
         # Dev-mode trap: installed mship may lag workspace source
         mship_source = self._detect_mship_dev_workspace()

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -219,7 +219,7 @@ class WorktreeManager:
                 bind_warnings = self._copy_bind_files(repo_name, repo_config, effective)
                 setup_warnings.extend(bind_warnings)
 
-                if not skip_setup:
+                if not skip_setup and shutil.which("task") is not None:
                     actual_setup = repo_config.tasks.get("setup", "setup")
                     setup_result = self._shell.run_task(
                         task_name="setup",
@@ -254,7 +254,7 @@ class WorktreeManager:
             bind_warnings = self._copy_bind_files(repo_name, repo_config, wt_path)
             setup_warnings.extend(bind_warnings)
 
-            if not skip_setup:
+            if not skip_setup and shutil.which("task") is not None:
                 actual_setup = repo_config.tasks.get("setup", "setup")
                 setup_result = self._shell.run_task(
                     task_name="setup",

--- a/tests/core/test_doctor.py
+++ b/tests/core/test_doctor.py
@@ -420,3 +420,37 @@ def test_skill_check_reports_missing_install(tmp_path, monkeypatch):
     assert by_name["skills/claude"].status == "warn"
     assert "0/1" in by_name["skills/claude"].message
     assert "mship skill install" in by_name["skills/claude"].message
+
+
+def test_doctor_go_task_pass_when_binary_present(workspace: Path, monkeypatch):
+    monkeypatch.setattr(
+        "mship.core.doctor.shutil.which",
+        lambda name: "/usr/local/bin/task" if name == "task" else None,
+    )
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    from mship.core.doctor import DoctorChecker
+    shell = MagicMock(spec=ShellRunner)
+    shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    report = DoctorChecker(config, shell).run()
+    go_task_checks = [c for c in report.checks if c.name == "go-task"]
+    assert len(go_task_checks) == 1
+    assert go_task_checks[0].status == "pass"
+    assert "go-task found" in go_task_checks[0].message
+
+
+def test_doctor_go_task_warn_when_binary_missing(workspace: Path, monkeypatch):
+    monkeypatch.setattr(
+        "mship.core.doctor.shutil.which",
+        lambda name: None,
+    )
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    from mship.core.doctor import DoctorChecker
+    shell = MagicMock(spec=ShellRunner)
+    shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    report = DoctorChecker(config, shell).run()
+    go_task_checks = [c for c in report.checks if c.name == "go-task"]
+    assert len(go_task_checks) == 1
+    assert go_task_checks[0].status == "warn"
+    assert "not installed" in go_task_checks[0].message
+    assert "https://taskfile.dev" in go_task_checks[0].message
+    assert "skip per-repo setup on spawn" in go_task_checks[0].message

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -108,8 +108,12 @@ def test_abort_removes_worktrees(worktree_deps):
     assert "to-abort" not in state.tasks
 
 
-def test_spawn_runs_setup_task(worktree_deps):
+def test_spawn_runs_setup_task(worktree_deps, monkeypatch):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    monkeypatch.setattr(
+        "mship.core.worktree.shutil.which",
+        lambda name: "/usr/local/bin/task" if name == "task" else None,
+    )
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
     mgr.spawn("with setup", repos=["shared"])
     shell.run_task.assert_called()
@@ -214,8 +218,12 @@ def test_spawn_returns_spawn_result_with_task(worktree_deps):
     assert result.setup_warnings == []
 
 
-def test_spawn_collects_setup_warnings_on_failure(worktree_deps):
+def test_spawn_collects_setup_warnings_on_failure(worktree_deps, monkeypatch):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    monkeypatch.setattr(
+        "mship.core.worktree.shutil.which",
+        lambda name: "/usr/local/bin/task" if name == "task" else None,
+    )
     # Make setup return non-zero
     shell.run_task.return_value = ShellResult(
         returncode=1, stdout="", stderr="setup task not found"
@@ -820,3 +828,24 @@ def test_spawn_copies_bind_files_and_coexists_with_symlink_dirs(tmp_path: Path):
     # Both succeeded with no warnings.
     bind_warnings = [w for w in result.setup_warnings if "bind_files" in w]
     assert bind_warnings == [], f"unexpected bind_files warnings: {bind_warnings}"
+
+
+def test_spawn_skips_setup_when_task_binary_missing(worktree_deps, monkeypatch):
+    """When `task` binary isn't on PATH, spawn skips the setup run_task
+    call silently — no warning appended, no mock invocation.
+    """
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    monkeypatch.setattr(
+        "mship.core.worktree.shutil.which",
+        lambda name: None if name == "task" else "/usr/bin/" + name,
+    )
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    result = mgr.spawn("task-missing-smoke", repos=["shared"])
+
+    # No setup warning about missing task binary
+    assert not any("setup failed" in w for w in result.setup_warnings)
+    # run_task was NOT called for setup (the guard short-circuits before the call)
+    assert not any(
+        call.kwargs.get("task_name") == "setup"
+        for call in shell.run_task.call_args_list
+    )


### PR DESCRIPTION
## Summary

Closes #51. `mship spawn` no longer prints `"mothership: setup failed (task 'setup') — /bin/sh: 1: task: not found"` on every invocation when go-task isn't installed. Instead:

- **`mship spawn`** silently skips the setup call when `shutil.which("task")` returns None.
- **`mship doctor`** surfaces the missing binary as a `warn`-status check (`go-task not installed (https://taskfile.dev); mship will skip per-repo setup on spawn`).

Previously, a session with three spawns produced three identical warnings. Now the signal lives in one predictable place (doctor) and appears exactly as many times as the user runs `mship doctor`.

## Scope

- Only the spawn-setup `run_task` invocation is gated. Other `run_task` callers (`mship run`, `mship test`, healthcheck task probes) still surface "task: not found" if the user tries to use those commands — those are one-time actionable errors, not repeated noise.
- No new config key, no caching, no TTL.
- Doctor's new check always fires (pass/warn), matching the existing `gh` pattern.

## Changes

- `src/mship/core/worktree.py` — `if not skip_setup:` guard extended with `and shutil.which("task") is not None` at both setup call-sites (git_root branch and normal-repo branch).
- `src/mship/core/doctor.py` — new `go-task` check added near the existing `gh` block.

## Test plan

- [x] `tests/core/test_worktree.py`: 1 new test (`test_spawn_skips_setup_when_task_binary_missing`). 2 existing tests (`test_spawn_runs_setup_task`, `test_spawn_collects_setup_warnings_on_failure`) updated to monkeypatch `shutil.which` so they still exercise the setup path on machines without go-task.
- [x] `tests/core/test_doctor.py`: 2 new tests for the `go-task` pass and warn cases.
- [x] Full suite: 873 passed.
- [x] Manual smoke: spawn in a go-task-less environment produces no setup warning; doctor surfaces the missing binary with the expected wording.
