### PR TITLE
feat(mship): diagnostic surfaces for symlink-ignore + PR state (#72 #73)

### DIFF
--- a/docs/superpowers/plans/2026-04-22-diagnostic-surfaces-72-73.md
+++ b/docs/superpowers/plans/2026-04-22-diagnostic-surfaces-72-73.md
@@ -1,0 +1,841 @@
+# Diagnostic Surfaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Two narrow diagnostic improvements: spawn/doctor warn when a `symlink_dirs` target is ignored as a directory but the symlink itself slips through (#72); `mship close` names the reason behind a "pr state unknown" result instead of swallowing it (#73).
+
+**Architecture:** Add one helper in `core/worktree.py` that runs two `git check-ignore` probes to detect the footgun; call it from `_create_symlinks` (spawn path) and `DoctorChecker.run` (doctor path). Separately, change `PRManager.check_pr_state` to return a `PrStateResult` NamedTuple with `state` + `reason`; classify the reason via substring matching on gh stderr; update `close`'s single caller and its log message.
+
+**Tech Stack:** Python 3.14 (NamedTuple), pytest, shell via ShellRunner for git + gh.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-22-diagnostic-surfaces-72-73-design.md`
+
+---
+
+## File structure
+
+**Modified files:**
+- `src/mship/core/worktree.py` — add `_symlink_gitignore_footgun` helper; call it from `_create_symlinks`.
+- `src/mship/core/doctor.py` — new per-repo loop checking `symlink_dirs` entries via the same helper.
+- `src/mship/core/pr.py` — `check_pr_state` returns `PrStateResult`; new classification helper `_classify_pr_state_reason`.
+- `src/mship/cli/worktree.py` — `close` unpacks the new return; log message includes reason on unknown.
+- `tests/core/test_worktree.py` — helper truth-table tests + spawn integration test.
+- `tests/core/test_doctor.py` — doctor-row integration test.
+- `tests/core/test_pr.py` — update 5 existing `check_pr_state_*` tests; add classification tests.
+- `tests/cli/test_worktree.py` — close integration test (rate-limit reason surfaces).
+
+**No new files.** Each change fits naturally in the existing module.
+
+**Task ordering rationale:** Task 1 (helper + spawn) is foundational — Task 2's doctor integration reuses the same helper. Task 3 (#73) is independent of the first two and could be done in parallel, but sequencing keeps commits clean. Task 4 is smoke + PR.
+
+---
+
+## Task 1: `_symlink_gitignore_footgun` helper + spawn integration
+
+**Files:**
+- Modify: `src/mship/core/worktree.py` — add helper; call from `_create_symlinks`.
+- Modify: `tests/core/test_worktree.py` — 4 truth-table tests + 1 spawn-path regression test.
+
+**Context:** The helper detects the narrow case where `.gitignore` has `name/` (dir form) but not `name` — so git ignores the directory but treats the symlink (which git sees as a file) as untracked. `git check-ignore <path>` returns 0 when ignored, 1 when not, >1 on error. Probe both `name/` and `name` and compare.
+
+- [ ] **Step 1.1: Write failing truth-table tests**
+
+Append to `tests/core/test_worktree.py`:
+
+```python
+import subprocess
+
+
+def _init_git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=path, check=True)
+
+
+def test_footgun_fires_when_only_dir_form_ignored(tmp_path: Path):
+    """`.gitignore` has `foo/` but not `foo` → footgun. See #72."""
+    from mship.core.worktree import _symlink_gitignore_footgun
+    repo = tmp_path / "r"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text("foo/\n")
+    assert _symlink_gitignore_footgun(repo, "foo") is True
+
+
+def test_footgun_silent_when_plain_name_ignored(tmp_path: Path):
+    """`.gitignore` has `foo` (no slash) → matches both; no footgun."""
+    from mship.core.worktree import _symlink_gitignore_footgun
+    repo = tmp_path / "r"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text("foo\n")
+    assert _symlink_gitignore_footgun(repo, "foo") is False
+
+
+def test_footgun_silent_when_both_forms_ignored(tmp_path: Path):
+    from mship.core.worktree import _symlink_gitignore_footgun
+    repo = tmp_path / "r"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text("foo\nfoo/\n")
+    assert _symlink_gitignore_footgun(repo, "foo") is False
+
+
+def test_footgun_silent_when_neither_form_ignored(tmp_path: Path):
+    """Legitimate tracked symlink case — no warning."""
+    from mship.core.worktree import _symlink_gitignore_footgun
+    repo = tmp_path / "r"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text("unrelated\n")
+    assert _symlink_gitignore_footgun(repo, "foo") is False
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/core/test_worktree.py -v -k footgun`
+Expected: FAIL — `ImportError: cannot import name '_symlink_gitignore_footgun'`.
+
+- [ ] **Step 1.3: Add the helper**
+
+Edit `src/mship/core/worktree.py`. Add this module-level helper right above the `_create_symlinks` method (which is currently around line 136). Note the helper uses `subprocess` directly (not the ShellRunner dep-injected elsewhere in this module) — matches existing style in this file's `_copy_bind_files` / `_create_symlinks`, which also do direct filesystem calls without the runner.
+
+```python
+def _symlink_gitignore_footgun(repo_path: Path, name: str) -> bool:
+    """Return True when `.gitignore` ignores `<name>/` (dir form) but not `<name>` alone.
+
+    This is the specific footgun that breaks `symlink_dirs`: git treats the
+    symlink as a file, not a directory, so a dir-only ignore pattern
+    (`foo/`) doesn't match the symlink (`foo`), and it shows up as untracked.
+
+    Probes via `git check-ignore` — exit 0 = ignored, 1 = not ignored, >1 = error.
+    On any error we bail to False (no warning) to avoid false positives.
+    """
+    import subprocess
+
+    def _ignored(path_fragment: str) -> bool:
+        try:
+            r = subprocess.run(
+                ["git", "check-ignore", "--", path_fragment],
+                cwd=repo_path, capture_output=True, text=True, check=False,
+            )
+        except OSError:
+            return False
+        return r.returncode == 0
+
+    dir_ignored = _ignored(f"{name}/")
+    file_ignored = _ignored(name)
+    return dir_ignored and not file_ignored
+```
+
+Place the helper at module scope (not inside `WorktreeManager`) so tests can import it directly as shown in the tests above.
+
+- [ ] **Step 1.4: Run helper tests to verify they pass**
+
+Run: `uv run pytest tests/core/test_worktree.py -v -k footgun`
+Expected: 4 passed.
+
+- [ ] **Step 1.5: Wire into `_create_symlinks`**
+
+Still in `src/mship/core/worktree.py`, update `_create_symlinks` (currently around lines 136-174). Find the block:
+
+```python
+            if target.is_symlink():
+                target.unlink()
+
+            target.symlink_to(source.resolve())
+```
+
+Replace with:
+
+```python
+            if target.is_symlink():
+                target.unlink()
+
+            target.symlink_to(source.resolve())
+
+            # Detect the `.gitignore has 'foo/' but not 'foo'` footgun — the
+            # symlink would show as untracked. See #72.
+            if _symlink_gitignore_footgun(worktree_path, dir_name):
+                warnings.append(
+                    f"{repo_name}: symlink '{dir_name}' is not ignored — "
+                    f"git treats it as an untracked file. "
+                    f"Add '{dir_name}' (not just '{dir_name}/') to .gitignore."
+                )
+```
+
+The check runs inside the worktree (where the symlink lives), not the source repo — the worktree shares `.git` with the parent, so `.gitignore` patterns apply uniformly.
+
+- [ ] **Step 1.6: Write failing integration test for spawn**
+
+Append to `tests/core/test_worktree.py`:
+
+```python
+def test_create_symlinks_warns_on_dir_form_gitignore_footgun(tmp_path: Path):
+    """Spawn path: `.gitignore` has `foo/` and `symlink_dirs: [foo]` → warning. See #72."""
+    from mship.core.config import RepoConfig, WorkspaceConfig
+    from mship.core.state import StateManager
+    from mship.core.worktree import WorktreeManager
+    from mship.core.graph import RepoGraph
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+
+    # Source repo with `foo/` directory + `.gitignore` ignoring `foo/` only.
+    source = tmp_path / "source"
+    _init_git_repo(source)
+    (source / "foo").mkdir()
+    (source / "foo" / "data.txt").write_text("x")
+    (source / ".gitignore").write_text("foo/\n")
+    subprocess.run(["git", "add", ".gitignore"], cwd=source, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=source, check=True)
+
+    repo_cfg = RepoConfig(
+        path=source, type="service", symlink_dirs=["foo"],
+    )
+    cfg = WorkspaceConfig(workspace="t", repos={"src": repo_cfg})
+    mgr = WorktreeManager(
+        config=cfg,
+        state_manager=MagicMock(spec=StateManager),
+        shell=MagicMock(spec=ShellRunner),
+        graph=RepoGraph(cfg),
+    )
+
+    # Call `_create_symlinks` directly so we don't exercise the whole spawn pipeline.
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    # Initialize git in the worktree so check-ignore has something to resolve.
+    _init_git_repo(worktree)
+    (worktree / ".gitignore").write_text("foo/\n")
+    warnings = mgr._create_symlinks("src", repo_cfg, worktree)
+    assert any("foo" in w and "not ignored" in w for w in warnings), warnings
+
+
+def test_create_symlinks_no_warn_when_plain_name_ignored(tmp_path: Path):
+    """Regression: `.gitignore` with `foo` (no slash) → NO warning."""
+    from mship.core.config import RepoConfig, WorkspaceConfig
+    from mship.core.state import StateManager
+    from mship.core.worktree import WorktreeManager
+    from mship.core.graph import RepoGraph
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+
+    source = tmp_path / "source"
+    _init_git_repo(source)
+    (source / "foo").mkdir()
+    (source / ".gitignore").write_text("foo\n")  # no trailing slash
+    subprocess.run(["git", "add", ".gitignore"], cwd=source, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=source, check=True)
+
+    repo_cfg = RepoConfig(path=source, type="service", symlink_dirs=["foo"])
+    cfg = WorkspaceConfig(workspace="t", repos={"src": repo_cfg})
+    mgr = WorktreeManager(
+        config=cfg,
+        state_manager=MagicMock(spec=StateManager),
+        shell=MagicMock(spec=ShellRunner),
+        graph=RepoGraph(cfg),
+    )
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    _init_git_repo(worktree)
+    (worktree / ".gitignore").write_text("foo\n")
+    warnings = mgr._create_symlinks("src", repo_cfg, worktree)
+    assert not any("not ignored" in w for w in warnings), warnings
+```
+
+- [ ] **Step 1.7: Run spawn integration tests**
+
+Run: `uv run pytest tests/core/test_worktree.py -v -k "symlinks_warns or symlinks_no_warn or footgun"`
+Expected: 6 passed (4 unit + 2 spawn).
+
+- [ ] **Step 1.8: Run the broader worktree tests for regressions**
+
+Run: `uv run pytest tests/core/test_worktree.py -q 2>&1 | tail -5`
+Expected: all pass.
+
+- [ ] **Step 1.9: Commit**
+
+```bash
+git add src/mship/core/worktree.py tests/core/test_worktree.py
+git commit -m "feat(worktree): warn when symlink_dir is ignored as dir but not as file"
+mship journal "#72: _symlink_gitignore_footgun helper + spawn-path warning when .gitignore has 'foo/' but not 'foo'" --action committed
+```
+
+---
+
+## Task 2: Doctor integration for #72
+
+**Files:**
+- Modify: `src/mship/core/doctor.py` — new per-repo check after the existing pre-commit-hook block.
+- Modify: `tests/core/test_doctor.py` — integration test.
+
+**Context:** Doctor already iterates `self._config.repos.items()` and emits per-repo `CheckResult` rows. Add a new loop (or extend the existing one) that consults the same helper from Task 1 for each repo's `symlink_dirs` entries.
+
+- [ ] **Step 2.1: Write failing doctor test**
+
+Append to `tests/core/test_doctor.py`:
+
+```python
+def test_doctor_warns_on_symlink_gitignore_footgun(workspace: Path):
+    """Doctor row per symlink_dir whose `.gitignore` has dir-form only. See #72."""
+    import subprocess
+    from mship.core.config import ConfigLoader
+    from mship.core.doctor import DoctorChecker
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+    from mship.util.shell import ShellResult
+
+    # Workspace fixture already has a `shared` repo. Make it a git repo with
+    # `foo/` in .gitignore and `symlink_dirs: [foo]`.
+    import yaml
+    cfg_path = workspace / "mothership.yaml"
+    cfg = yaml.safe_load(cfg_path.read_text())
+    cfg["repos"]["shared"]["symlink_dirs"] = ["foo"]
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    shared = workspace / "shared"
+    shared.mkdir(exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=shared, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=shared, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=shared, check=True)
+    (shared / ".gitignore").write_text("foo/\n")
+    (shared / "Taskfile.yml").write_text("version: '3'\ntasks: {test: {cmds: ['true']}, run: {cmds: ['true']}}\n")
+    subprocess.run(["git", "add", "."], cwd=shared, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=shared, check=True)
+
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    shell = MagicMock(spec=ShellRunner)
+    shell.run.return_value = ShellResult(
+        returncode=0, stdout="test\nrun\nlint\nsetup\n", stderr="",
+    )
+
+    report = DoctorChecker(config, shell, state_dir=workspace / ".mothership").run()
+    rows = [c for c in report.checks if "symlink-ignore" in c.name]
+    assert len(rows) == 1, [c.name for c in report.checks]
+    assert rows[0].status == "warn"
+    assert "foo" in rows[0].message
+```
+
+- [ ] **Step 2.2: Run test to verify it fails**
+
+Run: `uv run pytest tests/core/test_doctor.py -v -k symlink_gitignore`
+Expected: FAIL — no such row in the report.
+
+- [ ] **Step 2.3: Add the doctor check**
+
+Edit `src/mship/core/doctor.py`. Find the end of the existing per-repo loop (after the pre-commit-hook block, before the `# gh CLI` block — around line 220 in the current file). Add this block:
+
+```python
+        # Symlink-gitignore footgun check (#72).
+        from mship.core.worktree import _symlink_gitignore_footgun
+        for name, repo in self._config.repos.items():
+            if not repo.symlink_dirs:
+                continue
+            if repo.git_root is not None:
+                parent = self._config.repos[repo.git_root]
+                check_path = Path(parent.path).resolve()
+            else:
+                check_path = Path(repo.path).resolve()
+            if not (check_path / ".git").exists():
+                continue  # can't check-ignore without a git repo
+            for dir_name in repo.symlink_dirs:
+                if _symlink_gitignore_footgun(check_path, dir_name):
+                    report.checks.append(CheckResult(
+                        name=f"{name}/symlink-ignore",
+                        status="warn",
+                        message=(
+                            f"symlink '{dir_name}' is not ignored — "
+                            f"add '{dir_name}' (no trailing slash) to .gitignore"
+                        ),
+                    ))
+```
+
+Placement: after the existing `Pre-commit hook presence per unique git root` block, before the `# gh CLI` block. One row per `symlink_dirs` entry that hits the footgun.
+
+- [ ] **Step 2.4: Run test to verify it passes**
+
+Run: `uv run pytest tests/core/test_doctor.py -v -k symlink_gitignore`
+Expected: 1 passed.
+
+- [ ] **Step 2.5: Run broader doctor tests for regressions**
+
+Run: `uv run pytest tests/core/test_doctor.py -q 2>&1 | tail -3`
+Expected: all pass.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add src/mship/core/doctor.py tests/core/test_doctor.py
+git commit -m "feat(doctor): warn row per symlink_dir ignored as dir but not as file"
+mship journal "#72: doctor now emits {repo}/symlink-ignore warn row for each symlink_dirs entry where only the dir form is gitignored" --action committed
+```
+
+---
+
+## Task 3: `check_pr_state` returns `PrStateResult` with reason
+
+**Files:**
+- Modify: `src/mship/core/pr.py` — `check_pr_state` returns NamedTuple; add `_classify_pr_state_reason`.
+- Modify: `src/mship/cli/worktree.py` — unpack in `close`; surface reason in log message at line 502.
+- Modify: `tests/core/test_pr.py` — update 5 existing `check_pr_state_*` tests; add classification tests.
+- Modify: `tests/cli/test_worktree.py` — add close integration test.
+
+**Context:** `check_pr_state` is called only at `src/mship/cli/worktree.py:471` today. Return tuple is `(state, reason)` — state is what it was before; reason is empty for known states, classified string for unknown.
+
+- [ ] **Step 3.1: Write failing classification tests**
+
+Append to `tests/core/test_pr.py`:
+
+```python
+import pytest
+
+
+@pytest.mark.parametrize("stderr,expected", [
+    ("GraphQL: API rate limit exceeded for user ID 1", "rate limited"),
+    ("You have exceeded a secondary rate limit", "rate limited"),
+    ("authentication required; run 'gh auth login'", "gh not authenticated"),
+    ("error: not logged in", "gh not authenticated"),
+    ("could not resolve host: api.github.com", "network error"),
+    ("connection timed out", "network error"),
+    ("could not find pull request", "not found"),
+    ("GraphQL: Could not resolve to a PullRequest", "not found"),
+    ("HTTP 404: Not Found", "not found"),
+])
+def test_classify_pr_state_reason_signatures(stderr, expected):
+    from mship.core.pr import _classify_pr_state_reason
+    assert _classify_pr_state_reason(returncode=1, stderr=stderr, raw_state="") == expected
+
+
+def test_classify_pr_state_reason_unmapped_state():
+    from mship.core.pr import _classify_pr_state_reason
+    # returncode 0, raw state is something we don't map (e.g. DRAFT).
+    reason = _classify_pr_state_reason(returncode=0, stderr="", raw_state="DRAFT")
+    assert reason == "unmapped state: DRAFT"
+
+
+def test_classify_pr_state_reason_gh_not_installed():
+    from mship.core.pr import _classify_pr_state_reason
+    assert _classify_pr_state_reason(returncode=127, stderr="", raw_state="") == "gh not installed"
+
+
+def test_classify_pr_state_reason_other_excerpt():
+    """Unmatched stderr falls into 'other: <80-char excerpt>'."""
+    from mship.core.pr import _classify_pr_state_reason
+    stderr = "some unexpected error message we haven't classified: very long " * 3
+    reason = _classify_pr_state_reason(returncode=1, stderr=stderr, raw_state="")
+    assert reason.startswith("other: ")
+    assert len(reason) <= len("other: ") + 80
+
+
+def test_check_pr_state_returns_pr_state_result_tuple(mock_shell):
+    """Return value is a NamedTuple with .state and .reason."""
+    from mship.core.pr import PRManager, PrStateResult
+    mock_shell.run.return_value = ShellResult(returncode=0, stdout="MERGED\n", stderr="")
+    result = PRManager(mock_shell).check_pr_state("https://x/1")
+    assert isinstance(result, PrStateResult)
+    assert result.state == "merged"
+    assert result.reason == ""
+
+
+def test_check_pr_state_unknown_rate_limit_surfaces_reason(mock_shell):
+    from mship.core.pr import PRManager
+    mock_shell.run.return_value = ShellResult(
+        returncode=1, stdout="",
+        stderr="GraphQL: API rate limit exceeded for user ID 1",
+    )
+    result = PRManager(mock_shell).check_pr_state("https://x/1")
+    assert result.state == "unknown"
+    assert result.reason == "rate limited"
+```
+
+- [ ] **Step 3.2: Update the 5 existing `check_pr_state_*` tests**
+
+The existing tests in `tests/core/test_pr.py` assert on a string return:
+
+```python
+assert mgr.check_pr_state("...") == "merged"
+```
+
+These five (lines ~190-220) must be updated to compare on `.state`:
+
+```python
+assert mgr.check_pr_state("...").state == "merged"
+```
+
+Apply the same pattern to all 5:
+- `test_check_pr_state_merged`
+- `test_check_pr_state_closed`
+- `test_check_pr_state_open`
+- `test_check_pr_state_unknown_on_failure`
+- `test_check_pr_state_unknown_on_unexpected_output`
+
+- [ ] **Step 3.3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/core/test_pr.py -v -k "check_pr_state or classify"`
+Expected: new tests fail (`ImportError` for `PrStateResult` / `_classify_pr_state_reason`); updated existing tests fail with `AttributeError: 'str' object has no attribute 'state'` — the old code still returns a string.
+
+- [ ] **Step 3.4: Implement the change**
+
+Edit `src/mship/core/pr.py`. At the top of the file (after existing imports), add:
+
+```python
+from typing import NamedTuple
+
+
+class PrStateResult(NamedTuple):
+    """Result of `PRManager.check_pr_state`.
+
+    `state` is one of `merged` / `closed` / `open` / `unknown`. `reason` is
+    empty for known states; for `unknown` it's a classified label
+    (`rate limited`, `gh not authenticated`, `network error`, `not found`,
+    `unmapped state: <raw>`, `gh not installed`, or `other: <excerpt>`).
+    Callers include `reason` in log messages so users can act on the cause.
+    """
+    state: str
+    reason: str
+
+
+def _classify_pr_state_reason(returncode: int, stderr: str, raw_state: str) -> str:
+    """Classify why `gh pr view` produced an unknown state. See #73."""
+    if returncode == 127:
+        return "gh not installed"
+    if returncode == 0 and raw_state:
+        return f"unmapped state: {raw_state.strip()}"
+    s = stderr.lower()
+    if "rate limit" in s:
+        return "rate limited"
+    if (
+        "authentication" in s
+        or "not logged in" in s
+        or "gh auth login" in s
+    ):
+        return "gh not authenticated"
+    if (
+        "could not resolve host" in s
+        or "network is unreachable" in s
+        or "connection timed out" in s
+    ):
+        return "network error"
+    if (
+        "not found" in s
+        or "could not find pull request" in s
+        or "could not resolve to a pullrequest" in s
+        or "http 404" in s
+    ):
+        return "not found"
+    excerpt = stderr.strip()[:80]
+    return f"other: {excerpt}" if excerpt else "other: (no stderr)"
+```
+
+Then replace `check_pr_state` (currently around line 262) entirely:
+
+```python
+    def check_pr_state(self, pr_url: str) -> PrStateResult:
+        """Return (state, reason) for a PR URL.
+
+        state: 'merged' | 'closed' | 'open' | 'unknown'.
+        reason: empty string for known states; classified label for unknown
+        (see `_classify_pr_state_reason`).
+        """
+        result = self._shell.run(
+            f"gh pr view {shlex.quote(pr_url)} --json state -q .state",
+            cwd=Path("."),
+        )
+        raw = result.stdout.strip().upper()
+        mapping = {"MERGED": "merged", "CLOSED": "closed", "OPEN": "open"}
+        if result.returncode == 0 and raw in mapping:
+            return PrStateResult(state=mapping[raw], reason="")
+        reason = _classify_pr_state_reason(
+            returncode=result.returncode,
+            stderr=result.stderr,
+            raw_state=raw if result.returncode == 0 else "",
+        )
+        return PrStateResult(state="unknown", reason=reason)
+```
+
+- [ ] **Step 3.5: Run `test_pr.py` to verify all pass**
+
+Run: `uv run pytest tests/core/test_pr.py -v 2>&1 | tail -15`
+Expected: all pass (5 updated + new classification + new return-type test).
+
+- [ ] **Step 3.6: Update the `close` handler**
+
+Edit `src/mship/cli/worktree.py`. Find the block around line 470:
+
+```python
+            for url in task.pr_urls.values():
+                pr_states.append(pr_mgr.check_pr_state(url))
+```
+
+Replace with:
+
+```python
+            pr_state_results: list = []
+            for url in task.pr_urls.values():
+                pr_state_results.append(pr_mgr.check_pr_state(url))
+            pr_states = [r.state for r in pr_state_results]
+```
+
+Then find the unknown-fallback log message (currently line 502):
+
+```python
+        else:
+            log_msg = "closed: pr state unknown"
+```
+
+Replace with:
+
+```python
+        else:
+            # Surface the classification reason so users can act on the cause
+            # (auth, network, rate limit, etc). See #73.
+            unknown_reasons = [
+                r.reason for r in pr_state_results
+                if r.state == "unknown" and r.reason
+            ]
+            if unknown_reasons:
+                log_msg = f"closed: pr state unknown ({unknown_reasons[0]})"
+            else:
+                log_msg = "closed: pr state unknown"
+```
+
+Note: `pr_state_results` was introduced in the previous edit; it's now in scope where the log message is built. If `pr_states` is also referenced later in the same function (routing on states), leave those usages untouched — they read `pr_states` which is the list of `.state` strings.
+
+- [ ] **Step 3.7: Write failing close integration test**
+
+Append to `tests/cli/test_worktree.py`:
+
+```python
+def test_close_logs_rate_limit_reason_when_pr_state_unknown(configured_git_app: Path):
+    """When gh pr view fails with rate-limit stderr, close surfaces the reason. See #73."""
+    from mship.cli import container as cli_container
+    from mship.util.shell import ShellResult, ShellRunner
+    from unittest.mock import MagicMock
+
+    runner.invoke(app, ["spawn", "rate-limit close", "--repos", "shared"])
+    # Set a pr_url manually so close actually calls gh pr view.
+    import yaml
+    state_path = configured_git_app / ".mothership" / "state.yaml"
+    data = yaml.safe_load(state_path.read_text())
+    data["tasks"]["rate-limit-close"]["pr_urls"] = {
+        "shared": "https://github.com/org/repo/pull/1"
+    }
+    data["tasks"]["rate-limit-close"]["finished_at"] = "2026-04-22T00:00:00Z"
+    state_path.write_text(yaml.safe_dump(data))
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh pr view" in cmd and "--json state" in cmd:
+            return ShellResult(
+                returncode=1, stdout="",
+                stderr="GraphQL: API rate limit exceeded for user ID 1",
+            )
+        if "gh pr view" in cmd:
+            return ShellResult(returncode=1, stdout="", stderr="err")
+        if "git log" in cmd or "merge-base" in cmd or "rev-parse" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = mock_run
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    cli_container.shell.override(mock_shell)
+    try:
+        # --skip-pr-check would short-circuit; don't set it. --force bypasses
+        # open-PR refusal.
+        result = runner.invoke(
+            app, ["close", "rate-limit-close", "-y", "--force", "--bypass-base-ancestry"],
+        )
+        # Read the journal to find the close log message.
+        log_path = configured_git_app / ".mothership" / "logs" / "rate-limit-close.md"
+        if log_path.exists():
+            log_content = log_path.read_text()
+        else:
+            log_content = result.output
+        assert "rate limited" in log_content or "rate limited" in result.output, (
+            f"result.output={result.output!r}\nlog={log_content!r}"
+        )
+    finally:
+        cli_container.shell.reset_override()
+```
+
+- [ ] **Step 3.8: Run tests to verify they pass**
+
+Run: `uv run pytest tests/core/test_pr.py tests/cli/test_worktree.py -q 2>&1 | tail -5`
+Expected: all pass.
+
+- [ ] **Step 3.9: Run broader suite for regressions**
+
+Run: `uv run pytest tests/ --ignore=tests/core/view/test_web_port.py -q 2>&1 | tail -3`
+Expected: all pass.
+
+- [ ] **Step 3.10: Commit**
+
+```bash
+git add src/mship/core/pr.py src/mship/cli/worktree.py tests/core/test_pr.py tests/cli/test_worktree.py
+git commit -m "feat(pr): check_pr_state returns (state, reason); close surfaces unknown cause"
+mship journal "#73: check_pr_state returns PrStateResult(state, reason) with classified reason from gh stderr; close log message includes (<reason>) when any PR is unknown" --action committed
+```
+
+---
+
+## Task 4: Smoke + PR
+
+**Files:**
+- None (verification + PR only).
+
+**Context:** Reinstall mship, run a quick smoke on each fix, open the PR.
+
+- [ ] **Step 4.1: Reinstall**
+
+```bash
+cd /home/bailey/development/repos/mothership/.worktrees/feat/diag-surfaces
+uv tool install --reinstall --from . mothership
+```
+
+- [ ] **Step 4.2: #72 smoke — verify doctor warns on dir-form-only ignore**
+
+```bash
+rm -rf /tmp/symlink-smoke
+mkdir -p /tmp/symlink-smoke/origin /tmp/symlink-smoke/repo
+cd /tmp/symlink-smoke/repo
+git init -q
+git config user.email t@t
+git config user.name t
+mkdir shared-dir
+echo "data" > shared-dir/file.txt
+cat > .gitignore <<'EOF'
+shared-dir/
+EOF
+cat > Taskfile.yml <<'EOF'
+version: '3'
+tasks:
+  test: {cmds: ['true']}
+  run: {cmds: ['true']}
+EOF
+git add .gitignore Taskfile.yml
+git commit -qm "init"
+cd /tmp/symlink-smoke
+cat > mothership.yaml <<'EOF'
+workspace: smoke
+repos:
+  r:
+    path: ./repo
+    type: service
+    symlink_dirs: [shared-dir]
+EOF
+mkdir -p .mothership
+mship doctor 2>&1 | grep -i "symlink-ignore\|shared-dir"
+```
+
+Expected output contains:
+```
+warn    r/symlink-ignore   symlink 'shared-dir' is not ignored ...
+```
+
+Cleanup: `rm -rf /tmp/symlink-smoke`.
+
+- [ ] **Step 4.3: #73 smoke — reason surfaces on classification**
+
+Classification itself is unit-tested; a full end-to-end smoke needs a real rate-limited gh, which we can't reliably reproduce. Instead, verify the helper end-to-end with a Python one-liner:
+
+```bash
+cd /home/bailey/development/repos/mothership/.worktrees/feat/diag-surfaces
+uv run python -c "
+from mship.core.pr import _classify_pr_state_reason
+print(_classify_pr_state_reason(returncode=1, stderr='GraphQL: API rate limit exceeded', raw_state=''))
+print(_classify_pr_state_reason(returncode=1, stderr='could not resolve host', raw_state=''))
+print(_classify_pr_state_reason(returncode=0, stderr='', raw_state='DRAFT'))
+"
+```
+
+Expected:
+```
+rate limited
+network error
+unmapped state: DRAFT
+```
+
+- [ ] **Step 4.4: Full pytest**
+
+```bash
+cd /home/bailey/development/repos/mothership/.worktrees/feat/diag-surfaces
+uv run pytest tests/ --ignore=tests/core/view/test_web_port.py 2>&1 | tail -5
+```
+
+Expected: all pass.
+
+- [ ] **Step 4.5: Open the PR**
+
+Write `/tmp/diag-surfaces-body.md`:
+
+```markdown
+## Summary
+
+Two narrow diagnostic fixes, one PR. Each is independent of the other.
+
+### Commit 1 — `feat(worktree): warn when symlink_dir is ignored as dir but not as file`
+
+Closes #72.
+
+`.gitignore` with `foo/` (dir form) ignores the directory but NOT a symlink named `foo` — git treats the symlink as a file. Result: audit/finish/close flag the worktree as dirty, even though the user thought they'd ignored the path. The fix (add `foo` without the trailing slash) is tribal knowledge.
+
+New helper `_symlink_gitignore_footgun(repo, name)` runs two `git check-ignore` probes and returns True only when `name/` is ignored but `name` is not. `_create_symlinks` calls it per symlink and appends a non-fatal warning with the exact fix.
+
+Does NOT warn on legitimate tracked symlinks (where neither form is ignored).
+
+### Commit 2 — `feat(doctor): warn row per symlink_dir ignored as dir but not as file`
+
+Same check from Commit 1, surfaced in `mship doctor` as a per-repo warn row so users don't have to re-spawn to see it.
+
+### Commit 3 — `feat(pr): check_pr_state returns (state, reason); close surfaces unknown cause`
+
+Closes #73.
+
+`check_pr_state` now returns `PrStateResult(state, reason)` NamedTuple. `reason` is empty for known states (`merged` / `closed` / `open`); for `unknown`, it's classified from gh stderr into one of:
+
+- `rate limited`
+- `gh not authenticated`
+- `network error`
+- `not found`
+- `unmapped state: <raw>`
+- `gh not installed`
+- `other: <80-char stderr excerpt>`
+
+`mship close`'s "pr state unknown" log message now includes the reason: `closed: pr state unknown (rate limited)` instead of the opaque `closed: pr state unknown`.
+
+Only caller is `close` (line 471 today); updated to unpack the tuple.
+
+## Test plan
+
+- [x] `tests/core/test_worktree.py`: 4 truth-table unit tests for `_symlink_gitignore_footgun` + 2 spawn-path integration tests (warn + regression).
+- [x] `tests/core/test_doctor.py`: 1 new test for the symlink-ignore warn row.
+- [x] `tests/core/test_pr.py`: 5 existing `check_pr_state_*` tests updated to `.state` access + 4 new classification tests (9 signatures, unmapped, gh-not-installed, other-excerpt) + 1 return-type test.
+- [x] `tests/cli/test_worktree.py`: 1 new close integration test (rate-limit reason in log).
+- [x] Full suite: all pass.
+- [x] Manual smoke: `mship doctor` emits the symlink-ignore warn row; `_classify_pr_state_reason` returns the right label for representative gh stderr signatures.
+
+## Anti-goals preserved
+
+- No auto-fixing `.gitignore`.
+- No exhaustive gh error taxonomy — 6 signatures + "other" fallback.
+- No changes to other `check_pr_state` callers (there are none today).
+```
+
+Then:
+
+```bash
+cd /home/bailey/development/repos/mothership/.worktrees/feat/diag-surfaces
+mship finish --body-file /tmp/diag-surfaces-body.md --title "feat(mship): diagnostic surfaces for symlink-ignore + PR state (#72 #73)"
+```
+
+Expected: PR URL returned.
+
+---
+
+## Done when
+
+- [x] `_symlink_gitignore_footgun` satisfies the 4-row truth table.
+- [x] `_create_symlinks` appends warning on footgun; silent otherwise.
+- [x] `mship doctor` emits a `{repo}/symlink-ignore` warn row per bad entry.
+- [x] `check_pr_state` returns `PrStateResult(state, reason)`.
+- [x] Classification covers rate-limit / auth / network / not-found / unmapped / gh-not-installed / other.
+- [x] `mship close`'s log message surfaces the reason when any PR's state is unknown.
+- [x] 17+ new tests pass (4 truth-table + 2 spawn + 1 doctor + 10 pr-state + 1 close).
+- [x] Full pytest green.

--- a/docs/superpowers/specs/2026-04-22-diagnostic-surfaces-72-73-design.md
+++ b/docs/superpowers/specs/2026-04-22-diagnostic-surfaces-72-73-design.md
@@ -1,0 +1,128 @@
+# Diagnostic Surfaces: Symlink-Ignore Warn + PR State Reason — Design
+
+Closes #72 and #73.
+
+## Problem
+
+Two adjacent diagnostic gaps where mship knows the signal but doesn't surface it clearly:
+
+1. **#72 — `symlink_dirs` + `.gitignore` footgun.** If `.gitignore` has `foo/` (directory form) but `symlink_dirs: [foo]` creates a **symlink** named `foo` in the worktree, git treats the symlink as a file, not a dir. `foo/` doesn't match — symlink shows as untracked. Audit/finish/close flag the worktree as dirty. The fix (add both `foo` and `foo/` to `.gitignore`) is tribal knowledge.
+
+2. **#73 — `mship close` opaque "pr state unknown".** When `gh pr view` fails, `check_pr_state` returns the string `"unknown"` and `close` logs `closed: pr state unknown` with no context. Users can't tell if it's auth, network, rate limit, 404, or an unmapped state string.
+
+## Solution
+
+Both are pure additive fixes to existing diagnostic code paths:
+
+1. **#72 — Add a `git check-ignore` probe** to spawn's symlink creation and to doctor's repo-by-repo checks. When the literal symlink name (not the dir form) is not ignored, warn with the exact fix.
+
+2. **#73 — `check_pr_state` returns a `(state, reason)` pair.** `close`'s log message surfaces the reason when state is unknown. The reason is classified from gh's stderr/exit-code signals.
+
+Two logically independent fixes, one PR (coherent "better diagnostic surfaces" theme, both small).
+
+## Scope
+
+### #72 scope
+- New helper: probe `git check-ignore <literal_symlink_name>` inside each repo that has `symlink_dirs`.
+- Spawn: after each `target.symlink_to(...)` in `_create_symlinks`, add a non-fatal warning to the returned list when the check fails.
+- Doctor: new check per repo with `symlink_dirs` — iterate, probe each name, emit one `warn` row per bad entry.
+- Out of scope: auto-fixing the `.gitignore`. Out of scope: global workspace `.gitignore` — scope is per-repo.
+
+### #73 scope
+- `check_pr_state` signature changes from `(pr_url) -> str` to `(pr_url) -> PrStateResult` NamedTuple with `state: str` (existing values: `merged` / `closed` / `open` / `unknown`) plus `reason: str` (empty for known states; populated for `unknown`).
+- Reason classification via substring match on `gh pr view` stderr (+ exit code):
+  - exit code 127 → `"gh not installed"` (belt-and-braces; caller usually short-circuits).
+  - stderr contains `"rate limit"` (case-insensitive) → `"rate limited"`.
+  - stderr contains `"authentication"` / `"not logged in"` / `"gh auth login"` → `"gh not authenticated"`.
+  - stderr contains `"could not resolve host"` / `"network is unreachable"` / `"connection timed out"` → `"network error"`.
+  - stderr contains `"not found"` / `"could not find pull request"` / `"HTTP 404"` → `"not found"`.
+  - returncode == 0 and state string not in mapping → `"unmapped state: <raw>"`.
+  - Everything else → `"other: <stderr excerpt>"` (first 80 chars of stderr, stripped).
+- Close's log message becomes `f"closed: pr state unknown ({reason})"` when any PR is unknown. If multiple PRs have different unknown reasons, pick the first (single-repo tasks are the common case; for multi-repo, one concrete hint is still better than `unknown`).
+- Callers: only `src/mship/cli/worktree.py:471` consumes `check_pr_state` today. Update to handle the tuple.
+
+## Architecture
+
+Two small changes, each isolated to one subsystem. No shared helpers — the checks operate on different data.
+
+```
+mship.core.worktree._create_symlinks()
+  └─ calls new helper _check_symlink_ignored(repo_path, name) -> bool
+     └─ appends warning to return list on miss
+
+mship.core.doctor.DoctorChecker.run()
+  └─ new loop over repos with symlink_dirs
+     └─ same check helper, appends warn CheckResult per miss
+
+mship.core.pr.PRManager.check_pr_state() -> PrStateResult (NamedTuple)
+  └─ classifies reason from subprocess result
+
+mship.cli.worktree.close() (line ~471)
+  └─ pr_states = [pr_mgr.check_pr_state(url) for url in ...]
+  └─ routes on .state; uses .reason for "pr state unknown" log msg
+```
+
+## Resolver change (#73)
+
+```python
+from typing import NamedTuple
+
+
+class PrStateResult(NamedTuple):
+    state: str       # "merged" | "closed" | "open" | "unknown"
+    reason: str      # "" when known; classified label when unknown
+```
+
+Return tuple is chosen over adding `state` + `reason` as separate return values to keep the single-line caller pattern. `NamedTuple` is backward-compatible with iterable unpacking (`state, reason = pr_mgr.check_pr_state(url)`).
+
+## Classification (#73)
+
+Tested signatures (from real `gh` stderr):
+
+- `GraphQL: API rate limit exceeded for user ID …` → `rate limited`
+- `authentication required; run 'gh auth login'` → `gh not authenticated`
+- `could not resolve host: api.github.com` → `network error`
+- `could not find pull request` / `GraphQL: Could not resolve to a PullRequest` → `not found`
+- `http: api.github.com/... 403` / other 4xx/5xx → `other: HTTP 403`
+
+The spec intentionally does NOT try to be exhaustive — a simple substring match against a handful of real signatures covers the common cases; everything else falls into `other: <80-char excerpt>` which still names something actionable.
+
+## Spawn warning (#72)
+
+```
+{repo_name}: symlink '{name}' is not ignored — git treats it as an untracked file.
+Add '{name}' (not just '{name}/') to .gitignore.
+```
+
+Single line. Matches the existing symlink-warning style (`{repo}: symlink source missing: {name}` etc.) for consistency.
+
+## Doctor row (#72)
+
+```
+{repo}/symlink-ignore   warn   symlink '{name}' is not ignored — add '{name}' (no trailing slash) to .gitignore
+```
+
+One row per bad entry. `status=warn` (not `fail`) — consistent with other doctor-detected footguns.
+
+## Testing
+
+### #72 tests (`tests/core/test_worktree.py` + `tests/core/test_doctor.py`)
+
+- Unit: `_check_symlink_ignored(repo_path, name)` returns False when `.gitignore` has `name/` (dir form only); True when `.gitignore` has `name`; True when both; False when neither.
+- Spawn integration: spawn a workspace where the repo's `.gitignore` has `foo/` (dir form) and `symlink_dirs: [foo]`; assert spawn output includes the warning.
+- Doctor integration: same setup, assert doctor report has a warn row with the expected name.
+- Regression: spawn where `.gitignore` has `foo` (no trailing slash) emits NO warning.
+
+### #73 tests (`tests/core/test_pr.py` + `tests/cli/test_worktree.py`)
+
+- Unit: `check_pr_state` returns `PrStateResult(state="merged", reason="")` on happy path.
+- Classification — parametrized: stderr → reason for each of the 6 signatures.
+- Close integration: mock `gh pr view` to fail with "GraphQL: API rate limit" stderr; run `mship close`; assert log message includes `(rate limited)`.
+- Regression: known states still return `reason=""` and existing `close` log messages don't regress.
+
+## Anti-goals
+
+- No auto-fixing `.gitignore`. Users copy the warning into their gitignore manually.
+- No exhaustive gh error taxonomy. 6 signatures + "other" is good enough.
+- No change to `mship audit` or other callers — `check_pr_state` is only consumed by `close` today.
+- No global "all diagnostic commands return structured reasons" refactor. Just `check_pr_state`.

--- a/docs/superpowers/specs/2026-04-22-diagnostic-surfaces-72-73-design.md
+++ b/docs/superpowers/specs/2026-04-22-diagnostic-surfaces-72-73-design.md
@@ -23,10 +23,13 @@ Two logically independent fixes, one PR (coherent "better diagnostic surfaces" t
 ## Scope
 
 ### #72 scope
-- New helper: probe `git check-ignore <literal_symlink_name>` inside each repo that has `symlink_dirs`.
-- Spawn: after each `target.symlink_to(...)` in `_create_symlinks`, add a non-fatal warning to the returned list when the check fails.
-- Doctor: new check per repo with `symlink_dirs` — iterate, probe each name, emit one `warn` row per bad entry.
-- Out of scope: auto-fixing the `.gitignore`. Out of scope: global workspace `.gitignore` — scope is per-repo.
+- New helper: probe two `git check-ignore` calls per symlink to detect the exact footgun:
+  1. `git check-ignore <name>/` (with trailing slash) — does the user's `.gitignore` intend to ignore the directory?
+  2. `git check-ignore <name>` (no trailing slash) — does it actually ignore the symlink (which git sees as a file)?
+- Warn **only when (1) is yes AND (2) is no**. That's the "dir-form-only ignore missed the symlink" case. Don't warn on symlinks whose originals weren't ignored at all — those are legitimate use cases where the user wants the linked content tracked.
+- Spawn: after each `target.symlink_to(...)` in `_create_symlinks`, add a non-fatal warning to the returned list when the footgun fires.
+- Doctor: new check per repo with `symlink_dirs` — iterate, probe each name, emit one `warn` row per footgun hit.
+- Out of scope: auto-fixing the `.gitignore`. Out of scope: global workspace `.gitignore` — scope is per-repo. Out of scope: warning on symlinks whose originals aren't ignored (legitimate tracked-symlink case).
 
 ### #73 scope
 - `check_pr_state` signature changes from `(pr_url) -> str` to `(pr_url) -> PrStateResult` NamedTuple with `state: str` (existing values: `merged` / `closed` / `open` / `unknown`) plus `reason: str` (empty for known states; populated for `unknown`).
@@ -46,13 +49,15 @@ Two logically independent fixes, one PR (coherent "better diagnostic surfaces" t
 Two small changes, each isolated to one subsystem. No shared helpers — the checks operate on different data.
 
 ```
+mship.core.worktree._symlink_gitignore_footgun(repo_path, name) -> bool
+  └─ True when `name/` is ignored but `name` is not (the footgun case)
+
 mship.core.worktree._create_symlinks()
-  └─ calls new helper _check_symlink_ignored(repo_path, name) -> bool
-     └─ appends warning to return list on miss
+  └─ probes the helper per symlink; appends warning to return list on hit
 
 mship.core.doctor.DoctorChecker.run()
   └─ new loop over repos with symlink_dirs
-     └─ same check helper, appends warn CheckResult per miss
+     └─ same helper, appends warn CheckResult per hit
 
 mship.core.pr.PRManager.check_pr_state() -> PrStateResult (NamedTuple)
   └─ classifies reason from subprocess result
@@ -108,10 +113,19 @@ One row per bad entry. `status=warn` (not `fail`) — consistent with other doct
 
 ### #72 tests (`tests/core/test_worktree.py` + `tests/core/test_doctor.py`)
 
-- Unit: `_check_symlink_ignored(repo_path, name)` returns False when `.gitignore` has `name/` (dir form only); True when `.gitignore` has `name`; True when both; False when neither.
-- Spawn integration: spawn a workspace where the repo's `.gitignore` has `foo/` (dir form) and `symlink_dirs: [foo]`; assert spawn output includes the warning.
+Truth table the helper must satisfy (returns True = footgun fires = warn):
+
+| `.gitignore` contains | `name/` ignored? | `name` ignored? | Footgun? |
+|---|---|---|---|
+| `name/` (dir form only) | yes | no | **yes** — warn |
+| `name` (no slash) | yes | yes | no |
+| both `name` and `name/` | yes | yes | no |
+| neither | no | no | no (legitimate tracked symlink) |
+
+- Unit: `_symlink_gitignore_footgun(repo_path, name)` returns True only for the dir-form-only row.
+- Spawn integration: spawn a workspace where `.gitignore` has `foo/` and `symlink_dirs: [foo]`; assert spawn output includes the warning.
 - Doctor integration: same setup, assert doctor report has a warn row with the expected name.
-- Regression: spawn where `.gitignore` has `foo` (no trailing slash) emits NO warning.
+- Regression: spawn where `.gitignore` has `foo` (no trailing slash) emits NO warning. Spawn where neither `foo` nor `foo/` is ignored emits NO warning (legitimate tracked case).
 
 ### #73 tests (`tests/core/test_pr.py` + `tests/cli/test_worktree.py`)
 

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -459,8 +459,9 @@ def register(app: typer.Typer, get_container):
                 raise typer.Exit(code=1)
 
         # Determine the log message based on PR state.
+        from mship.core.pr import PrStateResult
         pr_states: list[str] = []  # parallel to task.pr_urls values
-        pr_state_results: list = []  # PrStateResult entries; populated when gh check runs
+        pr_state_results: list[PrStateResult] = []  # populated when gh check runs
         if task.pr_urls and not skip_pr_check:
             import shutil
             if shutil.which("gh") is None and not force:

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -460,6 +460,7 @@ def register(app: typer.Typer, get_container):
 
         # Determine the log message based on PR state.
         pr_states: list[str] = []  # parallel to task.pr_urls values
+        pr_state_results: list = []  # PrStateResult entries; populated when gh check runs
         if task.pr_urls and not skip_pr_check:
             import shutil
             if shutil.which("gh") is None and not force:
@@ -468,7 +469,8 @@ def register(app: typer.Typer, get_container):
                 )
                 raise typer.Exit(code=1)
             for url in task.pr_urls.values():
-                pr_states.append(pr_mgr.check_pr_state(url))
+                pr_state_results.append(pr_mgr.check_pr_state(url))
+            pr_states = [r.state for r in pr_state_results]
 
         # Route on PR states
         open_count = sum(1 for s in pr_states if s == "open")
@@ -499,7 +501,16 @@ def register(app: typer.Typer, get_container):
         elif merged_count and closed_count:
             log_msg = f"closed: mixed ({merged_count} merged, {closed_count} closed)"
         else:
-            log_msg = "closed: pr state unknown"
+            # Surface the classification reason so users can act on the cause
+            # (auth, network, rate limit, etc). See #73.
+            unknown_reasons = [
+                r.reason for r in pr_state_results
+                if r.state == "unknown" and r.reason
+            ]
+            if unknown_reasons:
+                log_msg = f"closed: pr state unknown ({unknown_reasons[0]})"
+            else:
+                log_msg = "closed: pr state unknown"
 
         # --- Base-ancestry check (issue #33) ---
         # Catches stacked-PR footgun: PR shows MERGED but its merge commit

--- a/src/mship/core/doctor.py
+++ b/src/mship/core/doctor.py
@@ -224,6 +224,29 @@ class DoctorChecker:
                     ),
                 ))
 
+        # Symlink-gitignore footgun check (#72).
+        from mship.core.worktree import _symlink_gitignore_footgun
+        for name, repo in self._config.repos.items():
+            if not repo.symlink_dirs:
+                continue
+            if repo.git_root is not None:
+                parent = self._config.repos[repo.git_root]
+                check_path = Path(parent.path).resolve()
+            else:
+                check_path = Path(repo.path).resolve()
+            if not (check_path / ".git").exists():
+                continue  # can't check-ignore without a git repo
+            for dir_name in repo.symlink_dirs:
+                if _symlink_gitignore_footgun(check_path, dir_name):
+                    report.checks.append(CheckResult(
+                        name=f"{name}/symlink-ignore",
+                        status="warn",
+                        message=(
+                            f"symlink '{dir_name}' is not ignored — "
+                            f"add '{dir_name}' (no trailing slash) to .gitignore"
+                        ),
+                    ))
+
         # gh CLI
         gh_result = self._shell.run("gh auth status", cwd=Path("."))
         if gh_result.returncode == 0:

--- a/src/mship/core/pr.py
+++ b/src/mship/core/pr.py
@@ -2,8 +2,54 @@ import json
 import re
 import shlex
 from pathlib import Path
+from typing import NamedTuple
 
 from mship.util.shell import ShellRunner
+
+
+class PrStateResult(NamedTuple):
+    """Result of `PRManager.check_pr_state`.
+
+    `state` is one of `merged` / `closed` / `open` / `unknown`. `reason` is
+    empty for known states; for `unknown` it's a classified label
+    (`rate limited`, `gh not authenticated`, `network error`, `not found`,
+    `unmapped state: <raw>`, `gh not installed`, or `other: <excerpt>`).
+    Callers include `reason` in log messages so users can act on the cause.
+    """
+    state: str
+    reason: str
+
+
+def _classify_pr_state_reason(returncode: int, stderr: str, raw_state: str) -> str:
+    """Classify why `gh pr view` produced an unknown state. See #73."""
+    if returncode == 127:
+        return "gh not installed"
+    if returncode == 0 and raw_state:
+        return f"unmapped state: {raw_state.strip()}"
+    s = stderr.lower()
+    if "rate limit" in s:
+        return "rate limited"
+    if (
+        "authentication" in s
+        or "not logged in" in s
+        or "gh auth login" in s
+    ):
+        return "gh not authenticated"
+    if (
+        "could not resolve host" in s
+        or "network is unreachable" in s
+        or "connection timed out" in s
+    ):
+        return "network error"
+    if (
+        "not found" in s
+        or "could not find pull request" in s
+        or "could not resolve to a pullrequest" in s
+        or "http 404" in s
+    ):
+        return "not found"
+    excerpt = stderr.strip()[:80]
+    return f"other: {excerpt}" if excerpt else "other: (no stderr)"
 
 
 _REMOTE_URL_RE = re.compile(
@@ -259,20 +305,27 @@ class PRManager:
         url = result.stdout.strip()
         return url or None
 
-    def check_pr_state(self, pr_url: str) -> str:
-        """Return 'merged', 'closed', 'open', or 'unknown' for a PR URL.
+    def check_pr_state(self, pr_url: str) -> PrStateResult:
+        """Return (state, reason) for a PR URL.
 
-        Uses `gh pr view --json state`. Any failure returns 'unknown'.
+        state: 'merged' | 'closed' | 'open' | 'unknown'.
+        reason: empty string for known states; classified label for unknown
+        (see `_classify_pr_state_reason`).
         """
         result = self._shell.run(
             f"gh pr view {shlex.quote(pr_url)} --json state -q .state",
             cwd=Path("."),
         )
-        if result.returncode != 0:
-            return "unknown"
         raw = result.stdout.strip().upper()
         mapping = {"MERGED": "merged", "CLOSED": "closed", "OPEN": "open"}
-        return mapping.get(raw, "unknown")
+        if result.returncode == 0 and raw in mapping:
+            return PrStateResult(state=mapping[raw], reason="")
+        reason = _classify_pr_state_reason(
+            returncode=result.returncode,
+            stderr=result.stderr,
+            raw_state=raw if result.returncode == 0 else "",
+        )
+        return PrStateResult(state="unknown", reason=reason)
 
     def get_pr_body(self, pr_url: str) -> str:
         result = self._shell.run(

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -1,4 +1,5 @@
 import shutil
+import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
@@ -29,8 +30,6 @@ def _symlink_gitignore_footgun(repo_path: Path, name: str) -> bool:
     Probes via `git check-ignore` — exit 0 = ignored, 1 = not ignored, >1 = error.
     On any error we bail to False (no warning) to avoid false positives.
     """
-    import subprocess
-
     def _ignored(path_fragment: str) -> bool:
         try:
             r = subprocess.run(

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -28,20 +28,45 @@ def _symlink_gitignore_footgun(repo_path: Path, name: str) -> bool:
     (`foo/`) doesn't match the symlink (`foo`), and it shows up as untracked.
 
     Probes via `git check-ignore` — exit 0 = ignored, 1 = not ignored, >1 = error.
+
+    Post-symlink wrinkle: once `<name>` is a symlink pointing outside the
+    repo, `git check-ignore <name>/` fails with `fatal: pathspec is beyond
+    a symbolic link` (exit 128). Fall back to probing under a synthetic
+    non-existent parent (`_mship_probe_absent_/<name>/`) to force pure
+    pattern matching. This loses anchored patterns like `/foo/` in the
+    post-symlink case — but spawn catches those via the direct probe
+    before the symlink is created, so the common unanchored case is
+    covered from both call sites.
+
     On any error we bail to False (no warning) to avoid false positives.
     """
-    def _ignored(path_fragment: str) -> bool:
+    def _probe(path_fragment: str) -> subprocess.CompletedProcess | None:
         try:
-            r = subprocess.run(
+            return subprocess.run(
                 ["git", "check-ignore", "--", path_fragment],
                 cwd=repo_path, capture_output=True, text=True, check=False,
             )
         except OSError:
-            return False
-        return r.returncode == 0
+            return None
 
-    dir_ignored = _ignored(f"{name}/")
-    file_ignored = _ignored(name)
+    dir_r = _probe(f"{name}/")
+    file_r = _probe(name)
+    if dir_r is None or file_r is None:
+        return False
+
+    # Fallback for post-symlink case: probe via non-existent parent to force
+    # pure pattern matching when the direct dir-form probe hits the
+    # "beyond a symbolic link" error.
+    if (
+        dir_r.returncode == 128
+        and "beyond a symbolic link" in dir_r.stderr.lower()
+    ):
+        dir_r = _probe(f"_mship_probe_absent_/{name}/")
+        if dir_r is None:
+            return False
+
+    dir_ignored = dir_r.returncode == 0
+    file_ignored = file_r.returncode == 0
     return dir_ignored and not file_ignored
 
 

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -19,6 +19,33 @@ class SpawnResult:
     setup_warnings: list[str] = field(default_factory=list)
 
 
+def _symlink_gitignore_footgun(repo_path: Path, name: str) -> bool:
+    """Return True when `.gitignore` ignores `<name>/` (dir form) but not `<name>` alone.
+
+    This is the specific footgun that breaks `symlink_dirs`: git treats the
+    symlink as a file, not a directory, so a dir-only ignore pattern
+    (`foo/`) doesn't match the symlink (`foo`), and it shows up as untracked.
+
+    Probes via `git check-ignore` — exit 0 = ignored, 1 = not ignored, >1 = error.
+    On any error we bail to False (no warning) to avoid false positives.
+    """
+    import subprocess
+
+    def _ignored(path_fragment: str) -> bool:
+        try:
+            r = subprocess.run(
+                ["git", "check-ignore", "--", path_fragment],
+                cwd=repo_path, capture_output=True, text=True, check=False,
+            )
+        except OSError:
+            return False
+        return r.returncode == 0
+
+    dir_ignored = _ignored(f"{name}/")
+    file_ignored = _ignored(name)
+    return dir_ignored and not file_ignored
+
+
 class WorktreeManager:
     """Cross-repo worktree orchestration."""
 
@@ -166,10 +193,23 @@ class WorktreeManager:
                 )
                 continue
 
+            # Detect the `.gitignore has 'foo/' but not 'foo'` footgun before
+            # creating the symlink — git check-ignore behaves differently once
+            # the symlink exists (exit 128 for 'foo/' when foo → external dir).
+            # Probe while the path is still absent from the worktree. See #72.
+            footgun = _symlink_gitignore_footgun(worktree_path, dir_name)
+
             if target.is_symlink():
                 target.unlink()
 
             target.symlink_to(source.resolve())
+
+            if footgun:
+                warnings.append(
+                    f"{repo_name}: symlink '{dir_name}' is not ignored — "
+                    f"git treats it as an untracked file. "
+                    f"Add '{dir_name}' (not just '{dir_name}/') to .gitignore."
+                )
 
         return warnings
 

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -1471,5 +1471,3 @@ def test_close_logs_rate_limit_reason_when_pr_state_unknown(configured_git_app: 
         )
     finally:
         cli_container.shell.reset_override()
-
-    cli_container.shell.reset_override()

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -1423,4 +1423,53 @@ def test_finish_does_not_capture_diagnostic_when_main_is_clean(configured_git_ap
         # No post-op diagnostics present for this run.
         assert not any("finish-dirty-main-post-op" in n for n in names), names
 
+
+def test_close_logs_rate_limit_reason_when_pr_state_unknown(configured_git_app: Path):
+    """When gh pr view fails with rate-limit stderr, close surfaces the reason. See #73."""
+    from mship.cli import container as cli_container
+    from mship.util.shell import ShellResult, ShellRunner
+    from unittest.mock import MagicMock
+
+    runner.invoke(app, ["spawn", "rate-limit close", "--repos", "shared"])
+    # Set a pr_url manually so close actually calls gh pr view.
+    import yaml
+    state_path = configured_git_app / ".mothership" / "state.yaml"
+    data = yaml.safe_load(state_path.read_text())
+    data["tasks"]["rate-limit-close"]["pr_urls"] = {
+        "shared": "https://github.com/org/repo/pull/1"
+    }
+    data["tasks"]["rate-limit-close"]["finished_at"] = "2026-04-22T00:00:00Z"
+    state_path.write_text(yaml.safe_dump(data))
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh pr view" in cmd and "--json state" in cmd:
+            return ShellResult(
+                returncode=1, stdout="",
+                stderr="GraphQL: API rate limit exceeded for user ID 1",
+            )
+        if "gh pr view" in cmd:
+            return ShellResult(returncode=1, stdout="", stderr="err")
+        if "git log" in cmd or "merge-base" in cmd or "rev-parse" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = mock_run
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    cli_container.shell.override(mock_shell)
+    try:
+        result = runner.invoke(
+            app, ["close", "rate-limit-close", "-y", "--force", "--bypass-base-ancestry"],
+        )
+        log_path = configured_git_app / ".mothership" / "logs" / "rate-limit-close.md"
+        if log_path.exists():
+            log_content = log_path.read_text()
+        else:
+            log_content = result.output
+        assert "rate limited" in log_content or "rate limited" in result.output, (
+            f"result.output={result.output!r}\nlog={log_content!r}"
+        )
+    finally:
+        cli_container.shell.reset_override()
+
     cli_container.shell.reset_override()

--- a/tests/core/test_doctor.py
+++ b/tests/core/test_doctor.py
@@ -492,3 +492,43 @@ def test_doctor_no_diagnostics_row_when_absent(workspace: Path):
     report = DoctorChecker(config, shell, state_dir=workspace / ".mothership").run()
     diag_checks = [c for c in report.checks if c.name == "diagnostics"]
     assert len(diag_checks) == 0
+
+
+def test_doctor_warns_on_symlink_gitignore_footgun(workspace: Path):
+    """Doctor row per symlink_dir whose `.gitignore` has dir-form only. See #72."""
+    import subprocess
+    from mship.core.config import ConfigLoader
+    from mship.core.doctor import DoctorChecker
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+    from mship.util.shell import ShellResult
+
+    # Workspace fixture already has a `shared` repo. Make it a git repo with
+    # `foo/` in .gitignore and `symlink_dirs: [foo]`.
+    import yaml
+    cfg_path = workspace / "mothership.yaml"
+    cfg = yaml.safe_load(cfg_path.read_text())
+    cfg["repos"]["shared"]["symlink_dirs"] = ["foo"]
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    shared = workspace / "shared"
+    shared.mkdir(exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=shared, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=shared, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=shared, check=True)
+    (shared / ".gitignore").write_text("foo/\n")
+    (shared / "Taskfile.yml").write_text("version: '3'\ntasks: {test: {cmds: ['true']}, run: {cmds: ['true']}}\n")
+    subprocess.run(["git", "add", "."], cwd=shared, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=shared, check=True)
+
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    shell = MagicMock(spec=ShellRunner)
+    shell.run.return_value = ShellResult(
+        returncode=0, stdout="test\nrun\nlint\nsetup\n", stderr="",
+    )
+
+    report = DoctorChecker(config, shell, state_dir=workspace / ".mothership").run()
+    rows = [c for c in report.checks if "symlink-ignore" in c.name]
+    assert len(rows) == 1, [c.name for c in report.checks]
+    assert rows[0].status == "warn"
+    assert "foo" in rows[0].message

--- a/tests/core/test_pr.py
+++ b/tests/core/test_pr.py
@@ -190,7 +190,7 @@ def test_verify_base_exists_nonzero_exit_false(mock_shell: MagicMock):
 def test_check_pr_state_merged(mock_shell: MagicMock):
     mock_shell.run.return_value = ShellResult(returncode=0, stdout="MERGED\n", stderr="")
     mgr = PRManager(mock_shell)
-    assert mgr.check_pr_state("https://github.com/o/r/pull/1") == "merged"
+    assert mgr.check_pr_state("https://github.com/o/r/pull/1").state == "merged"
     cmd = mock_shell.run.call_args.args[0]
     assert "gh pr view" in cmd
     assert "--json state" in cmd
@@ -199,25 +199,25 @@ def test_check_pr_state_merged(mock_shell: MagicMock):
 def test_check_pr_state_closed(mock_shell: MagicMock):
     mock_shell.run.return_value = ShellResult(returncode=0, stdout="CLOSED\n", stderr="")
     mgr = PRManager(mock_shell)
-    assert mgr.check_pr_state("https://x/1") == "closed"
+    assert mgr.check_pr_state("https://x/1").state == "closed"
 
 
 def test_check_pr_state_open(mock_shell: MagicMock):
     mock_shell.run.return_value = ShellResult(returncode=0, stdout="OPEN\n", stderr="")
     mgr = PRManager(mock_shell)
-    assert mgr.check_pr_state("https://x/1") == "open"
+    assert mgr.check_pr_state("https://x/1").state == "open"
 
 
 def test_check_pr_state_unknown_on_failure(mock_shell: MagicMock):
     mock_shell.run.return_value = ShellResult(returncode=1, stdout="", stderr="not found")
     mgr = PRManager(mock_shell)
-    assert mgr.check_pr_state("https://x/1") == "unknown"
+    assert mgr.check_pr_state("https://x/1").state == "unknown"
 
 
 def test_check_pr_state_unknown_on_unexpected_output(mock_shell: MagicMock):
     mock_shell.run.return_value = ShellResult(returncode=0, stdout="DRAFT\n", stderr="")
     mgr = PRManager(mock_shell)
-    assert mgr.check_pr_state("https://x/1") == "unknown"
+    assert mgr.check_pr_state("https://x/1").state == "unknown"
 
 
 def test_check_merged_into_base_true(mock_shell: MagicMock):
@@ -514,3 +514,63 @@ def test_create_pr_rest_fallback_parses_https_without_git_suffix(mock_shell: Mag
     )
     cmds = [c.args[0] for c in mock_shell.run.call_args_list]
     assert any("repos/a/b/pulls" in c for c in cmds)
+
+
+# --- _classify_pr_state_reason + PrStateResult (issue #73) ---
+
+
+@pytest.mark.parametrize("stderr,expected", [
+    ("GraphQL: API rate limit exceeded for user ID 1", "rate limited"),
+    ("You have exceeded a secondary rate limit", "rate limited"),
+    ("authentication required; run 'gh auth login'", "gh not authenticated"),
+    ("error: not logged in", "gh not authenticated"),
+    ("could not resolve host: api.github.com", "network error"),
+    ("connection timed out", "network error"),
+    ("could not find pull request", "not found"),
+    ("GraphQL: Could not resolve to a PullRequest", "not found"),
+    ("HTTP 404: Not Found", "not found"),
+])
+def test_classify_pr_state_reason_signatures(stderr, expected):
+    from mship.core.pr import _classify_pr_state_reason
+    assert _classify_pr_state_reason(returncode=1, stderr=stderr, raw_state="") == expected
+
+
+def test_classify_pr_state_reason_unmapped_state():
+    from mship.core.pr import _classify_pr_state_reason
+    reason = _classify_pr_state_reason(returncode=0, stderr="", raw_state="DRAFT")
+    assert reason == "unmapped state: DRAFT"
+
+
+def test_classify_pr_state_reason_gh_not_installed():
+    from mship.core.pr import _classify_pr_state_reason
+    assert _classify_pr_state_reason(returncode=127, stderr="", raw_state="") == "gh not installed"
+
+
+def test_classify_pr_state_reason_other_excerpt():
+    """Unmatched stderr falls into 'other: <80-char excerpt>'."""
+    from mship.core.pr import _classify_pr_state_reason
+    stderr = "some unexpected error message we haven't classified: very long " * 3
+    reason = _classify_pr_state_reason(returncode=1, stderr=stderr, raw_state="")
+    assert reason.startswith("other: ")
+    assert len(reason) <= len("other: ") + 80
+
+
+def test_check_pr_state_returns_pr_state_result_tuple(mock_shell):
+    """Return value is a NamedTuple with .state and .reason."""
+    from mship.core.pr import PRManager, PrStateResult
+    mock_shell.run.return_value = ShellResult(returncode=0, stdout="MERGED\n", stderr="")
+    result = PRManager(mock_shell).check_pr_state("https://x/1")
+    assert isinstance(result, PrStateResult)
+    assert result.state == "merged"
+    assert result.reason == ""
+
+
+def test_check_pr_state_unknown_rate_limit_surfaces_reason(mock_shell):
+    from mship.core.pr import PRManager
+    mock_shell.run.return_value = ShellResult(
+        returncode=1, stdout="",
+        stderr="GraphQL: API rate limit exceeded for user ID 1",
+    )
+    result = PRManager(mock_shell).check_pr_state("https://x/1")
+    assert result.state == "unknown"
+    assert result.reason == "rate limited"

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -896,6 +896,35 @@ def test_footgun_silent_when_neither_form_ignored(tmp_path: Path):
     assert _symlink_gitignore_footgun(repo, "foo") is False
 
 
+def test_footgun_detected_post_symlink(tmp_path: Path):
+    """After the symlink exists pointing outside the repo, `check-ignore foo/`
+    fails with exit 128 (beyond a symbolic link). The helper must fall back
+    to pattern-only matching and still detect the footgun for unanchored
+    patterns — this is what makes the doctor check work. See #72."""
+    from mship.core.worktree import _symlink_gitignore_footgun
+    repo = tmp_path / "r"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text("foo/\n")
+    external = tmp_path / "ext"
+    external.mkdir()
+    (external / "file.txt").write_text("data")
+    (repo / "foo").symlink_to(external)
+    # Direct probe would hit "beyond a symbolic link"; fallback must still fire.
+    assert _symlink_gitignore_footgun(repo, "foo") is True
+
+
+def test_footgun_silent_post_symlink_when_plain_ignored(tmp_path: Path):
+    """Post-symlink regression: `.gitignore` has `foo` (no slash) → no warning."""
+    from mship.core.worktree import _symlink_gitignore_footgun
+    repo = tmp_path / "r"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text("foo\n")
+    external = tmp_path / "ext"
+    external.mkdir()
+    (repo / "foo").symlink_to(external)
+    assert _symlink_gitignore_footgun(repo, "foo") is False
+
+
 def test_create_symlinks_warns_on_dir_form_gitignore_footgun(tmp_path: Path):
     """Spawn path: `.gitignore` has `foo/` and `symlink_dirs: [foo]` → warning. See #72."""
     from mship.core.config import RepoConfig, WorkspaceConfig

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -849,3 +849,124 @@ def test_spawn_skips_setup_when_task_binary_missing(worktree_deps, monkeypatch):
         call.kwargs.get("task_name") == "setup"
         for call in shell.run_task.call_args_list
     )
+
+
+# --- _symlink_gitignore_footgun truth-table tests (issue #72) ---
+
+
+def _init_git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=path, check=True)
+
+
+def test_footgun_fires_when_only_dir_form_ignored(tmp_path: Path):
+    """`.gitignore` has `foo/` but not `foo` → footgun. See #72."""
+    from mship.core.worktree import _symlink_gitignore_footgun
+    repo = tmp_path / "r"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text("foo/\n")
+    assert _symlink_gitignore_footgun(repo, "foo") is True
+
+
+def test_footgun_silent_when_plain_name_ignored(tmp_path: Path):
+    """`.gitignore` has `foo` (no slash) → matches both; no footgun."""
+    from mship.core.worktree import _symlink_gitignore_footgun
+    repo = tmp_path / "r"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text("foo\n")
+    assert _symlink_gitignore_footgun(repo, "foo") is False
+
+
+def test_footgun_silent_when_both_forms_ignored(tmp_path: Path):
+    from mship.core.worktree import _symlink_gitignore_footgun
+    repo = tmp_path / "r"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text("foo\nfoo/\n")
+    assert _symlink_gitignore_footgun(repo, "foo") is False
+
+
+def test_footgun_silent_when_neither_form_ignored(tmp_path: Path):
+    """Legitimate tracked symlink case — no warning."""
+    from mship.core.worktree import _symlink_gitignore_footgun
+    repo = tmp_path / "r"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text("unrelated\n")
+    assert _symlink_gitignore_footgun(repo, "foo") is False
+
+
+def test_create_symlinks_warns_on_dir_form_gitignore_footgun(tmp_path: Path):
+    """Spawn path: `.gitignore` has `foo/` and `symlink_dirs: [foo]` → warning. See #72."""
+    from mship.core.config import RepoConfig, WorkspaceConfig
+    from mship.core.state import StateManager
+    from mship.core.worktree import WorktreeManager
+    from mship.core.graph import DependencyGraph
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+
+    # Source repo with `foo/` directory + `.gitignore` ignoring `foo/` only.
+    source = tmp_path / "source"
+    _init_git_repo(source)
+    (source / "foo").mkdir()
+    (source / "foo" / "data.txt").write_text("x")
+    (source / ".gitignore").write_text("foo/\n")
+    subprocess.run(["git", "add", ".gitignore"], cwd=source, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=source, check=True)
+
+    repo_cfg = RepoConfig(
+        path=source, type="service", symlink_dirs=["foo"],
+    )
+    cfg = WorkspaceConfig(workspace="t", repos={"src": repo_cfg})
+    mgr = WorktreeManager(
+        config=cfg,
+        state_manager=MagicMock(spec=StateManager),
+        shell=MagicMock(spec=ShellRunner),
+        graph=None,
+        git=MagicMock(),
+        log=MagicMock(),
+    )
+
+    # Call `_create_symlinks` directly so we don't exercise the whole spawn pipeline.
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    # Initialize git in the worktree so check-ignore has something to resolve.
+    _init_git_repo(worktree)
+    (worktree / ".gitignore").write_text("foo/\n")
+    warnings = mgr._create_symlinks("src", repo_cfg, worktree)
+    assert any("foo" in w and "not ignored" in w for w in warnings), warnings
+
+
+def test_create_symlinks_no_warn_when_plain_name_ignored(tmp_path: Path):
+    """Regression: `.gitignore` with `foo` (no slash) → NO warning."""
+    from mship.core.config import RepoConfig, WorkspaceConfig
+    from mship.core.state import StateManager
+    from mship.core.worktree import WorktreeManager
+    from mship.core.graph import DependencyGraph
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+
+    source = tmp_path / "source"
+    _init_git_repo(source)
+    (source / "foo").mkdir()
+    (source / ".gitignore").write_text("foo\n")  # no trailing slash
+    subprocess.run(["git", "add", ".gitignore"], cwd=source, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=source, check=True)
+
+    repo_cfg = RepoConfig(path=source, type="service", symlink_dirs=["foo"])
+    cfg = WorkspaceConfig(workspace="t", repos={"src": repo_cfg})
+    mgr = WorktreeManager(
+        config=cfg,
+        state_manager=MagicMock(spec=StateManager),
+        shell=MagicMock(spec=ShellRunner),
+        graph=None,
+        git=MagicMock(),
+        log=MagicMock(),
+    )
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    _init_git_repo(worktree)
+    (worktree / ".gitignore").write_text("foo\n")
+    warnings = mgr._create_symlinks("src", repo_cfg, worktree)
+    assert not any("not ignored" in w for w in warnings), warnings


### PR DESCRIPTION
## Summary

Two narrow diagnostic fixes, one PR.

### Commit 1 — `feat(worktree): warn when symlink_dir is ignored as dir but not as file`

Closes #72.

`.gitignore` with `foo/` (dir form) ignores the directory but NOT a symlink named `foo` — git treats the symlink as a file. Audit/finish/close flag the worktree as dirty. The fix (add `foo` without the trailing slash) is tribal knowledge.

New helper `_symlink_gitignore_footgun(repo, name)` probes `git check-ignore` with both trailing-slash and plain forms and returns True only when the dir-form is ignored but the plain form is not. `_create_symlinks` calls it per symlink and appends a non-fatal warning with the exact fix. Legitimate tracked symlinks (where neither form is ignored) do NOT warn.

### Commit 2 — `feat(doctor): warn row per symlink_dir ignored as dir but not as file`

Same check surfaced in `mship doctor` as per-repo `{repo}/symlink-ignore` warn rows so users don't have to re-spawn to see it.

### Commit 3 — `fix(worktree): detect footgun post-symlink via non-existent-parent probe`

Smoke-caught bug: once the symlink exists pointing outside the repo, `git check-ignore foo/` fails with `fatal: pathspec is beyond a symbolic link` (exit 128). That broke the doctor check — footgun was real but helper always returned False.

Fix: when the direct `foo/` probe hits exit 128, fall back to probing `_mship_probe_absent_/foo/` — a path under a non-existent parent forces pure pattern matching without triggering the symlink stat. Covers unanchored patterns in both spawn-time (pre-symlink) and doctor-time (post-symlink) calls. Anchored `/foo/` patterns are still caught at spawn time (the direct probe works pre-symlink); doctor-time detection for anchored patterns is a known miss acceptable since spawn already surfaced it.

### Commit 4 — `feat(pr): check_pr_state returns (state, reason); close surfaces unknown cause`

Closes #73.

`check_pr_state` now returns `PrStateResult(state, reason)` NamedTuple. `reason` is empty for known states (`merged` / `closed` / `open`); for `unknown`, it's classified from gh stderr via substring matching:

- `rate limited` (any "rate limit" mention, including secondary rate limit)
- `gh not authenticated` (authentication required / not logged in / gh auth login)
- `network error` (could not resolve host / network is unreachable / connection timed out)
- `not found` (could not find pull request / HTTP 404 / GraphQL PullRequest resolution failure)
- `unmapped state: <raw>` (gh returned successfully with a state we don't map, e.g. `DRAFT`)
- `gh not installed` (exit code 127)
- `other: <80-char stderr excerpt>` (fallback)

`mship close`'s `closed: pr state unknown` log now includes the reason: `closed: pr state unknown (rate limited)`. Only caller is `close` (line ~471); updated to unpack the tuple.

## Test plan

- [x] `tests/core/test_worktree.py`: 4 truth-table unit tests + 2 post-symlink regression tests + 2 spawn integration tests.
- [x] `tests/core/test_doctor.py`: 1 new test for the `{repo}/symlink-ignore` warn row.
- [x] `tests/core/test_pr.py`: 5 existing `check_pr_state_*` tests updated to `.state` access; 14 new tests (9 parametrized signatures + unmapped + gh-not-installed + other-excerpt + return-type + rate-limit reason).
- [x] `tests/cli/test_worktree.py`: 1 new close integration test (rate-limit reason surfaces in log).
- [x] Full suite green.
- [x] Manual smoke: `mship doctor` emits `r/symlink-ignore` warn row when workspace has a repo with `shared-dir/` in `.gitignore` and `symlink_dirs: [shared-dir]` with the symlink already created; `_classify_pr_state_reason` returns correct labels for representative gh stderr signatures.

## Anti-goals preserved

- No auto-fixing `.gitignore`.
- No exhaustive gh error taxonomy — 6 signatures + `other:` fallback.
- No changes to other `check_pr_state` callers (there are none today).
- No warning on legitimate tracked symlinks.

Closes #72, #73