### PR TITLE
fix recursive pytest hang in test_run_with_env_runner

### DIFF
--- a/tests/util/test_shell.py
+++ b/tests/util/test_shell.py
@@ -60,15 +60,23 @@ def test_build_command_with_env_runner():
     assert cmd == "dotenvx run -- task test"
 
 
-def test_run_with_env_runner():
+def test_run_with_env_runner(tmp_path):
+    """`run_task` returns a ShellResult regardless of whether `task` is
+    installed or whether the cwd has a Taskfile target.
+
+    Uses `tmp_path` (no Taskfile.yml) so this test fails fast even in
+    environments where `task` is on PATH. Previously used `Path(".")`,
+    which in dev environments with go-task installed would invoke the
+    project's `task test` target — which itself runs `uv run pytest` —
+    causing infinite recursion and a hung suite. See #115.
+    """
     runner = ShellRunner()
     result = runner.run_task(
         task_name="test",
         actual_task_name="test",
-        cwd=Path("."),
+        cwd=tmp_path,
         env_runner=None,
     )
-    # task binary likely not installed in test env, so we just check it tried
     assert isinstance(result, ShellResult)
 
 


### PR DESCRIPTION
## Summary

Closes #115.

One-line fix: `tests/util/test_shell.py::test_run_with_env_runner` was calling `runner.run_task(cwd=Path("."))`. In environments where go-task is installed and the project's `Taskfile.yml` has `test: uv run pytest`, this recursed: pytest → run_task → `task test` → `uv run pytest` → … — hanging the full suite at ~96% indefinitely.

Fix: use `tmp_path` (no Taskfile present), so `task` exits fast whether or not it's installed. The test's intent — "`run_task` returns a `ShellResult` regardless of environment" — is preserved.

## Why this matters

The hang has been latent in this codebase since `31cb3c1 feat: add ShellRunner utility for subprocess execution with env_runner support`. It only fires in dev environments with go-task on PATH; CI escapes because go-task isn't installed there. Discovered while running PR1's test verification — every full-suite run in PR1, PR2, PR3 had to `--deselect` this test to complete.

## Test plan

- [x] `uv run pytest tests/util/test_shell.py::test_run_with_env_runner` completes in 0.07s (was: hung indefinitely).
- [x] **Full suite: 1109 passed** in 1m37s, **without `--deselect`** for the first time.

## Anti-goals preserved

- No removal of the test. It still validates that `run_task` returns a `ShellResult` even when the task can't be resolved.
- No new dependency on `pytest-timeout` (used locally for diagnosis only; the fix doesn't need it).
- No mocking. The test runs the real `subprocess` invocation; it just does so in a directory where `task` will fail fast.

Closes #115