### PR TITLE
mship finish --body-map per-repo PR bodies mirroring --base-map

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -682,6 +682,12 @@ def register(app: typer.Typer, get_container):
                  "Recommended for agents: write a Summary + Test plan rather than "
                  "letting finish fall back to the task description.",
         ),
+        body_map: Optional[str] = typer.Option(
+            None, "--body-map",
+            help="Per-repo PR body overrides, e.g. 'shared=/tmp/shared.md,api=/tmp/api.md'. "
+                 "Each value is a path to a markdown file. Repos not in the map fall back "
+                 "to --body / --body-file, then to the task description. See #114.",
+        ),
         force: bool = typer.Option(
             False, "--force", "-f",
             help="Push new commits to an already-finished task's existing PR(s). "
@@ -717,7 +723,7 @@ def register(app: typer.Typer, get_container):
         if force and handoff:
             output.error("--force is incompatible with --handoff")
             raise typer.Exit(code=1)
-        if force and (body is not None or body_file is not None):
+        if force and (body is not None or body_file is not None or body_map is not None):
             output.error(
                 "--force doesn't touch PR bodies — use `gh pr edit <url> --body-file <path>` "
                 "to update an existing PR body"
@@ -737,8 +743,8 @@ def register(app: typer.Typer, get_container):
         if body is not None and body_file is not None:
             output.error("--body and --body-file are mutually exclusive")
             raise typer.Exit(code=1)
-        if (body is not None or body_file is not None) and (push_only or handoff):
-            output.error("--body/--body-file has no effect with --push-only or --handoff")
+        if (body is not None or body_file is not None or body_map is not None) and (push_only or handoff):
+            output.error("--body/--body-file/--body-map has no effect with --push-only or --handoff")
             raise typer.Exit(code=1)
         custom_body: Optional[str] = None
         if body is not None:
@@ -761,6 +767,20 @@ def register(app: typer.Typer, get_container):
                 "to fall back to the task description."
             )
             raise typer.Exit(code=1)
+
+        # Parse --body-map; defer file reads until we know task.affected_repos.
+        from mship.core.body_resolver import (
+            EmptyBodyInMapError,
+            InvalidBodyMapError,
+            UnknownRepoInBodyMapError,
+            parse_body_map,
+        )
+        try:
+            body_map_parsed = parse_body_map(body_map or "")
+        except InvalidBodyMapError as e:
+            output.error(str(e))
+            raise typer.Exit(code=1)
+
         state_mgr = container.state_manager()
         state = state_mgr.load()
 
@@ -770,6 +790,17 @@ def register(app: typer.Typer, get_container):
         graph = container.graph()
         config = container.config()
         ordered = graph.topo_sort(task.affected_repos)
+
+        # Load --body-map files now that task.affected_repos is available.
+        from mship.core.body_resolver import load_body_map
+        try:
+            body_map_loaded = load_body_map(body_map_parsed, task.affected_repos)
+        except UnknownRepoInBodyMapError as e:
+            output.error(str(e))
+            raise typer.Exit(code=1)
+        except (InvalidBodyMapError, EmptyBodyInMapError) as e:
+            output.error(str(e))
+            raise typer.Exit(code=1)
 
         # --- Audit gate ---
         from mship.core.audit_gate import run_audit_gate, AuditGateBlocked, compute_finish_audit_scope
@@ -1149,7 +1180,19 @@ def register(app: typer.Typer, get_container):
                                 texts.append(line)
                 except Exception:
                     pass
-                pr_body_base = custom_body if custom_body is not None else task.description
+                # Per-PR body precedence: --body-map entry > --body/--body-file > task.description.
+                # Multi-repo groups (git_root sharing) use the rep_name's entry if any member matches.
+                map_body: Optional[str] = None
+                for member in group.members:
+                    if member in body_map_loaded:
+                        map_body = body_map_loaded[member]
+                        break
+                if map_body is not None:
+                    pr_body_base = map_body
+                elif custom_body is not None:
+                    pr_body_base = custom_body
+                else:
+                    pr_body_base = task.description
                 pr_body = append_closes_footer(pr_body_base, extract_issue_refs(texts))
 
                 try:

--- a/src/mship/core/body_resolver.py
+++ b/src/mship/core/body_resolver.py
@@ -1,0 +1,87 @@
+"""Resolve per-PR bodies for `mship finish --body-map`. See #114.
+
+Mirrors the shape of `base_resolver.py`. Body values are file paths read at
+finish time, not inline strings — bodies tend to be multi-line markdown that
+the user already has in a file.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+
+class InvalidBodyMapError(ValueError):
+    pass
+
+
+class UnknownRepoInBodyMapError(ValueError):
+    pass
+
+
+class EmptyBodyInMapError(ValueError):
+    pass
+
+
+def parse_body_map(raw: str) -> dict[str, str]:
+    """Parse 'repoA=path,repoB=path' into a dict.
+
+    Empty input returns {}. Whitespace around keys, values, and separators is
+    stripped. Raises InvalidBodyMapError on malformed input.
+    """
+    if not raw or not raw.strip():
+        return {}
+    out: dict[str, str] = {}
+    for pair in raw.split(","):
+        if "=" not in pair:
+            raise InvalidBodyMapError(
+                f"Invalid --body-map entry {pair!r}: expected repo=path"
+            )
+        key, _, value = pair.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if not key or not value:
+            raise InvalidBodyMapError(
+                f"Invalid --body-map entry {pair!r}: key and value must be non-empty"
+            )
+        out[key] = value
+    return out
+
+
+def load_body_map(
+    body_map: dict[str, str],
+    known_repos: Iterable[str],
+) -> dict[str, str]:
+    """Validate repos and read each file. Returns {repo: body_text}.
+
+    Raises:
+        UnknownRepoInBodyMapError: a key isn't in `known_repos`.
+        InvalidBodyMapError: a path can't be read.
+        EmptyBodyInMapError: a file is empty (whitespace-only counts as empty).
+
+    Empty input returns {} so callers can unconditionally call this and fall
+    back to the catch-all body source when the map is empty.
+    """
+    if not body_map:
+        return {}
+    known = set(known_repos)
+    unknown = [r for r in body_map if r not in known]
+    if unknown:
+        raise UnknownRepoInBodyMapError(
+            f"Unknown repo(s) in --body-map: {', '.join(sorted(unknown))}. "
+            f"Known: {sorted(known)}"
+        )
+    out: dict[str, str] = {}
+    for repo, path in body_map.items():
+        try:
+            content = Path(path).read_text()
+        except OSError as e:
+            raise InvalidBodyMapError(
+                f"Could not read --body-map file for {repo!r}: {path}: {e}"
+            )
+        if not content.strip():
+            raise EmptyBodyInMapError(
+                f"PR body for {repo!r} is empty: {path}. "
+                f"Write a Summary + Test plan, or omit the entry to fall back."
+            )
+        out[repo] = content
+    return out

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -447,6 +447,114 @@ def test_finish_body_file_passed_to_gh_pr_create(configured_git_app: Path):
         cli_container.shell.reset_override()
 
 
+def test_finish_body_map_per_repo_bodies(configured_git_app: Path):
+    """--body-map gives each PR its own body; --body-file is the catch-all
+    for repos not in the map. See #114."""
+    from mship.cli import container as cli_container
+
+    runner.invoke(app, ["spawn", "body map", "--repos", "shared,api-gateway"])
+
+    shared_body = configured_git_app / "shared.md"
+    shared_body.write_text("## Shared\n- lib change\n\n## Test plan\n- [ ] unit\n")
+    api_body = configured_git_app / "api.md"
+    api_body.write_text("## API\n- consumer update\n\n## Test plan\n- [ ] integration\n")
+    fallback_body = configured_git_app / "fallback.md"
+    fallback_body.write_text("## Fallback\n- shared body\n\n## Test plan\n- [ ] noop\n")
+
+    captured_per_repo: dict[str, str] = {}
+
+    def mock_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            cwd_str = str(cwd)
+            for repo in ("shared", "api-gateway"):
+                if repo in cwd_str:
+                    captured_per_repo[repo] = cmd
+                    break
+            return ShellResult(returncode=0, stdout="https://x/pr/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = mock_run
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    cli_container.shell.override(mock_shell)
+    try:
+        result = runner.invoke(
+            app, [
+                "finish",
+                "--task", "body-map",
+                "--body-map", f"shared={shared_body}",
+                "--body-file", str(fallback_body),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # 'shared' got its mapped body.
+        assert "## Shared" in captured_per_repo["shared"]
+        assert "- lib change" in captured_per_repo["shared"]
+        # 'api-gateway' was not in the map → fell back to --body-file.
+        assert "## Fallback" in captured_per_repo["api-gateway"]
+        assert "- shared body" in captured_per_repo["api-gateway"]
+    finally:
+        cli_container.shell.reset_override()
+
+
+def test_finish_body_map_unknown_repo_rejected(configured_git_app: Path):
+    """--body-map referencing a repo NOT in task.affected_repos errors clearly."""
+    from mship.cli import container as cli_container
+
+    runner.invoke(app, ["spawn", "unknown body", "--repos", "shared"])
+
+    body_path = configured_git_app / "ghost.md"
+    body_path.write_text("## body\n- noop\n\n## Test plan\n- [ ] x\n")
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    cli_container.shell.override(mock_shell)
+    try:
+        result = runner.invoke(
+            app, [
+                "finish",
+                "--task", "unknown-body",
+                "--body-map", f"ghost={body_path}",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "ghost" in result.output.lower() or "unknown" in result.output.lower()
+    finally:
+        cli_container.shell.reset_override()
+
+
+def test_finish_body_map_empty_body_rejected(configured_git_app: Path):
+    """An empty file in --body-map is rejected (consistent with --body-file rule)."""
+    from mship.cli import container as cli_container
+
+    runner.invoke(app, ["spawn", "empty body", "--repos", "shared"])
+
+    body_path = configured_git_app / "empty.md"
+    body_path.write_text("   \n\n  \n")
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    cli_container.shell.override(mock_shell)
+    try:
+        result = runner.invoke(
+            app, [
+                "finish",
+                "--task", "empty-body",
+                "--body-map", f"shared={body_path}",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "empty" in result.output.lower()
+    finally:
+        cli_container.shell.reset_override()
+
+
 def test_close_accepts_positional_slug(configured_git_app: Path):
     """`mship close <slug>` is an alternative to `--task <slug>`. See #40."""
     runner.invoke(app, ["spawn", "positional close", "--repos", "shared"])

--- a/tests/core/test_body_resolver.py
+++ b/tests/core/test_body_resolver.py
@@ -1,0 +1,90 @@
+"""Tests for body_resolver — `--body-map` parsing and per-repo body loading.
+
+Mirrors the shape of test_base_resolver.py but for PR bodies. See #114.
+"""
+from pathlib import Path
+
+import pytest
+
+from mship.core.body_resolver import (
+    EmptyBodyInMapError,
+    InvalidBodyMapError,
+    UnknownRepoInBodyMapError,
+    load_body_map,
+    parse_body_map,
+)
+
+
+def test_parse_body_map_empty_string_returns_empty_dict():
+    assert parse_body_map("") == {}
+    assert parse_body_map("   ") == {}
+
+
+def test_parse_body_map_single_pair():
+    assert parse_body_map("api=/tmp/api.md") == {"api": "/tmp/api.md"}
+
+
+def test_parse_body_map_multiple_pairs():
+    result = parse_body_map("api=/tmp/a.md,shared=/tmp/s.md")
+    assert result == {"api": "/tmp/a.md", "shared": "/tmp/s.md"}
+
+
+def test_parse_body_map_strips_whitespace():
+    assert parse_body_map(" api = /tmp/a.md , shared = /tmp/s.md ") == {
+        "api": "/tmp/a.md",
+        "shared": "/tmp/s.md",
+    }
+
+
+def test_parse_body_map_missing_equals_raises():
+    with pytest.raises(InvalidBodyMapError, match="expected repo=path"):
+        parse_body_map("api/tmp/a.md")
+
+
+def test_parse_body_map_empty_key_raises():
+    with pytest.raises(InvalidBodyMapError, match="non-empty"):
+        parse_body_map("=/tmp/a.md")
+
+
+def test_parse_body_map_empty_value_raises():
+    with pytest.raises(InvalidBodyMapError, match="non-empty"):
+        parse_body_map("api=")
+
+
+def test_load_body_map_reads_files(tmp_path: Path):
+    a = tmp_path / "a.md"
+    a.write_text("## API body\n")
+    s = tmp_path / "s.md"
+    s.write_text("## Shared body\n")
+    result = load_body_map(
+        {"api": str(a), "shared": str(s)},
+        known_repos=["api", "shared", "other"],
+    )
+    assert result == {"api": "## API body\n", "shared": "## Shared body\n"}
+
+
+def test_load_body_map_unknown_repo_raises(tmp_path: Path):
+    a = tmp_path / "a.md"
+    a.write_text("body")
+    with pytest.raises(UnknownRepoInBodyMapError, match="ghost"):
+        load_body_map({"ghost": str(a)}, known_repos=["api", "shared"])
+
+
+def test_load_body_map_missing_file_raises(tmp_path: Path):
+    with pytest.raises(InvalidBodyMapError, match="Could not read"):
+        load_body_map(
+            {"api": str(tmp_path / "missing.md")},
+            known_repos=["api"],
+        )
+
+
+def test_load_body_map_empty_body_raises(tmp_path: Path):
+    empty = tmp_path / "empty.md"
+    empty.write_text("   \n  \n")  # whitespace only
+    with pytest.raises(EmptyBodyInMapError, match="api"):
+        load_body_map({"api": str(empty)}, known_repos=["api"])
+
+
+def test_load_body_map_empty_input_returns_empty(tmp_path: Path):
+    """Empty parsed map produces empty loaded map — finish proceeds with fallback."""
+    assert load_body_map({}, known_repos=["api"]) == {}


### PR DESCRIPTION
## Summary

Closes #114.

```bash
mship finish --body-map shared=/tmp/shared.md,api=/tmp/api.md
```

Each value is a path to a markdown file. Repos not in the map fall back to `--body` / `--body-file`, then to the task description. Mirrors the `--base-map` shape exactly.

Useful when one repo's PR is doc-heavy and another's is code-heavy and the same shared body wastes reviewer attention on both. The workaround (writing per-repo sections in one shared body) is fine for small tasks but degrades at 3+ repos with very different review concerns.

## Precedence

```
--body-map entry for repo  >  --body / --body-file  >  task.description (auto)
```

Empty bodies are rejected at every level (consistent with the existing `--body-file` rule).

## New module: `src/mship/core/body_resolver.py`

Mirrors `base_resolver.py` shape:

- `parse_body_map(raw)` — `'repoA=path,repoB=path'` → `dict[str, str]`. Strips whitespace, raises `InvalidBodyMapError` on malformed input.
- `load_body_map(map, known_repos)` — validates repos, reads each file, returns `{repo: body_text}`. Raises `UnknownRepoInBodyMapError`, `InvalidBodyMapError` (unreadable), `EmptyBodyInMapError`.
- Eager file reads at finish time so all errors fire before any PR is created.

## Wiring in `mship finish`

- New `--body-map` typer option.
- Parsed early (before any state mutation); files loaded after task resolution.
- Validated against `task.affected_repos`, not `config.repos.keys()` — if you spawned with `--repos shared,api` you can only `--body-map` those two.
- Multi-repo PR groups (git_root sharing): picks the first matching member's body.

Existing flag conventions extended:
- Incompatible with `--push-only`, `--handoff` (no PR is created).
- Incompatible with `--force` (existing rule: `--force` doesn't touch bodies).
- Coexists with `--body` / `--body-file` (the latter is the catch-all).

## Test plan

- [x] `tests/core/test_body_resolver.py`: 12 unit tests
  - `parse_body_map`: empty, single, multiple, whitespace, malformed, empty key/value
  - `load_body_map`: reads files, unknown repo, missing file, empty body, empty input passthrough
- [x] `tests/cli/test_worktree.py`: 3 integration tests
  - `test_finish_body_map_per_repo_bodies` — two repos, one mapped + one falling back to `--body-file`. Verifies each PR gets its own body via captured `gh pr create` cwd.
  - `test_finish_body_map_unknown_repo_rejected` — `--body-map ghost=...` exits 1 with clear error.
  - `test_finish_body_map_empty_body_rejected` — whitespace-only file in map exits 1.
- [x] **Full suite: 1127 passed** in 1m39s.

## Anti-goals preserved

- **No inline body strings in map** (would be `--body-map shared='...'`). The values are paths only — bodies tend to be multi-line markdown the user already has on disk; inline strings would clash with shell quoting and the `--body` flag.
- **No glob patterns / repo wildcards** (`shared/*=path`). Validate against explicit `task.affected_repos`.
- **No "auto-generate per-repo bodies from journal"** — that's a different feature (could be a future flag), not what `--body-map` solves.

Closes #114