### PR TITLE
skills: reflect recent mship CLI additions

### DIFF
--- a/src/mship/skills/finishing-a-development-branch/SKILL.md
+++ b/src/mship/skills/finishing-a-development-branch/SKILL.md
@@ -104,6 +104,8 @@ EOF
 mship finish --body-file /tmp/pr-body.md
 ```
 
+**Post-finish iteration (reviewer feedback, CI fixes, typos):** don't spawn a new task. Stage the fix in the worktree and run `mship commit "<msg>"` — it commits across the task's affected repos, pushes to the existing PR, and journals per repo. Use this for small iterations until the PR merges.
+
 Then: Cleanup worktree (Step 5)
 
 #### Option 3: Keep As-Is
@@ -137,7 +139,7 @@ Then: Cleanup worktree (Step 5)
 
 **For Options 1, 2, 4:**
 
-*In a mothership workspace, worktree cleanup is handled by `mship close`. Run it after the local merge (Option 1) or after the PR merges on GitHub (Option 2 — check via `mship reconcile` or `gh pr view`). No manual `git worktree remove` needed.*
+*In a mothership workspace, worktree cleanup is handled by `mship close`. Run it after the local merge (Option 1) or after the PR merges on GitHub (Option 2 — check via `mship pr` for an aggregate view across tasks, `mship reconcile` for drift, or `gh pr view <url>` for a single PR). No manual `git worktree remove` needed.*
 
 **For Option 3:** Keep worktree.
 

--- a/src/mship/skills/test-driven-development/SKILL.md
+++ b/src/mship/skills/test-driven-development/SKILL.md
@@ -354,6 +354,8 @@ Bug found? Write failing test reproducing it. Follow TDD cycle. Test proves fix 
 
 Never fix bugs without a test.
 
+In a mothership workspace with an open debug thread (`mship debug hypothesis`), `mship test` auto-attaches `parent=<hypothesis-id>` to the test-run journal entry — linking the failing→passing transition to the hypothesis that predicted it. See the `systematic-debugging` skill for the full hypothesis → rule-out → resolved loop.
+
 ## Testing Anti-Patterns
 
 When adding mocks or test utilities, read @testing-anti-patterns.md to avoid common pitfalls:

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -206,11 +206,14 @@ For larger changes — new features, significant refactors — spawn a new task 
 ```bash
 mship status                          # task, phase, branch, drift, last log, finished warning
 mship audit [--repos r] [--json]
+mship pr                              # aggregate PR state across all active tasks
 mship view status|logs|diff|spec [--watch]
 mship view spec --web                 # serves HTML on localhost
 mship graph
 mship worktrees
 ```
+
+**`mship pr`** iterates active tasks with `pr_urls` and shows per-PR state (`open`/`merged`/`closed`/`unknown`) and base branch. Use this instead of `gh pr view <url>` per task when you want the full cross-task picture — it's the answer to "what's merged vs. still in review across everything I have open?" TTY → table; non-TTY → JSON `{tasks: [{slug, prs: [...]}]}`.
 
 **`audit` issue codes** (errors unless noted): `path_missing`, `not_a_git_repo`, `fetch_failed`, `detached_head`, `unexpected_branch`, `dirty_worktree`, `no_upstream`, `behind_remote`, `diverged`, `extra_worktrees`; `dirty_untracked` (warn — untracked files only, doesn't block); `ahead_remote` (info-only).
 
@@ -223,9 +226,12 @@ mship worktrees
 ```bash
 mship sync [--repos r]                # fast-forward behind-only clean repos
 mship prune [--force]                 # remove orphaned worktrees
+mship bind refresh [--task T] [--repos R] [--overwrite]
 ```
 
 **`sync` is strictly safe.** `git fetch --prune` + `git pull --ff-only` only. It never switches branches, never resets, never touches dirty trees — if a repo isn't cleanly behind the expected branch, it's skipped with a reason.
+
+**`bind refresh` re-syncs `bind_files`.** `bind_files` (declared in `mothership.yaml`) are files copied from a source repo into each worktree at spawn time — shared configs, prompts, fixtures. After spawn, source edits don't propagate automatically, so "works in main checkout but not in worktree" is a drift symptom. `mship bind refresh` re-copies matching files for each repo in `task.affected_repos` (or a `--repos` subset). Per-file outcomes: `copied`, `updated`, `unchanged`, or `skipped` (worktree-modified, preserved). Without `--overwrite`, worktree-modified files are preserved and the command exits 1 if any were skipped.
 
 ### Long-running services
 


### PR DESCRIPTION
## Summary

Skill currency pass — the in-tree `mship-skills` fork had drifted behind several recent CLI additions. Five targeted edits across three skills, all documentation, no code changes.

### `finishing-a-development-branch/SKILL.md`

- **Option 2** now flags `mship commit "<msg>"` as the post-finish iteration path for reviewer feedback / CI fixes / typos, so users don't spawn a new task for small changes on the same branch.
- **Step 5 cleanup** distinguishes the three PR-state-check paths: `mship pr` (aggregate across tasks — the new command from #41), `mship reconcile` (drift), `gh pr view <url>` (single PR). Prior wording only pointed at the last two.

### `test-driven-development/SKILL.md`

- **Debugging Integration** section now cross-refs the `systematic-debugging` skill and explains that `mship test` auto-attaches `parent=<hypothesis-id>` to the test-run journal entry during an open debug thread — linking the failing→passing transition to the hypothesis that predicted it (per #30 design intent).

### `working-with-mothership/SKILL.md`

- **Inspection section** adds `mship pr` with a paragraph on when to reach for it vs. per-PR `gh pr view`.
- **Maintenance section** adds `mship bind refresh` with a self-contained explanation of `bind_files` drift (the "works in main checkout but not in worktree" symptom), the four per-file outcomes (`copied` / `updated` / `unchanged` / `skipped`), and `--overwrite` semantics.

## Rationale

The in-tree skills fork is mship's bundled methodology — when CLI features ship without the skills catching up, users who rely on skill guidance miss the new primitives. This pass closes the gaps identified in a currency audit against recent issues (#29, #30, #41, #71). The `systematic-debugging` + `working-with-mothership` coverage of `mship debug` and `mship commit` was already current; these are the residual gaps.

No skill was actively contradicting the new CLI — this is silence-where-guidance-should-be, not stale instructions. Severity was documentation hygiene.

## Test plan

- [x] `mship test` — full suite green (pass, exit 0, 489s). No code changes so no functional risk; running the suite confirms nothing else drifted.
- [x] `git diff --stat` shows 11 insertions, 1 deletion across exactly the three intended SKILL.md files — no accidental edits elsewhere.
- [x] Reviewer: read each of the five added/modified paragraphs and confirm they match the described CLI behavior (`mship commit`, `mship pr`, `mship bind refresh`, `mship test` auto-parent attachment).
