### PR TITLE
spawn-cd-hint: print cd-into-worktree next-step hint after spawn (#129)

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -390,6 +390,12 @@ def register(app: typer.Typer, get_container):
                 output.print(f"  {repo}: {path}")
             for warning in result.setup_warnings:
                 output.warning(warning)
+            if task.worktrees:
+                first_repo = task.affected_repos[0] if task.affected_repos else next(iter(task.worktrees))
+                hint_path = task.worktrees.get(first_repo) or next(iter(task.worktrees.values()))
+                output.print("")
+                output.print("[bold]Next:[/bold] cd into the worktree before editing.")
+                output.print(f"  cd {hint_path}")
         else:
             data = task.model_dump(mode="json")
             data["setup_warnings"] = result.setup_warnings

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -100,6 +100,36 @@ def test_spawn_records_base_branch(configured_git_app: Path):
     assert state.tasks["record-base"].base_branch is None
 
 
+def test_spawn_tty_prints_cd_hint(configured_git_app: Path, monkeypatch):
+    """TTY spawn output includes a 'cd into the worktree' next-step hint
+    with a copy-pasteable cd command. See #129."""
+    from mship.cli.output import Output
+    monkeypatch.setattr(Output, "is_tty", property(lambda self: True))
+
+    result = runner.invoke(app, ["spawn", "cd hint", "--repos", "shared"])
+    assert result.exit_code == 0, result.output
+
+    mgr = StateManager(configured_git_app / ".mothership")
+    state = mgr.load()
+    worktree_path = state.tasks["cd-hint"].worktrees["shared"]
+
+    assert "Next:" in result.output
+    # Rich may soft-wrap long paths; flatten before checking the cd command.
+    flat = result.output.replace("\n", "").replace(" ", "")
+    assert f"cd{worktree_path}" in flat
+
+
+def test_spawn_non_tty_json_omits_cd_hint(configured_git_app: Path):
+    """Non-TTY spawn output is JSON only — no cd hint mixed in. See #129."""
+    import json as _json
+    result = runner.invoke(app, ["spawn", "json hint", "--repos", "shared"])
+    assert result.exit_code == 0, result.output
+    # Parses as JSON — proves no hint text was appended.
+    payload = _json.loads(result.output)
+    assert payload["slug"] == "json-hint"
+    assert "Next:" not in result.output
+
+
 def test_worktrees_list(configured_git_app: Path):
     runner.invoke(app, ["spawn", "test list", "--repos", "shared"])
     result = runner.invoke(app, ["worktrees"])


### PR DESCRIPTION
## Summary

Adds a "cd into the worktree" next-step hint to `mship spawn` TTY output. The hint surfaces in the spawn output itself the workflow correction that the README, AGENTS.md, and the working-with-mothership skill all repeat: after spawn, the next thing to do is cd into the worktree before editing anything.

Output now ends with:

```
Spawned task: feat-x
  Branch: feat/feat-x
  Phase: plan
  Repos: api
  api: /workspace/.worktrees/feat-x/api

Next: cd into the worktree before editing.
  cd /workspace/.worktrees/feat-x/api
```

The example uses the first affected repo's worktree path. JSON output (non-TTY) is unchanged so structured consumers see no shape drift.

Closes #129.

## Test plan

- [x] `tests/cli/test_worktree.py::test_spawn_tty_prints_cd_hint` — TTY mode (forced via `monkeypatch`) includes `Next:` and a `cd <worktree-path>` line.
- [x] `tests/cli/test_worktree.py::test_spawn_non_tty_json_omits_cd_hint` — non-TTY output parses cleanly as JSON and contains no hint text.
- [x] `mship test` (pytest, full suite) — all green.

Closes #129