### PR TITLE
spec_paths config so docs/superpowers/specs/ is found by mship phase dev

### DIFF
--- a/src/mship/container.py
+++ b/src/mship/container.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from dependency_injector import containers, providers
 
 from mship.core.config import ConfigLoader, WorkspaceConfig
@@ -73,6 +75,11 @@ class Container(containers.DeclarativeContainer):
         PhaseManager,
         state_manager=state_manager,
         log=log_manager,
+        config=config,
+        workspace_root=providers.Factory(
+            lambda config_path: Path(config_path).parent,
+            config_path,
+        ),
     )
 
     pr_manager = providers.Factory(

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -107,6 +107,11 @@ class WorkspaceConfig(BaseModel):
     # If set and the effective spawn scope exceeds N repos AND no --repos was
     # passed, require confirmation (TTY) or --yes (non-TTY). See #74.
     spawn_confirm_threshold: int | None = None
+    # Workspace-relative paths searched for specs by `mship phase dev`'s
+    # soft gate and `mship view spec`. None = default `["docs/superpowers/specs"]`
+    # which matches the bundled `brainstorming` / `writing-plans` skill
+    # convention. See #113.
+    spec_paths: list[str] | None = None
     repos: dict[str, RepoConfig]
 
     @model_validator(mode="after")

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -1,9 +1,13 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Literal
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
 
 from mship.core.log import LogManager
 from mship.core.state import StateManager
+
+if TYPE_CHECKING:
+    from mship.core.config import WorkspaceConfig
 
 Phase = Literal["plan", "dev", "review", "run"]
 PHASE_ORDER: list[Phase] = ["plan", "dev", "review", "run"]
@@ -22,9 +26,17 @@ class PhaseTransition:
 class PhaseManager:
     """Manages phase transitions with soft gates."""
 
-    def __init__(self, state_manager: StateManager, log: LogManager) -> None:
+    def __init__(
+        self,
+        state_manager: StateManager,
+        log: LogManager,
+        config: "WorkspaceConfig | None" = None,
+        workspace_root: Path | None = None,
+    ) -> None:
         self._state_manager = state_manager
         self._log = log
+        self._config = config
+        self._workspace_root = workspace_root
 
     def transition(
         self,
@@ -111,7 +123,23 @@ class PhaseManager:
         return warnings
 
     def _gate_dev(self, task_slug: str) -> list[str]:
-        return ["No spec found — consider writing one before developing"]
+        # Without DI'd config + workspace_root we can't actually search for
+        # specs — fall back to the always-warn stub. See #113 for the wiring.
+        if self._config is None or self._workspace_root is None:
+            return ["No spec found — consider writing one before developing"]
+        # Search workspace-level specs + all worktrees (no task= filter):
+        # specs are typically authored before the task slug exists.
+        from mship.core.view.spec_discovery import find_spec, SpecNotFoundError
+        try:
+            find_spec(
+                self._workspace_root,
+                None,
+                state=self._state_manager.load(),
+                spec_paths=self._config.spec_paths,
+            )
+        except SpecNotFoundError:
+            return ["No spec found — consider writing one before developing"]
+        return []
 
     def _gate_review(self, task) -> list[str]:
         # Unified reader honors both task.test_results and journal

--- a/src/mship/core/view/spec_discovery.py
+++ b/src/mship/core/view/spec_discovery.py
@@ -18,6 +18,7 @@ def find_spec(
     *,
     task: str | None = None,
     state: Optional["WorkspaceState"] = None,
+    spec_paths: list[str] | None = None,
 ) -> Path:
     """Resolve a spec file.
 
@@ -26,6 +27,9 @@ def find_spec(
     - `name_or_path=<name>, task=<slug>`: that name, searching only the task's worktrees.
     - `name_or_path=<name>, task=None, state=<state>`: that name, searching main + every worktree.
     - `name_or_path=<absolute path>`: that literal file.
+
+    `spec_paths` (workspace-relative) overrides the default `docs/superpowers/specs`
+    search root. None = default. See #113.
     """
     if name_or_path is not None:
         candidate = Path(name_or_path)
@@ -34,7 +38,7 @@ def find_spec(
                 return candidate
             raise SpecNotFoundError(f"Spec not found: {name_or_path}")
 
-    search_roots = _resolve_search_roots(workspace_root, task, state)
+    search_roots = _resolve_search_roots(workspace_root, task, state, spec_paths)
 
     if name_or_path is None:
         return _newest_across(search_roots, task)
@@ -54,18 +58,21 @@ def _resolve_search_roots(
     workspace_root: Path,
     task: str | None,
     state: "WorkspaceState | None",
+    spec_paths: list[str] | None = None,
 ) -> list[Path]:
+    subdirs = [Path(p) for p in spec_paths] if spec_paths else [SPEC_SUBDIR]
     if task is not None:
         if state is None or task not in state.tasks:
             raise SpecNotFoundError(f"Unknown task: {task!r}")
         worktrees = state.tasks[task].worktrees
-        roots = [Path(p) / SPEC_SUBDIR for p in worktrees.values()]
+        roots = [Path(p) / sub for p in worktrees.values() for sub in subdirs]
         return [r for r in roots if r.is_dir()] or roots
-    roots: list[Path] = [workspace_root / SPEC_SUBDIR]
+    roots: list[Path] = [workspace_root / sub for sub in subdirs]
     if state is not None:
         for t in state.tasks.values():
             for wt in t.worktrees.values():
-                roots.append(Path(wt) / SPEC_SUBDIR)
+                for sub in subdirs:
+                    roots.append(Path(wt) / sub)
     return roots
 
 

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -31,10 +31,63 @@ def state_with_task(tmp_path: Path) -> StateManager:
     return mgr
 
 
-def test_transition_plan_to_dev(state_with_task: StateManager):
-    pm = PhaseManager(state_with_task, MagicMock(spec=LogManager))
+def _make_phase_manager(state_mgr: StateManager, workspace_root: Path,
+                        spec_paths: list[str] | None = None) -> PhaseManager:
+    """Helper: build a PhaseManager with the optional spec_paths override."""
+    from mship.core.config import WorkspaceConfig, RepoConfig
+    config = WorkspaceConfig(
+        workspace="test",
+        repos={"shared": RepoConfig(path=Path("./shared"), type="library")},
+        spec_paths=spec_paths,
+    )
+    return PhaseManager(
+        state_mgr,
+        MagicMock(spec=LogManager),
+        config=config,
+        workspace_root=workspace_root,
+    )
+
+
+def test_transition_plan_to_dev_warns_when_no_spec_exists(state_with_task: StateManager, tmp_path: Path):
+    """No spec at any search path → warn (current behavior, but now actually evidence-based)."""
+    pm = _make_phase_manager(state_with_task, tmp_path)
     result = pm.transition("add-labels", "dev")
     assert result.new_phase == "dev"
+    assert any("spec" in w.lower() for w in result.warnings)
+
+
+def test_transition_plan_to_dev_silent_when_spec_at_default_path(
+    state_with_task: StateManager, tmp_path: Path,
+):
+    """Spec at the default `docs/superpowers/specs/` should suppress the warning. See #113."""
+    spec_dir = tmp_path / "docs" / "superpowers" / "specs"
+    spec_dir.mkdir(parents=True)
+    (spec_dir / "2026-04-27-add-labels-design.md").write_text("# spec\n")
+    pm = _make_phase_manager(state_with_task, tmp_path)
+    result = pm.transition("add-labels", "dev")
+    assert result.new_phase == "dev"
+    assert not any("spec" in w.lower() for w in result.warnings), result.warnings
+
+
+def test_transition_plan_to_dev_silent_when_spec_at_configured_path(
+    state_with_task: StateManager, tmp_path: Path,
+):
+    """A configured `spec_paths` override is honored. See #113."""
+    custom = tmp_path / "design" / "specs"
+    custom.mkdir(parents=True)
+    (custom / "feature.md").write_text("# spec\n")
+    pm = _make_phase_manager(state_with_task, tmp_path, spec_paths=["design/specs"])
+    result = pm.transition("add-labels", "dev")
+    assert not any("spec" in w.lower() for w in result.warnings), result.warnings
+
+
+def test_transition_plan_to_dev_warns_when_configured_path_empty(
+    state_with_task: StateManager, tmp_path: Path,
+):
+    """Configured spec_paths but no specs → still warns."""
+    (tmp_path / "design" / "specs").mkdir(parents=True)
+    pm = _make_phase_manager(state_with_task, tmp_path, spec_paths=["design/specs"])
+    result = pm.transition("add-labels", "dev")
     assert any("spec" in w.lower() for w in result.warnings)
 
 


### PR DESCRIPTION
## Summary

Closes #113.

`mship phase dev` no longer warns "No spec found" when a spec actually exists at the canonical `docs/superpowers/specs/` path used by the bundled `brainstorming` and `writing-plans` skills. Closes the convention gap between the in-tree skills fork (which **writes** specs to `docs/superpowers/specs/`) and the CLI default (which now **reads** from there).

## Two-part fix

### 1. Wire the dev-gate to actually search

The `"No spec found"` warning at `_gate_dev` was a **static stub** — it always fired regardless of repo state. The discovery function (`find_spec` in `src/mship/core/view/spec_discovery.py`) already existed and was used by `mship view spec`, but the phase gate never called it.

```python
# Before
def _gate_dev(self, task_slug: str) -> list[str]:
    return ["No spec found — consider writing one before developing"]

# After
def _gate_dev(self, task_slug: str) -> list[str]:
    if self._config is None or self._workspace_root is None:
        return ["No spec found — consider writing one before developing"]
    try:
        find_spec(self._workspace_root, None, state=..., spec_paths=self._config.spec_paths)
    except SpecNotFoundError:
        return ["No spec found — consider writing one before developing"]
    return []
```

### 2. Configurable `spec_paths` in `WorkspaceConfig`

Add a workspace-level override for teams using a different convention:

```yaml
spec_paths:
  - design/specs
  - docs/architecture
```

Default value (when omitted): `["docs/superpowers/specs"]` — the bundled-skills convention works out of the box.

Threaded through `find_spec` and `_resolve_search_roots` so `mship view spec` benefits automatically.

## Why backward-compat for `PhaseManager`

`config` and `workspace_root` are optional kwargs (default `None`). When either is missing, the gate falls back to the always-warn stub. This keeps every existing test (12+ instantiations across `test_phase.py` and `test_concurrent_mutations.py`) green without modification — they get the previous behavior. Production wiring through the DI container always provides both, so users see the new behavior.

## Test plan

- [x] `tests/core/test_phase.py`: 4 new tests
  - `test_transition_plan_to_dev_warns_when_no_spec_exists` — empty workspace still warns.
  - `test_transition_plan_to_dev_silent_when_spec_at_default_path` — spec at `docs/superpowers/specs/` suppresses warning.
  - `test_transition_plan_to_dev_silent_when_spec_at_configured_path` — `spec_paths` override honored.
  - `test_transition_plan_to_dev_warns_when_configured_path_empty` — configured path with no specs still warns.
- [x] **Full suite: 1112 passed** in 1m37s.

## Anti-goals

- **No glob/pattern matching** for spec discovery beyond what already existed (`.iterdir()` on the configured roots). The schema is "list of directories"; per-task name matching stays in the existing `find_spec(name_or_path=...)` API.
- **No automatic spec creation.** The gate detects absence and warns; it doesn't generate templates.
- **No removal of the always-warn fallback in `PhaseManager`.** Existing test fixtures don't carry config; the fallback keeps them green without forcing every test to mock a workspace.

## Skill/CLI coherence signal

This is the smallest fix that proves the substrate-with-bundled-methodology positioning: the bundled skills' write convention and the CLI's read convention are now aligned by default. Teams using a different methodology declare `spec_paths` per workspace; everyone else gets the bundled experience for free.

Closes #113