### PR TITLE
finish + phase honor test evidence (#81)

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -584,6 +584,12 @@ def register(app: typer.Typer, get_container):
                  "Updates finished_at and appends a `re-finished` journal entry. "
                  "Does not touch the PR body — use `gh pr edit` for that.",
         ),
+        require_tests: bool = typer.Option(
+            False, "--require-tests",
+            help="Block finish when any affected repo lacks passing test evidence "
+                 "(task.test_results or journal test_state=pass). Default: WARN only. "
+                 "See #81.",
+        ),
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),
     ):
         """Create PRs across repos in dependency order."""
@@ -821,6 +827,51 @@ def register(app: typer.Typer, get_container):
                 output.error(f"  {repo_name}: {branch} has no commits past {eff_base}")
             output.error("Commit your changes in each worktree, or run `mship close --yes --abandon`.")
             raise typer.Exit(code=1)
+
+        # --- Test-evidence gate (#81) ---
+        # Consult task.test_results + journal test_state entries. WARN by
+        # default; block only with --require-tests. Skipped-untouched repos
+        # don't need evidence (we're not finishing them).
+        from mship.core.test_evidence import (
+            format_missing_summary, read_evidence,
+        )
+
+        evidence_repo_paths: dict[str, Path] = {}
+        for repo_name in task.affected_repos:
+            if repo_name in untouched_repos:
+                continue
+            path = config.repos[repo_name].path
+            if repo_name in task.worktrees:
+                wt = Path(task.worktrees[repo_name])
+                if wt.exists():
+                    path = wt
+            evidence_repo_paths[repo_name] = path
+
+        evidence_task = task.model_copy(
+            update={"affected_repos": list(evidence_repo_paths.keys())}
+        )
+        evidence = read_evidence(
+            evidence_task, container.log_manager(),
+            shell=shell, repo_paths=evidence_repo_paths,
+        )
+        evidence_lines = format_missing_summary(evidence)
+        if evidence_lines:
+            if require_tests:
+                output.error("Test evidence missing — blocking finish (--require-tests):")
+                for line in evidence_lines:
+                    output.error(f"  {line}")
+                output.error(
+                    "Run `mship test` or record evidence via "
+                    "`mship journal --test-state pass`, then retry."
+                )
+                raise typer.Exit(code=1)
+            output.warning("Test-evidence warnings:")
+            for line in evidence_lines:
+                output.warning(f"  {line}")
+            output.warning(
+                "Pass `--require-tests` to treat as blocking, or record evidence via "
+                "`mship test` / `mship journal --test-state pass`."
+            )
 
         pr_list: list[dict] = []
         repushed_repos: list[str] = []  # repos where --force re-pushed commits

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -114,25 +114,17 @@ class PhaseManager:
         return ["No spec found — consider writing one before developing"]
 
     def _gate_review(self, task) -> list[str]:
-        warnings: list[str] = []
-        missing = []
-        failing = []
-        for repo in task.affected_repos:
-            result = task.test_results.get(repo)
-            if result is None:
-                missing.append(repo)
-            elif result.status == "fail":
-                failing.append(repo)
+        # Unified reader honors both task.test_results and journal
+        # `test_state=pass` entries so explicit evidence suppresses the
+        # warning. See #81.
+        from mship.core.test_evidence import format_missing_summary, read_evidence
 
-        if missing:
-            warnings.append(
-                f"Tests not run in: {', '.join(missing)} — consider running tests before review"
-            )
-        if failing:
-            warnings.append(
-                f"Tests not passing in: {', '.join(failing)} — consider fixing before review"
-            )
-        return warnings
+        evidence = read_evidence(task, self._log)
+        lines = format_missing_summary(evidence)
+        if not lines:
+            return []
+        hint = " — consider running tests before review"
+        return [lines[0] + hint] + lines[1:]
 
     def _gate_run(self, task) -> list[str]:
         return []

--- a/src/mship/core/test_evidence.py
+++ b/src/mship/core/test_evidence.py
@@ -1,0 +1,168 @@
+"""Unified reader for test-run evidence on an mship task.
+
+Consumers (`mship finish`, `mship phase`) ask "did we actually test this?"
+before opening PRs or transitioning phases. This module answers by folding
+two signal sources into a per-repo status:
+
+1. `task.test_results[<repo>]` populated by `mship test`. Strongest.
+2. Journal entries with `test_state` populated by `mship journal --test-state`.
+   Per-repo entries beat global (no-repo) entries; within each scope the
+   most recent wins.
+
+When a shell + per-repo paths are provided, `passed` evidence older than the
+latest commit on the task branch is demoted to `stale` — the user may have
+committed more work since running tests.
+
+See #81 for the issue + design rationale. No automatic test invocation:
+this module reads evidence, it never creates it.
+"""
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from mship.core.log import LogManager
+from mship.core.state import Task
+from mship.util.shell import ShellRunner
+
+
+EvidenceStatus = Literal["passed", "failed", "missing", "stale"]
+
+
+@dataclass(frozen=True)
+class RepoEvidence:
+    status: EvidenceStatus
+    source: Literal["test_results", "journal", "none"]
+    at: datetime | None
+
+
+_TEST_STATE_TO_STATUS: dict[str, EvidenceStatus] = {
+    "pass": "passed",
+    "fail": "failed",
+    "mixed": "failed",
+}
+
+
+def read_evidence(
+    task: Task,
+    log: LogManager,
+    *,
+    shell: ShellRunner | None = None,
+    repo_paths: dict[str, Path] | None = None,
+) -> dict[str, RepoEvidence]:
+    """Return per-repo test-run evidence for the task's affected repos.
+
+    Arguments:
+        task: the task whose affected_repos + test_results we inspect.
+        log:  the LogManager to read journal entries from.
+        shell: optional ShellRunner. When provided with `repo_paths`, the
+               reader upgrades stale `passed` evidence (evidence older than
+               the latest commit on the task branch) to `stale`.
+        repo_paths: optional {repo: path} used with `shell` for the stale
+                    check. Path is where `git log` should run for that repo.
+    """
+    global_latest, per_repo_latest = _scan_journal(task, log)
+    results: dict[str, RepoEvidence] = {}
+    for repo in task.affected_repos:
+        ev = _resolve_repo(repo, task, global_latest, per_repo_latest)
+        if (
+            ev.status == "passed"
+            and ev.at is not None
+            and shell is not None
+            and repo_paths is not None
+        ):
+            head_ts = _head_commit_time(shell, repo_paths.get(repo), task.branch)
+            if head_ts is not None and head_ts > ev.at:
+                ev = RepoEvidence(status="stale", source=ev.source, at=ev.at)
+        results[repo] = ev
+    return results
+
+
+def _scan_journal(
+    task: Task, log: LogManager,
+) -> tuple[tuple[datetime, str] | None, dict[str, tuple[datetime, str]]]:
+    global_latest: tuple[datetime, str] | None = None
+    per_repo_latest: dict[str, tuple[datetime, str]] = {}
+    # Iterate in file/chronological order; later entries win ties at the
+    # second-precision timestamp the journal stores.
+    for e in log.read(task.slug):
+        if e.test_state is None:
+            continue
+        if e.repo is None:
+            if global_latest is None or e.timestamp >= global_latest[0]:
+                global_latest = (e.timestamp, e.test_state)
+        else:
+            existing = per_repo_latest.get(e.repo)
+            if existing is None or e.timestamp >= existing[0]:
+                per_repo_latest[e.repo] = (e.timestamp, e.test_state)
+    return global_latest, per_repo_latest
+
+
+def _resolve_repo(
+    repo: str,
+    task: Task,
+    global_latest: tuple[datetime, str] | None,
+    per_repo_latest: dict[str, tuple[datetime, str]],
+) -> RepoEvidence:
+    tr = task.test_results.get(repo)
+    if tr is not None:
+        status: EvidenceStatus = (
+            "passed" if tr.status == "pass"
+            else "failed" if tr.status == "fail"
+            else "missing"
+        )
+        return RepoEvidence(status=status, source="test_results", at=tr.at)
+    if repo in per_repo_latest:
+        at, state = per_repo_latest[repo]
+        status = _TEST_STATE_TO_STATUS.get(state, "missing")
+        return RepoEvidence(status=status, source="journal", at=at)
+    if global_latest is not None:
+        at, state = global_latest
+        status = _TEST_STATE_TO_STATUS.get(state, "missing")
+        return RepoEvidence(status=status, source="journal", at=at)
+    return RepoEvidence(status="missing", source="none", at=None)
+
+
+def _head_commit_time(
+    shell: ShellRunner, repo_path: Path | None, branch: str,
+) -> datetime | None:
+    if repo_path is None:
+        return None
+    r = shell.run(
+        f"git log -1 --format=%cI {shlex.quote(branch)}",
+        cwd=repo_path,
+    )
+    if r.returncode != 0:
+        return None
+    raw = r.stdout.strip()
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def format_missing_summary(
+    evidence: dict[str, RepoEvidence],
+) -> list[str]:
+    """Human-readable warning lines for non-passed repos, grouped by status.
+
+    Returns an empty list when every repo has passing, non-stale evidence.
+    """
+    missing = [r for r, e in evidence.items() if e.status == "missing"]
+    stale = [r for r, e in evidence.items() if e.status == "stale"]
+    failing = [r for r, e in evidence.items() if e.status == "failed"]
+    lines: list[str] = []
+    if missing:
+        lines.append(f"Tests not run in: {', '.join(sorted(missing))}")
+    if stale:
+        lines.append(
+            f"Tests stale (branch has new commits) in: {', '.join(sorted(stale))}"
+        )
+    if failing:
+        lines.append(f"Tests failing in: {', '.join(sorted(failing))}")
+    return lines

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -72,6 +72,28 @@ def test_transition_to_review_warns_failing_tests(state_with_task: StateManager)
     assert any("auth-service" in w for w in result.warnings)
 
 
+def test_transition_to_review_suppresses_warn_when_journal_has_test_state_pass(
+    state_with_task: StateManager, tmp_path: Path,
+):
+    """Journal `test-state=pass` entries count as evidence. See #81."""
+    log = LogManager(tmp_path / "logs")
+    log.create("add-labels")
+    log.append("add-labels", "ran pytest in shared", repo="shared", test_state="pass")
+    log.append(
+        "add-labels", "ran pytest in auth-service",
+        repo="auth-service", test_state="pass",
+    )
+    state = state_with_task.load()
+    state.tasks["add-labels"].phase = "dev"
+    state_with_task.save(state)
+
+    pm = PhaseManager(state_with_task, log)
+    result = pm.transition("add-labels", "review")
+    assert result.warnings == [], (
+        f"expected no warnings with journal evidence; got {result.warnings}"
+    )
+
+
 def test_transition_to_review_no_warning_all_pass(state_with_task: StateManager):
     pm = PhaseManager(state_with_task, MagicMock(spec=LogManager))
     state = state_with_task.load()

--- a/tests/core/test_test_evidence.py
+++ b/tests/core/test_test_evidence.py
@@ -1,0 +1,158 @@
+"""Tests for the unified test-evidence reader. See #81."""
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mship.core.log import LogManager
+from mship.core.state import Task, TestResult
+from mship.util.shell import ShellResult, ShellRunner
+
+
+def _make_task(**overrides) -> Task:
+    defaults = dict(
+        slug="t",
+        description="d",
+        phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["a", "b"],
+        branch="feat/t",
+    )
+    defaults.update(overrides)
+    return Task(**defaults)
+
+
+def test_evidence_prefers_test_results_over_journal(tmp_path: Path):
+    from mship.core.test_evidence import read_evidence
+    log = LogManager(tmp_path / "logs")
+    log.create("t")
+    # Journal says fail, but task.test_results says pass — test_results wins.
+    log.append("t", "ran pytest", repo="a", test_state="fail")
+    task = _make_task(
+        affected_repos=["a"],
+        test_results={"a": TestResult(status="pass", at=datetime.now(timezone.utc))},
+    )
+    ev = read_evidence(task, log)
+    assert ev["a"].status == "passed"
+    assert ev["a"].source == "test_results"
+
+
+def test_evidence_uses_latest_per_repo_journal_when_no_test_results(tmp_path: Path):
+    from mship.core.test_evidence import read_evidence
+    log = LogManager(tmp_path / "logs")
+    log.create("t")
+    log.append("t", "early fail", repo="a", test_state="fail")
+    log.append("t", "later pass", repo="a", test_state="pass")
+    task = _make_task(affected_repos=["a"])
+    ev = read_evidence(task, log)
+    assert ev["a"].status == "passed"
+    assert ev["a"].source == "journal"
+
+
+def test_evidence_global_journal_applies_to_all_repos(tmp_path: Path):
+    """An entry with no repo= tag provides evidence for every affected repo."""
+    from mship.core.test_evidence import read_evidence
+    log = LogManager(tmp_path / "logs")
+    log.create("t")
+    log.append("t", "ran pytest in worktree", test_state="pass")
+    task = _make_task(affected_repos=["a", "b"])
+    ev = read_evidence(task, log)
+    assert ev["a"].status == "passed"
+    assert ev["b"].status == "passed"
+
+
+def test_evidence_per_repo_entry_wins_over_global(tmp_path: Path):
+    from mship.core.test_evidence import read_evidence
+    log = LogManager(tmp_path / "logs")
+    log.create("t")
+    log.append("t", "global pass", test_state="pass")
+    log.append("t", "per-repo fail", repo="a", test_state="fail")
+    task = _make_task(affected_repos=["a", "b"])
+    ev = read_evidence(task, log)
+    assert ev["a"].status == "failed"  # per-repo wins
+    assert ev["b"].status == "passed"  # global applies
+
+
+def test_evidence_missing_when_nothing(tmp_path: Path):
+    from mship.core.test_evidence import read_evidence
+    log = LogManager(tmp_path / "logs")
+    log.create("t")
+    task = _make_task(affected_repos=["a"])
+    ev = read_evidence(task, log)
+    assert ev["a"].status == "missing"
+    assert ev["a"].source == "none"
+
+
+def test_evidence_stale_when_branch_has_newer_commit(tmp_path: Path):
+    """Pass evidence older than the repo's task-branch HEAD → 'stale'."""
+    from mship.core.test_evidence import read_evidence
+    log = LogManager(tmp_path / "logs")
+    log.create("t")
+    evidence_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    task = _make_task(
+        affected_repos=["a"],
+        test_results={"a": TestResult(status="pass", at=evidence_at)},
+    )
+    # Commit timestamp is NEWER than the evidence.
+    head_ts = (datetime.now(timezone.utc)).isoformat()
+    shell = MagicMock(spec=ShellRunner)
+    shell.run.return_value = ShellResult(returncode=0, stdout=head_ts + "\n", stderr="")
+    ev = read_evidence(task, log, shell=shell, repo_paths={"a": Path("/tmp/a")})
+    assert ev["a"].status == "stale"
+
+
+def test_evidence_not_stale_when_commit_older_than_evidence(tmp_path: Path):
+    from mship.core.test_evidence import read_evidence
+    log = LogManager(tmp_path / "logs")
+    log.create("t")
+    evidence_at = datetime.now(timezone.utc)
+    task = _make_task(
+        affected_repos=["a"],
+        test_results={"a": TestResult(status="pass", at=evidence_at)},
+    )
+    head_ts = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    shell = MagicMock(spec=ShellRunner)
+    shell.run.return_value = ShellResult(returncode=0, stdout=head_ts + "\n", stderr="")
+    ev = read_evidence(task, log, shell=shell, repo_paths={"a": Path("/tmp/a")})
+    assert ev["a"].status == "passed"
+
+
+def test_evidence_stale_check_gracefully_skipped_when_no_shell(tmp_path: Path):
+    """Without shell, we can't check stale — just report passed."""
+    from mship.core.test_evidence import read_evidence
+    log = LogManager(tmp_path / "logs")
+    log.create("t")
+    task = _make_task(
+        affected_repos=["a"],
+        test_results={"a": TestResult(
+            status="pass", at=datetime.now(timezone.utc) - timedelta(hours=1),
+        )},
+    )
+    ev = read_evidence(task, log)
+    assert ev["a"].status == "passed"
+
+
+def test_format_missing_summary_empty_when_all_pass(tmp_path: Path):
+    from mship.core.test_evidence import read_evidence, format_missing_summary
+    log = LogManager(tmp_path / "logs")
+    log.create("t")
+    log.append("t", "pass", test_state="pass")
+    task = _make_task(affected_repos=["a", "b"])
+    ev = read_evidence(task, log)
+    assert format_missing_summary(ev) == []
+
+
+def test_format_missing_summary_groups_by_status(tmp_path: Path):
+    from mship.core.test_evidence import read_evidence, format_missing_summary
+    log = LogManager(tmp_path / "logs")
+    log.create("t")
+    log.append("t", "b failed", repo="b", test_state="fail")
+    task = _make_task(affected_repos=["a", "b", "c"])
+    ev = read_evidence(task, log)
+    lines = format_missing_summary(ev)
+    text = "\n".join(lines)
+    assert "a" in text and "c" in text  # both missing
+    assert "b" in text  # failing
+    assert any("missing" in l.lower() or "not run" in l.lower() for l in lines)
+    assert any("failing" in l.lower() for l in lines)

--- a/tests/test_finish_integration.py
+++ b/tests/test_finish_integration.py
@@ -695,3 +695,98 @@ def test_finish_pr_body_unchanged_when_no_issue_refs(finish_workspace):
     assert captured_body
     assert "Closes" not in captured_body[0]
     assert captured_body[0] == "ordinary task description"
+
+
+def test_finish_warns_when_no_test_evidence_default(finish_workspace):
+    """Default: missing test evidence is a WARNING (not a block). See #81."""
+    workspace, mock_shell = finish_workspace
+
+    result = runner.invoke(app, ["spawn", "no evidence", "--repos", "shared", "--force-audit"])
+    assert result.exit_code == 0, result.output
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "rev-list --count" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://x/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell.run.side_effect = mock_run
+
+    result = runner.invoke(app, ["finish", "--task", "no-evidence", "--force-audit"])
+    # Finish still succeeds; the warning is advisory.
+    assert result.exit_code == 0, result.output
+    # Warning text references the evidence gap.
+    lower = result.output.lower()
+    assert "test" in lower and ("not run" in lower or "missing" in lower or "evidence" in lower)
+
+
+def test_finish_blocks_when_require_tests_and_no_evidence(finish_workspace):
+    """--require-tests escalates missing evidence to a BLOCK. See #81."""
+    workspace, mock_shell = finish_workspace
+
+    result = runner.invoke(app, ["spawn", "require block", "--repos", "shared", "--force-audit"])
+    assert result.exit_code == 0, result.output
+
+    pushed: list[str] = []
+    prs: list[str] = []
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "rev-list --count" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
+        if "git push" in cmd:
+            pushed.append(cmd)
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            prs.append(cmd)
+            return ShellResult(returncode=0, stdout="https://x/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell.run.side_effect = mock_run
+
+    result = runner.invoke(
+        app, ["finish", "--task", "require-block", "--force-audit", "--require-tests"]
+    )
+    assert result.exit_code != 0
+    assert pushed == [], "finish must block before pushing when --require-tests"
+    assert prs == [], "finish must block before creating PRs when --require-tests"
+    assert "require-tests" in result.output.lower() or "blocking" in result.output.lower()
+
+
+def test_finish_evidence_via_journal_suppresses_warning(finish_workspace, tmp_path):
+    """Journal `test-state=pass` counts as evidence — no warning. See #81."""
+    workspace, mock_shell = finish_workspace
+
+    result = runner.invoke(app, ["spawn", "journal evidence", "--repos", "shared", "--force-audit"])
+    assert result.exit_code == 0, result.output
+
+    # Record journal evidence for the task (global scope — applies to all repos).
+    from mship.cli import container as cli_container
+    log_mgr = cli_container.log_manager()
+    log_mgr.append("journal-evidence", "ran pytest", test_state="pass")
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "rev-list --count" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://x/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell.run.side_effect = mock_run
+
+    result = runner.invoke(app, ["finish", "--task", "journal-evidence", "--force-audit"])
+    assert result.exit_code == 0, result.output
+    # No "not run" / "missing" / "evidence" warning.
+    lower = result.output.lower()
+    assert "test-evidence warnings" not in lower
+    assert "not run" not in lower


### PR DESCRIPTION
## Summary

Closes #81.

Ships a unified test-evidence reader + wires it into both consumers, so `mship finish` can gate on actual test runs and `mship phase review` stops shouting when evidence IS on record.

### Commit 1 — `feat(core): unified test-evidence reader`

New `src/mship/core/test_evidence.py`:

- `read_evidence(task, log, *, shell=None, repo_paths=None) -> dict[str, RepoEvidence]`
- Folds two signal sources per repo:
  1. `task.test_results[<repo>]` (populated by `mship test`) — strongest.
  2. Journal entries with `test_state` populated by `mship journal --test-state`. Per-repo entries beat global (no-repo) entries; within each scope, most recent wins.
- Stale-ness: with `shell + repo_paths`, `passed` evidence older than the repo's task-branch HEAD commit is demoted to `stale`.
- `format_missing_summary(evidence)` emits grouped warning lines (missing / stale / failing).
- 10 unit tests covering priority order, global-vs-per-repo, staleness edges.

### Commit 2 — `feat(phase): review gate uses unified reader`

`_gate_review` in `src/mship/core/phase.py` swaps its ad-hoc check for `read_evidence` + `format_missing_summary`. Journal `test_state=pass` entries now suppress the "Tests not run" warning they previously ignored. New test: `test_transition_to_review_suppresses_warn_when_journal_has_test_state_pass`. All 14 phase tests green.

### Commit 3 — `feat(finish): --require-tests gates on unified reader`

New `--require-tests` flag on `mship finish`:

- Default (flag absent): WARN on missing / stale / failed evidence, finish proceeds.
- With `--require-tests`: BLOCK — exit 1 before push, referring the user to `mship test` or `mship journal --test-state pass`.
- Gate runs after audit + empty-branch skip, before any push / PR creation.
- Skipped-untouched repos (from #83) are excluded from the evidence check — we're not finishing them anyway.

## Anti-goals (from the issue, preserved)

- No automatic test invocation — reader only reads existing evidence.
- No hard-block by default — `--require-tests` is opt-in.
- No change to the definition of `test_state` on journal entries.

## Test plan

- [x] `tests/core/test_test_evidence.py`: 10 reader tests (priority order, journal scopes, staleness, format summary).
- [x] `tests/core/test_phase.py`: 14 pass — new journal-suppresses-warning test + all existing behavior preserved.
- [x] `tests/test_finish_integration.py`: 20 pass — 3 new (warn-by-default, block with --require-tests, journal evidence suppresses warning) + existing happy/unhappy paths unchanged.
- [x] Full suite: **959 passed**.

Closes #81