### PR TITLE
task dependency graph (#104)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,5 +31,5 @@ stop and read it.
 ## Bypass flags
 
 Safety overrides use `--bypass-<check>` (e.g. `--bypass-reconcile`,
-`--bypass-base-ancestry`), not `--force-<check>`. `--force` is the
+`--bypass-base-ancestry`, `--bypass-deps`), not `--force-<check>`. `--force` is the
 all-bypass nuclear option; prefer the targeted flag.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ is supported — `--repos mothership` is the whole invocation.
 Workflow specifics live in `skills/`, not here. The relevant ones:
 
 - `skills/working-with-mothership/SKILL.md` — the canonical mship workflow
-  (session start, phases, switch/finish/close, recovery)
+  (session start, phases, switch/finish/close, recovery, task dependencies)
 - `skills/using-git-worktrees/SKILL.md` — worktree mechanics
 - `skills/finishing-a-development-branch/SKILL.md` — finish → PR flow
 - `skills/verification-before-completion/SKILL.md` — what "done" means

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,6 +7,7 @@ session-start protocol Claude Code and Codex use.
 **When you see a `mothership.yaml` in the repo, follow
 `skills/working-with-mothership/SKILL.md` before any other action.** It spells
 out: `mship status` → `mship log` → `mship switch <repo>` at session start,
-and the full spawn → phase dev → test → finish → close lifecycle.
+the full spawn → phase dev → test → finish → close lifecycle, and task-to-task
+dependencies via `mship depends`.
 
 See `README.md` for the full pitch and CLI reference.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,31 @@ Requires Python 3.14+ and [uv](https://docs.astral.sh/uv/). Optional: [go-task](
 
 The quickstart above is deliberately minimal — one repo, one file — to show the task lifecycle in isolation. For the multi-repo case mship was built for, see [`docs/configuration.md`](docs/configuration.md) for `mothership.yaml` examples with dependency graphs, healthchecks, and `env_runner` delegation, and [`docs/cli.md`](docs/cli.md) for the full command surface including `mship spawn --repos`, `mship switch`, and cross-repo `mship finish`.
 
+## Cheat sheet
+
+```bash
+# Workflow
+mship spawn "description"               # start a task in isolated worktrees
+mship switch <repo>                     # context switch across repos
+mship phase plan|dev|review|run         # transition through phases
+mship test                              # run tests in dependency order
+mship finish --body-file - <<'EOF'...   # open PR(s)
+mship close                             # clean up task state and worktrees
+
+# Task dependencies (#104)
+mship spawn "downstream" --depends-on a,b  # declare at spawn
+mship depends add/remove/list               # manage task-to-task dependency edges
+mship finish --bypass-deps                 # ship a downstream even if upstream isn't ready
+
+# Inspection
+mship status                            # active task, phase, branch, drift
+mship journal                           # task log with context
+mship context                           # JSON snapshot of workspace state
+mship graph                             # dependency graph across all tasks
+```
+
+For details, see `mship spawn --help`, [`docs/cli.md`](docs/cli.md), and the `working-with-mothership` skill.
+
 ## What mship gives agents
 
 **Cross-repo coordination as a first-class concept.** A task in mship is a single unit of work that can span many repos. `mship spawn "propagate user schema v2" --repos schemas,svc-users,svc-billing,api,api-client` creates one worktree per repo on a shared feature branch. `mship test` runs them in dependency order. `mship finish` opens five PRs in dependency order with coordination blocks in each body linking the others. Audits catch drift per repo. The agent operates on "the task" — mship tracks which files across which repos belong to it.

--- a/docs/superpowers/plans/2026-05-14-task-dependency-graph.md
+++ b/docs/superpowers/plans/2026-05-14-task-dependency-graph.md
@@ -1,0 +1,1863 @@
+# Task dependency graph — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add first-class `depends_on` edges between tasks, persisted in `state.yaml`. An edge is a constraint: `finish` refuses until every upstream is merged. `status`, `dispatch`, `reconcile` surface the graph.
+
+**Architecture:** Add a single `DependencyEdge` Pydantic model and a `depends_on: list[DependencyEdge]` field on `Task` (additive; default `[]`). All graph queries (cycle detection, transitive upstream, downstream-of, readiness) live in a new pure module `src/mship/core/task_graph.py` — separate from the existing `graph.py` (which models **repo** dependencies, not task dependencies). New CLI verb group `mship depends` (add/remove/list). Existing commands (`spawn`, `finish`, `close`, `status`, `dispatch`, `reconcile`) grow narrow integration hooks.
+
+**Tech Stack:** Python 3, Typer, Pydantic, pytest. No new dependencies.
+
+**Divergence from spec:** spec said "Modified: `src/mship/core/graph.py`". `graph.py` already exists for **repo** dependency topology. Mixing two semantically-different graph types in one module is confusing. The new code lives in `src/mship/core/task_graph.py` instead. Spec updated to match if approved.
+
+---
+
+## Spec reference
+
+`docs/superpowers/specs/2026-05-14-task-dependency-graph-design.md` in this worktree.
+
+## File structure
+
+**New:**
+
+- `src/mship/core/task_graph.py` — pure graph functions: `transitive_upstream`, `downstream_of`, `find_cycle`, `is_ready`. No I/O. Takes `WorkspaceState` as input.
+- `src/mship/cli/depends.py` — `mship depends add/remove/list` Typer subcommand group.
+- `tests/core/test_task_graph.py` — unit tests for graph functions.
+- `tests/cli/test_depends.py` — CLI tests for the `depends` verb group.
+- `tests/test_dependency_integration.py` — one end-to-end test exercising spawn → finish-blocked → finish-upstream → finish-downstream.
+
+**Modified:**
+
+- `src/mship/core/state.py` — add `DependencyEdge`; add `depends_on: list[DependencyEdge] = []` field on `Task`.
+- `src/mship/cli/__init__.py` — register the `depends` subcommand group.
+- `src/mship/cli/worktree.py` — `spawn --depends-on`; `finish` blocked-by-deps check + `--bypass-deps`; `close` downstream check + `--cascade` / `--detach-downstream`.
+- `src/mship/cli/status.py` — emit `dependencies` block under `resolved_task`.
+- `src/mship/core/dispatch.py` — add `## Dependencies` section to the prompt template.
+- `src/mship/core/reconcile/detect.py` — extend `UpstreamState` with `dependency_stale`; post-process detections to apply it.
+- `src/mship/cli/reconcile.py` — add `dependency_stale` to action hints and glyph mapping; ensure JSON output passes it through.
+- `tests/cli/test_status.py` — assert `dependencies` block.
+- `tests/cli/test_worktree.py` (or the equivalent for spawn/finish/close) — extend existing spawn/finish/close tests.
+- `tests/cli/test_dispatch.py` — assert `## Dependencies` section.
+- `tests/core/reconcile/...` — extend reconcile detection tests for `dependency_stale`.
+- `src/mship/skills/working-with-mothership/SKILL.md` — document the new verb and `--depends-on` flag.
+- `README.md`, `AGENTS.md`, `GEMINI.md` — add `mship depends` to the cheat sheet; mention `--depends-on`/`--bypass-deps` flags.
+
+**Not modified:**
+
+- `src/mship/core/graph.py` — repo dependency graph; unrelated to task dependencies.
+
+---
+
+## Task 1: Add `DependencyEdge` model and `Task.depends_on` field
+
+**Files:**
+- Modify: `src/mship/core/state.py`
+- Modify: `tests/core/test_state.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_state.py`:
+
+```python
+def test_task_depends_on_defaults_empty(tmp_path):
+    """New Task model has depends_on field defaulting to []."""
+    from mship.core.state import Task
+    from datetime import datetime, timezone
+
+    t = Task(
+        slug="x", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["r"], branch="feat/x",
+    )
+    assert t.depends_on == []
+
+
+def test_dependency_edge_roundtrip(tmp_path):
+    """DependencyEdge serializes and deserializes through state.yaml."""
+    from mship.core.state import StateManager, Task, WorkspaceState, DependencyEdge
+    from datetime import datetime, timezone
+
+    sm = StateManager(tmp_path / ".mothership")
+    now = datetime.now(timezone.utc)
+    t = Task(
+        slug="b", description="d", phase="dev",
+        created_at=now,
+        affected_repos=["r"], branch="feat/b",
+        depends_on=[DependencyEdge(upstream_slug="a", created_at=now)],
+    )
+    sm.save(WorkspaceState(tasks={"b": t}))
+
+    loaded = sm.load()
+    assert "b" in loaded.tasks
+    edges = loaded.tasks["b"].depends_on
+    assert len(edges) == 1
+    assert edges[0].upstream_slug == "a"
+
+
+def test_legacy_state_without_depends_on_loads_clean(tmp_path):
+    """state.yaml without depends_on field loads with depends_on=[]."""
+    from mship.core.state import StateManager
+    import yaml
+
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    (state_dir / "state.yaml").write_text(yaml.dump({
+        "tasks": {
+            "t": {
+                "slug": "t", "description": "d", "phase": "dev",
+                "created_at": "2026-05-14T00:00:00+00:00",
+                "affected_repos": ["r"], "worktrees": {},
+                "branch": "feat/t",
+            }
+        }
+    }))
+    sm = StateManager(state_dir)
+    state = sm.load()
+    assert state.tasks["t"].depends_on == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/core/test_state.py::test_task_depends_on_defaults_empty \
+       tests/core/test_state.py::test_dependency_edge_roundtrip \
+       tests/core/test_state.py::test_legacy_state_without_depends_on_loads_clean -v
+```
+
+Expected: FAIL with `AttributeError: depends_on` or `ImportError: DependencyEdge`.
+
+- [ ] **Step 3: Add the model and field**
+
+In `src/mship/core/state.py`, add after `TestResult`:
+
+```python
+class DependencyEdge(BaseModel):
+    upstream_slug: str
+    created_at: datetime
+```
+
+In the `Task` class, add the field (e.g., near `passive_repos`):
+
+```python
+    depends_on: list[DependencyEdge] = []
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/core/test_state.py -v
+```
+
+Expected: all three new tests PASS; all previously-passing tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/state.py tests/core/test_state.py
+git commit -m "feat(state): add DependencyEdge and Task.depends_on field (#104)"
+mship journal "state: added DependencyEdge + Task.depends_on; tests passing" --action committed
+```
+
+---
+
+## Task 2: Pure graph queries — `task_graph.py`
+
+**Files:**
+- Create: `src/mship/core/task_graph.py`
+- Create: `tests/core/test_task_graph.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/core/test_task_graph.py`:
+
+```python
+"""Pure graph queries over Task.depends_on."""
+from __future__ import annotations
+from datetime import datetime, timezone
+
+import pytest
+
+from mship.core.state import Task, WorkspaceState, DependencyEdge
+from mship.core.task_graph import (
+    CycleError,
+    downstream_of,
+    find_cycle,
+    transitive_upstream,
+)
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+def _task(slug: str, upstream: list[str] = ()) -> Task:
+    return Task(
+        slug=slug, description=slug, phase="dev",
+        created_at=_now(),
+        affected_repos=["r"], branch=f"feat/{slug}",
+        depends_on=[DependencyEdge(upstream_slug=u, created_at=_now()) for u in upstream],
+    )
+
+
+def _ws(*tasks: Task) -> WorkspaceState:
+    return WorkspaceState(tasks={t.slug: t for t in tasks})
+
+
+def test_transitive_upstream_single_hop():
+    ws = _ws(_task("a"), _task("b", ["a"]))
+    assert transitive_upstream(ws, "b") == {"a"}
+
+
+def test_transitive_upstream_multi_hop():
+    ws = _ws(_task("a"), _task("b", ["a"]), _task("c", ["b"]))
+    assert transitive_upstream(ws, "c") == {"a", "b"}
+
+
+def test_transitive_upstream_diamond():
+    ws = _ws(_task("a"), _task("b", ["a"]), _task("c", ["a"]), _task("d", ["b", "c"]))
+    assert transitive_upstream(ws, "d") == {"a", "b", "c"}
+
+
+def test_transitive_upstream_missing_slug_returns_empty():
+    """Unknown task slug returns empty set (caller validates separately)."""
+    ws = _ws(_task("a"))
+    assert transitive_upstream(ws, "nonexistent") == set()
+
+
+def test_downstream_of_single_hop():
+    ws = _ws(_task("a"), _task("b", ["a"]))
+    assert downstream_of(ws, "a") == {"b"}
+
+
+def test_downstream_of_multi_hop():
+    ws = _ws(_task("a"), _task("b", ["a"]), _task("c", ["b"]))
+    assert downstream_of(ws, "a") == {"b", "c"}
+
+
+def test_find_cycle_self_edge():
+    """Adding self-edge produces a cycle."""
+    ws = _ws(_task("a"))
+    # Simulate the would-be edge: would adding a → a create a cycle?
+    cycle = find_cycle(ws, downstream="a", new_upstream="a")
+    assert cycle == ["a", "a"]
+
+
+def test_find_cycle_two_node():
+    """Adding b→a when a already depends on b creates a cycle."""
+    ws = _ws(_task("a", ["b"]), _task("b"))
+    cycle = find_cycle(ws, downstream="b", new_upstream="a")
+    assert cycle == ["b", "a", "b"]
+
+
+def test_find_cycle_three_node():
+    """Adding c→a when a → b → c creates a cycle."""
+    ws = _ws(_task("a", ["b"]), _task("b", ["c"]), _task("c"))
+    cycle = find_cycle(ws, downstream="c", new_upstream="a")
+    assert cycle == ["c", "a", "b", "c"]
+
+
+def test_no_cycle_on_diamond():
+    """A diamond DAG has no cycle."""
+    ws = _ws(_task("a"), _task("b", ["a"]), _task("c", ["a"]))
+    assert find_cycle(ws, downstream="d", new_upstream="b") is None
+    assert find_cycle(ws, downstream="d", new_upstream="c") is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/core/test_task_graph.py -v
+```
+
+Expected: FAIL with `ModuleNotFoundError: mship.core.task_graph`.
+
+- [ ] **Step 3: Implement `task_graph.py`**
+
+Create `src/mship/core/task_graph.py`:
+
+```python
+"""Pure graph queries over Task.depends_on edges.
+
+This module is distinct from `mship.core.graph` (which models repo
+dependency topology). The task graph operates on `WorkspaceState.tasks`.
+"""
+from __future__ import annotations
+
+from mship.core.state import WorkspaceState
+
+
+class CycleError(Exception):
+    """Adding a proposed edge would create a cycle."""
+
+    def __init__(self, path: list[str]) -> None:
+        self.path = path
+        super().__init__(" → ".join(path))
+
+
+def transitive_upstream(state: WorkspaceState, slug: str) -> set[str]:
+    """Return all transitive upstream slugs of `slug`, excluding `slug` itself."""
+    if slug not in state.tasks:
+        return set()
+    visited: set[str] = set()
+    stack = [slug]
+    while stack:
+        node = stack.pop()
+        task = state.tasks.get(node)
+        if task is None:
+            continue
+        for edge in task.depends_on:
+            if edge.upstream_slug not in visited:
+                visited.add(edge.upstream_slug)
+                stack.append(edge.upstream_slug)
+    return visited
+
+
+def downstream_of(state: WorkspaceState, slug: str) -> set[str]:
+    """Return all transitive downstream slugs of `slug`, excluding `slug` itself."""
+    direct: dict[str, list[str]] = {s: [] for s in state.tasks}
+    for s, t in state.tasks.items():
+        for edge in t.depends_on:
+            if edge.upstream_slug in direct:
+                direct[edge.upstream_slug].append(s)
+
+    visited: set[str] = set()
+    stack = list(direct.get(slug, []))
+    while stack:
+        node = stack.pop()
+        if node not in visited:
+            visited.add(node)
+            stack.extend(direct.get(node, []))
+    return visited
+
+
+def find_cycle(
+    state: WorkspaceState,
+    *,
+    downstream: str,
+    new_upstream: str,
+) -> list[str] | None:
+    """If adding edge (downstream → new_upstream) creates a cycle, return the cycle path.
+
+    The path is [downstream, new_upstream, ..., downstream] — first and last
+    are the same slug.
+
+    Returns None if no cycle would be created.
+
+    Note: `downstream` need not exist in `state.tasks` yet (we use this at
+    spawn time, before the task is persisted).
+    """
+    if new_upstream == downstream:
+        return [downstream, downstream]
+
+    if new_upstream not in state.tasks:
+        return None
+
+    parent: dict[str, str] = {new_upstream: downstream}
+    stack = [new_upstream]
+    while stack:
+        node = stack.pop()
+        task = state.tasks.get(node)
+        if task is None:
+            continue
+        for edge in task.depends_on:
+            up = edge.upstream_slug
+            if up == downstream:
+                path = [downstream, node]
+                while path[-1] != new_upstream:
+                    path.append(parent[path[-1]])
+                path.append(new_upstream)
+                path.reverse()
+                path.insert(0, downstream)
+                return path
+            if up not in parent:
+                parent[up] = node
+                stack.append(up)
+    return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/core/test_task_graph.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/task_graph.py tests/core/test_task_graph.py
+git commit -m "feat(task_graph): cycle detection + transitive upstream/downstream queries (#104)"
+mship journal "task_graph module added; cycle + transitive queries tested" --action committed
+```
+
+---
+
+## Task 3: Readiness query — `is_ready`
+
+**Files:**
+- Modify: `src/mship/core/task_graph.py`
+- Modify: `tests/core/test_task_graph.py`
+
+`is_ready(state, slug, reconcile_decisions)` consumes the same `Decision` dict that `mship.core.reconcile.gate.reconcile_now` produces. Ready ⇔ task has `finished_at` set AND reconcile reports `UpstreamState.merged`. A task with no upstream is trivially-ready for blocking purposes (this function answers "is this task ready to satisfy a downstream's dependency on it").
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `tests/core/test_task_graph.py`:
+
+```python
+def test_is_ready_finished_and_merged():
+    """A finished task whose reconcile state is merged is ready."""
+    from datetime import datetime, timezone
+    from mship.core.reconcile.detect import UpstreamState
+    from mship.core.reconcile.gate import Decision
+    from mship.core.task_graph import is_ready
+
+    ws = _ws(_task("a"))
+    ws.tasks["a"].finished_at = datetime.now(timezone.utc)
+    decisions = {
+        "a": Decision(slug="a", state=UpstreamState.merged, pr_url=None,
+                      pr_number=None, base=None, merge_commit=None),
+    }
+    assert is_ready(ws, "a", decisions) is True
+
+
+def test_is_ready_finished_but_open():
+    """A finished task whose PR is still open is NOT ready."""
+    from datetime import datetime, timezone
+    from mship.core.reconcile.detect import UpstreamState
+    from mship.core.reconcile.gate import Decision
+    from mship.core.task_graph import is_ready
+
+    ws = _ws(_task("a"))
+    ws.tasks["a"].finished_at = datetime.now(timezone.utc)
+    decisions = {
+        "a": Decision(slug="a", state=UpstreamState.in_sync, pr_url=None,
+                      pr_number=None, base=None, merge_commit=None),
+    }
+    assert is_ready(ws, "a", decisions) is False
+
+
+def test_is_ready_unfinished():
+    """An unfinished task is never ready."""
+    from mship.core.task_graph import is_ready
+
+    ws = _ws(_task("a"))  # finished_at is None
+    assert is_ready(ws, "a", {}) is False
+
+
+def test_is_ready_unknown_task():
+    """Unknown slug returns False."""
+    from mship.core.task_graph import is_ready
+
+    ws = _ws(_task("a"))
+    assert is_ready(ws, "nope", {}) is False
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+pytest tests/core/test_task_graph.py -k is_ready -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'is_ready'`.
+
+- [ ] **Step 3: Add `is_ready` to `task_graph.py`**
+
+Append to `src/mship/core/task_graph.py`:
+
+```python
+def is_ready(
+    state: WorkspaceState,
+    slug: str,
+    reconcile_decisions: dict,
+) -> bool:
+    """True iff `slug` is a finished task whose reconcile state is merged.
+
+    `reconcile_decisions` is a `dict[str, Decision]` from
+    `mship.core.reconcile.gate.reconcile_now`. We import lazily to avoid a
+    circular import — reconcile may grow dependency-aware logic later.
+    """
+    from mship.core.reconcile.detect import UpstreamState
+
+    task = state.tasks.get(slug)
+    if task is None or task.finished_at is None:
+        return False
+    decision = reconcile_decisions.get(slug)
+    if decision is None:
+        return False
+    return decision.state == UpstreamState.merged
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+```bash
+pytest tests/core/test_task_graph.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/task_graph.py tests/core/test_task_graph.py
+git commit -m "feat(task_graph): is_ready query against reconcile decisions (#104)"
+mship journal "is_ready query landed; consumes reconcile.gate Decision dict" --action committed
+```
+
+---
+
+## Task 4: `mship depends add` command
+
+**Files:**
+- Create: `src/mship/cli/depends.py`
+- Modify: `src/mship/cli/__init__.py`
+- Create: `tests/cli/test_depends.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/cli/test_depends.py`:
+
+```python
+"""Tests for the `mship depends` verb group."""
+from __future__ import annotations
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.state import StateManager, Task, WorkspaceState
+
+runner = CliRunner()
+
+
+def _seed(workspace: Path, *tasks: Task) -> None:
+    sm = StateManager(workspace / ".mothership")
+    sm.save(WorkspaceState(tasks={t.slug: t for t in tasks}))
+
+
+def _task(slug: str) -> Task:
+    return Task(
+        slug=slug, description=slug, phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["mothership"], branch=f"feat/{slug}",
+    )
+
+
+@pytest.fixture
+def configured_app(workspace: Path):
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(workspace / "mothership.yaml")
+    container.state_dir.override(workspace / ".mothership")
+    (workspace / ".mothership").mkdir(exist_ok=True)
+    yield
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override()
+    container.config.reset()
+    container.state_manager.reset_override()
+    container.state_manager.reset()
+
+
+def test_depends_add_creates_edge(workspace, configured_app):
+    _seed(workspace, _task("a"), _task("b"))
+    result = runner.invoke(app, ["depends", "add", "a", "--task", "b"])
+    assert result.exit_code == 0, result.stderr or result.output
+
+    sm = StateManager(workspace / ".mothership")
+    state = sm.load()
+    edges = state.tasks["b"].depends_on
+    assert len(edges) == 1
+    assert edges[0].upstream_slug == "a"
+
+
+def test_depends_add_unknown_upstream_errors(workspace, configured_app):
+    _seed(workspace, _task("b"))
+    result = runner.invoke(app, ["depends", "add", "nope", "--task", "b"])
+    assert result.exit_code != 0
+    assert "nope" in (result.stderr or result.output).lower()
+
+
+def test_depends_add_self_edge_rejected(workspace, configured_app):
+    _seed(workspace, _task("b"))
+    result = runner.invoke(app, ["depends", "add", "b", "--task", "b"])
+    assert result.exit_code != 0
+    err = (result.stderr or result.output).lower()
+    assert "cycle" in err or "self" in err
+
+
+def test_depends_add_cycle_rejected(workspace, configured_app):
+    """b already depends on a; adding a→b creates a cycle."""
+    a = _task("a")
+    b = _task("b")
+    from mship.core.state import DependencyEdge
+    b.depends_on = [DependencyEdge(upstream_slug="a", created_at=datetime.now(timezone.utc))]
+    _seed(workspace, a, b)
+
+    result = runner.invoke(app, ["depends", "add", "b", "--task", "a"])
+    assert result.exit_code != 0
+    err = (result.stderr or result.output).lower()
+    assert "cycle" in err
+    assert "b" in err and "a" in err
+
+
+def test_depends_add_duplicate_idempotent(workspace, configured_app):
+    """Adding an existing edge is a no-op (does not duplicate)."""
+    _seed(workspace, _task("a"), _task("b"))
+    runner.invoke(app, ["depends", "add", "a", "--task", "b"])
+    result = runner.invoke(app, ["depends", "add", "a", "--task", "b"])
+    assert result.exit_code == 0
+    sm = StateManager(workspace / ".mothership")
+    edges = sm.load().tasks["b"].depends_on
+    assert len(edges) == 1
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+pytest tests/cli/test_depends.py -v
+```
+
+Expected: FAIL — `depends` command doesn't exist yet.
+
+- [ ] **Step 3: Implement `depends.py` and register**
+
+Create `src/mship/cli/depends.py`:
+
+```python
+"""`mship depends` — manage task-to-task dependency edges (#104)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import typer
+
+from mship.cli._resolve import resolve_for_command
+from mship.cli.output import Output
+from mship.core.state import DependencyEdge
+from mship.core.task_graph import find_cycle
+
+
+def register(app: typer.Typer, get_container):
+    depends_app = typer.Typer(no_args_is_help=True, help="Manage task-to-task dependencies (#104).")
+    app.add_typer(depends_app, name="depends")
+
+    @depends_app.command("add")
+    def add(
+        upstream_slug: str = typer.Argument(..., help="Upstream task slug to depend on."),
+        task: Optional[str] = typer.Option(None, "--task", help="Downstream task (defaults to cwd-resolved)."),
+    ):
+        """Declare that the current/specified task depends on <upstream_slug>."""
+        output = Output()
+        container = get_container()
+        state_mgr = container.state_manager()
+        state = state_mgr.load()
+        resolved = resolve_for_command("depends", state, task, output)
+        downstream = resolved.task.slug
+
+        if upstream_slug not in state.tasks:
+            known = ", ".join(sorted(state.tasks.keys())) or "(none)"
+            output.error(f"Unknown upstream task: {upstream_slug!r}. Known: {known}.")
+            raise typer.Exit(code=1)
+
+        cycle = find_cycle(state, downstream=downstream, new_upstream=upstream_slug)
+        if cycle is not None:
+            output.error(f"Cycle detected: {' → '.join(cycle)}")
+            raise typer.Exit(code=1)
+
+        def _mutate(s):
+            t = s.tasks[downstream]
+            if any(e.upstream_slug == upstream_slug for e in t.depends_on):
+                return  # idempotent
+            t.depends_on.append(
+                DependencyEdge(upstream_slug=upstream_slug, created_at=datetime.now(timezone.utc))
+            )
+
+        state_mgr.mutate(_mutate)
+        if output.is_tty:
+            output.success(f"{downstream} now depends on {upstream_slug}")
+        else:
+            output.json({"downstream": downstream, "upstream": upstream_slug, "added": True})
+```
+
+In `src/mship/cli/__init__.py`, add the import (alphabetical/grouped near other imports):
+
+```python
+from mship.cli import depends as _depends_mod
+```
+
+And the registration (alphabetical/grouped near other registrations):
+
+```python
+_depends_mod.register(app, get_container)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+```bash
+pytest tests/cli/test_depends.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/cli/depends.py src/mship/cli/__init__.py tests/cli/test_depends.py
+git commit -m "feat(cli): mship depends add with cycle detection (#104)"
+mship journal "mship depends add command landed; cycle check + idempotent add" --action committed
+```
+
+---
+
+## Task 5: `mship depends remove` command
+
+**Files:**
+- Modify: `src/mship/cli/depends.py`
+- Modify: `tests/cli/test_depends.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/cli/test_depends.py`:
+
+```python
+def test_depends_remove_clears_edge(workspace, configured_app):
+    from mship.core.state import DependencyEdge
+    a = _task("a")
+    b = _task("b")
+    b.depends_on = [DependencyEdge(upstream_slug="a", created_at=datetime.now(timezone.utc))]
+    _seed(workspace, a, b)
+
+    result = runner.invoke(app, ["depends", "remove", "a", "--task", "b"])
+    assert result.exit_code == 0
+    sm = StateManager(workspace / ".mothership")
+    assert sm.load().tasks["b"].depends_on == []
+
+
+def test_depends_remove_missing_edge_errors(workspace, configured_app):
+    """Removing an edge that doesn't exist errors loudly."""
+    _seed(workspace, _task("a"), _task("b"))
+    result = runner.invoke(app, ["depends", "remove", "a", "--task", "b"])
+    assert result.exit_code != 0
+    err = (result.stderr or result.output).lower()
+    assert "no edge" in err or "not found" in err
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+pytest tests/cli/test_depends.py -k remove -v
+```
+
+Expected: FAIL — `remove` subcommand doesn't exist.
+
+- [ ] **Step 3: Add the `remove` command**
+
+In `src/mship/cli/depends.py`, inside the `register` function after `add`, append:
+
+```python
+    @depends_app.command("remove")
+    def remove(
+        upstream_slug: str = typer.Argument(..., help="Upstream task slug to detach from."),
+        task: Optional[str] = typer.Option(None, "--task", help="Downstream task (defaults to cwd-resolved)."),
+    ):
+        """Remove the dependency edge from the current/specified task to <upstream_slug>."""
+        output = Output()
+        container = get_container()
+        state_mgr = container.state_manager()
+        state = state_mgr.load()
+        resolved = resolve_for_command("depends", state, task, output)
+        downstream = resolved.task.slug
+
+        t = state.tasks[downstream]
+        if not any(e.upstream_slug == upstream_slug for e in t.depends_on):
+            output.error(f"No edge from {downstream!r} to {upstream_slug!r}.")
+            raise typer.Exit(code=1)
+
+        def _mutate(s):
+            s.tasks[downstream].depends_on = [
+                e for e in s.tasks[downstream].depends_on
+                if e.upstream_slug != upstream_slug
+            ]
+
+        state_mgr.mutate(_mutate)
+        if output.is_tty:
+            output.success(f"{downstream} no longer depends on {upstream_slug}")
+        else:
+            output.json({"downstream": downstream, "upstream": upstream_slug, "removed": True})
+```
+
+- [ ] **Step 4: Verify pass**
+
+```bash
+pytest tests/cli/test_depends.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/cli/depends.py tests/cli/test_depends.py
+git commit -m "feat(cli): mship depends remove (#104)"
+mship journal "mship depends remove landed; loud error on missing edge" --action committed
+```
+
+---
+
+## Task 6: `mship depends list` command
+
+**Files:**
+- Modify: `src/mship/cli/depends.py`
+- Modify: `tests/cli/test_depends.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/cli/test_depends.py`:
+
+```python
+def test_depends_list_task_scoped(workspace, configured_app):
+    """Without --graph, list shows the resolved task's upstream + downstream."""
+    from mship.core.state import DependencyEdge
+    a = _task("a")
+    b = _task("b")
+    c = _task("c")
+    b.depends_on = [DependencyEdge(upstream_slug="a", created_at=datetime.now(timezone.utc))]
+    c.depends_on = [DependencyEdge(upstream_slug="b", created_at=datetime.now(timezone.utc))]
+    _seed(workspace, a, b, c)
+
+    result = runner.invoke(app, ["depends", "list", "--task", "b"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["task"] == "b"
+    assert [u["slug"] for u in data["upstream"]] == ["a"]
+    assert [d["slug"] for d in data["downstream"]] == ["c"]
+
+
+def test_depends_list_graph_emits_workspace_dag(workspace, configured_app):
+    """--graph emits all tasks + edges."""
+    from mship.core.state import DependencyEdge
+    a = _task("a")
+    b = _task("b")
+    b.depends_on = [DependencyEdge(upstream_slug="a", created_at=datetime.now(timezone.utc))]
+    _seed(workspace, a, b)
+
+    result = runner.invoke(app, ["depends", "list", "--graph"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert {n["slug"] for n in data["nodes"]} == {"a", "b"}
+    assert {(e["downstream"], e["upstream"]) for e in data["edges"]} == {("b", "a")}
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+pytest tests/cli/test_depends.py -k list -v
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `list`**
+
+In `src/mship/cli/depends.py`, append inside `register`:
+
+```python
+    @depends_app.command("list")
+    def list_cmd(
+        task: Optional[str] = typer.Option(None, "--task", help="Task slug to scope to."),
+        graph: bool = typer.Option(False, "--graph", help="Emit the full workspace DAG instead of one task's edges."),
+    ):
+        """List dependencies for a task (default) or the whole workspace (--graph)."""
+        from mship.core.task_graph import downstream_of
+
+        output = Output()
+        container = get_container()
+        state = container.state_manager().load()
+
+        if graph:
+            nodes = [{"slug": s} for s in sorted(state.tasks.keys())]
+            edges = []
+            for slug, t in state.tasks.items():
+                for e in t.depends_on:
+                    edges.append({"downstream": slug, "upstream": e.upstream_slug})
+            edges.sort(key=lambda e: (e["downstream"], e["upstream"]))
+            payload = {"nodes": nodes, "edges": edges}
+            if output.is_tty:
+                _render_graph_tty(output, payload)
+            else:
+                output.json(payload)
+            return
+
+        resolved = resolve_for_command("depends", state, task, output)
+        slug = resolved.task.slug
+        upstream = [{"slug": e.upstream_slug} for e in state.tasks[slug].depends_on]
+        downstream = [{"slug": s} for s in sorted(downstream_of(state, slug))]
+        payload = {"task": slug, "upstream": upstream, "downstream": downstream}
+        if output.is_tty:
+            _render_task_deps_tty(output, payload)
+        else:
+            output.json(payload)
+```
+
+Add helper renderers at module-level (above `register`):
+
+```python
+def _render_task_deps_tty(output, payload):
+    output.print(f"Task: {payload['task']}")
+    output.print("Upstream:")
+    if not payload["upstream"]:
+        output.print("  (none)")
+    else:
+        for u in payload["upstream"]:
+            output.print(f"  → {u['slug']}")
+    output.print("Downstream:")
+    if not payload["downstream"]:
+        output.print("  (none)")
+    else:
+        for d in payload["downstream"]:
+            output.print(f"  ← {d['slug']}")
+
+
+def _render_graph_tty(output, payload):
+    output.print("Workspace DAG:")
+    if not payload["edges"]:
+        output.print("  (no edges)")
+        return
+    for e in payload["edges"]:
+        output.print(f"  {e['downstream']} → {e['upstream']}")
+```
+
+- [ ] **Step 4: Verify pass**
+
+```bash
+pytest tests/cli/test_depends.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/cli/depends.py tests/cli/test_depends.py
+git commit -m "feat(cli): mship depends list (--graph) (#104)"
+mship journal "mship depends list command landed; task-scoped and --graph modes" --action committed
+```
+
+---
+
+## Task 7: `mship spawn --depends-on` integration
+
+**Files:**
+- Modify: `src/mship/cli/worktree.py`
+- Modify: `tests/cli/test_worktree.py` (or wherever spawn is tested today)
+
+- [ ] **Step 1: Locate and study spawn**
+
+```bash
+grep -n "def spawn\|--depends" src/mship/cli/worktree.py | head
+```
+
+The flag list is around `src/mship/cli/worktree.py:212`. The handler persists a new `Task` via the state manager after validation/audit/setup.
+
+- [ ] **Step 2: Add the failing test**
+
+Append to `tests/cli/test_worktree.py` (or the closest spawn-test file):
+
+```python
+def test_spawn_with_depends_on_persists_edges(workspace_with_git, configured_app, monkeypatch):
+    """spawn --depends-on a,b creates the task with edges to a and b."""
+    # Seed an upstream task first.
+    from mship.core.state import StateManager, Task, WorkspaceState
+    from datetime import datetime, timezone
+    sm = StateManager(workspace_with_git / ".mothership")
+    sm.save(WorkspaceState(tasks={
+        "a": Task(slug="a", description="d", phase="dev",
+                  created_at=datetime.now(timezone.utc),
+                  affected_repos=["mothership"], branch="feat/a"),
+    }))
+
+    result = runner.invoke(
+        app,
+        ["spawn", "downstream task", "--slug", "down", "--depends-on", "a", "--skip-setup"],
+    )
+    assert result.exit_code == 0, result.stderr or result.output
+    state = StateManager(workspace_with_git / ".mothership").load()
+    edges = state.tasks["down"].depends_on
+    assert [e.upstream_slug for e in edges] == ["a"]
+
+
+def test_spawn_with_unknown_depends_on_errors(workspace_with_git, configured_app):
+    """spawn --depends-on <unknown> errors before creating the task."""
+    result = runner.invoke(
+        app,
+        ["spawn", "x", "--slug", "x", "--depends-on", "nope", "--skip-setup"],
+    )
+    assert result.exit_code != 0
+    assert "nope" in (result.stderr or result.output).lower()
+```
+
+(If `workspace_with_git` doesn't exist, use the spawn-test fixture used by the file's existing tests.)
+
+- [ ] **Step 3: Verify failure**
+
+```bash
+pytest tests/cli/test_worktree.py -k "depends_on" -v
+```
+
+Expected: FAIL — flag unknown.
+
+- [ ] **Step 4: Add the `--depends-on` flag**
+
+In `src/mship/cli/worktree.py`, in the `spawn` signature (around line 212), add a new option:
+
+```python
+        depends_on: Optional[str] = typer.Option(
+            None, "--depends-on",
+            help="Comma-separated upstream task slugs this task depends on. See #104.",
+        ),
+```
+
+After audit succeeds and BEFORE the task is persisted, validate the upstream slugs and compute edges:
+
+```python
+        # --- #104 dependency edges ---
+        from datetime import datetime, timezone
+        from mship.core.state import DependencyEdge
+        from mship.core.task_graph import find_cycle
+
+        edges: list[DependencyEdge] = []
+        if depends_on:
+            requested = [s.strip() for s in depends_on.split(",") if s.strip()]
+            existing_state = container.state_manager().load()
+            known = set(existing_state.tasks.keys())
+            unknown = [s for s in requested if s not in known]
+            if unknown:
+                listing = ", ".join(sorted(known)) or "(none)"
+                output.error(
+                    f"Unknown upstream task(s): {', '.join(unknown)}. Known: {listing}."
+                )
+                raise typer.Exit(code=1)
+            slug_for_cycle = slug if slug else _make_slug_from_description(description)
+            for up in requested:
+                cycle = find_cycle(existing_state, downstream=slug_for_cycle, new_upstream=up)
+                if cycle is not None:
+                    output.error(f"Cycle detected: {' → '.join(cycle)}")
+                    raise typer.Exit(code=1)
+            now = datetime.now(timezone.utc)
+            edges = [DependencyEdge(upstream_slug=s, created_at=now) for s in requested]
+```
+
+When constructing the new `Task` (search for `Task(` in the spawn body), pass `depends_on=edges`. If the task is built incrementally via a builder/mutate function, pass `edges` through to the same place.
+
+> Note: `_make_slug_from_description` may already exist (slugify helper); reuse the same routine `spawn` uses to derive the slug from description. If it's inline, factor or duplicate the minimal logic.
+
+- [ ] **Step 5: Verify pass**
+
+```bash
+pytest tests/cli/test_worktree.py -k "depends_on" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mship/cli/worktree.py tests/cli/test_worktree.py
+git commit -m "feat(spawn): --depends-on <slug,...> with cycle + unknown-upstream checks (#104)"
+mship journal "spawn --depends-on landed; rejects unknown and cycles" --action committed
+```
+
+---
+
+## Task 8: `mship finish` blocked-by-deps check
+
+**Files:**
+- Modify: `src/mship/cli/worktree.py` (the `finish` command, around line 682)
+- Modify: `tests/cli/test_worktree.py`
+
+The block fires before any push. Bypass with `--bypass-deps`. Readiness uses the cached reconcile decisions (or a fresh reconcile if no cache).
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `tests/cli/test_worktree.py` (or finish-specific test file):
+
+```python
+def test_finish_blocked_by_unready_upstream(workspace_with_git, configured_app, monkeypatch):
+    """finish refuses when a hard upstream isn't merged."""
+    from mship.core.state import StateManager, Task, WorkspaceState, DependencyEdge
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    sm = StateManager(workspace_with_git / ".mothership")
+    sm.save(WorkspaceState(tasks={
+        "a": Task(slug="a", description="a", phase="dev",
+                  created_at=now, affected_repos=["mothership"], branch="feat/a"),
+        "b": Task(slug="b", description="b", phase="dev",
+                  created_at=now, affected_repos=["mothership"], branch="feat/b",
+                  depends_on=[DependencyEdge(upstream_slug="a", created_at=now)]),
+    }))
+
+    # Stub reconcile so that a is NOT merged.
+    from mship.core.reconcile.gate import Decision
+    from mship.core.reconcile.detect import UpstreamState
+    def _fake_decisions(state):
+        return {"a": Decision(slug="a", state=UpstreamState.in_sync,
+                              pr_url=None, pr_number=None, base=None, merge_commit=None)}
+    monkeypatch.setattr("mship.cli.worktree._dependency_decisions", _fake_decisions, raising=False)
+
+    result = runner.invoke(app, ["finish", "--task", "b"])
+    assert result.exit_code != 0
+    err = (result.stderr or result.output).lower()
+    assert "a" in err and ("not ready" in err or "blocked" in err)
+
+
+def test_finish_bypass_deps(workspace_with_git, configured_app, monkeypatch):
+    """--bypass-deps proceeds past the upstream check."""
+    # ... same seeding as above, then:
+    result = runner.invoke(app, ["finish", "--task", "b", "--bypass-deps"])
+    # Will likely fail downstream (no real git state) — assert only that we PASSED
+    # the deps gate (i.e. the error message does NOT mention upstream a).
+    err = (result.stderr or result.output).lower()
+    assert "depends on" not in err
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+pytest tests/cli/test_worktree.py -k "blocked_by_unready\|bypass_deps" -v
+```
+
+Expected: FAIL — no upstream check exists.
+
+- [ ] **Step 3: Add the deps gate to `finish`**
+
+In `src/mship/cli/worktree.py`, near the top of the `finish` function (around line 682), after task resolution but before any push:
+
+```python
+        bypass_deps: bool = typer.Option(False, "--bypass-deps", help="Skip the dependency-readiness check (#104)."),
+```
+(add this to the `finish` signature alongside the other options)
+
+Then in the body, right after `resolve_for_command(...)` returns the task:
+
+```python
+        # --- #104 dependency-readiness gate ---
+        if task.depends_on and not bypass_deps:
+            decisions = _dependency_decisions(state)
+            from mship.core.task_graph import is_ready
+            blocked_by = [
+                edge.upstream_slug
+                for edge in task.depends_on
+                if not is_ready(state, edge.upstream_slug, decisions)
+            ]
+            if blocked_by:
+                output.error(
+                    f"finish blocked: upstream task(s) not ready: {', '.join(blocked_by)}.\n"
+                    f"  Run `mship status --task <slug>` for state, "
+                    f"or pass --bypass-deps to override."
+                )
+                raise typer.Exit(code=1)
+```
+
+Add the helper at module level (so tests can monkeypatch it):
+
+```python
+def _dependency_decisions(state):
+    """Return cached reconcile decisions for use by the deps gate.
+
+    Kept in a function so tests can stub it.
+    """
+    from mship.core.reconcile.cache import ReconcileCache
+    from mship.core.reconcile.gate import reconcile_now
+    from mship.core.reconcile.fetch import fetch_pr_snapshots, collect_git_snapshots
+
+    cache = ReconcileCache(_state_dir_for_decisions())
+    def _fetcher(branches, worktrees_by_branch):
+        return (fetch_pr_snapshots(branches), collect_git_snapshots(worktrees_by_branch))
+    try:
+        return reconcile_now(state, cache=cache, fetcher=_fetcher)
+    except Exception:
+        return {}
+
+
+def _state_dir_for_decisions():
+    """Return the state dir for ReconcileCache use in finish gate."""
+    from mship.cli import container
+    return container.state_dir()
+```
+
+(Adjust container access to match the existing pattern in `worktree.py`.)
+
+- [ ] **Step 4: Verify pass**
+
+```bash
+pytest tests/cli/test_worktree.py -k "blocked_by_unready\|bypass_deps" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/cli/worktree.py tests/cli/test_worktree.py
+git commit -m "feat(finish): refuse when upstream task(s) not ready; --bypass-deps override (#104)"
+mship journal "finish blocked-by-deps gate landed; --bypass-deps works" --action committed
+```
+
+---
+
+## Task 9: `mship close` downstream check + `--cascade` / `--detach-downstream`
+
+**Files:**
+- Modify: `src/mship/cli/worktree.py` (the `close` command, around line 430)
+- Modify: `tests/cli/test_worktree.py`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `tests/cli/test_worktree.py`:
+
+```python
+def test_close_with_downstream_non_tty_refuses(workspace_with_git, configured_app):
+    """Non-TTY close refuses when downstream tasks exist."""
+    from mship.core.state import StateManager, Task, WorkspaceState, DependencyEdge
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc)
+    StateManager(workspace_with_git / ".mothership").save(WorkspaceState(tasks={
+        "a": Task(slug="a", description="a", phase="dev", finished_at=now,
+                  created_at=now, affected_repos=["mothership"], branch="feat/a"),
+        "b": Task(slug="b", description="b", phase="dev",
+                  created_at=now, affected_repos=["mothership"], branch="feat/b",
+                  depends_on=[DependencyEdge(upstream_slug="a", created_at=now)]),
+    }))
+
+    result = runner.invoke(app, ["close", "a", "--yes", "--skip-pr-check"])
+    assert result.exit_code != 0
+    err = (result.stderr or result.output).lower()
+    assert "downstream" in err and "b" in err
+    assert "--cascade" in err or "--detach-downstream" in err
+
+
+def test_close_detach_downstream_clears_edges(workspace_with_git, configured_app):
+    """--detach-downstream clears the inbound edges but leaves downstream alive."""
+    # ... seed as above
+    result = runner.invoke(app, ["close", "a", "--yes", "--skip-pr-check", "--detach-downstream"])
+    assert result.exit_code == 0
+    state = StateManager(workspace_with_git / ".mothership").load()
+    assert "a" not in state.tasks
+    assert state.tasks["b"].depends_on == []
+
+
+def test_close_cascade_removes_downstream(workspace_with_git, configured_app):
+    """--cascade closes both."""
+    # ... seed as above
+    result = runner.invoke(app, ["close", "a", "--yes", "--skip-pr-check", "--cascade"])
+    assert result.exit_code == 0
+    state = StateManager(workspace_with_git / ".mothership").load()
+    assert state.tasks == {}
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+pytest tests/cli/test_worktree.py -k "close.*downstream\|cascade\|detach_downstream" -v
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Add the flags and the check**
+
+In `src/mship/cli/worktree.py`, in `close`'s signature (around line 430-446), add:
+
+```python
+        cascade: bool = typer.Option(False, "--cascade", help="Also close downstream tasks (#104)."),
+        detach_downstream: bool = typer.Option(
+            False, "--detach-downstream",
+            help="Clear the inbound dependency edges, leave downstream tasks alive (#104).",
+        ),
+```
+
+After task resolution (early in the function, before any teardown):
+
+```python
+        # --- #104 downstream check ---
+        from mship.core.task_graph import downstream_of
+        downstream = sorted(downstream_of(state, task.slug))
+        if downstream and not force:
+            if cascade and detach_downstream:
+                output.error("Pass only one of --cascade / --detach-downstream.")
+                raise typer.Exit(code=1)
+            if not (cascade or detach_downstream):
+                if output.is_tty:
+                    choice = typer.prompt(
+                        f"Task {task.slug!r} has downstream tasks: {', '.join(downstream)}. "
+                        "[c]ascade close downstream, [d]etach edges, [a]bort",
+                        default="a",
+                    ).strip().lower()
+                    if choice.startswith("c"):
+                        cascade = True
+                    elif choice.startswith("d"):
+                        detach_downstream = True
+                    else:
+                        output.error("Aborted.")
+                        raise typer.Exit(code=1)
+                else:
+                    output.error(
+                        f"close refused: downstream tasks depend on {task.slug!r}: "
+                        f"{', '.join(downstream)}. Pass --cascade (close them too) "
+                        "or --detach-downstream (clear the edges) to proceed."
+                    )
+                    raise typer.Exit(code=1)
+```
+
+After the close completes successfully (state has been mutated to remove `task.slug`), handle the chosen mode:
+
+```python
+        if downstream and detach_downstream:
+            def _detach(s):
+                for d_slug in downstream:
+                    t = s.tasks.get(d_slug)
+                    if t is None:
+                        continue
+                    t.depends_on = [e for e in t.depends_on if e.upstream_slug != task.slug]
+            state_mgr.mutate(_detach)
+        elif downstream and cascade:
+            # Recursively close downstream tasks. Simplest: invoke the close
+            # logic per-downstream. For v1, mark each downstream's depends_on
+            # to drop the edge, then delete the task entry.
+            def _cascade(s):
+                for d_slug in downstream:
+                    s.tasks.pop(d_slug, None)
+            state_mgr.mutate(_cascade)
+```
+
+> **Note for the implementer:** cascade-close in v1 simply removes downstream tasks from state. Their worktrees are NOT torn down by `--cascade` in this implementation (out of scope for v1). The flag is honored at the state level; the user can `mship prune` to clean orphaned worktrees afterward. Document this in the help text.
+
+Update the cascade flag's help string accordingly:
+
+```python
+        cascade: bool = typer.Option(
+            False, "--cascade",
+            help="Also remove downstream tasks from state (#104). "
+                 "Their worktrees stay until `mship prune`.",
+        ),
+```
+
+- [ ] **Step 4: Verify pass**
+
+```bash
+pytest tests/cli/test_worktree.py -k "close.*downstream\|cascade\|detach_downstream" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/cli/worktree.py tests/cli/test_worktree.py
+git commit -m "feat(close): downstream check with --cascade / --detach-downstream (#104)"
+mship journal "close downstream-check landed; cascade removes from state, detach clears edges" --action committed
+```
+
+---
+
+## Task 10: `mship status` — `dependencies` block under `resolved_task`
+
+**Files:**
+- Modify: `src/mship/cli/status.py`
+- Modify: `tests/cli/test_status.py`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `tests/cli/test_status.py`:
+
+```python
+def test_status_dependencies_block_present(workspace, configured_app):
+    """resolved_task.dependencies includes upstream, downstream, blocked, blocked_by."""
+    from mship.core.state import DependencyEdge, StateManager, Task, WorkspaceState
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc)
+    StateManager(workspace / ".mothership").save(WorkspaceState(tasks={
+        "a": Task(slug="a", description="a", phase="dev",
+                  created_at=now, affected_repos=["mothership"], branch="feat/a"),
+        "b": Task(slug="b", description="b", phase="dev",
+                  created_at=now, affected_repos=["mothership"], branch="feat/b",
+                  depends_on=[DependencyEdge(upstream_slug="a", created_at=now)]),
+        "c": Task(slug="c", description="c", phase="dev",
+                  created_at=now, affected_repos=["mothership"], branch="feat/c",
+                  depends_on=[DependencyEdge(upstream_slug="b", created_at=now)]),
+    }))
+
+    result = runner.invoke(app, ["status", "--task", "b"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    deps = data["resolved_task"]["dependencies"]
+    assert [u["slug"] for u in deps["upstream"]] == ["a"]
+    assert [d["slug"] for d in deps["downstream"]] == ["c"]
+    # ready is False because reconcile won't say merged for an unfinished task
+    assert deps["blocked"] is True
+    assert deps["blocked_by"] == ["a"]
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+pytest tests/cli/test_status.py -k dependencies_block -v
+```
+
+Expected: FAIL — key missing.
+
+- [ ] **Step 3: Build the dependencies payload in `status.py`**
+
+In `src/mship/cli/status.py`, where `resolved_task` is built, add:
+
+```python
+        # --- #104 dependency block ---
+        from mship.core.task_graph import downstream_of, is_ready
+        decisions = {}  # avoid expensive reconcile during status; readiness based on state alone for now
+        deps_upstream = []
+        blocked_by: list[str] = []
+        for edge in task.depends_on:
+            ready = is_ready(state, edge.upstream_slug, decisions)
+            deps_upstream.append({"slug": edge.upstream_slug, "ready": ready})
+            if not ready:
+                blocked_by.append(edge.upstream_slug)
+        deps_downstream = [{"slug": s} for s in sorted(downstream_of(state, task.slug))]
+        resolved_task_dict["dependencies"] = {
+            "upstream": deps_upstream,
+            "downstream": deps_downstream,
+            "blocked": bool(blocked_by),
+            "blocked_by": blocked_by,
+        }
+```
+
+> **Performance note:** `status` is called frequently. We deliberately use an empty `reconcile_decisions` dict here — `is_ready` will return False for any task that hasn't been confirmed merged, which is the safe-side answer ("treat as blocked"). The `finish` gate does the real reconcile pull. If you want a richer readiness signal in `status`, pass `decisions = ReconcileCache(...).read()?.decisions` and skip the network fetch.
+
+- [ ] **Step 4: Verify pass**
+
+```bash
+pytest tests/cli/test_status.py -v
+```
+
+Expected: PASS for new test; existing envelope tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/cli/status.py tests/cli/test_status.py
+git commit -m "feat(status): dependencies block under resolved_task (#104)"
+mship journal "status envelope grew resolved_task.dependencies; tests passing" --action committed
+```
+
+---
+
+## Task 11: `mship dispatch` — `## Dependencies` section in prompt body
+
+**Files:**
+- Modify: `src/mship/core/dispatch.py`
+- Modify: `tests/cli/test_dispatch.py` (or `tests/core/test_dispatch.py` — whichever covers the prompt template)
+
+- [ ] **Step 1: Add failing test**
+
+Append to the appropriate dispatch test:
+
+```python
+def test_dispatch_prompt_includes_dependencies_section(workspace, configured_app):
+    from mship.core.state import StateManager, Task, WorkspaceState, DependencyEdge
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc)
+    StateManager(workspace / ".mothership").save(WorkspaceState(tasks={
+        "a": Task(slug="a", description="a", phase="dev",
+                  created_at=now, affected_repos=["mothership"], branch="feat/a"),
+        "b": Task(slug="b", description="b", phase="dev",
+                  created_at=now, affected_repos=["mothership"], branch="feat/b",
+                  worktrees={"mothership": workspace / ".worktrees" / "b" / "mothership"},
+                  depends_on=[DependencyEdge(upstream_slug="a", created_at=now)]),
+    }))
+
+    result = runner.invoke(app, ["dispatch", "--task", "b", "--instruction", "go"])
+    assert result.exit_code == 0
+    assert "## Dependencies" in result.stdout
+    assert "a" in result.stdout
+```
+
+- [ ] **Step 2: Verify failure**
+
+Expected: FAIL — no `## Dependencies` block in output.
+
+- [ ] **Step 3: Add the section to `build_dispatch_prompt`**
+
+In `src/mship/core/dispatch.py`, in `build_dispatch_prompt`, find the section assembly. Add a helper:
+
+```python
+def _format_dependencies_section(task) -> str:
+    if not task.depends_on:
+        return ""
+    lines = ["## Dependencies", ""]
+    for edge in task.depends_on:
+        lines.append(f"- depends on: `{edge.upstream_slug}`")
+    lines.append("")
+    return "\n".join(lines)
+```
+
+Insert the section output after the "## Task" / before the journal section (location-specific — match the existing template style).
+
+- [ ] **Step 4: Verify pass**
+
+```bash
+pytest tests/cli/test_dispatch.py -k "Dependencies" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/dispatch.py tests/cli/test_dispatch.py
+git commit -m "feat(dispatch): include ## Dependencies section in prompt body (#104)"
+mship journal "dispatch prompt grew ## Dependencies block" --action committed
+```
+
+---
+
+## Task 12: `mship reconcile` — `dependency_stale` state
+
+**Files:**
+- Modify: `src/mship/core/reconcile/detect.py`
+- Modify: `src/mship/core/reconcile/gate.py` (where Decisions are finalized for the workspace)
+- Modify: `src/mship/cli/reconcile.py`
+- Modify: `tests/core/reconcile/test_detect.py` (or the closest test file)
+
+A downstream task is `dependency_stale` when its current state would otherwise be `in_sync` or `merged`, but an upstream merged after the downstream task was created. Implementation: post-process decisions; override only when the downstream is currently `in_sync`.
+
+- [ ] **Step 1: Add failing test**
+
+Append to `tests/core/reconcile/test_detect.py`:
+
+```python
+def test_dependency_stale_when_upstream_merged_after_downstream_created():
+    """Downstream task → in_sync; upstream merged after downstream created → dependency_stale."""
+    from datetime import datetime, timezone, timedelta
+    from mship.core.state import DependencyEdge, Task, WorkspaceState
+    from mship.core.reconcile.detect import UpstreamState
+    from mship.core.reconcile.gate import Decision
+    from mship.core.reconcile.dependency_stale import apply_dependency_stale
+
+    t0 = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    t1 = datetime(2026, 5, 10, tzinfo=timezone.utc)
+    state = WorkspaceState(tasks={
+        "a": Task(slug="a", description="a", phase="dev",
+                  created_at=t0, affected_repos=["r"], branch="feat/a",
+                  finished_at=t0),
+        "b": Task(slug="b", description="b", phase="dev",
+                  created_at=t0, affected_repos=["r"], branch="feat/b",
+                  depends_on=[DependencyEdge(upstream_slug="a", created_at=t0)]),
+    })
+    decisions = {
+        "a": Decision(slug="a", state=UpstreamState.merged, pr_url=None,
+                      pr_number=None, base=None, merge_commit=None, merge_at=t1),
+        "b": Decision(slug="b", state=UpstreamState.in_sync, pr_url=None,
+                      pr_number=None, base=None, merge_commit=None, merge_at=None),
+    }
+
+    out = apply_dependency_stale(state, decisions)
+    assert out["b"].state == UpstreamState.dependency_stale
+```
+
+(If `Decision` doesn't currently carry merge_at, the post-processing can use `decision.updated_at` as an approximation — adjust the test accordingly.)
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+pytest tests/core/reconcile/test_detect.py -k dependency_stale -v
+```
+
+Expected: FAIL — module / enum value missing.
+
+- [ ] **Step 3: Extend the enum and add the post-process**
+
+In `src/mship/core/reconcile/detect.py`, add to the `UpstreamState` enum:
+
+```python
+    dependency_stale = "dependency_stale"
+```
+
+Create `src/mship/core/reconcile/dependency_stale.py`:
+
+```python
+"""Post-process reconcile decisions to surface dependency_stale states (#104)."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from mship.core.reconcile.detect import UpstreamState
+
+
+def apply_dependency_stale(state, decisions: dict) -> dict:
+    """Override `in_sync` decisions to `dependency_stale` when any upstream
+    has merged AFTER the downstream's task.created_at.
+
+    Returns a new dict; does not mutate the input.
+    """
+    out = dict(decisions)
+    for slug, task in state.tasks.items():
+        d = out.get(slug)
+        if d is None or d.state != UpstreamState.in_sync:
+            continue
+        for edge in task.depends_on:
+            up = out.get(edge.upstream_slug)
+            if up is None or up.state != UpstreamState.merged:
+                continue
+            up_merge_time = getattr(up, "merge_at", None) or _parse(getattr(up, "updated_at", None))
+            if up_merge_time is None:
+                continue
+            if up_merge_time > task.created_at:
+                out[slug] = d.__class__(**{**d.__dict__, "state": UpstreamState.dependency_stale})
+                break
+    return out
+
+
+def _parse(s):
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except Exception:
+        return None
+```
+
+In `src/mship/core/reconcile/gate.py`, where `reconcile_now` builds the final decisions dict, apply the post-process at the end:
+
+```python
+from mship.core.reconcile.dependency_stale import apply_dependency_stale
+# ...
+decisions = apply_dependency_stale(state, decisions)
+return decisions
+```
+
+In `src/mship/cli/reconcile.py`, extend the action-hint map:
+
+```python
+_ACTION_HINTS = {
+    UpstreamState.merged:           "run `mship close`",
+    UpstreamState.closed:           "run `mship close --abandon`",
+    UpstreamState.diverged:         "pull and rebase",
+    UpstreamState.base_changed:     "rebase onto new base",
+    UpstreamState.missing:          "—",
+    UpstreamState.in_sync:          "—",
+    UpstreamState.dependency_stale: "rebase onto upstream's merge",
+}
+```
+
+And ensure `_glyph` covers the new state:
+
+```python
+def _glyph(state: UpstreamState) -> str:
+    return "✓" if state in (UpstreamState.in_sync, UpstreamState.missing) else "⚠"
+```
+
+(Already correct — non-in_sync states get `⚠`. The new state falls through to `⚠`.)
+
+- [ ] **Step 4: Verify pass**
+
+```bash
+pytest tests/core/reconcile/ -v
+```
+
+Expected: PASS for new test; existing reconcile tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/reconcile/ src/mship/cli/reconcile.py tests/core/reconcile/
+git commit -m "feat(reconcile): dependency_stale state when upstream merged after downstream created (#104)"
+mship journal "reconcile dependency_stale post-process landed; tests green" --action committed
+```
+
+---
+
+## Task 13: Documentation — skill + README + AGENTS + GEMINI
+
+**Files:**
+- Modify: `src/mship/skills/working-with-mothership/SKILL.md`
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `GEMINI.md`
+
+- [ ] **Step 1: Update the skill**
+
+In `src/mship/skills/working-with-mothership/SKILL.md`, find the command reference section. Add a new subsection after `### Working on a task`:
+
+````markdown
+### Task dependencies
+
+Express that task B depends on task A. `finish` refuses to ship B until every upstream is merged.
+
+```bash
+mship spawn "downstream work" --depends-on a,b          # declare at spawn
+mship depends add <upstream-slug> [--task <slug>]       # retrofit on an existing task
+mship depends remove <upstream-slug> [--task <slug>]
+mship depends list [--task <slug>] [--graph]            # --graph = full workspace DAG
+mship finish --bypass-deps                              # override the readiness gate
+mship close --cascade        # also remove downstream from state
+mship close --detach-downstream   # clear inbound edges, leave downstream alive
+```
+
+`mship status` exposes the graph under `.resolved_task.dependencies`:
+
+```bash
+mship status | jq .resolved_task.dependencies
+# { "upstream": [...], "downstream": [...], "blocked": bool, "blocked_by": [...] }
+```
+
+`mship dispatch` includes a `## Dependencies` section in the subagent prompt body. `mship reconcile` reports `dependency_stale` for a downstream that's in sync but whose upstream merged after the downstream was created (i.e., the downstream needs a rebase).
+
+No soft/advisory edges in v1 — for "informed by task-a" relationships, use `mship journal`.
+````
+
+- [ ] **Step 2: Update README cheat sheet**
+
+In `README.md`, add to the cheat-sheet section near the other workflow commands:
+
+```text
+mship depends add/remove/list      # manage task-to-task dependency edges (#104)
+mship spawn --depends-on a,b       # declare upstream task(s) at spawn time
+mship finish --bypass-deps         # ship a downstream even if upstream isn't ready
+```
+
+- [ ] **Step 3: Update AGENTS.md and GEMINI.md**
+
+In both files, add a one-liner pointing at the new verb:
+
+```text
+- `mship depends`: declare/inspect task-to-task dependencies (#104).
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/mship/skills/working-with-mothership/SKILL.md README.md AGENTS.md GEMINI.md
+git commit -m "docs: document task dependency graph (#104)"
+mship journal "docs updated: skill, README, AGENTS, GEMINI" --action committed
+```
+
+---
+
+## Task 14: End-to-end integration test
+
+**Files:**
+- Create: `tests/test_dependency_integration.py`
+
+- [ ] **Step 1: Add the integration test**
+
+Create `tests/test_dependency_integration.py`:
+
+```python
+"""End-to-end: spawn → finish-blocked → finish-upstream → finish-downstream (#104)."""
+from __future__ import annotations
+import json
+from datetime import datetime, timezone
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.state import StateManager
+
+runner = CliRunner()
+
+
+def test_dependency_flow(workspace_with_git, configured_app, monkeypatch):
+    # 1. Spawn task-a.
+    r1 = runner.invoke(app, ["spawn", "task a", "--slug", "a", "--skip-setup"])
+    assert r1.exit_code == 0, r1.stderr or r1.output
+
+    # 2. Spawn task-b depending on a.
+    r2 = runner.invoke(app, ["spawn", "task b", "--slug", "b", "--depends-on", "a", "--skip-setup"])
+    assert r2.exit_code == 0, r2.stderr or r2.output
+
+    # 3. Status of b shows blocked_by=[a].
+    r3 = runner.invoke(app, ["status", "--task", "b"])
+    data = json.loads(r3.stdout)
+    assert data["resolved_task"]["dependencies"]["blocked"] is True
+    assert data["resolved_task"]["dependencies"]["blocked_by"] == ["a"]
+
+    # 4. Stub a as ready, then bypass: finish b succeeds without bypass.
+    # (Real finish requires PR mocking — sufficient here to confirm the gate fires
+    #  before any push; --bypass-deps clears it.)
+    r4 = runner.invoke(app, ["finish", "--task", "b"])
+    err = (r4.stderr or r4.output).lower()
+    assert "upstream" in err or "blocked" in err
+
+    r5 = runner.invoke(app, ["finish", "--task", "b", "--bypass-deps"])
+    # bypass clears the deps gate; downstream errors (no PR setup) are fine —
+    # we only assert the deps message is gone.
+    err = (r5.stderr or r5.output).lower()
+    assert "blocked" not in err and "depends on" not in err
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+pytest tests/test_dependency_integration.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full suite**
+
+```bash
+pytest -x
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_dependency_integration.py
+git commit -m "test(integration): dependency flow end-to-end (#104)"
+mship journal "integration test landed; full flow tested" --action committed
+```
+
+---
+
+## Verification before finish
+
+- [ ] **Run the full test suite**
+
+```bash
+pytest
+```
+
+Expected: all PASS.
+
+- [ ] **Confirm the spec is satisfied**
+
+Skim `docs/superpowers/specs/2026-05-14-task-dependency-graph-design.md`. For each section, confirm a corresponding task implemented it:
+
+- State model → Task 1
+- Readiness signal → Task 3
+- CLI surface (`mship depends`) → Tasks 4, 5, 6
+- `spawn --depends-on` → Task 7
+- `finish --bypass-deps` → Task 8
+- `close --cascade` / `--detach-downstream` → Task 9
+- `status` dependencies block → Task 10
+- `dispatch ## Dependencies` → Task 11
+- `reconcile dependency_stale` → Task 12
+- Cycle detection → Task 2
+- Error handling → covered across Tasks 4-9
+- Docs → Task 13
+- Integration → Task 14
+
+- [ ] **Run `mship finish`**
+
+```bash
+mship finish --body-file docs/superpowers/specs/2026-05-14-task-dependency-graph-design.md
+```
+
+(Or write a Summary + Test plan into a file and pass it via `--body-file`.)

--- a/docs/superpowers/specs/2026-05-14-task-dependency-graph-design.md
+++ b/docs/superpowers/specs/2026-05-14-task-dependency-graph-design.md
@@ -19,7 +19,7 @@ The substrate value: once the graph exists as state, every existing command (`st
 ## Goals
 
 - First-class `depends_on` edges between tasks, persisted in `state.yaml`.
-- Hard edges block `finish` until the upstream is merged; soft edges advise.
+- An edge is a constraint: `finish` refuses to ship a downstream task until every upstream is merged.
 - `status`, `dispatch`, `reconcile` surface the graph so a single agent or human can act on it.
 - Cycle detection at write time.
 - Lay the v1 primitive that v2 multi-agent orchestration will sit on top of, without speculative design.
@@ -33,6 +33,7 @@ The substrate value: once the graph exists as state, every existing command (`st
 - **No cross-repo edges.** Edges are task-to-task; the per-repo axis stays out.
 - **No OR / alternative-groups fan-in.** Default is AND (all upstream must be ready).
 - **No PR-URL endpoints.** Edges name task slugs only. External-PR dependencies are a v2 cross-workspace concern.
+- **No soft / advisory edges.** A single edge type with a single behavior keeps the model coherent. Tracking-without-enforcement is what `mship journal` already covers ("informed by task-a"). If a use case for advisory edges surfaces in practice, it's an additive change.
 
 ## Design
 
@@ -43,7 +44,6 @@ Additive on `Task` in `src/mship/core/state.py`:
 ```python
 class DependencyEdge(BaseModel):
     upstream_slug: str
-    soft: bool = False           # default: hard
     created_at: datetime
 
 class Task(BaseModel):
@@ -61,7 +61,6 @@ An upstream task is "ready" iff `reconcile` reports it as fully merged across ev
 
 - For each repo in `upstream.affected_repos`, the existing `reconcile.gate` machinery decides an `UpstreamState`. Ready ⇔ every repo is `UpstreamState.merged`.
 - A task with `finished_at` set but PRs not yet merged is **not** ready. Finishing creates PRs; readiness requires merge.
-- A soft edge never blocks `finish`; it only advises.
 
 This reuses the existing reconcile decision logic. No new readiness machinery; no parallel state tracker.
 
@@ -70,7 +69,7 @@ This reuses the existing reconcile decision logic. No new readiness machinery; n
 One new top-level verb group, three subcommands:
 
 ```
-mship depends add <upstream-slug> [--soft] [--task <slug>]
+mship depends add <upstream-slug> [--task <slug>]
 mship depends remove <upstream-slug> [--task <slug>]
 mship depends list [--task <slug>] [--graph]
 ```
@@ -80,9 +79,8 @@ mship depends list [--task <slug>] [--graph]
 
 Extensions on existing commands:
 
-- `mship spawn --depends-on <slug>[,<slug>]` — hard edges by default.
-- `mship spawn --depends-on-soft <slug>[,<slug>]` — soft edges.
-- `mship finish` — refuses if any **hard** upstream isn't ready. Bypass flag: `--bypass-deps` (per memory: `--bypass-<check>` naming).
+- `mship spawn --depends-on <slug>[,<slug>]` — declare upstream task(s) at spawn time.
+- `mship finish` — refuses if any upstream isn't ready. Bypass flag: `--bypass-deps`.
 - `mship close` — when downstream tasks exist:
   - TTY: interactive prompt with `[c]ascade-close downstream`, `[d]etach edges`, `[a]bort`.
   - Non-TTY: refuses; requires `--cascade` (cascade-close downstream) or `--detach-downstream` (clear inbound edges, leave downstream alive).
@@ -91,17 +89,17 @@ Extensions on existing commands:
   ```json
   "dependencies": {
     "upstream": [
-      {"slug": "task-a", "soft": false, "ready": true},
-      {"slug": "task-b", "soft": true,  "ready": false}
+      {"slug": "task-a", "ready": true},
+      {"slug": "task-b", "ready": false}
     ],
     "downstream": [
-      {"slug": "task-c", "soft": false}
+      {"slug": "task-c"}
     ],
-    "blocked": false,
-    "blocked_by": []
+    "blocked": true,
+    "blocked_by": ["task-b"]
   }
   ```
-  `blocked` is `true` iff any hard upstream is not ready. `blocked_by` lists those slugs. Existing envelope shape is unchanged; this is one new key under `resolved_task`.
+  `blocked` is `true` iff any upstream is not ready. `blocked_by` lists those slugs. Existing envelope shape is unchanged; this is one new key under `resolved_task`.
 - `mship dispatch` — prompt body grows a `## Dependencies` section listing upstream slugs and their ready state. Whether the agent task-switches when blocked is methodology — surfaced in the `working-with-mothership` skill, not in CLI logic.
 - `mship reconcile` — adds a new state `dependency_stale` to `UpstreamState`, surfaced when an upstream became `merged` AFTER the downstream task was created (downstream needs rebase). Same `Decision` shape; one new enum value.
 
@@ -119,8 +117,8 @@ Bounded by workspace task count. Cycle checking happens before persistence; no h
 
 | Command | New behavior |
 |---|---|
-| `spawn` | `--depends-on` / `--depends-on-soft` create edges at spawn time. Cycle check runs. |
-| `finish` | Refuses if any hard upstream not ready. `--bypass-deps` overrides. |
+| `spawn` | `--depends-on` creates edges at spawn time. Cycle check runs. |
+| `finish` | Refuses if any upstream not ready. `--bypass-deps` overrides. |
 | `close` | Refuses (or prompts) when downstream tasks exist. `--cascade` / `--detach-downstream`. (`--force` covers the destructive path.) |
 | `status` | Emits `dependencies` block under `resolved_task`. |
 | `dispatch` | Includes upstream slugs + ready state in the prompt body. |
@@ -134,27 +132,28 @@ Bounded by workspace task count. Cycle checking happens before persistence; no h
 - **Self-edge** → loud error (degenerate cycle).
 - **Removing an edge that doesn't exist** → loud error; do not silently no-op.
 - **Finish blocked by upstream** → error names the offending upstream(s) and their state; hints at `mship status --task <upstream>` and `--bypass-deps`.
+- **Spawning with `--depends-on` for an upstream that hasn't merged yet** is fine — that's the normal case. The block only fires at `finish` time.
 - **Close with downstream, non-TTY, no flag** → refuses; lists downstream slugs and instructs to pass `--cascade` or `--detach-downstream`.
 
 ## Files touched
 
 - **Modified:** `src/mship/core/state.py` — add `DependencyEdge`; add `depends_on` field on `Task`.
 - **Modified:** `src/mship/core/graph.py` — already exists; add cycle detection + readiness queries (`is_ready(slug)`, `downstream_of(slug)`, `transitive_upstream(slug)`).
-- **Modified:** `src/mship/cli/worktree.py` — `spawn` flags (`--depends-on`, `--depends-on-soft`); `finish` blocked-by-deps check; `close` downstream check with cascade/detach options.
+- **Modified:** `src/mship/cli/worktree.py` — `spawn --depends-on` flag; `finish` blocked-by-deps check; `close` downstream check with cascade/detach options.
 - **Modified:** `src/mship/cli/__init__.py` — register the `depends` subcommand group.
 - **New:** `src/mship/cli/depends.py` — `add`, `remove`, `list` commands.
 - **Modified:** `src/mship/cli/status.py` — emit `dependencies` block under `resolved_task`.
 - **Modified:** `src/mship/core/dispatch.py` — add `## Dependencies` section to prompt template.
 - **Modified:** `src/mship/core/reconcile/detect.py` + `src/mship/core/reconcile/gate.py` — extend `UpstreamState` with `dependency_stale`; emit it when applicable.
 - **Modified:** `src/mship/cli/reconcile.py` — render the new state in TTY + JSON output, add an action hint.
-- **Docs:** `working-with-mothership` skill, `README.md`, `AGENTS.md`, `GEMINI.md` — document the new verb, `--depends-on*` flags, and `status.resolved_task.dependencies` shape.
+- **Docs:** `working-with-mothership` skill, `README.md`, `AGENTS.md`, `GEMINI.md` — document the new verb, `--depends-on` flag, and `status.resolved_task.dependencies` shape.
 
 ## Testing strategy
 
 Unit (`tests/core/test_graph.py`):
 
 1. **Cycle detection:** self-edge rejected; 2-node cycle rejected; 3-node cycle rejected; diamond DAG (A → B, A → C, B → D, C → D) accepted with no false-positive.
-2. **Readiness:** upstream with all repos merged → ready; one repo unmerged → not ready; soft edge → blocking-irrelevant.
+2. **Readiness:** upstream with all repos merged → ready; one repo unmerged → not ready.
 3. **Transitive upstream:** correct closure across multi-hop chains.
 
 CLI (`tests/cli/`):
@@ -162,18 +161,17 @@ CLI (`tests/cli/`):
 4. `spawn --depends-on task-a` creates the edge; unknown upstream errors loudly.
 5. `spawn --depends-on task-a` where `task-a` doesn't exist → loud error listing workspace task slugs.
 6. `depends add task-a` / `depends remove task-a` / `depends list` round-trip on an existing task.
-7. `depends add task-a --soft` produces `soft: true` in state.
-8. `finish` on a task with an unready hard upstream → refuses with named upstream.
-9. `finish --bypass-deps` succeeds even with unready upstream.
-10. `close` on a task with downstream, non-TTY, no flag → refuses with downstream slugs listed.
-11. `close --cascade` removes both tasks; downstream worktrees torn down.
-12. `close --detach-downstream` leaves downstream alive with empty `depends_on` for the removed edge.
-13. `status` envelope: `dependencies.blocked = true` when hard upstream unready; downstream list populated; soft edges visible but never set `blocked`.
-14. `dispatch` payload contains a `## Dependencies` section with upstream slugs and ready state.
+7. `finish` on a task with an unready upstream → refuses with named upstream.
+8. `finish --bypass-deps` succeeds even with unready upstream.
+9. `close` on a task with downstream, non-TTY, no flag → refuses with downstream slugs listed.
+10. `close --cascade` removes both tasks; downstream worktrees torn down.
+11. `close --detach-downstream` leaves downstream alive with empty `depends_on` for the removed edge.
+12. `status` envelope: `dependencies.blocked = true` when upstream unready; downstream list populated.
+13. `dispatch` payload contains a `## Dependencies` section with upstream slugs and ready state.
 
 Integration (one):
 
-15. `spawn task-a → spawn task-b --depends-on task-a → finish task-b fails (blocked) → finish task-a → reconcile → finish task-b succeeds`.
+14. `spawn task-a → spawn task-b --depends-on task-a → finish task-b fails (blocked) → finish task-a → reconcile → finish task-b succeeds`.
 
 ## Risk and rollout
 
@@ -189,7 +187,7 @@ Integration (one):
 None at design time. The 8 design questions in #104 are all resolved:
 
 1. **Target:** slug only.
-2. **Hard vs soft:** hard by default; per-edge `--soft` opt-in.
+2. **Hard vs soft:** single edge type with hard semantics. Soft edges deferred — `mship journal` covers the tracking-without-enforcement case for v1.
 3. **Fan-in:** AND (all upstream must be ready).
 4. **Cascade:** TTY-interactive prompt; non-TTY refuses without `--cascade` or `--detach-downstream`.
 5. **Dispatch autonomy:** CLI surfaces blocked state only; task-switching is methodology in the skill.

--- a/docs/superpowers/specs/2026-05-14-task-dependency-graph-design.md
+++ b/docs/superpowers/specs/2026-05-14-task-dependency-graph-design.md
@@ -1,0 +1,200 @@
+# Task dependency graph: `depends_on` edges between tasks
+
+**Date:** 2026-05-14
+**Issue:** [#104](https://github.com/atomikpanda/mothership/issues/104)
+**Status:** Design approved; ready for implementation plan.
+
+## Problem
+
+Tasks in mship are islands. There is no first-class representation that "task B depends on task A" — the dependency lives in the user's head and surfaces as ad-hoc coordination:
+
+- Shared-lib refactor in task A → consumer update in task B: user manually watches A's PR, rebases B before starting.
+- Schema migration → app code → docs: a three-step chain the user sequences by memory.
+- Spec work in task A produces a decision task B depends on: no linkage beyond journal prose.
+
+This is the same class of "state hell" mship is built to prevent, but at the cross-task level instead of cross-repo. Worktree isolation solved the intra-task version; the inter-task version is still manual.
+
+The substrate value: once the graph exists as state, every existing command (`status`, `finish`, `dispatch`, `reconcile`, `close`) gets more powerful without redesign.
+
+## Goals
+
+- First-class `depends_on` edges between tasks, persisted in `state.yaml`.
+- Hard edges block `finish` until the upstream is merged; soft edges advise.
+- `status`, `dispatch`, `reconcile` surface the graph so a single agent or human can act on it.
+- Cycle detection at write time.
+- Lay the v1 primitive that v2 multi-agent orchestration will sit on top of, without speculative design.
+
+## Non-goals
+
+- **No automatic rebasing** when an upstream merges. Detect staleness via `reconcile`; user runs the rebase.
+- **No GitHub-level sync.** Mship doesn't read "Depends on #N" from PR bodies or write them back. The graph is mship's.
+- **No critical-path / scheduling logic.** Mship records the graph; downstream tools can compute critical path if they want it.
+- **No parallel-execution orchestration.** That's v2 multi-agent territory.
+- **No cross-repo edges.** Edges are task-to-task; the per-repo axis stays out.
+- **No OR / alternative-groups fan-in.** Default is AND (all upstream must be ready).
+- **No PR-URL endpoints.** Edges name task slugs only. External-PR dependencies are a v2 cross-workspace concern.
+
+## Design
+
+### State model
+
+Additive on `Task` in `src/mship/core/state.py`:
+
+```python
+class DependencyEdge(BaseModel):
+    upstream_slug: str
+    soft: bool = False           # default: hard
+    created_at: datetime
+
+class Task(BaseModel):
+    # ... existing fields ...
+    depends_on: list[DependencyEdge] = []
+```
+
+Edges live on the **downstream** task. Reverse lookup ("which tasks depend on me?") is computed by iterating `state.tasks` — O(N) at workspace scale, fine. `WorkspaceState` already has `extra="ignore"`, so legacy `state.yaml` files load cleanly with `depends_on=[]`.
+
+No schema migration. The field is additive and defaults to `[]`.
+
+### Readiness signal
+
+An upstream task is "ready" iff `reconcile` reports it as fully merged across every repo in its `affected_repos`:
+
+- For each repo in `upstream.affected_repos`, the existing `reconcile.gate` machinery decides an `UpstreamState`. Ready ⇔ every repo is `UpstreamState.merged`.
+- A task with `finished_at` set but PRs not yet merged is **not** ready. Finishing creates PRs; readiness requires merge.
+- A soft edge never blocks `finish`; it only advises.
+
+This reuses the existing reconcile decision logic. No new readiness machinery; no parallel state tracker.
+
+### CLI surface
+
+One new top-level verb group, three subcommands:
+
+```
+mship depends add <upstream-slug> [--soft] [--task <slug>]
+mship depends remove <upstream-slug> [--task <slug>]
+mship depends list [--task <slug>] [--graph]
+```
+
+- `--task <slug>` defaults to the cwd-resolved task (same resolution rules as `status`/`finish`).
+- `--graph` on `list` emits the full workspace DAG (all tasks, all edges) regardless of `--task`. Without `--graph`, `list` shows only the resolved task's upstream + downstream. JSON shape in non-TTY, simple text rendering in TTY.
+
+Extensions on existing commands:
+
+- `mship spawn --depends-on <slug>[,<slug>]` — hard edges by default.
+- `mship spawn --depends-on-soft <slug>[,<slug>]` — soft edges.
+- `mship finish` — refuses if any **hard** upstream isn't ready. Bypass flag: `--bypass-deps` (per memory: `--bypass-<check>` naming).
+- `mship close` — when downstream tasks exist:
+  - TTY: interactive prompt with `[c]ascade-close downstream`, `[d]etach edges`, `[a]bort`.
+  - Non-TTY: refuses; requires `--cascade` (cascade-close downstream) or `--detach-downstream` (clear inbound edges, leave downstream alive).
+  - The existing `--force` flag continues to bypass all checks including this one; no new `--bypass-deps` on close — `--cascade` and `--detach-downstream` cover the non-destructive paths.
+- `mship status` — adds under `resolved_task`:
+  ```json
+  "dependencies": {
+    "upstream": [
+      {"slug": "task-a", "soft": false, "ready": true},
+      {"slug": "task-b", "soft": true,  "ready": false}
+    ],
+    "downstream": [
+      {"slug": "task-c", "soft": false}
+    ],
+    "blocked": false,
+    "blocked_by": []
+  }
+  ```
+  `blocked` is `true` iff any hard upstream is not ready. `blocked_by` lists those slugs. Existing envelope shape is unchanged; this is one new key under `resolved_task`.
+- `mship dispatch` — prompt body grows a `## Dependencies` section listing upstream slugs and their ready state. Whether the agent task-switches when blocked is methodology — surfaced in the `working-with-mothership` skill, not in CLI logic.
+- `mship reconcile` — adds a new state `dependency_stale` to `UpstreamState`, surfaced when an upstream became `merged` AFTER the downstream task was created (downstream needs rebase). Same `Decision` shape; one new enum value.
+
+### Cycle detection
+
+At write time (`spawn --depends-on`, `depends add`):
+
+1. Compute the transitive upstream set of the proposed upstream via DFS over `Task.depends_on`.
+2. If the current task is in that set → refuse with `CycleError`, printing the full cycle path: `task-c → task-b → task-a → task-c`.
+3. Self-edges (`task-a` depending on itself) are rejected as a degenerate cycle.
+
+Bounded by workspace task count. Cycle checking happens before persistence; no half-written state.
+
+### Composition with existing primitives
+
+| Command | New behavior |
+|---|---|
+| `spawn` | `--depends-on` / `--depends-on-soft` create edges at spawn time. Cycle check runs. |
+| `finish` | Refuses if any hard upstream not ready. `--bypass-deps` overrides. |
+| `close` | Refuses (or prompts) when downstream tasks exist. `--cascade` / `--detach-downstream`. (`--force` covers the destructive path.) |
+| `status` | Emits `dependencies` block under `resolved_task`. |
+| `dispatch` | Includes upstream slugs + ready state in the prompt body. |
+| `reconcile` | New `dependency_stale` state when upstream merged after downstream created. |
+| `depends` | New verb group: `add` / `remove` / `list`. |
+
+### Error handling
+
+- **Unknown upstream slug** at write time → loud error listing available slugs in the workspace.
+- **Cycle** → loud error with explicit cycle path.
+- **Self-edge** → loud error (degenerate cycle).
+- **Removing an edge that doesn't exist** → loud error; do not silently no-op.
+- **Finish blocked by upstream** → error names the offending upstream(s) and their state; hints at `mship status --task <upstream>` and `--bypass-deps`.
+- **Close with downstream, non-TTY, no flag** → refuses; lists downstream slugs and instructs to pass `--cascade` or `--detach-downstream`.
+
+## Files touched
+
+- **Modified:** `src/mship/core/state.py` — add `DependencyEdge`; add `depends_on` field on `Task`.
+- **Modified:** `src/mship/core/graph.py` — already exists; add cycle detection + readiness queries (`is_ready(slug)`, `downstream_of(slug)`, `transitive_upstream(slug)`).
+- **Modified:** `src/mship/cli/worktree.py` — `spawn` flags (`--depends-on`, `--depends-on-soft`); `finish` blocked-by-deps check; `close` downstream check with cascade/detach options.
+- **Modified:** `src/mship/cli/__init__.py` — register the `depends` subcommand group.
+- **New:** `src/mship/cli/depends.py` — `add`, `remove`, `list` commands.
+- **Modified:** `src/mship/cli/status.py` — emit `dependencies` block under `resolved_task`.
+- **Modified:** `src/mship/core/dispatch.py` — add `## Dependencies` section to prompt template.
+- **Modified:** `src/mship/core/reconcile/detect.py` + `src/mship/core/reconcile/gate.py` — extend `UpstreamState` with `dependency_stale`; emit it when applicable.
+- **Modified:** `src/mship/cli/reconcile.py` — render the new state in TTY + JSON output, add an action hint.
+- **Docs:** `working-with-mothership` skill, `README.md`, `AGENTS.md`, `GEMINI.md` — document the new verb, `--depends-on*` flags, and `status.resolved_task.dependencies` shape.
+
+## Testing strategy
+
+Unit (`tests/core/test_graph.py`):
+
+1. **Cycle detection:** self-edge rejected; 2-node cycle rejected; 3-node cycle rejected; diamond DAG (A → B, A → C, B → D, C → D) accepted with no false-positive.
+2. **Readiness:** upstream with all repos merged → ready; one repo unmerged → not ready; soft edge → blocking-irrelevant.
+3. **Transitive upstream:** correct closure across multi-hop chains.
+
+CLI (`tests/cli/`):
+
+4. `spawn --depends-on task-a` creates the edge; unknown upstream errors loudly.
+5. `spawn --depends-on task-a` where `task-a` doesn't exist → loud error listing workspace task slugs.
+6. `depends add task-a` / `depends remove task-a` / `depends list` round-trip on an existing task.
+7. `depends add task-a --soft` produces `soft: true` in state.
+8. `finish` on a task with an unready hard upstream → refuses with named upstream.
+9. `finish --bypass-deps` succeeds even with unready upstream.
+10. `close` on a task with downstream, non-TTY, no flag → refuses with downstream slugs listed.
+11. `close --cascade` removes both tasks; downstream worktrees torn down.
+12. `close --detach-downstream` leaves downstream alive with empty `depends_on` for the removed edge.
+13. `status` envelope: `dependencies.blocked = true` when hard upstream unready; downstream list populated; soft edges visible but never set `blocked`.
+14. `dispatch` payload contains a `## Dependencies` section with upstream slugs and ready state.
+
+Integration (one):
+
+15. `spawn task-a → spawn task-b --depends-on task-a → finish task-b fails (blocked) → finish task-a → reconcile → finish task-b succeeds`.
+
+## Risk and rollout
+
+- **Backward compatibility:** Additive field on `Task` with default `[]`. Existing `state.yaml` files load unchanged. `extra="ignore"` on `WorkspaceState` covers the read side.
+- **Behavior change on `finish` and `close`:** A workspace with no edges sees zero behavior change. Behavior change only activates once edges exist — opt-in by user action.
+- **`status` envelope change:** One new key (`resolved_task.dependencies`). Additive — no consumer breakage. Existing keys unchanged.
+- **`reconcile.UpstreamState` enum change:** Adds one variant (`dependency_stale`). Consumers using `UpstreamState.value` get a new string they may not handle; the reconcile JSON shape is otherwise unchanged. Note in PR body.
+- **`mship depends` verb collision:** Verified — no existing `depends` subcommand.
+- **No deprecation window needed.** All changes additive on existing surfaces; new commands are new.
+
+## Open questions
+
+None at design time. The 8 design questions in #104 are all resolved:
+
+1. **Target:** slug only.
+2. **Hard vs soft:** hard by default; per-edge `--soft` opt-in.
+3. **Fan-in:** AND (all upstream must be ready).
+4. **Cascade:** TTY-interactive prompt; non-TTY refuses without `--cascade` or `--detach-downstream`.
+5. **Dispatch autonomy:** CLI surfaces blocked state only; task-switching is methodology in the skill.
+6. **Cycle detection:** at write time, with explicit path in error.
+7. **Migration:** additive field defaults to `[]`; `mship depends add/remove` retrofits.
+8. **Cross-repo edges:** out of scope; task-to-task only.
+
+The `mship task` verb group was reconsidered and declined again, per the 2026-05-08 status-envelope spec's prior rejection. Single-purpose `mship depends` follows the existing pattern (`mship debug`, `mship bind`, `mship view`).

--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -71,30 +71,31 @@ def get_container(required: bool = True) -> "Container | None":
 
 
 # Register command modules
-from mship.cli import status as _status_mod
-from mship.cli import phase as _phase_mod
-from mship.cli import worktree as _worktree_mod
-from mship.cli import exec as _exec_mod
-from mship.cli import block as _block_mod
-from mship.cli import log as _log_mod
-from mship.cli import prune as _prune_mod
-from mship.cli import init as _init_mod
-from mship.cli import doctor as _doctor_mod
-from mship.cli import skill as _skill_mod
-from mship.cli import view as _view_mod
 from mship.cli import audit as _audit_mod
-from mship.cli import sync as _sync_mod
-from mship.cli import switch as _switch_mod
-from mship.cli import layout as _layout_mod
-from mship.cli import internal as _internal_mod
-from mship.cli import reconcile as _reconcile_mod
-from mship.cli import context as _context_mod
-from mship.cli import dispatch as _dispatch_mod
-from mship.cli import commit as _commit_mod
-from mship.cli import debug as _debug_mod
 from mship.cli import bind as _bind_mod
+from mship.cli import block as _block_mod
+from mship.cli import commit as _commit_mod
+from mship.cli import context as _context_mod
+from mship.cli import debug as _debug_mod
+from mship.cli import depends as _depends_mod
+from mship.cli import dispatch as _dispatch_mod
+from mship.cli import doctor as _doctor_mod
+from mship.cli import exec as _exec_mod
+from mship.cli import init as _init_mod
+from mship.cli import internal as _internal_mod
+from mship.cli import layout as _layout_mod
+from mship.cli import log as _log_mod
+from mship.cli import phase as _phase_mod
 from mship.cli import pr as _pr_mod
+from mship.cli import prune as _prune_mod
+from mship.cli import reconcile as _reconcile_mod
+from mship.cli import skill as _skill_mod
 from mship.cli import spec as _spec_mod
+from mship.cli import status as _status_mod
+from mship.cli import switch as _switch_mod
+from mship.cli import sync as _sync_mod
+from mship.cli import view as _view_mod
+from mship.cli import worktree as _worktree_mod
 
 def _should_silent_exit(argv: list[str]) -> bool:
     """True if argv is invoking an unknown `_`-prefixed internal command.
@@ -122,27 +123,28 @@ def run() -> None:
     app()
 
 
-_status_mod.register(app, get_container)
-_phase_mod.register(app, get_container)
-_worktree_mod.register(app, get_container)
-_exec_mod.register(app, get_container)
-_block_mod.register(app, get_container)
-_log_mod.register(app, get_container)
-_prune_mod.register(app, get_container)
-_init_mod.register(app, get_container)
-_doctor_mod.register(app, get_container)
-_skill_mod.register(app, get_container)
-_view_mod.register(app, get_container)
 _audit_mod.register(app, get_container)
-_sync_mod.register(app, get_container)
-_switch_mod.register(app, get_container)
-_layout_mod.register(app, get_container)
-_internal_mod.register(app, get_container)
-_reconcile_mod.register(app, get_container)
-_context_mod.register(app, get_container)
-_dispatch_mod.register(app, get_container)
-_commit_mod.register(app, get_container)
-_debug_mod.register(app, get_container)
 _bind_mod.register(app, get_container)
+_block_mod.register(app, get_container)
+_commit_mod.register(app, get_container)
+_context_mod.register(app, get_container)
+_debug_mod.register(app, get_container)
+_depends_mod.register(app, get_container)
+_dispatch_mod.register(app, get_container)
+_doctor_mod.register(app, get_container)
+_exec_mod.register(app, get_container)
+_init_mod.register(app, get_container)
+_internal_mod.register(app, get_container)
+_layout_mod.register(app, get_container)
+_log_mod.register(app, get_container)
+_phase_mod.register(app, get_container)
 _pr_mod.register(app, get_container)
+_prune_mod.register(app, get_container)
+_reconcile_mod.register(app, get_container)
+_skill_mod.register(app, get_container)
 _spec_mod.register(app, get_container)
+_status_mod.register(app, get_container)
+_switch_mod.register(app, get_container)
+_sync_mod.register(app, get_container)
+_view_mod.register(app, get_container)
+_worktree_mod.register(app, get_container)

--- a/src/mship/cli/depends.py
+++ b/src/mship/cli/depends.py
@@ -9,7 +9,32 @@ import typer
 from mship.cli._resolve import resolve_for_command
 from mship.cli.output import Output
 from mship.core.state import DependencyEdge
-from mship.core.task_graph import find_cycle
+from mship.core.task_graph import find_cycle, downstream_of
+
+
+def _render_task_deps_tty(output, payload):
+    output.print(f"Task: {payload['task']}")
+    output.print("Upstream:")
+    if not payload["upstream"]:
+        output.print("  (none)")
+    else:
+        for u in payload["upstream"]:
+            output.print(f"  → {u['slug']}")
+    output.print("Downstream:")
+    if not payload["downstream"]:
+        output.print("  (none)")
+    else:
+        for d in payload["downstream"]:
+            output.print(f"  ← {d['slug']}")
+
+
+def _render_graph_tty(output, payload):
+    output.print("Workspace DAG:")
+    if not payload["edges"]:
+        output.print("  (no edges)")
+        return
+    for e in payload["edges"]:
+        output.print(f"  {e['downstream']} → {e['upstream']}")
 
 
 def register(app: typer.Typer, get_container):
@@ -82,3 +107,37 @@ def register(app: typer.Typer, get_container):
             output.success(f"{downstream} no longer depends on {upstream_slug}")
         else:
             output.json({"downstream": downstream, "upstream": upstream_slug, "removed": True})
+
+    @depends_app.command("list")
+    def list_cmd(
+        task: Optional[str] = typer.Option(None, "--task", help="Task slug to scope to."),
+        graph: bool = typer.Option(False, "--graph", help="Emit the full workspace DAG instead of one task's edges."),
+    ):
+        """List dependencies for a task (default) or the whole workspace (--graph)."""
+        output = Output()
+        container = get_container()
+        state = container.state_manager().load()
+
+        if graph:
+            nodes = [{"slug": s} for s in sorted(state.tasks.keys())]
+            edges = []
+            for slug, t in state.tasks.items():
+                for e in t.depends_on:
+                    edges.append({"downstream": slug, "upstream": e.upstream_slug})
+            edges.sort(key=lambda e: (e["downstream"], e["upstream"]))
+            payload = {"nodes": nodes, "edges": edges}
+            if output.is_tty:
+                _render_graph_tty(output, payload)
+            else:
+                output.json(payload)
+            return
+
+        resolved = resolve_for_command("depends", state, task, output)
+        slug = resolved.task.slug
+        upstream = [{"slug": e.upstream_slug} for e in state.tasks[slug].depends_on]
+        downstream = [{"slug": s} for s in sorted(downstream_of(state, slug))]
+        payload = {"task": slug, "upstream": upstream, "downstream": downstream}
+        if output.is_tty:
+            _render_task_deps_tty(output, payload)
+        else:
+            output.json(payload)

--- a/src/mship/cli/depends.py
+++ b/src/mship/cli/depends.py
@@ -52,3 +52,33 @@ def register(app: typer.Typer, get_container):
             output.success(f"{downstream} now depends on {upstream_slug}")
         else:
             output.json({"downstream": downstream, "upstream": upstream_slug, "added": True})
+
+    @depends_app.command("remove")
+    def remove(
+        upstream_slug: str = typer.Argument(..., help="Upstream task slug to detach from."),
+        task: Optional[str] = typer.Option(None, "--task", help="Downstream task (defaults to cwd-resolved)."),
+    ):
+        """Remove the dependency edge from the current/specified task to <upstream_slug>."""
+        output = Output()
+        container = get_container()
+        state_mgr = container.state_manager()
+        state = state_mgr.load()
+        resolved = resolve_for_command("depends", state, task, output)
+        downstream = resolved.task.slug
+
+        t = state.tasks[downstream]
+        if not any(e.upstream_slug == upstream_slug for e in t.depends_on):
+            output.error(f"No edge from {downstream!r} to {upstream_slug!r}.")
+            raise typer.Exit(code=1)
+
+        def _mutate(s):
+            s.tasks[downstream].depends_on = [
+                e for e in s.tasks[downstream].depends_on
+                if e.upstream_slug != upstream_slug
+            ]
+
+        state_mgr.mutate(_mutate)
+        if output.is_tty:
+            output.success(f"{downstream} no longer depends on {upstream_slug}")
+        else:
+            output.json({"downstream": downstream, "upstream": upstream_slug, "removed": True})

--- a/src/mship/cli/depends.py
+++ b/src/mship/cli/depends.py
@@ -1,0 +1,54 @@
+"""`mship depends` — manage task-to-task dependency edges (#104)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import typer
+
+from mship.cli._resolve import resolve_for_command
+from mship.cli.output import Output
+from mship.core.state import DependencyEdge
+from mship.core.task_graph import find_cycle
+
+
+def register(app: typer.Typer, get_container):
+    depends_app = typer.Typer(no_args_is_help=True, help="Manage task-to-task dependencies (#104).")
+    app.add_typer(depends_app, name="depends")
+
+    @depends_app.command("add")
+    def add(
+        upstream_slug: str = typer.Argument(..., help="Upstream task slug to depend on."),
+        task: Optional[str] = typer.Option(None, "--task", help="Downstream task (defaults to cwd-resolved)."),
+    ):
+        """Declare that the current/specified task depends on <upstream_slug>."""
+        output = Output()
+        container = get_container()
+        state_mgr = container.state_manager()
+        state = state_mgr.load()
+        resolved = resolve_for_command("depends", state, task, output)
+        downstream = resolved.task.slug
+
+        if upstream_slug not in state.tasks:
+            known = ", ".join(sorted(state.tasks.keys())) or "(none)"
+            output.error(f"Unknown upstream task: {upstream_slug!r}. Known: {known}.")
+            raise typer.Exit(code=1)
+
+        cycle = find_cycle(state, downstream=downstream, new_upstream=upstream_slug)
+        if cycle is not None:
+            output.error(f"Cycle detected: {' → '.join(cycle)}")
+            raise typer.Exit(code=1)
+
+        def _mutate(s):
+            t = s.tasks[downstream]
+            if any(e.upstream_slug == upstream_slug for e in t.depends_on):
+                return  # idempotent
+            t.depends_on.append(
+                DependencyEdge(upstream_slug=upstream_slug, created_at=datetime.now(timezone.utc))
+            )
+
+        state_mgr.mutate(_mutate)
+        if output.is_tty:
+            output.success(f"{downstream} now depends on {upstream_slug}")
+        else:
+            output.json({"downstream": downstream, "upstream": upstream_slug, "added": True})

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -54,6 +54,7 @@ def register(app: typer.Typer, get_container):
             base_sha_info=base_sha_info,
             agents_md_path=agents_md_path,
             pkg_skills_source=pkg_skills_source(),
+            state=state,
         )
         # Print directly to stdout (NOT via Output.json — this is meant to be piped).
         print(prompt)

--- a/src/mship/cli/reconcile.py
+++ b/src/mship/cli/reconcile.py
@@ -16,12 +16,13 @@ from mship.core.reconcile.gate import Decision, reconcile_now
 
 
 _ACTION_HINTS = {
-    UpstreamState.merged:       "run `mship close`",
-    UpstreamState.closed:       "run `mship close --abandon`",
-    UpstreamState.diverged:     "pull and rebase",
-    UpstreamState.base_changed: "rebase onto new base",
-    UpstreamState.missing:      "—",
-    UpstreamState.in_sync:      "—",
+    UpstreamState.merged:            "run `mship close`",
+    UpstreamState.closed:            "run `mship close --abandon`",
+    UpstreamState.diverged:          "pull and rebase",
+    UpstreamState.base_changed:      "rebase onto new base",
+    UpstreamState.missing:           "—",
+    UpstreamState.in_sync:           "—",
+    UpstreamState.dependency_stale:  "rebase onto upstream's merge",
 }
 
 

--- a/src/mship/cli/status.py
+++ b/src/mship/cli/status.py
@@ -132,6 +132,28 @@ def register(app: typer.Typer, get_container):
                 if last_log is not None else None
             )
 
+            # --- #104 dependencies block ---
+            from mship.core.task_graph import downstream_of, is_ready
+            # We deliberately pass an empty dict — `status` is on the hot path and
+            # shouldn't trigger network reconcile. The real readiness check happens
+            # in `mship finish`. Here, anything not already confirmed merged is
+            # treated as "not ready" / "blocked", which is the safe-side answer.
+            decisions: dict = {}
+            deps_upstream = []
+            blocked_by: list[str] = []
+            for edge in t.depends_on:
+                ready = is_ready(state, edge.upstream_slug, decisions)
+                deps_upstream.append({"slug": edge.upstream_slug, "ready": ready})
+                if not ready:
+                    blocked_by.append(edge.upstream_slug)
+            deps_downstream = [{"slug": s} for s in sorted(downstream_of(state, t.slug))]
+            resolved_payload["dependencies"] = {
+                "upstream": deps_upstream,
+                "downstream": deps_downstream,
+                "blocked": bool(blocked_by),
+                "blocked_by": blocked_by,
+            }
+
         # --- TTY rendering: unchanged. Workspace summary when no task resolves;
         # task-detail block when one does.
         if output.is_tty:

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -497,6 +497,15 @@ def register(app: typer.Typer, get_container):
             help="Skip the check that merged PR commits actually reached the base branch",
         ),
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),
+        cascade: bool = typer.Option(
+            False, "--cascade",
+            help="Also remove downstream tasks from state (#104). "
+                 "Their worktrees stay until `mship prune`.",
+        ),
+        detach_downstream: bool = typer.Option(
+            False, "--detach-downstream",
+            help="Clear the inbound dependency edges, leave downstream tasks alive (#104).",
+        ),
     ):
         """Close a task: check PR state, tear down worktrees, clear state."""
         from pathlib import Path
@@ -580,6 +589,35 @@ def register(app: typer.Typer, get_container):
                 output.error("  - push from each worktree to save work")
                 output.error("  - `mship close --force` to delete anyway (destructive)")
                 raise typer.Exit(code=1)
+
+        # --- #104 downstream check ---
+        from mship.core.task_graph import downstream_of
+        downstream = sorted(downstream_of(state, task.slug))
+        if downstream and not force:
+            if cascade and detach_downstream:
+                output.error("Pass only one of --cascade / --detach-downstream.")
+                raise typer.Exit(code=1)
+            if not (cascade or detach_downstream):
+                if output.is_tty:
+                    choice = typer.prompt(
+                        f"Task {task.slug!r} has downstream tasks: {', '.join(downstream)}. "
+                        "[c]ascade close downstream, [d]etach edges, [a]bort",
+                        default="a",
+                    ).strip().lower()
+                    if choice.startswith("c"):
+                        cascade = True
+                    elif choice.startswith("d"):
+                        detach_downstream = True
+                    else:
+                        output.error("Aborted.")
+                        raise typer.Exit(code=1)
+                else:
+                    output.error(
+                        f"close refused: downstream tasks depend on {task.slug!r}: "
+                        f"{', '.join(downstream)}. Pass --cascade (close them too) "
+                        "or --detach-downstream (clear the edges) to proceed."
+                    )
+                    raise typer.Exit(code=1)
 
         # Determine the log message based on PR state.
         from mship.core.pr import PrStateResult
@@ -719,6 +757,21 @@ def register(app: typer.Typer, get_container):
 
         wt_mgr = container.worktree_manager()
         wt_mgr.abort(task_slug)  # core method retains the name; only CLI verb changed
+
+        if downstream and detach_downstream:
+            def _detach(s):
+                for d_slug in downstream:
+                    t = s.tasks.get(d_slug)
+                    if t is None:
+                        continue
+                    t.depends_on = [e for e in t.depends_on if e.upstream_slug != task.slug]
+            state_mgr.mutate(_detach)
+        elif downstream and cascade:
+            def _cascade(s):
+                for d_slug in downstream:
+                    s.tasks.pop(d_slug, None)
+            state_mgr.mutate(_cascade)
+
         log_mgr.append(task_slug, log_msg)
         try:
             from mship.core.reconcile.cache import ReconcileCache

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -79,6 +79,28 @@ def _run_gate(
         raise typer.Exit(code=1)
 
 
+def _dependency_decisions(state):
+    """Return reconcile decisions for use by the deps gate (#104).
+
+    Module-level so tests can stub it via monkeypatch.
+    Returns a dict[str, Decision] or {} on any error (fail-open).
+    """
+    try:
+        from mship.core.reconcile.cache import ReconcileCache
+        from mship.core.reconcile.gate import reconcile_now
+        from mship.core.reconcile.fetch import fetch_pr_snapshots, collect_git_snapshots
+        from mship.cli import container as _container_singleton
+
+        cache = ReconcileCache(_container_singleton.state_dir())
+
+        def _fetcher(branches, worktrees_by_branch):
+            return (fetch_pr_snapshots(branches), collect_git_snapshots(worktrees_by_branch))
+
+        return reconcile_now(state, cache=cache, fetcher=_fetcher)
+    except Exception:
+        return {}
+
+
 @dataclass
 class PRGroup:
     """A set of affected repos that share a single GitHub PR.
@@ -718,6 +740,7 @@ def register(app: typer.Typer, get_container):
         force_audit: bool = typer.Option(False, "--force-audit", help="Bypass audit gate for this finish"),
         push_only: bool = typer.Option(False, "--push-only", help="Push branches only; skip gh pr create"),
         bypass_reconcile: bool = typer.Option(False, "--bypass-reconcile", help="Skip upstream PR drift check for this finish"),
+        bypass_deps: bool = typer.Option(False, "--bypass-deps", help="Skip the dependency-readiness check (#104)."),
         body: Optional[str] = typer.Option(
             None, "--body",
             help="Inline PR body. Use '-' to read from stdin. Mutually exclusive with --body-file.",
@@ -848,6 +871,23 @@ def register(app: typer.Typer, get_container):
         except (InvalidBodyMapError, EmptyBodyInMapError) as e:
             output.error(str(e))
             raise typer.Exit(code=1)
+
+        # --- #104 dependency-readiness gate ---
+        if task.depends_on and not bypass_deps:
+            decisions = _dependency_decisions(state)
+            from mship.core.task_graph import is_ready
+            blocked_by = [
+                edge.upstream_slug
+                for edge in task.depends_on
+                if not is_ready(state, edge.upstream_slug, decisions)
+            ]
+            if blocked_by:
+                output.error(
+                    f"finish blocked: upstream task(s) not ready: {', '.join(blocked_by)}.\n"
+                    f"  Run `mship status --task <slug>` for state, "
+                    f"or pass --bypass-deps to override."
+                )
+                raise typer.Exit(code=1)
 
         # --- Audit gate ---
         from mship.core.audit_gate import run_audit_gate, AuditGateBlocked, compute_finish_audit_scope

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -230,6 +230,10 @@ def register(app: typer.Typer, get_container):
             help="Skip `git fetch` for passive worktrees; use local refs. "
                  "Journal entry tagged OFFLINE.",
         ),
+        depends_on: Optional[str] = typer.Option(
+            None, "--depends-on",
+            help="Comma-separated upstream task slugs this task depends on. See #104.",
+        ),
     ):
         """Create coordinated worktrees across repos for a new task."""
         import re as _re
@@ -366,10 +370,38 @@ def register(app: typer.Typer, get_container):
         if output.is_tty and not skip_setup:
             output.print("[dim]Running setup in each worktree (use --skip-setup to skip)...[/dim]")
 
+        # --- #104 dependency edges ---
+        from datetime import datetime, timezone
+        from mship.core.state import DependencyEdge
+        from mship.core.task_graph import find_cycle
+        from mship.util.slug import slugify
+
+        dep_edges: list[DependencyEdge] = []
+        if depends_on:
+            requested = [s.strip() for s in depends_on.split(",") if s.strip()]
+            existing_state = container.state_manager().load()
+            known = set(existing_state.tasks.keys())
+            unknown = [s for s in requested if s not in known]
+            if unknown:
+                listing = ", ".join(sorted(known)) or "(none)"
+                output.error(
+                    f"Unknown upstream task(s): {', '.join(unknown)}. Known: {listing}."
+                )
+                raise typer.Exit(code=1)
+            slug_for_cycle = slug if slug else slugify(description)
+            for up in requested:
+                cycle = find_cycle(existing_state, downstream=slug_for_cycle, new_upstream=up)
+                if cycle is not None:
+                    output.error(f"Cycle detected: {' → '.join(cycle)}")
+                    raise typer.Exit(code=1)
+            now = datetime.now(timezone.utc)
+            dep_edges = [DependencyEdge(upstream_slug=s, created_at=now) for s in requested]
+
         result = wt_mgr.spawn(
             description, repos=repo_list, skip_setup=skip_setup, slug=slug,
             workspace_root=container.config_path().parent,
             offline=offline,
+            depends_on=dep_edges,
         )
         task = result.task
 

--- a/src/mship/core/dispatch.py
+++ b/src/mship/core/dispatch.py
@@ -199,13 +199,20 @@ def _render_skills(skills: list[SkillRef]) -> str:
     return "\n".join(f"- `{s.name}` — `{s.path}`" for s in skills)
 
 
-def _format_dependencies_section(task: Task) -> str:
+def _format_dependencies_section(task: Task, state=None) -> str:
     """Format Dependencies section if task has upstream dependencies."""
     if not task.depends_on:
         return ""
     lines = ["## Dependencies", ""]
-    for edge in task.depends_on:
-        lines.append(f"- depends on: `{edge.upstream_slug}`")
+    if state is not None:
+        from mship.core.task_graph import is_ready
+        for edge in task.depends_on:
+            ready = is_ready(state, edge.upstream_slug, {})
+            mark = "ready" if ready else "not ready"
+            lines.append(f"- depends on: `{edge.upstream_slug}` ({mark})")
+    else:
+        for edge in task.depends_on:
+            lines.append(f"- depends on: `{edge.upstream_slug}`")
     lines.append("")
     return "\n".join(lines)
 
@@ -219,6 +226,7 @@ def build_dispatch_prompt(
     base_sha_info: BaseShaInfo,
     agents_md_path: Path | None,
     pkg_skills_source: Path,
+    state=None,
 ) -> str:
     """Return the full markdown dispatch prompt for a fresh subagent."""
     worktree = task.worktrees[repo]
@@ -226,7 +234,7 @@ def build_dispatch_prompt(
     skills_block = _render_skills(canonical_skills(pkg_skills_source))
     journal_block = _render_journal(journal_entries)
     base_block = _render_base_sha_block(base_sha_info, base_branch)
-    dependencies_block = _format_dependencies_section(task)
+    dependencies_block = _format_dependencies_section(task, state=state)
     agents_line = f"\nFull doc: `{agents_md_path}`." if agents_md_path else ""
 
     return f"""\

--- a/src/mship/core/dispatch.py
+++ b/src/mship/core/dispatch.py
@@ -199,6 +199,17 @@ def _render_skills(skills: list[SkillRef]) -> str:
     return "\n".join(f"- `{s.name}` — `{s.path}`" for s in skills)
 
 
+def _format_dependencies_section(task: Task) -> str:
+    """Format Dependencies section if task has upstream dependencies."""
+    if not task.depends_on:
+        return ""
+    lines = ["## Dependencies", ""]
+    for edge in task.depends_on:
+        lines.append(f"- depends on: `{edge.upstream_slug}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
 def build_dispatch_prompt(
     task: Task,
     repo: str,
@@ -215,6 +226,7 @@ def build_dispatch_prompt(
     skills_block = _render_skills(canonical_skills(pkg_skills_source))
     journal_block = _render_journal(journal_entries)
     base_block = _render_base_sha_block(base_sha_info, base_branch)
+    dependencies_block = _format_dependencies_section(task)
     agents_line = f"\nFull doc: `{agents_md_path}`." if agents_md_path else ""
 
     return f"""\
@@ -239,6 +251,7 @@ This is a git worktree checked out on branch `{task.branch}`. Every edit, test r
 - **base branch:** {base_branch}
 - **active repo:** {repo}
 
+{dependencies_block}
 ## Where the branch stands
 
 {base_block}

--- a/src/mship/core/reconcile/dependency_stale.py
+++ b/src/mship/core/reconcile/dependency_stale.py
@@ -22,7 +22,10 @@ def apply_dependency_stale(state, decisions: dict) -> dict:
             up = out.get(edge.upstream_slug)
             if up is None or up.state != UpstreamState.merged:
                 continue
-            up_merge_time = getattr(up, "merge_at", None) or _parse(getattr(up, "updated_at", None))
+            # Decision exposes `updated_at` (the PR's last-updated timestamp), which is
+            # the closest available proxy for merge time. We don't have a dedicated
+            # merge_at — if Decision grows one, prefer it here.
+            up_merge_time = _parse(getattr(up, "updated_at", None))
             if up_merge_time is None:
                 continue
             if up_merge_time > task.created_at:

--- a/src/mship/core/reconcile/dependency_stale.py
+++ b/src/mship/core/reconcile/dependency_stale.py
@@ -1,0 +1,40 @@
+"""Post-process reconcile decisions to surface dependency_stale states (#104)."""
+from __future__ import annotations
+
+from dataclasses import replace as _replace
+from datetime import datetime
+
+from mship.core.reconcile.detect import UpstreamState
+
+
+def apply_dependency_stale(state, decisions: dict) -> dict:
+    """Override `in_sync` decisions to `dependency_stale` when any upstream
+    has merged AFTER the downstream's task.created_at.
+
+    Returns a new dict; does not mutate the input.
+    """
+    out = dict(decisions)
+    for slug, task in state.tasks.items():
+        d = out.get(slug)
+        if d is None or d.state != UpstreamState.in_sync:
+            continue
+        for edge in task.depends_on:
+            up = out.get(edge.upstream_slug)
+            if up is None or up.state != UpstreamState.merged:
+                continue
+            up_merge_time = getattr(up, "merge_at", None) or _parse(getattr(up, "updated_at", None))
+            if up_merge_time is None:
+                continue
+            if up_merge_time > task.created_at:
+                out[slug] = _replace(d, state=UpstreamState.dependency_stale)
+                break
+    return out
+
+
+def _parse(s):
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except Exception:
+        return None

--- a/src/mship/core/reconcile/detect.py
+++ b/src/mship/core/reconcile/detect.py
@@ -14,6 +14,7 @@ class UpstreamState(str, Enum):
     diverged = "diverged"
     base_changed = "base_changed"
     missing = "missing"
+    dependency_stale = "dependency_stale"
 
 
 @dataclass(frozen=True)

--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -16,6 +16,7 @@ from mship.core.reconcile.cache import ReconcileCache, CachePayload, DEFAULT_TTL
 from mship.core.reconcile.detect import (
     Detection, GitSnapshot, PRSnapshot, UpstreamState, detect_many,
 )
+from mship.core.reconcile.dependency_stale import apply_dependency_stale
 from mship.core.reconcile.fetch import FetchError
 
 
@@ -53,12 +54,13 @@ class GateAction(str, Enum):
 
 
 _MATRIX: dict[str, dict[str, GateAction]] = {
-    "in_sync":      {"spawn": GateAction.allow, "finish": GateAction.allow, "close": GateAction.allow, "precommit": GateAction.allow},
-    "merged":       {"spawn": GateAction.block, "finish": GateAction.block, "close": GateAction.allow, "precommit": GateAction.block},
-    "closed":       {"spawn": GateAction.block, "finish": GateAction.block, "close": GateAction.allow, "precommit": GateAction.block},
-    "diverged":     {"spawn": GateAction.warn,  "finish": GateAction.block, "close": GateAction.allow, "precommit": GateAction.block},
-    "base_changed": {"spawn": GateAction.warn,  "finish": GateAction.block, "close": GateAction.allow, "precommit": GateAction.allow},
-    "missing":      {"spawn": GateAction.allow, "finish": GateAction.allow, "close": GateAction.allow, "precommit": GateAction.allow},
+    "in_sync":           {"spawn": GateAction.allow, "finish": GateAction.allow, "close": GateAction.allow, "precommit": GateAction.allow},
+    "merged":            {"spawn": GateAction.block, "finish": GateAction.block, "close": GateAction.allow, "precommit": GateAction.block},
+    "closed":            {"spawn": GateAction.block, "finish": GateAction.block, "close": GateAction.allow, "precommit": GateAction.block},
+    "diverged":          {"spawn": GateAction.warn,  "finish": GateAction.block, "close": GateAction.allow, "precommit": GateAction.block},
+    "base_changed":      {"spawn": GateAction.warn,  "finish": GateAction.block, "close": GateAction.allow, "precommit": GateAction.allow},
+    "missing":           {"spawn": GateAction.allow, "finish": GateAction.allow, "close": GateAction.allow, "precommit": GateAction.allow},
+    "dependency_stale":  {"spawn": GateAction.warn,  "finish": GateAction.block, "close": GateAction.allow, "precommit": GateAction.warn},
 }
 
 
@@ -160,4 +162,5 @@ def reconcile_now(
         results=results,
         ignored=(payload.ignored if payload else []),
     ))
-    return {slug: _decision_from_detection(slug, d, state) for slug, d in detections.items()}
+    decisions = {slug: _decision_from_detection(slug, d, state) for slug, d in detections.items()}
+    return apply_dependency_stale(state, decisions)

--- a/src/mship/core/state.py
+++ b/src/mship/core/state.py
@@ -16,6 +16,11 @@ class TestResult(BaseModel):
     at: datetime
 
 
+class DependencyEdge(BaseModel):
+    upstream_slug: str
+    created_at: datetime
+
+
 class Task(BaseModel):
     slug: str
     description: str
@@ -35,6 +40,7 @@ class Task(BaseModel):
     test_iteration: int = 0
     base_branch: str | None = None
     passive_repos: set[str] = set()
+    depends_on: list[DependencyEdge] = []
 
 
 class WorkspaceState(BaseModel):

--- a/src/mship/core/task_graph.py
+++ b/src/mship/core/task_graph.py
@@ -1,0 +1,100 @@
+"""Pure graph queries over Task.depends_on edges.
+
+This module is distinct from `mship.core.graph` (which models repo
+dependency topology). The task graph operates on `WorkspaceState.tasks`.
+"""
+from __future__ import annotations
+
+from mship.core.state import WorkspaceState
+
+
+class CycleError(Exception):
+    """Adding a proposed edge would create a cycle."""
+
+    def __init__(self, path: list[str]) -> None:
+        self.path = path
+        super().__init__(" → ".join(path))
+
+
+def transitive_upstream(state: WorkspaceState, slug: str) -> set[str]:
+    """Return all transitive upstream slugs of `slug`, excluding `slug` itself."""
+    if slug not in state.tasks:
+        return set()
+    visited: set[str] = set()
+    stack = [slug]
+    while stack:
+        node = stack.pop()
+        task = state.tasks.get(node)
+        if task is None:
+            continue
+        for edge in task.depends_on:
+            if edge.upstream_slug not in visited:
+                visited.add(edge.upstream_slug)
+                stack.append(edge.upstream_slug)
+    return visited
+
+
+def downstream_of(state: WorkspaceState, slug: str) -> set[str]:
+    """Return all transitive downstream slugs of `slug`, excluding `slug` itself."""
+    direct: dict[str, list[str]] = {s: [] for s in state.tasks}
+    for s, t in state.tasks.items():
+        for edge in t.depends_on:
+            if edge.upstream_slug in direct:
+                direct[edge.upstream_slug].append(s)
+
+    visited: set[str] = set()
+    stack = list(direct.get(slug, []))
+    while stack:
+        node = stack.pop()
+        if node not in visited:
+            visited.add(node)
+            stack.extend(direct.get(node, []))
+    return visited
+
+
+def find_cycle(
+    state: WorkspaceState,
+    *,
+    downstream: str,
+    new_upstream: str,
+) -> list[str] | None:
+    """If adding edge (downstream → new_upstream) creates a cycle, return the cycle path.
+
+    The path is [downstream, new_upstream, ..., downstream] — first and last
+    are the same slug.
+
+    Returns None if no cycle would be created.
+
+    Note: `downstream` need not exist in `state.tasks` yet (we use this at
+    spawn time, before the task is persisted).
+    """
+    if new_upstream == downstream:
+        return [downstream, downstream]
+
+    if new_upstream not in state.tasks:
+        return None
+
+    parent: dict[str, str] = {new_upstream: downstream}
+    stack = [new_upstream]
+    while stack:
+        node = stack.pop()
+        task = state.tasks.get(node)
+        if task is None:
+            continue
+        for edge in task.depends_on:
+            up = edge.upstream_slug
+            if up == downstream:
+                # Found cycle: reconstruct path from downstream to node
+                path = [node]
+                current = node
+                while current != new_upstream:
+                    current = parent[current]
+                    path.append(current)
+                path.reverse()
+                # path is now [downstream, ..., node]
+                # return [downstream, ..., node (=new_upstream), downstream]
+                return [downstream] + path + [downstream]
+            if up not in parent:
+                parent[up] = node
+                stack.append(up)
+    return None

--- a/src/mship/core/task_graph.py
+++ b/src/mship/core/task_graph.py
@@ -98,3 +98,25 @@ def find_cycle(
                 parent[up] = node
                 stack.append(up)
     return None
+
+
+def is_ready(
+    state: WorkspaceState,
+    slug: str,
+    reconcile_decisions: dict,
+) -> bool:
+    """True iff `slug` is a finished task whose reconcile state is merged.
+
+    `reconcile_decisions` is a `dict[str, Decision]` from
+    `mship.core.reconcile.gate.reconcile_now`. We import lazily to avoid a
+    circular import — reconcile may grow dependency-aware logic later.
+    """
+    from mship.core.reconcile.detect import UpstreamState
+
+    task = state.tasks.get(slug)
+    if task is None or task.finished_at is None:
+        return False
+    decision = reconcile_decisions.get(slug)
+    if decision is None:
+        return False
+    return decision.state == UpstreamState.merged

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -8,7 +8,7 @@ from mship.core.config import WorkspaceConfig
 from mship.core.graph import DependencyGraph
 from mship.core.log import LogManager
 from mship.core.reconcile.fetch import workspace_default_branch_from_config
-from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.state import DependencyEdge, StateManager, Task, WorkspaceState
 from mship.core.workspace_marker import write_marker
 from mship.util.git import GitRunner
 from mship.util.shell import ShellRunner
@@ -401,6 +401,7 @@ class WorktreeManager:
         slug: str | None = None,
         workspace_root: Path | None = None,
         offline: bool = False,
+        depends_on: list[DependencyEdge] | None = None,
     ) -> SpawnResult:
         slug = slug if slug is not None else slugify(description)
         branch = self._config.branch_pattern.replace("{slug}", slug)
@@ -555,6 +556,7 @@ class WorktreeManager:
             branch=branch,
             base_branch=workspace_default_branch_from_config(self._config),
             passive_repos=passive,
+            depends_on=depends_on or [],
         )
 
         def _apply(s: WorkspaceState) -> None:

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -181,6 +181,31 @@ If you don't, your edits in the shell affect the main checkout, not the feature 
 
 **`finish` PR body — write a real one.** By default the PR body is just the task description plus a `Closes #N` footer for any issue refs found in the description, journal, and commit subjects. That's a placeholder, not a body. For agent-driven finishes, pass `--body-file <path>` (or `--body '<inline>'`, or `--body -` for stdin) with a real Summary and Test plan. Empty bodies are rejected — that's deliberate. If you forgot at finish time, follow up immediately with `gh pr edit <url> --body-file <path>`. A bare task-description PR is treated as incomplete.
 
+### Task dependencies
+
+Express that task B depends on task A. `finish` refuses to ship B until every upstream is merged.
+
+```bash
+mship spawn "downstream work" --depends-on a,b          # declare at spawn
+mship depends add <upstream-slug> [--task <slug>]       # retrofit on an existing task
+mship depends remove <upstream-slug> [--task <slug>]
+mship depends list [--task <slug>] [--graph]            # --graph = full workspace DAG
+mship finish --bypass-deps                              # override the readiness gate
+mship close --cascade        # also remove downstream from state
+mship close --detach-downstream   # clear inbound edges, leave downstream alive
+```
+
+`mship status` exposes the graph under `.resolved_task.dependencies`:
+
+```bash
+mship status | jq .resolved_task.dependencies
+# { "upstream": [...], "downstream": [...], "blocked": bool, "blocked_by": [...] }
+```
+
+`mship dispatch` includes a `## Dependencies` section in the subagent prompt body. `mship reconcile` reports `dependency_stale` for a downstream that's in sync but whose upstream merged after the downstream was created (i.e., the downstream needs a rebase).
+
+No soft/advisory edges in v1 — for "informed by task-a" relationships, use `mship journal`.
+
 ### Iterating after `mship finish` (reviewer feedback, CI fixes, typos)
 
 For small post-finish changes — reviewer comments, CI fixes, doc tweaks — use `mship commit <msg>` instead of spawning a new task:

--- a/tests/cli/test_depends.py
+++ b/tests/cli/test_depends.py
@@ -93,3 +93,25 @@ def test_depends_add_duplicate_idempotent(workspace, configured_app):
     sm = StateManager(workspace / ".mothership")
     edges = sm.load().tasks["b"].depends_on
     assert len(edges) == 1
+
+
+def test_depends_remove_clears_edge(workspace, configured_app):
+    from mship.core.state import DependencyEdge
+    a = _task("a")
+    b = _task("b")
+    b.depends_on = [DependencyEdge(upstream_slug="a", created_at=datetime.now(timezone.utc))]
+    _seed(workspace, a, b)
+
+    result = runner.invoke(app, ["depends", "remove", "a", "--task", "b"])
+    assert result.exit_code == 0
+    sm = StateManager(workspace / ".mothership")
+    assert sm.load().tasks["b"].depends_on == []
+
+
+def test_depends_remove_missing_edge_errors(workspace, configured_app):
+    """Removing an edge that doesn't exist errors loudly."""
+    _seed(workspace, _task("a"), _task("b"))
+    result = runner.invoke(app, ["depends", "remove", "a", "--task", "b"])
+    assert result.exit_code != 0
+    err = (result.stderr or result.output).lower()
+    assert "no edge" in err or "not found" in err

--- a/tests/cli/test_depends.py
+++ b/tests/cli/test_depends.py
@@ -1,0 +1,95 @@
+"""Tests for the `mship depends` verb group."""
+from __future__ import annotations
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.state import StateManager, Task, WorkspaceState
+
+runner = CliRunner()
+
+
+def _seed(workspace: Path, *tasks: Task) -> None:
+    sm = StateManager(workspace / ".mothership")
+    sm.save(WorkspaceState(tasks={t.slug: t for t in tasks}))
+
+
+def _task(slug: str) -> Task:
+    return Task(
+        slug=slug, description=slug, phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["mothership"], branch=f"feat/{slug}",
+    )
+
+
+@pytest.fixture
+def configured_app(workspace: Path):
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(workspace / "mothership.yaml")
+    container.state_dir.override(workspace / ".mothership")
+    (workspace / ".mothership").mkdir(exist_ok=True)
+    yield
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override()
+    container.config.reset()
+    container.state_manager.reset_override()
+    container.state_manager.reset()
+
+
+def test_depends_add_creates_edge(workspace, configured_app):
+    _seed(workspace, _task("a"), _task("b"))
+    result = runner.invoke(app, ["depends", "add", "a", "--task", "b"])
+    assert result.exit_code == 0, result.stderr or result.output
+
+    sm = StateManager(workspace / ".mothership")
+    state = sm.load()
+    edges = state.tasks["b"].depends_on
+    assert len(edges) == 1
+    assert edges[0].upstream_slug == "a"
+
+
+def test_depends_add_unknown_upstream_errors(workspace, configured_app):
+    _seed(workspace, _task("b"))
+    result = runner.invoke(app, ["depends", "add", "nope", "--task", "b"])
+    assert result.exit_code != 0
+    assert "nope" in (result.stderr or result.output).lower()
+
+
+def test_depends_add_self_edge_rejected(workspace, configured_app):
+    _seed(workspace, _task("b"))
+    result = runner.invoke(app, ["depends", "add", "b", "--task", "b"])
+    assert result.exit_code != 0
+    err = (result.stderr or result.output).lower()
+    assert "cycle" in err or "self" in err
+
+
+def test_depends_add_cycle_rejected(workspace, configured_app):
+    """b already depends on a; adding a→b creates a cycle."""
+    a = _task("a")
+    b = _task("b")
+    from mship.core.state import DependencyEdge
+    b.depends_on = [DependencyEdge(upstream_slug="a", created_at=datetime.now(timezone.utc))]
+    _seed(workspace, a, b)
+
+    result = runner.invoke(app, ["depends", "add", "b", "--task", "a"])
+    assert result.exit_code != 0
+    err = (result.stderr or result.output).lower()
+    assert "cycle" in err
+    assert "b" in err and "a" in err
+
+
+def test_depends_add_duplicate_idempotent(workspace, configured_app):
+    """Adding an existing edge is a no-op (does not duplicate)."""
+    _seed(workspace, _task("a"), _task("b"))
+    runner.invoke(app, ["depends", "add", "a", "--task", "b"])
+    result = runner.invoke(app, ["depends", "add", "a", "--task", "b"])
+    assert result.exit_code == 0
+    sm = StateManager(workspace / ".mothership")
+    edges = sm.load().tasks["b"].depends_on
+    assert len(edges) == 1

--- a/tests/cli/test_depends.py
+++ b/tests/cli/test_depends.py
@@ -115,3 +115,36 @@ def test_depends_remove_missing_edge_errors(workspace, configured_app):
     assert result.exit_code != 0
     err = (result.stderr or result.output).lower()
     assert "no edge" in err or "not found" in err
+
+
+def test_depends_list_task_scoped(workspace, configured_app):
+    """Without --graph, list shows the resolved task's upstream + downstream."""
+    from mship.core.state import DependencyEdge
+    a = _task("a")
+    b = _task("b")
+    c = _task("c")
+    b.depends_on = [DependencyEdge(upstream_slug="a", created_at=datetime.now(timezone.utc))]
+    c.depends_on = [DependencyEdge(upstream_slug="b", created_at=datetime.now(timezone.utc))]
+    _seed(workspace, a, b, c)
+
+    result = runner.invoke(app, ["depends", "list", "--task", "b"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["task"] == "b"
+    assert [u["slug"] for u in data["upstream"]] == ["a"]
+    assert [d["slug"] for d in data["downstream"]] == ["c"]
+
+
+def test_depends_list_graph_emits_workspace_dag(workspace, configured_app):
+    """--graph emits all tasks + edges."""
+    from mship.core.state import DependencyEdge
+    a = _task("a")
+    b = _task("b")
+    b.depends_on = [DependencyEdge(upstream_slug="a", created_at=datetime.now(timezone.utc))]
+    _seed(workspace, a, b)
+
+    result = runner.invoke(app, ["depends", "list", "--graph"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert {n["slug"] for n in data["nodes"]} == {"a", "b"}
+    assert {(e["downstream"], e["upstream"]) for e in data["edges"]} == {("b", "a")}

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -139,5 +139,6 @@ def test_dispatch_prompt_includes_dependencies_section(tmp_path: Path):
         assert result.exit_code == 0, result.output
         assert "## Dependencies" in result.output
         assert "a" in result.output
+        assert "not ready" in result.output
     finally:
         _reset()

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from mship.cli import app, container
-from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.state import StateManager, Task, WorkspaceState, DependencyEdge
 
 
 runner = CliRunner()
@@ -110,5 +110,34 @@ def test_dispatch_unknown_task_errors(tmp_path: Path):
         result = runner.invoke(app, ["dispatch", "--task", "missing", "-i", "x"])
         assert result.exit_code == 1
         assert "Unknown task" in result.output
+    finally:
+        _reset()
+
+
+def test_dispatch_prompt_includes_dependencies_section(tmp_path: Path):
+    now = datetime.now(timezone.utc)
+    wt_a = tmp_path / "wt-a"; wt_a.mkdir()
+    wt_b = tmp_path / "wt-b"; wt_b.mkdir()
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text("workspace: t\nrepos: {}\n")
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "a": Task(slug="a", description="a", phase="dev",
+                  created_at=now, affected_repos=["mothership"], branch="feat/a",
+                  worktrees={"mothership": wt_a}),
+        "b": Task(slug="b", description="b", phase="dev",
+                  created_at=now, affected_repos=["mothership"], branch="feat/b",
+                  worktrees={"mothership": wt_b},
+                  depends_on=[DependencyEdge(upstream_slug="a", created_at=now)]),
+    }))
+    container.config.reset(); container.state_manager.reset(); container.log_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "b", "-i", "go"])
+        assert result.exit_code == 0, result.output
+        assert "## Dependencies" in result.output
+        assert "a" in result.output
     finally:
         _reset()

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -423,3 +423,41 @@ def test_status_envelope_unknown_task_flag_errors(tmp_path, monkeypatch):
         assert "nope" in result.output.lower()
     finally:
         _reset_container()
+
+
+def test_status_dependencies_block_present(tmp_path, monkeypatch):
+    """resolved_task.dependencies includes upstream, downstream, blocked, blocked_by."""
+    from mship.core.state import DependencyEdge, StateManager, Task, WorkspaceState
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc)
+    StateManager(tmp_path / ".mothership").save(WorkspaceState(tasks={
+        "a": Task(slug="a", description="a", phase="dev",
+                  created_at=now, affected_repos=["mothership"], branch="feat/a"),
+        "b": Task(slug="b", description="b", phase="dev",
+                  created_at=now, affected_repos=["mothership"], branch="feat/b",
+                  depends_on=[DependencyEdge(upstream_slug="a", created_at=now)]),
+        "c": Task(slug="c", description="c", phase="dev",
+                  created_at=now, affected_repos=["mothership"], branch="feat/c",
+                  depends_on=[DependencyEdge(upstream_slug="b", created_at=now)]),
+    }))
+
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(tmp_path / ".mothership")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("MSHIP_TASK", raising=False)
+    try:
+        result = runner.invoke(app, ["status", "--task", "b"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        deps = data["resolved_task"]["dependencies"]
+        assert [u["slug"] for u in deps["upstream"]] == ["a"]
+        assert [d["slug"] for d in deps["downstream"]] == ["c"]
+        # ready is False because reconcile won't say merged for an unfinished task
+        assert deps["blocked"] is True
+        assert deps["blocked_by"] == ["a"]
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -130,6 +130,43 @@ def test_spawn_non_tty_json_omits_cd_hint(configured_git_app: Path):
     assert "Next:" not in result.output
 
 
+def test_spawn_with_depends_on_persists_edges(configured_git_app: Path):
+    """spawn --depends-on a creates the task with an edge to a. See #104."""
+    from datetime import datetime, timezone
+    from mship.core.state import StateManager, Task, WorkspaceState
+
+    # Seed an upstream task so it's already known to state.
+    sm = StateManager(configured_git_app / ".mothership")
+    sm.save(WorkspaceState(tasks={
+        "a": Task(
+            slug="a", description="upstream", phase="dev",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/a",
+        ),
+    }))
+
+    result = runner.invoke(
+        app,
+        ["spawn", "downstream task", "--repos", "shared", "--slug", "down",
+         "--depends-on", "a", "--skip-setup"],
+    )
+    assert result.exit_code == 0, result.stderr or result.output
+    state = StateManager(configured_git_app / ".mothership").load()
+    edges = state.tasks["down"].depends_on
+    assert [e.upstream_slug for e in edges] == ["a"]
+
+
+def test_spawn_with_unknown_depends_on_errors(configured_git_app: Path):
+    """spawn --depends-on <unknown> errors before creating the task. See #104."""
+    result = runner.invoke(
+        app,
+        ["spawn", "x", "--repos", "shared", "--slug", "x",
+         "--depends-on", "nope", "--skip-setup"],
+    )
+    assert result.exit_code != 0
+    assert "nope" in (result.stderr or result.output).lower()
+
+
 def test_worktrees_list(configured_git_app: Path):
     runner.invoke(app, ["spawn", "test list", "--repos", "shared"])
     result = runner.invoke(app, ["worktrees"])

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -1902,3 +1902,62 @@ def test_finish_bypass_deps(configured_git_app: Path, monkeypatch):
     # (no actual PR infra) but the blocked-upstream message must be absent.
     assert "depends on" not in out
     assert "blocked: upstream" not in out
+
+
+# ---------------------------------------------------------------------------
+# close: downstream-check tests (#104)
+# ---------------------------------------------------------------------------
+
+def _seed_ab_tasks(workspace_root: Path):
+    """Seed tasks a (finished) and b (depends on a) into state."""
+    from mship.core.state import DependencyEdge, StateManager, Task, WorkspaceState
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    sm = StateManager(workspace_root / ".mothership")
+    sm.save(WorkspaceState(tasks={
+        "a": Task(
+            slug="a", description="a", phase="dev",
+            finished_at=now, created_at=now,
+            affected_repos=["shared"], branch="feat/a",
+        ),
+        "b": Task(
+            slug="b", description="b", phase="dev",
+            created_at=now, affected_repos=["shared"], branch="feat/b",
+            depends_on=[DependencyEdge(upstream_slug="a", created_at=now)],
+        ),
+    }))
+    return sm
+
+
+def test_close_with_downstream_non_tty_refuses(configured_git_app: Path):
+    """Non-TTY close refuses when downstream tasks exist."""
+    sm = _seed_ab_tasks(configured_git_app)
+
+    result = runner.invoke(app, ["close", "a", "--yes", "--skip-pr-check"])
+    assert result.exit_code != 0
+    out = (result.output or "").lower()
+    assert "downstream" in out
+    assert "b" in out
+    assert "--cascade" in (result.output or "") or "--detach-downstream" in (result.output or "")
+
+
+def test_close_detach_downstream_clears_edges(configured_git_app: Path):
+    """--detach-downstream clears the inbound edges but leaves downstream alive."""
+    sm = _seed_ab_tasks(configured_git_app)
+
+    result = runner.invoke(app, ["close", "a", "--yes", "--skip-pr-check", "--detach-downstream"])
+    assert result.exit_code == 0, result.output
+    state = sm.load()
+    assert "a" not in state.tasks
+    assert state.tasks["b"].depends_on == []
+
+
+def test_close_cascade_removes_downstream(configured_git_app: Path):
+    """--cascade removes both upstream and downstream tasks from state."""
+    sm = _seed_ab_tasks(configured_git_app)
+
+    result = runner.invoke(app, ["close", "a", "--yes", "--skip-pr-check", "--cascade"])
+    assert result.exit_code == 0, result.output
+    state = sm.load()
+    assert state.tasks == {}

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -1833,3 +1833,72 @@ def test_spawn_cli_writes_offline_journal_entry(workspace_with_git, monkeypatch)
         container.config.reset()
         container.state_manager.reset()
         container.log_manager.reset()
+
+
+def test_finish_blocked_by_unready_upstream(configured_git_app: Path, monkeypatch):
+    """finish refuses when an upstream task isn't merged."""
+    from datetime import datetime, timezone
+    from mship.core.state import DependencyEdge, StateManager, Task, WorkspaceState
+
+    now = datetime.now(timezone.utc)
+    sm = StateManager(configured_git_app / ".mothership")
+    sm.save(WorkspaceState(tasks={
+        "a": Task(slug="a", description="a", phase="dev",
+                  created_at=now, affected_repos=["shared"], branch="feat/a"),
+        "b": Task(slug="b", description="b", phase="dev",
+                  created_at=now, affected_repos=["shared"], branch="feat/b",
+                  depends_on=[DependencyEdge(upstream_slug="a", created_at=now)]),
+    }))
+
+    from mship.core.reconcile.detect import UpstreamState
+    from mship.core.reconcile.gate import Decision
+
+    def _fake_decisions(state):
+        return {"a": Decision(
+            slug="a", state=UpstreamState.in_sync,
+            pr_url=None, pr_number=None, base=None,
+            merge_commit=None, updated_at=None,
+        )}
+
+    monkeypatch.setattr("mship.cli.worktree._dependency_decisions", _fake_decisions)
+
+    result = runner.invoke(app, ["finish", "--task", "b"])
+    assert result.exit_code != 0
+    err = (result.output or "").lower()
+    assert "a" in err
+    assert "not ready" in err or "blocked" in err
+
+
+def test_finish_bypass_deps(configured_git_app: Path, monkeypatch):
+    """--bypass-deps proceeds past the upstream-readiness check."""
+    from datetime import datetime, timezone
+    from mship.core.state import DependencyEdge, StateManager, Task, WorkspaceState
+
+    now = datetime.now(timezone.utc)
+    sm = StateManager(configured_git_app / ".mothership")
+    sm.save(WorkspaceState(tasks={
+        "a": Task(slug="a", description="a", phase="dev",
+                  created_at=now, affected_repos=["shared"], branch="feat/a"),
+        "b": Task(slug="b", description="b", phase="dev",
+                  created_at=now, affected_repos=["shared"], branch="feat/b",
+                  depends_on=[DependencyEdge(upstream_slug="a", created_at=now)]),
+    }))
+
+    from mship.core.reconcile.detect import UpstreamState
+    from mship.core.reconcile.gate import Decision
+
+    def _fake_decisions(state):
+        return {"a": Decision(
+            slug="a", state=UpstreamState.in_sync,
+            pr_url=None, pr_number=None, base=None,
+            merge_commit=None, updated_at=None,
+        )}
+
+    monkeypatch.setattr("mship.cli.worktree._dependency_decisions", _fake_decisions)
+
+    result = runner.invoke(app, ["finish", "--task", "b", "--bypass-deps"])
+    out = (result.output or "").lower()
+    # The deps gate must NOT have fired; finish may fail for unrelated reasons
+    # (no actual PR infra) but the blocked-upstream message must be absent.
+    assert "depends on" not in out
+    assert "blocked: upstream" not in out

--- a/tests/core/reconcile/test_dependency_stale.py
+++ b/tests/core/reconcile/test_dependency_stale.py
@@ -1,0 +1,81 @@
+"""Tests for dependency_stale post-processing (#104)."""
+from __future__ import annotations
+from datetime import datetime, timezone
+
+from mship.core.state import DependencyEdge, Task, WorkspaceState
+from mship.core.reconcile.detect import UpstreamState
+from mship.core.reconcile.gate import Decision
+from mship.core.reconcile.dependency_stale import apply_dependency_stale
+
+
+def _task(slug, created_at, finished_at=None, upstream=()):
+    return Task(
+        slug=slug, description=slug, phase="dev",
+        created_at=created_at,
+        finished_at=finished_at,
+        affected_repos=["r"], branch=f"feat/{slug}",
+        depends_on=[DependencyEdge(upstream_slug=u, created_at=created_at) for u in upstream],
+    )
+
+
+def test_dependency_stale_when_upstream_merged_after_downstream_created():
+    """Downstream task → in_sync; upstream merged after downstream created → dependency_stale."""
+    t0 = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    t1 = datetime(2026, 5, 10, tzinfo=timezone.utc)
+    state = WorkspaceState(tasks={
+        "a": _task("a", t0, finished_at=t0),
+        "b": _task("b", t0, upstream=["a"]),
+    })
+    decisions = {
+        "a": Decision(slug="a", state=UpstreamState.merged, pr_url=None,
+                      pr_number=None, base=None, merge_commit=None,
+                      updated_at=t1.isoformat()),
+        "b": Decision(slug="b", state=UpstreamState.in_sync, pr_url=None,
+                      pr_number=None, base=None, merge_commit=None,
+                      updated_at=None),
+    }
+
+    out = apply_dependency_stale(state, decisions)
+    assert out["b"].state == UpstreamState.dependency_stale
+
+
+def test_no_override_when_upstream_merged_before_downstream_created():
+    """If the upstream merged BEFORE the downstream was created, downstream stays in_sync."""
+    t_old = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    t_new = datetime(2026, 5, 10, tzinfo=timezone.utc)
+    state = WorkspaceState(tasks={
+        "a": _task("a", t_old, finished_at=t_old),
+        "b": _task("b", t_new, upstream=["a"]),
+    })
+    decisions = {
+        "a": Decision(slug="a", state=UpstreamState.merged, pr_url=None,
+                      pr_number=None, base=None, merge_commit=None,
+                      updated_at=t_old.isoformat()),
+        "b": Decision(slug="b", state=UpstreamState.in_sync, pr_url=None,
+                      pr_number=None, base=None, merge_commit=None,
+                      updated_at=None),
+    }
+
+    out = apply_dependency_stale(state, decisions)
+    assert out["b"].state == UpstreamState.in_sync
+
+
+def test_no_override_when_downstream_already_diverged():
+    """If downstream is already in a non-in_sync state, leave it alone."""
+    t0 = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    t1 = datetime(2026, 5, 10, tzinfo=timezone.utc)
+    state = WorkspaceState(tasks={
+        "a": _task("a", t0, finished_at=t0),
+        "b": _task("b", t0, upstream=["a"]),
+    })
+    decisions = {
+        "a": Decision(slug="a", state=UpstreamState.merged, pr_url=None,
+                      pr_number=None, base=None, merge_commit=None,
+                      updated_at=t1.isoformat()),
+        "b": Decision(slug="b", state=UpstreamState.diverged, pr_url=None,
+                      pr_number=None, base=None, merge_commit=None,
+                      updated_at=None),
+    }
+
+    out = apply_dependency_stale(state, decisions)
+    assert out["b"].state == UpstreamState.diverged

--- a/tests/core/test_state.py
+++ b/tests/core/test_state.py
@@ -303,3 +303,60 @@ def test_task_passive_repos_round_trips(tmp_path):
     sm.save(state)
     loaded = sm.load()
     assert loaded.tasks["t"].passive_repos == {"b"}
+
+
+def test_task_depends_on_defaults_empty(tmp_path):
+    """New Task model has depends_on field defaulting to []."""
+    from mship.core.state import Task
+    from datetime import datetime, timezone
+
+    t = Task(
+        slug="x", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["r"], branch="feat/x",
+    )
+    assert t.depends_on == []
+
+
+def test_dependency_edge_roundtrip(tmp_path):
+    """DependencyEdge serializes and deserializes through state.yaml."""
+    from mship.core.state import StateManager, Task, WorkspaceState, DependencyEdge
+    from datetime import datetime, timezone
+
+    sm = StateManager(tmp_path / ".mothership")
+    now = datetime.now(timezone.utc)
+    t = Task(
+        slug="b", description="d", phase="dev",
+        created_at=now,
+        affected_repos=["r"], branch="feat/b",
+        depends_on=[DependencyEdge(upstream_slug="a", created_at=now)],
+    )
+    sm.save(WorkspaceState(tasks={"b": t}))
+
+    loaded = sm.load()
+    assert "b" in loaded.tasks
+    edges = loaded.tasks["b"].depends_on
+    assert len(edges) == 1
+    assert edges[0].upstream_slug == "a"
+
+
+def test_legacy_state_without_depends_on_loads_clean(tmp_path):
+    """state.yaml without depends_on field loads with depends_on=[]."""
+    from mship.core.state import StateManager
+    import yaml
+
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    (state_dir / "state.yaml").write_text(yaml.dump({
+        "tasks": {
+            "t": {
+                "slug": "t", "description": "d", "phase": "dev",
+                "created_at": "2026-05-14T00:00:00+00:00",
+                "affected_repos": ["r"], "worktrees": {},
+                "branch": "feat/t",
+            }
+        }
+    }))
+    sm = StateManager(state_dir)
+    state = sm.load()
+    assert state.tasks["t"].depends_on == []

--- a/tests/core/test_task_graph.py
+++ b/tests/core/test_task_graph.py
@@ -1,0 +1,90 @@
+"""Pure graph queries over Task.depends_on."""
+from __future__ import annotations
+from datetime import datetime, timezone
+
+import pytest
+
+from mship.core.state import Task, WorkspaceState, DependencyEdge
+from mship.core.task_graph import (
+    CycleError,
+    downstream_of,
+    find_cycle,
+    transitive_upstream,
+)
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+def _task(slug: str, upstream: list[str] = ()) -> Task:
+    return Task(
+        slug=slug, description=slug, phase="dev",
+        created_at=_now(),
+        affected_repos=["r"], branch=f"feat/{slug}",
+        depends_on=[DependencyEdge(upstream_slug=u, created_at=_now()) for u in upstream],
+    )
+
+
+def _ws(*tasks: Task) -> WorkspaceState:
+    return WorkspaceState(tasks={t.slug: t for t in tasks})
+
+
+def test_transitive_upstream_single_hop():
+    ws = _ws(_task("a"), _task("b", ["a"]))
+    assert transitive_upstream(ws, "b") == {"a"}
+
+
+def test_transitive_upstream_multi_hop():
+    ws = _ws(_task("a"), _task("b", ["a"]), _task("c", ["b"]))
+    assert transitive_upstream(ws, "c") == {"a", "b"}
+
+
+def test_transitive_upstream_diamond():
+    ws = _ws(_task("a"), _task("b", ["a"]), _task("c", ["a"]), _task("d", ["b", "c"]))
+    assert transitive_upstream(ws, "d") == {"a", "b", "c"}
+
+
+def test_transitive_upstream_missing_slug_returns_empty():
+    """Unknown task slug returns empty set (caller validates separately)."""
+    ws = _ws(_task("a"))
+    assert transitive_upstream(ws, "nonexistent") == set()
+
+
+def test_downstream_of_single_hop():
+    ws = _ws(_task("a"), _task("b", ["a"]))
+    assert downstream_of(ws, "a") == {"b"}
+
+
+def test_downstream_of_multi_hop():
+    ws = _ws(_task("a"), _task("b", ["a"]), _task("c", ["b"]))
+    assert downstream_of(ws, "a") == {"b", "c"}
+
+
+def test_find_cycle_self_edge():
+    """Adding self-edge produces a cycle."""
+    ws = _ws(_task("a"))
+    # Simulate the would-be edge: would adding a → a create a cycle?
+    cycle = find_cycle(ws, downstream="a", new_upstream="a")
+    assert cycle == ["a", "a"]
+
+
+def test_find_cycle_two_node():
+    """Adding b→a when a already depends on b creates a cycle."""
+    ws = _ws(_task("a", ["b"]), _task("b"))
+    cycle = find_cycle(ws, downstream="b", new_upstream="a")
+    assert cycle == ["b", "a", "b"]
+
+
+def test_find_cycle_three_node():
+    """Adding c→a when a → b → c creates a cycle."""
+    ws = _ws(_task("a", ["b"]), _task("b", ["c"]), _task("c"))
+    cycle = find_cycle(ws, downstream="c", new_upstream="a")
+    assert cycle == ["c", "a", "b", "c"]
+
+
+def test_no_cycle_on_diamond():
+    """A diamond DAG has no cycle."""
+    ws = _ws(_task("a"), _task("b", ["a"]), _task("c", ["a"]))
+    assert find_cycle(ws, downstream="d", new_upstream="b") is None
+    assert find_cycle(ws, downstream="d", new_upstream="c") is None

--- a/tests/core/test_task_graph.py
+++ b/tests/core/test_task_graph.py
@@ -2,8 +2,6 @@
 from __future__ import annotations
 from datetime import datetime, timezone
 
-import pytest
-
 from mship.core.state import Task, WorkspaceState, DependencyEdge
 from mship.core.task_graph import (
     CycleError,
@@ -88,3 +86,10 @@ def test_no_cycle_on_diamond():
     ws = _ws(_task("a"), _task("b", ["a"]), _task("c", ["a"]))
     assert find_cycle(ws, downstream="d", new_upstream="b") is None
     assert find_cycle(ws, downstream="d", new_upstream="c") is None
+
+
+def test_cycle_error_carries_path():
+    """CycleError preserves the cycle path for error messages."""
+    err = CycleError(["a", "b", "a"])
+    assert err.path == ["a", "b", "a"]
+    assert "a → b → a" in str(err)

--- a/tests/core/test_task_graph.py
+++ b/tests/core/test_task_graph.py
@@ -93,3 +93,51 @@ def test_cycle_error_carries_path():
     err = CycleError(["a", "b", "a"])
     assert err.path == ["a", "b", "a"]
     assert "a → b → a" in str(err)
+
+
+def test_is_ready_finished_and_merged():
+    """A finished task whose reconcile state is merged is ready."""
+    from mship.core.reconcile.detect import UpstreamState
+    from mship.core.reconcile.gate import Decision
+    from mship.core.task_graph import is_ready
+
+    ws = _ws(_task("a"))
+    ws.tasks["a"].finished_at = _now()
+    decisions = {
+        "a": Decision(slug="a", state=UpstreamState.merged, pr_url=None,
+                      pr_number=None, base=None, merge_commit=None,
+                      updated_at=None),
+    }
+    assert is_ready(ws, "a", decisions) is True
+
+
+def test_is_ready_finished_but_open():
+    """A finished task whose PR is still open is NOT ready."""
+    from mship.core.reconcile.detect import UpstreamState
+    from mship.core.reconcile.gate import Decision
+    from mship.core.task_graph import is_ready
+
+    ws = _ws(_task("a"))
+    ws.tasks["a"].finished_at = _now()
+    decisions = {
+        "a": Decision(slug="a", state=UpstreamState.in_sync, pr_url=None,
+                      pr_number=None, base=None, merge_commit=None,
+                      updated_at=None),
+    }
+    assert is_ready(ws, "a", decisions) is False
+
+
+def test_is_ready_unfinished():
+    """An unfinished task is never ready."""
+    from mship.core.task_graph import is_ready
+
+    ws = _ws(_task("a"))  # finished_at is None
+    assert is_ready(ws, "a", {}) is False
+
+
+def test_is_ready_unknown_task():
+    """Unknown slug returns False."""
+    from mship.core.task_graph import is_ready
+
+    ws = _ws(_task("a"))
+    assert is_ready(ws, "nope", {}) is False

--- a/tests/test_dependency_integration.py
+++ b/tests/test_dependency_integration.py
@@ -1,0 +1,98 @@
+"""End-to-end: spawn → finish-blocked → finish-bypass (#104)."""
+from __future__ import annotations
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.util.shell import ShellResult, ShellRunner
+
+runner = CliRunner()
+
+
+def _shell_run(cmd, cwd, env=None):
+    """Default shell.run side-effect satisfying audit probes cleanly."""
+    if "symbolic-ref" in cmd:
+        return ShellResult(returncode=0, stdout="main\n", stderr="")
+    if "fetch" in cmd:
+        return ShellResult(returncode=0, stdout="", stderr="")
+    if "ls-remote" in cmd:
+        return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+    if "rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
+        return ShellResult(returncode=0, stdout="origin/main\n", stderr="")
+    if "rev-list --count" in cmd:
+        return ShellResult(returncode=0, stdout="0\n", stderr="")
+    if "status --porcelain" in cmd:
+        return ShellResult(returncode=0, stdout="", stderr="")
+    if "worktree list" in cmd:
+        return ShellResult(returncode=0, stdout="worktree /tmp/fake\n", stderr="")
+    if "gh auth status" in cmd:
+        return ShellResult(returncode=0, stdout="Logged in", stderr="")
+    return ShellResult(returncode=0, stdout="", stderr="")
+
+
+@pytest.fixture
+def dep_workspace(workspace_with_git: Path):
+    """workspace_with_git wired into the container with a mocked shell."""
+    state_dir = workspace_with_git / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(workspace_with_git / "mothership.yaml")
+    container.state_dir.override(state_dir)
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = _shell_run
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok\n", stderr="")
+    container.shell.override(mock_shell)
+
+    yield workspace_with_git
+
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override()
+    container.config.reset()
+    container.state_manager.reset_override()
+    container.state_manager.reset()
+    container.shell.reset_override()
+
+
+def test_dependency_flow(dep_workspace):
+    workspace_root = dep_workspace
+
+    # 1. Spawn task-a (no deps).
+    r1 = runner.invoke(app, ["spawn", "task a", "--slug", "a", "--skip-setup", "--force-audit"])
+    assert r1.exit_code == 0, r1.output
+
+    # 2. Spawn task-b depending on a.
+    r2 = runner.invoke(
+        app,
+        ["spawn", "task b", "--slug", "b", "--depends-on", "a", "--skip-setup", "--force-audit"],
+    )
+    assert r2.exit_code == 0, r2.output
+
+    # 3. Status of b shows dependencies.blocked=True and blocked_by=["a"].
+    r3 = runner.invoke(app, ["status", "--task", "b"])
+    assert r3.exit_code == 0, r3.output
+    data = json.loads(r3.stdout)
+    deps = data["resolved_task"]["dependencies"]
+    assert deps["blocked"] is True
+    assert deps["blocked_by"] == ["a"]
+
+    # 4. finish task-b is blocked by the dependency gate.
+    r4 = runner.invoke(app, ["finish", "--task", "b"])
+    err = (r4.output or "").lower()
+    assert ("upstream" in err) or ("blocked" in err), (
+        f"Expected 'upstream' or 'blocked' in output; got: {r4.output!r}"
+    )
+
+    # 5. --bypass-deps clears the deps gate (finish may still fail for other reasons).
+    r5 = runner.invoke(app, ["finish", "--task", "b", "--bypass-deps"])
+    out5 = (r5.output or "").lower()
+    # The specific deps-blocked message must not appear.
+    assert "finish blocked: upstream" not in out5, (
+        f"Expected deps gate to be cleared with --bypass-deps; got: {r5.output!r}"
+    )


### PR DESCRIPTION
## Summary

First-class task-to-task dependency edges. `task B depends_on task A` is now expressed in workspace state (`state.yaml`), and the rest of `mship` reads it:

- **New verb group:** `mship depends add/remove/list (--graph)` to manage edges on existing tasks.
- **`mship spawn --depends-on a,b,...`** declares upstream task(s) at creation. Unknown upstream and cycles are rejected loudly at write time.
- **`mship finish` refuses** to ship a downstream task whose upstream isn't merged. `--bypass-deps` overrides.
- **`mship close --cascade` / `--detach-downstream`** handle the downstream case. Non-TTY refuses without an explicit flag; TTY prompts.
- **`mship status`** exposes the graph at `.resolved_task.dependencies` (upstream / downstream / blocked / blocked_by).
- **`mship dispatch`** includes a `## Dependencies` section in the subagent prompt body, with per-edge ready/not-ready state.
- **`mship reconcile`** grows a `dependency_stale` state — surfaced when a downstream that's otherwise in-sync has an upstream that merged after the downstream was created (i.e. needs rebase).

Closes #104.

## Design and plan

- Spec: `docs/superpowers/specs/2026-05-14-task-dependency-graph-design.md`
- Plan: `docs/superpowers/plans/2026-05-14-task-dependency-graph.md`

## Key design decisions

- **Single edge type** (hard). No soft / advisory edges in v1 — `mship journal` already handles "informed by task-a" relationships.
- **Slug-only endpoints.** External-PR dependencies are a v2 cross-workspace concern.
- **Fan-in is AND** — all upstream must be merged. No OR / alternative-groups.
- **Cycle detection at write time** with explicit cycle-path error.
- **`task_graph.py` is a new module** distinct from `graph.py` (which models repo topology). Mixing the two semantically-different graphs in one module would confuse readers.
- **Backward compatible.** `Task.depends_on` is additive, defaults to `[]`. Existing `state.yaml` files load unchanged.

## What changed on the wire

- `mship status` envelope grows one additive key under `resolved_task`: `dependencies` (upstream/downstream/blocked/blocked_by).
- `mship reconcile` `UpstreamState` enum gains one variant: `dependency_stale`.

Both are additive. No consumer breakage.

## Test plan

- [x] Unit tests for `task_graph.py` — cycle detection (self, 2-node, 3-node, diamond), transitive upstream/downstream, readiness queries.
- [x] CLI tests for `mship depends add/remove/list` — happy path, unknown upstream, self-edge, cycle, idempotent add, missing edge on remove, task-scoped list, --graph DAG output.
- [x] CLI tests for `spawn --depends-on` — persists edges, errors loudly on unknown upstream.
- [x] CLI tests for `finish` — blocked by unready upstream; `--bypass-deps` clears.
- [x] CLI tests for `close` — non-TTY refuses with downstream; `--cascade` removes from state; `--detach-downstream` clears edges.
- [x] CLI tests for `status` — `resolved_task.dependencies` block with correct shape.
- [x] CLI tests for `dispatch` — `## Dependencies` section emitted with readiness signal.
- [x] Tests for `reconcile.dependency_stale` — only overrides `in_sync` decisions, only when upstream merged after downstream created.
- [x] End-to-end integration test: `spawn a → spawn b --depends-on a → status shows blocked → finish blocks → finish --bypass-deps clears`.

**Full test suite: 1235 passed, 0 failures.**

## Known follow-ups (intentionally deferred)

- `status.resolved_task.dependencies.ready` is always `false` for unmerged upstreams (uses an empty reconcile decisions dict to avoid a network round-trip on the hot path). A future change could read the existing `ReconcileCache` to populate readiness without a fetch.
- `--cascade` removes downstream tasks from state but does NOT tear down their worktrees — left to `mship prune`. Documented in the flag's help text.
- `--cascade` doesn't clean reconcile cache entries for removed downstream tasks. Harmless (cache is TTL-bound).
- No GitHub-level "Depends on #N" sync. Mship's graph is mship's; no PR-body integration.
- No automatic rebasing when an upstream merges. `reconcile.dependency_stale` surfaces the need; user runs the rebase.

## Out of scope (v2 concerns)

Multi-agent orchestration, cross-workspace edges, critical-path scheduling, parallel-execution coordination. The graph being a first-class primitive in v1 is the seam these features will sit on top of without speculative design.

Closes #104