### PR TITLE
feat(mship): bind refresh + pr aggregate view (#71 #41)

### DIFF
--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -92,6 +92,7 @@ from mship.cli import context as _context_mod
 from mship.cli import dispatch as _dispatch_mod
 from mship.cli import commit as _commit_mod
 from mship.cli import debug as _debug_mod
+from mship.cli import bind as _bind_mod
 
 def _should_silent_exit(argv: list[str]) -> bool:
     """True if argv is invoking an unknown `_`-prefixed internal command.
@@ -140,3 +141,4 @@ _context_mod.register(app, get_container)
 _dispatch_mod.register(app, get_container)
 _commit_mod.register(app, get_container)
 _debug_mod.register(app, get_container)
+_bind_mod.register(app, get_container)

--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -93,6 +93,7 @@ from mship.cli import dispatch as _dispatch_mod
 from mship.cli import commit as _commit_mod
 from mship.cli import debug as _debug_mod
 from mship.cli import bind as _bind_mod
+from mship.cli import pr as _pr_mod
 
 def _should_silent_exit(argv: list[str]) -> bool:
     """True if argv is invoking an unknown `_`-prefixed internal command.
@@ -142,3 +143,4 @@ _dispatch_mod.register(app, get_container)
 _commit_mod.register(app, get_container)
 _debug_mod.register(app, get_container)
 _bind_mod.register(app, get_container)
+_pr_mod.register(app, get_container)

--- a/src/mship/cli/bind.py
+++ b/src/mship/cli/bind.py
@@ -1,0 +1,103 @@
+"""`mship bind` sub-app — bind_files maintenance. See #71."""
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from mship.cli._resolve import resolve_for_command
+from mship.cli.output import Output
+
+
+def register(app: typer.Typer, get_container):
+    bind_app = typer.Typer(help="Manage bind_files across task worktrees.")
+
+    @bind_app.command()
+    def refresh(
+        repos: Optional[str] = typer.Option(
+            None, "--repos",
+            help="Comma-separated repo names. Default: all affected_repos.",
+        ),
+        overwrite: bool = typer.Option(
+            False, "--overwrite",
+            help="Replace worktree copies even when they differ from source. "
+                 "Without this flag, modified copies are preserved and the "
+                 "command exits non-zero.",
+        ),
+        task: Optional[str] = typer.Option(
+            None, "--task",
+            help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env.",
+        ),
+    ):
+        """Re-sync bind_files from source repos into the task's worktrees."""
+        container = get_container()
+        output = Output()
+        state = container.state_manager().load()
+        resolved = resolve_for_command("bind refresh", state, task, output)
+        t = resolved.task
+        config = container.config()
+        wt_mgr = container.worktree_manager()
+
+        repo_list = repos.split(",") if repos else list(t.affected_repos)
+        unknown = [r for r in repo_list if r not in t.affected_repos]
+        if unknown:
+            output.error(
+                f"--repos references repos not in task.affected_repos: {unknown}. "
+                f"Task repos: {sorted(t.affected_repos)}"
+            )
+            raise typer.Exit(code=1)
+
+        per_repo: list[dict] = []
+        any_skipped = False
+
+        for repo_name in repo_list:
+            repo_cfg = config.repos[repo_name]
+            wt = t.worktrees.get(repo_name)
+            if wt is None:
+                output.warning(f"{repo_name}: no worktree registered (skipping)")
+                continue
+            wt_path = Path(wt)
+            if not wt_path.is_dir():
+                output.warning(f"{repo_name}: worktree missing at {wt_path} (skipping)")
+                continue
+
+            result = wt_mgr.refresh_bind_files(
+                repo_name, repo_cfg, wt_path, overwrite=overwrite,
+            )
+            per_repo.append({"repo": repo_name, **result})
+            if result["skipped"]:
+                any_skipped = True
+
+        if output.is_tty:
+            for row in per_repo:
+                output.print(f"[bold]{row['repo']}[/bold]")
+                for rel in row["copied"]:
+                    output.print(f"  [green]copied[/green]    {rel}")
+                for rel in row["updated"]:
+                    output.print(f"  [yellow]updated[/yellow]   {rel}")
+                for rel in row["unchanged"]:
+                    output.print(f"  unchanged {rel}")
+                for rel in row["skipped"]:
+                    output.print(
+                        f"  [red]skipped[/red]   {rel} (worktree-modified; pass --overwrite to replace)"
+                    )
+                for w in row["warnings"]:
+                    output.warning(w)
+            if any_skipped and not overwrite:
+                output.print("")
+                output.print(
+                    "[yellow]Some files were skipped because they differ from source. "
+                    "Re-run with --overwrite to replace them.[/yellow]"
+                )
+        else:
+            output.json({
+                "task": t.slug,
+                "overwrite": overwrite,
+                "repos": per_repo,
+                "resolved_task": resolved.task.slug,
+                "resolution_source": resolved.source,
+            })
+
+        if any_skipped and not overwrite:
+            raise typer.Exit(code=1)
+
+    app.add_typer(bind_app, name="bind")

--- a/src/mship/cli/pr.py
+++ b/src/mship/cli/pr.py
@@ -1,0 +1,79 @@
+"""`mship pr` — aggregate PR state across active tasks. See #41."""
+import json
+import shlex
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from mship.cli.output import Output
+
+
+def register(app: typer.Typer, get_container):
+    @app.command()
+    def pr():
+        """Show PR state for every active task with recorded PR URLs."""
+        container = get_container()
+        output = Output()
+        state = container.state_manager().load()
+        shell = container.shell()
+
+        tasks_with_prs: list[dict] = []
+
+        for slug, task in sorted(state.tasks.items()):
+            if not task.pr_urls:
+                continue
+            prs: list[dict] = []
+            for repo_name, url in sorted(task.pr_urls.items()):
+                info = _fetch_pr_info(shell, url)
+                prs.append({"repo": repo_name, "url": url, **info})
+            tasks_with_prs.append({"slug": slug, "prs": prs})
+
+        if not tasks_with_prs:
+            if output.is_tty:
+                output.print("No active tasks with recorded PRs.")
+            else:
+                output.json({"tasks": []})
+            return
+
+        if output.is_tty:
+            for t in tasks_with_prs:
+                output.print(f"[bold]{t['slug']}[/bold]")
+                for p in t["prs"]:
+                    state_color = {
+                        "open": "green",
+                        "merged": "magenta",
+                        "closed": "red",
+                        "unknown": "yellow",
+                    }.get(p["state"], "white")
+                    num = f"#{p['number']}" if p["number"] else "?"
+                    base = p.get("base") or "?"
+                    output.print(
+                        f"  {p['repo']}: {num} "
+                        f"[{state_color}]{p['state']}[/{state_color}] "
+                        f"base={base}  {p['url']}"
+                    )
+        else:
+            output.json({"tasks": tasks_with_prs})
+
+    def _fetch_pr_info(shell, url: str) -> dict:
+        """Return {state, number, base, url}. Sets state='unknown' on any gh failure."""
+        cmd = (
+            f"gh pr view {shlex.quote(url)} "
+            "--json state,number,baseRefName -q "
+            "'[.state,.number,.baseRefName] | @tsv'"
+        )
+        r = shell.run(cmd, cwd=Path("."))
+        if r.returncode != 0:
+            return {"state": "unknown", "number": None, "base": None}
+        parts = r.stdout.strip().split("\t")
+        if len(parts) < 3:
+            return {"state": "unknown", "number": None, "base": None}
+        raw_state, num_str, base = parts[0], parts[1], parts[2]
+        mapping = {"OPEN": "open", "MERGED": "merged", "CLOSED": "closed"}
+        state = mapping.get(raw_state.upper(), "unknown")
+        try:
+            number = int(num_str)
+        except (ValueError, TypeError):
+            number = None
+        return {"state": state, "number": number, "base": base}

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -137,6 +137,79 @@ class WorktreeManager:
                     out.append(cand)
         return out
 
+    def refresh_bind_files(
+        self,
+        repo_name: str,
+        repo_config,
+        worktree_path: Path,
+        overwrite: bool = False,
+    ) -> dict:
+        """Re-sync bind_files from source into an existing worktree. See #71.
+
+        Returns a dict with keys:
+        - `copied`:    files that didn't exist in worktree and were copied
+        - `updated`:   files that differed and were overwritten (only when overwrite=True)
+        - `unchanged`: files that already matched source byte-for-byte
+        - `skipped`:   files that differed but were preserved (overwrite=False)
+        - `warnings`:  missing-source / not-a-regular-file warnings (same shape as _copy_bind_files)
+
+        All lists contain relative path strings. Caller decides exit status
+        based on whether `skipped` is non-empty.
+        """
+        result: dict[str, list] = {
+            "copied": [], "updated": [], "unchanged": [], "skipped": [],
+            "warnings": [],
+        }
+        if not repo_config.bind_files:
+            return result
+
+        if repo_config.git_root is not None:
+            parent = self._config.repos[repo_config.git_root]
+            source_root = parent.path / repo_config.path
+        else:
+            source_root = repo_config.path
+
+        for entry in repo_config.bind_files:
+            if any(c in entry for c in "*?["):
+                continue
+            if not (source_root / entry).exists():
+                result["warnings"].append(
+                    f"{repo_name}: bind_files source missing: {entry} (will not be copied)"
+                )
+
+        candidates = self._git_ignored_files(source_root)
+        matches = self._match_bind_patterns(repo_config.bind_files, candidates)
+
+        for rel in matches:
+            src = source_root / rel
+            dst = worktree_path / rel
+            rel_str = str(rel)
+
+            if not src.is_file():
+                result["warnings"].append(
+                    f"{repo_name}: bind_files match is not a regular file: {rel} (skipped)"
+                )
+                continue
+
+            if not dst.exists():
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dst)
+                result["copied"].append(rel_str)
+                continue
+
+            # dst exists — compare bytes.
+            if src.read_bytes() == dst.read_bytes():
+                result["unchanged"].append(rel_str)
+                continue
+
+            if overwrite:
+                shutil.copy2(src, dst)
+                result["updated"].append(rel_str)
+            else:
+                result["skipped"].append(rel_str)
+
+        return result
+
     def _copy_bind_files(
         self,
         repo_name: str,

--- a/tests/cli/test_bind.py
+++ b/tests/cli/test_bind.py
@@ -1,0 +1,96 @@
+"""Integration tests for `mship bind refresh`. See #71.
+
+Core refresh behavior is tested directly on `WorktreeManager.refresh_bind_files`
+in `tests/core/test_worktree.py`. These tests verify CLI wiring: JSON output,
+exit code on conflict, --overwrite flag, --repos filter, unknown-repo rejection.
+"""
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def patch_refresh(monkeypatch):
+    """Patch WorktreeManager.refresh_bind_files at the class level so every
+    Factory-created instance sees the mock."""
+    calls: list[dict] = []
+    default_result = {
+        "copied": [], "updated": [], "unchanged": [],
+        "skipped": [], "warnings": [],
+    }
+    result_by_repo: dict[str, dict] = {}
+
+    def _mock(self, repo_name, repo_config, worktree_path, overwrite=False):
+        calls.append({"repo": repo_name, "overwrite": overwrite})
+        return result_by_repo.get(repo_name, default_result)
+
+    from mship.core.worktree import WorktreeManager
+    monkeypatch.setattr(WorktreeManager, "refresh_bind_files", _mock)
+
+    def _set(repo_name: str, **kwargs):
+        result_by_repo[repo_name] = {**default_result, **kwargs}
+
+    _set.calls = calls  # type: ignore[attr-defined]
+    return _set
+
+
+def test_bind_refresh_reports_copied(configured_git_app: Path, patch_refresh):
+    runner.invoke(app, ["spawn", "copied test", "--repos", "shared", "--skip-setup"])
+    patch_refresh("shared", copied=[".env"])
+    result = runner.invoke(app, ["bind", "refresh", "--task", "copied-test"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["task"] == "copied-test"
+    assert payload["repos"][0]["copied"] == [".env"]
+
+
+def test_bind_refresh_exits_nonzero_on_skipped_without_overwrite(configured_git_app: Path, patch_refresh):
+    runner.invoke(app, ["spawn", "skip test", "--repos", "shared", "--skip-setup"])
+    patch_refresh("shared", skipped=[".env"])
+    result = runner.invoke(app, ["bind", "refresh", "--task", "skip-test"])
+    assert result.exit_code != 0
+
+
+def test_bind_refresh_overwrite_flag_passed_through(configured_git_app: Path, patch_refresh):
+    runner.invoke(app, ["spawn", "ow test", "--repos", "shared", "--skip-setup"])
+    patch_refresh("shared", updated=[".env"])
+    result = runner.invoke(app, ["bind", "refresh", "--task", "ow-test", "--overwrite"])
+    assert result.exit_code == 0, result.output
+    # Confirm overwrite=True flowed through to the mocked method.
+    assert patch_refresh.calls[0]["overwrite"] is True
+
+
+def test_bind_refresh_unknown_repo_errors(configured_git_app: Path, patch_refresh):
+    runner.invoke(app, ["spawn", "unk", "--repos", "shared", "--skip-setup"])
+    result = runner.invoke(
+        app, ["bind", "refresh", "--task", "unk", "--repos", "not-a-repo"],
+    )
+    assert result.exit_code != 0
+    assert "not-a-repo" in result.output
+
+
+def test_bind_refresh_repos_filter_scopes(configured_git_app: Path, patch_refresh):
+    runner.invoke(
+        app, ["spawn", "multi", "--repos", "shared,auth-service", "--skip-setup"],
+    )
+    result = runner.invoke(
+        app, ["bind", "refresh", "--task", "multi", "--repos", "shared"],
+    )
+    assert result.exit_code == 0, result.output
+    repos_called = [c["repo"] for c in patch_refresh.calls]
+    assert repos_called == ["shared"]  # auth-service NOT called
+
+
+def test_bind_refresh_surfaces_warnings(configured_git_app: Path, patch_refresh):
+    runner.invoke(app, ["spawn", "warn", "--repos", "shared", "--skip-setup"])
+    patch_refresh("shared", warnings=["shared: bind_files source missing: .absent"])
+    result = runner.invoke(app, ["bind", "refresh", "--task", "warn"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert any(".absent" in w for w in payload["repos"][0]["warnings"])

--- a/tests/cli/test_pr.py
+++ b/tests/cli/test_pr.py
@@ -1,0 +1,135 @@
+"""Integration tests for `mship pr`. See #41."""
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.util.shell import ShellResult, ShellRunner
+
+runner = CliRunner()
+
+
+def _set_pr_urls(workspace: Path, slug: str, pr_urls: dict[str, str]) -> None:
+    from datetime import datetime, timezone
+    state_path = workspace / ".mothership" / "state.yaml"
+    data = yaml.safe_load(state_path.read_text())
+    data["tasks"][slug]["pr_urls"] = pr_urls
+    data["tasks"][slug]["finished_at"] = datetime.now(timezone.utc).isoformat()
+    state_path.write_text(yaml.safe_dump(data))
+
+
+def _pr_view_shell(mapping: dict[str, tuple[str, int, str]]):
+    """Build a mock shell side_effect.
+
+    `mapping` is {url: (state, number, base)}; returns unknown for misses.
+    """
+    def _run(cmd, cwd, env=None):
+        if "gh pr view" in cmd:
+            for url, (state, number, base) in mapping.items():
+                if url in cmd:
+                    return ShellResult(
+                        returncode=0,
+                        stdout=f"{state}\t{number}\t{base}\n",
+                        stderr="",
+                    )
+            return ShellResult(returncode=1, stdout="", stderr="unknown")
+        # Fall through to audit defaults.
+        from tests.cli.conftest import _audit_ok_run
+        return _audit_ok_run(cmd, cwd, env)
+    return _run
+
+
+def test_pr_empty_when_no_tasks(configured_git_app: Path):
+    result = runner.invoke(app, ["pr"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload == {"tasks": []}
+
+
+def test_pr_lists_tasks_with_pr_urls(configured_git_app: Path):
+    runner.invoke(app, ["spawn", "first", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "second", "--repos", "shared", "--skip-setup"])
+    _set_pr_urls(configured_git_app, "first", {"shared": "https://github.com/o/r/pull/1"})
+    _set_pr_urls(configured_git_app, "second", {"shared": "https://github.com/o/r/pull/2"})
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = _pr_view_shell({
+        "pull/1": ("OPEN", 1, "main"),
+        "pull/2": ("MERGED", 2, "main"),
+    })
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    container.shell.override(mock_shell)
+    try:
+        result = runner.invoke(app, ["pr"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        slugs = [t["slug"] for t in payload["tasks"]]
+        assert "first" in slugs and "second" in slugs
+        states = {t["slug"]: t["prs"][0]["state"] for t in payload["tasks"]}
+        assert states["first"] == "open"
+        assert states["second"] == "merged"
+    finally:
+        container.shell.reset_override()
+
+
+def test_pr_skips_tasks_without_pr_urls(configured_git_app: Path):
+    runner.invoke(app, ["spawn", "no pr", "--repos", "shared", "--skip-setup"])
+    # Don't set pr_urls.
+    result = runner.invoke(app, ["pr"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload == {"tasks": []}
+
+
+def test_pr_gh_failure_shows_unknown(configured_git_app: Path):
+    runner.invoke(app, ["spawn", "fail", "--repos", "shared", "--skip-setup"])
+    _set_pr_urls(configured_git_app, "fail", {"shared": "https://github.com/o/r/pull/9"})
+
+    mock_shell = MagicMock(spec=ShellRunner)
+
+    def _run(cmd, cwd, env=None):
+        if "gh pr view" in cmd:
+            return ShellResult(returncode=1, stdout="", stderr="rate limit exceeded")
+        from tests.cli.conftest import _audit_ok_run
+        return _audit_ok_run(cmd, cwd, env)
+
+    mock_shell.run.side_effect = _run
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    container.shell.override(mock_shell)
+    try:
+        result = runner.invoke(app, ["pr"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["tasks"][0]["prs"][0]["state"] == "unknown"
+    finally:
+        container.shell.reset_override()
+
+
+def test_pr_multiple_repos_per_task(configured_git_app: Path):
+    runner.invoke(app, ["spawn", "multi", "--repos", "shared,auth-service", "--skip-setup"])
+    _set_pr_urls(configured_git_app, "multi", {
+        "shared": "https://github.com/o/r/pull/1",
+        "auth-service": "https://github.com/o/r/pull/2",
+    })
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = _pr_view_shell({
+        "pull/1": ("OPEN", 1, "main"),
+        "pull/2": ("OPEN", 2, "main"),
+    })
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    container.shell.override(mock_shell)
+    try:
+        result = runner.invoke(app, ["pr"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert len(payload["tasks"]) == 1
+        assert len(payload["tasks"][0]["prs"]) == 2
+        repos = {p["repo"] for p in payload["tasks"][0]["prs"]}
+        assert repos == {"shared", "auth-service"}
+    finally:
+        container.shell.reset_override()

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -1075,3 +1075,126 @@ def test_spawn_appends_marker_to_worktree_exclude(workspace_with_git: Path):
         container.state_dir.reset_override()
         container.config.reset()
         container.state_manager.reset()
+
+
+def test_refresh_bind_files_copies_missing(tmp_path: Path):
+    """First-time refresh copies files missing from worktree."""
+    from mship.core.config import ConfigLoader, RepoConfig, WorkspaceConfig
+    from mship.core.worktree import WorktreeManager
+    from mship.core.state import StateManager
+    from mship.util.git import GitRunner
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+
+    source = _init_repo_with_ignored_files(tmp_path)
+    repo_cfg = RepoConfig(path=source, type="service", bind_files=[".env"])
+    cfg = WorkspaceConfig(workspace="t", repos={"r": repo_cfg})
+    mgr = WorktreeManager(
+        config=cfg, graph=None,
+        state_manager=MagicMock(spec=StateManager),
+        git=GitRunner(), shell=ShellRunner(), log=None,
+    )
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    result = mgr.refresh_bind_files("r", repo_cfg, wt)
+    assert ".env" in result["copied"]
+    assert (wt / ".env").read_text() == "ENV=yes\n"
+
+
+def test_refresh_bind_files_unchanged_when_identical(tmp_path: Path):
+    from mship.core.config import RepoConfig, WorkspaceConfig
+    from mship.core.worktree import WorktreeManager
+    from mship.core.state import StateManager
+    from mship.util.git import GitRunner
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+
+    source = _init_repo_with_ignored_files(tmp_path)
+    repo_cfg = RepoConfig(path=source, type="service", bind_files=[".env"])
+    cfg = WorkspaceConfig(workspace="t", repos={"r": repo_cfg})
+    mgr = WorktreeManager(
+        config=cfg, graph=None,
+        state_manager=MagicMock(spec=StateManager),
+        git=GitRunner(), shell=ShellRunner(), log=None,
+    )
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    # Pre-seed worktree with identical content.
+    (wt / ".env").write_text("ENV=yes\n")
+    result = mgr.refresh_bind_files("r", repo_cfg, wt)
+    assert ".env" in result["unchanged"]
+    assert ".env" not in result["copied"]
+
+
+def test_refresh_bind_files_skip_modified_without_overwrite(tmp_path: Path):
+    from mship.core.config import RepoConfig, WorkspaceConfig
+    from mship.core.worktree import WorktreeManager
+    from mship.core.state import StateManager
+    from mship.util.git import GitRunner
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+
+    source = _init_repo_with_ignored_files(tmp_path)
+    repo_cfg = RepoConfig(path=source, type="service", bind_files=[".env"])
+    cfg = WorkspaceConfig(workspace="t", repos={"r": repo_cfg})
+    mgr = WorktreeManager(
+        config=cfg, graph=None,
+        state_manager=MagicMock(spec=StateManager),
+        git=GitRunner(), shell=ShellRunner(), log=None,
+    )
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    (wt / ".env").write_text("USER_EDIT=yes\n")  # differs from source
+    result = mgr.refresh_bind_files("r", repo_cfg, wt, overwrite=False)
+    assert ".env" in result["skipped"]
+    assert (wt / ".env").read_text() == "USER_EDIT=yes\n"  # preserved
+
+
+def test_refresh_bind_files_overwrite_replaces_modified(tmp_path: Path):
+    from mship.core.config import RepoConfig, WorkspaceConfig
+    from mship.core.worktree import WorktreeManager
+    from mship.core.state import StateManager
+    from mship.util.git import GitRunner
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+
+    source = _init_repo_with_ignored_files(tmp_path)
+    repo_cfg = RepoConfig(path=source, type="service", bind_files=[".env"])
+    cfg = WorkspaceConfig(workspace="t", repos={"r": repo_cfg})
+    mgr = WorktreeManager(
+        config=cfg, graph=None,
+        state_manager=MagicMock(spec=StateManager),
+        git=GitRunner(), shell=ShellRunner(), log=None,
+    )
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    (wt / ".env").write_text("USER_EDIT=yes\n")
+    result = mgr.refresh_bind_files("r", repo_cfg, wt, overwrite=True)
+    assert ".env" in result["updated"]
+    assert (wt / ".env").read_text() == "ENV=yes\n"  # replaced
+
+
+def test_refresh_bind_files_warns_on_missing_literal(tmp_path: Path):
+    from mship.core.config import RepoConfig, WorkspaceConfig
+    from mship.core.worktree import WorktreeManager
+    from mship.core.state import StateManager
+    from mship.util.git import GitRunner
+    from mship.util.shell import ShellRunner
+    from unittest.mock import MagicMock
+
+    source = _init_repo_with_ignored_files(tmp_path)
+    repo_cfg = RepoConfig(
+        path=source, type="service",
+        bind_files=[".env", "nonexistent.config"],
+    )
+    cfg = WorkspaceConfig(workspace="t", repos={"r": repo_cfg})
+    mgr = WorktreeManager(
+        config=cfg, graph=None,
+        state_manager=MagicMock(spec=StateManager),
+        git=GitRunner(), shell=ShellRunner(), log=None,
+    )
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    result = mgr.refresh_bind_files("r", repo_cfg, wt)
+    assert any("nonexistent.config" in w for w in result["warnings"])
+    assert ".env" in result["copied"]


### PR DESCRIPTION
## Summary

Two small visibility/maintenance wrappers, one PR.

### Commit 1 — `feat(cli): mship bind refresh re-syncs bind_files into existing worktrees`

Closes #71.

`bind_files` are copied once at spawn time. Source edits after spawn silently drift — "works in main checkout but not in worktree" is the usual symptom. `mship bind refresh` re-syncs:

```
mship bind refresh [--task <slug>] [--repos <names>] [--overwrite]
```

- Iterates `task.affected_repos` (or a `--repos` subset), re-copies `bind_files` matches for each.
- Per-file outcomes: `copied` (first-time), `updated` (overwritten), `unchanged` (identical), `skipped` (worktree-modified, preserved).
- Without `--overwrite`: files modified in the worktree are preserved. Exit 1 if any were skipped.
- Missing source files surface as warnings (same shape as spawn).
- Handles `git_root` subdir repos the same way `_copy_bind_files` does.

### Commit 2 — `feat(cli): mship pr aggregate view of PR state across tasks`

Closes #41.

Today checking PR state requires `gh pr view <n>` per task; `mship reconcile` only reports drift, not raw state. `mship pr` aggregates:

```
$ mship pr
auth-middleware-refactor
  shared: #42 open base=main  https://github.com/o/r/pull/42
ingest-rate-limits
  shared: #43 merged base=main  https://github.com/o/r/pull/43
```

- Iterates all active tasks; for each with `pr_urls`, runs `gh pr view --json state,number,baseRefName` per PR.
- State mapped to `open` / `merged` / `closed` with color coding; gh failure → `unknown` (reuses the classification pattern from #73).
- TTY: table output. Non-TTY: JSON `{tasks: [{slug, prs: [{repo, url, state, number, base}]}]}`.
- Scope cuts: no CI status, no `--watch`, no single-task detail mode (deferred per issue's "optional detail mode" note).

## Test plan

- [x] `tests/core/test_worktree.py`: 5 new unit tests for `WorktreeManager.refresh_bind_files` (copies missing, unchanged when identical, skip modified without overwrite, overwrite replaces, warn on missing literal).
- [x] `tests/cli/test_bind.py`: 6 integration tests using class-level patch (reports copied, exits non-zero on skipped, `--overwrite` flag passed through, unknown repo rejected, `--repos` filter scopes, warnings surfaced).
- [x] `tests/cli/test_pr.py`: 5 integration tests (empty, multi-task listing, skips tasks without prs, gh failure → unknown, multiple repos per task).
- [x] Broader `tests/cli/` + `tests/core/`: 972 passed.

## Anti-goals preserved

- `mship bind refresh`:
  - No `--all` (loop-over-tasks is rare; reduces surface).
  - Respects gitignore filtering same as spawn.
  - Does not touch files outside `bind_files` patterns.
- `mship pr`:
  - No CI status (separate `statusCheckRollup` query, heavier — add later if needed).
  - No `--watch`, no single-task detail mode.
  - Does not cache (the issue mentions brief caching for `--watch`; deferred with `--watch` itself).

Closes #41, #71