### PR TITLE
ergonomics bundle: spawn --slug + finish --title + close positional (#59 #45 #40)

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -215,13 +215,31 @@ def register(app: typer.Typer, get_container):
         skip_setup: bool = typer.Option(False, "--skip-setup", help="Skip running `task setup` in new worktrees"),
         force_audit: bool = typer.Option(False, "--force-audit", help="Bypass audit gate for this spawn"),
         bypass_reconcile: bool = typer.Option(False, "--bypass-reconcile", help="Skip upstream PR drift check for this spawn"),
+        slug: Optional[str] = typer.Option(
+            None, "--slug",
+            help="Override the auto-generated task slug (lowercase alphanumeric + dashes). "
+                 "Useful when the description would produce a 50+ char slug. See #59.",
+        ),
     ):
         """Create coordinated worktrees across repos for a new task."""
+        import re as _re
         from mship.core.audit_gate import run_audit_gate, AuditGateBlocked
         from mship.core.repo_state import audit_repos
 
         container = get_container()
         output = Output()
+
+        # Validate --slug format. Matches what slugify() produces: lowercase
+        # alphanumeric + internal dashes, no leading/trailing dashes, non-empty.
+        if slug is not None:
+            if not _re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", slug):
+                output.error(
+                    f"Invalid --slug {slug!r}: must be lowercase alphanumeric + "
+                    "internal dashes (e.g. 'add-labels'), no leading/trailing "
+                    "dashes, no spaces or underscores."
+                )
+                raise typer.Exit(code=1)
+
         _run_gate(get_container, command="spawn", bypass=bypass_reconcile, output=output)
         wt_mgr = container.worktree_manager()
         config = container.config()
@@ -290,7 +308,9 @@ def register(app: typer.Typer, get_container):
         if output.is_tty and not skip_setup:
             output.print("[dim]Running setup in each worktree (use --skip-setup to skip)...[/dim]")
 
-        result = wt_mgr.spawn(description, repos=repo_list, skip_setup=skip_setup)
+        result = wt_mgr.spawn(
+            description, repos=repo_list, skip_setup=skip_setup, slug=slug,
+        )
         task = result.task
 
         if pending_bypass:

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -610,6 +610,11 @@ def register(app: typer.Typer, get_container):
                  "(task.test_results or journal test_state=pass). Default: WARN only. "
                  "See #81.",
         ),
+        title: Optional[str] = typer.Option(
+            None, "--title",
+            help="Override the PR title (default: task.description). "
+                 "Multi-repo tasks use the same title for every PR. See #45.",
+        ),
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),
     ):
         """Create PRs across repos in dependency order."""
@@ -633,6 +638,15 @@ def register(app: typer.Typer, get_container):
                 "--force doesn't touch PR bodies — use `gh pr edit <url> --body-file <path>` "
                 "to update an existing PR body"
             )
+            raise typer.Exit(code=1)
+        if force and title is not None:
+            output.error(
+                "--force doesn't touch PR titles — use `gh pr edit <url> --title <text>` "
+                "to update an existing PR title"
+            )
+            raise typer.Exit(code=1)
+        if title is not None and (push_only or handoff):
+            output.error("--title has no effect with --push-only or --handoff")
             raise typer.Exit(code=1)
 
         # --- Resolve PR body source ---
@@ -1038,7 +1052,7 @@ def register(app: typer.Typer, get_container):
                     pr_url = pr_mgr.create_pr(
                         repo_path=group.rep_path,
                         branch=task.branch,
-                        title=task.description,
+                        title=title if title else task.description,
                         body=pr_body,
                         base=group.base,
                     )

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -359,6 +359,11 @@ def register(app: typer.Typer, get_container):
 
     @app.command()
     def close(
+        task_slug: Optional[str] = typer.Argument(
+            None,
+            help="Task slug to close (positional). Alternative to --task. "
+                 "Falls back to cwd > MSHIP_TASK when omitted. See #40.",
+        ),
         yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
         force: bool = typer.Option(False, "--force", "-f", help="Bypass ALL safety checks (destructive)"),
         abandon: bool = typer.Option(False, "--abandon", help="Close without finishing (discard PR flow)"),
@@ -377,6 +382,18 @@ def register(app: typer.Typer, get_container):
 
         container = get_container()
         output = Output()
+
+        # #40: positional `mship close <slug>` is an alternative spelling of
+        # `--task <slug>`. Conflicting different values must fail loudly.
+        if task_slug is not None and task is not None and task_slug != task:
+            output.error(
+                f"Conflicting task slug: positional {task_slug!r} vs --task {task!r}. "
+                "Pass one or the other."
+            )
+            raise typer.Exit(code=1)
+        if task is None and task_slug is not None:
+            task = task_slug
+
         _run_gate(get_container, command="close", bypass=bypass_reconcile, output=output)
         state_mgr = container.state_manager()
         state = state_mgr.load()

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -178,8 +178,9 @@ class WorktreeManager:
         description: str,
         repos: list[str] | None = None,
         skip_setup: bool = False,
+        slug: str | None = None,
     ) -> SpawnResult:
-        slug = slugify(description)
+        slug = slug if slug is not None else slugify(description)
         branch = self._config.branch_pattern.replace("{slug}", slug)
 
         # Early-exit preflight: avoid doing expensive worktree creation when

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -473,6 +473,65 @@ def test_finish_body_file_passed_to_gh_pr_create(configured_git_app: Path):
         cli_container.shell.reset_override()
 
 
+def test_finish_title_override_passed_to_gh_pr_create(configured_git_app: Path):
+    """--title replaces task.description in the gh pr create invocation. See #45."""
+    from mship.cli import container as cli_container
+
+    runner.invoke(app, ["spawn", "a long verbose description that shouldnt be the PR title", "--repos", "shared"])
+
+    captured: dict[str, str] = {}
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            captured["create_cmd"] = cmd
+            return ShellResult(returncode=0, stdout="https://x/pr/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = mock_run
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    cli_container.shell.override(mock_shell)
+    try:
+        result = runner.invoke(
+            app, [
+                "finish",
+                "--task", "a-long-verbose-description-that-shouldnt-be-the-pr-title",
+                "--title", "feat(spawn): concise PR title",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "feat(spawn): concise PR title" in captured["create_cmd"]
+        # Original description is NOT in --title position.
+        import shlex as _shlex
+        tokens = _shlex.split(captured["create_cmd"])
+        idx = tokens.index("--title")
+        assert tokens[idx + 1] == "feat(spawn): concise PR title"
+    finally:
+        cli_container.shell.reset_override()
+
+
+def test_finish_title_rejected_with_force(configured_git_app: Path):
+    """--force won't rewrite existing PR titles; conflict rejected like --body."""
+    runner.invoke(app, ["spawn", "force title mutex", "--repos", "shared"])
+    result = runner.invoke(
+        app, ["finish", "--task", "force-title-mutex", "--force", "--title", "t"]
+    )
+    assert result.exit_code != 0
+    assert "title" in result.output.lower()
+
+
+def test_finish_title_incompatible_with_push_only(configured_git_app: Path):
+    runner.invoke(app, ["spawn", "po title mutex", "--repos", "shared"])
+    result = runner.invoke(
+        app, ["finish", "--task", "po-title-mutex", "--push-only", "--title", "t"]
+    )
+    assert result.exit_code != 0
+
+
 def test_finish_body_and_body_file_mutually_exclusive(configured_git_app: Path):
     runner.invoke(app, ["spawn", "mutex test", "--repos", "shared"])
     result = runner.invoke(

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -473,6 +473,35 @@ def test_finish_body_file_passed_to_gh_pr_create(configured_git_app: Path):
         cli_container.shell.reset_override()
 
 
+def test_close_accepts_positional_slug(configured_git_app: Path):
+    """`mship close <slug>` is an alternative to `--task <slug>`. See #40."""
+    runner.invoke(app, ["spawn", "positional close", "--repos", "shared"])
+    result = runner.invoke(app, ["close", "positional-close", "-y", "--abandon"])
+    assert result.exit_code == 0, result.output
+    mgr = StateManager(configured_git_app / ".mothership")
+    assert "positional-close" not in mgr.load().tasks
+
+
+def test_close_positional_and_task_flag_conflict(configured_git_app: Path):
+    """Conflicting positional + --task values fail loudly."""
+    runner.invoke(app, ["spawn", "conflict a", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "conflict b", "--repos", "shared"])
+    result = runner.invoke(
+        app, ["close", "conflict-a", "--task", "conflict-b", "-y", "--abandon"],
+    )
+    assert result.exit_code != 0
+    assert "conflict" in result.output.lower()
+
+
+def test_close_positional_equal_to_task_flag_is_ok(configured_git_app: Path):
+    """Same value in both is not an error."""
+    runner.invoke(app, ["spawn", "equal case", "--repos", "shared"])
+    result = runner.invoke(
+        app, ["close", "equal-case", "--task", "equal-case", "-y", "--abandon"],
+    )
+    assert result.exit_code == 0, result.output
+
+
 def test_finish_title_override_passed_to_gh_pr_create(configured_git_app: Path):
     """--title replaces task.description in the gh pr create invocation. See #45."""
     from mship.cli import container as cli_container

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -64,6 +64,46 @@ def test_spawn(configured_git_app: Path):
     assert "add-labels-to-tasks" in state.tasks
 
 
+def test_spawn_slug_override(configured_git_app: Path):
+    """--slug overrides auto-generated slug. See #59."""
+    result = runner.invoke(
+        app, ["spawn", "a very long description for a simple task",
+              "--repos", "shared", "--slug", "short"],
+    )
+    assert result.exit_code == 0, result.output
+    mgr = StateManager(configured_git_app / ".mothership")
+    state = mgr.load()
+    assert "short" in state.tasks
+    # Auto-slug from the description is NOT registered.
+    assert not any("very-long" in s for s in state.tasks)
+    assert state.tasks["short"].branch == "feat/short"
+
+
+def test_spawn_slug_rejects_invalid_chars(configured_git_app: Path):
+    """Reject uppercase / underscores / spaces / empty. See #59."""
+    for bad in ["UPPER", "has_underscore", "with space", "", "-leading", "trailing-"]:
+        result = runner.invoke(
+            app, ["spawn", "d", "--repos", "shared", "--slug", bad],
+        )
+        assert result.exit_code != 0, f"expected rejection for slug={bad!r}: {result.output}"
+
+
+def test_spawn_slug_collision_errors(configured_git_app: Path):
+    """Two spawns with the same --slug → second fails with a clear error."""
+    first = runner.invoke(
+        app, ["spawn", "first", "--repos", "shared", "--slug", "dupe"],
+    )
+    assert first.exit_code == 0, first.output
+    second = runner.invoke(
+        app, ["spawn", "second", "--repos", "shared", "--slug", "dupe"],
+    )
+    assert second.exit_code != 0
+    # Collision ValueError bubbles up through the CLI (existing behavior for
+    # auto-slugs too); CliRunner captures it on `.exception`.
+    assert second.exception is not None
+    assert "already exists" in str(second.exception).lower()
+
+
 def test_spawn_all_repos(configured_git_app: Path):
     result = runner.invoke(app, ["spawn", "big change"])
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Summary

Three small ergonomics wins bundled as separate commits, one PR.

### Commit 1 — `feat(spawn): --slug to override auto-generated task slug`

Closes #59.

`mship spawn "<long description>"` auto-generates a slug from the description; long descriptions produce 40-60+ char slugs that haunt every downstream command (`--task <slug>`, branch names, PR branches, `mship status`).

New `--slug <short>` flag bypasses auto-generation:

```bash
mship spawn "refactor auth middleware to move session token storage" --slug auth-session-refactor
# branch: feat/auth-session-refactor
```

- Validated against the same format `slugify()` produces (lowercase alphanumeric, internal dashes only, non-empty, no leading/trailing dash).
- Slug collisions still fail fast with the existing clear error.

### Commit 2 — `feat(finish): --title to override PR title`

Closes #45.

`mship finish` hard-coded the PR title to `task.description`. Task descriptions are slug-friendly prose; PR titles usually want conventional-commits style (`feat(scope): change`). Today this required a follow-up `gh pr edit --title`.

New `--title <text>` flag passes through to `gh pr create --title <arg>`. Default behavior (no flag) unchanged — still `task.description`. Symmetric with the existing `--body/--body-file`:

- Rejected with `--force` (PR titles aren't rewritten on re-push; use `gh pr edit` for that).
- Rejected with `--push-only` / `--handoff` (no PR to title).
- Multi-repo tasks use the same title per PR (matches existing `task.description` behavior).

### Commit 3 — `feat(close): accept positional task slug`

Closes #40.

`mship close` targeting a non-cwd task required `--task <slug>` or `MSHIP_TASK=<slug>`. The `--task` spelling isn't the first thing a user reaches for in that scenario; positional is more natural.

New: `mship close <slug>` works as a direct alternative to `--task <slug>`. Existing resolution paths (cwd > env > flag) still work. Positional + conflicting `--task` fails loudly; matching values in both is fine.

```bash
mship close auth-session-refactor  # new
mship close --task auth-session-refactor  # existing
mship close  # existing (cwd/env resolution)
```

## Test plan

- [x] `tests/cli/test_worktree.py`: 3 new tests for `--slug` (override, invalid-chars, collision).
- [x] `tests/cli/test_worktree.py`: 3 new tests for `--title` (passthrough, --force mutex, --push-only mutex).
- [x] `tests/cli/test_worktree.py`: 3 new tests for positional close (positional alone, positional + flag conflict, matching values).
- [x] Full suite: **968 passed**.

Closes #40, #45, #59