### PR TITLE
hub worktree layout

### DIFF
--- a/docs/superpowers/plans/2026-04-28-hub-worktree-layout.md
+++ b/docs/superpowers/plans/2026-04-28-hub-worktree-layout.md
@@ -1,0 +1,2085 @@
+# Hub Worktree Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace per-repo `<repo>/.worktrees/feat/<slug>/` layout with per-task hub `<workspace>/.worktrees/<slug>/<repo>/`, and auto-materialize `depends_on` siblings as detached-HEAD passive worktrees pinned to `origin/<expected_branch || base_branch>`.
+
+**Architecture:** Per-task hub directory under workspace root. Affected repos checked out on `feat/<slug>`. Passive deps materialized at `origin/<ref>` after fetch (no stale local refs). Pre-commit hook refuses commits in passive worktrees. State.yaml gains `Task.passive_repos: set[str]` so all consumers can ask "is this passive?"
+
+**Tech Stack:** Python 3.13, pydantic, typer, pytest. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-28-hub-worktree-layout-design.md`
+
+**PR sequence:** 8 phases, each ending in green tests + commit. Each phase is a natural PR boundary; in particular, Phase 1 (state field) and Phase 2 (hub layout) must merge in order, after which Phases 3–8 can be parallelized if desired.
+
+---
+
+## File Map
+
+**Created:**
+- (none — extend existing modules)
+
+**Modified:**
+- `src/mship/core/state.py` — add `Task.passive_repos`
+- `src/mship/core/worktree.py` — hub layout, passive worktree creation, abort cleanup
+- `src/mship/util/git.py` — `worktree_add_detached`, `fetch_remote_ref` helpers
+- `src/mship/cli/worktree.py` — pass `--offline` to spawn
+- `src/mship/cli/internal.py` — `_check-commit` refuses passive worktrees
+- `src/mship/core/repo_state.py` — passive issue codes (`passive_drift`, `passive_dirty_worktree`, `passive_fetch_failed`)
+- `src/mship/cli/audit.py` — surface passive issues
+- `src/mship/core/repo_sync.py` — refresh passive worktrees
+- `src/mship/cli/sync.py` — `--no-passive` flag
+- `src/mship/core/prune.py` — scan `<workspace>/.worktrees/` for orphans alongside legacy `<repo>/.worktrees/`
+- `src/mship/core/doctor.py` — workspace `.gitignore` check
+- `src/mship/core/switch.py` — annotate passive in handoff
+- `src/mship/cli/switch.py` — warn when target is passive
+- `src/mship/cli/phase.py`, `src/mship/cli/exec.py` — refuse `phase`/`test` against passive active_repo
+
+**Tests modified or added:**
+- `tests/core/test_state.py`, `tests/core/test_worktree.py`, `tests/cli/test_internal.py`, `tests/test_hook_integration.py`, `tests/core/test_repo_state.py`, `tests/core/test_repo_sync.py`, `tests/cli/test_sync.py`, `tests/core/test_prune.py`, `tests/core/test_doctor.py`, `tests/core/test_switch.py`
+
+**No code change required (verify only):**
+- `mship bind refresh` — `WorktreeManager.refresh_bind_files` and `refresh_symlink_dirs` iterate over each `task.worktrees` entry (#71, #111). Passive worktrees live in the same `worktrees` dict, so they're picked up automatically. Phase 8 should add a smoke test confirming `bind refresh` covers passive worktrees, but no implementation change is required.
+
+---
+
+## Phase 1 — State model: `Task.passive_repos`
+
+Foundation. Adds the field that every later phase consults.
+
+### Task 1.1: Add `passive_repos` field to Task
+
+**Files:**
+- Modify: `src/mship/core/state.py:19-36`
+- Test: `tests/core/test_state.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_state.py`:
+
+```python
+def test_task_passive_repos_defaults_empty(tmp_path):
+    from mship.core.state import StateManager, Task, WorkspaceState
+    from datetime import datetime, timezone
+    sm = StateManager(tmp_path)
+    state = WorkspaceState(tasks={
+        "t": Task(
+            slug="t", description="d", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["a"], branch="feat/t",
+        )
+    })
+    sm.save(state)
+    loaded = sm.load()
+    assert loaded.tasks["t"].passive_repos == set()
+
+
+def test_task_passive_repos_round_trips(tmp_path):
+    from mship.core.state import StateManager, Task, WorkspaceState
+    from datetime import datetime, timezone
+    sm = StateManager(tmp_path)
+    state = WorkspaceState(tasks={
+        "t": Task(
+            slug="t", description="d", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["a", "b"], branch="feat/t",
+            passive_repos={"b"},
+        )
+    })
+    sm.save(state)
+    loaded = sm.load()
+    assert loaded.tasks["t"].passive_repos == {"b"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+uv run pytest tests/core/test_state.py::test_task_passive_repos_defaults_empty tests/core/test_state.py::test_task_passive_repos_round_trips -v
+```
+
+Expected: FAIL — `Task.__init__()` rejects unexpected `passive_repos`.
+
+- [ ] **Step 3: Add the field**
+
+Edit `src/mship/core/state.py`. Inside `class Task(BaseModel)`, after `base_branch: str | None = None`:
+
+```python
+    passive_repos: set[str] = set()
+```
+
+- [ ] **Step 4: Update `_save_nolock` so the set serializes deterministically**
+
+In `state.py`, find the section that converts `worktrees` for serialization:
+
+```python
+        for task in data.get("tasks", {}).values():
+            task["worktrees"] = {
+                k: str(v) for k, v in task.get("worktrees", {}).items()
+            }
+```
+
+Add immediately after:
+
+```python
+            if "passive_repos" in task:
+                task["passive_repos"] = sorted(task["passive_repos"])
+```
+
+(Pydantic dumps `set` as `list` already; sorting makes diff-friendly.)
+
+- [ ] **Step 5: Run tests, expect PASS**
+
+```
+uv run pytest tests/core/test_state.py -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mship/core/state.py tests/core/test_state.py
+git commit -m "feat(state): add Task.passive_repos for hub layout passive worktrees"
+mship journal "phase 1: passive_repos field on Task; round-trip tested" --action committed
+```
+
+---
+
+## Phase 2 — Hub layout for affected repos
+
+Move new spawns to `<workspace>/.worktrees/<slug>/<repo>/`. No passive yet — that's Phase 3. Legacy in-flight tasks unaffected.
+
+### Task 2.1: Compute hub paths in WorktreeManager.spawn
+
+**Files:**
+- Modify: `src/mship/core/worktree.py` (the `spawn` method, ~line 398)
+- Test: `tests/core/test_worktree.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_worktree.py`:
+
+```python
+def test_spawn_uses_hub_layout(worktree_deps):
+    """New spawns place worktrees at <workspace>/.worktrees/<slug>/<repo>/, not <repo>/.worktrees/."""
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("hub layout", repos=["shared", "auth-service"], workspace_root=workspace)
+    state = state_mgr.load()
+    task = state.tasks["hub-layout"]
+    expected_hub = workspace / ".worktrees" / "hub-layout"
+    assert Path(task.worktrees["shared"]) == expected_hub / "shared"
+    assert Path(task.worktrees["auth-service"]) == expected_hub / "auth-service"
+    assert (expected_hub / "shared").exists()
+    assert (expected_hub / "auth-service").exists()
+
+
+def test_spawn_writes_single_marker_at_hub_root(worktree_deps):
+    """One .mship-workspace marker per hub, not per worktree."""
+    from mship.core.workspace_marker import MARKER_NAME
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("marker test", repos=["shared", "auth-service"], workspace_root=workspace)
+    hub = workspace / ".worktrees" / "marker-test"
+    assert (hub / MARKER_NAME).is_file()
+    # No per-worktree markers
+    assert not (hub / "shared" / MARKER_NAME).exists()
+    assert not (hub / "auth-service" / MARKER_NAME).exists()
+
+
+def test_spawn_workspace_gitignore_includes_worktrees(worktree_deps, tmp_path):
+    """Workspace root .gitignore (if root is a git repo) gets `.worktrees` added."""
+    import subprocess
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    # Make the workspace root itself a git repo
+    subprocess.run(["git", "init", "-q", str(workspace)], check=True, capture_output=True)
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("ignore test", repos=["shared"], workspace_root=workspace)
+    gi = workspace / ".gitignore"
+    assert gi.exists()
+    assert ".worktrees" in gi.read_text().splitlines()
+```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+```
+uv run pytest tests/core/test_worktree.py::test_spawn_uses_hub_layout tests/core/test_worktree.py::test_spawn_writes_single_marker_at_hub_root tests/core/test_worktree.py::test_spawn_workspace_gitignore_includes_worktrees -v
+```
+
+Expected: FAIL — current spawn places worktrees under `<repo>/.worktrees/`.
+
+- [ ] **Step 3: Refactor `WorktreeManager.spawn` to use hub paths**
+
+Replace the body of the `for repo_name in ordered:` loop in `src/mship/core/worktree.py` (~lines 429–502).
+
+The new loop has THREE branches:
+1. `git_root` repos: nested under their parent's hub worktree (path math same as today, just rooted differently).
+2. Normal repos: hub worktree at `<hub>/<repo>/`.
+3. (Phase 3 will add a fourth branch for passive — placeholder NotImplementedError for now.)
+
+Replace from line 429 (`for repo_name in ordered:`) through line 502 (end of normal-repo branch) with:
+
+```python
+        if workspace_root is None:
+            raise ValueError(
+                "workspace_root required for hub layout spawn; "
+                "callers must pass container.config_path().parent"
+            )
+
+        hub = workspace_root / ".worktrees" / slug
+        hub.mkdir(parents=True, exist_ok=True)
+
+        # Workspace-root .gitignore gets .worktrees if root is a git repo.
+        if (workspace_root / ".git").exists():
+            if not self._git.is_ignored(workspace_root, ".worktrees"):
+                self._git.add_to_gitignore(workspace_root, ".worktrees")
+
+        for repo_name in ordered:
+            repo_config = self._config.repos[repo_name]
+
+            if repo_config.git_root is not None:
+                # Subdirectory child: nested inside parent's hub worktree.
+                parent_wt = worktrees.get(repo_config.git_root)
+                if parent_wt is None:
+                    parent_wt = self._config.repos[repo_config.git_root].path
+                effective = parent_wt / repo_config.path
+                worktrees[repo_name] = effective
+
+                symlink_warnings = self._create_symlinks(repo_name, repo_config, effective)
+                setup_warnings.extend(symlink_warnings)
+                bind_warnings = self._copy_bind_files(repo_name, repo_config, effective)
+                setup_warnings.extend(bind_warnings)
+
+                if not skip_setup and shutil.which("task") is not None:
+                    actual_setup = repo_config.tasks.get("setup", "setup")
+                    setup_result = self._shell.run_task(
+                        task_name="setup",
+                        actual_task_name=actual_setup,
+                        cwd=effective,
+                        env_runner=repo_config.env_runner or self._config.env_runner,
+                    )
+                    if setup_result.returncode != 0:
+                        setup_warnings.append(
+                            f"{repo_name}: setup failed (task '{actual_setup}') — "
+                            f"{setup_result.stderr.strip()[:200]}"
+                        )
+                continue
+
+            # Normal repo: hub worktree.
+            repo_path = repo_config.path
+            wt_path = hub / repo_name
+
+            self._git.worktree_add(
+                repo_path=repo_path,
+                worktree_path=wt_path,
+                branch=branch,
+            )
+            worktrees[repo_name] = wt_path
+
+            symlink_warnings = self._create_symlinks(repo_name, repo_config, wt_path)
+            setup_warnings.extend(symlink_warnings)
+            bind_warnings = self._copy_bind_files(repo_name, repo_config, wt_path)
+            setup_warnings.extend(bind_warnings)
+
+            if not skip_setup and shutil.which("task") is not None:
+                actual_setup = repo_config.tasks.get("setup", "setup")
+                setup_result = self._shell.run_task(
+                    task_name="setup",
+                    actual_task_name=actual_setup,
+                    cwd=wt_path,
+                    env_runner=repo_config.env_runner or self._config.env_runner,
+                )
+                if setup_result.returncode != 0:
+                    setup_warnings.append(
+                        f"{repo_name}: setup failed (task '{actual_setup}') — "
+                        f"{setup_result.stderr.strip()[:200]}"
+                    )
+
+        # Single .mship-workspace marker at the hub root.
+        write_marker(hub, workspace_root)
+```
+
+- [ ] **Step 4: Remove the old per-repo `.worktrees` and `.mship-workspace` gitignore additions**
+
+The old code (lines 464–467, before the refactor) added `.worktrees` and `MARKER_NAME` to the canonical repo's gitignore. These additions are no longer needed (worktrees and marker live in workspace, not in repos), and the per-repo additions are inert in the new layout. Leave any pre-existing entries as-is — don't backfill removals. The `add_to_gitignore` call on the workspace root replaces them.
+
+(No code change in this step beyond verifying you removed those lines in step 3's replacement.)
+
+- [ ] **Step 5: Run tests**
+
+```
+uv run pytest tests/core/test_worktree.py -v
+```
+
+Expected: the three new tests PASS. Some existing tests in `test_worktree.py` and integration tests will FAIL because they assume the old layout — fix in Task 2.2.
+
+- [ ] **Step 6: Commit (don't mship journal yet — phase isn't green)**
+
+```bash
+git add src/mship/core/worktree.py tests/core/test_worktree.py
+git commit -m "feat(worktree): hub layout for spawn (passive deferred to phase 3)"
+```
+
+### Task 2.2: Update existing tests that assume per-repo layout
+
+**Files:**
+- Modify: `tests/core/test_worktree.py`, `tests/test_hook_integration.py`, `tests/test_integration.py`, `tests/test_scaling_integration.py`, `tests/test_resilience_integration.py`, `tests/test_monorepo_integration.py`, `tests/cli/test_worktree.py`, `tests/cli/test_check_commit.py`, `tests/cli/test_internal_hooks.py`, `tests/cli/test_multi_task.py`, `tests/cli/test_internal.py`, `tests/cli/test_commit.py`
+
+- [ ] **Step 1: Find all assertions on the old path layout**
+
+```bash
+grep -rn '\.worktrees/feat\|/\.worktrees/' tests/ --include='*.py' | grep -v 'workspace/.worktrees/'
+```
+
+For each match, decide:
+- If the test expects `<repo>/.worktrees/feat/<slug>/`, rewrite to expect `<workspace>/.worktrees/<slug>/<repo>/`.
+- If the test seeds a fake worktree (via `git worktree add` directly) for an unrelated test, leave it — those aren't testing layout.
+- Existing per-repo `test_spawn_ensures_gitignore` (`tests/core/test_worktree.py:68-74`): now obsolete — delete it. Replace with `test_spawn_workspace_gitignore_includes_worktrees` (already added in Task 2.1).
+
+- [ ] **Step 2: Run the full test suite**
+
+```
+uv run pytest -q
+```
+
+Expected: failures concentrated in tests that check worktree paths or that the marker is per-worktree. Fix each by:
+- Updating expected path to hub layout
+- Updating any `<wt>/.mship-workspace` checks to `<hub>/.mship-workspace`
+
+(This step may take a single sitting of mechanical updates. Use the path pattern above as your guide.)
+
+- [ ] **Step 3: Confirm green**
+
+```
+uv run pytest -q
+```
+
+Expected: 0 failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/
+git commit -m "test: update tests for hub worktree layout"
+mship journal "phase 2 complete: hub layout shipped, all tests green" --action committed --test-state pass
+```
+
+### Task 2.3: Update `WorktreeManager.abort` for hub layout
+
+**Files:**
+- Modify: `src/mship/core/worktree.py:536-567`
+- Test: `tests/core/test_worktree.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_worktree.py`:
+
+```python
+def test_abort_removes_hub_directory(worktree_deps):
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("abort test", repos=["shared", "auth-service"], workspace_root=workspace)
+    hub = workspace / ".worktrees" / "abort-test"
+    assert hub.exists()
+    mgr.abort("abort-test")
+    assert not hub.exists(), "abort should rm -rf the hub directory"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+uv run pytest tests/core/test_worktree.py::test_abort_removes_hub_directory -v
+```
+
+Expected: FAIL — current `abort` removes individual git worktrees but leaves the hub dir.
+
+- [ ] **Step 3: Update `abort`**
+
+In `src/mship/core/worktree.py`, after the existing per-repo cleanup loop in `abort` (after line 562 `pass`), and before `def _abort(s):`, add:
+
+```python
+        # Remove the hub directory for this task. Best-effort: legacy
+        # per-repo-layout tasks won't have a hub dir, which is fine.
+        try:
+            workspace_root = (
+                Path(next(iter(self._config.repos.values())).path)
+                .resolve()
+                .parents[0]
+            )
+            # The above is a fallback; prefer config-derived path:
+            if hasattr(self._config, "_workspace_root"):
+                workspace_root = Path(self._config._workspace_root)
+            hub = workspace_root / ".worktrees" / task_slug
+            if hub.exists() and hub.is_dir():
+                import shutil as _shutil
+                _shutil.rmtree(hub, ignore_errors=True)
+        except Exception:
+            pass
+```
+
+Wait — `WorkspaceConfig` doesn't expose workspace_root. Better approach: derive it from `task.worktrees` (each entry is under the hub).
+
+Replace the snippet above with:
+
+```python
+        # Remove the hub directory for this task. Inferred from the first
+        # worktree's parent.parent, which is `<workspace>/.worktrees/<slug>/`.
+        # Legacy per-repo-layout tasks have a different parent shape — leave
+        # those alone.
+        try:
+            sample_wt = next(iter(task.worktrees.values()), None)
+            if sample_wt is not None:
+                hub = Path(sample_wt).parent
+                # Sanity: only remove if it looks like a hub (parent ends in .worktrees)
+                if hub.name == task_slug and hub.parent.name == ".worktrees":
+                    if hub.exists():
+                        import shutil as _shutil
+                        _shutil.rmtree(hub, ignore_errors=True)
+        except Exception:
+            pass
+```
+
+- [ ] **Step 4: Run test, expect PASS**
+
+```
+uv run pytest tests/core/test_worktree.py::test_abort_removes_hub_directory -v
+```
+
+- [ ] **Step 5: Run full suite to confirm no regression**
+
+```
+uv run pytest -q
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mship/core/worktree.py tests/core/test_worktree.py
+git commit -m "feat(worktree): abort removes hub directory"
+mship journal "phase 2.3: abort cleans hub dir" --action committed
+```
+
+---
+
+## Phase 3 — Passive worktrees (`depends_on` materialization)
+
+Auto-materialize sibling repos that affected repos `depends_on` but the user didn't include in `--repos`. Detached HEAD at `origin/<expected_branch || base_branch>`. Symlinks + binds, no `task setup`.
+
+### Task 3.1: Add `worktree_add_detached` and `fetch_remote_ref` to GitRunner
+
+**Files:**
+- Modify: `src/mship/util/git.py`
+- Test: `tests/util/test_git.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/util/test_git.py`:
+
+```python
+def test_worktree_add_detached(tmp_path):
+    import subprocess
+    from mship.util.git import GitRunner
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True, capture_output=True)
+    subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                    "commit", "--allow-empty", "-qm", "init"],
+                   cwd=repo, check=True, capture_output=True)
+    sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,
+                         check=True, capture_output=True, text=True).stdout.strip()
+    git = GitRunner()
+    wt = tmp_path / "wt"
+    git.worktree_add_detached(repo_path=repo, worktree_path=wt, ref=sha)
+    head = subprocess.run(["git", "-C", str(wt), "rev-parse", "HEAD"],
+                          check=True, capture_output=True, text=True).stdout.strip()
+    assert head == sha
+    branch = subprocess.run(["git", "-C", str(wt), "symbolic-ref", "-q", "HEAD"],
+                            capture_output=True, text=True).returncode
+    assert branch != 0, "expected detached HEAD (symbolic-ref returns nonzero)"
+
+
+def test_fetch_remote_ref_succeeds(tmp_path):
+    """Smoke: fetch_remote_ref returns True when origin has the branch."""
+    import subprocess
+    from mship.util.git import GitRunner
+    bare = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", "-q", "-b", "main", str(bare)],
+                   check=True, capture_output=True)
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "clone", "-q", str(bare), str(clone)],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                    "commit", "--allow-empty", "-qm", "init"],
+                   cwd=clone, check=True, capture_output=True)
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=clone,
+                   check=True, capture_output=True)
+    git = GitRunner()
+    assert git.fetch_remote_ref(repo_path=clone, ref="main") is True
+
+
+def test_fetch_remote_ref_returns_false_on_failure(tmp_path):
+    """Returns False when origin doesn't have the ref (or no remote)."""
+    import subprocess
+    from mship.util.git import GitRunner
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "-q", str(repo)], check=True, capture_output=True)
+    git = GitRunner()
+    assert git.fetch_remote_ref(repo_path=repo, ref="nonexistent") is False
+```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+```
+uv run pytest tests/util/test_git.py::test_worktree_add_detached tests/util/test_git.py::test_fetch_remote_ref_succeeds tests/util/test_git.py::test_fetch_remote_ref_returns_false_on_failure -v
+```
+
+Expected: FAIL — methods don't exist yet.
+
+- [ ] **Step 3: Add the methods**
+
+In `src/mship/util/git.py`, after `worktree_add` (~line 16):
+
+```python
+    def worktree_add_detached(self, repo_path: Path, worktree_path: Path, ref: str) -> None:
+        """Create a detached-HEAD worktree at `worktree_path` pointing at `ref`.
+
+        `ref` may be a SHA, a tag, or a remote ref like `origin/main`.
+        """
+        worktree_path.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["git", "worktree", "add", "--detach", str(worktree_path), ref],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def fetch_remote_ref(self, repo_path: Path, ref: str, remote: str = "origin") -> bool:
+        """Fetch a single ref from `remote`. Returns True on success, False on any failure.
+
+        Used by passive-worktree materialization: we want to know if origin has
+        the ref, and we want it locally as `<remote>/<ref>` for `worktree add`.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "fetch", remote, ref],
+                cwd=repo_path, capture_output=True, text=True, check=False, timeout=60,
+            )
+            return result.returncode == 0
+        except (OSError, subprocess.SubprocessError):
+            return False
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```
+uv run pytest tests/util/test_git.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/util/git.py tests/util/test_git.py
+git commit -m "feat(git): add worktree_add_detached and fetch_remote_ref helpers"
+mship journal "phase 3.1: git helpers for passive worktrees" --action committed
+```
+
+### Task 3.2: Compute passive repo set in spawn
+
+**Files:**
+- Modify: `src/mship/core/worktree.py` (the `spawn` method)
+- Test: `tests/core/test_worktree.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_worktree.py`:
+
+```python
+def test_spawn_materializes_passive_dep(worktree_deps):
+    """When --repos is auth-service only, shared (its dep) becomes passive."""
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    # auth-service depends_on shared; spawn auth-service alone
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    # workspace_with_git fixture has no remotes set up; pass offline=True
+    # so we use the local main branch instead of origin/main.
+    mgr.spawn("passive dep", repos=["auth-service"],
+              workspace_root=workspace, offline=True)
+    state = state_mgr.load()
+    task = state.tasks["passive-dep"]
+    # affected_repos contains only what user asked for
+    assert task.affected_repos == ["auth-service"]
+    # passive_repos contains the dep
+    assert task.passive_repos == {"shared"}
+    # both are in worktrees
+    assert "auth-service" in task.worktrees
+    assert "shared" in task.worktrees
+    # passive worktree exists on disk
+    assert Path(task.worktrees["shared"]).exists()
+
+
+def test_spawn_passive_worktree_is_detached(worktree_deps):
+    import subprocess
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("detached check", repos=["auth-service"],
+              workspace_root=workspace, offline=True)
+    state = state_mgr.load()
+    passive_wt = Path(state.tasks["detached-check"].worktrees["shared"])
+    rc = subprocess.run(["git", "-C", str(passive_wt), "symbolic-ref", "-q", "HEAD"],
+                        capture_output=True).returncode
+    assert rc != 0, "passive worktree should be on detached HEAD"
+
+
+def test_spawn_passive_skips_task_setup(worktree_deps):
+    """Passive worktrees materialize symlinks/binds but don't run `task setup`."""
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("no setup", repos=["auth-service"],
+              workspace_root=workspace, offline=True)
+    # `shell.run_task` should be called for affected (auth-service) but not passive (shared).
+    setup_calls = [c for c in shell.run_task.call_args_list
+                   if c.kwargs.get("task_name") == "setup"]
+    cwds = {Path(c.kwargs.get("cwd")).name for c in setup_calls}
+    assert "auth-service" in cwds
+    assert "shared" not in cwds
+```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+```
+uv run pytest tests/core/test_worktree.py::test_spawn_materializes_passive_dep tests/core/test_worktree.py::test_spawn_passive_worktree_is_detached tests/core/test_worktree.py::test_spawn_passive_skips_task_setup -v
+```
+
+Expected: FAIL — `spawn` has no `offline` kwarg, no passive logic.
+
+- [ ] **Step 3: Add `offline` parameter and passive expansion to `spawn`**
+
+In `src/mship/core/worktree.py`, change the `spawn` signature:
+
+```python
+    def spawn(
+        self,
+        description: str,
+        repos: list[str] | None = None,
+        skip_setup: bool = False,
+        slug: str | None = None,
+        workspace_root: Path | None = None,
+        offline: bool = False,
+    ) -> SpawnResult:
+```
+
+Inside `spawn`, after `ordered = self._graph.topo_sort(repos)`, compute the passive set:
+
+```python
+        # Passive expansion: collect transitive depends_on of each repo in
+        # `ordered` that isn't already in `ordered`. Topo-sort the union so
+        # passive deps materialize before their consumers.
+        affected = set(ordered)
+        passive: set[str] = set()
+        frontier = list(ordered)
+        while frontier:
+            r = frontier.pop()
+            for dep in self._graph.direct_deps(r):
+                if dep not in affected and dep not in passive:
+                    passive.add(dep)
+                    frontier.append(dep)
+        all_repos = self._graph.topo_sort(list(affected | passive))
+```
+
+(Confirm `DependencyGraph` has a `direct_deps(name)` method or equivalent. If not, replace with the existing API — likely `self._config.repos[r].depends_on` iterated with `.repo` access.)
+
+Then change the `for repo_name in ordered:` loop header to:
+
+```python
+        for repo_name in all_repos:
+            repo_config = self._config.repos[repo_name]
+            is_passive = repo_name in passive
+```
+
+And inside the normal-repo branch, replace the `git.worktree_add(...)` + setup section with conditional logic:
+
+```python
+            # Normal repo: hub worktree.
+            repo_path = repo_config.path
+            wt_path = hub / repo_name
+
+            if is_passive:
+                # Passive: detached HEAD at origin/<expected || base>.
+                ref = repo_config.expected_branch or repo_config.base_branch
+                if ref is None:
+                    raise ValueError(
+                        f"Passive materialization for '{repo_name}' requires "
+                        f"`expected_branch` or `base_branch` declared in "
+                        f"mothership.yaml."
+                    )
+                if not offline:
+                    fetched = self._git.fetch_remote_ref(repo_path=repo_path, ref=ref)
+                    if not fetched:
+                        raise RuntimeError(
+                            f"Failed to fetch origin/{ref} for passive repo "
+                            f"'{repo_name}'. Re-run with `--offline` to use "
+                            f"the local ref."
+                        )
+                    target_ref = f"origin/{ref}"
+                else:
+                    target_ref = ref
+                self._git.worktree_add_detached(
+                    repo_path=repo_path,
+                    worktree_path=wt_path,
+                    ref=target_ref,
+                )
+            else:
+                self._git.worktree_add(
+                    repo_path=repo_path,
+                    worktree_path=wt_path,
+                    branch=branch,
+                )
+            worktrees[repo_name] = wt_path
+
+            symlink_warnings = self._create_symlinks(repo_name, repo_config, wt_path)
+            setup_warnings.extend(symlink_warnings)
+            bind_warnings = self._copy_bind_files(repo_name, repo_config, wt_path)
+            setup_warnings.extend(bind_warnings)
+
+            # Skip task setup for passive worktrees.
+            if not is_passive and not skip_setup and shutil.which("task") is not None:
+                actual_setup = repo_config.tasks.get("setup", "setup")
+                setup_result = self._shell.run_task(
+                    task_name="setup",
+                    actual_task_name=actual_setup,
+                    cwd=wt_path,
+                    env_runner=repo_config.env_runner or self._config.env_runner,
+                )
+                if setup_result.returncode != 0:
+                    setup_warnings.append(
+                        f"{repo_name}: setup failed (task '{actual_setup}') — "
+                        f"{setup_result.stderr.strip()[:200]}"
+                    )
+```
+
+Then update the Task construction to record passive_repos:
+
+```python
+        task = Task(
+            slug=slug,
+            description=description,
+            phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=ordered,
+            worktrees=worktrees,
+            branch=branch,
+            base_branch=base_branch,
+            passive_repos=passive,
+        )
+```
+
+- [ ] **Step 4: Verify `DependencyGraph` API**
+
+```
+grep -n "def \|direct_deps\|depends_on" src/mship/core/graph.py | head -20
+```
+
+If `direct_deps` doesn't exist, add it (or inline the iteration over `self._config.repos[r].depends_on`).
+
+If you need to add `direct_deps` to `DependencyGraph`:
+
+```python
+    def direct_deps(self, repo_name: str) -> list[str]:
+        """Return the direct dependency names of `repo_name`."""
+        return [d.repo for d in self._config.repos[repo_name].depends_on]
+```
+
+- [ ] **Step 5: Run tests, expect PASS**
+
+```
+uv run pytest tests/core/test_worktree.py::test_spawn_materializes_passive_dep tests/core/test_worktree.py::test_spawn_passive_worktree_is_detached tests/core/test_worktree.py::test_spawn_passive_skips_task_setup -v
+```
+
+- [ ] **Step 6: Run full suite**
+
+```
+uv run pytest -q
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/mship/core/worktree.py src/mship/core/graph.py tests/core/test_worktree.py
+git commit -m "feat(worktree): materialize depends_on as detached passive worktrees"
+mship journal "phase 3.2: passive depends_on materialization" --action committed
+```
+
+### Task 3.3: Wire `--offline` flag through CLI
+
+**Files:**
+- Modify: `src/mship/cli/worktree.py` (the `spawn` typer command, ~line 212)
+- Test: `tests/cli/test_worktree.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/cli/test_worktree.py`:
+
+```python
+def test_spawn_cli_passes_offline_flag(workspace_with_git, tmp_path, monkeypatch):
+    """`mship spawn --offline` sets offline=True in the manager call."""
+    from typer.testing import CliRunner
+    from unittest.mock import patch
+    from mship.cli import app, container
+    from pathlib import Path
+
+    container.config_path.override(workspace_with_git / "mothership.yaml")
+    container.state_dir.override(workspace_with_git / ".mothership")
+    monkeypatch.chdir(workspace_with_git)
+    try:
+        runner = CliRunner()
+        with patch("mship.core.worktree.WorktreeManager.spawn") as mock_spawn:
+            from mship.core.worktree import SpawnResult
+            from mship.core.state import Task
+            from datetime import datetime, timezone
+            mock_spawn.return_value = SpawnResult(
+                task=Task(
+                    slug="x", description="x", phase="plan",
+                    created_at=datetime.now(timezone.utc),
+                    affected_repos=["shared"], branch="feat/x",
+                    worktrees={"shared": Path("/tmp/x")},
+                ),
+            )
+            result = runner.invoke(
+                app, ["spawn", "x", "--repos", "shared",
+                      "--skip-setup", "--force-audit", "--offline"],
+            )
+            assert result.exit_code == 0, result.output
+            assert mock_spawn.call_args.kwargs.get("offline") is True
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+```
+uv run pytest tests/cli/test_worktree.py::test_spawn_cli_passes_offline_flag -v
+```
+
+Expected: FAIL — `--offline` not a registered option.
+
+- [ ] **Step 3: Add `--offline` to the `spawn` CLI command**
+
+In `src/mship/cli/worktree.py`, in the `def spawn(...)` typer command (around line 212), add a parameter:
+
+```python
+        offline: bool = typer.Option(
+            False, "--offline",
+            help="Skip `git fetch` for passive worktrees; use local refs. "
+                 "Journal entry tagged OFFLINE.",
+        ),
+```
+
+And in the `wt_mgr.spawn(...)` call (~line 364), add `offline=offline`:
+
+```python
+        result = wt_mgr.spawn(
+            description, repos=repo_list, skip_setup=skip_setup, slug=slug,
+            workspace_root=container.config_path().parent,
+            offline=offline,
+        )
+```
+
+After the `_log_bypass` for-loop (~line 373), add an OFFLINE journal entry:
+
+```python
+        if offline:
+            container.log_manager().append(task.slug, "OFFLINE: passive fetches skipped")
+```
+
+- [ ] **Step 4: Run test, expect PASS**
+
+```
+uv run pytest tests/cli/test_worktree.py::test_spawn_cli_passes_offline_flag -v
+```
+
+- [ ] **Step 5: Run full suite**
+
+```
+uv run pytest -q
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mship/cli/worktree.py tests/cli/test_worktree.py
+git commit -m "feat(spawn): --offline flag for passive worktrees"
+mship journal "phase 3.3: --offline CLI flag wired" --action committed
+```
+
+---
+
+## Phase 4 — Pre-commit hook refuses passive worktrees
+
+### Task 4.1: Update `_check-commit` to refuse passive
+
+**Files:**
+- Modify: `src/mship/cli/internal.py:8-127`
+- Test: `tests/cli/test_internal.py`, `tests/test_hook_integration.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/cli/test_internal.py`:
+
+```python
+def test_check_commit_refuses_passive_worktree(tmp_path, monkeypatch):
+    """A commit attempted in a registered-but-passive worktree is rejected."""
+    from datetime import datetime, timezone
+    from mship.core.state import StateManager, Task, WorkspaceState
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+
+    # Workspace skeleton
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\nrepos:\n  shared:\n    path: ./shared\n    type: library\n"
+    )
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    passive_wt = tmp_path / ".worktrees" / "x" / "shared"
+    passive_wt.mkdir(parents=True)
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "x": Task(
+            slug="x", description="x", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/x",
+            worktrees={"shared": passive_wt},
+            passive_repos={"shared"},
+        )
+    }))
+
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    monkeypatch.chdir(passive_wt)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(app, ["_check-commit", str(passive_wt)])
+        assert result.exit_code == 1
+        assert "passive worktree" in (result.output or "").lower()
+        assert "shared" in (result.output or "")
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+```
+uv run pytest tests/cli/test_internal.py::test_check_commit_refuses_passive_worktree -v
+```
+
+Expected: FAIL — current `_check-commit` allows the commit because the path matches a registered worktree.
+
+- [ ] **Step 3: Update `_check-commit`**
+
+In `src/mship/cli/internal.py`, locate the block where `matched_task` is set (around line 40-46). After `matched_task = state.tasks[slug]; break` and before the reconcile gate, add the passive check.
+
+Find this block (~line 40-44):
+
+```python
+        matched_task = None
+        for slug, wt in registered:
+            if tl == wt:
+                matched_task = state.tasks[slug]
+                break
+```
+
+Change to also capture the matched repo name:
+
+```python
+        matched_task = None
+        matched_repo: str | None = None
+        try:
+            registered = [
+                (slug, repo, Path(wt).resolve())
+                for slug, task in state.tasks.items()
+                for repo, wt in task.worktrees.items()
+            ]
+        except (OSError, RuntimeError):
+            raise typer.Exit(code=0)
+        for slug, repo, wt in registered:
+            if tl == wt:
+                matched_task = state.tasks[slug]
+                matched_repo = repo
+                break
+```
+
+(Replace the earlier `registered = [...]` block to include the repo name.)
+
+Then immediately after this match block (just before `if matched_task is not None:`), add:
+
+```python
+        if matched_task is not None and matched_repo in matched_task.passive_repos:
+            import sys
+            sys.stderr.write(
+                f"⛔ mship: refusing commit — {tl} is a passive worktree of "
+                f"`{matched_repo}` for task `{matched_task.slug}`.\n"
+                f"   To edit {matched_repo}, close this task and respawn with "
+                f"`--repos {matched_repo},...`\n"
+                f"   (or `git commit --no-verify` to override).\n"
+            )
+            raise typer.Exit(code=1)
+```
+
+Update the existing rejection-list build (~line 92) to use the new 3-tuple `registered` shape: change `for slug, wt in registered:` to `for slug, _repo, wt in registered:`.
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```
+uv run pytest tests/cli/test_internal.py -v
+```
+
+Expected: new test passes; existing tests in `test_internal.py` still pass.
+
+- [ ] **Step 5: Add an integration test (real git commit through hook)**
+
+Append to `tests/test_hook_integration.py`:
+
+```python
+def test_commit_in_passive_worktree_refused(workspace_for_hooks, monkeypatch):
+    """End-to-end: spawn with --repos affected; commit attempt in passive worktree refused."""
+    import os
+    from pathlib import Path
+    from mship.core.state import StateManager, Task, WorkspaceState
+    from datetime import datetime, timezone
+
+    tmp_path, repo = workspace_for_hooks
+    runner.invoke(app, ["init", "--install-hooks"])
+
+    # Manually create a passive worktree by seeding state (simulating a real
+    # spawn that materialized 'cli' as passive — we reuse the existing
+    # workspace_for_hooks fixture which has a single 'cli' repo).
+    state_dir = tmp_path / ".mothership"
+    sm = StateManager(state_dir)
+    state = sm.load()
+    # Create an empty subdirectory that pretends to be a passive worktree;
+    # the hook only checks state, not git plumbing.
+    passive_wt = tmp_path / ".worktrees" / "x" / "cli"
+    passive_wt.mkdir(parents=True)
+    state.tasks["x"] = Task(
+        slug="x", description="x", phase="plan",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["cli"], branch="feat/x",
+        worktrees={"cli": passive_wt},
+        passive_repos={"cli"},
+    )
+    sm.save(state)
+
+    # Initialize the passive dir as a worktree of the same git history so
+    # `git commit` has a valid context.
+    import subprocess
+    subprocess.run(["git", "worktree", "add", "--detach", str(passive_wt), "HEAD"],
+                   cwd=repo, check=True, capture_output=True)
+    # Install the hook into the passive worktree's git dir
+    runner.invoke(app, ["init", "--install-hooks"])
+
+    (passive_wt / "p.py").write_text("p\n")
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "add", "p.py"], cwd=passive_wt, check=True, capture_output=True, env=env)
+    result = subprocess.run(
+        ["git", "commit", "-m", "should refuse"],
+        cwd=passive_wt, capture_output=True, text=True, env=env,
+    )
+    assert result.returncode != 0
+    assert "passive worktree" in result.stderr.lower()
+```
+
+- [ ] **Step 6: Run test**
+
+```
+uv run pytest tests/test_hook_integration.py::test_commit_in_passive_worktree_refused -v
+```
+
+- [ ] **Step 7: Run full suite**
+
+```
+uv run pytest -q
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/mship/cli/internal.py tests/cli/test_internal.py tests/test_hook_integration.py
+git commit -m "feat(hook): pre-commit refuses commits in passive worktrees"
+mship journal "phase 4: pre-commit refuses passive worktree commits" --action committed
+```
+
+---
+
+## Phase 5 — Audit extensions
+
+Add `passive_drift`, `passive_dirty_worktree`, `passive_fetch_failed` issue codes; surface them in `audit_repos`.
+
+### Task 5.1: Add a passive-aware audit pass
+
+**Files:**
+- Modify: `src/mship/core/repo_state.py`
+- Test: `tests/core/test_repo_state.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_repo_state.py`:
+
+```python
+def test_audit_passive_drift_warns(tmp_path):
+    """Passive worktree behind origin/<ref> emits a warn-level passive_drift issue."""
+    import subprocess
+    from mship.core.repo_state import audit_passive_worktrees
+    # Set up: bare repo, clone, push two commits, passive worktree at the first.
+    bare = tmp_path / "bare.git"
+    subprocess.run(["git", "init", "--bare", "-q", "-b", "main", str(bare)],
+                   check=True, capture_output=True)
+    src = tmp_path / "src"
+    subprocess.run(["git", "clone", "-q", str(bare), str(src)],
+                   check=True, capture_output=True)
+    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "commit", "--allow-empty", "-qm", "c1"], cwd=src,
+                   check=True, capture_output=True, env={**__import__("os").environ, **env})
+    sha1 = subprocess.run(["git", "rev-parse", "HEAD"], cwd=src,
+                          check=True, capture_output=True, text=True).stdout.strip()
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-qm", "c2"], cwd=src,
+                   check=True, capture_output=True, env={**__import__("os").environ, **env})
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+    # Make a worktree of `src` at the OLD sha1 — drift exists relative to origin/main
+    passive = tmp_path / "passive"
+    subprocess.run(["git", "worktree", "add", "--detach", str(passive), sha1],
+                   cwd=src, check=True, capture_output=True)
+    issues = audit_passive_worktrees(
+        passive_paths={"shared": passive},
+        ref_per_repo={"shared": "main"},
+        canonical_paths={"shared": src},
+    )
+    codes = [i.code for i in issues["shared"]]
+    assert "passive_drift" in codes
+
+
+def test_audit_passive_fetch_failed_errors(tmp_path):
+    """Fetch failure produces an error-level passive_fetch_failed issue."""
+    import subprocess
+    from mship.core.repo_state import audit_passive_worktrees
+    # Repo with no remote — fetch will fail.
+    src = tmp_path / "src"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(src)],
+                   check=True, capture_output=True)
+    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "commit", "--allow-empty", "-qm", "c"], cwd=src,
+                   check=True, capture_output=True, env={**__import__("os").environ, **env})
+    passive = tmp_path / "passive"
+    subprocess.run(["git", "worktree", "add", "--detach", str(passive), "main"],
+                   cwd=src, check=True, capture_output=True)
+    issues = audit_passive_worktrees(
+        passive_paths={"shared": passive},
+        ref_per_repo={"shared": "main"},
+        canonical_paths={"shared": src},
+    )
+    codes = [(i.code, i.severity) for i in issues["shared"]]
+    assert ("passive_fetch_failed", "error") in codes
+```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+```
+uv run pytest tests/core/test_repo_state.py::test_audit_passive_drift_warns tests/core/test_repo_state.py::test_audit_passive_fetch_failed_errors -v
+```
+
+Expected: FAIL — `audit_passive_worktrees` doesn't exist.
+
+- [ ] **Step 3: Implement `audit_passive_worktrees`**
+
+In `src/mship/core/repo_state.py`, add at the end of the file:
+
+```python
+def audit_passive_worktrees(
+    passive_paths: dict[str, Path],
+    ref_per_repo: dict[str, str],
+    canonical_paths: dict[str, Path],
+) -> dict[str, list[Issue]]:
+    """Audit passive worktrees for drift / dirtiness / fetch failure.
+
+    For each passive repo:
+      - Run `git fetch origin <ref>` against the canonical checkout. If it fails,
+        emit `passive_fetch_failed` (error). Skip remaining checks.
+      - Compare `<passive>/HEAD` against `<canonical>/origin/<ref>`. If they
+        differ, emit `passive_drift` (warn).
+      - Run `git status --porcelain` in the passive worktree. If non-empty
+        after filtering untracked, emit `passive_dirty_worktree` (warn).
+
+    Returns a per-repo list of issues (empty list if clean).
+    """
+    import subprocess
+    out: dict[str, list[Issue]] = {}
+    for name, passive in passive_paths.items():
+        issues: list[Issue] = []
+        ref = ref_per_repo.get(name)
+        canonical = canonical_paths.get(name)
+        if ref is None or canonical is None:
+            out[name] = issues
+            continue
+
+        fetch = subprocess.run(
+            ["git", "fetch", "origin", ref],
+            cwd=canonical, capture_output=True, text=True, check=False, timeout=60,
+        )
+        if fetch.returncode != 0:
+            issues.append(Issue(
+                "passive_fetch_failed", "error",
+                f"git fetch origin {ref} failed: {fetch.stderr.strip()[:160]}",
+            ))
+            out[name] = issues
+            continue
+
+        rev_passive = subprocess.run(
+            ["git", "-C", str(passive), "rev-parse", "HEAD"],
+            capture_output=True, text=True, check=False,
+        )
+        rev_origin = subprocess.run(
+            ["git", "-C", str(canonical), "rev-parse", f"origin/{ref}"],
+            capture_output=True, text=True, check=False,
+        )
+        if (rev_passive.returncode == 0 and rev_origin.returncode == 0
+                and rev_passive.stdout.strip() != rev_origin.stdout.strip()):
+            issues.append(Issue(
+                "passive_drift", "warn",
+                f"passive HEAD {rev_passive.stdout.strip()[:8]} drifted "
+                f"from origin/{ref} ({rev_origin.stdout.strip()[:8]})",
+            ))
+
+        status = subprocess.run(
+            ["git", "-C", str(passive), "status", "--porcelain"],
+            capture_output=True, text=True, check=False,
+        )
+        if status.returncode == 0:
+            modified = sum(
+                1 for line in status.stdout.splitlines()
+                if line.strip() and not line.startswith("??")
+            )
+            if modified:
+                issues.append(Issue(
+                    "passive_dirty_worktree", "warn",
+                    f"{modified} modified file(s) in passive worktree",
+                ))
+        out[name] = issues
+    return out
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```
+uv run pytest tests/core/test_repo_state.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/repo_state.py tests/core/test_repo_state.py
+git commit -m "feat(audit): passive_drift, passive_fetch_failed, passive_dirty_worktree"
+mship journal "phase 5: passive audit issue codes" --action committed
+```
+
+### Task 5.2: Wire passive audit into `mship audit` CLI
+
+**Files:**
+- Modify: `src/mship/cli/audit.py`
+- Test: `tests/cli/` — add a smoke test that `mship audit` lists passive issues
+
+- [ ] **Step 1: Write the failing test**
+
+Examine `src/mship/cli/audit.py` for the existing structure. Find where it builds the report and prints. Add an integration test in `tests/cli/test_audit.py` (create file if absent):
+
+```python
+def test_audit_includes_passive_repos(tmp_path, monkeypatch):
+    """`mship audit` output includes passive repos with their drift/fetch issues."""
+    import subprocess
+    from datetime import datetime, timezone
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+    from mship.core.state import StateManager, Task, WorkspaceState
+
+    bare = tmp_path / "shared.git"
+    subprocess.run(["git", "init", "--bare", "-q", "-b", "main", str(bare)],
+                   check=True, capture_output=True)
+    src = tmp_path / "shared"
+    subprocess.run(["git", "clone", "-q", str(bare), str(src)],
+                   check=True, capture_output=True)
+    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    import os
+    full_env = {**os.environ, **env}
+    subprocess.run(["git", "-c", f"user.email={env['GIT_AUTHOR_EMAIL']}",
+                    "-c", f"user.name={env['GIT_AUTHOR_NAME']}",
+                    "commit", "--allow-empty", "-qm", "init"],
+                   cwd=src, check=True, capture_output=True, env=full_env)
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+    (src / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    subprocess.run(["git", "add", "Taskfile.yml"], cwd=src, check=True, capture_output=True, env=full_env)
+    subprocess.run(["git", "-c", f"user.email={env['GIT_AUTHOR_EMAIL']}",
+                    "-c", f"user.name={env['GIT_AUTHOR_NAME']}",
+                    "commit", "-qm", "add taskfile"],
+                   cwd=src, check=True, capture_output=True, env=full_env)
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\nrepos:\n  shared:\n    path: ./shared\n    type: library\n"
+        "    base_branch: main\n    expected_branch: main\n"
+    )
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+
+    # Passive worktree at an older sha so origin/main has advanced — but here both refs are at HEAD; the audit is just smoke.
+    passive = tmp_path / ".worktrees" / "x" / "shared"
+    subprocess.run(["git", "worktree", "add", "--detach", str(passive), "HEAD"],
+                   cwd=src, check=True, capture_output=True)
+
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "x": Task(
+            slug="x", description="x", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/x",
+            worktrees={"shared": passive},
+            passive_repos={"shared"},
+        )
+    }))
+
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    monkeypatch.chdir(tmp_path)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(app, ["audit", "--json"])
+        assert result.exit_code == 0, result.output
+        # The report should mention shared as a passive entry (regardless of issues).
+        import json
+        report = json.loads(result.stdout)
+        names = [r["name"] for r in report["repos"]]
+        assert "shared" in names
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+```
+
+- [ ] **Step 2: Run test, expect FAIL or PASS depending on existing audit behavior**
+
+```
+uv run pytest tests/cli/test_audit.py -v
+```
+
+If it passes (audit already reports `shared` because it's in config.repos), good — we're confirming no regression. If it fails (audit doesn't see passive repos at all), proceed to step 3.
+
+- [ ] **Step 3: Wire passive results into audit CLI**
+
+In `src/mship/cli/audit.py`, after the existing `audit_repos(...)` call, also call `audit_passive_worktrees` for passive repos found in state.yaml. Merge the per-repo issue lists into the existing `RepoAudit` entries (or append a new `RepoAudit` for purely-passive repos not in `audit_names`).
+
+The exact code depends on the current structure of `cli/audit.py`. Read it first; then for each task in state, for each `passive_repo`, build a `passive_paths`, `ref_per_repo`, `canonical_paths` dict and call `audit_passive_worktrees`. Append issues to the matching `RepoAudit` (rebuilding the tuple).
+
+- [ ] **Step 4: Run test, expect PASS**
+
+```
+uv run pytest tests/cli/test_audit.py -v && uv run pytest -q
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/cli/audit.py tests/cli/test_audit.py
+git commit -m "feat(audit): surface passive worktree issues in audit output"
+mship journal "phase 5.2: audit CLI surfaces passive issues" --action committed
+```
+
+---
+
+## Phase 6 — Sync refresh for passive worktrees
+
+### Task 6.1: Add passive refresh to sync
+
+**Files:**
+- Modify: `src/mship/core/repo_sync.py`, `src/mship/cli/sync.py`
+- Test: `tests/cli/test_sync.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/cli/test_sync.py`:
+
+```python
+def test_sync_refreshes_passive_worktree(tmp_path, monkeypatch):
+    """`mship sync` re-fetches and resets passive worktrees to origin/<ref>."""
+    import subprocess
+    import os
+    from datetime import datetime, timezone
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+    from mship.core.state import StateManager, Task, WorkspaceState
+
+    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    full_env = {**os.environ, **env}
+
+    bare = tmp_path / "shared.git"
+    subprocess.run(["git", "init", "--bare", "-q", "-b", "main", str(bare)],
+                   check=True, capture_output=True)
+    src = tmp_path / "shared"
+    subprocess.run(["git", "clone", "-q", str(bare), str(src)],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-qm", "c1"],
+                   cwd=src, check=True, capture_output=True, env=full_env)
+    sha1 = subprocess.run(["git", "rev-parse", "HEAD"], cwd=src,
+                          check=True, capture_output=True, text=True).stdout.strip()
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+    (src / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    subprocess.run(["git", "add", "."], cwd=src, check=True, capture_output=True, env=full_env)
+    subprocess.run(["git", "commit", "-qm", "c2"], cwd=src, check=True, capture_output=True, env=full_env)
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+    sha2 = subprocess.run(["git", "rev-parse", "HEAD"], cwd=src,
+                          check=True, capture_output=True, text=True).stdout.strip()
+
+    # Passive worktree at OLD sha1
+    passive = tmp_path / ".worktrees" / "x" / "shared"
+    subprocess.run(["git", "worktree", "add", "--detach", str(passive), sha1],
+                   cwd=src, check=True, capture_output=True)
+
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\nrepos:\n  shared:\n    path: ./shared\n    type: library\n"
+        "    base_branch: main\n    expected_branch: main\n"
+    )
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "x": Task(
+            slug="x", description="x", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/x",
+            worktrees={"shared": passive},
+            passive_repos={"shared"},
+        )
+    }))
+
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    monkeypatch.chdir(tmp_path)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(app, ["sync"])
+        assert result.exit_code in (0, 1), result.output  # 1 acceptable if canonical has issues
+        head_after = subprocess.run(
+            ["git", "-C", str(passive), "rev-parse", "HEAD"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert head_after == sha2, "passive worktree should be reset to origin/main HEAD"
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+
+
+def test_sync_no_passive_skips_passive_refresh(tmp_path, monkeypatch):
+    """`mship sync --no-passive` leaves passive worktrees alone."""
+    # Same setup as above, but pass --no-passive and assert HEAD unchanged.
+    # (Skipped here for brevity — copy the setup, change runner.invoke args
+    # to ["sync", "--no-passive"], and assert head_after == sha1.)
+    pass
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+```
+uv run pytest tests/cli/test_sync.py::test_sync_refreshes_passive_worktree -v
+```
+
+- [ ] **Step 3: Add `refresh_passive_worktrees` to `repo_sync.py`**
+
+In `src/mship/core/repo_sync.py`, add at the end:
+
+```python
+def refresh_passive_worktrees(
+    state_manager,
+    config: WorkspaceConfig,
+) -> list["SyncResult"]:
+    """Re-fetch and reset each passive worktree to `origin/<expected || base>`.
+
+    Safe by construction: passive worktrees are detached HEAD, mship-managed,
+    and pre-commit-hook-protected. Nothing the user could lose by hard reset.
+    Returns a SyncResult per (task, repo) tuple for reporting.
+    """
+    import subprocess
+    state = state_manager.load()
+    results: list[SyncResult] = []
+    for task in state.tasks.values():
+        for repo_name in task.passive_repos:
+            wt = task.worktrees.get(repo_name)
+            if wt is None or not Path(wt).exists():
+                continue
+            repo_cfg = config.repos.get(repo_name)
+            if repo_cfg is None:
+                continue
+            ref = repo_cfg.expected_branch or repo_cfg.base_branch
+            if ref is None:
+                results.append(SyncResult(
+                    name=f"{task.slug}/{repo_name}", status="skipped",
+                    message="no expected_branch or base_branch declared",
+                ))
+                continue
+            canonical = repo_cfg.path
+            fetch = subprocess.run(
+                ["git", "fetch", "origin", ref], cwd=canonical,
+                capture_output=True, text=True, check=False, timeout=60,
+            )
+            if fetch.returncode != 0:
+                results.append(SyncResult(
+                    name=f"{task.slug}/{repo_name}", status="skipped",
+                    message=f"fetch failed: {fetch.stderr.strip()[:160]}",
+                ))
+                continue
+            reset = subprocess.run(
+                ["git", "-C", str(wt), "reset", "--hard", f"origin/{ref}"],
+                capture_output=True, text=True, check=False,
+            )
+            if reset.returncode == 0:
+                results.append(SyncResult(
+                    name=f"{task.slug}/{repo_name}", status="fast_forwarded",
+                    message=f"reset to origin/{ref}",
+                ))
+            else:
+                results.append(SyncResult(
+                    name=f"{task.slug}/{repo_name}", status="skipped",
+                    message=f"reset failed: {reset.stderr.strip()[:160]}",
+                ))
+    return results
+```
+
+- [ ] **Step 4: Wire `--no-passive` into `cli/sync.py`**
+
+Replace the `def sync(...)` parameters:
+
+```python
+    def sync(
+        repos: Optional[str] = typer.Option(None, "--repos", help="Comma-separated repo names"),
+        no_passive: bool = typer.Option(
+            False, "--no-passive",
+            help="Skip refreshing passive worktrees (default: include).",
+        ),
+    ):
+```
+
+After the existing sync results loop (after `output.print(...)` block), add:
+
+```python
+        if not no_passive:
+            from mship.core.repo_sync import refresh_passive_worktrees
+            passive_results = refresh_passive_worktrees(
+                container.state_manager(), config,
+            )
+            for r in passive_results:
+                if r.status == "fast_forwarded":
+                    output.print(f"  [green]{r.name}[/green]: {r.message}")
+                else:
+                    output.print(f"  [yellow]{r.name}[/yellow]: skipped ({r.message})")
+```
+
+- [ ] **Step 5: Run tests, expect PASS**
+
+```
+uv run pytest tests/cli/test_sync.py -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mship/core/repo_sync.py src/mship/cli/sync.py tests/cli/test_sync.py
+git commit -m "feat(sync): refresh passive worktrees, --no-passive opt-out"
+mship journal "phase 6: sync refreshes passive worktrees" --action committed
+```
+
+---
+
+## Phase 7 — Switch / phase / test guards for passive
+
+### Task 7.1: Switch warns on passive
+
+**Files:**
+- Modify: `src/mship/cli/switch.py`
+- Test: `tests/cli/test_switch.py`
+
+- [ ] **Step 1: Read existing switch CLI**
+
+```bash
+cat src/mship/cli/switch.py
+```
+
+Identify where the handoff is rendered and where `active_repo` is set on the task.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `tests/cli/test_switch.py`:
+
+```python
+def test_switch_to_passive_warns(tmp_path, monkeypatch):
+    """`mship switch <passive-repo>` succeeds but prints a passive warning."""
+    from datetime import datetime, timezone
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+    from mship.core.state import StateManager, Task, WorkspaceState
+
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\nrepos:\n"
+        "  api:\n    path: ./api\n    type: service\n    base_branch: main\n    expected_branch: main\n"
+        "  shared:\n    path: ./shared\n    type: library\n    base_branch: main\n    expected_branch: main\n"
+    )
+    for n in ("api", "shared"):
+        d = tmp_path / n
+        d.mkdir()
+        (d / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+        import subprocess
+        subprocess.run(["git", "init", "-q", str(d)], check=True, capture_output=True)
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    api_wt = tmp_path / ".worktrees" / "x" / "api"
+    shared_wt = tmp_path / ".worktrees" / "x" / "shared"
+    api_wt.mkdir(parents=True); shared_wt.mkdir(parents=True)
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "x": Task(
+            slug="x", description="x", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["api"], branch="feat/x",
+            worktrees={"api": api_wt, "shared": shared_wt},
+            passive_repos={"shared"},
+        )
+    }))
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    monkeypatch.chdir(api_wt)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(app, ["switch", "shared"])
+        assert result.exit_code == 0, result.output
+        assert "passive" in result.output.lower()
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+```
+
+- [ ] **Step 3: Run test, expect FAIL**
+
+```
+uv run pytest tests/cli/test_switch.py::test_switch_to_passive_warns -v
+```
+
+- [ ] **Step 4: Add the warning in `cli/switch.py`**
+
+After the switch operation succeeds and the handoff is built, check `repo_name in task.passive_repos`. If true, print a yellow warning before the normal handoff output:
+
+```python
+        if repo_name in t.passive_repos:
+            output.print(
+                f"[yellow]⚠[/yellow] Switched to `{repo_name}` (passive — read-only on "
+                f"`{config.repos[repo_name].expected_branch or config.repos[repo_name].base_branch}`).\n"
+                f"  To edit, close this task and respawn with `--repos {repo_name},...`"
+            )
+```
+
+(Adapt variable names to match the local context in `switch.py`.)
+
+- [ ] **Step 5: Run test, expect PASS; run full suite**
+
+```
+uv run pytest tests/cli/test_switch.py -v && uv run pytest -q
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mship/cli/switch.py tests/cli/test_switch.py
+git commit -m "feat(switch): warn when target repo is passive"
+mship journal "phase 7.1: switch to passive warns" --action committed
+```
+
+### Task 7.2: phase + test refuse passive active_repo
+
+**Files:**
+- Modify: `src/mship/cli/phase.py`, `src/mship/cli/exec.py` (the `test` command)
+- Test: extend `tests/cli/test_phase.py` and `tests/cli/test_exec.py`
+
+- [ ] **Step 1: Write failing tests for both**
+
+Append to `tests/cli/test_phase.py`:
+
+```python
+def test_phase_refuses_when_active_repo_is_passive(tmp_path, monkeypatch):
+    """`mship phase dev` errors if active_repo is passive."""
+    from datetime import datetime, timezone
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+    from mship.core.state import StateManager, Task, WorkspaceState
+
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\nrepos:\n  shared:\n    path: ./shared\n    type: library\n"
+    )
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "x": Task(
+            slug="x", description="x", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/x",
+            worktrees={"shared": tmp_path / "wt"},
+            passive_repos={"shared"},
+            active_repo="shared",
+        )
+    }))
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    monkeypatch.chdir(tmp_path)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(app, ["phase", "dev"])
+        assert result.exit_code != 0
+        assert "passive" in (result.output or "").lower()
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+```
+
+Append a similar test to `tests/cli/test_exec.py` (or wherever `mship test` is exercised) with the same shape, asserting `mship test` errors out.
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+```
+uv run pytest tests/cli/test_phase.py::test_phase_refuses_when_active_repo_is_passive -v
+```
+
+- [ ] **Step 3: Add the guards**
+
+In `src/mship/cli/phase.py`, near the top of the command body (before the soft-gate checks), add:
+
+```python
+        if t.active_repo and t.active_repo in t.passive_repos:
+            output.error(
+                f"Cannot transition phase: active_repo '{t.active_repo}' is passive. "
+                f"Switch to an affected repo first, or close & respawn with "
+                f"`--repos {t.active_repo},...` to make it editable."
+            )
+            raise typer.Exit(code=1)
+```
+
+Repeat the equivalent guard in `src/mship/cli/exec.py` for `mship test`. (Find the test command body; add the same check before invoking the test runner.)
+
+- [ ] **Step 4: Run tests, expect PASS; run full suite**
+
+```
+uv run pytest -q
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/cli/phase.py src/mship/cli/exec.py tests/cli/test_phase.py tests/cli/test_exec.py
+git commit -m "feat(phase,test): refuse when active_repo is passive"
+mship journal "phase 7.2: phase/test refuse passive active_repo" --action committed
+```
+
+---
+
+## Phase 8 — Prune + doctor + miscellaneous
+
+### Task 8.1: Prune scans hub layout
+
+**Files:**
+- Modify: `src/mship/core/prune.py:30-65`
+- Test: `tests/core/test_prune.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_prune.py`:
+
+```python
+def test_prune_detects_hub_layout_orphan(tmp_path):
+    """An orphan dir under <workspace>/.worktrees/<slug>/<repo>/ is detected."""
+    import subprocess
+    from mship.core.config import ConfigLoader
+    from mship.core.state import StateManager
+    from mship.core.prune import PruneManager
+    from mship.util.git import GitRunner
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\nrepos:\n  shared:\n    path: ./shared\n    type: library\n"
+    )
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    subprocess.run(["git", "init", "-q", str(tmp_path / "shared")],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                    "commit", "--allow-empty", "-qm", "init"],
+                   cwd=tmp_path / "shared", check=True, capture_output=True)
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    sm = StateManager(state_dir)
+    config = ConfigLoader.load(tmp_path / "mothership.yaml")
+    # Seed an orphan: hub-style worktree with no state entry
+    orphan = tmp_path / ".worktrees" / "stale-task" / "shared"
+    subprocess.run(["git", "worktree", "add", str(orphan), "-b", "feat/stale"],
+                   cwd=tmp_path / "shared", check=True, capture_output=True)
+    pm = PruneManager(config, sm, GitRunner())
+    orphans = pm.scan()
+    paths = {str(o.path.resolve()) for o in orphans}
+    assert str(orphan.resolve()) in paths
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+```
+uv run pytest tests/core/test_prune.py::test_prune_detects_hub_layout_orphan -v
+```
+
+Expected: FAIL — current `scan` only walks `<repo>/.worktrees/`, not the workspace hub.
+
+- [ ] **Step 3: Extend `PruneManager.scan`**
+
+In `src/mship/core/prune.py`, in `scan()`, after the existing per-repo `<repo>/.worktrees` walk, add a workspace-root walk:
+
+```python
+        # Hub layout: scan <workspace>/.worktrees/<slug>/<repo>/
+        # Workspace root is the parent dir of mothership.yaml — not stored on
+        # WorkspaceConfig, so derive from any repo's path.parent.
+        candidates: set[Path] = set()
+        for repo_cfg in self._config.repos.values():
+            candidates.add(repo_cfg.path.parent)
+        for ws_root in candidates:
+            hub_root = ws_root / ".worktrees"
+            if not hub_root.is_dir():
+                continue
+            for slug_dir in hub_root.iterdir():
+                if not slug_dir.is_dir():
+                    continue
+                for repo_dir in slug_dir.iterdir():
+                    if not repo_dir.is_dir():
+                        continue
+                    if not (repo_dir / ".git").exists():
+                        continue
+                    resolved = str(repo_dir.resolve())
+                    if resolved in tracked_paths:
+                        continue
+                    # Find the matching repo by path.parent matching ws_root
+                    matched_repo = None
+                    for name, rc in self._config.repos.items():
+                        if rc.path.parent.resolve() == ws_root.resolve():
+                            # Heuristic: orphan in hub, attribute to a repo
+                            # so worktree_remove gets called against the right
+                            # canonical checkout. If multiple repos share a
+                            # workspace, attribute by directory name.
+                            if rc.path.name == repo_dir.name:
+                                matched_repo = name
+                                break
+                    if matched_repo is None:
+                        # Unknown repo dir under hub — best-effort, skip
+                        continue
+                    orphans.append(OrphanedWorktree(
+                        repo=matched_repo,
+                        path=repo_dir,
+                        reason="not_in_state",
+                    ))
+```
+
+- [ ] **Step 4: Run test, expect PASS**
+
+```
+uv run pytest tests/core/test_prune.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/prune.py tests/core/test_prune.py
+git commit -m "feat(prune): scan hub-layout worktrees alongside legacy per-repo"
+mship journal "phase 8.1: prune covers hub layout" --action committed
+```
+
+### Task 8.2: Doctor checks workspace `.gitignore`
+
+**Files:**
+- Modify: `src/mship/core/doctor.py`
+- Test: `tests/core/test_doctor.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_doctor.py`:
+
+```python
+def test_doctor_warns_when_workspace_gitignore_missing_worktrees(tmp_path):
+    """If workspace root is a git repo and .gitignore lacks `.worktrees`, doctor warns."""
+    import subprocess
+    from mship.core.config import ConfigLoader
+    from mship.core.doctor import DoctorChecker
+    from mship.core.state import StateManager
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\nrepos:\n  a:\n    path: ./a\n    type: service\n"
+    )
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, capture_output=True)
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    config = ConfigLoader.load(tmp_path / "mothership.yaml")
+    checker = DoctorChecker(config, StateManager(state_dir), workspace_root=tmp_path)
+    report = checker.run()
+    relevant = [c for c in report.checks if "worktrees" in c.message.lower()]
+    assert any(c.severity == "warn" for c in relevant), [c.message for c in report.checks]
+```
+
+(Confirm `DoctorChecker.__init__` signature; if it doesn't take `workspace_root`, adapt the test or extend the constructor.)
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+```
+uv run pytest tests/core/test_doctor.py::test_doctor_warns_when_workspace_gitignore_missing_worktrees -v
+```
+
+- [ ] **Step 3: Add the check in `DoctorChecker.run`**
+
+In `src/mship/core/doctor.py`, inside `DoctorChecker.run`, append a check:
+
+```python
+        # Workspace .gitignore should include .worktrees if root is a git repo
+        ws = self._workspace_root  # adapt to wherever workspace root lives on the checker
+        if ws and (ws / ".git").exists():
+            gi = ws / ".gitignore"
+            entries = gi.read_text().splitlines() if gi.exists() else []
+            if ".worktrees" not in entries:
+                checks.append(CheckResult(
+                    severity="warn",
+                    message=f"workspace .gitignore missing `.worktrees` entry (will be added on next spawn)",
+                ))
+```
+
+If `DoctorChecker` doesn't currently know workspace_root, plumb it through (constructor parameter, set from container).
+
+- [ ] **Step 4: Run test, expect PASS**
+
+```
+uv run pytest tests/core/test_doctor.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/doctor.py tests/core/test_doctor.py
+git commit -m "feat(doctor): check workspace .gitignore for .worktrees"
+mship journal "phase 8.2: doctor checks workspace gitignore" --action committed
+```
+
+### Task 8.3: Final integration — full hub-layout end-to-end test
+
+**Files:**
+- Test: `tests/test_integration.py`
+
+- [ ] **Step 1: Write the integration test**
+
+Append to `tests/test_integration.py`:
+
+```python
+def test_full_hub_layout_e2e(tmp_path, monkeypatch):
+    """Spawn → commit in affected → audit → close — under hub layout, with passive."""
+    import os, subprocess
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+
+    # Two repos: api depends on shared
+    for n in ("api", "shared"):
+        d = tmp_path / n
+        d.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main", str(d)],
+                       check=True, capture_output=True)
+        (d / "Taskfile.yml").write_text("version: '3'\ntasks:\n  setup:\n    cmds:\n      - echo ok\n")
+        (d / "README.md").write_text(n)
+        subprocess.run(["git", "add", "."], cwd=d, check=True, capture_output=True, env=env)
+        subprocess.run(["git", "commit", "-qm", "init"], cwd=d, check=True, capture_output=True, env=env)
+
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: e2e\nrepos:\n"
+        "  api:\n    path: ./api\n    type: service\n    base_branch: main\n    expected_branch: main\n    depends_on: [shared]\n"
+        "  shared:\n    path: ./shared\n    type: library\n    base_branch: main\n    expected_branch: main\n"
+    )
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(tmp_path / ".mothership")
+    monkeypatch.chdir(tmp_path)
+    try:
+        runner = CliRunner()
+        # Spawn affected=api, expect shared to be passive
+        result = runner.invoke(app, ["spawn", "feature", "--repos", "api",
+                                     "--skip-setup", "--force-audit", "--offline"])
+        assert result.exit_code == 0, result.output
+
+        from mship.core.state import StateManager
+        state = StateManager(tmp_path / ".mothership").load()
+        task = state.tasks["feature"]
+        # Hub layout: both worktrees as siblings under <workspace>/.worktrees/feature/
+        hub = tmp_path / ".worktrees" / "feature"
+        assert task.worktrees["api"] == hub / "api"
+        assert task.worktrees["shared"] == hub / "shared"
+        # Passive set
+        assert task.passive_repos == {"shared"}
+        # Sibling resolution (the win case)
+        from_api = task.worktrees["api"] / ".." / "shared"
+        assert from_api.resolve() == task.worktrees["shared"].resolve()
+        # Single .mship-workspace marker
+        assert (hub / ".mship-workspace").is_file()
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+```
+
+- [ ] **Step 2: Run test, expect PASS**
+
+```
+uv run pytest tests/test_integration.py::test_full_hub_layout_e2e -v
+```
+
+- [ ] **Step 3: Run full suite**
+
+```
+uv run pytest -q
+```
+
+Expected: 0 failures.
+
+- [ ] **Step 4: Commit + version bump**
+
+Bump `pyproject.toml` version `0.1.1 → 0.2.0`:
+
+```bash
+sed -i 's/^version = "0.1.1"$/version = "0.2.0"/' pyproject.toml
+grep '^version' pyproject.toml  # confirm 0.2.0
+```
+
+```bash
+git add tests/test_integration.py pyproject.toml
+git commit -m "chore: bump to 0.2.0; add full hub-layout e2e test"
+mship journal "phase 8.3: e2e green; version bumped to 0.2.0" --action committed --test-state pass
+```
+
+---
+
+## Done
+
+After all phases:
+1. Run `mship test` to record final test pass.
+2. Run `mship phase review` (then `run` if applicable).
+3. Run `mship finish --body-file docs/superpowers/specs/2026-04-28-hub-worktree-layout-design.md` (or write a dedicated PR body).
+4. Note: each phase is a natural PR. Either bundle (one big PR with the full feature) or split (8 PRs, merged in order). For agent-driven execution, bundling reduces churn — but ask the human reviewer.

--- a/docs/superpowers/specs/2026-04-28-hub-worktree-layout-design.md
+++ b/docs/superpowers/specs/2026-04-28-hub-worktree-layout-design.md
@@ -1,0 +1,271 @@
+# Hub Worktree Layout Design Spec
+
+Resolves #87 (worktree layout breaks sibling-relative paths). Defers and partially obviates #110 (`external_symlinks`); see "Out of Scope" section.
+
+## Overview
+
+mship currently places each repo's worktrees inside that repo: `<repo>/.worktrees/feat/<slug>/`. This breaks every cross-repo path pattern that depends on siblings being siblings — editable Python deps (`pip install -e ../shared`), Taskfile cross-cd (`cd ../shared && task build`), docker-compose volume mounts, IDE workspace files, etc. mship is positioned as the coordination layer for cross-repo work, but the layout actively undermines the cross-repo coordination it's supposed to enable.
+
+This spec replaces the per-repo layout with a **per-task hub layout**: every worktree for a task — including auto-materialized dependencies — lives as a sibling under `<workspace>/.worktrees/<slug>/`. Cross-repo references resolve correctly by construction.
+
+The change is structural, not configurable. Per-repo layout is removed entirely; no opt-in/opt-out setting. mship is pre-1.0; the cost of carrying two layouts forever vastly exceeds the cost of a clean break now.
+
+## 1. Hub Layout
+
+### Layout
+
+```
+<workspace>/
+├── mothership.yaml
+├── api/                       ← canonical checkout (unchanged)
+├── shared/                    ← canonical checkout (unchanged)
+└── .worktrees/
+    └── <slug>/                ← per-task hub
+        ├── api/               ← affected: feat/<slug>
+        ├── shared/            ← affected or passive (see §2)
+        └── .mship-workspace   ← single marker per hub
+```
+
+`<slug>` is the existing branch slug. Branch name on each affected worktree stays `feat/<slug>` per current `branch_pattern`.
+
+### Why this shape
+
+- `cd ../sibling` from inside any worktree resolves to the sibling task worktree, by construction. No symlink layer, no scanner, no path-rewriting.
+- A single `.mship-workspace` marker at the hub root is sufficient — any walk-up from inside any sibling lands on it. Subrepo workspace discovery (#84) keeps working.
+- `git worktree add` semantics are unchanged. mship just passes a different destination path to git. No new git feature, flag, or invocation.
+
+### Git plumbing
+
+`git worktree add <hub>/<slug>/<repo> feat/<slug>` from each canonical repo. Git tracks each worktree by absolute path and writes a per-worktree admin dir at `<canonical-repo>/.git/worktrees/<slug>/` — exactly as today, just with a different destination path. `git worktree list`, `git worktree remove`, `git worktree move` all work normally.
+
+### Workspace `.gitignore`
+
+If the workspace root itself lives in a git repo (common when a single repo IS the workspace), mship adds `.worktrees` to that root's `.gitignore` on first spawn. Same logic as today's per-repo `.gitignore` handling, just at a different path.
+
+### Removal of per-repo layout
+
+- Drop the `worktree_layout` field from `mothership.yaml` (it never shipped — this is preemptive).
+- All new spawns use hub layout unconditionally. No flag, no env var, no setting.
+- In-flight tasks created before upgrade are unaffected (state.yaml stores absolute paths). They finish out under their original layout. See §4 for the migration story.
+
+## 2. Passive Worktrees
+
+A *passive worktree* is a sibling repo materialized in the hub because some affected repo declared `depends_on` on it, but the user didn't include it in `--repos`. It's read-only-by-convention (pre-commit hook refuses commits) and pinned to a stable origin ref.
+
+### When materialized
+
+At spawn, mship walks `depends_on` from each affected repo. Any transitive dep that isn't in `affected_repos` becomes passive. Same hub layout slot: `<workspace>/.worktrees/<slug>/<dep>/`.
+
+`depends_on` is the only auto-materialization signal. Cross-repo references not modeled in `depends_on` (Taskfile cross-cd to a non-dep, ad-hoc scripts) require explicit declaration via the future `external_symlinks` feature (out of scope; see §5). This is a deliberate trade — auto-discovery via per-ecosystem scanners (Python pyproject, Node package.json, Taskfile, docker-compose) is a maintenance liability and gets things wrong; explicit declaration is principled and auditable.
+
+### What branch they're on
+
+For each passive repo, mship resolves the branch ref as:
+- `expected_branch` if set in `mothership.yaml`, else
+- `base_branch` if set, else
+- **error**: "passive materialization for `<repo>` requires `expected_branch` or `base_branch` declared in mothership.yaml."
+
+Then:
+
+```
+git fetch origin <ref>
+git worktree add --detach <hub>/<slug>/<dep> origin/<ref>
+```
+
+**Detached HEAD at the just-fetched origin ref.** The local branch is never consulted, so "I forgot to fetch and got a stale passive worktree" is impossible by construction.
+
+### Setup treatment
+
+Materialize `symlink_dirs` (e.g., `node_modules`) and `bind_files` (e.g., `.env`). **Do NOT run `task setup`.** Rationale: the consumer's `cd ../shared && task build` typically only needs shared's source plus its already-installed deps (which `symlink_dirs` provides). `task setup` for passive deps would balloon spawn time for a benefit only realized in unusual cases (codegen-during-setup, schema generation).
+
+A per-repo escape hatch (`passive_setup: skip | symlinks-only | full`, default `symlinks-only`) is **deferred** until a concrete use case appears. YAGNI.
+
+### State.yaml schema
+
+Existing `Task.worktrees: dict[str, Path]` stays one entry per repo (affected or passive). New field:
+
+```python
+class Task(BaseModel):
+    worktrees: dict[str, Path]
+    passive_repos: set[str] = set()  # subset of worktrees.keys()
+    ...
+```
+
+`passive_repos` lets `mship status`, `mship audit`, and the pre-commit hook ask "is this passive?" without inferring it from branch state or path.
+
+### Pre-commit hook
+
+After the existing "matches a registered worktree" check passes, also check `repo_name in matched_task.passive_repos`. If so, refuse:
+
+```
+⛔ mship: refusing commit — <path> is a passive worktree of `<repo>`
+   for task `<slug>`. To edit <repo>, close this task and respawn
+   with `--repos <repo>,<other-affected> ...`
+   (or `git commit --no-verify` to override).
+```
+
+### Offline escape hatch
+
+`mship spawn --offline` skips the `git fetch` and uses the local `<ref>`. A journal entry tagged `OFFLINE` is written so the choice is audit-visible. Single flag, applies to all passive fetches in this spawn.
+
+## 3. Lifecycle Integration
+
+### `spawn`
+
+1. Resolve affected repos from `--repos` (existing logic).
+2. Walk `depends_on` graph; deps not in affected become passive.
+3. Run audit (existing gate). For passive repos: `git fetch origin <ref>` and validate. Fetch failure blocks unless `--offline` (graceful) or `--force-audit` (logged bypass).
+4. For affected repos: `git worktree add <hub>/<slug>/<repo> feat/<slug>` (existing flow, new path).
+5. For passive repos: `git worktree add --detach <hub>/<slug>/<dep> origin/<ref>`, materialize `symlink_dirs` + `bind_files`, no `task setup`.
+6. Write `.mship-workspace` marker at hub root.
+7. Persist `worktrees` and `passive_repos` to state.
+
+### `audit`
+
+Existing checks against canonical checkouts unchanged. New issue codes for passive worktrees:
+
+- `passive_drift` (warn) — passive worktree's HEAD ≠ `origin/<ref>` after fetch. Surfaces drift over a long-running task.
+- `passive_dirty_worktree` (warn) — user manually edited a passive worktree (hook refuses commits, but `git stash`, manual `git add` etc. can still leave dirty trees).
+- `passive_fetch_failed` (error) — fetch for a passive ref failed (network, auth). Same severity treatment as existing `fetch_failed` for affected repos.
+
+Existing `extra_worktrees` check uses state.yaml as source of truth, so legacy per-repo worktrees from in-flight tasks aren't flagged.
+
+### `sync`
+
+- Canonical checkouts: existing semantics (strictly safe, fast-forward only).
+- Passive worktrees: `git fetch origin <ref>`, then `git reset --hard origin/<ref>`. Safe because passive worktrees are mship-managed, detached HEAD, and hook-protected from commits — there is nothing the user could lose.
+- Default: includes passive worktrees. `--no-passive` opts out.
+
+### `close`
+
+After existing close gates (recovery-path check, PR state routing) pass:
+1. `git worktree remove` each entry in `task.worktrees`.
+2. `rm -rf <workspace>/.worktrees/<slug>/`.
+
+Passive worktrees come out alongside affected ones.
+
+### `prune`
+
+Two responsibilities:
+1. Existing: orphaned worktrees in registered locations. Extends naturally to hub.
+2. New: legacy `<repo>/.worktrees/feat/<slug>/` dirs from pre-hub tasks that have closed. Detected via `git worktree list` showing them as orphaned plumbing.
+
+### `bind refresh`
+
+Already covers `bind_files` + `symlink_dirs` (#71, #111). Extends to passive worktrees with no flag change — same per-repo iteration just covers more entries.
+
+### `switch`
+
+`mship switch <repo>` may target a passive repo. The handoff message warns:
+
+```
+⚠ Switched to `<repo>` (passive — read-only on `<ref>`).
+  To edit, close this task and respawn with `--repos <repo>,...`
+```
+
+`mship test` and `mship phase` against a passive-active repo error out with the same guidance.
+
+### `doctor`
+
+Add a check: workspace root has `.worktrees` in its `.gitignore` if the root lives in a git repo. mship adds it on first spawn (existing behavior, new path); doctor verifies for sanity.
+
+### `run` / `logs`
+
+Unchanged. `run` operates on canonical checkouts per current semantics; healthchecks etc. unaffected by worktree topology.
+
+## 4. Migration
+
+### No data migration required
+
+State.yaml stores absolute worktree paths. In-flight tasks remember exactly where they live and finish out under the original layout. Only spawns *after* upgrade use hub layout.
+
+### Crossover state
+
+Workspaces with both legacy and hub tasks are bounded and well-defined:
+
+- **Old tasks** stay under `<repo>/.worktrees/feat/<slug>/`. `mship status`, `mship test`, `mship finish`, `mship close` all work — they read absolute paths from state.yaml.
+- **New tasks** live under `<workspace>/.worktrees/<slug>/`. Same commands, same code paths.
+- `mship audit` compares against state.yaml's recorded paths, so neither layout produces false positives.
+- `mship prune` cleans up legacy `<repo>/.worktrees/` dirs as those tasks close. After the last legacy task closes, the directory is gone for good.
+
+### Versioning
+
+Bump to **0.2.0**. Behavior change in shape (worktree paths move) but not in API. No field removed, no flag changed — per-repo layout was implementation, not documented config.
+
+### Release notes copy
+
+> **mship 0.2.0 — Worktree layout change**
+>
+> New tasks spawned after upgrade live under `<workspace>/.worktrees/<slug>/<repo>/` (a per-task hub of sibling worktrees) instead of `<repo>/.worktrees/feat/<slug>/`. This makes cross-repo references (`cd ../sibling`, editable Python deps, etc.) work naturally inside a task.
+>
+> **In-flight tasks created before upgrade are unaffected** — they finish out under their original paths.
+>
+> **Watch out for:**
+> - IDE workspace files or scripts pinned to old worktree paths. Update them when you create your next task.
+> - The workspace root needs `.worktrees` in its `.gitignore` if the workspace itself lives in a git repo. mship adds it automatically on first spawn.
+>
+> **New behavior:** If a task touches `api` and `api.depends_on` includes `shared`, mship now materializes `shared` in the hub on its base/expected branch as a *passive worktree* — read-only, kept fresh from origin. To edit `shared`, include it in `--repos` like before.
+
+## 5. Out of Scope
+
+Called out explicitly so it's not a surprise later:
+
+### `external_symlinks` (#110)
+
+Deferred to a follow-up spec. Hub layout solves the bulk of #110's motivation:
+
+| Original #110 use case | Now handled by |
+|---|---|
+| `cd ../sibling` in Taskfile | Hub layout |
+| Editable Python deps to other repos in the task | Hub layout |
+| Linking to non-affected sibling repos | Passive worktrees |
+| Build caches at fixed absolute paths | Future `external_symlinks` |
+| Secret/config mounts at fixed paths | Future `external_symlinks` |
+| Workspace-internal non-repo dirs | Future `external_symlinks` |
+
+The residual cases are real but small. Defer until we see what users actually struggle with under hub layout.
+
+### Monorepo subdirectory off-by-one
+
+Repos with `git_root: <parent>` and `path: <subdir>` live at `<workspace>/.worktrees/<slug>/<parent>/<subdir>/`. From there, `../sibling` resolves to `<workspace>/.worktrees/<slug>/<parent>/sibling`, not the actual sibling at `<workspace>/.worktrees/<slug>/sibling`. The Taskfile would need `../../sibling`.
+
+This is the same off-by-one that exists in per-repo today (`web`'s worktree was at `<parent>/.worktrees/feat/<slug>/web/`, with the same problem). Hub doesn't fix it; doesn't worsen it. Tracking issue if it becomes painful.
+
+## 6. Supported Configurations
+
+| Workspace shape | Behavior |
+|---|---|
+| Single-repo workspace | Worktree at `<workspace>/.worktrees/<slug>/<repo>/`. One extra nesting level vs. per-repo, otherwise identical. No siblings, no passive worktrees ever materialized. |
+| Multi-repo metarepo | Affected repos sit as siblings in the hub. Passive deps materialize alongside. `cd ../sibling` works by construction. **The win case.** |
+| Monorepo with `git_root` subdirs | Parent worktree at `<workspace>/.worktrees/<slug>/<parent>/`. Subdir child at `<workspace>/.worktrees/<slug>/<parent>/<subdir>/`. Cross-repo references from a subdir have the off-by-one noted in §5. Same as today. |
+| Repo with `path: .` (workspace IS canonical repo) | Worktree at `<workspace>/.worktrees/<slug>/<name>/` — inside that repo's own canonical checkout. `.gitignore` already handles this. |
+| Repos at paths outside workspace (`path: ../external-repo`) | Canonical checkout wherever; worktree is still in the hub at `<workspace>/.worktrees/<slug>/<repo>/`. `git worktree add` accepts any absolute destination. |
+
+## 7. Considered & Rejected Alternatives
+
+### Opt-in `worktree_layout: per-repo | hub` setting (default per-repo)
+
+Keeps both layouts forever as a documented choice. **Rejected** because:
+- Permanent maintenance tax: every worktree-touching code path branches; tests double; doctor / audit / sync / prune carry the matrix.
+- The setting is itself a footgun — users will pick `per-repo` (it sounds simpler) and then file bugs about cross-repo paths breaking, the exact thing hub was designed to fix. Shipping a known-broken-by-design option as a configurable choice is anti-product.
+- Per-repo offers no segment of users a meaningfully better experience. Single-repo workspaces don't suffer from hub; multi-repo workspaces benefit from it.
+
+### Default-flip with deprecation grace period
+
+Default per-repo for one or two minor versions; deprecation warning when field is unset; flip default to hub. **Rejected** because:
+- mship is pre-1.0. Now is exactly when clean breaks are appropriate.
+- Adds two release cycles of carrying both layouts before the eventual flip — same maintenance tax as opt-in, just bounded.
+
+### Hidden `MSHIP_LEGACY_LAYOUT=1` env var escape hatch
+
+Considered as a hedge in case hub layout has a bug we don't catch in testing. **Rejected** because:
+- Argument for testing, not for shipping a documented-but-undocumented escape hatch.
+- If we discover a workspace that genuinely can't move, we'd add an escape hatch then with a real motivating example. Speculative escape hatches accrue cost without proven value.
+
+### Auto-discover cross-repo references via per-ecosystem scanners
+
+Scan Taskfiles, `pyproject.toml` editable deps, `package.json` workspace links, `docker-compose.yml` volume mounts, etc. to auto-materialize passive worktrees beyond `depends_on`. **Rejected** because:
+- Each scanner is a maintenance liability (different ecosystems, frequent format churn) and will have false positives/negatives.
+- Spawn becomes magic — user passes `--repos api`, gets worktrees they didn't request.
+- Doesn't actually eliminate explicit declaration for non-repo external resources (caches, secrets) — adds magic on top of, not instead of, `external_symlinks`.
+- Better answer: clear error message when a missing path is hit (`"add 'shared' to --repos or declare it in external_symlinks"`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mothership"
-version = "0.1.1"
+version = "0.2.0"
 description = "Phase-based workflow engine for multi-repo AI development"
 requires-python = ">=3.14"
 dependencies = [
@@ -33,4 +33,5 @@ dev = [
     "pytest>=8.0",
     "pytest-tmp-files>=0.0.2",
     "pytest-asyncio>=0.23",
+    "coverage>=7.13.5",
 ]

--- a/src/mship/cli/audit.py
+++ b/src/mship/cli/audit.py
@@ -119,7 +119,8 @@ def register(app: typer.Typer, get_container):
         except Exception as e:
             # Best-effort: failing to audit passive worktrees should not break
             # the canonical audit output.
-            output.warning(f"passive audit unavailable: {e}")
+            if not json_output:
+                output.warning(f"passive audit unavailable: {e}")
 
         if json_output:
             import json as _json

--- a/src/mship/cli/audit.py
+++ b/src/mship/cli/audit.py
@@ -35,6 +35,92 @@ def register(app: typer.Typer, get_container):
             output.error(str(e))
             raise typer.Exit(code=1)
 
+        # Surface passive worktree issues (passive_drift, passive_fetch_failed,
+        # passive_dirty_worktree). Iterates state.tasks; for each (task, repo)
+        # in task.passive_repos, audits the worktree and merges issues into
+        # the matching RepoAudit entry in `report`.
+        try:
+            from mship.core.repo_state import (
+                audit_passive_worktrees, RepoAudit, AuditReport, Issue,
+            )
+            state = container.state_manager().load()
+
+            # Group passive worktrees by task. For each task, run a separate
+            # audit so messages can include the task slug for disambiguation.
+            passive_per_task: list[tuple[str, dict, dict, dict]] = []
+            for task_slug, task in state.tasks.items():
+                if not task.passive_repos:
+                    continue
+                paths: dict = {}
+                refs: dict = {}
+                canonicals: dict = {}
+                for repo_name in task.passive_repos:
+                    if repo_name not in config.repos:
+                        continue
+                    rc = config.repos[repo_name]
+                    ref = getattr(rc, "expected_branch", None) or getattr(rc, "base_branch", None)
+                    if ref is None:
+                        continue
+                    wt = task.worktrees.get(repo_name)
+                    if wt is None:
+                        continue
+                    paths[repo_name] = wt
+                    refs[repo_name] = ref
+                    canonicals[repo_name] = rc.path
+                if paths:
+                    passive_per_task.append((task_slug, paths, refs, canonicals))
+
+            extra_issues_per_repo: dict[str, list] = {}
+            for task_slug, paths, refs, canonicals in passive_per_task:
+                per_repo = audit_passive_worktrees(paths, refs, canonicals)
+                for repo_name, issues in per_repo.items():
+                    if not issues:
+                        continue
+                    # Tag each issue with the task slug for disambiguation
+                    tagged = [
+                        Issue(i.code, i.severity,
+                              f"[task {task_slug}] {i.message}")
+                        for i in issues
+                    ]
+                    extra_issues_per_repo.setdefault(repo_name, []).extend(tagged)
+
+            if extra_issues_per_repo:
+                # Rebuild report.repos so RepoAudit instances containing passive
+                # repos pick up the merged issues.
+                new_repos = []
+                seen: set[str] = set()
+                for r in report.repos:
+                    seen.add(r.name)
+                    extra = extra_issues_per_repo.get(r.name, [])
+                    if extra:
+                        new_repos.append(RepoAudit(
+                            name=r.name,
+                            path=r.path,
+                            current_branch=r.current_branch,
+                            issues=tuple(list(r.issues) + extra),
+                        ))
+                    else:
+                        new_repos.append(r)
+                # Repos with passive issues but not in the audit_repos report
+                # (e.g. excluded by --repos filter). Append fresh entries.
+                for repo_name, extra in extra_issues_per_repo.items():
+                    if repo_name in seen:
+                        continue
+                    rc = config.repos.get(repo_name)
+                    if rc is None:
+                        continue
+                    new_repos.append(RepoAudit(
+                        name=repo_name,
+                        path=rc.path,
+                        current_branch=None,
+                        issues=tuple(extra),
+                    ))
+                report = AuditReport(repos=tuple(new_repos))
+        except Exception as e:
+            # Best-effort: failing to audit passive worktrees should not break
+            # the canonical audit output.
+            output.warning(f"passive audit unavailable: {e}")
+
         if json_output:
             import json as _json
             print(_json.dumps(report.to_json(workspace=config.workspace), indent=2))

--- a/src/mship/cli/doctor.py
+++ b/src/mship/cli/doctor.py
@@ -14,7 +14,12 @@ def register(app: typer.Typer, get_container):
 
         config = container.config()
         shell = container.shell()
-        checker = DoctorChecker(config, shell, state_dir=container.state_dir())
+        checker = DoctorChecker(
+            config,
+            shell,
+            state_dir=container.state_dir(),
+            workspace_root=container.config_path().parent,
+        )
         report = checker.run()
 
         if output.is_tty:

--- a/src/mship/cli/exec.py
+++ b/src/mship/cli/exec.py
@@ -78,6 +78,14 @@ def register(app: typer.Typer, get_container):
         resolved = resolve_for_command("exec", state, task, output)
         t = resolved.task
 
+        if t.active_repo and t.active_repo in t.passive_repos:
+            output.error(
+                f"Cannot run tests: active_repo '{t.active_repo}' is passive. "
+                f"Switch to an affected repo first, or close & respawn with "
+                f"`--repos {t.active_repo},...` to make it editable."
+            )
+            raise typer.Exit(code=1)
+
         from pathlib import Path as _P
         from mship.cli._cwd_check import format_cwd_warning
         if t.active_repo is not None and t.active_repo in t.worktrees:

--- a/src/mship/cli/internal.py
+++ b/src/mship/cli/internal.py
@@ -30,18 +30,31 @@ def register(app: typer.Typer, get_container):
         try:
             tl = Path(toplevel).resolve()
             registered = [
-                (slug, Path(wt).resolve())
+                (slug, repo, Path(wt).resolve())
                 for slug, task in state.tasks.items()
-                for wt in task.worktrees.values()
+                for repo, wt in task.worktrees.items()
             ]
         except (OSError, RuntimeError):
             raise typer.Exit(code=0)
 
         matched_task = None
-        for slug, wt in registered:
+        matched_repo: str | None = None
+        for slug, repo, wt in registered:
             if tl == wt:
                 matched_task = state.tasks[slug]
+                matched_repo = repo
                 break
+
+        if matched_task is not None and matched_repo in matched_task.passive_repos:
+            import sys
+            sys.stderr.write(
+                f"⛔ mship: refusing commit — {tl} is a passive worktree of "
+                f"`{matched_repo}` for task `{matched_task.slug}`.\n"
+                f"   To edit {matched_repo}, close this task and respawn with "
+                f"`--repos {matched_repo},...`\n"
+                f"   (or `git commit --no-verify` to override).\n"
+            )
+            raise typer.Exit(code=1)
 
         if matched_task is not None:
             # Reconcile gate (per-task, unchanged behavior)
@@ -88,7 +101,7 @@ def register(app: typer.Typer, get_container):
             f"\u26d4 mship: refusing commit — {tl} is not a registered worktree.\n"
             f"   Active task worktrees:\n"
         )
-        for slug, wt in registered:
+        for slug, _repo, wt in registered:
             sys.stderr.write(f"     {wt} ({slug})\n")
 
         # If the rejected toplevel has uncommitted changes, it's almost
@@ -110,7 +123,7 @@ def register(app: typer.Typer, get_container):
                 f"\n   {tl} has uncommitted changes — looks like edits landed here\n"
                 f"   instead of the worktree. To move them:\n"
             )
-            for slug, wt in registered:
+            for slug, _repo, wt in registered:
                 q_wt = shlex.quote(str(wt))
                 sys.stderr.write(
                     f"     git -C {q_tl} stash push -u -m {slug}-misrouted\n"

--- a/src/mship/cli/phase.py
+++ b/src/mship/cli/phase.py
@@ -28,6 +28,14 @@ def register(app: typer.Typer, get_container):
         resolved = resolve_for_command("phase", state, task, output)
         t = resolved.task
 
+        if t.active_repo and t.active_repo in t.passive_repos:
+            output.error(
+                f"Cannot transition phase: active_repo '{t.active_repo}' is passive. "
+                f"Switch to an affected repo first, or close & respawn with "
+                f"`--repos {t.active_repo},...` to make it editable."
+            )
+            raise typer.Exit(code=1)
+
         if t.blocked_reason and not force:
             output.error(
                 f"Task is blocked: {t.blocked_reason}. "

--- a/src/mship/cli/switch.py
+++ b/src/mship/cli/switch.py
@@ -36,8 +36,9 @@ def register(app: typer.Typer, get_container):
             target = t.active_repo
             is_switch = False
         else:
-            if repo not in t.affected_repos:
-                valid = ", ".join(t.affected_repos)
+            all_repos = list(t.affected_repos) + [r for r in t.passive_repos if r not in t.affected_repos]
+            if repo not in all_repos:
+                valid = ", ".join(all_repos)
                 output.error(f"Unknown repo '{repo}'. Valid: {valid}.")
                 raise typer.Exit(code=1)
             target = repo
@@ -63,10 +64,13 @@ def register(app: typer.Typer, get_container):
 
         handoff = build_handoff(config, state_mgr.load(), shell, log_mgr, repo=target, task_slug=t.slug)
 
+        is_passive = target in t.passive_repos
+
         if not output.is_tty:
             json_payload = handoff.to_json()
             json_payload["resolved_task"] = resolved.task.slug
             json_payload["resolution_source"] = resolved.source
+            json_payload["is_passive"] = is_passive
             output.json(json_payload)
             return
 
@@ -104,6 +108,13 @@ def register(app: typer.Typer, get_container):
         lines.append(
             f"[bold]{verb}:[/bold] {handoff.repo} (task: {handoff.task_slug}, phase: {handoff.phase})"
         )
+        if is_passive:
+            repo_cfg = config.repos.get(target)
+            ref = (repo_cfg.expected_branch or repo_cfg.base_branch) if repo_cfg else target
+            lines.append(
+                f"[yellow]⚠[/yellow] Switched to `{target}` (passive — read-only on `{ref}`).\n"
+                f"  To edit, close this task and respawn with `--repos {target},...`"
+            )
         lines.append(f"[bold]Branch:[/bold]   {handoff.branch}")
         lines.append(f"[bold]Worktree:[/bold] {handoff.worktree_path}")
         lines.append("")

--- a/src/mship/cli/switch.py
+++ b/src/mship/cli/switch.py
@@ -112,7 +112,9 @@ def register(app: typer.Typer, get_container):
             repo_cfg = config.repos.get(target)
             ref = (repo_cfg.expected_branch or repo_cfg.base_branch) if repo_cfg else target
             lines.append(
-                f"[yellow]⚠[/yellow] Switched to `{target}` (passive — read-only on `{ref}`).\n"
+                f"[yellow]⚠[/yellow] Switched to `{target}` (passive — read-only on `{ref}`)."
+            )
+            lines.append(
                 f"  To edit, close this task and respawn with `--repos {target},...`"
             )
         lines.append(f"[bold]Branch:[/bold]   {handoff.branch}")

--- a/src/mship/cli/sync.py
+++ b/src/mship/cli/sync.py
@@ -9,6 +9,10 @@ def register(app: typer.Typer, get_container):
     @app.command()
     def sync(
         repos: Optional[str] = typer.Option(None, "--repos", help="Comma-separated repo names"),
+        no_passive: bool = typer.Option(
+            False, "--no-passive",
+            help="Skip refreshing passive worktrees (default: include).",
+        ),
     ):
         """Fast-forward repos that audit cleanly and are behind origin."""
         from mship.core.repo_state import audit_repos
@@ -45,5 +49,16 @@ def register(app: typer.Typer, get_container):
                 output.print(f"  [green]{r.name}[/green]: fast-forwarded ({r.message})")
             else:
                 output.print(f"  [yellow]{r.name}[/yellow]: skipped ({r.message})")
+
+        if not no_passive:
+            from mship.core.repo_sync import refresh_passive_worktrees
+            passive_results = refresh_passive_worktrees(
+                container.state_manager(), config,
+            )
+            for r in passive_results:
+                if r.status == "fast_forwarded":
+                    output.print(f"  [green]{r.name}[/green]: {r.message}")
+                else:
+                    output.print(f"  [yellow]{r.name}[/yellow]: skipped ({r.message})")
 
         raise typer.Exit(code=1 if out.has_errors else 0)

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -225,6 +225,11 @@ def register(app: typer.Typer, get_container):
             help="Skip confirmation prompts (required in non-TTY mode when "
                  "spawn would exceed spawn_confirm_threshold). See #74.",
         ),
+        offline: bool = typer.Option(
+            False, "--offline",
+            help="Skip `git fetch` for passive worktrees; use local refs. "
+                 "Journal entry tagged OFFLINE.",
+        ),
     ):
         """Create coordinated worktrees across repos for a new task."""
         import re as _re
@@ -364,6 +369,7 @@ def register(app: typer.Typer, get_container):
         result = wt_mgr.spawn(
             description, repos=repo_list, skip_setup=skip_setup, slug=slug,
             workspace_root=container.config_path().parent,
+            offline=offline,
         )
         task = result.task
 
@@ -371,6 +377,9 @@ def register(app: typer.Typer, get_container):
             log_mgr = container.log_manager()
             for codes in pending_bypass:
                 log_mgr.append(task.slug, f"BYPASSED AUDIT: spawn — {', '.join(codes)}")
+
+        if offline:
+            container.log_manager().append(task.slug, "OFFLINE: passive fetches skipped")
 
         if output.is_tty:
             output.success(f"Spawned task: {task.slug}")

--- a/src/mship/core/doctor.py
+++ b/src/mship/core/doctor.py
@@ -118,10 +118,12 @@ class DoctorChecker:
         shell: ShellRunner,
         *,
         state_dir: Path | None = None,
+        workspace_root: Path | None = None,
     ) -> None:
         self._config = config
         self._shell = shell
         self._state_dir = state_dir
+        self._workspace_root = workspace_root
 
     def run(self) -> DoctorReport:
         report = DoctorReport()
@@ -322,6 +324,21 @@ class DoctorChecker:
 
         # Append skill-availability checks (workspace-independent)
         report.checks.extend(check_skill_availability())
+
+        # Workspace .gitignore check: warn if .worktrees not listed
+        ws = self._workspace_root
+        if ws is not None and (ws / ".git").exists():
+            gi = ws / ".gitignore"
+            entries = gi.read_text().splitlines() if gi.exists() else []
+            if ".worktrees" not in entries:
+                report.checks.append(CheckResult(
+                    name="workspace/gitignore",
+                    status="warn",
+                    message=(
+                        "workspace .gitignore missing `.worktrees` entry "
+                        "(will be added on next spawn)"
+                    ),
+                ))
 
         return report
 

--- a/src/mship/core/graph.py
+++ b/src/mship/core/graph.py
@@ -91,3 +91,7 @@ class DependencyGraph:
                 visited.add(node)
                 stack.extend(self._reverse[node])
         return sorted(visited)
+
+    def direct_deps(self, repo_name: str) -> list[str]:
+        """Return the direct dependency names of `repo_name`."""
+        return list(self._reverse[repo_name])

--- a/src/mship/core/prune.py
+++ b/src/mship/core/prune.py
@@ -73,12 +73,16 @@ class PruneManager:
                     resolved = str(repo_dir.resolve())
                     if resolved in tracked_paths:
                         continue
-                    # Match the directory name against a configured repo.
-                    matched_repo = None
-                    for name, rc in self._config.repos.items():
-                        if rc.path.name == repo_dir.name:
-                            matched_repo = name
-                            break
+                    # Hub worktrees are created under <hub>/<slug>/<repo_name>/,
+                    # so prefer matching the directory name as a configured repo
+                    # key. Fall back to the canonical path name for compatibility
+                    # with older or unusual layouts.
+                    matched_repo = repo_dir.name if repo_dir.name in self._config.repos else None
+                    if matched_repo is None:
+                        for name, rc in self._config.repos.items():
+                            if rc.path.name == repo_dir.name:
+                                matched_repo = name
+                                break
                     if matched_repo is None:
                         continue
                     orphans.append(OrphanedWorktree(

--- a/src/mship/core/prune.py
+++ b/src/mship/core/prune.py
@@ -51,6 +51,42 @@ class PruneManager:
                         reason="not_in_state",
                     ))
 
+        # Hub layout: scan <workspace>/.worktrees/<slug>/<repo>/
+        # Workspace root is the parent dir of mothership.yaml — not stored on
+        # WorkspaceConfig, so derive from any repo's path.parent. Multiple
+        # repos in different workspace roots is unusual but supported.
+        candidates: set[Path] = set()
+        for repo_cfg in self._config.repos.values():
+            candidates.add(repo_cfg.path.parent.resolve())
+        for ws_root in candidates:
+            hub_root = ws_root / ".worktrees"
+            if not hub_root.is_dir():
+                continue
+            for slug_dir in hub_root.iterdir():
+                if not slug_dir.is_dir():
+                    continue
+                for repo_dir in slug_dir.iterdir():
+                    if not repo_dir.is_dir():
+                        continue
+                    if not (repo_dir / ".git").exists():
+                        continue
+                    resolved = str(repo_dir.resolve())
+                    if resolved in tracked_paths:
+                        continue
+                    # Match the directory name against a configured repo.
+                    matched_repo = None
+                    for name, rc in self._config.repos.items():
+                        if rc.path.name == repo_dir.name:
+                            matched_repo = name
+                            break
+                    if matched_repo is None:
+                        continue
+                    orphans.append(OrphanedWorktree(
+                        repo=matched_repo,
+                        path=repo_dir,
+                        reason="not_in_state",
+                    ))
+
         # Check state entries pointing to nonexistent worktrees
         for task_slug, task in state.tasks.items():
             for repo_name, wt_path in task.worktrees.items():

--- a/src/mship/core/prune.py
+++ b/src/mship/core/prune.py
@@ -52,12 +52,15 @@ class PruneManager:
                     ))
 
         # Hub layout: scan <workspace>/.worktrees/<slug>/<repo>/
-        # Workspace root is the parent dir of mothership.yaml — not stored on
-        # WorkspaceConfig, so derive from any repo's path.parent. Multiple
-        # repos in different workspace roots is unusual but supported.
+        # Workspace root is not stored on WorkspaceConfig, so derive it from
+        # each configured repo. In a single-repo workspace the repo path may
+        # itself be the workspace root (for example "."), so use repo_cfg.path
+        # when it contains mothership.yaml; otherwise fall back to its parent.
         candidates: set[Path] = set()
         for repo_cfg in self._config.repos.values():
-            candidates.add(repo_cfg.path.parent.resolve())
+            repo_path = repo_cfg.path.resolve()
+            ws_root = repo_path if (repo_path / "mothership.yaml").exists() else repo_path.parent
+            candidates.add(ws_root)
         for ws_root in candidates:
             hub_root = ws_root / ".worktrees"
             if not hub_root.is_dir():

--- a/src/mship/core/repo_state.py
+++ b/src/mship/core/repo_state.py
@@ -357,3 +357,76 @@ def audit_repos(
         for n in target_names
     )
     return AuditReport(repos=repos)
+
+
+def audit_passive_worktrees(
+    passive_paths: dict[str, Path],
+    ref_per_repo: dict[str, str],
+    canonical_paths: dict[str, Path],
+) -> dict[str, list[Issue]]:
+    """Audit passive worktrees for drift / dirtiness / fetch failure.
+
+    For each passive repo:
+      - Run `git fetch origin <ref>` against the canonical checkout. If it fails,
+        emit `passive_fetch_failed` (error). Skip remaining checks.
+      - Compare `<passive>/HEAD` against `<canonical>/origin/<ref>`. If they
+        differ, emit `passive_drift` (warn).
+      - Run `git status --porcelain` in the passive worktree. If non-empty
+        after filtering untracked, emit `passive_dirty_worktree` (warn).
+
+    Returns a per-repo list of issues (empty list if clean).
+    """
+    import subprocess
+    out: dict[str, list[Issue]] = {}
+    for name, passive in passive_paths.items():
+        issues: list[Issue] = []
+        ref = ref_per_repo.get(name)
+        canonical = canonical_paths.get(name)
+        if ref is None or canonical is None:
+            out[name] = issues
+            continue
+
+        fetch = subprocess.run(
+            ["git", "fetch", "origin", ref],
+            cwd=canonical, capture_output=True, text=True, check=False, timeout=60,
+        )
+        if fetch.returncode != 0:
+            issues.append(Issue(
+                "passive_fetch_failed", "error",
+                f"git fetch origin {ref} failed: {fetch.stderr.strip()[:160]}",
+            ))
+            out[name] = issues
+            continue
+
+        rev_passive = subprocess.run(
+            ["git", "-C", str(passive), "rev-parse", "HEAD"],
+            capture_output=True, text=True, check=False,
+        )
+        rev_origin = subprocess.run(
+            ["git", "-C", str(canonical), "rev-parse", f"origin/{ref}"],
+            capture_output=True, text=True, check=False,
+        )
+        if (rev_passive.returncode == 0 and rev_origin.returncode == 0
+                and rev_passive.stdout.strip() != rev_origin.stdout.strip()):
+            issues.append(Issue(
+                "passive_drift", "warn",
+                f"passive HEAD {rev_passive.stdout.strip()[:8]} drifted "
+                f"from origin/{ref} ({rev_origin.stdout.strip()[:8]})",
+            ))
+
+        status = subprocess.run(
+            ["git", "-C", str(passive), "status", "--porcelain"],
+            capture_output=True, text=True, check=False,
+        )
+        if status.returncode == 0:
+            modified = sum(
+                1 for line in status.stdout.splitlines()
+                if line.strip() and not line.startswith("??")
+            )
+            if modified:
+                issues.append(Issue(
+                    "passive_dirty_worktree", "warn",
+                    f"{modified} modified file(s) in passive worktree",
+                ))
+        out[name] = issues
+    return out

--- a/src/mship/core/repo_sync.py
+++ b/src/mship/core/repo_sync.py
@@ -200,6 +200,70 @@ def _result_for(
     return SyncResult(repo.name, repo.path, "up_to_date", "no action")
 
 
+def refresh_passive_worktrees(
+    state_manager,
+    config: WorkspaceConfig,
+) -> list[SyncResult]:
+    """Re-fetch and reset each passive worktree to `origin/<expected || base>`.
+
+    Safe by construction: passive worktrees are detached HEAD, mship-managed,
+    and pre-commit-hook-protected. Nothing the user could lose by hard reset.
+    Returns a SyncResult per (task, repo) tuple for reporting.
+    """
+    import subprocess
+    state = state_manager.load()
+    results: list[SyncResult] = []
+    for task in state.tasks.values():
+        for repo_name in task.passive_repos:
+            wt = task.worktrees.get(repo_name)
+            if wt is None or not Path(wt).exists():
+                continue
+            repo_cfg = config.repos.get(repo_name)
+            if repo_cfg is None:
+                continue
+            ref = repo_cfg.expected_branch or repo_cfg.base_branch
+            if ref is None:
+                results.append(SyncResult(
+                    name=f"{task.slug}/{repo_name}",
+                    path=Path(wt),
+                    status="skipped",
+                    message="no expected_branch or base_branch declared",
+                ))
+                continue
+            canonical = repo_cfg.path
+            fetch = subprocess.run(
+                ["git", "fetch", "origin", ref], cwd=canonical,
+                capture_output=True, text=True, check=False, timeout=60,
+            )
+            if fetch.returncode != 0:
+                results.append(SyncResult(
+                    name=f"{task.slug}/{repo_name}",
+                    path=Path(wt),
+                    status="skipped",
+                    message=f"fetch failed: {fetch.stderr.strip()[:160]}",
+                ))
+                continue
+            reset = subprocess.run(
+                ["git", "-C", str(wt), "reset", "--hard", f"origin/{ref}"],
+                capture_output=True, text=True, check=False,
+            )
+            if reset.returncode == 0:
+                results.append(SyncResult(
+                    name=f"{task.slug}/{repo_name}",
+                    path=Path(wt),
+                    status="fast_forwarded",
+                    message=f"reset to origin/{ref}",
+                ))
+            else:
+                results.append(SyncResult(
+                    name=f"{task.slug}/{repo_name}",
+                    path=Path(wt),
+                    status="skipped",
+                    message=f"reset failed: {reset.stderr.strip()[:160]}",
+                ))
+    return results
+
+
 def sync_repos(
     report: AuditReport,
     config: WorkspaceConfig,

--- a/src/mship/core/state.py
+++ b/src/mship/core/state.py
@@ -34,6 +34,7 @@ class Task(BaseModel):
     last_switched_at_sha: dict[str, dict[str, str]] = {}
     test_iteration: int = 0
     base_branch: str | None = None
+    passive_repos: set[str] = set()
 
 
 class WorkspaceState(BaseModel):
@@ -84,6 +85,8 @@ class StateManager:
             task["worktrees"] = {
                 k: str(v) for k, v in task.get("worktrees", {}).items()
             }
+            if "passive_repos" in task:
+                task["passive_repos"] = sorted(task["passive_repos"])
         fd, tmp_path = tempfile.mkstemp(
             dir=self._state_dir, suffix=".yaml.tmp"
         )

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -562,6 +562,26 @@ class WorktreeManager:
             except Exception:
                 pass
 
+        # Remove the hub directory for this task. Inferred from the first
+        # worktree's parent.parent, which is `<workspace>/.worktrees/<slug>/`.
+        # Legacy per-repo-layout tasks have a different parent shape — leave
+        # those alone.
+        try:
+            sample_wt = None
+            for name, wt in task.worktrees.items():
+                if self._config.repos[name].git_root is None:
+                    sample_wt = wt
+                    break
+            if sample_wt is not None:
+                hub = Path(sample_wt).parent
+                # Sanity: only remove if it looks like a hub (parent ends in .worktrees)
+                if hub.name == task_slug and hub.parent.name == ".worktrees":
+                    if hub.exists():
+                        import shutil as _shutil
+                        _shutil.rmtree(hub, ignore_errors=True)
+        except Exception:
+            pass
+
         # Only update state after all cleanup attempts
         def _abort(s):
             s.tasks.pop(task_slug, None)

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -400,6 +400,7 @@ class WorktreeManager:
         skip_setup: bool = False,
         slug: str | None = None,
         workspace_root: Path | None = None,
+        offline: bool = False,
     ) -> SpawnResult:
         slug = slug if slug is not None else slugify(description)
         branch = self._config.branch_pattern.replace("{slug}", slug)
@@ -421,6 +422,20 @@ class WorktreeManager:
 
         ordered = self._graph.topo_sort(repos)
 
+        # Passive expansion: collect transitive depends_on of each repo in
+        # `ordered` that isn't already in `ordered`. Topo-sort the union so
+        # passive deps materialize before their consumers.
+        affected = set(ordered)
+        passive: set[str] = set()
+        frontier = list(ordered)
+        while frontier:
+            r = frontier.pop()
+            for dep in self._graph.direct_deps(r):
+                if dep not in affected and dep not in passive:
+                    passive.add(dep)
+                    frontier.append(dep)
+        all_repos = self._graph.topo_sort(list(affected | passive))
+
         worktrees: dict[str, Path] = {}
         setup_warnings: list[str] = []
 
@@ -433,13 +448,16 @@ class WorktreeManager:
         hub = workspace_root / ".worktrees" / slug
         hub.mkdir(parents=True, exist_ok=True)
 
+        base_branch = workspace_default_branch_from_config(self._config) or "main"
+
         # Workspace-root .gitignore gets .worktrees if root is a git repo.
         if (workspace_root / ".git").exists():
             if not self._git.is_ignored(workspace_root, ".worktrees"):
                 self._git.add_to_gitignore(workspace_root, ".worktrees")
 
-        for repo_name in ordered:
+        for repo_name in all_repos:
             repo_config = self._config.repos[repo_name]
+            is_passive = repo_name in passive
 
             if repo_config.git_root is not None:
                 # Subdirectory child: nested inside parent's hub worktree.
@@ -473,11 +491,35 @@ class WorktreeManager:
             repo_path = repo_config.path
             wt_path = hub / repo_name
 
-            self._git.worktree_add(
-                repo_path=repo_path,
-                worktree_path=wt_path,
-                branch=branch,
-            )
+            if is_passive:
+                # Passive: detached HEAD at origin/<expected || base>.
+                ref = (
+                    repo_config.expected_branch
+                    or repo_config.base_branch
+                    or base_branch
+                )
+                if not offline:
+                    fetched = self._git.fetch_remote_ref(repo_path=repo_path, ref=ref)
+                    if not fetched:
+                        raise RuntimeError(
+                            f"Failed to fetch origin/{ref} for passive repo "
+                            f"'{repo_name}'. Re-run with `--offline` to use "
+                            f"the local ref."
+                        )
+                    target_ref = f"origin/{ref}"
+                else:
+                    target_ref = ref
+                self._git.worktree_add_detached(
+                    repo_path=repo_path,
+                    worktree_path=wt_path,
+                    ref=target_ref,
+                )
+            else:
+                self._git.worktree_add(
+                    repo_path=repo_path,
+                    worktree_path=wt_path,
+                    branch=branch,
+                )
             worktrees[repo_name] = wt_path
 
             symlink_warnings = self._create_symlinks(repo_name, repo_config, wt_path)
@@ -485,7 +527,8 @@ class WorktreeManager:
             bind_warnings = self._copy_bind_files(repo_name, repo_config, wt_path)
             setup_warnings.extend(bind_warnings)
 
-            if not skip_setup and shutil.which("task") is not None:
+            # Skip task setup for passive worktrees.
+            if not is_passive and not skip_setup and shutil.which("task") is not None:
                 actual_setup = repo_config.tasks.get("setup", "setup")
                 setup_result = self._shell.run_task(
                     task_name="setup",
@@ -502,7 +545,6 @@ class WorktreeManager:
         # Single .mship-workspace marker at the hub root.
         write_marker(hub, workspace_root)
 
-        base_branch = workspace_default_branch_from_config(self._config) or "main"
         task = Task(
             slug=slug,
             description=description,
@@ -512,6 +554,7 @@ class WorktreeManager:
             worktrees=worktrees,
             branch=branch,
             base_branch=base_branch,
+            passive_repos=passive,
         )
 
         def _apply(s: WorkspaceState) -> None:

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -448,8 +448,6 @@ class WorktreeManager:
         hub = workspace_root / ".worktrees" / slug
         hub.mkdir(parents=True, exist_ok=True)
 
-        base_branch = workspace_default_branch_from_config(self._config) or "main"
-
         # Workspace-root .gitignore gets .worktrees if root is a git repo.
         if (workspace_root / ".git").exists():
             if not self._git.is_ignored(workspace_root, ".worktrees"):
@@ -493,11 +491,13 @@ class WorktreeManager:
 
             if is_passive:
                 # Passive: detached HEAD at origin/<expected || base>.
-                ref = (
-                    repo_config.expected_branch
-                    or repo_config.base_branch
-                    or base_branch
-                )
+                ref = repo_config.expected_branch or repo_config.base_branch
+                if ref is None:
+                    raise ValueError(
+                        f"Passive materialization for '{repo_name}' requires "
+                        f"`expected_branch` or `base_branch` declared in "
+                        f"mothership.yaml."
+                    )
                 if not offline:
                     fetched = self._git.fetch_remote_ref(repo_path=repo_path, ref=ref)
                     if not fetched:
@@ -553,7 +553,7 @@ class WorktreeManager:
             affected_repos=ordered,
             worktrees=worktrees,
             branch=branch,
-            base_branch=base_branch,
+            base_branch=workspace_default_branch_from_config(self._config),
             passive_repos=passive,
         )
 

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -9,9 +9,7 @@ from mship.core.graph import DependencyGraph
 from mship.core.log import LogManager
 from mship.core.reconcile.fetch import workspace_default_branch_from_config
 from mship.core.state import StateManager, Task, WorkspaceState
-from mship.core.workspace_marker import (
-    MARKER_NAME, write_marker,
-)
+from mship.core.workspace_marker import write_marker
 from mship.util.git import GitRunner
 from mship.util.shell import ShellRunner
 from mship.util.slug import slugify

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -470,7 +470,7 @@ class WorktreeManager:
                 bind_warnings = self._copy_bind_files(repo_name, repo_config, effective)
                 setup_warnings.extend(bind_warnings)
 
-                if not skip_setup and shutil.which("task") is not None:
+                if not is_passive and not skip_setup and shutil.which("task") is not None:
                     actual_setup = repo_config.tasks.get("setup", "setup")
                     setup_result = self._shell.run_task(
                         task_name="setup",
@@ -595,7 +595,6 @@ class WorktreeManager:
                     worktree_path=Path(wt_path),
                 )
             except Exception:
-                import shutil
                 shutil.rmtree(Path(wt_path), ignore_errors=True)
             try:
                 self._git.branch_delete(
@@ -620,8 +619,7 @@ class WorktreeManager:
                 # Sanity: only remove if it looks like a hub (parent ends in .worktrees)
                 if hub.name == task_slug and hub.parent.name == ".worktrees":
                     if hub.exists():
-                        import shutil as _shutil
-                        _shutil.rmtree(hub, ignore_errors=True)
+                        shutil.rmtree(hub, ignore_errors=True)
         except Exception:
             pass
 

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -426,18 +426,31 @@ class WorktreeManager:
         worktrees: dict[str, Path] = {}
         setup_warnings: list[str] = []
 
+        if workspace_root is None:
+            raise ValueError(
+                "workspace_root required for hub layout spawn; "
+                "callers must pass container.config_path().parent"
+            )
+
+        hub = workspace_root / ".worktrees" / slug
+        hub.mkdir(parents=True, exist_ok=True)
+
+        # Workspace-root .gitignore gets .worktrees if root is a git repo.
+        if (workspace_root / ".git").exists():
+            if not self._git.is_ignored(workspace_root, ".worktrees"):
+                self._git.add_to_gitignore(workspace_root, ".worktrees")
+
         for repo_name in ordered:
             repo_config = self._config.repos[repo_name]
 
             if repo_config.git_root is not None:
-                # Subdirectory service: share parent's worktree
+                # Subdirectory child: nested inside parent's hub worktree.
                 parent_wt = worktrees.get(repo_config.git_root)
                 if parent_wt is None:
                     parent_wt = self._config.repos[repo_config.git_root].path
                 effective = parent_wt / repo_config.path
                 worktrees[repo_name] = effective
 
-                # Create symlinks before setup so setup can use the linked dirs
                 symlink_warnings = self._create_symlinks(repo_name, repo_config, effective)
                 setup_warnings.extend(symlink_warnings)
                 bind_warnings = self._copy_bind_files(repo_name, repo_config, effective)
@@ -458,15 +471,10 @@ class WorktreeManager:
                         )
                 continue
 
-            # Normal repo: create its own worktree
+            # Normal repo: hub worktree.
             repo_path = repo_config.path
+            wt_path = hub / repo_name
 
-            if not self._git.is_ignored(repo_path, ".worktrees"):
-                self._git.add_to_gitignore(repo_path, ".worktrees")
-            if not self._git.is_ignored(repo_path, MARKER_NAME):
-                self._git.add_to_gitignore(repo_path, MARKER_NAME)
-
-            wt_path = repo_path / ".worktrees" / branch
             self._git.worktree_add(
                 repo_path=repo_path,
                 worktree_path=wt_path,
@@ -474,14 +482,6 @@ class WorktreeManager:
             )
             worktrees[repo_name] = wt_path
 
-            # Drop the .mship-workspace marker so subrepo worktrees can
-            # discover the workspace (#84). Tracked .gitignore (above) keeps
-            # it out of `git status`; per-worktree info/exclude doesn't work
-            # because git resolves info/exclude to the shared main-repo path.
-            if workspace_root is not None:
-                write_marker(wt_path, workspace_root)
-
-            # Create symlinks before setup so setup can use the linked dirs
             symlink_warnings = self._create_symlinks(repo_name, repo_config, wt_path)
             setup_warnings.extend(symlink_warnings)
             bind_warnings = self._copy_bind_files(repo_name, repo_config, wt_path)
@@ -500,6 +500,9 @@ class WorktreeManager:
                         f"{repo_name}: setup failed (task '{actual_setup}') — "
                         f"{setup_result.stderr.strip()[:200]}"
                     )
+
+        # Single .mship-workspace marker at the hub root.
+        write_marker(hub, workspace_root)
 
         base_branch = workspace_default_branch_from_config(self._config) or "main"
         task = Task(

--- a/src/mship/util/git.py
+++ b/src/mship/util/git.py
@@ -15,6 +15,35 @@ class GitRunner:
             text=True,
         )
 
+    def worktree_add_detached(self, repo_path: Path, worktree_path: Path, ref: str) -> None:
+        """Create a detached-HEAD worktree at `worktree_path` pointing at `ref`.
+
+        `ref` may be a SHA, a tag, or a remote ref like `origin/main`.
+        """
+        worktree_path.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["git", "worktree", "add", "--detach", str(worktree_path), ref],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def fetch_remote_ref(self, repo_path: Path, ref: str, remote: str = "origin") -> bool:
+        """Fetch a single ref from `remote`. Returns True on success, False on any failure.
+
+        Used by passive-worktree materialization: we want to know if origin has
+        the ref, and we want it locally as `<remote>/<ref>` for `worktree add`.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "fetch", remote, ref],
+                cwd=repo_path, capture_output=True, text=True, check=False, timeout=60,
+            )
+            return result.returncode == 0
+        except (OSError, subprocess.SubprocessError):
+            return False
+
     def worktree_remove(self, repo_path: Path, worktree_path: Path) -> None:
         subprocess.run(
             ["git", "worktree", "remove", str(worktree_path), "--force"],

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -14,6 +14,8 @@ def _audit_ok_run(cmd, cwd, env=None):
         return ShellResult(returncode=0, stdout="main\n", stderr="")
     if "fetch" in cmd:
         return ShellResult(returncode=0, stdout="", stderr="")
+    if "ls-remote" in cmd:
+        return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
     if "rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
         return ShellResult(returncode=0, stdout="origin/main\n", stderr="")
     if "rev-list --count" in cmd:

--- a/tests/cli/test_audit.py
+++ b/tests/cli/test_audit.py
@@ -149,3 +149,127 @@ def test_audit_warn_displays_yellow_lane(audit_workspace):
         assert "warn(s)" in result.output  # footer counter includes warn
     finally:
         _reset()
+
+
+def test_audit_includes_passive_repo_drift(tmp_path, monkeypatch):
+    """`mship audit` surfaces passive_drift for a passive worktree behind origin."""
+    import os
+    import subprocess
+    from datetime import datetime, timezone
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+    from mship.core.state import StateManager, Task, WorkspaceState
+
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+
+    bare = tmp_path / "shared.git"
+    subprocess.run(["git", "init", "--bare", "-q", "-b", "main", str(bare)],
+                   check=True, capture_output=True)
+    src = tmp_path / "shared"
+    subprocess.run(["git", "clone", "-q", str(bare), str(src)],
+                   check=True, capture_output=True)
+    (src / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    subprocess.run(["git", "add", "."], cwd=src, check=True, capture_output=True, env=env)
+    subprocess.run(["git", "commit", "-qm", "c1"], cwd=src,
+                   check=True, capture_output=True, env=env)
+    sha1 = subprocess.run(["git", "rev-parse", "HEAD"], cwd=src,
+                          check=True, capture_output=True, text=True).stdout.strip()
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-qm", "c2"], cwd=src,
+                   check=True, capture_output=True, env=env)
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+
+    # Passive worktree at the OLD sha1
+    passive = tmp_path / ".worktrees" / "x" / "shared"
+    subprocess.run(["git", "worktree", "add", "--detach", str(passive), sha1],
+                   cwd=src, check=True, capture_output=True)
+
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\nrepos:\n  shared:\n    path: ./shared\n    type: library\n"
+        "    base_branch: main\n    expected_branch: main\n"
+    )
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "x": Task(
+            slug="x", description="x", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/x",
+            worktrees={"shared": passive},
+            passive_repos={"shared"},
+        )
+    }))
+
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    monkeypatch.chdir(tmp_path)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(app, ["audit", "--json"])
+        # The exit code can be 0 or 1 depending on whether the canonical checkout
+        # has its own issues. We just want to verify passive_drift surfaces.
+        import json as _json
+        report = _json.loads(result.stdout)
+        # Find the shared repo entry
+        shared_entry = next(r for r in report["repos"] if r["name"] == "shared")
+        codes = [i["code"] for i in shared_entry["issues"]]
+        assert "passive_drift" in codes, f"expected passive_drift in shared issues; got {codes}"
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+
+
+def test_audit_no_passive_no_extra_issues(tmp_path, monkeypatch):
+    """Smoke: when there are no passive worktrees, audit behaves as before (no extra calls/state)."""
+    import os
+    import subprocess
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+    from mship.core.state import StateManager, WorkspaceState
+
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    src = tmp_path / "shared"
+    src.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(src)], check=True, capture_output=True)
+    (src / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    subprocess.run(["git", "add", "."], cwd=src, check=True, capture_output=True, env=env)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=src,
+                   check=True, capture_output=True, env=env)
+
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\nrepos:\n  shared:\n    path: ./shared\n    type: library\n"
+    )
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    StateManager(state_dir).save(WorkspaceState())
+
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    monkeypatch.chdir(tmp_path)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(app, ["audit", "--json"])
+        # JSON valid + has shared repo entry
+        import json as _json
+        report = _json.loads(result.stdout)
+        names = [r["name"] for r in report["repos"]]
+        assert "shared" in names
+        # No passive_* issues since there are no passive worktrees
+        for r in report["repos"]:
+            for i in r["issues"]:
+                assert not i["code"].startswith("passive_"), f"unexpected passive issue: {i}"
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()

--- a/tests/cli/test_exec.py
+++ b/tests/cli/test_exec.py
@@ -730,3 +730,44 @@ def test_test_run_journal_entry_no_parent_when_no_debug_thread(configured_git_ap
     assert result.exit_code == 0, result.output
     log = (configured_git_app / ".mothership" / "logs" / "plain-test.md").read_text()
     assert "parent=" not in log
+
+
+def test_test_refuses_when_active_repo_is_passive(tmp_path, monkeypatch):
+    """`mship test` errors if active_repo is passive."""
+    from datetime import datetime, timezone
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+    from mship.core.state import StateManager, Task, WorkspaceState
+
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\nrepos:\n  shared:\n    path: ./shared\n    type: library\n"
+    )
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "x": Task(
+            slug="x", description="x", phase="dev",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/x",
+            worktrees={"shared": tmp_path / "wt"},
+            passive_repos={"shared"},
+            active_repo="shared",
+        )
+    }))
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    container.config.reset()
+    container.state_manager.reset()
+    monkeypatch.chdir(tmp_path)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(app, ["test", "--task", "x"])
+        assert result.exit_code != 0
+        assert "passive" in (result.output or "").lower()
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()

--- a/tests/cli/test_internal.py
+++ b/tests/cli/test_internal.py
@@ -106,3 +106,5 @@ def test_check_commit_refuses_passive_worktree(tmp_path, monkeypatch):
     finally:
         container.config_path.reset_override()
         container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()

--- a/tests/cli/test_internal.py
+++ b/tests/cli/test_internal.py
@@ -63,3 +63,46 @@ def test_journal_commit_silent_outside_workspace(tmp_path, monkeypatch):
     result = runner.invoke(app, ["_journal-commit"])
     assert result.exit_code == 0
     assert "No mothership.yaml" not in (result.output or "")
+
+
+def test_check_commit_refuses_passive_worktree(tmp_path, monkeypatch):
+    """A commit attempted in a registered-but-passive worktree is rejected."""
+    from datetime import datetime, timezone
+    from mship.core.state import StateManager, Task, WorkspaceState
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+
+    # Workspace skeleton
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\nrepos:\n  shared:\n    path: ./shared\n    type: library\n"
+    )
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    passive_wt = tmp_path / ".worktrees" / "x" / "shared"
+    passive_wt.mkdir(parents=True)
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "x": Task(
+            slug="x", description="x", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/x",
+            worktrees={"shared": passive_wt},
+            passive_repos={"shared"},
+        )
+    }))
+
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    monkeypatch.chdir(passive_wt)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(app, ["_check-commit", str(passive_wt)])
+        assert result.exit_code == 1
+        # CliRunner mixes stdout and stderr by default; check `output`.
+        out = (result.output or "")
+        assert "passive worktree" in out.lower()
+        assert "shared" in out
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()

--- a/tests/cli/test_phase.py
+++ b/tests/cli/test_phase.py
@@ -95,3 +95,44 @@ def test_phase_blocked_with_force_transitions(configured_app_with_task, workspac
     state = mgr.load()
     assert state.tasks["add-labels"].phase == "dev"
     assert state.tasks["add-labels"].blocked_reason is None
+
+
+def test_phase_refuses_when_active_repo_is_passive(tmp_path, monkeypatch):
+    """`mship phase dev` errors if active_repo is passive."""
+    from datetime import datetime, timezone
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+    from mship.core.state import StateManager, Task, WorkspaceState
+
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\nrepos:\n  shared:\n    path: ./shared\n    type: library\n"
+    )
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "x": Task(
+            slug="x", description="x", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/x",
+            worktrees={"shared": tmp_path / "wt"},
+            passive_repos={"shared"},
+            active_repo="shared",
+        )
+    }))
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    container.config.reset()
+    container.state_manager.reset()
+    monkeypatch.chdir(tmp_path)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(app, ["phase", "dev", "--task", "x"])
+        assert result.exit_code != 0
+        assert "passive" in (result.output or "").lower()
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()

--- a/tests/cli/test_switch.py
+++ b/tests/cli/test_switch.py
@@ -155,3 +155,71 @@ def test_switch_includes_worktree_path_in_output(switch_workspace, monkeypatch):
             assert str(cli_wt) in result.output
     finally:
         _reset()
+
+
+def test_switch_to_passive_warns(tmp_path, monkeypatch):
+    """`mship switch <passive-repo>` succeeds but prints a passive warning."""
+    import os
+    import subprocess
+    from datetime import datetime, timezone
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+    from mship.core.state import StateManager, Task, WorkspaceState
+
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\nrepos:\n"
+        "  api:\n    path: ./api\n    type: service\n    base_branch: main\n    expected_branch: main\n"
+        "  shared:\n    path: ./shared\n    type: library\n    base_branch: main\n    expected_branch: main\n"
+    )
+    for n in ("api", "shared"):
+        d = tmp_path / n
+        d.mkdir()
+        (d / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+        subprocess.run(["git", "init", "-q", str(d)], check=True, capture_output=True)
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    api_wt = tmp_path / ".worktrees" / "x" / "api"
+    shared_wt = tmp_path / ".worktrees" / "x" / "shared"
+    api_wt.mkdir(parents=True); shared_wt.mkdir(parents=True)
+    # In real spawns passive repos are NOT in affected_repos (only explicit --repos are).
+    # Both are in worktrees so switch can reach them; passive_repos marks the read-only ones.
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "x": Task(
+            slug="x", description="x", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["api"], branch="feat/x",
+            worktrees={"api": api_wt, "shared": shared_wt},
+            passive_repos={"shared"},
+        )
+    }))
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    container.config.reset()
+    container.state_manager.reset()
+    monkeypatch.chdir(api_wt)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(app, ["switch", "shared", "--task", "x"])
+        # Switch can succeed (exit 0) but must mention "passive"
+        out = (result.output or "").lower()
+        # Must explicitly mention "passive" in a warning context, not just in
+        # the worktree path (which may contain the test name "passive_warns").
+        # Check for a JSON "is_passive" key or a standalone warning line.
+        import json as _json
+        warned = False
+        try:
+            payload = _json.loads(result.output)
+            warned = payload.get("is_passive", False)
+        except _json.JSONDecodeError:
+            # TTY mode: look for a warning line mentioning passive
+            warned = any(
+                "passive" in line.lower()
+                for line in result.output.splitlines()
+                if "worktree" not in line.lower() and "worktrees" not in line.lower()
+            )
+        assert warned, f"expected a passive warning in output; got: {result.output}"
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()

--- a/tests/cli/test_sync.py
+++ b/tests/cli/test_sync.py
@@ -46,3 +46,157 @@ def test_sync_records_last_workspace_fetch_at(audit_workspace):
         container.config_path.reset_override()
         container.state_dir.reset_override()
         container.config.reset()
+
+
+def test_sync_refreshes_passive_worktree(tmp_path, monkeypatch):
+    """`mship sync` re-fetches and resets passive worktrees to origin/<ref>."""
+    import os
+    import subprocess
+    from datetime import datetime, timezone
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+    from mship.core.state import StateManager, Task, WorkspaceState
+
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+
+    bare = tmp_path / "shared.git"
+    subprocess.run(["git", "init", "--bare", "-q", "-b", "main", str(bare)],
+                   check=True, capture_output=True)
+    src = tmp_path / "shared"
+    subprocess.run(["git", "clone", "-q", str(bare), str(src)],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-qm", "c1"],
+                   cwd=src, check=True, capture_output=True, env=env)
+    sha1 = subprocess.run(["git", "rev-parse", "HEAD"], cwd=src,
+                          check=True, capture_output=True, text=True).stdout.strip()
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+    (src / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    subprocess.run(["git", "add", "."], cwd=src, check=True, capture_output=True, env=env)
+    subprocess.run(["git", "commit", "-qm", "c2"], cwd=src,
+                   check=True, capture_output=True, env=env)
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+    sha2 = subprocess.run(["git", "rev-parse", "HEAD"], cwd=src,
+                          check=True, capture_output=True, text=True).stdout.strip()
+
+    # Passive worktree at OLD sha1
+    passive = tmp_path / ".worktrees" / "x" / "shared"
+    subprocess.run(["git", "worktree", "add", "--detach", str(passive), sha1],
+                   cwd=src, check=True, capture_output=True)
+
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\nrepos:\n  shared:\n    path: ./shared\n    type: library\n"
+        "    base_branch: main\n    expected_branch: main\n"
+    )
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "x": Task(
+            slug="x", description="x", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/x",
+            worktrees={"shared": passive},
+            passive_repos={"shared"},
+        )
+    }))
+
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    container.config.reset()
+    container.state_manager.reset()
+    monkeypatch.chdir(tmp_path)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(app, ["sync"])
+        # Exit code can be 0 or 1 depending on canonical audit. We care about
+        # the passive worktree's HEAD afterwards.
+        head_after = subprocess.run(
+            ["git", "-C", str(passive), "rev-parse", "HEAD"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert head_after == sha2, (
+            f"passive worktree should reset to origin/main HEAD ({sha2}), "
+            f"got {head_after}; CLI output: {result.output}"
+        )
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+
+
+def test_sync_no_passive_skips_passive_refresh(tmp_path, monkeypatch):
+    """`mship sync --no-passive` leaves passive worktrees alone."""
+    import os
+    import subprocess
+    from datetime import datetime, timezone
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+    from mship.core.state import StateManager, Task, WorkspaceState
+
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+
+    bare = tmp_path / "shared.git"
+    subprocess.run(["git", "init", "--bare", "-q", "-b", "main", str(bare)],
+                   check=True, capture_output=True)
+    src = tmp_path / "shared"
+    subprocess.run(["git", "clone", "-q", str(bare), str(src)],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-qm", "c1"],
+                   cwd=src, check=True, capture_output=True, env=env)
+    sha1 = subprocess.run(["git", "rev-parse", "HEAD"], cwd=src,
+                          check=True, capture_output=True, text=True).stdout.strip()
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+    (src / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    subprocess.run(["git", "add", "."], cwd=src, check=True, capture_output=True, env=env)
+    subprocess.run(["git", "commit", "-qm", "c2"], cwd=src,
+                   check=True, capture_output=True, env=env)
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+
+    passive = tmp_path / ".worktrees" / "x" / "shared"
+    subprocess.run(["git", "worktree", "add", "--detach", str(passive), sha1],
+                   cwd=src, check=True, capture_output=True)
+
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\nrepos:\n  shared:\n    path: ./shared\n    type: library\n"
+        "    base_branch: main\n    expected_branch: main\n"
+    )
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "x": Task(
+            slug="x", description="x", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/x",
+            worktrees={"shared": passive},
+            passive_repos={"shared"},
+        )
+    }))
+
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    container.config.reset()
+    container.state_manager.reset()
+    monkeypatch.chdir(tmp_path)
+    try:
+        runner = CliRunner()
+        runner.invoke(app, ["sync", "--no-passive"])
+        head_after = subprocess.run(
+            ["git", "-C", str(passive), "rev-parse", "HEAD"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert head_after == sha1, "with --no-passive, passive worktree HEAD must NOT change"
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -1676,3 +1676,38 @@ def test_spawn_threshold_not_triggered_with_explicit_repos(configured_git_app: P
 
     result = runner.invoke(app, ["spawn", "explicit scope", "--repos", "shared,auth-service"])
     assert result.exit_code == 0, result.output
+
+
+def test_spawn_cli_passes_offline_flag(workspace_with_git, tmp_path, monkeypatch):
+    """`mship spawn --offline` sets offline=True in the manager call."""
+    from typer.testing import CliRunner
+    from unittest.mock import patch
+    from mship.cli import app, container
+    from pathlib import Path
+
+    container.config_path.override(workspace_with_git / "mothership.yaml")
+    container.state_dir.override(workspace_with_git / ".mothership")
+    monkeypatch.chdir(workspace_with_git)
+    try:
+        runner = CliRunner()
+        with patch("mship.core.worktree.WorktreeManager.spawn") as mock_spawn:
+            from mship.core.worktree import SpawnResult
+            from mship.core.state import Task
+            from datetime import datetime, timezone
+            mock_spawn.return_value = SpawnResult(
+                task=Task(
+                    slug="x", description="x", phase="plan",
+                    created_at=datetime.now(timezone.utc),
+                    affected_repos=["shared"], branch="feat/x",
+                    worktrees={"shared": Path("/tmp/x")},
+                ),
+            )
+            result = runner.invoke(
+                app, ["spawn", "x", "--repos", "shared",
+                      "--skip-setup", "--force-audit", "--offline"],
+            )
+            assert result.exit_code == 0, result.output
+            assert mock_spawn.call_args.kwargs.get("offline") is True
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -1687,6 +1687,8 @@ def test_spawn_cli_passes_offline_flag(workspace_with_git, tmp_path, monkeypatch
 
     container.config_path.override(workspace_with_git / "mothership.yaml")
     container.state_dir.override(workspace_with_git / ".mothership")
+    container.config.reset()
+    container.state_manager.reset()
     monkeypatch.chdir(workspace_with_git)
     try:
         runner = CliRunner()
@@ -1711,3 +1713,56 @@ def test_spawn_cli_passes_offline_flag(workspace_with_git, tmp_path, monkeypatch
     finally:
         container.config_path.reset_override()
         container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+
+
+def test_spawn_cli_writes_offline_journal_entry(workspace_with_git, monkeypatch):
+    """`mship spawn --offline` writes an OFFLINE-tagged journal entry post-spawn."""
+    from typer.testing import CliRunner
+    from unittest.mock import patch
+    from mship.cli import app, container
+    from mship.core.log import LogManager
+    from mship.core.worktree import SpawnResult
+    from mship.core.state import Task
+    from datetime import datetime, timezone
+    from pathlib import Path
+
+    state_dir = workspace_with_git / ".mothership"
+    container.config_path.override(workspace_with_git / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    container.config.reset()
+    container.state_manager.reset()
+    container.log_manager.reset()
+    monkeypatch.chdir(workspace_with_git)
+    try:
+        runner = CliRunner()
+        # Mock spawn so we don't need real git work; the OFFLINE journal write
+        # is in the CLI handler post-spawn, so it still fires.
+        with patch("mship.core.worktree.WorktreeManager.spawn") as mock_spawn:
+            mock_spawn.return_value = SpawnResult(
+                task=Task(
+                    slug="off", description="off", phase="plan",
+                    created_at=datetime.now(timezone.utc),
+                    affected_repos=["shared"], branch="feat/off",
+                    worktrees={"shared": Path("/tmp/off")},
+                ),
+            )
+            result = runner.invoke(
+                app, ["spawn", "off", "--repos", "shared",
+                      "--skip-setup", "--force-audit", "--offline"],
+            )
+            assert result.exit_code == 0, result.output
+
+        entries = LogManager(state_dir / "logs").read("off")
+        offline_entries = [e for e in entries if "OFFLINE" in e.message]
+        assert offline_entries, (
+            f"expected an OFFLINE journal entry; got: "
+            f"{[e.message for e in entries]}"
+        )
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+        container.log_manager.reset()

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -19,6 +19,8 @@ def _audit_ok_run(cmd, cwd, env=None):
         return ShellResult(returncode=0, stdout="main\n", stderr="")
     if "fetch" in cmd:
         return ShellResult(returncode=0, stdout="", stderr="")
+    if "ls-remote" in cmd:
+        return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
     if "rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
         return ShellResult(returncode=0, stdout="origin/main\n", stderr="")
     if "rev-list --count" in cmd:
@@ -87,12 +89,15 @@ def test_spawn_all_repos(configured_git_app: Path):
     assert set(task.affected_repos) == {"shared", "auth-service", "api-gateway"}
 
 
-def test_spawn_records_base_branch_main(configured_git_app: Path):
+def test_spawn_records_base_branch(configured_git_app: Path):
+    """Spawn records base_branch from workspace config if available, else None."""
     result = runner.invoke(app, ["spawn", "record base", "--repos", "shared"])
     assert result.exit_code == 0, result.output
     mgr = StateManager(configured_git_app / ".mothership")
     state = mgr.load()
-    assert state.tasks["record-base"].base_branch == "main"
+    # gh is unavailable in unit tests, so workspace_default_branch_from_config
+    # returns None; base_branch is recorded as None (no silent "main" fallback).
+    assert state.tasks["record-base"].base_branch is None
 
 
 def test_worktrees_list(configured_git_app: Path):
@@ -378,6 +383,10 @@ def test_finish_creates_prs(configured_git_app: Path):
     def mock_run(cmd, cwd, env=None):
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "git push" in cmd:
             return ShellResult(returncode=0, stdout="", stderr="")
         if "gh pr create" in cmd:
@@ -422,6 +431,10 @@ def test_finish_body_file_passed_to_gh_pr_create(configured_git_app: Path):
     def mock_run(cmd, cwd, env=None):
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "git push" in cmd:
             return ShellResult(returncode=0, stdout="", stderr="")
         if "gh pr create" in cmd:
@@ -452,7 +465,7 @@ def test_finish_body_map_per_repo_bodies(configured_git_app: Path):
     for repos not in the map. See #114."""
     from mship.cli import container as cli_container
 
-    runner.invoke(app, ["spawn", "body map", "--repos", "shared,api-gateway"])
+    runner.invoke(app, ["spawn", "body map", "--repos", "shared,auth-service,api-gateway"])
 
     shared_body = configured_git_app / "shared.md"
     shared_body.write_text("## Shared\n- lib change\n\n## Test plan\n- [ ] unit\n")
@@ -466,6 +479,10 @@ def test_finish_body_map_per_repo_bodies(configured_git_app: Path):
     def mock_run(cmd, cwd, env=None):
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "git push" in cmd:
             return ShellResult(returncode=0, stdout="", stderr="")
         if "gh pr create" in cmd:
@@ -595,6 +612,10 @@ def test_finish_title_override_passed_to_gh_pr_create(configured_git_app: Path):
     def mock_run(cmd, cwd, env=None):
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "git push" in cmd:
             return ShellResult(returncode=0, stdout="", stderr="")
         if "gh pr create" in cmd:
@@ -1219,6 +1240,7 @@ def test_finish_shared_git_root_creates_one_pr_records_on_all(configured_git_app
     path: .
     git_root: shared
     type: service
+    base_branch: main
 """)
 
     runner.invoke(app, ["spawn", "group prs", "--repos", "shared,infra", "--skip-setup"])
@@ -1229,6 +1251,10 @@ def test_finish_shared_git_root_creates_one_pr_records_on_all(configured_git_app
         nonlocal create_pr_call_count
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "git push" in cmd:
             return ShellResult(returncode=0, stdout="", stderr="")
         if "rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
@@ -1280,6 +1306,10 @@ def test_finish_harvests_existing_pr_instead_of_creating(configured_git_app: Pat
         nonlocal create_pr_called
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "git push" in cmd:
             return ShellResult(returncode=0, stdout="", stderr="")
         if "rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
@@ -1321,6 +1351,10 @@ def test_finish_harvests_on_create_pr_duplicate_stderr(configured_git_app: Path)
         nonlocal list_call_count
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "git push" in cmd:
             return ShellResult(returncode=0, stdout="", stderr="")
         if "rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
@@ -1374,10 +1408,14 @@ def test_finish_calls_ensure_upstream_after_push(configured_git_app: Path):
         nonlocal set_upstream_called, ensure_upstream_probe_count
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
         if "symbolic-ref" in cmd and "HEAD" in cmd:
             return ShellResult(returncode=0, stdout="main\n", stderr="")
         if "fetch" in cmd:
             return ShellResult(returncode=0, stdout="", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd and "@{u}" not in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "rev-list --count" in cmd:
             return ShellResult(returncode=0, stdout="0\n", stderr="")
         if "status --porcelain" in cmd:
@@ -1433,6 +1471,10 @@ def test_finish_captures_diagnostic_when_main_is_dirty_post_op(configured_git_ap
     def mock_run(cmd, cwd, env=None):
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "git push" in cmd:
             return ShellResult(returncode=0, stdout="", stderr="")
         if "rev-parse --abbrev-ref --symbolic-full-name" in cmd and "@{u}" in cmd:
@@ -1479,6 +1521,10 @@ def test_finish_does_not_capture_diagnostic_when_main_is_clean(configured_git_ap
     def mock_run(cmd, cwd, env=None):
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "git push" in cmd:
             return ShellResult(returncode=0, stdout="", stderr="")
         if "rev-parse --abbrev-ref --symbolic-full-name" in cmd and "@{u}" in cmd:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,14 +19,17 @@ repos:
   shared:
     path: ./shared
     type: library
+    base_branch: main
     depends_on: []
   auth-service:
     path: ./auth-service
     type: service
+    base_branch: main
     depends_on: [shared]
   api-gateway:
     path: ./api-gateway
     type: service
+    base_branch: main
     depends_on: [shared, auth-service]
 """
     )

--- a/tests/core/test_concurrent_mutations.py
+++ b/tests/core/test_concurrent_mutations.py
@@ -169,7 +169,7 @@ def _real_spawn_worker(workspace_str: str, result_path_str: str, desc: str) -> N
     mgr = WorktreeManager(config, graph, sm, git, shell, log)
     result_path = Path(result_path_str)
     try:
-        mgr.spawn(desc, repos=["shared"])
+        mgr.spawn(desc, repos=["shared"], workspace_root=workspace)
         result_path.write_text("ok")
     except ValueError as e:
         # Expected error on the losing racer

--- a/tests/core/test_doctor.py
+++ b/tests/core/test_doctor.py
@@ -572,3 +572,25 @@ def test_not_applicable_overlap_rejected():
             tasks={"run": "serve"},
             not_applicable=["run"],
         )
+
+
+def test_doctor_warns_when_workspace_gitignore_missing_worktrees(tmp_path):
+    """If workspace root is a git repo and .gitignore lacks `.worktrees`, doctor warns."""
+    import subprocess
+    from mship.core.config import ConfigLoader
+    from mship.core.doctor import DoctorChecker
+    from unittest.mock import MagicMock
+    from mship.util.shell import ShellRunner, ShellResult
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\nrepos:\n  a:\n    path: ./a\n    type: service\n"
+    )
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, capture_output=True)
+    config = ConfigLoader.load(tmp_path / "mothership.yaml")
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    checker = DoctorChecker(config, mock_shell, workspace_root=tmp_path)
+    report = checker.run()
+    relevant = [c for c in report.checks if "worktrees" in c.message.lower()]
+    assert any(c.status == "warn" for c in relevant), [c.message for c in report.checks]

--- a/tests/core/test_prune.py
+++ b/tests/core/test_prune.py
@@ -131,3 +131,37 @@ def test_prune_partial_missing_keeps_task(prune_deps):
     # But shared worktree entry should be removed
     assert "shared" not in state.tasks["partial"].worktrees
     assert "auth-service" in state.tasks["partial"].worktrees
+
+
+def test_prune_detects_hub_layout_orphan(tmp_path):
+    """An orphan dir under <workspace>/.worktrees/<slug>/<repo>/ is detected."""
+    import os
+    import subprocess
+    from mship.core.config import ConfigLoader
+    from mship.core.state import StateManager
+    from mship.core.prune import PruneManager
+    from mship.util.git import GitRunner
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\nrepos:\n  shared:\n    path: ./shared\n    type: library\n"
+    )
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    subprocess.run(["git", "init", "-q", str(tmp_path / "shared")],
+                   check=True, capture_output=True)
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "commit", "--allow-empty", "-qm", "init"],
+                   cwd=tmp_path / "shared", check=True, capture_output=True, env=env)
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    sm = StateManager(state_dir)
+    config = ConfigLoader.load(tmp_path / "mothership.yaml")
+    # Seed an orphan: hub-style worktree with no state entry
+    orphan = tmp_path / ".worktrees" / "stale-task" / "shared"
+    subprocess.run(["git", "worktree", "add", str(orphan), "-b", "feat/stale"],
+                   cwd=tmp_path / "shared", check=True, capture_output=True)
+    pm = PruneManager(config, sm, GitRunner())
+    orphans = pm.scan()
+    paths = {str(o.path.resolve()) for o in orphans}
+    assert str(orphan.resolve()) in paths

--- a/tests/core/test_repo_state.py
+++ b/tests/core/test_repo_state.py
@@ -557,3 +557,112 @@ def test_probe_dirty_mixed_emits_both(audit_workspace):
     assert ("dirty_worktree", "error") in codes
     assert ("dirty_untracked", "warn") in codes
     assert cli.has_errors is True
+
+
+# ---------------------------------------------------------------------------
+# Task 5.1: audit_passive_worktrees
+# ---------------------------------------------------------------------------
+
+
+def test_audit_passive_drift_warns(tmp_path):
+    """Passive worktree behind origin/<ref> emits a warn-level passive_drift issue."""
+    import os
+    import subprocess
+    from mship.core.repo_state import audit_passive_worktrees
+
+    bare = tmp_path / "bare.git"
+    subprocess.run(["git", "init", "--bare", "-q", "-b", "main", str(bare)],
+                   check=True, capture_output=True)
+    src = tmp_path / "src"
+    subprocess.run(["git", "clone", "-q", str(bare), str(src)],
+                   check=True, capture_output=True)
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "commit", "--allow-empty", "-qm", "c1"], cwd=src,
+                   check=True, capture_output=True, env=env)
+    sha1 = subprocess.run(["git", "rev-parse", "HEAD"], cwd=src,
+                          check=True, capture_output=True, text=True).stdout.strip()
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-qm", "c2"], cwd=src,
+                   check=True, capture_output=True, env=env)
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+
+    # Passive worktree at the OLD sha — drift exists vs origin/main
+    passive = tmp_path / "passive"
+    subprocess.run(["git", "worktree", "add", "--detach", str(passive), sha1],
+                   cwd=src, check=True, capture_output=True)
+
+    issues = audit_passive_worktrees(
+        passive_paths={"shared": passive},
+        ref_per_repo={"shared": "main"},
+        canonical_paths={"shared": src},
+    )
+    codes = [i.code for i in issues["shared"]]
+    assert "passive_drift" in codes
+
+
+def test_audit_passive_fetch_failed_errors(tmp_path):
+    """Fetch failure produces an error-level passive_fetch_failed issue."""
+    import os
+    import subprocess
+    from mship.core.repo_state import audit_passive_worktrees
+
+    src = tmp_path / "src"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(src)],
+                   check=True, capture_output=True)
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "commit", "--allow-empty", "-qm", "c"], cwd=src,
+                   check=True, capture_output=True, env=env)
+    passive = tmp_path / "passive"
+    subprocess.run(["git", "worktree", "add", "--detach", str(passive), "main"],
+                   cwd=src, check=True, capture_output=True)
+
+    issues = audit_passive_worktrees(
+        passive_paths={"shared": passive},
+        ref_per_repo={"shared": "main"},
+        canonical_paths={"shared": src},
+    )
+    codes = [(i.code, i.severity) for i in issues["shared"]]
+    assert ("passive_fetch_failed", "error") in codes
+
+
+def test_audit_passive_dirty_worktree_warns(tmp_path):
+    """Modified files in a passive worktree produce a warn-level passive_dirty_worktree issue."""
+    import os
+    import subprocess
+    from mship.core.repo_state import audit_passive_worktrees
+
+    bare = tmp_path / "bare.git"
+    subprocess.run(["git", "init", "--bare", "-q", "-b", "main", str(bare)],
+                   check=True, capture_output=True)
+    src = tmp_path / "src"
+    subprocess.run(["git", "clone", "-q", str(bare), str(src)],
+                   check=True, capture_output=True)
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    (src / "f.txt").write_text("orig\n")
+    subprocess.run(["git", "add", "f.txt"], cwd=src, check=True, capture_output=True, env=env)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=src,
+                   check=True, capture_output=True, env=env)
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=src,
+                   check=True, capture_output=True)
+
+    passive = tmp_path / "passive"
+    subprocess.run(["git", "worktree", "add", "--detach", str(passive), "main"],
+                   cwd=src, check=True, capture_output=True)
+    # Modify a tracked file in the passive worktree
+    (passive / "f.txt").write_text("modified\n")
+
+    issues = audit_passive_worktrees(
+        passive_paths={"shared": passive},
+        ref_per_repo={"shared": "main"},
+        canonical_paths={"shared": src},
+    )
+    codes = [i.code for i in issues["shared"]]
+    assert "passive_dirty_worktree" in codes

--- a/tests/core/test_state.py
+++ b/tests/core/test_state.py
@@ -270,3 +270,36 @@ def test_task_base_branch_set_via_kwarg():
         base_branch="main",
     )
     assert t.base_branch == "main"
+
+
+def test_task_passive_repos_defaults_empty(tmp_path):
+    from mship.core.state import StateManager, Task, WorkspaceState
+    from datetime import datetime, timezone
+    sm = StateManager(tmp_path)
+    state = WorkspaceState(tasks={
+        "t": Task(
+            slug="t", description="d", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["a"], branch="feat/t",
+        )
+    })
+    sm.save(state)
+    loaded = sm.load()
+    assert loaded.tasks["t"].passive_repos == set()
+
+
+def test_task_passive_repos_round_trips(tmp_path):
+    from mship.core.state import StateManager, Task, WorkspaceState
+    from datetime import datetime, timezone
+    sm = StateManager(tmp_path)
+    state = WorkspaceState(tasks={
+        "t": Task(
+            slug="t", description="d", phase="plan",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["a", "b"], branch="feat/t",
+            passive_repos={"b"},
+        )
+    })
+    sm.save(state)
+    loaded = sm.load()
+    assert loaded.tasks["t"].passive_repos == {"b"}

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -1339,3 +1339,52 @@ def test_abort_removes_hub_directory(worktree_deps):
     assert hub.exists()
     mgr.abort("abort-test")
     assert not hub.exists(), "abort should rm -rf the hub directory"
+
+
+def test_spawn_materializes_passive_dep(worktree_deps):
+    """When --repos is auth-service only, shared (its dep) becomes passive."""
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    # auth-service depends_on shared; spawn auth-service alone
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    # workspace_with_git fixture has no remotes set up; pass offline=True
+    # so we use the local main branch instead of origin/main.
+    mgr.spawn("passive dep", repos=["auth-service"],
+              workspace_root=workspace, offline=True)
+    state = state_mgr.load()
+    task = state.tasks["passive-dep"]
+    # affected_repos contains only what user asked for
+    assert task.affected_repos == ["auth-service"]
+    # passive_repos contains the dep
+    assert task.passive_repos == {"shared"}
+    # both are in worktrees
+    assert "auth-service" in task.worktrees
+    assert "shared" in task.worktrees
+    # passive worktree exists on disk
+    assert Path(task.worktrees["shared"]).exists()
+
+
+def test_spawn_passive_worktree_is_detached(worktree_deps):
+    import subprocess
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("detached check", repos=["auth-service"],
+              workspace_root=workspace, offline=True)
+    state = state_mgr.load()
+    passive_wt = Path(state.tasks["detached-check"].worktrees["shared"])
+    rc = subprocess.run(["git", "-C", str(passive_wt), "symbolic-ref", "-q", "HEAD"],
+                        capture_output=True).returncode
+    assert rc != 0, "passive worktree should be on detached HEAD"
+
+
+def test_spawn_passive_skips_task_setup(worktree_deps):
+    """Passive worktrees materialize symlinks/binds but don't run `task setup`."""
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("no setup", repos=["auth-service"],
+              workspace_root=workspace, offline=True)
+    # `shell.run_task` should be called for affected (auth-service) but not passive (shared).
+    setup_calls = [c for c in shell.run_task.call_args_list
+                   if c.kwargs.get("task_name") == "setup"]
+    cwds = {Path(c.kwargs.get("cwd")).name for c in setup_calls}
+    assert "auth-service" in cwds
+    assert "shared" not in cwds

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -34,22 +34,23 @@ def worktree_deps(workspace_with_git: Path):
 def test_spawn_creates_worktrees(worktree_deps):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
-    mgr.spawn("add labels to tasks", repos=["shared", "auth-service"])
+    mgr.spawn("add labels to tasks", repos=["shared", "auth-service"], workspace_root=workspace)
     state = state_mgr.load()
     assert "add-labels-to-tasks" in state.tasks
     task = state.tasks["add-labels-to-tasks"]
     assert task.phase == "plan"
     assert set(task.affected_repos) == {"shared", "auth-service"}
     assert task.branch == "feat/add-labels-to-tasks"
+    hub = workspace / ".worktrees" / "add-labels-to-tasks"
     for repo_name in ["shared", "auth-service"]:
-        wt_path = task.worktrees[repo_name]
-        assert Path(wt_path).exists()
+        assert task.worktrees[repo_name] == hub / repo_name
+        assert Path(task.worktrees[repo_name]).exists()
 
 
 def test_spawn_dependency_order(worktree_deps):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
-    mgr.spawn("fix auth", repos=["auth-service", "shared"])
+    mgr.spawn("fix auth", repos=["auth-service", "shared"], workspace_root=workspace)
     state = state_mgr.load()
     task = state.tasks["fix-auth"]
     assert "shared" in task.worktrees
@@ -59,31 +60,11 @@ def test_spawn_dependency_order(worktree_deps):
 def test_spawn_all_repos(worktree_deps):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
-    mgr.spawn("big change")
+    mgr.spawn("big change", workspace_root=workspace)
     state = state_mgr.load()
     task = state.tasks["big-change"]
     assert set(task.affected_repos) == {"shared", "auth-service", "api-gateway"}
 
-
-def test_spawn_ensures_gitignore(worktree_deps):
-    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
-    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
-    mgr.spawn("test gitignore", repos=["shared"])
-    gitignore = workspace / "shared" / ".gitignore"
-    assert gitignore.exists()
-    assert ".worktrees" in gitignore.read_text()
-
-
-def test_spawn_gitignores_mship_workspace_marker(worktree_deps):
-    """The .mship-workspace marker file dropped in each worktree should be
-    gitignored so it doesn't show up as untracked in `git status`. See #107.
-    """
-    from mship.core.workspace_marker import MARKER_NAME
-    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
-    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
-    mgr.spawn("test marker gitignore", repos=["shared"])
-    gitignore = (workspace / "shared" / ".gitignore").read_text()
-    assert MARKER_NAME in gitignore
 
 
 def test_spawn_custom_branch_pattern(workspace_with_git: Path):
@@ -101,7 +82,7 @@ def test_spawn_custom_branch_pattern(workspace_with_git: Path):
     shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
 
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, MagicMock(spec=LogManager))
-    mgr.spawn("custom branch", repos=["shared"])
+    mgr.spawn("custom branch", repos=["shared"], workspace_root=workspace)
     state = state_mgr.load()
     task = state.tasks["custom-branch"]
     assert task.branch == "mship/custom-branch"
@@ -110,7 +91,7 @@ def test_spawn_custom_branch_pattern(workspace_with_git: Path):
 def test_abort_removes_worktrees(worktree_deps):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
-    mgr.spawn("to abort", repos=["shared"])
+    mgr.spawn("to abort", repos=["shared"], workspace_root=workspace)
     state = state_mgr.load()
     wt_path = state.tasks["to-abort"].worktrees["shared"]
 
@@ -127,22 +108,22 @@ def test_spawn_runs_setup_task(worktree_deps, monkeypatch):
         lambda name: "/usr/local/bin/task" if name == "task" else None,
     )
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
-    mgr.spawn("with setup", repos=["shared"])
+    mgr.spawn("with setup", repos=["shared"], workspace_root=workspace)
     shell.run_task.assert_called()
 
 
 def test_spawn_duplicate_slug_raises(worktree_deps):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
-    mgr.spawn("duplicate test", repos=["shared"])
+    mgr.spawn("duplicate test", repos=["shared"], workspace_root=workspace)
     with pytest.raises(ValueError, match="already exists"):
-        mgr.spawn("duplicate test", repos=["shared"])
+        mgr.spawn("duplicate test", repos=["shared"], workspace_root=workspace)
 
 
 def test_abort_succeeds_even_if_branch_delete_fails(worktree_deps):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
-    mgr.spawn("abort fail test", repos=["shared"])
+    mgr.spawn("abort fail test", repos=["shared"], workspace_root=workspace)
 
     # Make branch_delete fail
     original_branch_delete = git.branch_delete
@@ -203,14 +184,16 @@ repos:
     log = MagicMock(spec=LogManager)
 
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
-    mgr.spawn("mono test", repos=["root", "web"])
+    mgr.spawn("mono test", repos=["root", "web"], workspace_root=tmp_path)
 
     state = state_mgr.load()
     task = state.tasks["mono-test"]
 
-    # root gets a worktree at <root>/.worktrees/feat/mono-test
+    # root gets a worktree at <workspace>/.worktrees/mono-test/root
     assert "root" in task.worktrees
     root_wt = Path(task.worktrees["root"])
+    expected_root_wt = tmp_path / ".worktrees" / "mono-test" / "root"
+    assert root_wt == expected_root_wt
     assert root_wt.exists()
     # web's worktree is a subdirectory of root's worktree
     assert "web" in task.worktrees
@@ -224,7 +207,7 @@ def test_spawn_returns_spawn_result_with_task(worktree_deps):
     from mship.core.worktree import SpawnResult
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
-    result = mgr.spawn("result test", repos=["shared"])
+    result = mgr.spawn("result test", repos=["shared"], workspace_root=workspace)
     assert isinstance(result, SpawnResult)
     assert result.task.slug == "result-test"
     assert result.setup_warnings == []
@@ -241,7 +224,7 @@ def test_spawn_collects_setup_warnings_on_failure(worktree_deps, monkeypatch):
         returncode=1, stdout="", stderr="setup task not found"
     )
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
-    result = mgr.spawn("warning test", repos=["shared"])
+    result = mgr.spawn("warning test", repos=["shared"], workspace_root=workspace)
     assert len(result.setup_warnings) == 1
     assert "shared" in result.setup_warnings[0]
     assert "setup" in result.setup_warnings[0].lower()
@@ -250,7 +233,7 @@ def test_spawn_collects_setup_warnings_on_failure(worktree_deps, monkeypatch):
 def test_spawn_skip_setup_does_not_call_setup(worktree_deps):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
-    mgr.spawn("skip test", repos=["shared"], skip_setup=True)
+    mgr.spawn("skip test", repos=["shared"], skip_setup=True, workspace_root=workspace)
     # run_task should not have been called (no setup ran)
     shell.run_task.assert_not_called()
 
@@ -830,7 +813,7 @@ def test_spawn_copies_bind_files_and_coexists_with_symlink_dirs(tmp_path: Path):
         shell=ShellRunner(),
         log=LogManager(logs_dir=state_dir / "logs"),
     )
-    result = mgr.spawn(description="add labels", skip_setup=True)
+    result = mgr.spawn(description="add labels", skip_setup=True, workspace_root=tmp_path)
     wt = result.task.worktrees["r"]
 
     # bind_files: .env is copied byte-identical.
@@ -852,7 +835,7 @@ def test_spawn_skips_setup_when_task_binary_missing(worktree_deps, monkeypatch):
         lambda name: None if name == "task" else "/usr/bin/" + name,
     )
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
-    result = mgr.spawn("task-missing-smoke", repos=["shared"])
+    result = mgr.spawn("task-missing-smoke", repos=["shared"], workspace_root=workspace)
 
     # No setup warning about missing task binary
     assert not any("setup failed" in w for w in result.setup_warnings)
@@ -1014,7 +997,7 @@ def test_create_symlinks_no_warn_when_plain_name_ignored(tmp_path: Path):
 
 
 def test_spawn_writes_workspace_marker_in_each_worktree(workspace_with_git: Path):
-    """Spawn writes `.mship-workspace` in every worktree it creates. See #84."""
+    """Spawn writes `.mship-workspace` at the hub root (not per-worktree). See #84."""
     from mship.cli import container
     from mship.core.workspace_marker import MARKER_NAME
     from typer.testing import CliRunner
@@ -1032,47 +1015,21 @@ def test_spawn_writes_workspace_marker_in_each_worktree(workspace_with_git: Path
             app, ["spawn", "marker test", "--repos", "shared", "--skip-setup", "--force-audit"]
         )
         assert result.exit_code == 0, result.output
-        wt = workspace_with_git / "shared" / ".worktrees" / "feat" / "marker-test"
-        marker = wt / MARKER_NAME
+        hub = workspace_with_git / ".worktrees" / "marker-test"
+        marker = hub / MARKER_NAME
         assert marker.is_file(), (
             f"expected marker at {marker}; "
-            f"worktree contents: {list(wt.iterdir()) if wt.is_dir() else 'wt not created'}"
+            f"hub contents: {list(hub.iterdir()) if hub.is_dir() else 'hub not created'}"
         )
         assert marker.read_text().strip() == str(workspace_with_git.resolve())
+        # No per-worktree marker
+        assert not (hub / "shared" / MARKER_NAME).exists()
     finally:
         container.config_path.reset_override()
         container.state_dir.reset_override()
         container.config.reset()
         container.state_manager.reset()
 
-
-def test_spawn_adds_marker_to_gitignore(workspace_with_git: Path):
-    """Marker is added to the repo's tracked .gitignore so `git status` stays
-    clean. Per-worktree info/exclude doesn't work because git resolves it to
-    the shared main-repo path. See #107."""
-    from mship.cli import container, app
-    from mship.core.workspace_marker import MARKER_NAME
-    from typer.testing import CliRunner
-    runner = CliRunner()
-
-    container.config.reset()
-    container.state_manager.reset()
-    container.config_path.override(workspace_with_git / "mothership.yaml")
-    container.state_dir.override(workspace_with_git / ".mothership")
-    (workspace_with_git / ".mothership").mkdir(exist_ok=True)
-
-    try:
-        result = runner.invoke(
-            app, ["spawn", "exclude test", "--repos", "shared", "--skip-setup", "--force-audit"]
-        )
-        assert result.exit_code == 0, result.output
-        gitignore = (workspace_with_git / "shared" / ".gitignore").read_text()
-        assert MARKER_NAME in gitignore, f"{MARKER_NAME} not in {gitignore!r}"
-    finally:
-        container.config_path.reset_override()
-        container.state_dir.reset_override()
-        container.config.reset()
-        container.state_manager.reset()
 
 
 def test_refresh_bind_files_copies_missing(tmp_path: Path):

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -1332,3 +1332,43 @@ def test_refresh_symlink_dirs_empty_config_returns_empty(tmp_path: Path):
     wt.mkdir()
     result = mgr.refresh_symlink_dirs("r", repo_cfg, wt)
     assert result == {"copied": [], "updated": [], "unchanged": [], "skipped": [], "warnings": []}
+
+
+def test_spawn_uses_hub_layout(worktree_deps):
+    """New spawns place worktrees at <workspace>/.worktrees/<slug>/<repo>/, not <repo>/.worktrees/."""
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("hub layout", repos=["shared", "auth-service"], workspace_root=workspace)
+    state = state_mgr.load()
+    task = state.tasks["hub-layout"]
+    expected_hub = workspace / ".worktrees" / "hub-layout"
+    assert Path(task.worktrees["shared"]) == expected_hub / "shared"
+    assert Path(task.worktrees["auth-service"]) == expected_hub / "auth-service"
+    assert (expected_hub / "shared").exists()
+    assert (expected_hub / "auth-service").exists()
+
+
+def test_spawn_writes_single_marker_at_hub_root(worktree_deps):
+    """One .mship-workspace marker per hub, not per worktree."""
+    from mship.core.workspace_marker import MARKER_NAME
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("marker test", repos=["shared", "auth-service"], workspace_root=workspace)
+    hub = workspace / ".worktrees" / "marker-test"
+    assert (hub / MARKER_NAME).is_file()
+    # No per-worktree markers
+    assert not (hub / "shared" / MARKER_NAME).exists()
+    assert not (hub / "auth-service" / MARKER_NAME).exists()
+
+
+def test_spawn_workspace_gitignore_includes_worktrees(worktree_deps, tmp_path):
+    """Workspace root .gitignore (if root is a git repo) gets `.worktrees` added."""
+    import subprocess
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    # Make the workspace root itself a git repo
+    subprocess.run(["git", "init", "-q", str(workspace)], check=True, capture_output=True)
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("ignore test", repos=["shared"], workspace_root=workspace)
+    gi = workspace / ".gitignore"
+    assert gi.exists()
+    assert ".worktrees" in gi.read_text().splitlines()

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -1329,3 +1329,13 @@ def test_spawn_workspace_gitignore_includes_worktrees(worktree_deps, tmp_path):
     gi = workspace / ".gitignore"
     assert gi.exists()
     assert ".worktrees" in gi.read_text().splitlines()
+
+
+def test_abort_removes_hub_directory(worktree_deps):
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("abort test", repos=["shared", "auth-service"], workspace_root=workspace)
+    hub = workspace / ".worktrees" / "abort-test"
+    assert hub.exists()
+    mgr.abort("abort-test")
+    assert not hub.exists(), "abort should rm -rf the hub directory"

--- a/tests/test_finish_integration.py
+++ b/tests/test_finish_integration.py
@@ -19,9 +19,14 @@ def finish_workspace(workspace_with_git: Path):
     container.config_path.override(workspace_with_git / "mothership.yaml")
     container.state_dir.override(state_dir)
 
+    def _default_run(cmd, cwd, env=None):
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
     mock_shell = MagicMock(spec=ShellRunner)
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok\n", stderr="")
-    mock_shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    mock_shell.run.side_effect = _default_run
     container.shell.override(mock_shell)
 
     yield workspace_with_git, mock_shell
@@ -45,6 +50,10 @@ def test_finish_single_repo_no_coordination_block(finish_workspace):
         call_log.append(cmd)
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "git push" in cmd:
             return ShellResult(returncode=0, stdout="", stderr="")
         if "gh pr create" in cmd:
@@ -78,6 +87,10 @@ def test_finish_multi_repo_adds_coordination(finish_workspace):
         call_log.append(cmd)
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "git push" in cmd:
             return ShellResult(returncode=0, stdout="", stderr="")
         if "gh pr create" in cmd:
@@ -110,12 +123,19 @@ def test_finish_idempotent_rerun(finish_workspace):
     assert result.exit_code == 0, result.output
 
     # First finish
-    mock_shell.run.side_effect = lambda cmd, cwd, env=None: (
-        ShellResult(returncode=0, stdout="Logged in", stderr="") if "gh auth" in cmd
-        else ShellResult(returncode=0, stdout="", stderr="") if "git push" in cmd
-        else ShellResult(returncode=0, stdout="https://github.com/org/shared/pull/1\n", stderr="") if "gh pr create" in cmd
-        else ShellResult(returncode=0, stdout="", stderr="")
-    )
+    def _first_finish_run(cmd, cwd, env=None):
+        if "gh auth" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://github.com/org/shared/pull/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+    mock_shell.run.side_effect = _first_finish_run
 
     result = runner.invoke(app, ["finish", "--task", "idempotent-test"])
     assert result.exit_code == 0, result.output
@@ -160,6 +180,8 @@ def test_finish_not_blocked_by_own_worktree(finish_workspace):
             return ShellResult(returncode=0, stdout="main\n", stderr="")
         if "rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
             return ShellResult(returncode=0, stdout="origin/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "rev-list --count" in cmd:
             return ShellResult(returncode=0, stdout="0\n", stderr="")
         if "git worktree list --porcelain" in cmd:
@@ -334,6 +356,8 @@ def test_finish_unrelated_dirty_repo_does_not_block(finish_workspace):
             return ShellResult(returncode=0, stdout="main\n", stderr="")
         if "rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
             return ShellResult(returncode=0, stdout="origin/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "rev-list --count" in cmd:
             return ShellResult(returncode=0, stdout="0\n", stderr="")
         if "worktree list" in cmd:
@@ -634,7 +658,7 @@ def test_finish_does_not_block_on_drift_in_unrelated_repo(finish_workspace):
     # Spawn affecting shared (will have commits) and api-gateway (untouched).
     # api-gateway depends on shared, but shared has no upstream deps so the
     # scope of "shared has commits" is just {shared} — api-gateway is excluded.
-    result = runner.invoke(app, ["spawn", "scoped finish", "--repos", "shared,api-gateway", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "scoped finish", "--repos", "shared,auth-service,api-gateway", "--force-audit"])
     assert result.exit_code == 0
 
     def mock_run(cmd, cwd, env=None):
@@ -645,6 +669,8 @@ def test_finish_does_not_block_on_drift_in_unrelated_repo(finish_workspace):
             return ShellResult(returncode=0, stdout="https://x/pr/1\n", stderr="")
         if "git push" in cmd:
             return ShellResult(returncode=0, stdout="", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
         if "git fetch" in cmd:
             return ShellResult(returncode=0, stdout="", stderr="")
         if "symbolic-ref --short HEAD" in cmd:
@@ -742,6 +768,8 @@ def test_finish_pr_body_unchanged_when_no_issue_refs(finish_workspace):
     def mock_run(cmd, cwd, env=None):
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
         if "rev-list --count" in cmd and "origin/" in cmd:
             return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "rev-list --count" in cmd:
@@ -778,6 +806,8 @@ def test_finish_warns_when_no_test_evidence_default(finish_workspace):
     def mock_run(cmd, cwd, env=None):
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
         if "rev-list --count" in cmd:
             return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "git push" in cmd:
@@ -809,6 +839,8 @@ def test_finish_blocks_when_require_tests_and_no_evidence(finish_workspace):
     def mock_run(cmd, cwd, env=None):
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
         if "rev-list --count" in cmd:
             return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "git push" in cmd:
@@ -845,6 +877,8 @@ def test_finish_evidence_via_journal_suppresses_warning(finish_workspace, tmp_pa
     def mock_run(cmd, cwd, env=None):
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
         if "rev-list --count" in cmd:
             return ShellResult(returncode=0, stdout="1\n", stderr="")
         if "git push" in cmd:

--- a/tests/test_hook_integration.py
+++ b/tests/test_hook_integration.py
@@ -280,3 +280,41 @@ def test_commit_in_main_checkout_allowed_with_zero_tasks(workspace_for_hooks):
         cwd=repo, capture_output=True, text=True, env=env,
     )
     assert result.returncode == 0, (result.stdout, result.stderr)
+
+
+def test_commit_in_passive_worktree_refused(workspace_for_hooks, monkeypatch):
+    """End-to-end: commit attempt in a passive worktree refused via the real git hook."""
+    from datetime import datetime, timezone
+    from mship.core.state import StateManager, Task, WorkspaceState
+
+    tmp_path, repo = workspace_for_hooks
+    runner.invoke(app, ["init", "--install-hooks"])
+
+    state_dir = tmp_path / ".mothership"
+    sm = StateManager(state_dir)
+    state = sm.load()
+    passive_wt = tmp_path / ".worktrees" / "x" / "cli"
+    passive_wt.parent.mkdir(parents=True, exist_ok=True)
+    # Create a real git worktree of `repo` at HEAD to give us a valid git context
+    subprocess.run(["git", "worktree", "add", "--detach", str(passive_wt), "HEAD"],
+                   cwd=repo, check=True, capture_output=True)
+    state.tasks["x"] = Task(
+        slug="x", description="x", phase="plan",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["cli"], branch="feat/x",
+        worktrees={"cli": passive_wt},
+        passive_repos={"cli"},
+    )
+    sm.save(state)
+
+    (passive_wt / "p.py").write_text("p\n")
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "add", "p.py"], cwd=passive_wt, check=True, capture_output=True, env=env)
+    result = subprocess.run(
+        ["git", "commit", "-m", "should refuse"],
+        cwd=passive_wt, capture_output=True, text=True, env=env,
+    )
+    assert result.returncode != 0
+    assert "passive worktree" in result.stderr.lower()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -141,3 +141,63 @@ def test_spawn_force_audit_bypasses_and_logs(audit_workspace):
         assert any("BYPASSED AUDIT" in e.message for e in entries)
     finally:
         _reset_audit_container()
+
+
+def test_full_hub_layout_e2e(tmp_path, monkeypatch):
+    """Spawn → assert hub layout, sibling resolution, passive expansion, single marker."""
+    import os, subprocess
+    from typer.testing import CliRunner
+    from mship.cli import app, container
+
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+
+    # Two repos: api depends on shared
+    for n in ("api", "shared"):
+        d = tmp_path / n
+        d.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main", str(d)],
+                       check=True, capture_output=True)
+        (d / "Taskfile.yml").write_text("version: '3'\ntasks:\n  setup:\n    cmds:\n      - echo ok\n")
+        (d / "README.md").write_text(n)
+        subprocess.run(["git", "add", "."], cwd=d, check=True, capture_output=True, env=env)
+        subprocess.run(["git", "commit", "-qm", "init"], cwd=d, check=True, capture_output=True, env=env)
+
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: e2e\nrepos:\n"
+        "  api:\n    path: ./api\n    type: service\n    base_branch: main\n    expected_branch: main\n    depends_on: [shared]\n"
+        "  shared:\n    path: ./shared\n    type: library\n    base_branch: main\n    expected_branch: main\n"
+    )
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(tmp_path / ".mothership")
+    container.config.reset()
+    container.state_manager.reset()
+    monkeypatch.chdir(tmp_path)
+    try:
+        runner = CliRunner()
+        # Spawn affected=api, expect shared to be passive
+        result = runner.invoke(app, ["spawn", "feature", "--repos", "api",
+                                     "--skip-setup", "--force-audit", "--offline"])
+        assert result.exit_code == 0, result.output
+
+        from mship.core.state import StateManager
+        from pathlib import Path as _P
+        state = StateManager(tmp_path / ".mothership").load()
+        task = state.tasks["feature"]
+        # Hub layout: both worktrees as siblings under <workspace>/.worktrees/feature/
+        hub = tmp_path / ".worktrees" / "feature"
+        assert _P(task.worktrees["api"]) == hub / "api"
+        assert _P(task.worktrees["shared"]) == hub / "shared"
+        # Passive set
+        assert task.passive_repos == {"shared"}
+        # Sibling resolution (the win case)
+        from_api = _P(task.worktrees["api"]) / ".." / "shared"
+        assert from_api.resolve() == _P(task.worktrees["shared"]).resolve()
+        # Single .mship-workspace marker at hub root
+        assert (hub / ".mship-workspace").is_file()
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()

--- a/tests/util/test_git.py
+++ b/tests/util/test_git.py
@@ -89,3 +89,53 @@ def test_has_uncommitted_changes_dirty(git_repo: Path):
     (git_repo / "file.txt").write_text("hello")
     runner = GitRunner()
     assert runner.has_uncommitted_changes(git_repo) is True
+
+
+def test_worktree_add_detached(tmp_path):
+    import subprocess
+    from mship.util.git import GitRunner
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True, capture_output=True)
+    subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                    "commit", "--allow-empty", "-qm", "init"],
+                   cwd=repo, check=True, capture_output=True)
+    sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,
+                         check=True, capture_output=True, text=True).stdout.strip()
+    git = GitRunner()
+    wt = tmp_path / "wt"
+    git.worktree_add_detached(repo_path=repo, worktree_path=wt, ref=sha)
+    head = subprocess.run(["git", "-C", str(wt), "rev-parse", "HEAD"],
+                          check=True, capture_output=True, text=True).stdout.strip()
+    assert head == sha
+    branch = subprocess.run(["git", "-C", str(wt), "symbolic-ref", "-q", "HEAD"],
+                            capture_output=True, text=True).returncode
+    assert branch != 0, "expected detached HEAD (symbolic-ref returns nonzero)"
+
+
+def test_fetch_remote_ref_succeeds(tmp_path):
+    """Smoke: fetch_remote_ref returns True when origin has the branch."""
+    import subprocess
+    from mship.util.git import GitRunner
+    bare = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", "-q", "-b", "main", str(bare)],
+                   check=True, capture_output=True)
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "clone", "-q", str(bare), str(clone)],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                    "commit", "--allow-empty", "-qm", "init"],
+                   cwd=clone, check=True, capture_output=True)
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=clone,
+                   check=True, capture_output=True)
+    git = GitRunner()
+    assert git.fetch_remote_ref(repo_path=clone, ref="main") is True
+
+
+def test_fetch_remote_ref_returns_false_on_failure(tmp_path):
+    """Returns False when origin doesn't have the ref (or no remote)."""
+    import subprocess
+    from mship.util.git import GitRunner
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "-q", str(repo)], check=True, capture_output=True)
+    git = GitRunner()
+    assert git.fetch_remote_ref(repo_path=repo, ref="nonexistent") is False


### PR DESCRIPTION
## Summary

Replaces the per-repo worktree layout (`<repo>/.worktrees/feat/<slug>/`) with a per-task **hub** (`<workspace>/.worktrees/<slug>/<repo>/`). Cross-repo references — `cd ../sibling` in Taskfiles, editable Python deps, docker mounts, IDE workspace files — now work by construction because a task's worktrees are sibling directories.

Auto-materializes `depends_on` siblings as **passive worktrees**: detached HEAD at `origin/<expected_branch || base_branch>`, fetched at spawn so staleness is impossible by construction. Pre-commit hook refuses commits in passive worktrees with a targeted error message.

**Closes #87.** Partially obviates #110 (hub layout solves the bulk of `external_symlinks`'s motivation; the residual cases — build caches, secret mounts, workspace-internal non-repo dirs — are deferred to a focused follow-up spec).

**Bumps version to 0.2.0.**

### What landed

- **Hub layout for spawn** — `<workspace>/.worktrees/<slug>/<repo>/` for every new task; single `.mship-workspace` marker at the hub root; workspace `.gitignore` gets `.worktrees`.
- **`Task.passive_repos: set[str]`** — state schema additive, round-trips through `state.yaml`.
- **Passive worktree materialization** — at spawn, BFS-walks `depends_on`, fetches `origin/<ref>` for each transitive dep not in `--repos`, materializes detached HEAD; symlinks/binds yes, `task setup` no.
- **`mship spawn --offline`** — escape hatch for the fetch step; uses local refs, journals an `OFFLINE` entry.
- **Pre-commit hook** — refuses commits in passive worktrees with a targeted message naming the repo + task + recovery instructions.
- **Audit** — three new issue codes: `passive_drift` (warn), `passive_dirty_worktree` (warn), `passive_fetch_failed` (error). Surfaced in `mship audit` output, attached to the canonical repo's audit entry.
- **Sync** — `mship sync` re-fetches and resets passive worktrees to `origin/<ref>`. `--no-passive` opts out.
- **Switch** — warns when target is passive (read-only on `<ref>`).
- **Phase + test** — refuse to operate when `active_repo` is passive, with a clear "respawn with `--repos <repo>,...`" message.
- **Prune** — scans `<workspace>/.worktrees/<slug>/<repo>/` for orphans alongside the legacy per-repo scan.
- **Doctor** — warns if workspace root is a git repo but its `.gitignore` lacks `.worktrees`.
- **Abort** — removes the hub directory after per-repo `worktree_remove` (sanity-checked against the slug+`.worktrees` parent shape so legacy tasks aren't touched).

### Migration

**No data migration required.** `state.yaml` stores absolute paths, so in-flight per-repo tasks finish out under their original layout. Only spawns *after* upgrade use hub. `mship prune` cleans up legacy `<repo>/.worktrees/` dirs as those tasks close. `mship audit` compares against state-recorded paths, so neither layout produces false positives during the crossover.

Watch out for IDE workspace files / scripts pinned to old paths — update them when creating your next task.

### Out of scope (explicit)

- `external_symlinks` (#110) — deferred to follow-up. Hub solves cross-repo siblings; remaining residual cases (build caches, secret mounts, etc.) belong to a separate, focused spec.
- Monorepo subdirectory off-by-one (`web` → `../sibling` is wrong, needs `../../sibling`) — pre-existing constraint in mship's monorepo support, unchanged by this PR.

### References

- Spec: `docs/superpowers/specs/2026-04-28-hub-worktree-layout-design.md`
- Plan: `docs/superpowers/plans/2026-04-28-hub-worktree-layout.md`

## Test plan

- [x] Full test suite green: **1160 passed, 0 failures** (up from 1136 pre-change; +24 new tests covering the new behavior).
- [x] Final end-to-end review (subagent) confirmed every spec section is implemented; no critical or important issues.
- [x] E2e integration test (`test_full_hub_layout_e2e`) asserts hub paths, sibling resolution (`worktrees["api"] / ".." / "shared"` resolves to the actual passive worktree), passive-set membership, and single `.mship-workspace` marker at hub root.
- [x] Regression coverage:
  - `tests/test_hook_integration.py::test_commit_in_passive_worktree_refused`
  - `tests/cli/test_internal.py::test_check_commit_refuses_passive_worktree`
  - `tests/cli/test_sync.py::test_sync_refreshes_passive_worktree` + `test_sync_no_passive_skips_passive_refresh`
  - `tests/cli/test_switch.py::test_switch_to_passive_warns`
  - `tests/cli/test_phase.py::test_phase_refuses_when_active_repo_is_passive`
  - `tests/cli/test_exec.py::test_test_refuses_when_active_repo_is_passive`
  - `tests/core/test_repo_state.py::test_audit_passive_drift_warns` + `_fetch_failed_errors` + `_dirty_worktree_warns`
  - `tests/core/test_prune.py::test_prune_detects_hub_layout_orphan`
  - `tests/core/test_doctor.py::test_doctor_warns_when_workspace_gitignore_missing_worktrees`
  - `tests/cli/test_worktree.py::test_spawn_cli_writes_offline_journal_entry`
- [ ] Manual smoke test post-merge: spawn a task in a real workspace; confirm hub layout, passive materialization, `cd ../sibling` works, `mship audit` surfaces passive issues correctly.

Closes #86, #87