### PR TITLE
logs-no-task-target: detect missing logs target in Taskfile and emit clear error (#125); drive-by: update finish hint strings to require message

### DIFF
--- a/src/mship/cli/exec.py
+++ b/src/mship/cli/exec.py
@@ -15,6 +15,33 @@ def _relpath(path_str: str) -> str:
         return path_str
 
 
+def _taskfile_has_target(repo_path, target: str) -> bool:
+    """True if `<repo_path>/Taskfile.yml` (or .yaml) defines `target`.
+
+    Reads the local Taskfile only; `includes:` are not recursed into. That
+    covers the common case — `mship logs` looks for a target defined
+    locally in the repo's Taskfile. False on missing file or parse error,
+    which is the correct, fail-loud signal for the caller.
+    """
+    from pathlib import Path
+    import yaml
+    p = Path(repo_path)
+    candidates = [p / "Taskfile.yml", p / "Taskfile.yaml"]
+    taskfile = next((c for c in candidates if c.exists()), None)
+    if taskfile is None:
+        return False
+    try:
+        data = yaml.safe_load(taskfile.read_text())
+    except Exception:
+        return False
+    if not isinstance(data, dict):
+        return False
+    tasks = data.get("tasks", {})
+    if not isinstance(tasks, dict):
+        return False
+    return target in tasks
+
+
 def _file_nonempty(path_str: str) -> bool:
     """True if the path exists and has non-zero size. False on OSError."""
     from pathlib import Path
@@ -473,6 +500,19 @@ def register(app: typer.Typer, get_container):
                 wt_path = Path(resolved_task.worktrees[name])
                 if wt_path.exists():
                     cwd = wt_path
+
+            # Declarative target check (#125): without this, a missing
+            # `logs:` target lets go-task print its general help text
+            # instead of an actionable error. Reads the local Taskfile
+            # only — `includes:` aren't recursed into.
+            if not _taskfile_has_target(cwd, actual_task):
+                output.error(
+                    f"'{name}' has no '{actual_task}' task in its Taskfile.\n"
+                    f"  Add a `{actual_task}:` task to {cwd}/Taskfile.yml, "
+                    f"or alias it via `tasks: {{logs: <real-name>}}` "
+                    f"in mothership.yaml."
+                )
+                raise typer.Exit(code=1)
 
             if all_services:
                 output.print(f"[bold]── {name} ──[/bold]")

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1046,7 +1046,8 @@ def register(app: typer.Typer, get_container):
                     output.error(f"  {line}")
                 output.error(
                     "Run `mship test` or record evidence via "
-                    "`mship journal --test-state pass`, then retry."
+                    "`mship journal \"tests verified externally\" --test-state pass`, "
+                    "then retry."
                 )
                 raise typer.Exit(code=1)
             output.warning("Test-evidence warnings:")
@@ -1054,7 +1055,8 @@ def register(app: typer.Typer, get_container):
                 output.warning(f"  {line}")
             output.warning(
                 "Pass `--require-tests` to treat as blocking, or record evidence via "
-                "`mship test` / `mship journal --test-state pass`."
+                "`mship test` / "
+                "`mship journal \"tests verified externally\" --test-state pass`."
             )
 
         pr_list: list[dict] = []

--- a/tests/cli/test_exec.py
+++ b/tests/cli/test_exec.py
@@ -935,3 +935,92 @@ def test_mship_test_path_share_skips_when_partner_is_not_applicable(workspace: P
         assert persisted.test_results["tailrd"].status == "pass"
     finally:
         _reset_container()
+
+
+# ---------------------------------------------------------------------------
+# mship logs: declarative Taskfile-target check (#125)
+#
+# Previously: when the requested service had no `logs` target in its
+# Taskfile, mship shelled out to `task <name>` and the user got a wall
+# of go-task help text instead of an actionable error.
+# ---------------------------------------------------------------------------
+
+
+def test_mship_logs_known_service_missing_logs_target_errors(configured_exec_app):
+    """Service is registered, but its Taskfile has no `logs` target → exit 1
+    with a targeted error that names the missing target. See #125."""
+    workspace, mock_shell = configured_exec_app
+    # The `workspace` fixture writes Taskfiles with only `test:` defined,
+    # so `logs:` is missing for every repo.
+    result = runner.invoke(app, ["logs", "shared"])
+    assert result.exit_code == 1, result.output
+    assert "shared" in result.output
+    assert "logs" in result.output.lower()
+    # Should NOT have shelled out to `task logs` — the whole point.
+    mock_shell.run_task.assert_not_called()
+
+
+def test_mship_logs_runs_when_taskfile_has_logs_target(configured_exec_app):
+    """When the Taskfile DOES define `logs:`, the command shells out as
+    before — the new check is non-intrusive for the happy path."""
+    workspace, mock_shell = configured_exec_app
+    (workspace / "shared" / "Taskfile.yml").write_text(
+        "version: '3'\n"
+        "tasks:\n"
+        "  test:\n    cmds: [echo t]\n"
+        "  logs:\n    cmds: [echo logs]\n"
+    )
+    mock_shell.run_task.return_value = ShellResult(
+        returncode=0, stdout="some log output\n", stderr="",
+    )
+    result = runner.invoke(app, ["logs", "shared"])
+    assert result.exit_code == 0, result.output
+    assert mock_shell.run_task.call_count == 1
+    assert "some log output" in result.output
+
+
+def test_mship_logs_aliased_target_via_mship_yaml(workspace: Path):
+    """When the repo aliases `logs: <real-name>` in mothership.yaml, the
+    check looks for the aliased target in the Taskfile, not 'logs'."""
+    state_dir = workspace / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(workspace / "mothership.yaml")
+    container.state_dir.override(state_dir)
+
+    # Override mothership.yaml to alias logs → tail for `shared`.
+    (workspace / "mothership.yaml").write_text(
+        "workspace: test-platform\n"
+        "repos:\n"
+        "  shared:\n"
+        "    path: ./shared\n"
+        "    type: library\n"
+        "    base_branch: main\n"
+        "    depends_on: []\n"
+        "    tasks:\n"
+        "      logs: tail\n"
+    )
+    (workspace / "shared" / "Taskfile.yml").write_text(
+        "version: '3'\n"
+        "tasks:\n"
+        "  tail:\n    cmds: [echo tailing]\n"
+    )
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="tailing\n", stderr="")
+    container.shell.override(mock_shell)
+    try:
+        result = runner.invoke(app, ["logs", "shared"])
+        assert result.exit_code == 0, result.output
+        # The aliased target name was actually invoked.
+        call = mock_shell.run_task.call_args
+        assert call.kwargs.get("actual_task_name") == "tail"
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset_override()
+        container.config.reset()
+        container.state_manager.reset_override()
+        container.state_manager.reset()
+        container.shell.reset_override()


### PR DESCRIPTION
## Summary

`mship logs <service>` previously shelled out to `task <name>` and, if the requested target didn't exist, the underlying go-task runner printed its general help text. The user asked for logs and got a wall of go-task documentation with no signal anything was wrong — confusing tooling failure mode masquerading as success.

Now a declarative pre-check parses the local Taskfile.yml and refuses to invoke `task` when the target is missing, surfacing a targeted error:

```
ERROR: 'shared' has no 'logs' task in its Taskfile.
  Add a `logs:` task to /path/to/shared/Taskfile.yml, or alias it via
  `tasks: {logs: <real-name>}` in mothership.yaml.
```

The check is local-only (no recursion into `includes:`), which the issue body explicitly identified as the right scope ("declarative checks against `mothership.yaml` and the Taskfile catch the common case").

The "service is registered" check is unchanged — that gate already existed at `src/mship/cli/exec.py:438`.

## Drive-by: hint string update

While in the area, updated two hint strings in `mship finish` (`src/mship/cli/worktree.py:1047,1056`) that pointed users at the now-invalid `mship journal --test-state pass` (no-message) form. Following #108, that invocation now errors out — so the old hints were about to start lying. New form:

```
mship journal "tests verified externally" --test-state pass
```

Closes #125. Composes cleanly with #108 (PR #135) — they touch different files and the hint update is correct in either merge order.

## Test plan

- [x] `tests/cli/test_exec.py::test_mship_logs_known_service_missing_logs_target_errors` — exit 1 + targeted error; `shell.run_task` not called.
- [x] `tests/cli/test_exec.py::test_mship_logs_runs_when_taskfile_has_logs_target` — happy path unchanged.
- [x] `tests/cli/test_exec.py::test_mship_logs_aliased_target_via_mship_yaml` — aliased target via `tasks: {logs: tail}` works; check looks for the aliased name.
- [x] Existing `test_logs_invalid_service_lists_available` (registered-services gate) unchanged and passing.
- [x] `mship test` (full pytest suite) — green, no regressions.

Closes #125