### PR TITLE
view-spec-non-tty: print spec to stdout when stdout is not a TTY (#124)

### DIFF
--- a/src/mship/cli/view/spec.py
+++ b/src/mship/cli/view/spec.py
@@ -308,6 +308,21 @@ def register(app: typer.Typer, get_container):
             _serve_web(path, port)
             return
 
+        # Non-TTY short-circuit (#124): the SpecView TUI hangs forever when
+        # stdout isn't a terminal (agent pipes, redirects, CI). Mirror the
+        # `mship status` pattern — print the resolved spec to stdout and exit.
+        from mship.cli.output import Output
+        if not Output().is_tty:
+            try:
+                path = find_spec(
+                    workspace_root, name_or_path, task=resolved_task_slug, state=state,
+                )
+            except SpecNotFoundError as e:
+                typer.echo(f"Error: {e}", err=True)
+                raise typer.Exit(code=1)
+            typer.echo(path.read_text(), nl=False)
+            return
+
         view = SpecView(
             workspace_root=workspace_root,
             name_or_path=name_or_path,

--- a/tests/cli/view/test_spec_view.py
+++ b/tests/cli/view/test_spec_view.py
@@ -335,3 +335,82 @@ async def test_spec_view_watch_transitions_to_fallback_when_task_appears(tmp_pat
         # Either a spec was rendered (none in tmp_path/docs/superpowers/specs)
         # or the task fallback with the description appears.
         assert "My task description" in text or "No spec yet for task" in text
+
+
+# --- Non-TTY short-circuit tests (#124) ---
+
+
+def _setup_workspace(tmp_path: Path):
+    """Configure container overrides for an empty workspace. Caller is
+    responsible for resetting overrides via container.*.reset_override()."""
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text("workspace: t\nrepos: {}\n")
+    StateManager(state_dir).save(WorkspaceState(tasks={}))
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+
+
+def _reset_overrides():
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override()
+    container.config.reset()
+    container.state_manager.reset_override()
+    container.state_manager.reset()
+
+
+def test_spec_cli_non_tty_prints_spec_and_exits(tmp_path):
+    """Non-TTY: short-circuit the TUI, print spec contents, exit 0. See #124."""
+    runner = CliRunner()
+    _setup_workspace(tmp_path)
+    spec_file = tmp_path / "design.md"
+    spec_file.write_text("# Hello\n\nSpec body content.\n")
+    try:
+        # Pass an explicit absolute path so task resolution is bypassed
+        # (the bug is the TUI hang in non-TTY, not task lookup).
+        result = runner.invoke(app, ["view", "spec", str(spec_file)])
+        assert result.exit_code == 0, result.output
+        assert "Spec body content." in result.output
+    finally:
+        _reset_overrides()
+
+
+def test_spec_cli_non_tty_missing_spec_exits_1(tmp_path):
+    """Non-TTY: missing spec errors with code 1, no TUI launch. See #124."""
+    runner = CliRunner()
+    _setup_workspace(tmp_path)
+    try:
+        result = runner.invoke(app, ["view", "spec", str(tmp_path / "nope.md")])
+        assert result.exit_code == 1, result.output
+        # Should be the SpecNotFoundError surfaced, not a TUI hang.
+        assert "not found" in result.output.lower() or "no spec" in result.output.lower()
+    finally:
+        _reset_overrides()
+
+
+def test_spec_cli_non_tty_does_not_construct_specview(tmp_path, monkeypatch):
+    """Non-TTY path must not instantiate the Textual app at all. See #124."""
+    runner = CliRunner()
+    _setup_workspace(tmp_path)
+    spec_file = tmp_path / "s.md"
+    spec_file.write_text("# stub\nbody\n")
+
+    constructed = []
+    from mship.cli.view import spec as spec_mod
+    real_init = spec_mod.SpecView.__init__
+
+    def _trap_init(self, *a, **kw):
+        constructed.append(True)
+        real_init(self, *a, **kw)
+
+    monkeypatch.setattr(spec_mod.SpecView, "__init__", _trap_init)
+    try:
+        result = runner.invoke(app, ["view", "spec", str(spec_file)])
+        assert result.exit_code == 0, result.output
+        assert constructed == [], "SpecView must not be constructed in non-TTY mode"
+    finally:
+        _reset_overrides()

--- a/tests/cli/view/test_view_cli.py
+++ b/tests/cli/view/test_view_cli.py
@@ -89,8 +89,16 @@ def test_spec_non_watch_no_task_exits_1(empty_workspace):
     assert "no active task" in (result.output or "").lower()
 
 
+def _force_tty(monkeypatch):
+    """Force Output.is_tty=True so non-TTY short-circuit (#124) doesn't trip
+    in tests that exercise the interactive --watch view path."""
+    from mship.cli.output import Output
+    monkeypatch.setattr(Output, "is_tty", property(lambda self: True))
+
+
 def test_spec_watch_no_task_constructs_view_without_exit(empty_workspace, monkeypatch):
     from mship.cli.view import spec as spec_mod
+    _force_tty(monkeypatch)
     captured = {}
     monkeypatch.setattr(spec_mod.SpecView, "run", lambda self: captured.setdefault("view", self))
     runner = CliRunner()
@@ -105,6 +113,7 @@ def test_spec_watch_no_task_constructs_view_without_exit(empty_workspace, monkey
 
 def test_spec_watch_with_unknown_task_constructs_view_without_exit(empty_workspace, monkeypatch):
     from mship.cli.view import spec as spec_mod
+    _force_tty(monkeypatch)
     captured = {}
     monkeypatch.setattr(spec_mod.SpecView, "run", lambda self: captured.setdefault("view", self))
     runner = CliRunner()


### PR DESCRIPTION
## Summary

`mship view spec` previously hung indefinitely when stdout wasn't a terminal — the worst possible failure mode for an agent invocation. The CLI unconditionally instantiated `SpecView` (a Textual alt-screen app) and called `view.run()`, which grabbed a terminal that didn't exist and never exited.

When stdout isn't a TTY, the command now:

- Resolves the spec path via `find_spec` (same logic as `--web`).
- Echoes the file contents to stdout via `typer.echo(... nl=False)`.
- On `SpecNotFoundError`, echoes the error to stderr and exits 1.

This mirrors the JSON-on-non-TTY pattern already used by `mship status`. JSON-mode `--web` is unchanged. The TTY/`--watch` interactive path is unchanged for terminal users.

Two existing `--watch` tests in `test_view_cli.py` previously exercised the deferred-resolution view path through CliRunner's non-TTY stdout. They now force `Output.is_tty=True` (matching the `_force_tty` pattern from `tests/cli/test_exec.py`) so they continue to test the interactive path.

Closes #124.

## Test plan

- [x] `tests/cli/view/test_spec_view.py::test_spec_cli_non_tty_prints_spec_and_exits` — non-TTY prints contents and exits 0.
- [x] `tests/cli/view/test_spec_view.py::test_spec_cli_non_tty_missing_spec_exits_1` — missing spec → exit 1, no TUI.
- [x] `tests/cli/view/test_spec_view.py::test_spec_cli_non_tty_does_not_construct_specview` — `SpecView.__init__` not called in the non-TTY path (no Textual import side effects).
- [x] `tests/cli/view/test_view_cli.py` `--watch` tests updated and passing.
- [x] `mship test` (full pytest suite) — all green, no regressions.

Closes #124