### PR TITLE
feat(mship): stale-main-index diagnostics + sync auto-recovery

### DIFF
--- a/docs/superpowers/plans/2026-04-21-stale-main-index-diagnostics-and-recovery.md
+++ b/docs/superpowers/plans/2026-04-21-stale-main-index-diagnostics-and-recovery.md
@@ -1,0 +1,1301 @@
+# Stale-Main-Index Diagnostics + Sync Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship instrumentation + mitigation for the recurring "stale main index after merge" bug. `mship sync` auto-recovers when dirty tracked files on main already match `origin/<branch>`; diagnostics snapshots capture forensics data for the future root-cause fix.
+
+**Architecture:** One new module (`src/mship/core/diagnostics.py`) with `capture_snapshot()`. Two integration points: `mship sync`'s `_result_for` in `repo_sync.py` (hash-compare + reset recovery), plus silent post-op capture in `mship finish` and `mship close`. `mship doctor` gains a `diagnostics` row when snapshots exist. State mutation (reset) only happens AFTER every dirty file's blob hash is verified against `origin/<branch>` — wrong guesses never touch user work.
+
+**Tech Stack:** Python 3.14, stdlib `pathlib` + `datetime`, `git hash-object` / `git rev-parse` via `ShellRunner`, pytest with `file://` bare repos for real-git integration.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-21-stale-main-index-diagnostics-and-recovery-design.md`
+
+---
+
+## File structure
+
+**New files:**
+- `src/mship/core/diagnostics.py` — `capture_snapshot(command, reason, state_dir, *, repos=None, extra=None) -> Path | None`.
+- `tests/core/test_diagnostics.py` — unit tests for the library.
+- `tests/core/test_sync_recovery.py` — unit tests for `_try_recover_stale_main` against real `file://` repos.
+
+**Modified files:**
+- `src/mship/core/repo_sync.py` — new `_try_recover_stale_main`; `_result_for` and `sync_repos` gain `state_dir` parameter.
+- `src/mship/cli/sync.py` — pass `container.state_dir()` to `sync_repos`.
+- `src/mship/core/doctor.py` — `DoctorChecker.__init__` accepts `state_dir`; `run()` appends a `diagnostics` row when snapshots exist.
+- `src/mship/cli/doctor.py` — pass `container.state_dir()` to `DoctorChecker`.
+- `src/mship/cli/worktree.py` — post-op silent capture in `finish` and `close` commands.
+- `tests/core/test_doctor.py` — new tests for the diagnostics row.
+- `tests/cli/test_worktree.py` — new integration tests for post-op capture in finish/close.
+
+**Task ordering rationale:** Task 1 (diagnostics library) is fully independent — unit-testable without the rest of the stack. Task 2 (sync recovery) uses it. Task 3 (finish/close post-op) uses it. Task 4 (doctor row) is independent of 2/3 but depends on 1. Task 5 is smoke + PR. Tasks 1-4 can be implemented in any order after 1 ships; I order them by dependency + risk.
+
+---
+
+## Task 1: Diagnostics library
+
+**Files:**
+- Create: `src/mship/core/diagnostics.py`
+- Create: `tests/core/test_diagnostics.py`
+
+**Context:** Pure library. No mship-specific side effects. `capture_snapshot` writes a JSON blob to `<state_dir>/diagnostics/<ts>-<command>-<reason>.json` with git state for the caller-provided repos plus environment info. Write failures are caught and returned as None (best-effort).
+
+- [ ] **Step 1.1: Write failing tests**
+
+Create `tests/core/test_diagnostics.py`:
+
+```python
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _init_git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=path, check=True)
+    (path / "README.md").write_text("initial\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=path, check=True)
+
+
+def test_capture_snapshot_writes_json_with_required_keys(tmp_path):
+    from mship.core.diagnostics import capture_snapshot
+    state_dir = tmp_path / ".mothership"
+    path = capture_snapshot("sync", "test-reason", state_dir)
+    assert path is not None
+    assert path.is_file()
+    assert path.parent == state_dir / "diagnostics"
+    data = json.loads(path.read_text())
+    for key in ("captured_at", "command", "reason", "cwd", "mship_version",
+                "python_version", "path_env"):
+        assert key in data, f"missing key {key}"
+    assert data["command"] == "sync"
+    assert data["reason"] == "test-reason"
+
+
+def test_capture_snapshot_filename_is_filesystem_safe(tmp_path):
+    """ISO timestamps contain colons on some platforms; must be replaced."""
+    from mship.core.diagnostics import capture_snapshot
+    state_dir = tmp_path / ".mothership"
+    path = capture_snapshot("sync", "a-reason", state_dir)
+    assert path is not None
+    # No colons in the filename portion.
+    assert ":" not in path.name
+    # Filename starts with a UTC ISO-like timestamp ending in Z.
+    assert path.name.endswith(".json")
+    assert "sync" in path.name
+    assert "a-reason" in path.name
+
+
+def test_capture_snapshot_creates_directory(tmp_path):
+    """diagnostics/ subdir is created on first call."""
+    from mship.core.diagnostics import capture_snapshot
+    state_dir = tmp_path / ".mothership"
+    assert not (state_dir / "diagnostics").exists()
+    capture_snapshot("sync", "r", state_dir)
+    assert (state_dir / "diagnostics").is_dir()
+
+
+def test_capture_snapshot_populates_repos(tmp_path):
+    from mship.core.diagnostics import capture_snapshot
+    repo = tmp_path / "r"
+    _init_git_repo(repo)
+    state_dir = tmp_path / ".mothership"
+    path = capture_snapshot("sync", "r", state_dir, repos={"r": repo})
+    data = json.loads(path.read_text())
+    assert "repos" in data
+    assert "r" in data["repos"]
+    repo_info = data["repos"]["r"]
+    for key in ("git_status_porcelain", "head_sha", "head_branch"):
+        assert key in repo_info
+    assert repo_info["git_status_porcelain"] == ""  # clean repo
+    assert len(repo_info["head_sha"]) == 40  # full SHA
+
+
+def test_capture_snapshot_extra_kwarg_included(tmp_path):
+    from mship.core.diagnostics import capture_snapshot
+    state_dir = tmp_path / ".mothership"
+    path = capture_snapshot("sync", "r", state_dir, extra={"foo": "bar", "n": 42})
+    data = json.loads(path.read_text())
+    assert data["extra"] == {"foo": "bar", "n": 42}
+
+
+def test_capture_snapshot_returns_none_on_write_failure(tmp_path, monkeypatch):
+    """Write failure never raises; returns None."""
+    from mship.core.diagnostics import capture_snapshot
+    state_dir = tmp_path / ".mothership"
+    # Make the target directory creation fail by making its parent read-only.
+    def _raise(*args, **kwargs):
+        raise OSError("simulated disk full")
+    monkeypatch.setattr(Path, "mkdir", _raise)
+    result = capture_snapshot("sync", "r", state_dir)
+    assert result is None
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+Run: `pytest tests/core/test_diagnostics.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'mship.core.diagnostics'`.
+
+- [ ] **Step 1.3: Create the module**
+
+Write `src/mship/core/diagnostics.py`:
+
+```python
+"""Forensics snapshot library for mship's self-diagnosing commands.
+
+Writes JSON blobs to <state_dir>/diagnostics/<ts>-<command>-<reason>.json
+when commands observe anomalous state. Best-effort — write failures are
+caught and returned as None so callers are never interrupted.
+
+Filename format: <ISO-8601 UTC, colons replaced with `-`>-<command>-<reason>.json.
+
+See `docs/superpowers/specs/2026-04-21-stale-main-index-diagnostics-and-recovery-design.md`.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+def _git_state(repo_path: Path) -> dict:
+    """Per-repo git state captured for the snapshot. Best-effort."""
+    info: dict = {
+        "git_status_porcelain": None,
+        "head_sha": None,
+        "head_branch": None,
+        "upstream_tracking": None,
+        "reflog_tail": None,
+        "stash_count": None,
+    }
+    try:
+        r = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=repo_path, capture_output=True, text=True, check=False,
+        )
+        info["git_status_porcelain"] = r.stdout
+    except OSError:
+        pass
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_path, capture_output=True, text=True, check=False,
+        )
+        info["head_sha"] = r.stdout.strip() or None
+    except OSError:
+        pass
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=repo_path, capture_output=True, text=True, check=False,
+        )
+        info["head_branch"] = r.stdout.strip() or None
+    except OSError:
+        pass
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+            cwd=repo_path, capture_output=True, text=True, check=False,
+        )
+        if r.returncode == 0:
+            info["upstream_tracking"] = r.stdout.strip()
+    except OSError:
+        pass
+    try:
+        r = subprocess.run(
+            ["git", "reflog", "-n", "10"],
+            cwd=repo_path, capture_output=True, text=True, check=False,
+        )
+        info["reflog_tail"] = r.stdout.splitlines()
+    except OSError:
+        pass
+    try:
+        r = subprocess.run(
+            ["git", "stash", "list"],
+            cwd=repo_path, capture_output=True, text=True, check=False,
+        )
+        info["stash_count"] = len([l for l in r.stdout.splitlines() if l])
+    except OSError:
+        pass
+    return info
+
+
+def _mship_version() -> str | None:
+    try:
+        from importlib.metadata import version
+        return version("mothership")
+    except Exception:
+        return None
+
+
+def _safe_timestamp() -> str:
+    """ISO-8601 UTC timestamp with filesystem-safe separators.
+
+    Colons (invalid on Windows, awkward on macOS) are replaced with hyphens.
+    """
+    ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    # ends with +00:00, which includes a colon — strip tz and append Z
+    if ts.endswith("+00:00"):
+        ts = ts[:-len("+00:00")] + "Z"
+    return ts.replace(":", "-")
+
+
+def capture_snapshot(
+    command: str,
+    reason: str,
+    state_dir: Path,
+    *,
+    repos: dict[str, Path] | None = None,
+    extra: dict | None = None,
+) -> Path | None:
+    """Write a JSON forensics snapshot. Returns the path, or None on failure.
+
+    command: invoking mship command name (e.g. "sync", "finish").
+    reason:  short tag identifying what triggered capture (e.g. "dirty-main-pre-recovery").
+    state_dir: workspace's .mothership directory.
+    repos: optional {name: path} to capture per-repo git state.
+    extra: caller-supplied free-form data.
+    """
+    try:
+        diag_dir = Path(state_dir) / "diagnostics"
+        diag_dir.mkdir(parents=True, exist_ok=True)
+
+        payload: dict = {
+            "captured_at": _safe_timestamp(),
+            "command": command,
+            "reason": reason,
+            "cwd": str(Path.cwd()),
+            "mship_version": _mship_version(),
+            "python_version": sys.version,
+            "path_env": os.environ.get("PATH", ""),
+        }
+        if repos:
+            payload["repos"] = {name: _git_state(Path(p)) for name, p in repos.items()}
+        if extra:
+            payload["extra"] = extra
+
+        filename = f"{_safe_timestamp()}-{command}-{reason}.json"
+        target = diag_dir / filename
+        target.write_text(json.dumps(payload, indent=2))
+        return target
+    except OSError as e:
+        log.debug("capture_snapshot write failed: %s", e)
+        return None
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+Run: `pytest tests/core/test_diagnostics.py -v`
+Expected: 6 passed.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/mship/core/diagnostics.py tests/core/test_diagnostics.py
+git commit -m "feat(core): diagnostics snapshot library"
+mship journal "capture_snapshot() writes JSON forensics blobs to .mothership/diagnostics/; best-effort, non-raising" --action committed
+```
+
+---
+
+## Task 2: `mship sync` hash-compare recovery
+
+**Files:**
+- Modify: `src/mship/core/repo_sync.py` — new `_try_recover_stale_main`; `_result_for` and `sync_repos` gain `state_dir` parameter.
+- Modify: `src/mship/cli/sync.py` — pass `container.state_dir()` to `sync_repos`.
+- Create: `tests/core/test_sync_recovery.py`
+
+**Context:** When `mship sync` sees ONLY `dirty_worktree` blocking a repo, attempt recovery by hashing each dirty tracked file and comparing against the same path on `origin/<branch>`. If every file matches, the dirty state IS the fast-forward delta and we reset those files. If any file differs, bail before touching anything.
+
+- [ ] **Step 2.1: Write failing tests**
+
+Create `tests/core/test_sync_recovery.py`:
+
+```python
+"""Integration tests for _try_recover_stale_main.
+
+Uses real `file://` bare-repo origins so git commands exercise actual
+index/working-tree logic.
+"""
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mship.core.repo_sync import _try_recover_stale_main
+from mship.core.repo_state import RepoAudit, Issue
+from mship.core.config import RepoConfig, WorkspaceConfig
+from mship.util.shell import ShellRunner
+
+
+def _run(cwd, *args, check=True):
+    return subprocess.run(["git", *args], cwd=cwd, check=check,
+                          capture_output=True, text=True)
+
+
+def _setup_workspace(tmp_path: Path, behind: bool = True,
+                     dirty_matches_upstream: bool = True,
+                     extra_untracked: bool = False,
+                     dirty_file_not_in_upstream: bool = False) -> Path:
+    """Return the local repo path. Configures an origin ahead of local."""
+    origin = tmp_path / "origin.git"
+    local = tmp_path / "local"
+    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True)
+    subprocess.run(["git", "clone", "-q", str(origin), str(local)], check=True)
+    _run(local, "config", "user.email", "t@t")
+    _run(local, "config", "user.name", "t")
+
+    # Commit A on local, push to origin.
+    (local / "a.txt").write_text("A\n")
+    _run(local, "add", ".")
+    _run(local, "commit", "-qm", "A")
+    _run(local, "push", "-qu", "origin", "main" if _current_branch(local) == "main" else _current_branch(local))
+
+    if behind:
+        # Make a commit B on a fresh clone pushed to origin.
+        other = tmp_path / "other"
+        subprocess.run(["git", "clone", "-q", str(origin), str(other)], check=True)
+        _run(other, "config", "user.email", "t@t")
+        _run(other, "config", "user.name", "t")
+        if dirty_file_not_in_upstream:
+            # Don't add the file upstream that's dirty locally.
+            (other / "unrelated.txt").write_text("unrelated upstream\n")
+            _run(other, "add", ".")
+        else:
+            (other / "a.txt").write_text("B\n")
+            _run(other, "add", ".")
+        _run(other, "commit", "-qm", "B")
+        _run(other, "push", "-q")
+        # Now origin is ahead of local.
+
+    # Dirty local working tree.
+    if dirty_matches_upstream and behind and not dirty_file_not_in_upstream:
+        (local / "a.txt").write_text("B\n")  # matches upstream
+    elif dirty_file_not_in_upstream:
+        (local / "a.txt").write_text("user work on a file upstream doesn't touch\n")
+    else:
+        (local / "a.txt").write_text("user work\n")
+    if extra_untracked:
+        (local / "user-note.txt").write_text("untracked\n")
+    return local
+
+
+def _current_branch(local: Path) -> str:
+    r = _run(local, "rev-parse", "--abbrev-ref", "HEAD")
+    return r.stdout.strip()
+
+
+def _make_audit(name: str, path: Path) -> RepoAudit:
+    """A RepoAudit whose only issue is dirty_worktree."""
+    return RepoAudit(
+        name=name, path=path, branch=_current_branch(path),
+        issues=[Issue("dirty_worktree", "error", "1 modified tracked file")],
+    )
+
+
+def _make_cfg(name: str, path: Path) -> WorkspaceConfig:
+    return WorkspaceConfig(
+        workspace="t",
+        repos={name: RepoConfig(path=path, type="service")},
+    )
+
+
+def test_happy_path_dirty_matches_upstream(tmp_path):
+    local = _setup_workspace(tmp_path, behind=True, dirty_matches_upstream=True)
+    audit = _make_audit("r", local)
+    cfg = _make_cfg("r", local)
+    state_dir = tmp_path / ".mothership"
+
+    recovered, msg = _try_recover_stale_main(audit, cfg, ShellRunner(), state_dir)
+
+    assert recovered is True
+    assert "recovered" in msg.lower()
+    # Working tree is now clean.
+    status = _run(local, "status", "--porcelain").stdout.strip()
+    assert status == ""
+    # Diagnostic file exists.
+    diags = list((state_dir / "diagnostics").glob("*.json"))
+    assert len(diags) == 1
+
+
+def test_user_work_preserved_when_hash_mismatches(tmp_path):
+    local = _setup_workspace(tmp_path, behind=True, dirty_matches_upstream=False)
+    audit = _make_audit("r", local)
+    cfg = _make_cfg("r", local)
+    state_dir = tmp_path / ".mothership"
+
+    recovered, msg = _try_recover_stale_main(audit, cfg, ShellRunner(), state_dir)
+
+    assert recovered is False
+    assert "does not match upstream" in msg.lower() or "real user work" in msg.lower()
+    # Original dirty content preserved.
+    assert (local / "a.txt").read_text() == "user work\n"
+    # Two diagnostics: pre-recovery + real-user-work.
+    diags = list((state_dir / "diagnostics").glob("*.json"))
+    assert len(diags) == 2
+
+
+def test_not_behind_origin_is_not_recoverable(tmp_path):
+    local = _setup_workspace(tmp_path, behind=False, dirty_matches_upstream=False)
+    audit = _make_audit("r", local)
+    cfg = _make_cfg("r", local)
+    state_dir = tmp_path / ".mothership"
+
+    recovered, msg = _try_recover_stale_main(audit, cfg, ShellRunner(), state_dir)
+
+    assert recovered is False
+    assert "not behind" in msg.lower()
+    # Original content untouched.
+    assert (local / "a.txt").read_text() == "user work\n"
+    # One diagnostic (pre-recovery).
+    diags = list((state_dir / "diagnostics").glob("*.json"))
+    assert len(diags) == 1
+
+
+def test_untracked_files_block_recovery(tmp_path):
+    local = _setup_workspace(tmp_path, behind=True, dirty_matches_upstream=True,
+                             extra_untracked=True)
+    audit = _make_audit("r", local)
+    cfg = _make_cfg("r", local)
+    state_dir = tmp_path / ".mothership"
+
+    recovered, msg = _try_recover_stale_main(audit, cfg, ShellRunner(), state_dir)
+
+    assert recovered is False
+    assert "untracked" in msg.lower()
+    # Tracked dirty file NOT reset (content preserved).
+    assert (local / "a.txt").read_text() == "B\n"
+    assert (local / "user-note.txt").exists()
+
+
+def test_dirty_file_not_in_upstream_is_not_recoverable(tmp_path):
+    local = _setup_workspace(tmp_path, behind=True,
+                             dirty_matches_upstream=False,
+                             dirty_file_not_in_upstream=True)
+    audit = _make_audit("r", local)
+    cfg = _make_cfg("r", local)
+    state_dir = tmp_path / ".mothership"
+
+    recovered, msg = _try_recover_stale_main(audit, cfg, ShellRunner(), state_dir)
+
+    assert recovered is False
+    assert ("does not match upstream" in msg.lower()
+            or "not match" in msg.lower())
+    # User content preserved.
+    assert "user work" in (local / "a.txt").read_text()
+
+
+def test_multi_file_all_match_triggers_recovery(tmp_path):
+    """Two dirty files, both match upstream → recovery succeeds."""
+    origin = tmp_path / "origin.git"
+    local = tmp_path / "local"
+    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True)
+    subprocess.run(["git", "clone", "-q", str(origin), str(local)], check=True)
+    _run(local, "config", "user.email", "t@t")
+    _run(local, "config", "user.name", "t")
+
+    (local / "a.txt").write_text("A1\n")
+    (local / "b.txt").write_text("B1\n")
+    _run(local, "add", ".")
+    _run(local, "commit", "-qm", "initial")
+    branch = _current_branch(local)
+    _run(local, "push", "-qu", "origin", branch)
+
+    # Upstream advance.
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "-q", str(origin), str(other)], check=True)
+    _run(other, "config", "user.email", "t@t")
+    _run(other, "config", "user.name", "t")
+    (other / "a.txt").write_text("A2\n")
+    (other / "b.txt").write_text("B2\n")
+    _run(other, "add", ".")
+    _run(other, "commit", "-qm", "advance")
+    _run(other, "push", "-q")
+
+    # Dirty both files matching upstream.
+    (local / "a.txt").write_text("A2\n")
+    (local / "b.txt").write_text("B2\n")
+
+    audit = _make_audit("r", local)
+    cfg = _make_cfg("r", local)
+    state_dir = tmp_path / ".mothership"
+
+    recovered, msg = _try_recover_stale_main(audit, cfg, ShellRunner(), state_dir)
+    assert recovered is True
+    # Working tree clean.
+    assert _run(local, "status", "--porcelain").stdout.strip() == ""
+
+
+def test_multi_file_one_mismatches_preserves_all(tmp_path):
+    """Two dirty files; first matches, second doesn't.
+    Recovery bails before touching anything — both files preserved."""
+    origin = tmp_path / "origin.git"
+    local = tmp_path / "local"
+    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True)
+    subprocess.run(["git", "clone", "-q", str(origin), str(local)], check=True)
+    _run(local, "config", "user.email", "t@t")
+    _run(local, "config", "user.name", "t")
+    (local / "a.txt").write_text("A1\n")
+    (local / "b.txt").write_text("B1\n")
+    _run(local, "add", ".")
+    _run(local, "commit", "-qm", "initial")
+    branch = _current_branch(local)
+    _run(local, "push", "-qu", "origin", branch)
+
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "-q", str(origin), str(other)], check=True)
+    _run(other, "config", "user.email", "t@t")
+    _run(other, "config", "user.name", "t")
+    (other / "a.txt").write_text("A2\n")
+    (other / "b.txt").write_text("B2\n")
+    _run(other, "add", ".")
+    _run(other, "commit", "-qm", "advance")
+    _run(other, "push", "-q")
+
+    # Dirty: a.txt matches upstream, b.txt has user work.
+    (local / "a.txt").write_text("A2\n")
+    (local / "b.txt").write_text("user work\n")
+
+    audit = _make_audit("r", local)
+    cfg = _make_cfg("r", local)
+    state_dir = tmp_path / ".mothership"
+
+    recovered, msg = _try_recover_stale_main(audit, cfg, ShellRunner(), state_dir)
+    assert recovered is False
+    # Both files preserved — no reset happened.
+    assert (local / "a.txt").read_text() == "A2\n"
+    assert (local / "b.txt").read_text() == "user work\n"
+```
+
+- [ ] **Step 2.2: Run tests to verify they fail**
+
+Run: `pytest tests/core/test_sync_recovery.py -v`
+Expected: FAIL — `ImportError: cannot import name '_try_recover_stale_main' from 'mship.core.repo_sync'`.
+
+- [ ] **Step 2.3: Add the recovery helper**
+
+Edit `src/mship/core/repo_sync.py`. Add these imports at the top if missing:
+
+```python
+from pathlib import Path
+from mship.core.diagnostics import capture_snapshot
+```
+
+Add the helper — place it just above `def _result_for(...)`:
+
+```python
+def _repo_root_path(repo: RepoAudit, cfg: WorkspaceConfig) -> Path:
+    """Resolve to the effective path (handles git_root)."""
+    r = cfg.repos[repo.name]
+    if r.git_root is not None:
+        return Path(cfg.repos[r.git_root].path)
+    return Path(r.path)
+
+
+def _try_recover_stale_main(
+    repo: RepoAudit,
+    cfg: WorkspaceConfig,
+    shell: ShellRunner,
+    state_dir: Path,
+) -> tuple[bool, str]:
+    """Attempt to recover from dirty-main-matches-upstream state.
+
+    Returns (recovered, message). If recovered, the working tree has been
+    reset so the caller's fast-forward path can run. If not recovered, no
+    state mutation occurred — user's working tree untouched.
+    """
+    root = _repo_root_path(repo, cfg)
+    # 1. Snapshot before doing anything.
+    capture_snapshot(
+        "sync", "dirty-main-pre-recovery", state_dir,
+        repos={repo.name: root},
+    )
+
+    branch = repo.branch or _detect_branch(root, shell)
+    if not branch:
+        return (False, "could not resolve branch for recovery check")
+
+    # 2. Behind check.
+    import shlex as _shlex
+    r = shell.run(
+        f"git rev-list --count {_shlex.quote(branch)}..origin/{_shlex.quote(branch)}",
+        cwd=root,
+    )
+    if r.returncode != 0:
+        return (False, f"behind-check failed: {r.stderr.strip()}")
+    try:
+        behind = int(r.stdout.strip() or "0")
+    except ValueError:
+        behind = 0
+    if behind == 0:
+        return (False, "not behind origin; not the recoverable pattern")
+
+    # 3. Untracked check — recovery only handles the modified-tracked-files pattern.
+    r = shell.run("git ls-files --others --exclude-standard", cwd=root)
+    if r.returncode == 0 and r.stdout.strip():
+        return (False, "untracked files present; recovery skipped to preserve data")
+
+    # 4. Dirty tracked files enumeration.
+    r = shell.run("git diff --name-only HEAD", cwd=root)
+    if r.returncode != 0:
+        return (False, f"diff --name-only failed: {r.stderr.strip()}")
+    dirty_files = [p for p in r.stdout.splitlines() if p.strip()]
+    if not dirty_files:
+        return (False, "no dirty tracked files; nothing to recover")
+
+    # 5. Per-file hash compare — PROVE redundancy BEFORE mutating state.
+    mismatches: list[str] = []
+    for path in dirty_files:
+        wh = shell.run(f"git hash-object -- {_shlex.quote(path)}", cwd=root)
+        if wh.returncode != 0:
+            mismatches.append(f"{path} (hash-object failed)")
+            break
+        working_hash = wh.stdout.strip()
+
+        uh = shell.run(
+            f"git rev-parse origin/{_shlex.quote(branch)}:{_shlex.quote(path)}",
+            cwd=root,
+        )
+        if uh.returncode != 0:
+            mismatches.append(path)
+            break
+        upstream_hash = uh.stdout.strip()
+
+        if working_hash != upstream_hash:
+            mismatches.append(path)
+            break
+
+    if mismatches:
+        capture_snapshot(
+            "sync", "dirty-main-real-user-work", state_dir,
+            repos={repo.name: root},
+            extra={"mismatched_files": mismatches},
+        )
+        return (
+            False,
+            f"dirty file {mismatches[0]} does not match upstream; real user work",
+        )
+
+    # 6. All files verified redundant — safe to reset.
+    for path in dirty_files:
+        r = shell.run(f"git checkout -- {_shlex.quote(path)}", cwd=root)
+        if r.returncode != 0:
+            capture_snapshot(
+                "sync", "dirty-main-reset-failed", state_dir,
+                repos={repo.name: root},
+                extra={"failed_path": path, "stderr": r.stderr},
+            )
+            return (
+                False,
+                f"checkout failed on {path} after hashes matched: {r.stderr.strip()}",
+            )
+
+    return (True, "recovered from stale main state")
+
+
+def _detect_branch(root: Path, shell: ShellRunner) -> str | None:
+    r = shell.run("git rev-parse --abbrev-ref HEAD", cwd=root)
+    if r.returncode != 0:
+        return None
+    out = r.stdout.strip()
+    return out if out and out != "HEAD" else None
+```
+
+Update `_result_for` to accept `state_dir` and call recovery when appropriate:
+
+```python
+def _result_for(
+    repo: RepoAudit,
+    cfg: WorkspaceConfig,
+    shell: ShellRunner,
+    state_dir: Path,
+) -> SyncResult:
+    blocking = [i for i in repo.issues if i.code in _BLOCKING_CODES]
+    # Recovery attempt: only when dirty_worktree is the SOLE blocking code.
+    if blocking and all(i.code == "dirty_worktree" for i in blocking):
+        recovered, msg = _try_recover_stale_main(repo, cfg, shell, state_dir)
+        if recovered:
+            # Rebuild just the behind-remote signal — recovery just reset
+            # files but didn't pull. Existing behind-remote arm handles the
+            # fast-forward.
+            root = _git_root_path(cfg, repo.name)
+            r = shell.run("git pull --ff-only", cwd=root)
+            if r.returncode != 0:
+                return SyncResult(
+                    repo.name, repo.path, "skipped",
+                    f"pull failed after recovery: {r.stderr.strip() or 'unknown'}",
+                )
+            return SyncResult(
+                repo.name, repo.path, "fast_forwarded",
+                f"recovered from stale main state",
+            )
+        # Recovery declined → fall through to original skip.
+    if blocking:
+        first = blocking[0]
+        return SyncResult(repo.name, repo.path, "skipped",
+                          f"{first.code} — {first.message}")
+    behind = [i for i in repo.issues if i.code == "behind_remote"]
+    if behind:
+        root = _git_root_path(cfg, repo.name)
+        r = shell.run("git pull --ff-only", cwd=root)
+        if r.returncode != 0:
+            return SyncResult(repo.name, repo.path, "skipped",
+                              f"pull failed: {r.stderr.strip() or 'unknown error'}")
+        msg = behind[0].message
+        return SyncResult(repo.name, repo.path, "fast_forwarded", msg)
+    return SyncResult(repo.name, repo.path, "up_to_date", "no action")
+```
+
+Update `sync_repos` to accept `state_dir`:
+
+```python
+def sync_repos(
+    report: AuditReport,
+    config: WorkspaceConfig,
+    shell: ShellRunner,
+    state_dir: Path,
+) -> SyncReport:
+    ...
+    for repo_audit in report.repos:
+        ...
+        results.append(_result_for(repo_audit, config, shell, state_dir))
+    ...
+```
+
+Find the existing `sync_repos` body and update the per-repo call site accordingly. The rest of the function (shared-root dedup) stays identical.
+
+- [ ] **Step 2.4: Update the CLI caller**
+
+Edit `src/mship/cli/sync.py`. Find:
+
+```python
+out = sync_repos(report, config, shell)
+```
+
+Replace with:
+
+```python
+out = sync_repos(report, config, shell, container.state_dir())
+```
+
+- [ ] **Step 2.5: Run tests to verify they pass**
+
+Run: `pytest tests/core/test_sync_recovery.py -v`
+Expected: 7 passed.
+
+- [ ] **Step 2.6: Run broader tests**
+
+Run: `pytest tests/core/test_diagnostics.py tests/core/test_sync_recovery.py tests/core/ -v --ignore=tests/core/view/test_web_port.py 2>&1 | tail -10`
+
+If any existing test in `tests/core/` fails because `sync_repos` / `_result_for` signature changed, update the call site to pass a `state_dir` (use `tmp_path / ".mothership"` in tests). These should be small fixes.
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add src/mship/core/repo_sync.py src/mship/cli/sync.py tests/core/test_sync_recovery.py
+git commit -m "feat(sync): hash-compare recovery for stale-main-index bug"
+mship journal "_try_recover_stale_main resets dirty tracked files only when every file's hash matches origin/<branch>; never stashes, never resets --hard" --action committed
+```
+
+---
+
+## Task 3: Post-op sanity captures in `mship finish` and `mship close`
+
+**Files:**
+- Modify: `src/mship/cli/worktree.py` — add silent post-op captures in `finish` and `close`.
+- Modify: `tests/cli/test_worktree.py` — add integration tests.
+
+**Context:** When `mship finish` and `mship close` complete their work, the main checkouts of affected repos should be clean. Capture a snapshot (silent; no user-visible change) if they're dirty. No refusal, no warning — we're collecting evidence.
+
+- [ ] **Step 3.1: Write failing tests**
+
+Append to `tests/cli/test_worktree.py`:
+
+```python
+def test_finish_captures_diagnostic_when_main_is_dirty_post_op(configured_git_app: Path):
+    """If main is dirty after finish completes, a diagnostic is captured."""
+    from mship.cli import container as cli_container
+    from mship.util.shell import ShellResult, ShellRunner
+    from unittest.mock import MagicMock
+
+    runner.invoke(app, ["spawn", "dirty diag", "--repos", "shared", "--skip-setup"])
+
+    # Pre-dirty the main repo's shared/ working tree by writing an extra
+    # file directly to simulate whatever causes the bug.
+    shared_path = configured_git_app / "shared" / "dirty-marker.txt"
+    shared_path.parent.mkdir(parents=True, exist_ok=True)
+    shared_path.write_text("synthetic dirty content\n")
+    # Stage so `git status --porcelain` reports it as a change.
+    import subprocess as _sp
+    _sp.run(["git", "add", "dirty-marker.txt"], cwd=configured_git_app / "shared", check=True)
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref --symbolic-full-name" in cmd and "@{u}" in cmd:
+            return ShellResult(returncode=0, stdout="origin/feat/dirty-diag", stderr="")
+        if "gh pr list --head" in cmd:
+            return ShellResult(returncode=0, stdout="\n", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://github.com/org/shared/pull/1\n", stderr="")
+        if "git status --porcelain" in cmd:
+            # Simulate dirty state on the main repo path (our post-op check).
+            if "shared" in str(cwd):
+                return ShellResult(returncode=0, stdout="M  dirty-marker.txt\n", stderr="")
+            return ShellResult(returncode=0, stdout="", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = mock_run
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    cli_container.shell.override(mock_shell)
+
+    result = runner.invoke(app, ["finish", "--task", "dirty-diag"])
+    # Finish succeeds (diagnostic is silent).
+    assert result.exit_code == 0, result.output
+
+    # A finish-dirty-main-post-op diagnostic exists.
+    diag_dir = configured_git_app / ".mothership" / "diagnostics"
+    if diag_dir.is_dir():
+        names = [p.name for p in diag_dir.glob("*.json")]
+        assert any("finish-dirty-main-post-op" in n for n in names), names
+    else:
+        pytest.fail("diagnostics dir not created")
+
+    cli_container.shell.reset_override()
+
+
+def test_finish_does_not_capture_diagnostic_when_main_is_clean(configured_git_app: Path):
+    """Clean happy path — no post-op diagnostic."""
+    from mship.cli import container as cli_container
+    from mship.util.shell import ShellResult, ShellRunner
+    from unittest.mock import MagicMock
+
+    runner.invoke(app, ["spawn", "clean diag", "--repos", "shared", "--skip-setup"])
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref --symbolic-full-name" in cmd and "@{u}" in cmd:
+            return ShellResult(returncode=0, stdout="origin/feat/clean-diag", stderr="")
+        if "gh pr list --head" in cmd:
+            return ShellResult(returncode=0, stdout="\n", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://github.com/org/shared/pull/1\n", stderr="")
+        if "git status --porcelain" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = mock_run
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    cli_container.shell.override(mock_shell)
+
+    result = runner.invoke(app, ["finish", "--task", "clean-diag"])
+    assert result.exit_code == 0, result.output
+
+    diag_dir = configured_git_app / ".mothership" / "diagnostics"
+    if diag_dir.is_dir():
+        names = [p.name for p in diag_dir.glob("*.json")]
+        # No post-op diagnostics present for this run.
+        assert not any("finish-dirty-main-post-op" in n for n in names), names
+
+    cli_container.shell.reset_override()
+```
+
+- [ ] **Step 3.2: Run tests to verify they fail**
+
+Run: `pytest tests/cli/test_worktree.py::test_finish_captures_diagnostic_when_main_is_dirty_post_op -v`
+Expected: FAIL — either no diagnostic captured, or `assert any(...)` returns False.
+
+- [ ] **Step 3.3: Add post-op capture to `mship finish`**
+
+Edit `src/mship/cli/worktree.py`. Locate the `finish` command handler. Find the successful-exit path (usually right before `typer.Exit(code=0)` or just before `return`).
+
+Insert this defensive block just before the final successful exit (or at the end of the command body, wrapped in try/except so diagnostics never break finish):
+
+```python
+        # Post-op diagnostic: if any affected repo's main-checkout path is
+        # dirty after finish completed, capture a snapshot. Silent — users
+        # see the snapshot count via `mship doctor`. See spec 2026-04-21.
+        try:
+            from mship.core.diagnostics import capture_snapshot
+            post_op_repos: dict[str, Path] = {}
+            for _repo_name in t.affected_repos:
+                _repo_cfg = config.repos.get(_repo_name)
+                if _repo_cfg is None:
+                    continue
+                if _repo_cfg.git_root is not None:
+                    _parent = config.repos.get(_repo_cfg.git_root)
+                    if _parent is None:
+                        continue
+                    _main_path = Path(_parent.path).resolve()
+                else:
+                    _main_path = Path(_repo_cfg.path).resolve()
+                if _main_path.is_dir():
+                    post_op_repos[_repo_name] = _main_path
+            any_dirty = False
+            for _name, _path in post_op_repos.items():
+                _res = shell.run("git status --porcelain", cwd=_path)
+                if _res.returncode == 0 and _res.stdout.strip():
+                    any_dirty = True
+                    break
+            if any_dirty and post_op_repos:
+                capture_snapshot(
+                    "finish", "dirty-main-post-op",
+                    container.state_dir(),
+                    repos=post_op_repos,
+                )
+        except Exception:
+            # Diagnostics is strictly best-effort.
+            pass
+```
+
+Place this AFTER all the normal finish logic (PR creation, state mutation, `finished_at` stamp, coordination block updates) and BEFORE the final return/exit.
+
+- [ ] **Step 3.4: Add post-op capture to `mship close`**
+
+Still in `src/mship/cli/worktree.py`, find the `close` command handler. Insert the same post-op block just before the successful exit. The same snippet works verbatim; re-use it.
+
+- [ ] **Step 3.5: Run tests to verify they pass**
+
+Run: `pytest tests/cli/test_worktree.py -v -k "captures_diagnostic or does_not_capture"`
+Expected: 2 passed.
+
+- [ ] **Step 3.6: Run the full test file to catch regressions**
+
+Run: `pytest tests/cli/test_worktree.py -v 2>&1 | tail -15`
+Expected: all green.
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add src/mship/cli/worktree.py tests/cli/test_worktree.py
+git commit -m "feat(worktree): silent post-op diagnostic capture on finish + close"
+mship journal "mship finish and mship close now capture a diagnostic if main is dirty post-op (data collection for the stale-main-index bug)" --action committed
+```
+
+---
+
+## Task 4: `mship doctor` diagnostics row
+
+**Files:**
+- Modify: `src/mship/core/doctor.py` — `DoctorChecker.__init__` accepts `state_dir`; `run()` appends a `diagnostics` row when snapshots exist.
+- Modify: `src/mship/cli/doctor.py` — pass `container.state_dir()`.
+- Modify: `tests/core/test_doctor.py` — new tests.
+
+**Context:** When `.mothership/diagnostics/` contains any `.json` file, `mship doctor` surfaces a `warn` row with the count and the suggestion to review or prune.
+
+- [ ] **Step 4.1: Write failing tests**
+
+Append to `tests/core/test_doctor.py`:
+
+```python
+def test_doctor_diagnostics_row_warn_when_snapshots_present(workspace: Path):
+    from mship.core.config import ConfigLoader
+    from mship.core.doctor import DoctorChecker
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+    # Pre-create a diagnostic file.
+    diag_dir = workspace / ".mothership" / "diagnostics"
+    diag_dir.mkdir(parents=True, exist_ok=True)
+    (diag_dir / "2026-01-01T00-00-00Z-sync-pre-recovery.json").write_text("{}")
+
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    shell = MagicMock(spec=ShellRunner)
+    from mship.util.shell import ShellResult
+    shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+
+    report = DoctorChecker(config, shell, state_dir=workspace / ".mothership").run()
+    diag_checks = [c for c in report.checks if c.name == "diagnostics"]
+    assert len(diag_checks) == 1
+    assert diag_checks[0].status == "warn"
+    assert "1" in diag_checks[0].message or "snapshot" in diag_checks[0].message.lower()
+
+
+def test_doctor_no_diagnostics_row_when_absent(workspace: Path):
+    from mship.core.config import ConfigLoader
+    from mship.core.doctor import DoctorChecker
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+    from mship.util.shell import ShellResult
+
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    shell = MagicMock(spec=ShellRunner)
+    shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+
+    report = DoctorChecker(config, shell, state_dir=workspace / ".mothership").run()
+    diag_checks = [c for c in report.checks if c.name == "diagnostics"]
+    assert len(diag_checks) == 0
+```
+
+- [ ] **Step 4.2: Run tests to verify they fail**
+
+Run: `pytest tests/core/test_doctor.py -v -k diagnostics`
+Expected: FAIL — `DoctorChecker.__init__() got an unexpected keyword argument 'state_dir'`.
+
+- [ ] **Step 4.3: Update `DoctorChecker` to accept `state_dir`**
+
+Edit `src/mship/core/doctor.py`. Find:
+
+```python
+class DoctorChecker:
+    """Run health checks on a mothership workspace."""
+
+    def __init__(self, config: WorkspaceConfig, shell: ShellRunner) -> None:
+        self._config = config
+        self._shell = shell
+```
+
+Replace with:
+
+```python
+class DoctorChecker:
+    """Run health checks on a mothership workspace."""
+
+    def __init__(
+        self,
+        config: WorkspaceConfig,
+        shell: ShellRunner,
+        *,
+        state_dir: Path | None = None,
+    ) -> None:
+        self._config = config
+        self._shell = shell
+        self._state_dir = state_dir
+```
+
+(Default `state_dir=None` keeps existing test callers working; the diagnostics row only appears when state_dir is provided AND the directory has snapshots.)
+
+In the `run()` method, AFTER the existing `go-task binary` check block (around line 230-ish, before `# Dev-mode trap:` or similar), insert:
+
+```python
+        # Pending diagnostics snapshots (spec 2026-04-21).
+        if self._state_dir is not None:
+            diag_dir = Path(self._state_dir) / "diagnostics"
+            if diag_dir.is_dir():
+                count = sum(1 for _ in diag_dir.glob("*.json"))
+                if count > 0:
+                    report.checks.append(CheckResult(
+                        name="diagnostics",
+                        status="warn",
+                        message=(
+                            f"{count} snapshot(s) in .mothership/diagnostics/ — "
+                            f"review for unexpected-state captures; `rm -rf` to clear"
+                        ),
+                    ))
+```
+
+- [ ] **Step 4.4: Update the CLI wiring**
+
+Edit `src/mship/cli/doctor.py`. Find:
+
+```python
+        checker = DoctorChecker(config, shell)
+```
+
+Replace with:
+
+```python
+        checker = DoctorChecker(config, shell, state_dir=container.state_dir())
+```
+
+- [ ] **Step 4.5: Run tests to verify they pass**
+
+Run: `pytest tests/core/test_doctor.py -v`
+Expected: all pass (2 new + existing). The existing tests that construct `DoctorChecker(config, shell)` without `state_dir` still work because the param is keyword-only with a default.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add src/mship/core/doctor.py src/mship/cli/doctor.py tests/core/test_doctor.py
+git commit -m "feat(doctor): diagnostics row when .mothership/diagnostics/ has snapshots"
+mship journal "mship doctor now surfaces a warn row when forensic snapshots are pending review" --action committed
+```
+
+---
+
+## Task 5: End-to-end smoke + finish PR
+
+**Files:**
+- None (verification + PR only).
+
+**Context:** Unit + integration tests already cover the recovery, capture, and doctor-row paths. A quick end-to-end manual smoke verifies the integration when run against a real `mship sync` invocation.
+
+- [ ] **Step 5.1: Reinstall tool**
+
+```bash
+cd /home/bailey/development/repos/mothership/.worktrees/feat/fix-stale-main-index-warn-on-wrong-cwd-gate-finish-on-tests
+uv tool install --reinstall --from . mothership
+```
+
+- [ ] **Step 5.2: Smoke the recovery path**
+
+Set up a scratch workspace where main is one commit behind origin AND the dirty tracked file matches upstream content:
+
+```bash
+rm -rf /tmp/stale-smoke
+mkdir -p /tmp/stale-smoke && cd /tmp/stale-smoke
+
+# Origin (bare) and local clone.
+git init --bare -q origin.git
+git clone -q origin.git local
+cd local
+git config user.email "t@t" && git config user.name "t"
+echo "A" > a.txt && git add . && git commit -qm "A"
+git push -qu origin main
+
+# Advance origin from another clone.
+cd ..
+git clone -q origin.git other
+cd other
+git config user.email "t@t" && git config user.name "t"
+echo "B" > a.txt && git add . && git commit -qm "B"
+git push -q
+
+# Back in local: dirty a.txt to match upstream (simulates the bug pattern).
+cd ../local
+echo "B" > a.txt   # working tree matches origin/main without having pulled
+
+# Set up minimal mothership workspace rooted at local.
+cat > mothership.yaml <<'EOF'
+workspace: stale-smoke
+repos:
+  self:
+    path: .
+    type: service
+EOF
+mkdir -p .mothership
+
+# Run mship sync; it should auto-recover.
+mship sync
+```
+
+Expected output contains:
+- `self: fast-forwarded (recovered from stale main state)` or similar recovery message.
+- After the command, `git status --porcelain` shows clean.
+- `.mothership/diagnostics/<ts>-sync-dirty-main-pre-recovery.json` exists.
+
+Run `mship doctor` to confirm the row:
+
+```bash
+mship doctor 2>&1 | grep -i diagnostic
+```
+
+Expected: `warn   diagnostics   1 snapshot(s) …`.
+
+- [ ] **Step 5.3: Smoke the refuse path**
+
+Reset, then dirty a.txt with content that DOESN'T match upstream:
+
+```bash
+cd /tmp/stale-smoke/local
+git reset --hard HEAD
+echo "Z" > a.txt   # user work, not in upstream
+
+mship sync; echo "EXIT: $?"
+```
+
+Expected:
+- `self: skipped (dirty_worktree — ...)` — refusal, original message.
+- `EXIT: 1`.
+- `.mothership/diagnostics/` now has TWO files (pre-recovery + real-user-work).
+- `a.txt` still contains "Z" (untouched).
+
+- [ ] **Step 5.4: Cleanup**
+
+```bash
+rm -rf /tmp/stale-smoke
+```
+
+- [ ] **Step 5.5: Full pytest**
+
+```bash
+cd /home/bailey/development/repos/mothership/.worktrees/feat/fix-stale-main-index-warn-on-wrong-cwd-gate-finish-on-tests
+pytest tests/ 2>&1 | tail -5
+```
+
+Expected: all pass.
+
+- [ ] **Step 5.6: Open PR**
+
+Write `/tmp/stale-recovery-body.md`:
+
+```markdown
+## Summary
+
+Two-part change to address the recurring "stale main index after merge" bug observed multiple times this session:
+
+1. **Diagnostics library** — new `capture_snapshot()` writes JSON forensics blobs to `.mothership/diagnostics/<ts>-<command>-<reason>.json` whenever mship commands detect anomalous state. Ships the instrumentation the future root-cause investigation will need.
+
+2. **`mship sync` auto-recovery** — when audit blocks solely on `dirty_worktree`, compare each dirty tracked file's blob hash against `origin/<branch>`. If every file matches, the dirty state IS the fast-forward delta: reset those files and let the normal fast-forward run. If any file doesn't match, bail before touching anything — user's working tree stays exactly as it was.
+
+`mship finish` and `mship close` also capture silent post-op diagnostics when they observe main dirty at exit. `mship doctor` gains a `diagnostics` warn row when snapshots are pending review.
+
+## Why hash-compare instead of stash
+
+- Provably safe: no state mutation until every file's redundancy is verified. Wrong guess → no files touched.
+- No stash/pop edge cases. No `git reset --hard` in any path.
+- Untracked files block recovery outright (preserves anything unexpected).
+
+## Scope
+
+- Only `mship sync` actively recovers. `mship finish` / `mship close` only capture diagnostics, no behavior change.
+- Recovery only triggers when `dirty_worktree` is the SOLE blocking audit code.
+- No root-cause fix yet — this ships the instrumentation and the mitigation together.
+
+## Related
+
+- Issues #80, #81 filed for the other two papercuts (wrong-cwd warning, finish test-evidence gate); followups.
+- Decision log + algorithm details in the spec.
+
+## Test plan
+
+- [x] `tests/core/test_diagnostics.py`: 6 unit tests for `capture_snapshot` (happy, filename-safe, dir-creation, repos populated, extra kwarg, write-failure-non-fatal).
+- [x] `tests/core/test_sync_recovery.py`: 7 integration tests against real `file://` origins (happy, user-work-preserved, not-behind, untracked, file-missing-upstream, multi-match, multi-mismatch-preserves-all).
+- [x] `tests/cli/test_worktree.py`: 2 new integration tests for finish post-op capture (dirty → captured; clean → not captured).
+- [x] `tests/core/test_doctor.py`: 2 new tests for the diagnostics row.
+- [x] Full suite: all pass.
+- [x] Manual smoke: scratch workspace with dirty-main-matches-upstream state → `mship sync` recovers; with real user work → refusal preserved + two diagnostics captured.
+
+Closes the top-ranked recurring papercut from session feedback.
+```
+
+Then:
+
+```bash
+cd /home/bailey/development/repos/mothership/.worktrees/feat/fix-stale-main-index-warn-on-wrong-cwd-gate-finish-on-tests
+mship finish --body-file /tmp/stale-recovery-body.md
+```
+
+Expected: PR URL returned.
+
+---
+
+## Done when
+
+- [x] `capture_snapshot()` writes diagnostics with all required keys; write-failure non-fatal.
+- [x] `_try_recover_stale_main()` proves redundancy via hash-compare before any state mutation; untracked files block; never uses stash or `reset --hard`.
+- [x] `sync_repos` and `_result_for` plumb `state_dir`; CLI sync passes `container.state_dir()`.
+- [x] `mship finish` / `mship close` silently capture post-op diagnostics when main is dirty.
+- [x] `mship doctor` surfaces a `warn diagnostics` row when `.mothership/diagnostics/` has snapshots; zero rows when absent.
+- [x] 17 new tests pass (6 diagnostics + 7 sync recovery + 2 finish post-op + 2 doctor).
+- [x] Full pytest green.
+- [x] Manual smoke confirms recovery on the bug pattern and preservation on real user work.

--- a/docs/superpowers/specs/2026-04-21-stale-main-index-diagnostics-and-recovery-design.md
+++ b/docs/superpowers/specs/2026-04-21-stale-main-index-diagnostics-and-recovery-design.md
@@ -1,0 +1,341 @@
+# Stale-main-index diagnostics + `mship sync` auto-recovery — Design
+
+## Context
+
+After a PR is merged on GitHub, the normal post-merge flow from the main checkout is:
+
+```
+$ git checkout main
+$ mship sync      # fast-forward main, catch up
+$ mship close --task <slug>
+```
+
+In at least two observed cases this session, `mship sync` refused with:
+
+```
+mothership: skipped (dirty_worktree — N modified tracked files)
+```
+
+Inspection showed the modified tracked files on main are **exactly the PR's changes** — the same diff that would come in from `origin/main` once main fast-forwards. The user didn't stage anything; the state appeared during the normal `mship finish` → GitHub-merge → return-to-main flow.
+
+Recovery today requires: `git reset HEAD <files>`, `git checkout -- <files>`, `mship sync`. Manual, fragile, and the user loses the tiny confidence boost `mship sync` was supposed to provide.
+
+Root cause is unknown. Hypotheses include:
+- Git worktree operations writing to main's index via the shared `.git/` directory.
+- A hook firing from a worktree but applying to main's path.
+- `uv tool install --reinstall --from .` touching main during the session.
+- Something in `mship finish`'s pipeline (gh CLI calls, body edits) producing a side effect on the main checkout.
+
+Diagnosing requires data we don't have today: state snapshots captured at the moment of the anomaly. Shipping instrumentation now is what makes a root-cause fix possible later.
+
+## Goal
+
+Two-part change:
+
+1. **Instrument** — add a lightweight diagnostics library that captures forensics snapshots (JSON) when commands detect anomalous state. No snapshots on the happy path; only on the specific conditions we care about.
+2. **Mitigate** — teach `mship sync` to auto-recover when it sees the signature pattern (dirty main whose content matches the fast-forward delta). Users stop hitting the manual-recovery wall. The mitigation logs every recovery attempt via the diagnostics library so we still collect evidence for the future root-cause fix.
+
+## Success criterion
+
+**Before change:** user runs `git checkout main; mship sync` after their PR merges. Gets `dirty_worktree` refusal. Must manually reset and retry.
+
+**After change:** user runs `git checkout main; mship sync`. Either:
+- (If the bug recurs) `mship sync` auto-recovers, logs the event to `.mothership/diagnostics/<ts>-sync-dirty-main-pre-recovery.json`, fast-forwards, prints `"recovered from stale main state; diagnostic at <path>"`, continues.
+- (If real user work is dirty) refuses with the existing error (unchanged behavior). Diagnostic is still captured.
+
+`mship doctor` gains a row: `warn   diagnostics   N snapshots present — review or prune` when `.mothership/diagnostics/` is non-empty.
+
+`mship finish` / `mship close` capture a snapshot if they detect main dirty immediately after exit (no user-facing warning; data collection only).
+
+## Anti-goals
+
+- **No root-cause fix yet.** The purpose is instrumentation; the root cause may need multiple reproduction cycles to nail down.
+- **No new CLI subcommand** (`mship diagnostics`). Files live under `.mothership/diagnostics/`; user inspects with `cat`; doctor surfaces the count.
+- **No automatic rotation** of diagnostic files. Doctor reports the count, user decides when to `rm -rf .mothership/diagnostics/`.
+- **No change to the audit gate matrix.** Recovery happens BEFORE the gate's refusal becomes user-visible, as a preflight in `_result_for`.
+- **No change to `mship finish` or `mship close` user-facing output.** Post-op sanity check writes the diagnostic silently.
+- **No destructive auto-recover.** `git reset --hard` is NEVER used for recovery. `git stash --include-untracked` + `git stash pop` handles the recovery semantically so any real user work is always recoverable.
+- **No new CLI flag** to opt into / out of recovery. The recovery is safe by construction (stash-based); it only applies when the pattern matches.
+
+## Architecture
+
+### 1. Diagnostics library — `src/mship/core/diagnostics.py` (new)
+
+Single public function:
+
+```python
+def capture_snapshot(
+    command: str,
+    reason: str,
+    state_dir: Path,
+    *,
+    repos: dict[str, Path] | None = None,
+    extra: dict | None = None,
+) -> Path | None:
+    """Write a JSON forensics blob to <state_dir>/diagnostics/<ts>-<command>-<reason>.json.
+
+    Returns the written path, or None on write failure (never raises).
+    """
+```
+
+Captured keys:
+- `captured_at` — ISO-8601 UTC timestamp.
+- `command` — the invoking mship command name (`"sync"`, `"finish"`, `"close"`).
+- `reason` — short tag (`"dirty-main-pre-recovery"`, `"dirty-main-post-op"`, etc.).
+- `cwd` — where the command was invoked from.
+- `mship_version` — from `importlib.metadata.version("mothership")`.
+- `python_version` — `sys.version`.
+- `path_env` — `os.environ.get("PATH")`.
+- `repos` — per-repo dict of `{git_status_porcelain, head_sha, head_branch, upstream_tracking, reflog_tail (last 10), stash_count}`. Only populated when the caller passes `repos={name: path}`.
+- `extra` — caller-provided free-form data (e.g., the stash output after a recovery attempt).
+
+Write failure handling: `except OSError: logger.debug(...); return None`. Diagnostics is best-effort — never blocks the caller.
+
+Filename format: `<iso8601-with-z>-<command>-<reason>.json`, with colons replaced by `-` for filesystem safety (e.g., `2026-04-21T14-23-08Z-sync-dirty-main-pre-recovery.json`).
+
+Directory created with `mkdir(parents=True, exist_ok=True)` on first call.
+
+### 2. `mship sync` recovery — edit `src/mship/core/repo_sync.py::_result_for`
+
+Today `_result_for(repo_audit, cfg, shell)` early-returns `SyncResult(..., "skipped", "dirty_worktree — ...")` when a blocking code appears on the repo audit. The new behavior: when the ONLY blocking code is `dirty_worktree` (not combined with other blocking codes), run a recovery attempt. If recovery succeeds, re-run the sync for that repo (the fast-forward branch); if it fails, return the original skip.
+
+New helper in the same module:
+
+```python
+def _try_recover_stale_main(
+    repo: RepoAudit,
+    cfg: WorkspaceConfig,
+    shell: ShellRunner,
+    state_dir: Path,
+) -> tuple[bool, str]:
+    """Attempt to recover from a dirty-main-that-matches-upstream state.
+
+    Returns (recovered, message). On `recovered=True`, the working tree is
+    now at origin/<branch> with all stashed content verified redundant.
+    On `recovered=False`, the working tree and index are restored to their
+    pre-attempt state; the caller should proceed with the original skip.
+
+    Always captures a diagnostic snapshot regardless of outcome.
+    """
+```
+
+Algorithm — hash-compare dirty tracked files against `origin/<branch>`; reset if they all already match:
+
+```
+1. Capture diagnostic: capture_snapshot("sync", "dirty-main-pre-recovery", state_dir, repos={name: root}).
+2. Behind check: `git rev-list --count <branch>..origin/<branch>` > 0.
+   If not behind → return (False, "not behind origin; not the recoverable pattern").
+3. Untracked check: `git ls-files --others --exclude-standard`.
+   If any untracked present → return (False, "untracked files present; recovery skipped to preserve data").
+   Rationale: the observed bug pattern involves only modified tracked files, not untracked adds.
+   Refusing when untracked exist keeps the safety bar high.
+4. Dirty-file enumeration: `git diff --name-only HEAD` → list of modified tracked files.
+5. Per-file hash compare:
+   For each file in the list:
+     a. Compute working-tree blob hash: `git hash-object -- <file>`.
+     b. Look up the same file's blob on origin/<branch>:
+        `git rev-parse origin/<branch>:<file>` → gives the blob SHA if the file exists upstream.
+        If the file does NOT exist on origin/<branch> (rev-parse fails) → the dirty state includes
+        a file not in upstream. Not the recoverable pattern.
+     c. If hashes match, file is redundant.
+     d. If hashes differ, file contains real work not in upstream → return
+        (False, "dirty file <name> does not match upstream; real user work").
+        Capture a second diagnostic: capture_snapshot("sync", "dirty-main-real-user-work",
+        ..., extra={"mismatched_file": <name>}).
+6. All files matched upstream: safe to reset.
+   `git checkout -- <file list>` → working tree is clean (just those tracked files restored).
+7. Return (True, "recovered from stale main state").
+
+The caller's existing behind-remote logic then runs `git pull --ff-only` and reports fast-forwarded.
+```
+
+Why hash-compare instead of stash:
+- No state mutation until we've proven every dirty file is redundant. If we bail at step 5d, the working tree is untouched — user's real work stays exactly where it was.
+- Simpler, more auditable. Diagnostic snapshots record the exact file names and hashes involved.
+- Avoids stash/pop edge cases (stash apply conflicts, untracked file interactions).
+
+Integration point in `_result_for`:
+
+```python
+def _result_for(repo: RepoAudit, cfg: WorkspaceConfig, shell: ShellRunner, state_dir: Path) -> SyncResult:
+    blocking = [i for i in repo.issues if i.code in _BLOCKING_CODES]
+    # New: attempt recovery only for the specific `dirty_worktree` solo case.
+    if blocking and all(i.code == "dirty_worktree" for i in blocking):
+        recovered, msg = _try_recover_stale_main(repo, cfg, shell, state_dir)
+        if recovered:
+            # Re-audit one-shot to get the post-recovery `behind_remote` info.
+            # Simpler: we know a fast-forward just ran (part of recovery),
+            # so mark as fast_forwarded with the recovery message.
+            return SyncResult(repo.name, repo.path, "fast_forwarded", msg)
+        # Recovery declined → fall through to the original skip.
+    if blocking:
+        first = blocking[0]
+        return SyncResult(repo.name, repo.path, "skipped",
+                          f"{first.code} — {first.message}")
+    # ... rest unchanged (behind_remote fast-forward, up_to_date fallthrough) ...
+```
+
+Signature change: `_result_for` and `sync_repos` gain a `state_dir: Path` parameter plumbed through from the CLI (where `container.state_dir()` is already available).
+
+### 3. Post-op sanity checks in `mship finish` and `mship close`
+
+Both commands already accept a `container` and thus can read `container.state_dir()`. Before the CLI handler returns success:
+
+```python
+# At the end of finish (just before typer.Exit or successful return)
+from mship.core.diagnostics import capture_snapshot
+
+try:
+    post_op_repos: dict[str, Path] = {}
+    for repo_name in task.affected_repos:
+        repo_path = config.repos[repo_name].path  # main checkout path, NOT worktree
+        if repo_path and Path(repo_path).is_dir():
+            post_op_repos[repo_name] = Path(repo_path).resolve()
+    if post_op_repos:
+        # Check any dirty state on main-checkout paths.
+        any_dirty = False
+        for name, path in post_op_repos.items():
+            res = shell.run("git status --porcelain", cwd=path)
+            if res.returncode == 0 and res.stdout.strip():
+                any_dirty = True
+                break
+        if any_dirty:
+            capture_snapshot(
+                "finish", "dirty-main-post-op",
+                container.state_dir(),
+                repos=post_op_repos,
+            )
+except Exception:
+    # Never let diagnostics failure break the command.
+    pass
+```
+
+Same pattern for `close`. Guarded `try/except` around the entire block so diagnostics never break user workflows.
+
+### 4. `mship doctor` row — edit `src/mship/core/doctor.py::DoctorChecker.diagnose`
+
+Insert after existing checks:
+
+```python
+# Pending diagnostics (instrumentation captured anomalies)
+diag_dir = self._state_dir / "diagnostics"
+if diag_dir.is_dir():
+    count = sum(1 for _ in diag_dir.glob("*.json"))
+    if count > 0:
+        report.checks.append(CheckResult(
+            name="diagnostics",
+            status="warn",
+            message=(
+                f"{count} snapshot(s) in .mothership/diagnostics/ "
+                f"— review for unexpected-state captures; `rm -rf` to clear"
+            ),
+        ))
+```
+
+`DoctorChecker.__init__` already receives `state_dir` (verify; if not, add).
+
+## Data flow
+
+**Happy path (user's main is already clean):**
+
+1. `mship sync` → audit → no blocking codes → fast-forward if behind.
+2. No diagnostics captured, no recovery attempted, no behavior change.
+
+**Stale-main bug recurs:**
+
+1. `mship sync` → audit reports `dirty_worktree` on the mothership repo.
+2. `_result_for` sees only `dirty_worktree` in blocking → calls `_try_recover_stale_main`.
+3. Diagnostic snapshot written: `.mothership/diagnostics/<ts>-sync-dirty-main-pre-recovery.json`.
+4. Recovery algorithm runs. Stash → ff → stash-show empty → drop stash.
+5. `_result_for` returns `"fast_forwarded"` with the recovery message.
+6. CLI prints `"mothership: fast-forwarded (recovered from stale main state)"`.
+
+**Real user work on main (false-positive guard):**
+
+1. User has real uncommitted edits on main that are NOT already in origin/main.
+2. `mship sync` → audit reports `dirty_worktree`.
+3. Recovery attempts stash → ff → stash-show non-empty → pop stash back.
+4. Second diagnostic captured: `"dirty-main-real-user-work"`.
+5. `_result_for` returns the original `"skipped"` with the original message.
+6. User sees the existing refuse behavior. Their work is untouched.
+
+**`mship finish` leaves main dirty (collecting evidence):**
+
+1. Finish flow runs normally; PRs opened; `finished_at` stamped.
+2. Post-op sanity check runs `git status --porcelain` on each affected repo's main path.
+3. If dirty → diagnostic captured: `"finish-dirty-main-post-op"`.
+4. Exit unchanged; user sees normal finish output.
+
+**`mship doctor` after the bug was triggered once:**
+
+1. Doctor iterates checks.
+2. Finds `.mothership/diagnostics/2026-04-21T14-23-08Z-sync-dirty-main-pre-recovery.json`.
+3. Prints `warn   diagnostics   1 snapshot(s) in .mothership/diagnostics/ — review for unexpected-state captures; \`rm -rf\` to clear`.
+
+## Error handling
+
+- **Snapshot write fails** (disk full, permissions, path too long): `capture_snapshot` catches `OSError`, returns None, logs at debug level. Caller continues.
+- **`git hash-object` fails** (rare — file gone mid-run): recovery returns `(False, "hash-object failed: ...")`; no state mutation. Caller falls through to original skip.
+- **`git rev-parse origin/<branch>:<file>` fails** (file not in upstream): recovery returns `(False, "dirty file <name> does not match upstream ...")`. State untouched; user preserved.
+- **`git checkout -- <files>` fails during the reset phase** (after hashes verified): unexpected but possible (disk full, lock contention). Recovery logs a third diagnostic `"dirty-main-reset-failed"` and returns `(False, ...)`. Working tree may be in a partial-reset state; diagnostic captures enough to investigate.
+- **Network partition on behind-check** (`git rev-list` doesn't hit network; it reads local refs): rev-list works offline. If `origin/<branch>` is stale on disk, the behind-check may miss updates. Acceptable — user can `git fetch` manually if needed.
+- **Recovery is called from CI or non-interactive context**: same behavior, no prompts. If the caller needs to opt out later, add `--no-recover` then.
+
+## Testing
+
+### Unit — `tests/core/test_diagnostics.py` (new)
+
+1. **Happy snapshot write.** `capture_snapshot("sync", "test", tmp_path)` creates `<tmp_path>/diagnostics/<ts>-sync-test.json` with all expected keys populated.
+2. **Write failure is non-fatal.** `monkeypatch.setattr(Path, "write_text", lambda *a, **kw: (_ for _ in ()).throw(OSError("disk full")))`; `capture_snapshot(...)` returns None and doesn't raise.
+3. **Filename is filesystem-safe.** Colons from the ISO timestamp are replaced with `-`.
+4. **repos kwarg is populated.** Pass `repos={"r": /tmp/repo}`; snapshot contains per-repo git_status, head_sha, head_branch, reflog_tail.
+5. **extra kwarg is included verbatim.** Pass `extra={"foo": "bar"}`; snapshot contains `"extra": {"foo": "bar"}`.
+
+### Unit — `tests/core/test_sync_recovery.py` (new)
+
+Each test sets up a `tmp_path` workspace with a real `file://` origin git repo so recovery can exercise real git commands.
+
+1. **Happy path: dirty main matches upstream delta.** Origin has commits A→B; local main is at A; copy B's file content into the local working tree (dirty state matching upstream). Run `_try_recover_stale_main`. Assert returns `(True, "recovered ...")`, working tree is clean after the reset, one diagnostic file exists (pre-recovery).
+2. **User work on main is preserved.** Origin at A→B; local main at A with a modification to a file whose content differs from B's version (real user work). Run recovery. Assert returns `(False, "dirty file ... does not match upstream ...")`, working tree still has the original edit (not reset), two diagnostic files exist (pre-recovery + real-user-work).
+3. **Not behind origin.** Origin at A; local main at A with a dirty edit. Run recovery. Assert returns `(False, "not behind origin ...")`; no file hash comparison performed; one diagnostic captured.
+4. **Untracked files present.** Origin A→B; local at A behind; local has a dirty tracked edit matching B AND one untracked file. Run recovery. Assert returns `(False, "untracked files present ...")`; tracked file is NOT reset (preserved); one diagnostic captured.
+5. **Dirty file doesn't exist upstream.** Origin at A→B (where B doesn't introduce `foo.py`); local at A with a dirty modified `foo.py`. Run recovery. `git rev-parse origin/<branch>:foo.py` fails → returns `(False, "dirty file foo.py does not match upstream ...")`; file preserved; one or two diagnostics.
+6. **Multiple dirty files all match.** Two files modified, both match their upstream blob. Assert returns `(True, ...)`, both files reset, working tree clean.
+7. **Multiple dirty files, one mismatches.** Two files modified; first matches upstream, second doesn't. Assert returns `(False, ...)` mid-loop before touching either file (state mutation only happens after all files verified). Both files preserved.
+
+### Unit — `tests/core/test_doctor.py` (extend)
+
+6. **Doctor row when diagnostics dir has files.** Create `<state_dir>/diagnostics/fake.json`. Run doctor. Assert a `CheckResult(name="diagnostics", status="warn", ...)` is in the report with count=1.
+7. **No row when diagnostics dir is empty or missing.** No `diagnostics` row in the report.
+
+### Integration — `tests/cli/test_worktree.py` (extend for finish + close)
+
+8. **`mship finish` captures post-op diagnostic when main is artificially dirtied.** Hook into the mock shell to write to a file in the main repo path during the finish flow. Run finish. Assert `.mothership/diagnostics/<ts>-finish-dirty-main-post-op.json` exists after the command.
+9. **`mship finish` doesn't capture when main is clean.** Normal finish flow. Assert no diagnostic file appears.
+
+### Integration — `tests/cli/test_sync.py` (if exists; else extend test_worktree)
+
+10. **End-to-end recovery smoke.** `file://` origin workspace. Stage the dirty-main-matches-upstream pattern. Run `mship sync` via CliRunner. Assert exit 0, `fast-forwarded` in output, diagnostic file exists.
+
+### Regression
+
+- Existing `_result_for` tests stay green. The signature change adds `state_dir` — update existing callers/tests to pass it.
+- `_BLOCKING_CODES` unchanged.
+- Full `pytest tests/` green.
+
+### No manual smoke
+
+The diagnostic file mechanism and the stash-recovery are covered by unit + integration tests. Manual smoke would require triggering the actual mystery bug, which we can't do on-demand.
+
+## Decisions log
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Hash-compare recovery, never `git reset --hard` and never stash | Per-file hash compare against `origin/<branch>` proves redundancy BEFORE mutating state. If any file doesn't match, we bail before touching anything. `reset --hard` or stash-based approaches mutate state first and depend on a reversal step that can fail. |
+| 2 | Recovery only triggers when `dirty_worktree` is the SOLE blocking code | Prevents recovery from running when the repo also has `fetch_failed`, `diverged`, or similar — those cases need human intervention. |
+| 3 | Two diagnostics per recovery attempt (pre-recovery + sad-path if user-work detected) | Pre-recovery snapshot captures the trigger state. Sad-path snapshot captures what user-work looked like, which is exactly what we need to narrow hypotheses. |
+| 4 | No automatic rotation of diagnostics | Doctor surfaces count; user decides when to prune. Automation is premature before we know how often real captures fire. |
+| 5 | No `mship diagnostics` subcommand | Files are JSON; `cat` works; the value of a CLI wrapper is tiny. Add later if pattern emerges. |
+| 6 | Post-op checks in `mship finish` / `close` are silent | Data collection only. Surfacing a warning every time the bug fires would train users to ignore it (see #51). Doctor's row is the visible signal. |
+| 7 | Doctor check uses `status=warn`, not `pass` or `fail` | Snapshots are anomalies worth looking at but not failures. Warn matches the signaling intent. |
+| 8 | Recovery message uses `"recovered from stale main state"` (not `"stale-main-index bug"`) | User-facing; describes the observed behavior without committing to a specific root-cause narrative. |

--- a/src/mship/cli/doctor.py
+++ b/src/mship/cli/doctor.py
@@ -14,7 +14,7 @@ def register(app: typer.Typer, get_container):
 
         config = container.config()
         shell = container.shell()
-        checker = DoctorChecker(config, shell)
+        checker = DoctorChecker(config, shell, state_dir=container.state_dir())
         report = checker.run()
 
         if output.is_tty:

--- a/src/mship/cli/sync.py
+++ b/src/mship/cli/sync.py
@@ -36,7 +36,7 @@ def register(app: typer.Typer, get_container):
             output.error(str(e))
             raise typer.Exit(code=1)
 
-        out = sync_repos(report, config, shell)
+        out = sync_repos(report, config, shell, container.state_dir())
         write_last_sync_at(container.state_dir())
         for r in out.results:
             if r.status == "up_to_date":

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -5,6 +5,7 @@ from typing import Optional
 import typer
 
 from mship.cli.output import Output
+from mship.core.diagnostics import capture_snapshot
 
 
 def _read_stdin_body_or_exit(output: Output) -> str:
@@ -159,6 +160,51 @@ def _build_pr_groups(
             base=base,
         ))
     return groups
+
+
+def _capture_dirty_main_post_op(command: str, task, config, shell, state_dir: Path) -> None:
+    """Capture a diagnostic snapshot if any affected repo's main checkout is dirty.
+
+    Called after `finish` and `close` complete successfully. Strictly best-effort:
+    all exceptions are swallowed so diagnostics never interrupt normal operation.
+
+    Args:
+        command:   The CLI verb that just ran ("finish" or "close").
+        task:      The state.Task whose affected_repos we inspect.
+        config:    WorkspaceConfig holding repo path/git_root metadata.
+        shell:     ShellRunner used to run `git status --porcelain`.
+        state_dir: Path to the mothership state directory (passed to capture_snapshot).
+    """
+    try:
+        post_op_repos: dict[str, Path] = {}
+        for _repo_name in task.affected_repos:
+            _repo_cfg = config.repos.get(_repo_name)
+            if _repo_cfg is None:
+                continue
+            if _repo_cfg.git_root is not None:
+                _parent = config.repos.get(_repo_cfg.git_root)
+                if _parent is None:
+                    continue
+                _main_path = Path(_parent.path).resolve()
+            else:
+                _main_path = Path(_repo_cfg.path).resolve()
+            if _main_path.is_dir():
+                post_op_repos[_repo_name] = _main_path
+        any_dirty = False
+        for _name, _path in post_op_repos.items():
+            _res = shell.run("git status --porcelain", cwd=_path)
+            if _res.returncode == 0 and _res.stdout.strip():
+                any_dirty = True
+                break
+        if any_dirty:
+            capture_snapshot(
+                command, "dirty-main-post-op",
+                state_dir,
+                repos=post_op_repos,
+            )
+    except Exception:
+        # Diagnostics is strictly best-effort.
+        pass
 
 
 def register(app: typer.Typer, get_container):
@@ -511,39 +557,7 @@ def register(app: typer.Typer, get_container):
         # Post-op diagnostic: if any affected repo's main-checkout path is
         # dirty after close completed, capture a snapshot. Silent — users
         # see the snapshot count via `mship doctor`. See spec 2026-04-21.
-        try:
-            from mship.core.diagnostics import capture_snapshot
-            shell = container.shell()
-            config = container.config()
-            post_op_repos: dict[str, Path] = {}
-            for _repo_name in task.affected_repos:
-                _repo_cfg = config.repos.get(_repo_name)
-                if _repo_cfg is None:
-                    continue
-                if _repo_cfg.git_root is not None:
-                    _parent = config.repos.get(_repo_cfg.git_root)
-                    if _parent is None:
-                        continue
-                    _main_path = Path(_parent.path).resolve()
-                else:
-                    _main_path = Path(_repo_cfg.path).resolve()
-                if _main_path.is_dir():
-                    post_op_repos[_repo_name] = _main_path
-            any_dirty = False
-            for _name, _path in post_op_repos.items():
-                _res = shell.run("git status --porcelain", cwd=_path)
-                if _res.returncode == 0 and _res.stdout.strip():
-                    any_dirty = True
-                    break
-            if any_dirty and post_op_repos:
-                capture_snapshot(
-                    "close", "dirty-main-post-op",
-                    container.state_dir(),
-                    repos=post_op_repos,
-                )
-        except Exception:
-            # Diagnostics is strictly best-effort.
-            pass
+        _capture_dirty_main_post_op("close", task, config, container.shell(), container.state_dir())
 
     @app.command()
     def finish(
@@ -1016,34 +1030,4 @@ def register(app: typer.Typer, get_container):
         # Post-op diagnostic: if any affected repo's main-checkout path is
         # dirty after finish completed, capture a snapshot. Silent — users
         # see the snapshot count via `mship doctor`. See spec 2026-04-21.
-        try:
-            from mship.core.diagnostics import capture_snapshot
-            post_op_repos: dict[str, Path] = {}
-            for _repo_name in t.affected_repos:
-                _repo_cfg = config.repos.get(_repo_name)
-                if _repo_cfg is None:
-                    continue
-                if _repo_cfg.git_root is not None:
-                    _parent = config.repos.get(_repo_cfg.git_root)
-                    if _parent is None:
-                        continue
-                    _main_path = Path(_parent.path).resolve()
-                else:
-                    _main_path = Path(_repo_cfg.path).resolve()
-                if _main_path.is_dir():
-                    post_op_repos[_repo_name] = _main_path
-            any_dirty = False
-            for _name, _path in post_op_repos.items():
-                _res = shell.run("git status --porcelain", cwd=_path)
-                if _res.returncode == 0 and _res.stdout.strip():
-                    any_dirty = True
-                    break
-            if any_dirty and post_op_repos:
-                capture_snapshot(
-                    "finish", "dirty-main-post-op",
-                    container.state_dir(),
-                    repos=post_op_repos,
-                )
-        except Exception:
-            # Diagnostics is strictly best-effort.
-            pass
+        _capture_dirty_main_post_op("finish", t, config, shell, container.state_dir())

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -508,6 +508,43 @@ def register(app: typer.Typer, get_container):
             pass
         output.success(f"{log_msg.capitalize()}: {task_slug}")
 
+        # Post-op diagnostic: if any affected repo's main-checkout path is
+        # dirty after close completed, capture a snapshot. Silent — users
+        # see the snapshot count via `mship doctor`. See spec 2026-04-21.
+        try:
+            from mship.core.diagnostics import capture_snapshot
+            shell = container.shell()
+            config = container.config()
+            post_op_repos: dict[str, Path] = {}
+            for _repo_name in task.affected_repos:
+                _repo_cfg = config.repos.get(_repo_name)
+                if _repo_cfg is None:
+                    continue
+                if _repo_cfg.git_root is not None:
+                    _parent = config.repos.get(_repo_cfg.git_root)
+                    if _parent is None:
+                        continue
+                    _main_path = Path(_parent.path).resolve()
+                else:
+                    _main_path = Path(_repo_cfg.path).resolve()
+                if _main_path.is_dir():
+                    post_op_repos[_repo_name] = _main_path
+            any_dirty = False
+            for _name, _path in post_op_repos.items():
+                _res = shell.run("git status --porcelain", cwd=_path)
+                if _res.returncode == 0 and _res.stdout.strip():
+                    any_dirty = True
+                    break
+            if any_dirty and post_op_repos:
+                capture_snapshot(
+                    "close", "dirty-main-post-op",
+                    container.state_dir(),
+                    repos=post_op_repos,
+                )
+        except Exception:
+            # Diagnostics is strictly best-effort.
+            pass
+
     @app.command()
     def finish(
         handoff: bool = typer.Option(False, "--handoff", help="Generate CI handoff manifest"),
@@ -975,3 +1012,38 @@ def register(app: typer.Typer, get_container):
                 "finished_at": task.finished_at.isoformat(),
             })
             output.print("Task finished. After merge, run `mship close` to clean up.")
+
+        # Post-op diagnostic: if any affected repo's main-checkout path is
+        # dirty after finish completed, capture a snapshot. Silent — users
+        # see the snapshot count via `mship doctor`. See spec 2026-04-21.
+        try:
+            from mship.core.diagnostics import capture_snapshot
+            post_op_repos: dict[str, Path] = {}
+            for _repo_name in t.affected_repos:
+                _repo_cfg = config.repos.get(_repo_name)
+                if _repo_cfg is None:
+                    continue
+                if _repo_cfg.git_root is not None:
+                    _parent = config.repos.get(_repo_cfg.git_root)
+                    if _parent is None:
+                        continue
+                    _main_path = Path(_parent.path).resolve()
+                else:
+                    _main_path = Path(_repo_cfg.path).resolve()
+                if _main_path.is_dir():
+                    post_op_repos[_repo_name] = _main_path
+            any_dirty = False
+            for _name, _path in post_op_repos.items():
+                _res = shell.run("git status --porcelain", cwd=_path)
+                if _res.returncode == 0 and _res.stdout.strip():
+                    any_dirty = True
+                    break
+            if any_dirty and post_op_repos:
+                capture_snapshot(
+                    "finish", "dirty-main-post-op",
+                    container.state_dir(),
+                    repos=post_op_repos,
+                )
+        except Exception:
+            # Diagnostics is strictly best-effort.
+            pass

--- a/src/mship/core/diagnostics.py
+++ b/src/mship/core/diagnostics.py
@@ -1,0 +1,146 @@
+"""Forensics snapshot library for mship's self-diagnosing commands.
+
+Writes JSON blobs to <state_dir>/diagnostics/<ts>-<command>-<reason>.json
+when commands observe anomalous state. Best-effort — write failures are
+caught and returned as None so callers are never interrupted.
+
+Filename format: <ISO-8601 UTC, colons replaced with `-`>-<command>-<reason>.json.
+
+See `docs/superpowers/specs/2026-04-21-stale-main-index-diagnostics-and-recovery-design.md`.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+def _git_state(repo_path: Path) -> dict:
+    """Per-repo git state captured for the snapshot. Best-effort."""
+    info: dict = {
+        "git_status_porcelain": None,
+        "head_sha": None,
+        "head_branch": None,
+        "upstream_tracking": None,
+        "reflog_tail": None,
+        "stash_count": None,
+    }
+    try:
+        r = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=repo_path, capture_output=True, text=True, check=False,
+        )
+        info["git_status_porcelain"] = r.stdout
+    except OSError:
+        pass
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_path, capture_output=True, text=True, check=False,
+        )
+        info["head_sha"] = r.stdout.strip() or None
+    except OSError:
+        pass
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=repo_path, capture_output=True, text=True, check=False,
+        )
+        info["head_branch"] = r.stdout.strip() or None
+    except OSError:
+        pass
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+            cwd=repo_path, capture_output=True, text=True, check=False,
+        )
+        if r.returncode == 0:
+            info["upstream_tracking"] = r.stdout.strip()
+    except OSError:
+        pass
+    try:
+        r = subprocess.run(
+            ["git", "reflog", "-n", "10"],
+            cwd=repo_path, capture_output=True, text=True, check=False,
+        )
+        info["reflog_tail"] = r.stdout.splitlines()
+    except OSError:
+        pass
+    try:
+        r = subprocess.run(
+            ["git", "stash", "list"],
+            cwd=repo_path, capture_output=True, text=True, check=False,
+        )
+        info["stash_count"] = len([l for l in r.stdout.splitlines() if l])
+    except OSError:
+        pass
+    return info
+
+
+def _mship_version() -> str | None:
+    try:
+        from importlib.metadata import version
+        return version("mothership")
+    except Exception:
+        return None
+
+
+def _safe_timestamp() -> str:
+    """ISO-8601 UTC timestamp with filesystem-safe separators.
+
+    Colons (invalid on Windows, awkward on macOS) are replaced with hyphens.
+    """
+    ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    # ends with +00:00, which includes a colon — strip tz and append Z
+    if ts.endswith("+00:00"):
+        ts = ts[:-len("+00:00")] + "Z"
+    return ts.replace(":", "-")
+
+
+def capture_snapshot(
+    command: str,
+    reason: str,
+    state_dir: Path,
+    *,
+    repos: dict[str, Path] | None = None,
+    extra: dict | None = None,
+) -> Path | None:
+    """Write a JSON forensics snapshot. Returns the path, or None on failure.
+
+    command: invoking mship command name (e.g. "sync", "finish").
+    reason:  short tag identifying what triggered capture (e.g. "dirty-main-pre-recovery").
+    state_dir: workspace's .mothership directory.
+    repos: optional {name: path} to capture per-repo git state.
+    extra: caller-supplied free-form data.
+    """
+    try:
+        diag_dir = Path(state_dir) / "diagnostics"
+        diag_dir.mkdir(parents=True, exist_ok=True)
+
+        payload: dict = {
+            "captured_at": _safe_timestamp(),
+            "command": command,
+            "reason": reason,
+            "cwd": str(Path.cwd()),
+            "mship_version": _mship_version(),
+            "python_version": sys.version,
+            "path_env": os.environ.get("PATH", ""),
+        }
+        if repos:
+            payload["repos"] = {name: _git_state(Path(p)) for name, p in repos.items()}
+        if extra:
+            payload["extra"] = extra
+
+        filename = f"{_safe_timestamp()}-{command}-{reason}.json"
+        target = diag_dir / filename
+        target.write_text(json.dumps(payload, indent=2))
+        return target
+    except OSError as e:
+        log.debug("capture_snapshot write failed: %s", e)
+        return None

--- a/src/mship/core/diagnostics.py
+++ b/src/mship/core/diagnostics.py
@@ -123,8 +123,9 @@ def capture_snapshot(
         diag_dir = Path(state_dir) / "diagnostics"
         diag_dir.mkdir(parents=True, exist_ok=True)
 
+        ts = _safe_timestamp()
         payload: dict = {
-            "captured_at": _safe_timestamp(),
+            "captured_at": ts,
             "command": command,
             "reason": reason,
             "cwd": str(Path.cwd()),
@@ -137,7 +138,7 @@ def capture_snapshot(
         if extra:
             payload["extra"] = extra
 
-        filename = f"{_safe_timestamp()}-{command}-{reason}.json"
+        filename = f"{ts}-{command}-{reason}.json"
         target = diag_dir / filename
         target.write_text(json.dumps(payload, indent=2))
         return target

--- a/src/mship/core/doctor.py
+++ b/src/mship/core/doctor.py
@@ -112,9 +112,16 @@ def _format_skill_check(agent: str, installed: int, dangling: int, foreign: int,
 class DoctorChecker:
     """Run health checks on a mothership workspace."""
 
-    def __init__(self, config: WorkspaceConfig, shell: ShellRunner) -> None:
+    def __init__(
+        self,
+        config: WorkspaceConfig,
+        shell: ShellRunner,
+        *,
+        state_dir: Path | None = None,
+    ) -> None:
         self._config = config
         self._shell = shell
+        self._state_dir = state_dir
 
     def run(self) -> DoctorReport:
         report = DoctorReport()
@@ -242,6 +249,21 @@ class DoctorChecker:
                     "mship will skip per-repo setup on spawn"
                 ),
             ))
+
+        # Pending diagnostics snapshots (spec 2026-04-21).
+        if self._state_dir is not None:
+            diag_dir = Path(self._state_dir) / "diagnostics"
+            if diag_dir.is_dir():
+                count = sum(1 for _ in diag_dir.glob("*.json"))
+                if count > 0:
+                    report.checks.append(CheckResult(
+                        name="diagnostics",
+                        status="warn",
+                        message=(
+                            f"{count} snapshot(s) in .mothership/diagnostics/ — "
+                            f"review for unexpected-state captures; `rm -rf` to clear"
+                        ),
+                    ))
 
         # Dev-mode trap: installed mship may lag workspace source
         mship_source = self._detect_mship_dev_workspace()

--- a/src/mship/core/repo_sync.py
+++ b/src/mship/core/repo_sync.py
@@ -1,11 +1,13 @@
 """Safe fast-forward reconciliation for repos that audit as behind-only."""
 from __future__ import annotations
 
+import shlex
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
 from mship.core.config import WorkspaceConfig
+from mship.core.diagnostics import capture_snapshot
 from mship.core.repo_state import AuditReport, RepoAudit
 from mship.util.shell import ShellRunner
 
@@ -43,8 +45,149 @@ def _git_root_path(cfg: WorkspaceConfig, name: str) -> Path:
     return repo.path
 
 
-def _result_for(repo: RepoAudit, cfg: WorkspaceConfig, shell: ShellRunner) -> SyncResult:
+def _repo_root_path(repo: RepoAudit, cfg: WorkspaceConfig) -> Path:
+    """Resolve to the effective git root path (handles git_root indirection)."""
+    r = cfg.repos[repo.name]
+    if r.git_root is not None:
+        return Path(cfg.repos[r.git_root].path)
+    return Path(r.path)
+
+
+def _detect_branch(root: Path, shell: ShellRunner) -> str | None:
+    r = shell.run("git rev-parse --abbrev-ref HEAD", cwd=root)
+    if r.returncode != 0:
+        return None
+    out = r.stdout.strip()
+    return out if out and out != "HEAD" else None
+
+
+def _try_recover_stale_main(
+    repo: RepoAudit,
+    cfg: WorkspaceConfig,
+    shell: ShellRunner,
+    state_dir: Path,
+) -> tuple[bool, str]:
+    """Attempt to recover from dirty-main-matches-upstream state.
+
+    Returns (recovered, message). If recovered, the working tree has been
+    reset so the caller's fast-forward path can run. If not recovered, no
+    state mutation occurred — user's working tree untouched.
+    """
+    root = _repo_root_path(repo, cfg)
+    # 1. Snapshot before doing anything.
+    capture_snapshot(
+        "sync", "dirty-main-pre-recovery", state_dir,
+        repos={repo.name: root},
+    )
+
+    branch = repo.current_branch or _detect_branch(root, shell)
+    if not branch:
+        return (False, "could not resolve branch for recovery check")
+
+    # 2. Fetch to ensure remote-tracking ref is current.
+    shell.run("git fetch origin", cwd=root)
+
+    # 3. Behind check.
+    r = shell.run(
+        f"git rev-list --count {shlex.quote(branch)}..origin/{shlex.quote(branch)}",
+        cwd=root,
+    )
+    if r.returncode != 0:
+        return (False, f"behind-check failed: {r.stderr.strip()}")
+    try:
+        behind = int(r.stdout.strip() or "0")
+    except ValueError:
+        behind = 0
+    if behind == 0:
+        return (False, "not behind origin; not the recoverable pattern")
+
+    # 4. Untracked check — recovery only handles the modified-tracked-files pattern.
+    r = shell.run("git ls-files --others --exclude-standard", cwd=root)
+    if r.returncode == 0 and r.stdout.strip():
+        return (False, "untracked files present; recovery skipped to preserve data")
+
+    # 5. Dirty tracked files enumeration.
+    r = shell.run("git diff --name-only HEAD", cwd=root)
+    if r.returncode != 0:
+        return (False, f"diff --name-only failed: {r.stderr.strip()}")
+    dirty_files = [p for p in r.stdout.splitlines() if p.strip()]
+    if not dirty_files:
+        return (False, "no dirty tracked files; nothing to recover")
+
+    # 6. Per-file hash compare — PROVE redundancy BEFORE mutating state.
+    mismatches: list[str] = []
+    for path in dirty_files:
+        wh = shell.run(f"git hash-object -- {shlex.quote(path)}", cwd=root)
+        if wh.returncode != 0:
+            mismatches.append(f"{path} (hash-object failed)")
+            break
+        working_hash = wh.stdout.strip()
+
+        uh = shell.run(
+            f"git rev-parse origin/{shlex.quote(branch)}:{shlex.quote(path)}",
+            cwd=root,
+        )
+        if uh.returncode != 0:
+            mismatches.append(path)
+            break
+        upstream_hash = uh.stdout.strip()
+
+        if working_hash != upstream_hash:
+            mismatches.append(path)
+            break
+
+    if mismatches:
+        capture_snapshot(
+            "sync", "dirty-main-real-user-work", state_dir,
+            repos={repo.name: root},
+            extra={"mismatched_files": mismatches},
+        )
+        return (
+            False,
+            f"dirty file {mismatches[0]} does not match upstream; real user work",
+        )
+
+    # 7. All files verified redundant — safe to reset.
+    for path in dirty_files:
+        r = shell.run(f"git checkout -- {shlex.quote(path)}", cwd=root)
+        if r.returncode != 0:
+            capture_snapshot(
+                "sync", "dirty-main-reset-failed", state_dir,
+                repos={repo.name: root},
+                extra={"failed_path": path, "stderr": r.stderr},
+            )
+            return (
+                False,
+                f"checkout failed on {path} after hashes matched: {r.stderr.strip()}",
+            )
+
+    return (True, "recovered from stale main state")
+
+
+def _result_for(
+    repo: RepoAudit,
+    cfg: WorkspaceConfig,
+    shell: ShellRunner,
+    state_dir: Path,
+) -> SyncResult:
     blocking = [i for i in repo.issues if i.code in _BLOCKING_CODES]
+    # Recovery attempt: only when dirty_worktree is the SOLE blocking code.
+    if blocking and all(i.code == "dirty_worktree" for i in blocking):
+        recovered, msg = _try_recover_stale_main(repo, cfg, shell, state_dir)
+        if recovered:
+            # Recovery just reset files but didn't pull — do that now.
+            root = _git_root_path(cfg, repo.name)
+            r = shell.run("git pull --ff-only", cwd=root)
+            if r.returncode != 0:
+                return SyncResult(
+                    repo.name, repo.path, "skipped",
+                    f"pull failed after recovery: {r.stderr.strip() or 'unknown'}",
+                )
+            return SyncResult(
+                repo.name, repo.path, "fast_forwarded",
+                "recovered from stale main state",
+            )
+        # Recovery declined → fall through to original skip.
     if blocking:
         first = blocking[0]
         return SyncResult(repo.name, repo.path, "skipped",
@@ -62,7 +205,12 @@ def _result_for(repo: RepoAudit, cfg: WorkspaceConfig, shell: ShellRunner) -> Sy
     return SyncResult(repo.name, repo.path, "up_to_date", "no action")
 
 
-def sync_repos(report: AuditReport, config: WorkspaceConfig, shell: ShellRunner) -> SyncReport:
+def sync_repos(
+    report: AuditReport,
+    config: WorkspaceConfig,
+    shell: ShellRunner,
+    state_dir: Path,
+) -> SyncReport:
     # Avoid double fast-forwarding subdir repos that share a git root.
     seen_roots: set[str] = set()
     results: list[SyncResult] = []
@@ -78,5 +226,5 @@ def sync_repos(report: AuditReport, config: WorkspaceConfig, shell: ShellRunner)
             ))
             continue
         seen_roots.add(root_key)
-        results.append(_result_for(repo_audit, config, shell))
+        results.append(_result_for(repo_audit, config, shell, state_dir))
     return SyncReport(results=tuple(results))

--- a/src/mship/core/repo_sync.py
+++ b/src/mship/core/repo_sync.py
@@ -45,13 +45,6 @@ def _git_root_path(cfg: WorkspaceConfig, name: str) -> Path:
     return repo.path
 
 
-def _repo_root_path(repo: RepoAudit, cfg: WorkspaceConfig) -> Path:
-    """Resolve to the effective git root path (handles git_root indirection)."""
-    r = cfg.repos[repo.name]
-    if r.git_root is not None:
-        return Path(cfg.repos[r.git_root].path)
-    return Path(r.path)
-
 
 def _detect_branch(root: Path, shell: ShellRunner) -> str | None:
     r = shell.run("git rev-parse --abbrev-ref HEAD", cwd=root)
@@ -73,7 +66,7 @@ def _try_recover_stale_main(
     reset so the caller's fast-forward path can run. If not recovered, no
     state mutation occurred — user's working tree untouched.
     """
-    root = _repo_root_path(repo, cfg)
+    root = Path(_git_root_path(cfg, repo.name))
     # 1. Snapshot before doing anything.
     capture_snapshot(
         "sync", "dirty-main-pre-recovery", state_dir,
@@ -85,7 +78,9 @@ def _try_recover_stale_main(
         return (False, "could not resolve branch for recovery check")
 
     # 2. Fetch to ensure remote-tracking ref is current.
-    shell.run("git fetch origin", cwd=root)
+    fetch_r = shell.run("git fetch origin", cwd=root)
+    if fetch_r.returncode != 0:
+        return (False, f"fetch failed: {fetch_r.stderr.strip() or 'unknown'}")
 
     # 3. Behind check.
     r = shell.run(

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -1201,3 +1201,98 @@ def test_finish_calls_ensure_upstream_after_push(configured_git_app: Path):
     assert set_upstream_called, "ensure_upstream should have run set-upstream-to"
 
     cli_container.shell.reset_override()
+
+
+def test_finish_captures_diagnostic_when_main_is_dirty_post_op(configured_git_app: Path):
+    """If main is dirty after finish completes, a diagnostic is captured."""
+    from mship.cli import container as cli_container
+    from mship.util.shell import ShellResult, ShellRunner
+    from unittest.mock import MagicMock
+
+    runner.invoke(app, ["spawn", "dirty diag", "--repos", "shared", "--skip-setup"])
+
+    # Pre-dirty the main repo's shared/ working tree by writing an extra
+    # file directly to simulate whatever causes the bug.
+    shared_path = configured_git_app / "shared" / "dirty-marker.txt"
+    shared_path.parent.mkdir(parents=True, exist_ok=True)
+    shared_path.write_text("synthetic dirty content\n")
+    # Stage so `git status --porcelain` reports it as a change.
+    import subprocess as _sp
+    _sp.run(["git", "add", "dirty-marker.txt"], cwd=configured_git_app / "shared", check=True)
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref --symbolic-full-name" in cmd and "@{u}" in cmd:
+            return ShellResult(returncode=0, stdout="origin/feat/dirty-diag", stderr="")
+        if "gh pr list --head" in cmd:
+            return ShellResult(returncode=0, stdout="\n", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://github.com/org/shared/pull/1\n", stderr="")
+        if "git status --porcelain" in cmd:
+            # Simulate dirty state on the main repo path (our post-op check).
+            if "shared" in str(cwd):
+                return ShellResult(returncode=0, stdout="M  dirty-marker.txt\n", stderr="")
+            return ShellResult(returncode=0, stdout="", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = mock_run
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    cli_container.shell.override(mock_shell)
+
+    result = runner.invoke(app, ["finish", "--task", "dirty-diag", "--force-audit"])
+    # Finish succeeds (diagnostic is silent).
+    assert result.exit_code == 0, result.output
+
+    # A finish-dirty-main-post-op diagnostic exists.
+    diag_dir = configured_git_app / ".mothership" / "diagnostics"
+    if diag_dir.is_dir():
+        names = [p.name for p in diag_dir.glob("*.json")]
+        assert any("finish-dirty-main-post-op" in n for n in names), names
+    else:
+        pytest.fail("diagnostics dir not created")
+
+    cli_container.shell.reset_override()
+
+
+def test_finish_does_not_capture_diagnostic_when_main_is_clean(configured_git_app: Path):
+    """Clean happy path — no post-op diagnostic."""
+    from mship.cli import container as cli_container
+    from mship.util.shell import ShellResult, ShellRunner
+    from unittest.mock import MagicMock
+
+    runner.invoke(app, ["spawn", "clean diag", "--repos", "shared", "--skip-setup"])
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "rev-parse --abbrev-ref --symbolic-full-name" in cmd and "@{u}" in cmd:
+            return ShellResult(returncode=0, stdout="origin/feat/clean-diag", stderr="")
+        if "gh pr list --head" in cmd:
+            return ShellResult(returncode=0, stdout="\n", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://github.com/org/shared/pull/1\n", stderr="")
+        if "git status --porcelain" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = mock_run
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    cli_container.shell.override(mock_shell)
+
+    result = runner.invoke(app, ["finish", "--task", "clean-diag"])
+    assert result.exit_code == 0, result.output
+
+    diag_dir = configured_git_app / ".mothership" / "diagnostics"
+    if diag_dir.is_dir():
+        names = [p.name for p in diag_dir.glob("*.json")]
+        # No post-op diagnostics present for this run.
+        assert not any("finish-dirty-main-post-op" in n for n in names), names
+
+    cli_container.shell.reset_override()

--- a/tests/core/test_diagnostics.py
+++ b/tests/core/test_diagnostics.py
@@ -1,0 +1,90 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _init_git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=path, check=True)
+    (path / "README.md").write_text("initial\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=path, check=True)
+
+
+def test_capture_snapshot_writes_json_with_required_keys(tmp_path):
+    from mship.core.diagnostics import capture_snapshot
+    state_dir = tmp_path / ".mothership"
+    path = capture_snapshot("sync", "test-reason", state_dir)
+    assert path is not None
+    assert path.is_file()
+    assert path.parent == state_dir / "diagnostics"
+    data = json.loads(path.read_text())
+    for key in ("captured_at", "command", "reason", "cwd", "mship_version",
+                "python_version", "path_env"):
+        assert key in data, f"missing key {key}"
+    assert data["command"] == "sync"
+    assert data["reason"] == "test-reason"
+
+
+def test_capture_snapshot_filename_is_filesystem_safe(tmp_path):
+    """ISO timestamps contain colons on some platforms; must be replaced."""
+    from mship.core.diagnostics import capture_snapshot
+    state_dir = tmp_path / ".mothership"
+    path = capture_snapshot("sync", "a-reason", state_dir)
+    assert path is not None
+    # No colons in the filename portion.
+    assert ":" not in path.name
+    # Filename starts with a UTC ISO-like timestamp ending in Z.
+    assert path.name.endswith(".json")
+    assert "sync" in path.name
+    assert "a-reason" in path.name
+
+
+def test_capture_snapshot_creates_directory(tmp_path):
+    """diagnostics/ subdir is created on first call."""
+    from mship.core.diagnostics import capture_snapshot
+    state_dir = tmp_path / ".mothership"
+    assert not (state_dir / "diagnostics").exists()
+    capture_snapshot("sync", "r", state_dir)
+    assert (state_dir / "diagnostics").is_dir()
+
+
+def test_capture_snapshot_populates_repos(tmp_path):
+    from mship.core.diagnostics import capture_snapshot
+    repo = tmp_path / "r"
+    _init_git_repo(repo)
+    state_dir = tmp_path / ".mothership"
+    path = capture_snapshot("sync", "r", state_dir, repos={"r": repo})
+    data = json.loads(path.read_text())
+    assert "repos" in data
+    assert "r" in data["repos"]
+    repo_info = data["repos"]["r"]
+    for key in ("git_status_porcelain", "head_sha", "head_branch"):
+        assert key in repo_info
+    assert repo_info["git_status_porcelain"] == ""  # clean repo
+    assert len(repo_info["head_sha"]) == 40  # full SHA
+
+
+def test_capture_snapshot_extra_kwarg_included(tmp_path):
+    from mship.core.diagnostics import capture_snapshot
+    state_dir = tmp_path / ".mothership"
+    path = capture_snapshot("sync", "r", state_dir, extra={"foo": "bar", "n": 42})
+    data = json.loads(path.read_text())
+    assert data["extra"] == {"foo": "bar", "n": 42}
+
+
+def test_capture_snapshot_returns_none_on_write_failure(tmp_path, monkeypatch):
+    """Write failure never raises; returns None."""
+    from mship.core.diagnostics import capture_snapshot
+    state_dir = tmp_path / ".mothership"
+    # Make the target directory creation fail by making its parent read-only.
+    def _raise(*args, **kwargs):
+        raise OSError("simulated disk full")
+    monkeypatch.setattr(Path, "mkdir", _raise)
+    result = capture_snapshot("sync", "r", state_dir)
+    assert result is None

--- a/tests/core/test_doctor.py
+++ b/tests/core/test_doctor.py
@@ -454,3 +454,41 @@ def test_doctor_go_task_warn_when_binary_missing(workspace: Path, monkeypatch):
     assert "not installed" in go_task_checks[0].message
     assert "https://taskfile.dev" in go_task_checks[0].message
     assert "skip per-repo setup on spawn" in go_task_checks[0].message
+
+
+def test_doctor_diagnostics_row_warn_when_snapshots_present(workspace: Path):
+    from mship.core.config import ConfigLoader
+    from mship.core.doctor import DoctorChecker
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+    # Pre-create a diagnostic file.
+    diag_dir = workspace / ".mothership" / "diagnostics"
+    diag_dir.mkdir(parents=True, exist_ok=True)
+    (diag_dir / "2026-01-01T00-00-00Z-sync-pre-recovery.json").write_text("{}")
+
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    shell = MagicMock(spec=ShellRunner)
+    from mship.util.shell import ShellResult
+    shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+
+    report = DoctorChecker(config, shell, state_dir=workspace / ".mothership").run()
+    diag_checks = [c for c in report.checks if c.name == "diagnostics"]
+    assert len(diag_checks) == 1
+    assert diag_checks[0].status == "warn"
+    assert "1" in diag_checks[0].message or "snapshot" in diag_checks[0].message.lower()
+
+
+def test_doctor_no_diagnostics_row_when_absent(workspace: Path):
+    from mship.core.config import ConfigLoader
+    from mship.core.doctor import DoctorChecker
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+    from mship.util.shell import ShellResult
+
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    shell = MagicMock(spec=ShellRunner)
+    shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+
+    report = DoctorChecker(config, shell, state_dir=workspace / ".mothership").run()
+    diag_checks = [c for c in report.checks if c.name == "diagnostics"]
+    assert len(diag_checks) == 0

--- a/tests/core/test_repo_sync.py
+++ b/tests/core/test_repo_sync.py
@@ -23,15 +23,15 @@ def _result_for(rep, name):
     return next(r for r in rep.results if r.name == name)
 
 
-def test_sync_clean_repo_up_to_date(audit_workspace):
+def test_sync_clean_repo_up_to_date(audit_workspace, tmp_path):
     cfg, shell = _load(audit_workspace)
     report = audit_repos(cfg, shell)
-    out = sync_repos(report, cfg, shell)
+    out = sync_repos(report, cfg, shell, tmp_path / ".mothership")
     r = _result_for(out, "cli")
     assert r.status == "up_to_date"
 
 
-def test_sync_behind_repo_fast_forwards(audit_workspace):
+def test_sync_behind_repo_fast_forwards(audit_workspace, tmp_path):
     cfg, shell = _load(audit_workspace)
     clone = audit_workspace / "cli"
     (clone / "y.txt").write_text("y")
@@ -41,23 +41,23 @@ def test_sync_behind_repo_fast_forwards(audit_workspace):
     _sh("git", "reset", "--hard", "HEAD^", cwd=clone)
 
     report = audit_repos(cfg, shell)
-    out = sync_repos(report, cfg, shell)
+    out = sync_repos(report, cfg, shell, tmp_path / ".mothership")
     r = _result_for(out, "cli")
     assert r.status == "fast_forwarded"
     assert "1" in r.message  # 1 commit
 
 
-def test_sync_dirty_skipped(audit_workspace):
+def test_sync_dirty_skipped(audit_workspace, tmp_path):
     cfg, shell = _load(audit_workspace)
     (audit_workspace / "cli" / "README.md").write_text("modified\n")  # tracked-modified
     report = audit_repos(cfg, shell)
-    out = sync_repos(report, cfg, shell)
+    out = sync_repos(report, cfg, shell, tmp_path / ".mothership")
     r = _result_for(out, "cli")
     assert r.status == "skipped"
     assert "dirty_worktree" in r.message
 
 
-def test_sync_diverged_skipped(audit_workspace):
+def test_sync_diverged_skipped(audit_workspace, tmp_path):
     cfg, shell = _load(audit_workspace)
     clone = audit_workspace / "cli"
     (clone / "a.txt").write_text("a"); _sh("git", "add", "a.txt", cwd=clone); _sh("git", "commit", "-qm", "a", cwd=clone)
@@ -66,7 +66,7 @@ def test_sync_diverged_skipped(audit_workspace):
     (clone / "b.txt").write_text("b"); _sh("git", "add", "b.txt", cwd=clone); _sh("git", "commit", "-qm", "b", cwd=clone)
 
     report = audit_repos(cfg, shell)
-    out = sync_repos(report, cfg, shell)
+    out = sync_repos(report, cfg, shell, tmp_path / ".mothership")
     r = _result_for(out, "cli")
     assert r.status == "skipped"
     assert "diverged" in r.message

--- a/tests/core/test_sync_recovery.py
+++ b/tests/core/test_sync_recovery.py
@@ -1,0 +1,254 @@
+"""Integration tests for _try_recover_stale_main.
+
+Uses real `file://` bare-repo origins so git commands exercise actual
+index/working-tree logic.
+"""
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mship.core.repo_sync import _try_recover_stale_main
+from mship.core.repo_state import RepoAudit, Issue
+from mship.core.config import RepoConfig, WorkspaceConfig
+from mship.util.shell import ShellRunner
+
+
+def _run(cwd, *args, check=True):
+    return subprocess.run(["git", *args], cwd=cwd, check=check,
+                          capture_output=True, text=True)
+
+
+def _setup_workspace(tmp_path: Path, behind: bool = True,
+                     dirty_matches_upstream: bool = True,
+                     extra_untracked: bool = False,
+                     dirty_file_not_in_upstream: bool = False) -> Path:
+    """Return the local repo path. Configures an origin ahead of local."""
+    origin = tmp_path / "origin.git"
+    local = tmp_path / "local"
+    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True)
+    subprocess.run(["git", "clone", "-q", str(origin), str(local)], check=True)
+    _run(local, "config", "user.email", "t@t")
+    _run(local, "config", "user.name", "t")
+
+    # Commit A on local, push to origin.
+    (local / "a.txt").write_text("A\n")
+    _run(local, "add", ".")
+    _run(local, "commit", "-qm", "A")
+    _run(local, "push", "-qu", "origin", _current_branch(local))
+
+    if behind:
+        # Make a commit B on a fresh clone pushed to origin.
+        other = tmp_path / "other"
+        subprocess.run(["git", "clone", "-q", str(origin), str(other)], check=True)
+        _run(other, "config", "user.email", "t@t")
+        _run(other, "config", "user.name", "t")
+        if dirty_file_not_in_upstream:
+            # Don't add the file upstream that's dirty locally.
+            (other / "unrelated.txt").write_text("unrelated upstream\n")
+            _run(other, "add", ".")
+        else:
+            (other / "a.txt").write_text("B\n")
+            _run(other, "add", ".")
+        _run(other, "commit", "-qm", "B")
+        _run(other, "push", "-q")
+        # Now origin is ahead of local.
+
+    # Dirty local working tree.
+    if dirty_matches_upstream and behind and not dirty_file_not_in_upstream:
+        (local / "a.txt").write_text("B\n")  # matches upstream
+    elif dirty_file_not_in_upstream:
+        (local / "a.txt").write_text("user work on a file upstream doesn't touch\n")
+    else:
+        (local / "a.txt").write_text("user work\n")
+    if extra_untracked:
+        (local / "user-note.txt").write_text("untracked\n")
+    return local
+
+
+def _current_branch(local: Path) -> str:
+    r = _run(local, "rev-parse", "--abbrev-ref", "HEAD")
+    return r.stdout.strip()
+
+
+def _make_audit(name: str, path: Path) -> RepoAudit:
+    """A RepoAudit whose only issue is dirty_worktree."""
+    return RepoAudit(
+        name=name, path=path, current_branch=_current_branch(path),
+        issues=(Issue("dirty_worktree", "error", "1 modified tracked file"),),
+    )
+
+
+def _make_cfg(name: str, path: Path) -> WorkspaceConfig:
+    return WorkspaceConfig(
+        workspace="t",
+        repos={name: RepoConfig(path=path, type="service")},
+    )
+
+
+def test_happy_path_dirty_matches_upstream(tmp_path):
+    local = _setup_workspace(tmp_path, behind=True, dirty_matches_upstream=True)
+    audit = _make_audit("r", local)
+    cfg = _make_cfg("r", local)
+    state_dir = tmp_path / ".mothership"
+
+    recovered, msg = _try_recover_stale_main(audit, cfg, ShellRunner(), state_dir)
+
+    assert recovered is True
+    assert "recovered" in msg.lower()
+    # Working tree is now clean.
+    status = _run(local, "status", "--porcelain").stdout.strip()
+    assert status == ""
+    # Diagnostic file exists.
+    diags = list((state_dir / "diagnostics").glob("*.json"))
+    assert len(diags) == 1
+
+
+def test_user_work_preserved_when_hash_mismatches(tmp_path):
+    local = _setup_workspace(tmp_path, behind=True, dirty_matches_upstream=False)
+    audit = _make_audit("r", local)
+    cfg = _make_cfg("r", local)
+    state_dir = tmp_path / ".mothership"
+
+    recovered, msg = _try_recover_stale_main(audit, cfg, ShellRunner(), state_dir)
+
+    assert recovered is False
+    assert "does not match upstream" in msg.lower() or "real user work" in msg.lower()
+    # Original dirty content preserved.
+    assert (local / "a.txt").read_text() == "user work\n"
+    # Two diagnostics: pre-recovery + real-user-work.
+    diags = list((state_dir / "diagnostics").glob("*.json"))
+    assert len(diags) == 2
+
+
+def test_not_behind_origin_is_not_recoverable(tmp_path):
+    local = _setup_workspace(tmp_path, behind=False, dirty_matches_upstream=False)
+    audit = _make_audit("r", local)
+    cfg = _make_cfg("r", local)
+    state_dir = tmp_path / ".mothership"
+
+    recovered, msg = _try_recover_stale_main(audit, cfg, ShellRunner(), state_dir)
+
+    assert recovered is False
+    assert "not behind" in msg.lower()
+    # Original content untouched.
+    assert (local / "a.txt").read_text() == "user work\n"
+    # One diagnostic (pre-recovery).
+    diags = list((state_dir / "diagnostics").glob("*.json"))
+    assert len(diags) == 1
+
+
+def test_untracked_files_block_recovery(tmp_path):
+    local = _setup_workspace(tmp_path, behind=True, dirty_matches_upstream=True,
+                             extra_untracked=True)
+    audit = _make_audit("r", local)
+    cfg = _make_cfg("r", local)
+    state_dir = tmp_path / ".mothership"
+
+    recovered, msg = _try_recover_stale_main(audit, cfg, ShellRunner(), state_dir)
+
+    assert recovered is False
+    assert "untracked" in msg.lower()
+    # Tracked dirty file NOT reset (content preserved).
+    assert (local / "a.txt").read_text() == "B\n"
+    assert (local / "user-note.txt").exists()
+
+
+def test_dirty_file_not_in_upstream_is_not_recoverable(tmp_path):
+    local = _setup_workspace(tmp_path, behind=True,
+                             dirty_matches_upstream=False,
+                             dirty_file_not_in_upstream=True)
+    audit = _make_audit("r", local)
+    cfg = _make_cfg("r", local)
+    state_dir = tmp_path / ".mothership"
+
+    recovered, msg = _try_recover_stale_main(audit, cfg, ShellRunner(), state_dir)
+
+    assert recovered is False
+    assert ("does not match upstream" in msg.lower()
+            or "not match" in msg.lower())
+    # User content preserved.
+    assert "user work" in (local / "a.txt").read_text()
+
+
+def test_multi_file_all_match_triggers_recovery(tmp_path):
+    """Two dirty files, both match upstream → recovery succeeds."""
+    origin = tmp_path / "origin.git"
+    local = tmp_path / "local"
+    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True)
+    subprocess.run(["git", "clone", "-q", str(origin), str(local)], check=True)
+    _run(local, "config", "user.email", "t@t")
+    _run(local, "config", "user.name", "t")
+
+    (local / "a.txt").write_text("A1\n")
+    (local / "b.txt").write_text("B1\n")
+    _run(local, "add", ".")
+    _run(local, "commit", "-qm", "initial")
+    branch = _current_branch(local)
+    _run(local, "push", "-qu", "origin", branch)
+
+    # Upstream advance.
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "-q", str(origin), str(other)], check=True)
+    _run(other, "config", "user.email", "t@t")
+    _run(other, "config", "user.name", "t")
+    (other / "a.txt").write_text("A2\n")
+    (other / "b.txt").write_text("B2\n")
+    _run(other, "add", ".")
+    _run(other, "commit", "-qm", "advance")
+    _run(other, "push", "-q")
+
+    # Dirty both files matching upstream.
+    (local / "a.txt").write_text("A2\n")
+    (local / "b.txt").write_text("B2\n")
+
+    audit = _make_audit("r", local)
+    cfg = _make_cfg("r", local)
+    state_dir = tmp_path / ".mothership"
+
+    recovered, msg = _try_recover_stale_main(audit, cfg, ShellRunner(), state_dir)
+    assert recovered is True
+    # Working tree clean.
+    assert _run(local, "status", "--porcelain").stdout.strip() == ""
+
+
+def test_multi_file_one_mismatches_preserves_all(tmp_path):
+    """Two dirty files; first matches, second doesn't.
+    Recovery bails before touching anything — both files preserved."""
+    origin = tmp_path / "origin.git"
+    local = tmp_path / "local"
+    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True)
+    subprocess.run(["git", "clone", "-q", str(origin), str(local)], check=True)
+    _run(local, "config", "user.email", "t@t")
+    _run(local, "config", "user.name", "t")
+    (local / "a.txt").write_text("A1\n")
+    (local / "b.txt").write_text("B1\n")
+    _run(local, "add", ".")
+    _run(local, "commit", "-qm", "initial")
+    branch = _current_branch(local)
+    _run(local, "push", "-qu", "origin", branch)
+
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "-q", str(origin), str(other)], check=True)
+    _run(other, "config", "user.email", "t@t")
+    _run(other, "config", "user.name", "t")
+    (other / "a.txt").write_text("A2\n")
+    (other / "b.txt").write_text("B2\n")
+    _run(other, "add", ".")
+    _run(other, "commit", "-qm", "advance")
+    _run(other, "push", "-q")
+
+    # Dirty: a.txt matches upstream, b.txt has user work.
+    (local / "a.txt").write_text("A2\n")
+    (local / "b.txt").write_text("user work\n")
+
+    audit = _make_audit("r", local)
+    cfg = _make_cfg("r", local)
+    state_dir = tmp_path / ".mothership"
+
+    recovered, msg = _try_recover_stale_main(audit, cfg, ShellRunner(), state_dir)
+    assert recovered is False
+    # Both files preserved — no reset happened.
+    assert (local / "a.txt").read_text() == "A2\n"
+    assert (local / "b.txt").read_text() == "user work\n"


### PR DESCRIPTION
## Summary

Two-part change to address the recurring "stale main index after merge" bug observed multiple times this session:

1. **Diagnostics library** — new `capture_snapshot()` writes JSON forensics blobs to `.mothership/diagnostics/<ts>-<command>-<reason>.json` whenever mship commands detect anomalous state. Ships the instrumentation the future root-cause investigation will need.

2. **`mship sync` auto-recovery** — when audit blocks solely on `dirty_worktree`, compare each dirty tracked file's blob hash against `origin/<branch>`. If every file matches, the dirty state IS the fast-forward delta: reset those files and let the normal fast-forward run. If any file doesn't match, bail before touching anything — user's working tree stays exactly as it was.

`mship finish` and `mship close` also capture silent post-op diagnostics when they observe main dirty at exit. `mship doctor` gains a `diagnostics` warn row when snapshots are pending review.

## Why hash-compare instead of stash

- Provably safe: no state mutation until every file's redundancy is verified. Wrong guess → no files touched.
- No stash/pop edge cases. No `git reset --hard` in any path.
- Untracked files block recovery outright (preserves anything unexpected).

## Scope

- Only `mship sync` actively recovers. `mship finish` / `mship close` only capture diagnostics, no behavior change.
- Recovery only triggers when `dirty_worktree` is the SOLE blocking audit code.
- No root-cause fix yet — this ships the instrumentation and the mitigation together.

## Related

- Issues #80, #81 filed for the other two papercuts (wrong-cwd warning, finish test-evidence gate); followups.
- Decision log + algorithm details in the spec.

## Test plan

- [x] `tests/core/test_diagnostics.py`: 6 unit tests for `capture_snapshot` (happy, filename-safe, dir-creation, repos populated, extra kwarg, write-failure-non-fatal).
- [x] `tests/core/test_sync_recovery.py`: 7 integration tests against real `file://` origins (happy, user-work-preserved, not-behind, untracked, file-missing-upstream, multi-match, multi-mismatch-preserves-all).
- [x] `tests/cli/test_worktree.py`: 2 new integration tests for finish post-op capture (dirty → captured; clean → not captured).
- [x] `tests/core/test_doctor.py`: 2 new tests for the diagnostics row.
- [x] Full suite: all pass.
- [x] Manual smoke: scratch workspace with dirty-main-matches-upstream state → `mship sync` recovers; with real user work → refusal preserved + two diagnostics captured.

Closes the top-ranked recurring papercut from session feedback.