### PR TITLE
scope finish audit-block to task.affected_repos + transitive deps

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -772,7 +772,7 @@ def register(app: typer.Typer, get_container):
         ordered = graph.topo_sort(task.affected_repos)
 
         # --- Audit gate ---
-        from mship.core.audit_gate import run_audit_gate, AuditGateBlocked
+        from mship.core.audit_gate import run_audit_gate, AuditGateBlocked, compute_finish_audit_scope
         from mship.core.repo_state import audit_repos
 
         shell = container.shell()
@@ -791,6 +791,13 @@ def register(app: typer.Typer, get_container):
             from mship.core.repo_state import without_no_upstream_on_task_branch
             report = without_no_upstream_on_task_branch(report, task.branch)
 
+        # Scope blocking to repos that will actually produce a PR (have local
+        # commits past their base) plus their transitive deps. Drift in repos
+        # that won't be pushed is informational, not blocking. See #112.
+        scope_repos = compute_finish_audit_scope(
+            task, config, graph, container.pr_manager(),
+        )
+
         def _log_bypass(codes: list[str]) -> None:
             container.log_manager().append(
                 task.slug, f"BYPASSED AUDIT: finish — {', '.join(codes)}"
@@ -803,6 +810,7 @@ def register(app: typer.Typer, get_container):
                 force=force_audit,
                 command_name="finish",
                 on_bypass=_log_bypass,
+                scope_repos=scope_repos,
             )
         except AuditGateBlocked as e:
             output.error(str(e))

--- a/src/mship/core/audit_gate.py
+++ b/src/mship/core/audit_gate.py
@@ -18,6 +18,7 @@ def run_audit_gate(
     force: bool,
     command_name: str,
     on_bypass: Callable[[list[str]], None],
+    scope_repos: "frozenset[str] | None" = None,
 ) -> None:
     """Apply the audit gate.
 
@@ -25,15 +26,22 @@ def run_audit_gate(
     - Errors + force=True: call on_bypass(codes) and return.
     - Errors + block=True: raise AuditGateBlocked with the issue summary.
     - Errors + block=False: print nothing here; caller is expected to warn.
-    """
-    if not report.has_errors:
-        return
 
+    `scope_repos` (optional): if provided, only errors in repos that are in
+    this set count toward blocking. Errors in out-of-scope repos are skipped.
+    Used by `mship finish` (#112) to scope blocking to repos with pending work
+    plus their transitive deps. None = no filter (current behavior).
+    """
     error_codes: list[str] = []
     for repo in report.repos:
+        if scope_repos is not None and repo.name not in scope_repos:
+            continue
         for issue in repo.issues:
             if issue.severity == "error":
                 error_codes.append(f"{repo.name}:{issue.code}")
+
+    if not error_codes:
+        return
 
     if force:
         on_bypass(error_codes)
@@ -45,6 +53,39 @@ def run_audit_gate(
             + ", ".join(error_codes)
         )
     # block=False, not forced: caller handles warning
+
+
+def compute_finish_audit_scope(task, config, graph, pr_mgr) -> "frozenset[str]":
+    """Repos whose drift should block `mship finish`. See #112.
+
+    A repo is in scope when either:
+    - It is in `task.affected_repos` AND has commits past its effective base
+      (i.e. the finish will push it as a PR), OR
+    - It is a transitive dependency (via `mothership.yaml#repos.<r>.depends_on`)
+      of any in-scope repo (drift in deps can break the task's build/test).
+
+    Repos in `affected_repos` without commits are excluded — they won't
+    produce a PR, so workspace-wide drift in them is informational only.
+    """
+    repos_with_work: set[str] = set()
+    for repo_name in task.affected_repos:
+        wt = task.worktrees.get(repo_name)
+        if wt is None:
+            continue
+        wt_path = Path(wt)
+        if not wt_path.exists():
+            continue
+        repo_cfg = config.repos.get(repo_name)
+        if repo_cfg is None:
+            continue
+        base = repo_cfg.base_branch or "main"
+        if pr_mgr.count_commits_ahead(wt_path, base, task.branch) > 0:
+            repos_with_work.add(repo_name)
+
+    in_scope: set[str] = set(repos_with_work)
+    for repo_name in repos_with_work:
+        in_scope.update(graph.dependencies(repo_name))
+    return frozenset(in_scope)
 
 
 def collect_known_worktree_paths(state_manager) -> "frozenset[Path]":

--- a/tests/core/test_audit_gate.py
+++ b/tests/core/test_audit_gate.py
@@ -87,6 +87,206 @@ def test_collect_known_worktree_paths_no_tasks():
     assert result == frozenset()
 
 
+def _two_repo_blocking_report():
+    """Report with one error in 'cli' and one error in 'unrelated'."""
+    return AuditReport(repos=(
+        RepoAudit(name="cli", path=Path("/"), current_branch="main",
+                  issues=(Issue("dirty_worktree", "error", "x"),)),
+        RepoAudit(name="unrelated", path=Path("/"), current_branch="main",
+                  issues=(Issue("behind_remote", "error", "2 commits behind"),)),
+    ))
+
+
+def test_gate_scope_repos_filters_out_of_scope_errors():
+    """Errors in repos outside scope_repos do not block. See #112."""
+    # Only 'unrelated' has an error; 'cli' is clean.
+    report = AuditReport(repos=(
+        RepoAudit(name="cli", path=Path("/"), current_branch="main", issues=()),
+        RepoAudit(name="unrelated", path=Path("/"), current_branch="main",
+                  issues=(Issue("behind_remote", "error", "2 commits behind"),)),
+    ))
+    run_audit_gate(
+        report,
+        block=True, force=False, command_name="finish",
+        on_bypass=lambda codes: None,
+        scope_repos=frozenset({"cli"}),  # 'unrelated' is out of scope
+    )
+    # No exception — the only error is in 'unrelated', which is out of scope.
+
+
+def test_gate_scope_repos_still_blocks_on_in_scope_error():
+    """Errors in repos that ARE in scope_repos still block."""
+    with pytest.raises(AuditGateBlocked) as exc:
+        run_audit_gate(
+            _two_repo_blocking_report(),
+            block=True, force=False, command_name="finish",
+            on_bypass=lambda codes: None,
+            scope_repos=frozenset({"cli", "unrelated"}),  # both in scope
+        )
+    assert "dirty_worktree" in str(exc.value)
+    # 'unrelated' is in scope so its error also blocks.
+    assert "behind_remote" in str(exc.value)
+
+
+def test_gate_scope_repos_force_bypass_only_emits_in_scope_codes():
+    """With --force-audit, on_bypass receives only in-scope codes."""
+    seen: list[list[str]] = []
+    run_audit_gate(
+        _two_repo_blocking_report(),
+        block=True, force=True, command_name="finish",
+        on_bypass=lambda codes: seen.append(list(codes)),
+        scope_repos=frozenset({"cli"}),  # 'unrelated' excluded
+    )
+    # The bypass log only mentions cli's error, not unrelated's.
+    assert seen == [["cli:dirty_worktree"]]
+
+
+def test_gate_scope_repos_none_unchanged_behavior():
+    """scope_repos=None (default) preserves current behavior — all errors block."""
+    with pytest.raises(AuditGateBlocked) as exc:
+        run_audit_gate(
+            _two_repo_blocking_report(),
+            block=True, force=False, command_name="finish",
+            on_bypass=lambda codes: None,
+            # scope_repos not passed → defaults to None
+        )
+    assert "dirty_worktree" in str(exc.value)
+    assert "behind_remote" in str(exc.value)
+
+
+def test_compute_finish_audit_scope_includes_repos_with_commits(tmp_path: Path):
+    """Repos in affected_repos with local commits past their base are in scope. See #112."""
+    from mship.core.audit_gate import compute_finish_audit_scope
+    from unittest.mock import MagicMock
+
+    task = MagicMock()
+    task.affected_repos = ["cli"]
+    task.worktrees = {"cli": str(tmp_path / "cli")}
+    task.branch = "feat/x"
+    (tmp_path / "cli").mkdir()
+
+    config = MagicMock()
+    config.repos = {"cli": MagicMock(base_branch="main")}
+
+    graph = MagicMock()
+    graph.dependencies.return_value = []  # no deps
+
+    pr_mgr = MagicMock()
+    pr_mgr.count_commits_ahead.return_value = 3  # has commits
+
+    scope = compute_finish_audit_scope(task, config, graph, pr_mgr)
+    assert scope == frozenset({"cli"})
+
+
+def test_compute_finish_audit_scope_excludes_repos_without_commits(tmp_path: Path):
+    """Repos in affected_repos without local commits are NOT in scope (no PR to push)."""
+    from mship.core.audit_gate import compute_finish_audit_scope
+    from unittest.mock import MagicMock
+
+    task = MagicMock()
+    task.affected_repos = ["cli", "untouched"]
+    task.worktrees = {"cli": str(tmp_path / "cli"), "untouched": str(tmp_path / "untouched")}
+    task.branch = "feat/x"
+    (tmp_path / "cli").mkdir()
+    (tmp_path / "untouched").mkdir()
+
+    config = MagicMock()
+    config.repos = {
+        "cli": MagicMock(base_branch="main"),
+        "untouched": MagicMock(base_branch="main"),
+    }
+
+    graph = MagicMock()
+    graph.dependencies.return_value = []
+
+    pr_mgr = MagicMock()
+    # cli has commits, untouched doesn't.
+    pr_mgr.count_commits_ahead.side_effect = lambda path, base, branch: 3 if "cli" in str(path) else 0
+
+    scope = compute_finish_audit_scope(task, config, graph, pr_mgr)
+    assert scope == frozenset({"cli"})  # 'untouched' is excluded
+
+
+def test_compute_finish_audit_scope_includes_transitive_deps(tmp_path: Path):
+    """Transitive deps of repos with commits are also in scope (drift in deps could break build)."""
+    from mship.core.audit_gate import compute_finish_audit_scope
+    from unittest.mock import MagicMock
+
+    task = MagicMock()
+    task.affected_repos = ["api"]
+    task.worktrees = {"api": str(tmp_path / "api")}
+    task.branch = "feat/x"
+    (tmp_path / "api").mkdir()
+
+    config = MagicMock()
+    config.repos = {"api": MagicMock(base_branch="main")}
+
+    graph = MagicMock()
+    graph.dependencies.return_value = ["shared", "auth"]  # api depends on shared + auth
+
+    pr_mgr = MagicMock()
+    pr_mgr.count_commits_ahead.return_value = 2  # api has commits
+
+    scope = compute_finish_audit_scope(task, config, graph, pr_mgr)
+    assert scope == frozenset({"api", "shared", "auth"})
+
+
+def test_compute_finish_audit_scope_falls_back_to_main_when_no_base_branch(tmp_path: Path):
+    """When repo config has no base_branch, fall back to 'main'."""
+    from mship.core.audit_gate import compute_finish_audit_scope
+    from unittest.mock import MagicMock
+
+    task = MagicMock()
+    task.affected_repos = ["cli"]
+    task.worktrees = {"cli": str(tmp_path / "cli")}
+    task.branch = "feat/x"
+    (tmp_path / "cli").mkdir()
+
+    config = MagicMock()
+    cli_cfg = MagicMock()
+    cli_cfg.base_branch = None  # not configured
+    config.repos = {"cli": cli_cfg}
+
+    graph = MagicMock()
+    graph.dependencies.return_value = []
+
+    pr_mgr = MagicMock()
+    pr_mgr.count_commits_ahead.return_value = 1
+
+    compute_finish_audit_scope(task, config, graph, pr_mgr)
+    # Verify pr_mgr was called with 'main' as the base.
+    args, kwargs = pr_mgr.count_commits_ahead.call_args
+    # signature: count_commits_ahead(repo_path, base, branch)
+    assert "main" in args or kwargs.get("base") == "main"
+
+
+def test_compute_finish_audit_scope_skips_repos_without_worktree(tmp_path: Path):
+    """Repos with no worktree path (or non-existent path) are not audited — silently excluded."""
+    from mship.core.audit_gate import compute_finish_audit_scope
+    from unittest.mock import MagicMock
+
+    task = MagicMock()
+    task.affected_repos = ["cli", "missing"]
+    task.worktrees = {"cli": str(tmp_path / "cli")}  # no entry for 'missing'
+    task.branch = "feat/x"
+    (tmp_path / "cli").mkdir()
+
+    config = MagicMock()
+    config.repos = {
+        "cli": MagicMock(base_branch="main"),
+        "missing": MagicMock(base_branch="main"),
+    }
+
+    graph = MagicMock()
+    graph.dependencies.return_value = []
+
+    pr_mgr = MagicMock()
+    pr_mgr.count_commits_ahead.return_value = 2
+
+    scope = compute_finish_audit_scope(task, config, graph, pr_mgr)
+    assert "missing" not in scope
+
+
 def test_gate_does_not_block_when_only_warn_issues():
     """A repo audit with only `dirty_untracked` (warn) must not trip the gate."""
     audit = RepoAudit(

--- a/tests/test_finish_integration.py
+++ b/tests/test_finish_integration.py
@@ -279,7 +279,11 @@ def test_finish_fails_when_base_missing_on_remote(finish_workspace):
 
 
 def test_finish_blocks_when_affected_repo_is_dirty(finish_workspace):
-    """Dirty affected repo blocks finish under default block_finish=true."""
+    """Dirty affected repo blocks finish under default block_finish=true.
+
+    Note: shared must have local commits (rev-list count > 0) so it's in the
+    audit scope per #112 — drift in repos with no pending work no longer blocks.
+    """
     workspace, mock_shell = finish_workspace
 
     result = runner.invoke(app, ["spawn", "finish gate", "--repos", "shared", "--force-audit"])
@@ -295,7 +299,8 @@ def test_finish_blocks_when_affected_repo_is_dirty(finish_workspace):
         if "rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
             return ShellResult(returncode=0, stdout="origin/main\n", stderr="")
         if "rev-list --count" in cmd:
-            return ShellResult(returncode=0, stdout="0\n", stderr="")
+            # shared has 1 commit past origin/main → in audit scope.
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "worktree list" in cmd:
             return ShellResult(returncode=0, stdout="worktree /tmp/shared\n", stderr="")
         if "gh auth status" in cmd:
@@ -578,7 +583,11 @@ def test_finish_suppresses_no_upstream_for_task_branch(finish_workspace):
 
 
 def test_finish_still_blocks_other_audit_errors(finish_workspace):
-    """The fix must only suppress no_upstream; dirty_worktree etc. still block."""
+    """The fix must only suppress no_upstream; dirty_worktree etc. still block.
+
+    Note: shared must have local commits (count > 0) so it's in the audit scope
+    per #112 — drift in repos with no pending work is no longer a blocking error.
+    """
     workspace, mock_shell = finish_workspace
 
     result = runner.invoke(app, ["spawn", "still blocks", "--repos", "shared", "--force-audit"])
@@ -600,6 +609,9 @@ def test_finish_still_blocks_other_audit_errors(finish_workspace):
             return ShellResult(returncode=0, stdout=".git\n", stderr="")
         if "git worktree list" in cmd:
             return ShellResult(returncode=0, stdout="worktree /tmp/shared\n", stderr="")
+        if "git rev-list --count" in cmd:
+            # shared has 1 commit past origin/main → in audit scope.
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         return ShellResult(returncode=0, stdout="", stderr="")
 
     mock_shell.run.side_effect = mock_run
@@ -607,6 +619,65 @@ def test_finish_still_blocks_other_audit_errors(finish_workspace):
     result = runner.invoke(app, ["finish", "--task", "still-blocks"])
     assert result.exit_code != 0
     assert "dirty_worktree" in result.output
+
+
+def test_finish_does_not_block_on_drift_in_unrelated_repo(finish_workspace):
+    """Drift in a repo without local commits should NOT block finish (#112).
+
+    The user's reported scenario: an unrelated repo is `behind_remote` but has
+    no commits on the task branch. Previously this blocked finish; now it
+    should be silently filtered out of the audit-blocking scope while
+    affected_repos with actual commits still get audited.
+    """
+    workspace, mock_shell = finish_workspace
+
+    # Spawn affecting shared (will have commits) and api-gateway (untouched).
+    # api-gateway depends on shared, but shared has no upstream deps so the
+    # scope of "shared has commits" is just {shared} — api-gateway is excluded.
+    result = runner.invoke(app, ["spawn", "scoped finish", "--repos", "shared,api-gateway", "--force-audit"])
+    assert result.exit_code == 0
+
+    def mock_run(cmd, cwd, env=None):
+        cwd_str = str(cwd) if cwd else ""
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://x/pr/1\n", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "git fetch" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "symbolic-ref --short HEAD" in cmd:
+            return ShellResult(returncode=0, stdout="feat/scoped-finish\n", stderr="")
+        if "git rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
+            return ShellResult(returncode=128, stdout="", stderr="")
+        if "git rev-parse --git-common-dir" in cmd:
+            return ShellResult(returncode=0, stdout=".git\n", stderr="")
+        if "git worktree list" in cmd:
+            return ShellResult(returncode=0, stdout="worktree /tmp\n", stderr="")
+        if "git status --porcelain" in cmd:
+            # api-gateway is dirty — but it has no commits on this task, so
+            # it's out of audit scope and the dirty state should NOT block.
+            if "api-gateway" in cwd_str:
+                return ShellResult(returncode=0, stdout=" M unrelated.py\n", stderr="")
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "git rev-list --count" in cmd:
+            # shared has commits; api-gateway does not.
+            if "shared" in cwd_str:
+                return ShellResult(returncode=0, stdout="1\n", stderr="")
+            return ShellResult(returncode=0, stdout="0\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell.run.side_effect = mock_run
+
+    result = runner.invoke(
+        app,
+        ["finish", "--task", "scoped-finish", "--body", "## Summary\nx\n## Test plan\n- [x] manual"],
+    )
+    # Tailrd's dirty_worktree is out of scope (no commits) → does not block.
+    # Shared has commits and clean state → finish proceeds.
+    assert result.exit_code == 0, result.output
+    assert "blocked by audit" not in result.output
 
 
 def test_finish_auto_links_issue_refs_in_description(finish_workspace):


### PR DESCRIPTION
## Summary

Closes #112.

`mship finish` now only blocks on audit errors in repos that **will actually produce a PR** (have local commits past their effective base) or are **transitive deps of those** (drift in deps could break the task's build/test). Drift in `task.affected_repos` entries with no commits is informational, not blocking — they won't be pushed, so workspace-wide drift in them doesn't affect what's about to ship.

The user's reported scenario: spawn auto-included `marshal` in `affected_repos`, marshal had `behind_remote: 2 commits` but no work for the task, finish refused to proceed until `mship sync --repos marshal`. With this fix, marshal's drift is silently filtered from the blocking gate (still visible to standalone `mship audit`).

## Substrate principle

A finish gate's purpose is to protect what's about to ship. Repos with no commits past base aren't shipping. Their drift is unrelated to this finish. Treating them as blocking errors is overzealous and forces irrelevant workspace hygiene mid-finish.

The fix uses signals that already exist:
- `pr_mgr.count_commits_ahead` (the same call finish uses to detect untouched repos for PR creation, per #83)
- `graph.dependencies(repo)` (the existing transitive-deps function)

No new state, no new config knobs, no new methodology assumptions.

## Implementation

### `run_audit_gate` — new optional `scope_repos` parameter

```python
def run_audit_gate(
    report, *, block, force, command_name, on_bypass,
    scope_repos: frozenset[str] | None = None,  # NEW
) -> None:
```

`None` preserves current behavior (all errors trigger blocking). A frozenset filters to only those repos. `force` bypass codes are similarly filtered.

### `compute_finish_audit_scope` — new helper

```python
def compute_finish_audit_scope(task, config, graph, pr_mgr) -> frozenset[str]:
    """{ repos in affected_repos with commits past base } ∪ { their transitive deps }"""
```

Falls back to `"main"` when a repo has no `base_branch` configured. Skips repos whose worktree path is missing (defensive — they couldn't produce a PR anyway).

### `mship finish` — wire up

```python
scope_repos = compute_finish_audit_scope(
    task, config, graph, container.pr_manager(),
)
run_audit_gate(report, ..., scope_repos=scope_repos)
```

Standalone `mship audit` and `mship spawn`'s audit gate are **unchanged** — the scoping is finish-specific.

## Out of scope

- **Spawn's audit gate**: at spawn time the task has no commits yet, so the same scoping logic doesn't apply. Drift behavior at spawn is the same as before.
- **Surfacing out-of-scope drift in finish output**: the issue body suggested optionally warning. Not done — the user can run `mship audit` separately for the workspace view; finish output stays focused on what's blocking.
- **Cycle handling**: `graph.dependencies` already handles this (it's BFS over the DAG); no special case needed.

## Test plan

- [x] `tests/core/test_audit_gate.py`: 4 new tests for the `scope_repos` parameter (filters out-of-scope errors, still blocks in-scope, force-bypass logs only in-scope codes, None preserves unchanged behavior). 5 new tests for `compute_finish_audit_scope` (includes repos with commits, excludes untouched, includes transitive deps, falls back to main, skips missing worktrees). All 16 pass.
- [x] `tests/test_finish_integration.py`: 1 new integration test (`test_finish_does_not_block_on_drift_in_unrelated_repo`) — spawns affecting `shared,api-gateway`, mocks shared with commits + clean, api-gateway with no commits + dirty. Verifies finish proceeds.
- [x] `tests/test_finish_integration.py`: 2 existing tests updated. Both mocked `rev-list --count` returning 0 unconditionally, which under the new scope means the affected repo is out-of-scope and the dirty-worktree check wouldn't block. Both preserved their intent by mocking count=1, keeping `shared` in scope so the gate still blocks on dirty_worktree as the test expects.
- [x] **Full suite: 1104 passed, 1 deselected** in 1m36s. The deselect is pre-existing #115 (`test_run_with_env_runner` recursive hang).

## Anti-goals preserved

- No global "scope-aware audit" — the scoping is exclusively for `mship finish`. Standalone `mship audit` and `mship spawn` are untouched.
- No new config knobs. The existing `audit.block_finish` workspace policy is unchanged; this PR refines what the gate considers a blocking error.
- No surfacing of out-of-scope drift as a warning in finish output. Users wanting the workspace view should run `mship audit`.

Closes #112