### PR TITLE
feat(mship): not_applicable tasks + spawn scope guardrails (#76 #74)

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -220,6 +220,11 @@ def register(app: typer.Typer, get_container):
             help="Override the auto-generated task slug (lowercase alphanumeric + dashes). "
                  "Useful when the description would produce a 50+ char slug. See #59.",
         ),
+        yes: bool = typer.Option(
+            False, "--yes", "-y",
+            help="Skip confirmation prompts (required in non-TTY mode when "
+                 "spawn would exceed spawn_confirm_threshold). See #74.",
+        ),
     ):
         """Create coordinated worktrees across repos for a new task."""
         import re as _re
@@ -245,7 +250,55 @@ def register(app: typer.Typer, get_container):
         config = container.config()
         shell = container.shell()
 
+        user_passed_repos = repos is not None
         repo_list = repos.split(",") if repos else None
+
+        # Apply default_scope + spawn_confirm_threshold (#74) when the user
+        # didn't pass --repos. Workspace-level controls in mothership.yaml.
+        if not user_passed_repos:
+            ds = config.default_scope
+            if ds == "none":
+                output.error(
+                    "default_scope is 'none' — spawn requires explicit --repos. "
+                    f"Available repos: {', '.join(sorted(config.repos.keys()))}"
+                )
+                raise typer.Exit(code=1)
+            if isinstance(ds, list):
+                repo_list = list(ds)
+
+        effective_scope = repo_list if repo_list else list(config.repos.keys())
+
+        # Threshold confirmation (#74): only fires when user didn't pass --repos
+        # AND effective scope exceeds the workspace-configured threshold.
+        if (
+            not user_passed_repos
+            and config.spawn_confirm_threshold is not None
+            and len(effective_scope) > config.spawn_confirm_threshold
+        ):
+            repos_flag = f"--repos {','.join(sorted(effective_scope))}"
+            if yes:
+                pass  # --yes bypasses
+            elif output.is_tty:
+                import typer as _typer
+                proceed = _typer.confirm(
+                    f"Spawn will create worktrees for {len(effective_scope)} repos "
+                    f"(exceeds spawn_confirm_threshold={config.spawn_confirm_threshold}). "
+                    f"Continue?",
+                    default=False,
+                )
+                if not proceed:
+                    output.error(
+                        f"Aborted. To proceed with the full set: {repos_flag}"
+                    )
+                    raise typer.Exit(code=1)
+            else:
+                output.error(
+                    f"Spawn would create worktrees for {len(effective_scope)} repos "
+                    f"(exceeds spawn_confirm_threshold={config.spawn_confirm_threshold}). "
+                    f"Pass --yes to confirm, or scope explicitly: {repos_flag}"
+                )
+                raise typer.Exit(code=1)
+
         audit_names = repo_list if repo_list else list(config.repos.keys())
 
         from mship.core.audit_gate import collect_known_worktree_paths

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -99,7 +99,33 @@ class WorkspaceConfig(BaseModel):
     env_runner: str | None = None
     branch_pattern: str = "feat/{slug}"
     audit: AuditPolicy = AuditPolicy()
+    # Default repo scope when `mship spawn` is invoked without --repos.
+    # - "all" (default): use every repo — today's behavior.
+    # - "none": require explicit --repos; no-flag spawn errors with the repo list.
+    # - list[str]: use those repos as the default. See #74.
+    default_scope: str | list[str] = "all"
+    # If set and the effective spawn scope exceeds N repos AND no --repos was
+    # passed, require confirmation (TTY) or --yes (non-TTY). See #74.
+    spawn_confirm_threshold: int | None = None
     repos: dict[str, RepoConfig]
+
+    @model_validator(mode="after")
+    def validate_default_scope(self) -> "WorkspaceConfig":
+        """default_scope may be 'all', 'none', or a list of existing repo names."""
+        if isinstance(self.default_scope, str):
+            if self.default_scope not in ("all", "none"):
+                raise ValueError(
+                    f"default_scope must be 'all', 'none', or a list of "
+                    f"repo names; got {self.default_scope!r}"
+                )
+        elif isinstance(self.default_scope, list):
+            unknown = [r for r in self.default_scope if r not in self.repos]
+            if unknown:
+                raise ValueError(
+                    f"default_scope references unknown repos: {unknown}. "
+                    f"Valid repos: {sorted(self.repos.keys())}"
+                )
+        return self
 
     @model_validator(mode="after")
     def validate_depends_on_refs(self) -> "WorkspaceConfig":

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -35,6 +35,7 @@ class RepoConfig(BaseModel):
     depends_on: list[Dependency] = []
     env_runner: str | None = None
     tasks: dict[str, str] = {}
+    not_applicable: list[str] = []
     tags: list[str] = []
     git_root: str | None = None
     start_mode: Literal["foreground", "background"] = "foreground"
@@ -59,6 +60,19 @@ class RepoConfig(BaseModel):
                     normalized.append(dep)
             data["depends_on"] = normalized
         return data
+
+    @model_validator(mode="after")
+    def validate_not_applicable(self) -> "RepoConfig":
+        """A canonical task can't be both declared (tasks: ...) and declared
+        not applicable — those are contradictory intents. See #76."""
+        overlap = set(self.tasks.keys()) & set(self.not_applicable)
+        if overlap:
+            raise ValueError(
+                f"tasks and not_applicable overlap on {sorted(overlap)}; "
+                f"a task is either declared (in `tasks`) or explicitly "
+                f"not applicable, not both"
+            )
+        return self
 
     @model_validator(mode="after")
     def validate_bind_files(self) -> "RepoConfig":

--- a/src/mship/core/doctor.py
+++ b/src/mship/core/doctor.py
@@ -170,6 +170,13 @@ class DoctorChecker:
                 continue  # skip per-task checks for this repo
             task_output = result.stdout
             for canonical in ["test", "run", "lint", "setup"]:
+                if canonical in repo.not_applicable:
+                    report.checks.append(CheckResult(
+                        name=f"{name}/task:{canonical}",
+                        status="pass",
+                        message=f"task '{canonical}' not applicable (declared)",
+                    ))
+                    continue
                 actual = repo.tasks.get(canonical, canonical)
                 if actual in task_output:
                     msg = (

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -1471,3 +1471,80 @@ def test_close_logs_rate_limit_reason_when_pr_state_unknown(configured_git_app: 
         )
     finally:
         cli_container.shell.reset_override()
+
+
+def test_spawn_default_scope_none_requires_explicit_repos(configured_git_app: Path):
+    """default_scope: none → spawn without --repos errors. See #74."""
+    import yaml
+    cfg_path = configured_git_app / "mothership.yaml"
+    cfg = yaml.safe_load(cfg_path.read_text())
+    cfg["default_scope"] = "none"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    from mship.cli import container as cli_container
+    cli_container.config.reset()
+
+    result = runner.invoke(app, ["spawn", "no scope"])
+    assert result.exit_code != 0
+    assert "default_scope" in result.output
+    assert "--repos" in result.output
+
+
+def test_spawn_default_scope_list_selects_repos(configured_git_app: Path):
+    """default_scope: [shared] → spawn without --repos uses that list. See #74."""
+    import yaml
+    cfg_path = configured_git_app / "mothership.yaml"
+    cfg = yaml.safe_load(cfg_path.read_text())
+    cfg["default_scope"] = ["shared"]
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    from mship.cli import container as cli_container
+    cli_container.config.reset()
+
+    result = runner.invoke(app, ["spawn", "scoped default"])
+    assert result.exit_code == 0, result.output
+    mgr = StateManager(configured_git_app / ".mothership")
+    state = mgr.load()
+    assert state.tasks["scoped-default"].affected_repos == ["shared"]
+
+
+def test_spawn_threshold_non_tty_requires_yes(configured_git_app: Path):
+    """spawn_confirm_threshold: 1 + 3 repos → non-TTY without --yes errors. See #74."""
+    import yaml
+    cfg_path = configured_git_app / "mothership.yaml"
+    cfg = yaml.safe_load(cfg_path.read_text())
+    cfg["spawn_confirm_threshold"] = 1
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    from mship.cli import container as cli_container
+    cli_container.config.reset()
+
+    # CliRunner is non-TTY by default.
+    result = runner.invoke(app, ["spawn", "big fan out"])
+    assert result.exit_code != 0
+    assert "spawn_confirm_threshold" in result.output
+    assert "--yes" in result.output
+
+
+def test_spawn_threshold_bypassed_with_yes(configured_git_app: Path):
+    import yaml
+    cfg_path = configured_git_app / "mothership.yaml"
+    cfg = yaml.safe_load(cfg_path.read_text())
+    cfg["spawn_confirm_threshold"] = 1
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    from mship.cli import container as cli_container
+    cli_container.config.reset()
+
+    result = runner.invoke(app, ["spawn", "confirmed fan out", "--yes"])
+    assert result.exit_code == 0, result.output
+
+
+def test_spawn_threshold_not_triggered_with_explicit_repos(configured_git_app: Path):
+    """--repos always bypasses the threshold (user explicitly scoped). See #74."""
+    import yaml
+    cfg_path = configured_git_app / "mothership.yaml"
+    cfg = yaml.safe_load(cfg_path.read_text())
+    cfg["spawn_confirm_threshold"] = 1
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    from mship.cli import container as cli_container
+    cli_container.config.reset()
+
+    result = runner.invoke(app, ["spawn", "explicit scope", "--repos", "shared,auth-service"])
+    assert result.exit_code == 0, result.output

--- a/tests/core/test_doctor.py
+++ b/tests/core/test_doctor.py
@@ -532,3 +532,43 @@ def test_doctor_warns_on_symlink_gitignore_footgun(workspace: Path):
     assert len(rows) == 1, [c.name for c in report.checks]
     assert rows[0].status == "warn"
     assert "foo" in rows[0].message
+
+
+def test_doctor_not_applicable_emits_pass_row(workspace: Path):
+    """Canonical tasks listed in not_applicable become pass rows with the
+    declared-not-applicable message instead of warn rows. See #76."""
+    import yaml as _yaml
+    cfg_path = workspace / "mothership.yaml"
+    cfg = _yaml.safe_load(cfg_path.read_text())
+    cfg["repos"]["shared"]["not_applicable"] = ["run", "lint"]
+    cfg_path.write_text(_yaml.safe_dump(cfg))
+
+    config = ConfigLoader.load(cfg_path)
+    shell = MagicMock(spec=ShellRunner)
+    # Return a Taskfile listing with only `test` and `setup` (not run/lint).
+    shell.run.return_value = ShellResult(
+        returncode=0, stdout="test\nsetup\n", stderr="",
+    )
+
+    report = DoctorChecker(config, shell).run()
+    rows = {c.name: c for c in report.checks if c.name.startswith("shared/task:")}
+    # run + lint are declared not applicable — must be pass, not warn.
+    assert rows["shared/task:run"].status == "pass"
+    assert "not applicable" in rows["shared/task:run"].message
+    assert rows["shared/task:lint"].status == "pass"
+    assert "not applicable" in rows["shared/task:lint"].message
+    # setup is present in the Taskfile → pass (existing behavior).
+    assert rows["shared/task:setup"].status == "pass"
+
+
+def test_not_applicable_overlap_rejected():
+    """Same task in both `tasks` and `not_applicable` is a config error."""
+    import pytest
+    from mship.core.config import RepoConfig
+    with pytest.raises(ValueError, match="overlap"):
+        RepoConfig(
+            path=Path("/tmp/x"),
+            type="service",
+            tasks={"run": "serve"},
+            not_applicable=["run"],
+        )


### PR DESCRIPTION
## Summary

Two small config-driven friction-reduction features.

### Commit 1 — `feat(config): not_applicable list opts repo out of doctor task warns`

Closes #76.

Per-repo `not_applicable: [<canonical_task>, ...]` declaration in `mothership.yaml`. Doctor emits a `pass` row with `"task 'X' not applicable (declared)"` instead of the noisy `warn` for any canonical task (`test`/`run`/`lint`/`setup`) that's explicitly marked as not applicable. Config validator rejects the same task appearing in both `tasks` and `not_applicable`.

```yaml
repos:
  cli-tool:
    path: ./cli-tool
    type: library
    tasks:
      test: test
    not_applicable: [run, setup]   # explicit opt-out
```

Deferred to a followup: `mship run` / `mship test` etc. treating `not_applicable` repos as hard-skip. v1 just stops the doctor noise.

### Commit 2 — `feat(spawn): default_scope + spawn_confirm_threshold guardrails`

Closes #74.

Workspace-level controls in `mothership.yaml` to prevent accidental metarepo fan-out:

```yaml
default_scope: [core, api]         # or "all" (default) / "none"
spawn_confirm_threshold: 3
```

- `default_scope: "all"` — today's behavior.
- `default_scope: "none"` — spawn without `--repos` errors with the available repo list.
- `default_scope: [<repos>]` — no-flag spawn uses that subset as the default.
- `spawn_confirm_threshold: N` — if no-flag spawn would exceed N, require confirmation. TTY → `typer.confirm()`; non-TTY → error unless `--yes` is passed.
- `--repos` always bypasses the threshold (user explicitly scoped).
- New `--yes` / `-y` flag on `mship spawn` to skip the confirmation prompt.

Deferred to a followup: `--repos auto` heuristic (per issue — optional follow-up).

## Test plan

- [x] `tests/core/test_doctor.py`: 1 new test for not-applicable pass rows.
- [x] `tests/core/test_config.py`: validator rejects overlap (in `test_doctor.py` actually — lightweight; can move if preferred).
- [x] `tests/cli/test_worktree.py`: 5 new tests — default_scope `none` errors / `list` selects / threshold non-TTY errors / threshold bypassed with --yes / threshold not triggered with --repos.
- [x] Full suite: 928 passed (broader core + cli).

## Anti-goals preserved

- No change to `mship run`/`test`/etc. behavior for not-applicable repos (deferred).
- No `--repos auto` heuristic (deferred).
- No change to existing workspaces that don't set these fields — pure additive.

Closes #74, #76