### PR TITLE
mship finish: REST fallback when gh GraphQL is rate-limited (#88)

### DIFF
--- a/src/mship/core/pr.py
+++ b/src/mship/core/pr.py
@@ -1,7 +1,29 @@
+import json
+import re
 import shlex
 from pathlib import Path
 
 from mship.util.shell import ShellRunner
+
+
+_REMOTE_URL_RE = re.compile(
+    r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/\s]+?)(?:\.git)?/?$"
+)
+
+
+def _parse_github_slug(remote_url: str) -> tuple[str, str] | None:
+    m = _REMOTE_URL_RE.search(remote_url.strip())
+    if not m:
+        return None
+    return m.group("owner"), m.group("repo")
+
+
+def _is_graphql_rate_limit(stderr: str) -> bool:
+    s = stderr.lower()
+    return (
+        ("graphql" in s and "rate limit" in s)
+        or "secondary rate limit" in s
+    )
 
 
 class PRManager:
@@ -73,10 +95,56 @@ class PRManager:
                 existing = self.list_pr_for_branch(repo_path, branch)
                 if existing is not None:
                     return existing
+            if _is_graphql_rate_limit(result.stderr):
+                rest_url = self._create_pr_via_rest(
+                    repo_path, branch, title, body, base,
+                )
+                if rest_url is not None:
+                    return rest_url
+                # REST also failed — surface the original graphql error
+                # since that's the cause users need to see.
+                raise RuntimeError(
+                    f"Failed to create PR (rate-limited; REST fallback also failed): "
+                    f"{result.stderr.strip()}"
+                )
             raise RuntimeError(
                 f"Failed to create PR: {result.stderr.strip()}"
             )
         return result.stdout.strip()
+
+    def _create_pr_via_rest(
+        self, repo_path: Path, branch: str, title: str, body: str,
+        base: str | None,
+    ) -> str | None:
+        """Call GitHub's REST endpoint for PR creation (no GraphQL quota).
+
+        Returns the PR html_url on success, or None on any failure so the
+        caller can surface the original rate-limit error.
+        """
+        remote = self._shell.run("git remote get-url origin", cwd=repo_path)
+        if remote.returncode != 0:
+            return None
+        slug = _parse_github_slug(remote.stdout)
+        if slug is None:
+            return None
+        owner, repo = slug
+        cmd = (
+            f"gh api repos/{owner}/{repo}/pulls -X POST "
+            f"-f title={shlex.quote(title)} "
+            f"-f head={shlex.quote(branch)} "
+            f"-f body={shlex.quote(body)}"
+        )
+        if base is not None:
+            cmd += f" -f base={shlex.quote(base)}"
+        result = self._shell.run(cmd, cwd=repo_path)
+        if result.returncode != 0:
+            return None
+        try:
+            payload = json.loads(result.stdout)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        url = payload.get("html_url")
+        return url if isinstance(url, str) and url else None
 
     def count_commits_ahead(self, repo_path: Path, base: str, branch: str) -> int:
         """Return the number of commits on `branch` not on `base`.

--- a/tests/core/test_pr.py
+++ b/tests/core/test_pr.py
@@ -390,3 +390,127 @@ def test_create_pr_non_duplicate_error_still_raises(mock_shell: MagicMock):
             repo_path=Path("/repo"), branch="feat/x",
             title="t", body="b", base="main",
         )
+
+
+def test_create_pr_falls_back_to_rest_on_graphql_rate_limit(mock_shell: MagicMock):
+    """When gh pr create fails with GraphQL rate limit, fall back to REST."""
+    from mship.core.pr import PRManager
+    import json
+    mock_shell.run.side_effect = [
+        # 1. gh pr create hits the rate limit.
+        ShellResult(
+            returncode=1, stdout="",
+            stderr="GraphQL: API rate limit already exceeded for user ID 1.",
+        ),
+        # 2. git remote get-url origin → https URL.
+        ShellResult(
+            returncode=0,
+            stdout="https://github.com/org/repo.git\n",
+            stderr="",
+        ),
+        # 3. gh api repos/org/repo/pulls -X POST → JSON body.
+        ShellResult(
+            returncode=0,
+            stdout=json.dumps({"html_url": "https://github.com/org/repo/pull/99"}),
+            stderr="",
+        ),
+    ]
+    pr_mgr = PRManager(mock_shell)
+    url = pr_mgr.create_pr(
+        repo_path=Path("/repo"), branch="feat/x",
+        title="T", body="B", base="main",
+    )
+    assert url == "https://github.com/org/repo/pull/99"
+    # REST call is visible in the commands.
+    cmds = [c.args[0] for c in mock_shell.run.call_args_list]
+    assert any("gh api repos/org/repo/pulls" in c for c in cmds)
+
+
+def test_create_pr_falls_back_on_secondary_rate_limit(mock_shell: MagicMock):
+    """Secondary rate-limit signature also triggers REST fallback."""
+    from mship.core.pr import PRManager
+    import json
+    mock_shell.run.side_effect = [
+        ShellResult(
+            returncode=1, stdout="",
+            stderr="You have exceeded a secondary rate limit.",
+        ),
+        ShellResult(returncode=0, stdout="git@github.com:org/repo.git\n", stderr=""),
+        ShellResult(
+            returncode=0,
+            stdout=json.dumps({"html_url": "https://github.com/org/repo/pull/7"}),
+            stderr="",
+        ),
+    ]
+    pr_mgr = PRManager(mock_shell)
+    url = pr_mgr.create_pr(
+        repo_path=Path("/repo"), branch="feat/x",
+        title="T", body="B", base="main",
+    )
+    assert url == "https://github.com/org/repo/pull/7"
+
+
+def test_create_pr_rest_fallback_fails_surfaces_original_error(mock_shell: MagicMock):
+    """If REST also fails, surface the original GraphQL error, not the REST error."""
+    from mship.core.pr import PRManager
+    mock_shell.run.side_effect = [
+        ShellResult(
+            returncode=1, stdout="",
+            stderr="GraphQL: API rate limit already exceeded for user ID 1.",
+        ),
+        ShellResult(returncode=0, stdout="https://github.com/org/repo.git\n", stderr=""),
+        ShellResult(returncode=1, stdout="", stderr="rest api also broken"),
+    ]
+    pr_mgr = PRManager(mock_shell)
+    with pytest.raises(RuntimeError) as exc_info:
+        pr_mgr.create_pr(
+            repo_path=Path("/repo"), branch="feat/x",
+            title="T", body="B", base="main",
+        )
+    # Must include the ORIGINAL graphql signal so the user knows the cause.
+    assert "rate limit" in str(exc_info.value).lower()
+
+
+def test_create_pr_rest_fallback_parses_ssh_remote_url(mock_shell: MagicMock):
+    """SSH-style git@github.com:owner/repo.git parses correctly."""
+    from mship.core.pr import PRManager
+    import json
+    mock_shell.run.side_effect = [
+        ShellResult(returncode=1, stdout="", stderr="GraphQL: API rate limit exceeded"),
+        ShellResult(returncode=0, stdout="git@github.com:owner/repo.git\n", stderr=""),
+        ShellResult(
+            returncode=0,
+            stdout=json.dumps({"html_url": "https://github.com/owner/repo/pull/1"}),
+            stderr="",
+        ),
+    ]
+    pr_mgr = PRManager(mock_shell)
+    pr_mgr.create_pr(
+        repo_path=Path("/repo"), branch="feat/x",
+        title="T", body="B",
+    )
+    cmds = [c.args[0] for c in mock_shell.run.call_args_list]
+    # Owner/repo extracted from ssh-style remote.
+    assert any("repos/owner/repo/pulls" in c for c in cmds)
+
+
+def test_create_pr_rest_fallback_parses_https_without_git_suffix(mock_shell: MagicMock):
+    """HTTPS remote without .git suffix also parses."""
+    from mship.core.pr import PRManager
+    import json
+    mock_shell.run.side_effect = [
+        ShellResult(returncode=1, stdout="", stderr="GraphQL: API rate limit exceeded"),
+        ShellResult(returncode=0, stdout="https://github.com/a/b\n", stderr=""),
+        ShellResult(
+            returncode=0,
+            stdout=json.dumps({"html_url": "https://github.com/a/b/pull/3"}),
+            stderr="",
+        ),
+    ]
+    pr_mgr = PRManager(mock_shell)
+    pr_mgr.create_pr(
+        repo_path=Path("/repo"), branch="feat/x",
+        title="T", body="B",
+    )
+    cmds = [c.args[0] for c in mock_shell.run.call_args_list]
+    assert any("repos/a/b/pulls" in c for c in cmds)


### PR DESCRIPTION
## Summary

Closes #88.

`mship finish` failed three times this session with `GraphQL: API rate limit already exceeded`. Each time the PR got opened by hand via `gh api repos/.../pulls -X POST` — the REST endpoint shares auth but not the GraphQL quota.

This PR adds that fallback to `PRManager.create_pr`:

1. When `gh pr create` fails and stderr matches the GraphQL rate-limit signature (`graphql … rate limit` or `secondary rate limit`), call `_create_pr_via_rest`.
2. `_create_pr_via_rest` reads `git remote get-url origin`, parses `owner/repo` from the URL (handles both `https://github.com/a/b[.git]` and `git@github.com:a/b[.git]`), then runs `gh api repos/<owner>/<repo>/pulls -X POST -f title=… -f head=… -f body=… [-f base=…]` and returns the `html_url` from the JSON response.
3. If REST also fails, surface the **original** GraphQL rate-limit error so the user sees the actual cause — not the REST follow-up error.

## Scope

- `create_pr` only. Other `gh` calls (`gh pr view`, `gh pr list`, `gh auth status`) weren't observed hitting rate limits this session, and most have straightforward REST equivalents if the same pattern needs to spread.
- No behavior change on happy path.
- No new dependencies — `json`, `re`, `shlex` all stdlib.

## Test plan

- [x] 5 new tests in `tests/core/test_pr.py`:
  - `test_create_pr_falls_back_to_rest_on_graphql_rate_limit`
  - `test_create_pr_falls_back_on_secondary_rate_limit`
  - `test_create_pr_rest_fallback_fails_surfaces_original_error`
  - `test_create_pr_rest_fallback_parses_ssh_remote_url`
  - `test_create_pr_rest_fallback_parses_https_without_git_suffix`
- [x] `tests/core/test_pr.py`: 42/42 pass.
- [x] Broader `tests/core/` + `tests/cli/`: 836/836 pass.

Closes #88