### PR TITLE
spec-new-cmd: bless .mothership/tasks/<slug>/SPEC.md and add mship spec new (#126)

### DIFF
--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -94,6 +94,7 @@ from mship.cli import commit as _commit_mod
 from mship.cli import debug as _debug_mod
 from mship.cli import bind as _bind_mod
 from mship.cli import pr as _pr_mod
+from mship.cli import spec as _spec_mod
 
 def _should_silent_exit(argv: list[str]) -> bool:
     """True if argv is invoking an unknown `_`-prefixed internal command.
@@ -144,3 +145,4 @@ _commit_mod.register(app, get_container)
 _debug_mod.register(app, get_container)
 _bind_mod.register(app, get_container)
 _pr_mod.register(app, get_container)
+_spec_mod.register(app, get_container)

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -1,0 +1,104 @@
+"""`mship spec` sub-app: scaffold and manage per-task spec files.
+
+The blessed location is `<workspace>/.mothership/tasks/<slug>/SPEC.md` —
+mship-private, task-scoped, easy for the dev-phase gate to check. See #126.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from mship.cli._resolve import resolve_for_command
+from mship.cli.output import Output
+
+
+SPEC_TEMPLATE = """\
+# Spec: {slug}
+
+**Description:** {description}
+**Created:** {created}
+**Affected repos:** {repos}
+
+## Goals
+
+_What outcome does this task produce? Why does it matter?_
+
+## Approach
+
+_How will the implementation work? What are the key decisions?_
+
+## Acceptance criteria
+
+- [ ] _what success looks like, in user-visible terms_
+"""
+
+
+def blessed_spec_path(state_dir: Path, slug: str) -> Path:
+    """The mship-blessed task-scoped spec location."""
+    return state_dir / "tasks" / slug / "SPEC.md"
+
+
+def render_template(slug: str, description: str, repos: list[str]) -> str:
+    return SPEC_TEMPLATE.format(
+        slug=slug,
+        description=description,
+        created=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        repos=", ".join(repos) if repos else "(none)",
+    )
+
+
+def register(parent: typer.Typer, get_container):
+    spec_app = typer.Typer(
+        name="spec",
+        help="Manage per-task specs (`.mothership/tasks/<slug>/SPEC.md`).",
+        no_args_is_help=True,
+    )
+
+    @spec_app.command("new")
+    def new(
+        force: bool = typer.Option(
+            False, "--force", "-f",
+            help="Overwrite an existing spec at the blessed path.",
+        ),
+        task_opt: Optional[str] = typer.Option(
+            None, "--task",
+            help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var.",
+        ),
+    ):
+        """Scaffold a stub spec at `.mothership/tasks/<slug>/SPEC.md`."""
+        container = get_container()
+        output = Output()
+        state_mgr = container.state_manager()
+        state = state_mgr.load()
+
+        resolved = resolve_for_command("spec new", state, task_opt, output)
+        t = resolved.task
+
+        state_dir = container.state_dir()
+        path = blessed_spec_path(state_dir, t.slug)
+        if path.exists() and not force:
+            output.error(
+                f"Spec already exists: {path}\n"
+                f"  Pass --force to overwrite, or `mship view spec` to read it."
+            )
+            raise typer.Exit(code=1)
+
+        body = render_template(t.slug, t.description, list(t.affected_repos))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+
+        if output.is_tty:
+            output.success(f"Created spec: {path}")
+            output.print("[dim]Edit the file, then `mship phase dev` to start work.[/dim]")
+        else:
+            output.json({
+                "task": t.slug,
+                "path": str(path),
+                "resolved_task": resolved.task.slug,
+                "resolution_source": resolved.source,
+            })
+
+    parent.add_typer(spec_app)

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -123,13 +123,23 @@ class PhaseManager:
         return warnings
 
     def _gate_dev(self, task_slug: str) -> list[str]:
+        warn = (
+            "No spec found — consider writing one before developing "
+            "(create one with `mship spec new` or set `spec_paths` "
+            "in mothership.yaml)"
+        )
         # Without DI'd config + workspace_root we can't actually search for
         # specs — fall back to the always-warn stub. See #113 for the wiring.
         if self._config is None or self._workspace_root is None:
-            return ["No spec found — consider writing one before developing"]
-        # Search workspace-level specs + all worktrees (no task= filter):
-        # specs are typically authored before the task slug exists.
-        from mship.core.view.spec_discovery import find_spec, SpecNotFoundError
+            return [warn]
+        # Blessed task-scoped path (#126) is the primary check. If absent,
+        # fall through to the workspace-level + worktree search so existing
+        # workspaces (`docs/superpowers/specs/...`) still satisfy the gate.
+        from mship.core.view.spec_discovery import (
+            SpecNotFoundError, blessed_spec_path, find_spec,
+        )
+        if blessed_spec_path(self._workspace_root, task_slug).is_file():
+            return []
         try:
             find_spec(
                 self._workspace_root,
@@ -138,7 +148,7 @@ class PhaseManager:
                 spec_paths=self._config.spec_paths,
             )
         except SpecNotFoundError:
-            return ["No spec found — consider writing one before developing"]
+            return [warn]
         return []
 
     def _gate_review(self, task) -> list[str]:

--- a/src/mship/core/view/spec_discovery.py
+++ b/src/mship/core/view/spec_discovery.py
@@ -11,6 +11,15 @@ class SpecNotFoundError(Exception):
 
 SPEC_SUBDIR = Path("docs") / "superpowers" / "specs"
 
+# Blessed mship-private, task-scoped spec location (#126). Lives under the
+# workspace state dir; one SPEC.md per task at a known path so the
+# dev-phase gate has something deterministic to find.
+BLESSED_TASK_SPEC_DIR = Path(".mothership") / "tasks"  # joined with <slug>/SPEC.md
+
+
+def blessed_spec_path(workspace_root: Path, slug: str) -> Path:
+    return workspace_root / BLESSED_TASK_SPEC_DIR / slug / "SPEC.md"
+
 
 def find_spec(
     workspace_root: Path,
@@ -37,6 +46,14 @@ def find_spec(
             if candidate.is_file():
                 return candidate
             raise SpecNotFoundError(f"Spec not found: {name_or_path}")
+
+    # Blessed task-scoped path (#126) takes precedence when task is set and
+    # no explicit name was passed. One file at a known path beats the
+    # workspace-wide newest-mtime lookup.
+    if task is not None and name_or_path is None:
+        blessed = blessed_spec_path(workspace_root, task)
+        if blessed.is_file():
+            return blessed
 
     search_roots = _resolve_search_roots(workspace_root, task, state, spec_paths)
 

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -1,0 +1,206 @@
+"""Tests for `mship spec new` (#126)."""
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.state import StateManager, Task, WorkspaceState
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def configured_app_with_task(workspace: Path):
+    state_dir = workspace / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(workspace / "mothership.yaml")
+    container.state_dir.override(state_dir)
+
+    mgr = StateManager(state_dir)
+    task = Task(
+        slug="add-labels",
+        description="Add labels to tasks",
+        phase="plan",
+        created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        affected_repos=["shared", "auth-service"],
+        branch="feat/add-labels",
+    )
+    mgr.save(WorkspaceState(tasks={"add-labels": task}))
+
+    yield workspace
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override()
+    container.config.reset()
+    container.state_manager.reset_override()
+    container.state_manager.reset()
+
+
+def _blessed_path(workspace: Path, slug: str) -> Path:
+    return workspace / ".mothership" / "tasks" / slug / "SPEC.md"
+
+
+def test_spec_new_creates_blessed_file(configured_app_with_task: Path):
+    """`mship spec new` scaffolds .mothership/tasks/<slug>/SPEC.md."""
+    result = runner.invoke(app, ["spec", "new", "--task", "add-labels"])
+    assert result.exit_code == 0, result.output
+    p = _blessed_path(configured_app_with_task, "add-labels")
+    assert p.is_file()
+    body = p.read_text()
+    # Template includes task metadata so the file isn't blank.
+    assert "add-labels" in body
+    assert "Add labels to tasks" in body
+    assert "shared" in body  # affected_repos
+    assert "auth-service" in body
+
+
+def test_spec_new_refuses_when_file_exists(configured_app_with_task: Path):
+    """Without --force, refuse to overwrite an existing spec."""
+    p = _blessed_path(configured_app_with_task, "add-labels")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("# pre-existing content\n")
+
+    result = runner.invoke(app, ["spec", "new", "--task", "add-labels"])
+    assert result.exit_code != 0, result.output
+    assert "exists" in result.output.lower() or "already" in result.output.lower()
+    # Original content untouched.
+    assert p.read_text() == "# pre-existing content\n"
+
+
+def test_spec_new_force_overwrites(configured_app_with_task: Path):
+    """--force replaces existing content with the template."""
+    p = _blessed_path(configured_app_with_task, "add-labels")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("# pre-existing content\n")
+
+    result = runner.invoke(app, ["spec", "new", "--task", "add-labels", "--force"])
+    assert result.exit_code == 0, result.output
+    body = p.read_text()
+    assert "# pre-existing content" not in body
+    assert "add-labels" in body
+
+
+def test_spec_new_outputs_path_on_tty(configured_app_with_task: Path, monkeypatch):
+    """TTY output includes the created path so the user can copy-paste."""
+    from mship.cli.output import Output
+    monkeypatch.setattr(Output, "is_tty", property(lambda self: True))
+    result = runner.invoke(app, ["spec", "new", "--task", "add-labels"])
+    assert result.exit_code == 0, result.output
+    p = _blessed_path(configured_app_with_task, "add-labels")
+    # Rich may soft-wrap long paths; flatten before checking.
+    flat = result.output.replace("\n", "").replace(" ", "")
+    assert str(p) in flat
+
+
+def test_spec_new_resolves_unknown_task(configured_app_with_task: Path):
+    """An explicit unknown --task slug errors clearly."""
+    result = runner.invoke(app, ["spec", "new", "--task", "nope"])
+    assert result.exit_code != 0
+    assert "nope" in result.output
+
+
+# --- find_spec discovery of the blessed path (#126) ---
+
+
+def test_find_spec_discovers_blessed_path_when_task_set(tmp_path: Path):
+    """`mship view spec` (find_spec with task=<slug>) finds the blessed file."""
+    from mship.core.state import Task, WorkspaceState
+    from mship.core.view.spec_discovery import find_spec
+
+    blessed = tmp_path / ".mothership" / "tasks" / "demo" / "SPEC.md"
+    blessed.parent.mkdir(parents=True)
+    blessed.write_text("# demo spec\n")
+
+    task = Task(
+        slug="demo",
+        description="d",
+        phase="plan",
+        created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        affected_repos=["a"],
+        branch="feat/demo",
+    )
+    state = WorkspaceState(tasks={"demo": task})
+    found = find_spec(tmp_path, None, task="demo", state=state)
+    assert found == blessed
+
+
+# --- _gate_dev satisfaction by blessed path (#126) ---
+
+
+def test_gate_dev_satisfied_by_blessed_path(tmp_path: Path):
+    """`mship phase dev` doesn't warn when the task's blessed SPEC.md exists,
+    even with no spec in the workspace-level docs/superpowers/specs dir."""
+    from unittest.mock import MagicMock
+    from mship.core.config import RepoConfig, WorkspaceConfig
+    from mship.core.log import LogManager
+    from mship.core.phase import PhaseManager
+    from mship.core.state import StateManager, Task, WorkspaceState
+
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    mgr = StateManager(state_dir)
+    task = Task(
+        slug="add-labels",
+        description="Add labels",
+        phase="plan",
+        created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        affected_repos=["shared"],
+        branch="feat/add-labels",
+        worktrees={"shared": tmp_path / "shared"},
+    )
+    mgr.save(WorkspaceState(tasks={"add-labels": task}))
+
+    # Place the blessed spec; nothing in docs/superpowers/specs.
+    blessed = state_dir / "tasks" / "add-labels" / "SPEC.md"
+    blessed.parent.mkdir(parents=True)
+    blessed.write_text("# spec\n")
+
+    config = WorkspaceConfig(
+        workspace="t",
+        repos={"shared": RepoConfig(path=Path("./shared"), type="library")},
+    )
+    pm = PhaseManager(
+        mgr, MagicMock(spec=LogManager),
+        config=config, workspace_root=tmp_path,
+    )
+    result = pm.transition("add-labels", "dev")
+    assert not any("spec" in w.lower() for w in result.warnings), result.warnings
+
+
+def test_gate_dev_hint_mentions_spec_new(tmp_path: Path):
+    """The empty-workspace warning points at `mship spec new`."""
+    from unittest.mock import MagicMock
+    from mship.core.config import RepoConfig, WorkspaceConfig
+    from mship.core.log import LogManager
+    from mship.core.phase import PhaseManager
+    from mship.core.state import StateManager, Task, WorkspaceState
+
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    mgr = StateManager(state_dir)
+    task = Task(
+        slug="add-labels",
+        description="d",
+        phase="plan",
+        created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        affected_repos=["shared"],
+        branch="feat/add-labels",
+        worktrees={"shared": tmp_path / "shared"},
+    )
+    mgr.save(WorkspaceState(tasks={"add-labels": task}))
+    config = WorkspaceConfig(
+        workspace="t",
+        repos={"shared": RepoConfig(path=Path("./shared"), type="library")},
+    )
+    pm = PhaseManager(
+        mgr, MagicMock(spec=LogManager),
+        config=config, workspace_root=tmp_path,
+    )
+    result = pm.transition("add-labels", "dev")
+    spec_warn = next((w for w in result.warnings if "spec" in w.lower()), None)
+    assert spec_warn is not None, result.warnings
+    assert "mship spec new" in spec_warn


### PR DESCRIPTION
## Summary

Closes #126. The dev-phase soft gate has been effectively a no-op for greenfield workspaces: it called `find_spec` with no task filter, so any random old spec satisfied it, and when nothing existed it warned without telling the user how to fix it. #113 made `spec_paths` configurable but didn't pick a default the gate could rely on.

This change blesses a default mship-private, task-scoped spec path and adds the command to scaffold it.

### What changed

- **Blessed location:** `<workspace>/.mothership/tasks/<slug>/SPEC.md`. One file per task at a known path — easy for the gate to check, easy for `mship spec new` to scaffold reliably. Not committed by default; tasks can keep their design notes private.
- **`mship spec new`** (`--force`, `--task`) renders a template pre-populated with the task's slug, description, affected repos, and creation date so the file isn't blank:

  ```
  # Spec: <slug>
  **Description:** ...
  **Affected repos:** ...
  ## Goals
  ## Approach
  ## Acceptance criteria
  ```

- **`find_spec`** checks the blessed path first when called with `task=<slug>` and no explicit name, so `mship view spec` finds the scaffolded file without extra wiring.
- **Dev-phase gate** also checks the blessed path. If present, the gate is satisfied. Otherwise the existing workspace-wide search runs — **additive**, no behavior change for workspaces that keep specs at `docs/superpowers/specs/...` (#113 default).
- **Hint text** now points at actionable next steps:

  ```
  No spec found — consider writing one before developing
  (create one with `mship spec new` or set `spec_paths` in mothership.yaml)
  ```

### Why additive (not strict task-scoping)

Strict scoping (always pass `task=<slug>` to `find_spec`) would fix the "old spec from another task suppresses the warning" subbug but break every workspace currently using #113's `docs/superpowers/specs/...` convention. The blessed path gives users a first-class option that *is* per-task scoped, while existing workspaces continue to work unchanged.

## Test plan

`tests/cli/test_spec.py` (8 new tests):

- [x] `test_spec_new_creates_blessed_file` — file appears at the right path with task metadata.
- [x] `test_spec_new_refuses_when_file_exists` — exit 1, original content preserved.
- [x] `test_spec_new_force_overwrites` — `--force` replaces content.
- [x] `test_spec_new_outputs_path_on_tty` — TTY message includes the created path.
- [x] `test_spec_new_resolves_unknown_task` — bad `--task` slug errors clearly.
- [x] `test_find_spec_discovers_blessed_path_when_task_set` — `mship view spec` finds it.
- [x] `test_gate_dev_satisfied_by_blessed_path` — phase dev no warning when blessed path exists.
- [x] `test_gate_dev_hint_mentions_spec_new` — empty workspace warning points at `mship spec new`.

Existing `tests/core/test_phase.py` gate tests still pass (additive change).

`mship test` (full pytest suite) — green, no regressions.

Closes #126