### PR TITLE
journal-flag-no-message: error loudly when structured journal flags are passed without a message (#108)

### DIFF
--- a/src/mship/cli/log.py
+++ b/src/mship/cli/log.py
@@ -40,6 +40,20 @@ def register(app: typer.Typer, get_container):
         if t.active_repo is not None and t.active_repo in t.worktrees:
             cwd_warn = format_cwd_warning(_P.cwd(), _P(t.worktrees[t.active_repo]))
 
+        # Structured-flag validation (#108): `mship journal --test-state pass`
+        # (or --action / --open) without a message silently dropped the flag
+        # and fell through to read mode. That made `--test-state pass`
+        # ineffective as test-evidence — the unified reader (#81) had nothing
+        # to read. Fail loud instead.
+        if message is None and not show_open and (
+            test_state is not None or action is not None or open_question is not None
+        ):
+            output.error(
+                "Structured journal flags require a message argument. Try:\n"
+                "  mship journal \"tests verified externally\" --test-state pass"
+            )
+            raise typer.Exit(code=1)
+
         if show_open:
             entries = log_mgr.read(t.slug)
             opens = [e for e in entries if e.open_question]

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -242,3 +242,66 @@ def test_log_silent_when_cwd_inside_active_worktree(workspace_with_git, monkeypa
         container.config.reset()
         container.state_manager.reset()
         container.log_manager.reset()
+
+
+# --- Structured-flag-without-message validation (#108) ---
+#
+# Root cause of #108: `mship journal --test-state pass` (no message) silently
+# fell through to the read path. The flag was accepted but no entry was
+# written, so the unified test-evidence reader had no journal evidence to
+# consider. The reader was correct (#81 / 68753e5); the CLI was lossy.
+
+
+def test_journal_test_state_without_message_errors(configured_app_with_task: Path):
+    """`mship journal --test-state pass` (no message) must error, not silently
+    drop the flag. See #108."""
+    result = runner.invoke(
+        app, ["journal", "--test-state", "pass", "--task", "add-labels"],
+    )
+    assert result.exit_code != 0, result.output
+    assert "message" in result.output.lower()
+
+
+def test_journal_action_without_message_errors(configured_app_with_task: Path):
+    """`mship journal --action ...` without a message also errors."""
+    result = runner.invoke(
+        app, ["journal", "--action", "ran tests", "--task", "add-labels"],
+    )
+    assert result.exit_code != 0, result.output
+    assert "message" in result.output.lower()
+
+
+def test_journal_open_without_message_errors(configured_app_with_task: Path):
+    """`mship journal --open ...` without a message also errors."""
+    result = runner.invoke(
+        app, ["journal", "--open", "blocked on api key", "--task", "add-labels"],
+    )
+    assert result.exit_code != 0, result.output
+    assert "message" in result.output.lower()
+
+
+def test_journal_test_state_with_message_writes_entry(configured_app_with_task: Path):
+    """The recommended invocation still writes a usable journal entry."""
+    result = runner.invoke(
+        app,
+        ["journal", "tests verified externally",
+         "--test-state", "pass", "--task", "add-labels"],
+    )
+    assert result.exit_code == 0, result.output
+
+    log_mgr = LogManager(configured_app_with_task / ".mothership" / "logs")
+    entries = log_mgr.read("add-labels")
+    state_entries = [e for e in entries if e.test_state == "pass"]
+    assert len(state_entries) == 1, [e.message for e in entries]
+    assert state_entries[0].message == "tests verified externally"
+
+
+def test_journal_no_args_still_reads(configured_app_with_task: Path):
+    """Bare `mship journal` (no message, no structured flags) still reads
+    entries \u2014 the validation only fires when flags are present."""
+    runner.invoke(
+        app, ["journal", "first entry", "--task", "add-labels"],
+    )
+    result = runner.invoke(app, ["journal", "--task", "add-labels"])
+    assert result.exit_code == 0, result.output
+    assert "first entry" in result.output


### PR DESCRIPTION
## Summary

Root-cause fix for #108: `mship journal --test-state pass` (no message) silently fell through to the journal read path, dropping the `--test-state` flag without writing an entry. The unified test-evidence reader (#81) was correct — it had nothing to read because the CLI never recorded the entry.

This is why the originally reported repro persisted after the supposed reader fix in 68753e5: the user followed the "documented workaround" `mship journal --test-state pass`, the command silently no-op'd, and the next `mship phase review` correctly reported "Tests failing in: infra" because no contradicting journal entry existed.

The fix is at the CLI layer (`src/mship/cli/log.py`): when any structured flag (`--test-state`, `--action`, `--open`) is passed without a message and not in `--show-open` mode, exit 1 with a hint pointing at the correct invocation:

```
ERROR: Structured journal flags require a message argument. Try:
  mship journal "tests verified externally" --test-state pass
```

Bare `mship journal` (read mode) and `mship journal --show-open` are unaffected — the new check only fires when a structured flag is present without a message.

Closes #108. The unified-reader regression test from 68753e5 (`test_evidence_journal_newer_than_test_results_wins`) is unchanged and still passes — that path was always correct; the bug was upstream of the reader.

## Test plan

- [x] `tests/cli/test_log.py::test_journal_test_state_without_message_errors`
- [x] `tests/cli/test_log.py::test_journal_action_without_message_errors`
- [x] `tests/cli/test_log.py::test_journal_open_without_message_errors`
- [x] `tests/cli/test_log.py::test_journal_test_state_with_message_writes_entry` — recommended invocation still writes a usable entry that the unified reader picks up.
- [x] `tests/cli/test_log.py::test_journal_no_args_still_reads` — bare read mode unaffected.
- [x] `mship test` (full pytest suite) — green, no regressions.

Closes #108