### PR TITLE
structured Spec object (MOS-145)

### DIFF
--- a/docs/superpowers/plans/2026-06-13-spec-object.md
+++ b/docs/superpowers/plans/2026-06-13-spec-object.md
@@ -1,0 +1,878 @@
+# Structured Spec Object Implementation Plan (MOS-145)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give mship a first-class, markdown-canonical `Spec` object (frontmatter + body) with a status lifecycle, a registry, a task↔spec pointer, and a migrated `mship spec new` that writes structured specs to `<workspace>/specs/`.
+
+**Architecture:** A `Spec` pydantic model is the in-memory shape; the canonical artifact is a markdown file with YAML frontmatter in `<workspace_root>/specs/YYYY-MM-DD-<id>.md`. `SpecStore` parses/serializes/registers files (no content in `state.yaml`; only a `Task.spec_id` pointer). A central transition map governs `Spec.status`. `find_spec` is extended so `mship view spec` and the dev-gate can resolve specs from `specs/`. Design: [docs/superpowers/specs/2026-06-13-spec-object-design.md](../specs/2026-06-13-spec-object-design.md).
+
+**Tech Stack:** Python, pydantic v2, PyYAML, Typer, pytest. Mirrors the existing `Task`/`StateManager` patterns in `src/mship/core/state.py`.
+
+---
+
+## File structure
+
+- **Create** `src/mship/core/spec.py` — `Spec` model + nested `AcceptanceCriterion`/`OpenQuestion`, `SpecStatus`, the transition map, `validate_transition`. One responsibility: the Spec domain model + its lifecycle rules.
+- **Create** `src/mship/core/spec_store.py` — frontmatter `parse_spec`/`serialize_spec` + `SpecStore` (filesystem registry: save/load/list/find_by_id). One responsibility: Spec persistence + discovery.
+- **Modify** `src/mship/core/state.py` — add `Task.spec_id: str | None`.
+- **Modify** `src/mship/core/view/spec_discovery.py` — extend `find_spec` to resolve `specs/` by id and by `task_slug`.
+- **Modify** `src/mship/cli/spec.py` — repurpose `mship spec new` to write structured specs into `specs/`, task-optional.
+- **Test** `tests/core/test_spec.py` (create), `tests/core/test_spec_store.py` (create), `tests/core/test_state.py` (extend), `tests/core/view/test_spec_discovery.py` (extend), `tests/cli/test_spec.py` (rewrite the `spec new` cases).
+
+Run all tests with: `uv run pytest` (the repo uses `uv`; `testpaths = ["tests"]`).
+
+---
+
+## Task 1: `Spec` model + nested types
+
+**Files:**
+- Create: `src/mship/core/spec.py`
+- Test: `tests/core/test_spec.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/core/test_spec.py
+from datetime import datetime, timezone
+
+from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec
+
+
+def _spec(**kw):
+    now = datetime(2026, 6, 13, tzinfo=timezone.utc)
+    base = dict(id="demo", title="Demo", status="drafting", created_at=now, updated_at=now)
+    base.update(kw)
+    return Spec(**base)
+
+
+def test_spec_defaults_are_empty():
+    s = _spec()
+    assert s.affected_repos == []
+    assert s.acceptance_criteria == []
+    assert s.open_questions == []
+    assert s.non_goals == []
+    assert s.risks == []
+    assert s.task_slug is None
+    assert s.body == ""
+
+
+def test_dispatch_ready_requires_approved_and_no_open_questions():
+    s = _spec(status="approved", open_questions=[OpenQuestion(id="q1", text="?", answer=None)])
+    assert s.dispatch_ready is False
+    s2 = _spec(status="approved", open_questions=[OpenQuestion(id="q1", text="?", answer="yes")])
+    assert s2.dispatch_ready is True
+    s3 = _spec(status="needs_review")
+    assert s3.dispatch_ready is False
+
+
+def test_acceptance_criterion_verdict_defaults_unreviewed():
+    ac = AcceptanceCriterion(id="ac1", text="works")
+    assert ac.verdict == "unreviewed"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/core/test_spec.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'mship.core.spec'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/mship/core/spec.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+SpecStatus = Literal[
+    "captured", "drafting", "needs_review", "needs_clarification",
+    "approved", "dispatched", "implemented", "archived",
+]
+
+
+class AcceptanceCriterion(BaseModel):
+    id: str
+    text: str
+    verdict: Literal["unreviewed", "approved", "flagged"] = "unreviewed"
+
+
+class OpenQuestion(BaseModel):
+    id: str
+    text: str
+    answer: str | None = None
+
+
+class Spec(BaseModel):
+    id: str
+    title: str
+    status: SpecStatus
+    created_at: datetime
+    updated_at: datetime
+    affected_repos: list[str] = []
+    acceptance_criteria: list[AcceptanceCriterion] = []
+    open_questions: list[OpenQuestion] = []
+    non_goals: list[str] = []
+    risks: list[str] = []
+    task_slug: str | None = None
+    body: str = ""
+
+    @property
+    def dispatch_ready(self) -> bool:
+        return self.status == "approved" and all(
+            q.answer is not None for q in self.open_questions
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/core/test_spec.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit (pair with `mship journal` in a mothership workspace)**
+
+```bash
+git add src/mship/core/spec.py tests/core/test_spec.py
+git commit -m "feat(spec): add Spec model + nested acceptance/question types"
+mship journal "added Spec pydantic model + dispatch_ready; unit tests passing" --action committed
+```
+
+---
+
+## Task 2: Status transition map + validator
+
+**Files:**
+- Modify: `src/mship/core/spec.py`
+- Test: `tests/core/test_spec.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/core/test_spec.py (append)
+import pytest
+
+from mship.core.spec import InvalidTransition, can_transition, validate_transition
+
+
+@pytest.mark.parametrize("current,target", [
+    ("captured", "drafting"),
+    ("drafting", "needs_review"),
+    ("needs_review", "approved"),
+    ("needs_review", "needs_clarification"),
+    ("needs_clarification", "needs_review"),
+    ("approved", "dispatched"),
+    ("approved", "needs_clarification"),   # re-open
+    ("dispatched", "implemented"),
+    ("implemented", "archived"),
+    ("drafting", "archived"),              # abandon from any non-terminal
+    ("approved", "archived"),              # abandon
+])
+def test_legal_transitions_allowed(current, target):
+    assert can_transition(current, target) is True
+    validate_transition(current, target)  # must not raise
+
+
+@pytest.mark.parametrize("current,target", [
+    ("captured", "approved"),     # skips drafting/review
+    ("drafting", "dispatched"),   # skips review/approval
+    ("archived", "drafting"),     # terminal
+    ("approved", "approved"),     # no-op
+])
+def test_illegal_transitions_rejected(current, target):
+    assert can_transition(current, target) is False
+    with pytest.raises(InvalidTransition):
+        validate_transition(current, target)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/core/test_spec.py -k transition -v`
+Expected: FAIL — `ImportError: cannot import name 'InvalidTransition'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/mship/core/spec.py (append)
+TERMINAL_STATUSES: set[str] = {"archived"}
+
+ALLOWED_TRANSITIONS: dict[str, set[str]] = {
+    "captured": {"drafting"},
+    "drafting": {"needs_review"},
+    "needs_review": {"needs_clarification", "approved"},
+    "needs_clarification": {"needs_review", "drafting"},
+    "approved": {"dispatched", "needs_clarification"},
+    "dispatched": {"implemented"},
+    "implemented": {"archived"},
+    "archived": set(),
+}
+
+
+class InvalidTransition(Exception):
+    pass
+
+
+def can_transition(current: str, target: str) -> bool:
+    if current == target:
+        return False
+    # Abandon: any non-terminal status may jump to archived.
+    if target == "archived" and current not in TERMINAL_STATUSES:
+        return True
+    return target in ALLOWED_TRANSITIONS.get(current, set())
+
+
+def validate_transition(current: str, target: str) -> None:
+    if not can_transition(current, target):
+        raise InvalidTransition(f"illegal spec transition: {current} -> {target}")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/core/test_spec.py -v`
+Expected: PASS (all Task 1 + Task 2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/spec.py tests/core/test_spec.py
+git commit -m "feat(spec): add status transition map + validate_transition"
+mship journal "added spec lifecycle transition validator (incl. abandon edge); tests passing" --action committed
+```
+
+---
+
+## Task 3: Frontmatter parse / serialize
+
+**Files:**
+- Create: `src/mship/core/spec_store.py`
+- Test: `tests/core/test_spec_store.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/core/test_spec_store.py
+from datetime import datetime, timezone
+
+from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec
+from mship.core.spec_store import SpecParseError, parse_spec, serialize_spec
+
+
+def _spec():
+    now = datetime(2026, 6, 13, 10, 0, 0, tzinfo=timezone.utc)
+    return Spec(
+        id="decision-queue", title="Decision queue", status="needs_review",
+        created_at=now, updated_at=now,
+        affected_repos=["mothership", "ground-control"],
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="view questions")],
+        open_questions=[OpenQuestion(id="q1", text="Android in v0?")],
+        non_goals=["chat"],
+        body="## Problem\n\nAgents block away from the desk.\n",
+    )
+
+
+def test_round_trip_is_identity():
+    s = _spec()
+    assert parse_spec(serialize_spec(s)) == s
+
+
+def test_body_is_preserved_verbatim():
+    s = _spec()
+    parsed = parse_spec(serialize_spec(s))
+    assert parsed.body == "## Problem\n\nAgents block away from the desk.\n"
+
+
+def test_missing_frontmatter_raises():
+    import pytest
+    with pytest.raises(SpecParseError):
+        parse_spec("# just markdown, no frontmatter\n")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/core/test_spec_store.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'mship.core.spec_store'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/mship/core/spec_store.py
+from __future__ import annotations
+
+import yaml
+
+from mship.core.spec import Spec
+
+
+class SpecParseError(Exception):
+    pass
+
+
+def parse_spec(text: str) -> Spec:
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        raise SpecParseError("spec file missing YAML frontmatter")
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        raise SpecParseError("unterminated YAML frontmatter")
+    fm_text = "".join(lines[1:end])
+    body = "".join(lines[end + 1:])
+    data = yaml.safe_load(fm_text) or {}
+    return Spec(**data, body=body)
+
+
+def serialize_spec(spec: Spec) -> str:
+    data = spec.model_dump(mode="json", exclude={"body"})
+    fm = yaml.safe_dump(data, sort_keys=False, default_flow_style=False)
+    return f"---\n{fm}---\n{spec.body}"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/core/test_spec_store.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/spec_store.py tests/core/test_spec_store.py
+git commit -m "feat(spec): markdown frontmatter parse/serialize with round-trip fidelity"
+mship journal "spec frontmatter parse/serialize round-trips; body preserved verbatim" --action committed
+```
+
+---
+
+## Task 4: `SpecStore` registry (save / load / list / find_by_id)
+
+**Files:**
+- Modify: `src/mship/core/spec_store.py`
+- Test: `tests/core/test_spec_store.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/core/test_spec_store.py (append)
+from pathlib import Path
+
+from mship.core.spec_store import SpecStore
+
+
+def _new_spec(spec_id: str):
+    now = datetime(2026, 6, 13, tzinfo=timezone.utc)
+    return Spec(id=spec_id, title=spec_id, status="drafting", created_at=now, updated_at=now)
+
+
+def test_save_then_find_by_id(tmp_path: Path):
+    store = SpecStore(tmp_path / "specs")
+    path = store.save(_new_spec("alpha"))
+    assert path.name == "2026-06-13-alpha.md"
+    assert path.is_file()
+    found = store.find_by_id("alpha")
+    assert found is not None and found.id == "alpha"
+
+
+def test_find_by_id_is_exact_not_mtime(tmp_path: Path):
+    store = SpecStore(tmp_path / "specs")
+    store.save(_new_spec("alpha"))
+    store.save(_new_spec("beta"))   # newer mtime
+    # Exact id match, not newest-by-mtime (subsumes MOS-140).
+    assert store.find_by_id("alpha").id == "alpha"
+
+
+def test_list_returns_all(tmp_path: Path):
+    store = SpecStore(tmp_path / "specs")
+    store.save(_new_spec("alpha"))
+    store.save(_new_spec("beta"))
+    assert sorted(s.id for s in store.list()) == ["alpha", "beta"]
+
+
+def test_find_by_id_missing_returns_none(tmp_path: Path):
+    assert SpecStore(tmp_path / "specs").find_by_id("nope") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/core/test_spec_store.py -k "save or find or list" -v`
+Expected: FAIL — `ImportError: cannot import name 'SpecStore'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/mship/core/spec_store.py (append)
+import tempfile
+from pathlib import Path
+
+
+class SpecStore:
+    """Filesystem registry for markdown-canonical specs under `specs/`."""
+
+    def __init__(self, specs_dir: Path) -> None:
+        self._dir = Path(specs_dir)
+
+    def path_for(self, spec: Spec) -> Path:
+        return self._dir / f"{spec.created_at:%Y-%m-%d}-{spec.id}.md"
+
+    def save(self, spec: Spec) -> Path:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        path = self.path_for(spec)
+        fd, tmp = tempfile.mkstemp(dir=self._dir, suffix=".md.tmp")
+        try:
+            with open(fd, "w") as f:
+                f.write(serialize_spec(spec))
+            Path(tmp).replace(path)
+        except Exception:
+            Path(tmp).unlink(missing_ok=True)
+            raise
+        return path
+
+    def load(self, path: Path) -> Spec:
+        return parse_spec(Path(path).read_text())
+
+    def list(self) -> list[Spec]:
+        if not self._dir.is_dir():
+            return []
+        return [self.load(p) for p in sorted(self._dir.glob("*.md"))]
+
+    def find_by_id(self, spec_id: str) -> Spec | None:
+        for spec in self.list():
+            if spec.id == spec_id:
+                return spec
+        return None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/core/test_spec_store.py -v`
+Expected: PASS (all Task 3 + Task 4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/spec_store.py tests/core/test_spec_store.py
+git commit -m "feat(spec): SpecStore registry with atomic save + exact id lookup"
+mship journal "SpecStore save/list/find_by_id; id match is exact (subsumes #140 for specs/)" --action committed
+```
+
+---
+
+## Task 5: `Task.spec_id` pointer
+
+**Files:**
+- Modify: `src/mship/core/state.py:19-37` (the `Task` model)
+- Test: `tests/core/test_state.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/core/test_state.py (append)
+def test_task_spec_id_defaults_none():
+    from datetime import datetime, timezone
+    from mship.core.state import Task
+    t = Task(
+        slug="t", description="d", phase="plan",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["a"], branch="feat/t",
+    )
+    assert t.spec_id is None
+
+
+def test_task_spec_id_round_trips(tmp_path):
+    from datetime import datetime, timezone
+    from mship.core.state import StateManager, Task, WorkspaceState
+    sm = StateManager(tmp_path)
+    sm.save(WorkspaceState(tasks={"t": Task(
+        slug="t", description="d", phase="plan",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["a"], branch="feat/t", spec_id="decision-queue",
+    )}))
+    assert sm.load().tasks["t"].spec_id == "decision-queue"
+
+
+def test_legacy_state_without_spec_id_loads(tmp_path):
+    """Old state.yaml (no spec_id key) loads cleanly (default None)."""
+    import yaml
+    from mship.core.state import StateManager
+    (tmp_path / "state.yaml").write_text(yaml.safe_dump({
+        "tasks": {"t": {
+            "slug": "t", "description": "d", "phase": "dev",
+            "created_at": "2026-04-10T00:00:00+00:00",
+            "affected_repos": ["a"], "branch": "feat/t",
+        }}
+    }))
+    assert StateManager(tmp_path).load().tasks["t"].spec_id is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/core/test_state.py -k spec_id -v`
+Expected: FAIL — `AttributeError: 'Task' object has no attribute 'spec_id'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/mship/core/state.py`, add one field to `Task` (after `passive_repos`):
+
+```python
+    passive_repos: set[str] = set()
+    spec_id: str | None = None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/core/test_state.py -v`
+Expected: PASS (existing + 3 new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/state.py tests/core/test_state.py
+git commit -m "feat(spec): add Task.spec_id pointer (back-compat default None)"
+mship journal "Task.spec_id pointer added; legacy state.yaml loads cleanly" --action committed
+```
+
+---
+
+## Task 6: Extend `find_spec` to resolve `specs/`
+
+**Files:**
+- Modify: `src/mship/core/view/spec_discovery.py:24-71` (the `find_spec` function) + add a helper
+- Test: `tests/core/view/test_spec_discovery.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/core/view/test_spec_discovery.py (append)
+from datetime import datetime, timezone
+from pathlib import Path
+
+from mship.core.spec import Spec
+from mship.core.spec_store import SpecStore
+from mship.core.view.spec_discovery import find_spec
+
+
+def _seed(tmp_path: Path, spec_id: str, task_slug=None) -> Path:
+    now = datetime(2026, 6, 13, tzinfo=timezone.utc)
+    store = SpecStore(tmp_path / "specs")
+    return store.save(Spec(
+        id=spec_id, title=spec_id, status="drafting",
+        created_at=now, updated_at=now, task_slug=task_slug,
+    ))
+
+
+def test_find_spec_resolves_specs_dir_by_id(tmp_path: Path):
+    path = _seed(tmp_path, "decision-queue")
+    assert find_spec(tmp_path, "decision-queue") == path
+
+
+def test_find_spec_resolves_specs_dir_by_task_slug(tmp_path: Path):
+    from mship.core.state import Task, WorkspaceState
+    path = _seed(tmp_path, "decision-queue", task_slug="dq")
+    state = WorkspaceState(tasks={"dq": Task(
+        slug="dq", description="d", phase="plan",
+        created_at=datetime(2026, 6, 13, tzinfo=timezone.utc),
+        affected_repos=["a"], branch="feat/dq",
+    )})
+    assert find_spec(tmp_path, None, task="dq", state=state) == path
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/core/view/test_spec_discovery.py -k specs_dir -v`
+Expected: FAIL — `SpecNotFoundError` (specs/ not consulted yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the helper + constant near the top of `src/mship/core/view/spec_discovery.py`:
+
+```python
+SPECS_DIR = Path("specs")
+
+
+def _find_in_specs_dir(workspace_root: Path, *, spec_id=None, task_slug=None):
+    """Return the path of a spec file in `<workspace_root>/specs` matching
+    `spec_id` (frontmatter id) or `task_slug` (bound task), else None."""
+    from mship.core.spec_store import SpecParseError, parse_spec
+    specs_dir = workspace_root / SPECS_DIR
+    if not specs_dir.is_dir():
+        return None
+    for p in sorted(specs_dir.glob("*.md")):
+        try:
+            spec = parse_spec(p.read_text())
+        except SpecParseError:
+            continue
+        if spec_id is not None and spec.id == spec_id:
+            return p
+        if task_slug is not None and spec.task_slug == task_slug:
+            return p
+    return None
+```
+
+Then wire it into `find_spec`. After the blessed-path block (the `if task is not None and name_or_path is None:` clause) add a `specs/` lookup, and add an id lookup for the named case. The function becomes:
+
+```python
+def find_spec(workspace_root, name_or_path, *, task=None, state=None, spec_paths=None):
+    if name_or_path is not None:
+        candidate = Path(name_or_path)
+        if candidate.is_absolute():
+            if candidate.is_file():
+                return candidate
+            raise SpecNotFoundError(f"Spec not found: {name_or_path}")
+
+    if task is not None and name_or_path is None:
+        blessed = blessed_spec_path(workspace_root, task)
+        if blessed.is_file():
+            return blessed
+        in_specs = _find_in_specs_dir(workspace_root, task_slug=task)
+        if in_specs is not None:
+            return in_specs
+
+    if name_or_path is not None:
+        by_id = _find_in_specs_dir(workspace_root, spec_id=name_or_path)
+        if by_id is not None:
+            return by_id
+
+    search_roots = _resolve_search_roots(workspace_root, task, state, spec_paths)
+
+    if name_or_path is None:
+        return _newest_across(search_roots, task)
+
+    for root in search_roots:
+        for candidate_name in (name_or_path, f"{name_or_path}.md"):
+            p = root / candidate_name
+            if p.is_file():
+                return p
+
+    available_msg = _available_msg(search_roots)
+    where = f"task {task!r}" if task else "any known location"
+    raise SpecNotFoundError(f"Spec not found: {name_or_path!r} (searched {where}).{available_msg}")
+```
+
+(The blessed-path precedence and all legacy fallbacks are unchanged; `specs/` is consulted *after* the blessed path and *before* the newest-by-mtime fallback.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/core/view/test_spec_discovery.py -v`
+Expected: PASS (existing discovery tests + 2 new). The pre-existing blessed-path test still passes (precedence preserved).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/view/spec_discovery.py tests/core/view/test_spec_discovery.py
+git commit -m "feat(spec): find_spec resolves specs/ by id and task_slug"
+mship journal "find_spec now discovers specs/ (by id + task binding); blessed precedence intact" --action committed
+```
+
+---
+
+## Task 7: Migrate `mship spec new` to structured specs in `specs/`
+
+**Files:**
+- Modify: `src/mship/cli/spec.py` (replace `SPEC_TEMPLATE`/`render_template`/`new`; remove now-dead helpers)
+- Test: `tests/cli/test_spec.py` (rewrite the `spec new` cases)
+
+- [ ] **Step 1: Confirm no external importers of the dead helpers**
+
+Run: `rg -n "render_template|SPEC_TEMPLATE|from mship.cli.spec import" src tests`
+Expected: only references inside `src/mship/cli/spec.py` itself (safe to remove). If anything else imports them, leave a thin shim — do not break it.
+
+- [ ] **Step 2: Rewrite the failing tests**
+
+Replace the five `test_spec_new_*` tests (the blessed-path ones) in `tests/cli/test_spec.py` with the new contract. Keep the `find_spec`/gate tests (`test_find_spec_discovers_blessed_path_when_task_set`, `test_gate_dev_*`) untouched — blessed-path behavior is still valid.
+
+```python
+# tests/cli/test_spec.py — replace the test_spec_new_* block with:
+from mship.core.spec_store import SpecStore
+
+
+def _store(workspace: Path) -> SpecStore:
+    return SpecStore(workspace / "specs")
+
+
+def test_spec_new_creates_structured_file(configured_app_with_task: Path):
+    result = runner.invoke(app, ["spec", "new", "--title", "Add labels"])
+    assert result.exit_code == 0, result.output
+    spec = _store(configured_app_with_task).find_by_id("add-labels")
+    assert spec is not None
+    assert spec.status == "drafting"
+    assert spec.title == "Add labels"
+    assert "## Problem" in spec.body
+
+
+def test_spec_new_with_task_prefills_repos_and_binds(configured_app_with_task: Path):
+    result = runner.invoke(app, ["spec", "new", "--task", "add-labels"])
+    assert result.exit_code == 0, result.output
+    spec = _store(configured_app_with_task).find_by_id("add-labels")
+    assert spec is not None
+    assert spec.task_slug == "add-labels"
+    assert spec.affected_repos == ["shared", "auth-service"]
+    assert spec.title == "Add labels to tasks"
+
+
+def test_spec_new_requires_title_or_task(configured_app_with_task: Path):
+    result = runner.invoke(app, ["spec", "new"])
+    assert result.exit_code != 0
+    assert "title" in result.output.lower()
+
+
+def test_spec_new_refuses_existing(configured_app_with_task: Path):
+    runner.invoke(app, ["spec", "new", "--title", "Add labels"])
+    result = runner.invoke(app, ["spec", "new", "--title", "Add labels"])
+    assert result.exit_code != 0
+    assert "exists" in result.output.lower() or "already" in result.output.lower()
+
+
+def test_spec_new_force_overwrites(configured_app_with_task: Path):
+    runner.invoke(app, ["spec", "new", "--title", "Add labels"])
+    result = runner.invoke(app, ["spec", "new", "--title", "Add labels", "--force"])
+    assert result.exit_code == 0, result.output
+
+
+def test_spec_new_unknown_task_errors(configured_app_with_task: Path):
+    result = runner.invoke(app, ["spec", "new", "--task", "nope"])
+    assert result.exit_code != 0
+    assert "nope" in result.output
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/cli/test_spec.py -k spec_new -v`
+Expected: FAIL — old `new` writes the blessed path / requires `--task`; new assertions about `specs/` + `--title` don't hold yet.
+
+- [ ] **Step 4: Implement the migrated command**
+
+Replace the body of `src/mship/cli/spec.py` from `SPEC_TEMPLATE` through the `new` command with:
+
+```python
+SPEC_BODY_TEMPLATE = """\
+## Problem
+
+_What problem does this solve? Why now?_
+
+## User story
+
+_As a <user>, I want <capability>, so that <benefit>._
+
+## Approach
+
+_How will it work? Key decisions._
+"""
+
+
+def register(parent: typer.Typer, get_container):
+    spec_app = typer.Typer(
+        name="spec",
+        help="Manage structured specs (`<workspace>/specs/<date>-<id>.md`).",
+        no_args_is_help=True,
+    )
+
+    @spec_app.command("new")
+    def new(
+        title: Optional[str] = typer.Option(None, "--title", help="Spec title (required unless --task is given)."),
+        spec_id: Optional[str] = typer.Option(None, "--id", help="Stable spec id (slug). Defaults to a slug of the title."),
+        task_opt: Optional[str] = typer.Option(None, "--task", help="Bind to an existing task: prefill affected_repos + task_slug."),
+        force: bool = typer.Option(False, "--force", "-f", help="Overwrite an existing spec file."),
+    ):
+        """Create a structured spec at `<workspace>/specs/YYYY-MM-DD-<id>.md`."""
+        from mship.core.spec import Spec
+        from mship.core.spec_store import SpecStore
+        from mship.util.slug import slugify
+
+        container = get_container()
+        output = Output()
+        workspace_root = Path(container.config_path()).parent
+        store = SpecStore(workspace_root / "specs")
+
+        affected_repos: list[str] = []
+        task_slug: Optional[str] = None
+        if task_opt is not None:
+            state = container.state_manager().load()
+            if task_opt not in state.tasks:
+                known = ", ".join(sorted(state.tasks)) or "(none)"
+                output.error(f"Unknown task: {task_opt}. Known: {known}.")
+                raise typer.Exit(1)
+            t = state.tasks[task_opt]
+            affected_repos = list(t.affected_repos)
+            task_slug = t.slug
+            if title is None:
+                title = t.description
+            if spec_id is None:
+                spec_id = t.slug
+
+        if title is None:
+            output.error("Provide --title (or --task to derive it).")
+            raise typer.Exit(1)
+        if spec_id is None:
+            spec_id = slugify(title)
+
+        now = datetime.now(timezone.utc)
+        spec = Spec(
+            id=spec_id, title=title, status="drafting",
+            created_at=now, updated_at=now,
+            affected_repos=affected_repos, task_slug=task_slug,
+            body=SPEC_BODY_TEMPLATE,
+        )
+        path = store.path_for(spec)
+        if path.exists() and not force:
+            output.error(f"Spec already exists: {path}\n  Pass --force to overwrite.")
+            raise typer.Exit(1)
+        store.save(spec)
+
+        if output.is_tty:
+            output.success(f"Created spec: {path}")
+            output.print("[dim]Edit the prose; lifecycle commands (draft/review/approve) follow.[/dim]")
+        else:
+            output.json({
+                "id": spec.id, "path": str(path),
+                "status": spec.status, "task_slug": task_slug,
+            })
+
+    parent.add_typer(spec_app)
+```
+
+Delete the now-unused `SPEC_TEMPLATE`, `render_template`, and `blessed_spec_path` from `src/mship/cli/spec.py`, plus the `resolve_for_command` import if Step 1 confirmed nothing else uses them. (The `blessed_spec_path` used by discovery lives in `spec_discovery.py` and is untouched.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/cli/test_spec.py -v`
+Expected: PASS — new `spec_new` tests pass; the retained `find_spec`/gate tests still pass.
+
+- [ ] **Step 6: Run the full suite (no regressions)**
+
+Run: `uv run pytest`
+Expected: PASS. If any unrelated test imported the deleted helpers, fix per Step 1.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/mship/cli/spec.py tests/cli/test_spec.py
+git commit -m "feat(spec): migrate 'mship spec new' to structured specs/ (task-optional)"
+mship journal "mship spec new writes structured frontmatter specs to specs/; task-optional" --action committed
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (design doc → task):
+- Data model / frontmatter schema → Task 1 (model), Task 3 (frontmatter).
+- Status lifecycle + transition map → Task 2.
+- Relationship to Task (`spec_id`/`task_slug`) → Task 5 (`Task.spec_id`); `task_slug` is on `Spec` (Task 1) and set by `spec new --task` (Task 7).
+- Discovery / registry → Task 4 (`SpecStore`), Task 6 (`find_spec`).
+- `mship spec new` migration (task-optional) → Task 7.
+- Migration/back-compat → Task 5 (legacy state.yaml), Task 6 (blessed + legacy paths retained).
+- Testing (round-trip, transition, registry, back-compat) → Tasks 1–7.
+
+**Out of scope (correct — separate issues):** `spec draft` agent boundary (A2), review-unit emission (A3), questions (A4), approve (A5), dispatch wiring + the `approved→dispatched`/`dispatched→implemented` boundary writes (A6), serve API (B1), dev-gate *requiring* an approved spec (A7).
+
+**Placeholder scan:** none — every code step shows complete code; prose-template underscores are intentional file content.
+
+**Type consistency:** `Spec`, `AcceptanceCriterion`, `OpenQuestion`, `SpecStatus`, `InvalidTransition`, `can_transition`/`validate_transition`, `parse_spec`/`serialize_spec`, `SpecStore.{path_for,save,load,list,find_by_id}`, `Task.spec_id` — names are consistent across tasks.
+
+---
+
+## Execution Handoff
+
+Implement in a dedicated worktree. **First step before any code:** `mship spawn` a task for MOS-145 (this is real work in the `mothership` repo, and we're on `main`).

--- a/docs/superpowers/specs/2026-06-13-spec-object-design.md
+++ b/docs/superpowers/specs/2026-06-13-spec-object-design.md
@@ -1,0 +1,187 @@
+# Structured Spec object — design (MOS-145)
+
+> Status: design approved 2026-06-13. Feeds `writing-plans`.
+> Part of the **Ground Control** initiative (Linear epic MOS-144). This is the
+> keystone every other workstream-A/B/C issue depends on.
+
+## Context
+
+Ground Control's loop is `capture → draft → review → approve → dispatch`. That
+requires **Specs as first-class objects** that exist *before* any task and carry
+structured fields (status, acceptance criteria, open questions) so a mobile
+review surface and a serve API can drive them.
+
+Today mship has none of that:
+
+- `mship spec new` scaffolds a **freeform** markdown stub at the task-scoped
+  blessed path `.mothership/tasks/<slug>/SPEC.md` (`src/mship/cli/spec.py`).
+- Specs are resolved by `find_spec` (`src/mship/core/view/spec_discovery.py`)
+  with a newest-by-mtime fallback (the MOS-140 bug).
+- `WorkspaceState` (`src/mship/core/state.py`) holds structured `Task` objects in
+  `.mothership/state.yaml` (atomic write + flock); there is **no** Spec model and
+  specs are **task-scoped** — you need a task first.
+
+This issue (A1) builds the structured Spec substrate. The verbs that consume it —
+`spec draft` (A2 / MOS-146), `spec review` (A3 / MOS-147), `spec questions`
+(A4 / MOS-148), `spec approve` (A5 / MOS-149), `dispatch --spec` (A6 / MOS-150) —
+are separate issues.
+
+## Decisions (and rationale)
+
+1. **Source of truth: markdown-canonical.** A Spec is a markdown file with YAML
+   frontmatter; mship parses (and writes) it. Keeps specs git-diffable,
+   PR-reviewable, and human-authored — consistent with the existing
+   `docs/superpowers/specs` convention. mship state never duplicates spec
+   content (no divergence).
+
+2. **Location: a dedicated `specs/` dir at the workspace root.** Live,
+   lifecycle-tracked Specs live in `<workspace_root>/specs/`, distinct from the
+   freeform design docs in `docs/superpowers/specs` (which remain brainstorming
+   *inputs* a `spec draft` can consume). The registry is a scan of `specs/`.
+
+3. **Branch convention (resolves MOS-141): specs are workspace-level.** Because
+   `specs/` lives at the workspace-repo root, and feature branches are cut in the
+   **member** repos (not the workspace repo), the "which branch is the spec on"
+   ambiguity dissolves — specs sit on the workspace repo's default branch,
+   independent of member-repo branches. Specs are captured before any task/branch
+   exists; dispatch cuts the member-repo branch *from* current state.
+
+4. **Lifecycle: Spec.status and Task.phase are independent, synced at two
+   boundaries.** Spec.status owns pre-task shaping; `Task.phase`
+   (plan/dev/review/run) owns execution. They touch only at **dispatch**
+   (`approved → dispatched`, create task) and **finish** (`dispatched →
+   implemented`). Post-dispatch, Spec.status is a coarse overlay, not a mirror of
+   phase.
+
+## Data model
+
+A `Spec` is parsed from frontmatter (pydantic model, mirroring the `Task`
+pattern). Body prose is preserved verbatim and round-tripped.
+
+```yaml
+---
+id: ground-control-decision-queue     # stable kebab id; also the filename slug
+title: Ground Control decision queue
+status: needs_review
+created_at: 2026-06-13T10:00:00Z
+updated_at: 2026-06-13T11:30:00Z
+affected_repos: [mothership, ground-control]
+acceptance_criteria:
+  - { id: ac1, text: "User can view blocking questions", verdict: unreviewed }
+  - { id: ac2, text: "Answer is recorded in mship journal", verdict: approved }
+open_questions:
+  - { id: q1, text: "Android in v0?", answer: null }   # answer: null = open
+non_goals: ["real-time chat", "mobile IDE"]
+risks: ["voice in v0 expands scope"]
+task_slug: null                        # set at dispatch (task pointer)
+---
+
+## Problem
+<prose>
+## User story
+<prose>
+## Approach
+<prose>
+```
+
+Field notes:
+
+- `acceptance_criteria[].verdict ∈ {unreviewed, approved, flagged}` — addressable
+  review units for A3.
+- `open_questions[].answer = null` means open — gates approval (A5).
+- `dispatch_ready` is **derived** (`status == approved` ∧ no open questions), not
+  stored, so it can't drift.
+- Filename `specs/YYYY-MM-DD-<id>.md`; `id` is also in frontmatter so discovery
+  never has to guess by mtime.
+
+## Status lifecycle
+
+```
+captured → drafting → needs_review ⇄ needs_clarification
+                          │
+                          ▼
+                       approved ──(dispatch)──► dispatched ──► implemented ──► archived
+                          ▲                                                       ▲
+                          └──────(re-open / request-changes)                      │
+   any non-terminal ──────────────────(abandon)─────────────────────────────────┘
+```
+
+A central transition map is the single authority; illegal transitions raise.
+Allowed edges:
+
+| From | To |
+|------|----|
+| captured | drafting |
+| drafting | needs_review |
+| needs_review | needs_clarification, approved |
+| needs_clarification | needs_review, drafting |
+| approved | dispatched, needs_clarification *(re-open)* |
+| dispatched | implemented |
+| implemented | archived |
+| *any non-terminal* | archived *(abandon)* |
+
+`approved → dispatched` is performed **only** by `mship dispatch --spec` (A6);
+`dispatched → implemented` only by `mship finish`. No other path crosses the
+spec/task boundary.
+
+## Relationship to Task
+
+- `Task` gains `spec_id: str | None` (default `None`); the spec frontmatter gains
+  `task_slug: str | None`. Both set at dispatch — a **bidirectional pointer, not
+  duplicated content**.
+- Backward-compatible: old `state.yaml` loads cleanly (pydantic default +
+  existing `extra="ignore"` on `WorkspaceState`).
+
+## Discovery / registry
+
+- Registry = scan `<workspace_root>/specs/*.md`, parse frontmatter, key by `id`.
+  Exact-`id` match is authoritative — **subsumes the MOS-140 newest-by-mtime bug**
+  for the new dir.
+- `mship view spec` is extended to resolve from `specs/` by id. Legacy paths
+  (`docs/superpowers/specs`, `.mothership/tasks/<slug>/SPEC.md`) stay supported.
+
+## Scope of this issue (A1)
+
+A1 ships the **substrate only**:
+
+- `Spec` pydantic model.
+- `parse_spec(path) → Spec` and `write_spec(Spec) → path` with faithful
+  frontmatter round-trip (body preserved verbatim).
+- Registry scan + id lookup.
+- Transition validator (the table above).
+- `Task.spec_id` field + back-compat load.
+- `mship spec new` migrated to emit the new frontmatter format into `specs/`
+  (keeps the command; changes template + location). **Now task-optional:** with
+  no resolvable task it creates a standalone spec (`status: drafting`); when a
+  task *is* resolvable it prefills `affected_repos` + binds `task_slug`. (Rich
+  creation/`draft` is A2 — A1 only needs a working create path to exercise the
+  model.)
+- Atomic file writes (tmp + replace, mirroring `StateManager`); the `task↔spec`
+  pointer in `state.yaml` uses the existing locked `mutate`.
+
+**Out of scope (separate issues):** `spec draft` agent boundary (A2), review-unit
+emission (A3), questions (A4), approve/request-changes (A5), dispatch wiring (A6),
+the serve API (B1).
+
+## Migration & back-compat
+
+- Legacy freeform specs remain *readable* by `mship view spec`; **no forced
+  migration**. An optional `mship spec import` can follow later.
+- The 54 historical design docs in `docs/superpowers/specs` stay as freeform
+  brainstorming inputs.
+
+## Testing
+
+- **Unit:** frontmatter round-trip is identity (parse→write→parse, body
+  preserved); transition validator accepts every legal edge and rejects every
+  illegal one; registry scan + id match; `Task.spec_id` back-compat load of old
+  `state.yaml`.
+- **Integration:** `mship spec new` produces a valid frontmatter'd file in
+  `specs/`; a status transition updates frontmatter atomically.
+
+## Follow-ons
+
+- MOS-141 is effectively resolved by decision (3); close it with a note pointing
+  here, or fold its docs change into this work.
+- MOS-140's fix is subsumed for `specs/`; the legacy `docs/superpowers/specs`
+  newest-by-mtime path can still get the filename-match fix independently.

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -1,104 +1,100 @@
-"""`mship spec` sub-app: scaffold and manage per-task spec files.
+"""`mship spec` sub-app: scaffold and manage structured spec files.
 
-The blessed location is `<workspace>/.mothership/tasks/<slug>/SPEC.md` —
-mship-private, task-scoped, easy for the dev-phase gate to check. See #126.
+Specs live at `<workspace>/specs/YYYY-MM-DD-<id>.md` — workspace-level,
+task-optional, frontmatter-structured. See #145.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from pathlib import Path
 from typing import Optional
 
 import typer
 
-from mship.cli._resolve import resolve_for_command
 from mship.cli.output import Output
 
 
-SPEC_TEMPLATE = """\
-# Spec: {slug}
+SPEC_BODY_TEMPLATE = """\
+## Problem
 
-**Description:** {description}
-**Created:** {created}
-**Affected repos:** {repos}
+_What problem does this solve? Why now?_
 
-## Goals
+## User story
 
-_What outcome does this task produce? Why does it matter?_
+_As a <user>, I want <capability>, so that <benefit>._
 
 ## Approach
 
-_How will the implementation work? What are the key decisions?_
-
-## Acceptance criteria
-
-- [ ] _what success looks like, in user-visible terms_
+_How will it work? Key decisions._
 """
-
-
-def blessed_spec_path(state_dir: Path, slug: str) -> Path:
-    """The mship-blessed task-scoped spec location."""
-    return state_dir / "tasks" / slug / "SPEC.md"
-
-
-def render_template(slug: str, description: str, repos: list[str]) -> str:
-    return SPEC_TEMPLATE.format(
-        slug=slug,
-        description=description,
-        created=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-        repos=", ".join(repos) if repos else "(none)",
-    )
 
 
 def register(parent: typer.Typer, get_container):
     spec_app = typer.Typer(
         name="spec",
-        help="Manage per-task specs (`.mothership/tasks/<slug>/SPEC.md`).",
+        help="Manage structured specs (`<workspace>/specs/<date>-<id>.md`).",
         no_args_is_help=True,
     )
 
     @spec_app.command("new")
     def new(
-        force: bool = typer.Option(
-            False, "--force", "-f",
-            help="Overwrite an existing spec at the blessed path.",
-        ),
-        task_opt: Optional[str] = typer.Option(
-            None, "--task",
-            help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var.",
-        ),
+        title: Optional[str] = typer.Option(None, "--title", help="Spec title (required unless --task is given)."),
+        spec_id: Optional[str] = typer.Option(None, "--id", help="Stable spec id (slug). Defaults to a slug of the title."),
+        task_opt: Optional[str] = typer.Option(None, "--task", help="Bind to an existing task: prefill affected_repos + task_slug."),
+        force: bool = typer.Option(False, "--force", "-f", help="Overwrite an existing spec file."),
     ):
-        """Scaffold a stub spec at `.mothership/tasks/<slug>/SPEC.md`."""
+        """Create a structured spec at `<workspace>/specs/YYYY-MM-DD-<id>.md`."""
+        from datetime import datetime, timezone
+        from pathlib import Path
+        from mship.core.spec import Spec
+        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
+        from mship.util.slug import slugify
+
         container = get_container()
         output = Output()
-        state_mgr = container.state_manager()
-        state = state_mgr.load()
+        workspace_root = Path(container.config_path()).parent
+        store = SpecStore(workspace_root / SPECS_DIRNAME)
 
-        resolved = resolve_for_command("spec new", state, task_opt, output)
-        t = resolved.task
+        affected_repos: list[str] = []
+        task_slug: Optional[str] = None
+        if task_opt is not None:
+            state = container.state_manager().load()
+            if task_opt not in state.tasks:
+                known = ", ".join(sorted(state.tasks)) or "(none)"
+                output.error(f"Unknown task: {task_opt}. Known: {known}.")
+                raise typer.Exit(1)
+            t = state.tasks[task_opt]
+            affected_repos = list(t.affected_repos)
+            task_slug = t.slug
+            if title is None:
+                title = t.description
+            if spec_id is None:
+                spec_id = t.slug
 
-        state_dir = container.state_dir()
-        path = blessed_spec_path(state_dir, t.slug)
+        if title is None:
+            output.error("Provide --title (or --task to derive it).")
+            raise typer.Exit(1)
+        if spec_id is None:
+            spec_id = slugify(title)
+
+        now = datetime.now(timezone.utc)
+        spec = Spec(
+            id=spec_id, title=title, status="drafting",
+            created_at=now, updated_at=now,
+            affected_repos=affected_repos, task_slug=task_slug,
+            body=SPEC_BODY_TEMPLATE,
+        )
+        path = store.path_for(spec)
         if path.exists() and not force:
-            output.error(
-                f"Spec already exists: {path}\n"
-                f"  Pass --force to overwrite, or `mship view spec` to read it."
-            )
-            raise typer.Exit(code=1)
-
-        body = render_template(t.slug, t.description, list(t.affected_repos))
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(body)
+            output.error(f"Spec already exists: {path}\n  Pass --force to overwrite.")
+            raise typer.Exit(1)
+        store.save(spec)
 
         if output.is_tty:
             output.success(f"Created spec: {path}")
-            output.print("[dim]Edit the file, then `mship phase dev` to start work.[/dim]")
+            output.print("[dim]Edit the prose; lifecycle commands (draft/review/approve) follow.[/dim]")
         else:
             output.json({
-                "task": t.slug,
-                "path": str(path),
-                "resolved_task": resolved.task.slug,
-                "resolution_source": resolved.source,
+                "id": spec.id, "path": str(path),
+                "status": spec.status, "task_slug": task_slug,
             })
 
     parent.add_typer(spec_app)

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -38,7 +38,7 @@ def register(parent: typer.Typer, get_container):
     def new(
         title: Optional[str] = typer.Option(None, "--title", help="Spec title (required unless --task is given)."),
         spec_id: Optional[str] = typer.Option(None, "--id", help="Stable spec id (slug). Defaults to a slug of the title."),
-        task_opt: Optional[str] = typer.Option(None, "--task", help="Bind to an existing task: prefill affected_repos + task_slug."),
+        task_opt: Optional[str] = typer.Option(None, "--task", help="Link to an existing task: sets task_slug and prefills title + repos."),
         force: bool = typer.Option(False, "--force", "-f", help="Overwrite an existing spec file."),
     ):
         """Create a structured spec at `<workspace>/specs/YYYY-MM-DD-<id>.md`."""
@@ -74,6 +74,9 @@ def register(parent: typer.Typer, get_container):
             raise typer.Exit(1)
         if spec_id is None:
             spec_id = slugify(title)
+        if not spec_id:
+            output.error("Could not derive a spec id from the title; pass --id explicitly.")
+            raise typer.Exit(1)
 
         now = datetime.now(timezone.utc)
         spec = Spec(

--- a/src/mship/core/spec.py
+++ b/src/mship/core/spec.py
@@ -45,3 +45,35 @@ class Spec(BaseModel):
         return self.status == "approved" and all(
             q.answer is not None for q in self.open_questions
         )
+
+
+TERMINAL_STATUSES: set[str] = {"archived"}
+
+ALLOWED_TRANSITIONS: dict[str, set[str]] = {
+    "captured": {"drafting"},
+    "drafting": {"needs_review"},
+    "needs_review": {"needs_clarification", "approved"},
+    "needs_clarification": {"needs_review", "drafting"},
+    "approved": {"dispatched", "needs_clarification"},
+    "dispatched": {"implemented"},
+    "implemented": {"archived"},
+    "archived": set(),
+}
+
+
+class InvalidTransition(Exception):
+    pass
+
+
+def can_transition(current: str, target: str) -> bool:
+    if current == target:
+        return False
+    # Abandon: any non-terminal status may jump to archived.
+    if target == "archived" and current not in TERMINAL_STATUSES:
+        return True
+    return target in ALLOWED_TRANSITIONS.get(current, set())
+
+
+def validate_transition(current: str, target: str) -> None:
+    if not can_transition(current, target):
+        raise InvalidTransition(f"illegal spec transition: {current} -> {target}")

--- a/src/mship/core/spec.py
+++ b/src/mship/core/spec.py
@@ -66,12 +66,21 @@ class InvalidTransition(Exception):
 
 
 def can_transition(current: str, target: str) -> bool:
+    """Whether `current` may transition to `target`.
+
+    Takes raw strings (not the `SpecStatus` Literal) for caller convenience;
+    unknown `current` values simply have no outgoing edges. The map is
+    authoritative; the abandon rule is an additive fallback that lets any
+    non-terminal status jump straight to `archived`.
+    """
     if current == target:
         return False
+    if target in ALLOWED_TRANSITIONS.get(current, set()):
+        return True
     # Abandon: any non-terminal status may jump to archived.
     if target == "archived" and current not in TERMINAL_STATUSES:
         return True
-    return target in ALLOWED_TRANSITIONS.get(current, set())
+    return False
 
 
 def validate_transition(current: str, target: str) -> None:

--- a/src/mship/core/spec.py
+++ b/src/mship/core/spec.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+SpecStatus = Literal[
+    "captured", "drafting", "needs_review", "needs_clarification",
+    "approved", "dispatched", "implemented", "archived",
+]
+
+
+class AcceptanceCriterion(BaseModel):
+    id: str
+    text: str
+    verdict: Literal["unreviewed", "approved", "flagged"] = "unreviewed"
+
+
+class OpenQuestion(BaseModel):
+    id: str
+    text: str
+    answer: str | None = None
+
+
+class Spec(BaseModel):
+    id: str
+    title: str
+    status: SpecStatus
+    created_at: datetime
+    updated_at: datetime
+    affected_repos: list[str] = []
+    acceptance_criteria: list[AcceptanceCriterion] = []
+    open_questions: list[OpenQuestion] = []
+    non_goals: list[str] = []
+    risks: list[str] = []
+    task_slug: str | None = None
+    body: str = ""
+
+    @property
+    def dispatch_ready(self) -> bool:
+        return self.status == "approved" and all(
+            q.answer is not None for q in self.open_questions
+        )

--- a/src/mship/core/spec.py
+++ b/src/mship/core/spec.py
@@ -40,6 +40,8 @@ class Spec(BaseModel):
 
     @property
     def dispatch_ready(self) -> bool:
+        # acceptance_criteria verdicts are gated at approval time (status == "approved");
+        # they are intentionally not re-checked here. Only open questions block dispatch.
         return self.status == "approved" and all(
             q.answer is not None for q in self.open_questions
         )

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -54,7 +54,7 @@ class SpecStore:
         Saving again with the same id + creation date overwrites the file
         (this is the intended update mechanism).
         """
-        if "/" in spec.id or "\\" in spec.id or spec.id in (".", "..") or spec.id.startswith("."):
+        if not spec.id or "/" in spec.id or "\\" in spec.id or spec.id in (".", "..") or spec.id.startswith("."):
             raise ValueError(f"unsafe spec id for filename: {spec.id!r}")
         return self._dir / f"{spec.created_at:%Y-%m-%d}-{spec.id}.md"
 

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -47,6 +47,13 @@ class SpecStore:
         self._dir = Path(specs_dir)
 
     def path_for(self, spec: Spec) -> Path:
+        """Path for a spec's file: `<specs_dir>/<created_at date>-<id>.md`.
+
+        Saving again with the same id + creation date overwrites the file
+        (this is the intended update mechanism).
+        """
+        if "/" in spec.id or "\\" in spec.id or spec.id in (".", "..") or spec.id.startswith("."):
+            raise ValueError(f"unsafe spec id for filename: {spec.id!r}")
         return self._dir / f"{spec.created_at:%Y-%m-%d}-{spec.id}.md"
 
     def save(self, spec: Spec) -> Path:

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import yaml
+
+from mship.core.spec import Spec
+
+
+class SpecParseError(Exception):
+    pass
+
+
+def parse_spec(text: str) -> Spec:
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        raise SpecParseError("spec file missing YAML frontmatter")
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        raise SpecParseError("unterminated YAML frontmatter")
+    fm_text = "".join(lines[1:end])
+    body = "".join(lines[end + 1:])
+    data = yaml.safe_load(fm_text) or {}
+    return Spec(**data, body=body)
+
+
+def serialize_spec(spec: Spec) -> str:
+    data = spec.model_dump(mode="json", exclude={"body"})
+    fm = yaml.safe_dump(data, sort_keys=False, default_flow_style=False)
+    return f"---\n{fm}---\n{spec.body}"

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -7,6 +7,8 @@ from pydantic import ValidationError
 
 from mship.core.spec import Spec
 
+SPECS_DIRNAME = "specs"  # canonical name of the workspace-level specs directory
+
 
 class SpecParseError(Exception):
     pass

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import yaml
+from pydantic import ValidationError
 
 from mship.core.spec import Spec
 
@@ -22,8 +23,13 @@ def parse_spec(text: str) -> Spec:
         raise SpecParseError("unterminated YAML frontmatter")
     fm_text = "".join(lines[1:end])
     body = "".join(lines[end + 1:])
-    data = yaml.safe_load(fm_text) or {}
-    return Spec(**data, body=body)
+    try:
+        data = yaml.safe_load(fm_text) or {}
+        return Spec(**data, body=body)
+    except yaml.YAMLError as exc:
+        raise SpecParseError(f"invalid YAML frontmatter: {exc}") from exc
+    except ValidationError as exc:
+        raise SpecParseError(f"spec frontmatter failed validation: {exc}") from exc
 
 
 def serialize_spec(spec: Spec) -> str:

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import tempfile
 import yaml
+from pathlib import Path
 from pydantic import ValidationError
 
 from mship.core.spec import Spec
@@ -36,3 +38,40 @@ def serialize_spec(spec: Spec) -> str:
     data = spec.model_dump(mode="json", exclude={"body"})
     fm = yaml.safe_dump(data, sort_keys=False, default_flow_style=False)
     return f"---\n{fm}---\n{spec.body}"
+
+
+class SpecStore:
+    """Filesystem registry for markdown-canonical specs under `specs/`."""
+
+    def __init__(self, specs_dir: Path) -> None:
+        self._dir = Path(specs_dir)
+
+    def path_for(self, spec: Spec) -> Path:
+        return self._dir / f"{spec.created_at:%Y-%m-%d}-{spec.id}.md"
+
+    def save(self, spec: Spec) -> Path:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        path = self.path_for(spec)
+        fd, tmp = tempfile.mkstemp(dir=self._dir, suffix=".md.tmp")
+        try:
+            with open(fd, "w") as f:
+                f.write(serialize_spec(spec))
+            Path(tmp).replace(path)
+        except Exception:
+            Path(tmp).unlink(missing_ok=True)
+            raise
+        return path
+
+    def load(self, path: Path) -> Spec:
+        return parse_spec(Path(path).read_text())
+
+    def list(self) -> list[Spec]:
+        if not self._dir.is_dir():
+            return []
+        return [self.load(p) for p in sorted(self._dir.glob("*.md"))]
+
+    def find_by_id(self, spec_id: str) -> Spec | None:
+        for spec in self.list():
+            if spec.id == spec_id:
+                return spec
+        return None

--- a/src/mship/core/state.py
+++ b/src/mship/core/state.py
@@ -40,6 +40,7 @@ class Task(BaseModel):
     test_iteration: int = 0
     base_branch: str | None = None
     passive_repos: set[str] = set()
+    spec_id: str | None = None
     depends_on: list[DependencyEdge] = []
 
 

--- a/src/mship/core/view/spec_discovery.py
+++ b/src/mship/core/view/spec_discovery.py
@@ -16,6 +16,28 @@ SPEC_SUBDIR = Path("docs") / "superpowers" / "specs"
 # dev-phase gate has something deterministic to find.
 BLESSED_TASK_SPEC_DIR = Path(".mothership") / "tasks"  # joined with <slug>/SPEC.md
 
+# Structured spec store directory (Task 6 / MOS-145).
+SPECS_DIR = Path("specs")
+
+
+def _find_in_specs_dir(workspace_root: Path, *, spec_id=None, task_slug=None):
+    """Return the path of a spec file in `<workspace_root>/specs` matching
+    `spec_id` (frontmatter id) or `task_slug` (bound task), else None."""
+    from mship.core.spec_store import SpecParseError, parse_spec
+    specs_dir = workspace_root / SPECS_DIR
+    if not specs_dir.is_dir():
+        return None
+    for p in sorted(specs_dir.glob("*.md")):
+        try:
+            spec = parse_spec(p.read_text())
+        except SpecParseError:
+            continue
+        if spec_id is not None and spec.id == spec_id:
+            return p
+        if task_slug is not None and spec.task_slug == task_slug:
+            return p
+    return None
+
 
 def blessed_spec_path(workspace_root: Path, slug: str) -> Path:
     return workspace_root / BLESSED_TASK_SPEC_DIR / slug / "SPEC.md"
@@ -54,11 +76,20 @@ def find_spec(
         blessed = blessed_spec_path(workspace_root, task)
         if blessed.is_file():
             return blessed
+        # Fall back to specs/ dir bound to this task slug before the legacy lookup.
+        found = _find_in_specs_dir(workspace_root, task_slug=task)
+        if found is not None:
+            return found
 
     search_roots = _resolve_search_roots(workspace_root, task, state, spec_paths)
 
     if name_or_path is None:
         return _newest_across(search_roots, task)
+
+    # Try specs/ dir by frontmatter id before the legacy search-roots name loop.
+    found = _find_in_specs_dir(workspace_root, spec_id=name_or_path)
+    if found is not None:
+        return found
 
     for root in search_roots:
         for candidate_name in (name_or_path, f"{name_or_path}.md"):

--- a/src/mship/core/view/spec_discovery.py
+++ b/src/mship/core/view/spec_discovery.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
+from mship.core.spec_store import SPECS_DIRNAME
+
 if TYPE_CHECKING:
     from mship.core.state import WorkspaceState
 
@@ -17,12 +19,13 @@ SPEC_SUBDIR = Path("docs") / "superpowers" / "specs"
 BLESSED_TASK_SPEC_DIR = Path(".mothership") / "tasks"  # joined with <slug>/SPEC.md
 
 # Structured spec store directory (Task 6 / MOS-145).
-SPECS_DIR = Path("specs")
+SPECS_DIR = Path(SPECS_DIRNAME)
 
 
 def _find_in_specs_dir(workspace_root: Path, *, spec_id=None, task_slug=None):
     """Return the path of a spec file in `<workspace_root>/specs` matching
     `spec_id` (frontmatter id) or `task_slug` (bound task), else None."""
+    # imported lazily to keep this discovery module loosely coupled to the store
     from mship.core.spec_store import SpecParseError, parse_spec
     specs_dir = workspace_root / SPECS_DIR
     if not specs_dir.is_dir():

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -158,6 +158,37 @@ def test_gate_dev_satisfied_by_blessed_path(tmp_path: Path):
     assert not any("spec" in w.lower() for w in result.warnings), result.warnings
 
 
+def test_spec_new_id_override(configured_app_with_task: Path):
+    result = runner.invoke(app, ["spec", "new", "--title", "Something", "--id", "my-id"])
+    assert result.exit_code == 0, result.output
+    assert _store(configured_app_with_task).find_by_id("my-id") is not None
+
+
+def test_spec_new_title_overrides_task_description(configured_app_with_task: Path):
+    result = runner.invoke(app, ["spec", "new", "--task", "add-labels", "--title", "Override"])
+    assert result.exit_code == 0, result.output
+    spec = _store(configured_app_with_task).find_by_id("add-labels")
+    assert spec.title == "Override"          # explicit title wins over task.description
+    assert spec.task_slug == "add-labels"    # still bound + prefilled
+
+
+def test_spec_new_empty_title_errors(configured_app_with_task: Path):
+    result = runner.invoke(app, ["spec", "new", "--title", ""])
+    assert result.exit_code != 0
+
+
+def test_spec_new_json_output_non_tty(configured_app_with_task: Path, monkeypatch):
+    import json
+    from mship.cli.output import Output
+    monkeypatch.setattr(Output, "is_tty", property(lambda self: False))
+    result = runner.invoke(app, ["spec", "new", "--title", "Json Spec"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["id"] == "json-spec"
+    assert payload["status"] == "drafting"
+    assert "path" in payload
+
+
 def test_gate_dev_hint_mentions_spec_new(tmp_path: Path):
     """The empty-workspace warning points at `mship spec new`."""
     from unittest.mock import MagicMock

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -1,4 +1,4 @@
-"""Tests for `mship spec new` (#126)."""
+"""Tests for `mship spec new` (#126, #145)."""
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -6,6 +6,7 @@ import pytest
 from typer.testing import CliRunner
 
 from mship.cli import app, container
+from mship.core.spec_store import SpecStore
 from mship.core.state import StateManager, Task, WorkspaceState
 
 runner = CliRunner()
@@ -40,64 +41,50 @@ def configured_app_with_task(workspace: Path):
     container.state_manager.reset()
 
 
-def _blessed_path(workspace: Path, slug: str) -> Path:
-    return workspace / ".mothership" / "tasks" / slug / "SPEC.md"
+def _store(workspace: Path) -> SpecStore:
+    return SpecStore(workspace / "specs")
 
 
-def test_spec_new_creates_blessed_file(configured_app_with_task: Path):
-    """`mship spec new` scaffolds .mothership/tasks/<slug>/SPEC.md."""
+def test_spec_new_creates_structured_file(configured_app_with_task: Path):
+    result = runner.invoke(app, ["spec", "new", "--title", "Add labels"])
+    assert result.exit_code == 0, result.output
+    spec = _store(configured_app_with_task).find_by_id("add-labels")
+    assert spec is not None
+    assert spec.status == "drafting"
+    assert spec.title == "Add labels"
+    assert "## Problem" in spec.body
+
+
+def test_spec_new_with_task_prefills_repos_and_binds(configured_app_with_task: Path):
     result = runner.invoke(app, ["spec", "new", "--task", "add-labels"])
     assert result.exit_code == 0, result.output
-    p = _blessed_path(configured_app_with_task, "add-labels")
-    assert p.is_file()
-    body = p.read_text()
-    # Template includes task metadata so the file isn't blank.
-    assert "add-labels" in body
-    assert "Add labels to tasks" in body
-    assert "shared" in body  # affected_repos
-    assert "auth-service" in body
+    spec = _store(configured_app_with_task).find_by_id("add-labels")
+    assert spec is not None
+    assert spec.task_slug == "add-labels"
+    assert spec.affected_repos == ["shared", "auth-service"]
+    assert spec.title == "Add labels to tasks"
 
 
-def test_spec_new_refuses_when_file_exists(configured_app_with_task: Path):
-    """Without --force, refuse to overwrite an existing spec."""
-    p = _blessed_path(configured_app_with_task, "add-labels")
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text("# pre-existing content\n")
+def test_spec_new_requires_title_or_task(configured_app_with_task: Path):
+    result = runner.invoke(app, ["spec", "new"])
+    assert result.exit_code != 0
+    assert "title" in result.output.lower()
 
-    result = runner.invoke(app, ["spec", "new", "--task", "add-labels"])
-    assert result.exit_code != 0, result.output
+
+def test_spec_new_refuses_existing(configured_app_with_task: Path):
+    runner.invoke(app, ["spec", "new", "--title", "Add labels"])
+    result = runner.invoke(app, ["spec", "new", "--title", "Add labels"])
+    assert result.exit_code != 0
     assert "exists" in result.output.lower() or "already" in result.output.lower()
-    # Original content untouched.
-    assert p.read_text() == "# pre-existing content\n"
 
 
 def test_spec_new_force_overwrites(configured_app_with_task: Path):
-    """--force replaces existing content with the template."""
-    p = _blessed_path(configured_app_with_task, "add-labels")
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text("# pre-existing content\n")
-
-    result = runner.invoke(app, ["spec", "new", "--task", "add-labels", "--force"])
+    runner.invoke(app, ["spec", "new", "--title", "Add labels"])
+    result = runner.invoke(app, ["spec", "new", "--title", "Add labels", "--force"])
     assert result.exit_code == 0, result.output
-    body = p.read_text()
-    assert "# pre-existing content" not in body
-    assert "add-labels" in body
 
 
-def test_spec_new_outputs_path_on_tty(configured_app_with_task: Path, monkeypatch):
-    """TTY output includes the created path so the user can copy-paste."""
-    from mship.cli.output import Output
-    monkeypatch.setattr(Output, "is_tty", property(lambda self: True))
-    result = runner.invoke(app, ["spec", "new", "--task", "add-labels"])
-    assert result.exit_code == 0, result.output
-    p = _blessed_path(configured_app_with_task, "add-labels")
-    # Rich may soft-wrap long paths; flatten before checking.
-    flat = result.output.replace("\n", "").replace(" ", "")
-    assert str(p) in flat
-
-
-def test_spec_new_resolves_unknown_task(configured_app_with_task: Path):
-    """An explicit unknown --task slug errors clearly."""
+def test_spec_new_unknown_task_errors(configured_app_with_task: Path):
     result = runner.invoke(app, ["spec", "new", "--task", "nope"])
     assert result.exit_code != 0
     assert "nope" in result.output

--- a/tests/core/test_spec.py
+++ b/tests/core/test_spec.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timezone
+
+from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec
+
+
+def _spec(**kw):
+    now = datetime(2026, 6, 13, tzinfo=timezone.utc)
+    base = dict(id="demo", title="Demo", status="drafting", created_at=now, updated_at=now)
+    base.update(kw)
+    return Spec(**base)
+
+
+def test_spec_defaults_are_empty():
+    s = _spec()
+    assert s.affected_repos == []
+    assert s.acceptance_criteria == []
+    assert s.open_questions == []
+    assert s.non_goals == []
+    assert s.risks == []
+    assert s.task_slug is None
+    assert s.body == ""
+
+
+def test_dispatch_ready_requires_approved_and_no_open_questions():
+    s = _spec(status="approved", open_questions=[OpenQuestion(id="q1", text="?", answer=None)])
+    assert s.dispatch_ready is False
+    s2 = _spec(status="approved", open_questions=[OpenQuestion(id="q1", text="?", answer="yes")])
+    assert s2.dispatch_ready is True
+    s3 = _spec(status="needs_review")
+    assert s3.dispatch_ready is False
+
+
+def test_acceptance_criterion_verdict_defaults_unreviewed():
+    ac = AcceptanceCriterion(id="ac1", text="works")
+    assert ac.verdict == "unreviewed"

--- a/tests/core/test_spec.py
+++ b/tests/core/test_spec.py
@@ -33,3 +33,38 @@ def test_dispatch_ready_requires_approved_and_no_open_questions():
 def test_acceptance_criterion_verdict_defaults_unreviewed():
     ac = AcceptanceCriterion(id="ac1", text="works")
     assert ac.verdict == "unreviewed"
+
+
+import pytest
+
+from mship.core.spec import InvalidTransition, can_transition, validate_transition
+
+
+@pytest.mark.parametrize("current,target", [
+    ("captured", "drafting"),
+    ("drafting", "needs_review"),
+    ("needs_review", "approved"),
+    ("needs_review", "needs_clarification"),
+    ("needs_clarification", "needs_review"),
+    ("approved", "dispatched"),
+    ("approved", "needs_clarification"),   # re-open
+    ("dispatched", "implemented"),
+    ("implemented", "archived"),
+    ("drafting", "archived"),              # abandon from any non-terminal
+    ("approved", "archived"),              # abandon
+])
+def test_legal_transitions_allowed(current, target):
+    assert can_transition(current, target) is True
+    validate_transition(current, target)  # must not raise
+
+
+@pytest.mark.parametrize("current,target", [
+    ("captured", "approved"),     # skips drafting/review
+    ("drafting", "dispatched"),   # skips review/approval
+    ("archived", "drafting"),     # terminal
+    ("approved", "approved"),     # no-op
+])
+def test_illegal_transitions_rejected(current, target):
+    assert can_transition(current, target) is False
+    with pytest.raises(InvalidTransition):
+        validate_transition(current, target)

--- a/tests/core/test_spec.py
+++ b/tests/core/test_spec.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
 
-from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec
+import pytest
+
+from mship.core.spec import AcceptanceCriterion, InvalidTransition, OpenQuestion, Spec, can_transition, validate_transition
 
 
 def _spec(**kw):
@@ -35,11 +37,6 @@ def test_acceptance_criterion_verdict_defaults_unreviewed():
     assert ac.verdict == "unreviewed"
 
 
-import pytest
-
-from mship.core.spec import InvalidTransition, can_transition, validate_transition
-
-
 @pytest.mark.parametrize("current,target", [
     ("captured", "drafting"),
     ("drafting", "needs_review"),
@@ -52,6 +49,8 @@ from mship.core.spec import InvalidTransition, can_transition, validate_transiti
     ("implemented", "archived"),
     ("drafting", "archived"),              # abandon from any non-terminal
     ("approved", "archived"),              # abandon
+    ("needs_clarification", "archived"),   # abandon
+    ("dispatched", "archived"),            # abandon
 ])
 def test_legal_transitions_allowed(current, target):
     assert can_transition(current, target) is True

--- a/tests/core/test_spec_store.py
+++ b/tests/core/test_spec_store.py
@@ -1,9 +1,10 @@
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
 from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec
-from mship.core.spec_store import SpecParseError, parse_spec, serialize_spec
+from mship.core.spec_store import SpecParseError, SpecStore, parse_spec, serialize_spec
 
 
 def _spec():
@@ -51,11 +52,6 @@ def test_malformed_yaml_raises_spec_parse_error():
         parse_spec("---\nid: [unclosed\n---\nbody\n")
 
 
-from pathlib import Path
-
-from mship.core.spec_store import SpecStore
-
-
 def _new_spec(spec_id: str):
     now = datetime(2026, 6, 13, tzinfo=timezone.utc)
     return Spec(id=spec_id, title=spec_id, status="drafting", created_at=now, updated_at=now)
@@ -86,3 +82,21 @@ def test_list_returns_all(tmp_path: Path):
 
 def test_find_by_id_missing_returns_none(tmp_path: Path):
     assert SpecStore(tmp_path / "specs").find_by_id("nope") is None
+
+
+def test_save_overwrites_and_reflects_update(tmp_path: Path):
+    store = SpecStore(tmp_path / "specs")
+    store.save(_new_spec("alpha"))
+    updated = _new_spec("alpha")
+    updated.status = "needs_review"
+    store.save(updated)
+    assert store.find_by_id("alpha").status == "needs_review"
+    assert len(store.list()) == 1  # same path, overwritten not duplicated
+
+
+def test_path_for_rejects_unsafe_id(tmp_path: Path):
+    store = SpecStore(tmp_path / "specs")
+    bad = _new_spec("alpha")
+    bad.id = "../escape"
+    with pytest.raises(ValueError):
+        store.save(bad)

--- a/tests/core/test_spec_store.py
+++ b/tests/core/test_spec_store.py
@@ -49,3 +49,40 @@ def test_invalid_schema_frontmatter_raises_spec_parse_error():
 def test_malformed_yaml_raises_spec_parse_error():
     with pytest.raises(SpecParseError):
         parse_spec("---\nid: [unclosed\n---\nbody\n")
+
+
+from pathlib import Path
+
+from mship.core.spec_store import SpecStore
+
+
+def _new_spec(spec_id: str):
+    now = datetime(2026, 6, 13, tzinfo=timezone.utc)
+    return Spec(id=spec_id, title=spec_id, status="drafting", created_at=now, updated_at=now)
+
+
+def test_save_then_find_by_id(tmp_path: Path):
+    store = SpecStore(tmp_path / "specs")
+    path = store.save(_new_spec("alpha"))
+    assert path.name == "2026-06-13-alpha.md"
+    assert path.is_file()
+    found = store.find_by_id("alpha")
+    assert found is not None and found.id == "alpha"
+
+
+def test_find_by_id_is_exact_not_mtime(tmp_path: Path):
+    store = SpecStore(tmp_path / "specs")
+    store.save(_new_spec("alpha"))
+    store.save(_new_spec("beta"))   # newer mtime
+    assert store.find_by_id("alpha").id == "alpha"
+
+
+def test_list_returns_all(tmp_path: Path):
+    store = SpecStore(tmp_path / "specs")
+    store.save(_new_spec("alpha"))
+    store.save(_new_spec("beta"))
+    assert sorted(s.id for s in store.list()) == ["alpha", "beta"]
+
+
+def test_find_by_id_missing_returns_none(tmp_path: Path):
+    assert SpecStore(tmp_path / "specs").find_by_id("nope") is None

--- a/tests/core/test_spec_store.py
+++ b/tests/core/test_spec_store.py
@@ -33,3 +33,19 @@ def test_body_is_preserved_verbatim():
 def test_missing_frontmatter_raises():
     with pytest.raises(SpecParseError):
         parse_spec("# just markdown, no frontmatter\n")
+
+
+def test_unterminated_frontmatter_raises():
+    with pytest.raises(SpecParseError):
+        parse_spec("---\nid: foo\n")  # no closing ---
+
+
+def test_invalid_schema_frontmatter_raises_spec_parse_error():
+    # valid YAML, but missing required Spec fields -> SpecParseError, not raw ValidationError
+    with pytest.raises(SpecParseError):
+        parse_spec("---\nid: foo\n---\nbody\n")
+
+
+def test_malformed_yaml_raises_spec_parse_error():
+    with pytest.raises(SpecParseError):
+        parse_spec("---\nid: [unclosed\n---\nbody\n")

--- a/tests/core/test_spec_store.py
+++ b/tests/core/test_spec_store.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec
+from mship.core.spec_store import SpecParseError, parse_spec, serialize_spec
+
+
+def _spec():
+    now = datetime(2026, 6, 13, 10, 0, 0, tzinfo=timezone.utc)
+    return Spec(
+        id="decision-queue", title="Decision queue", status="needs_review",
+        created_at=now, updated_at=now,
+        affected_repos=["mothership", "ground-control"],
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="view questions")],
+        open_questions=[OpenQuestion(id="q1", text="Android in v0?")],
+        non_goals=["chat"],
+        body="## Problem\n\nAgents block away from the desk.\n",
+    )
+
+
+def test_round_trip_is_identity():
+    s = _spec()
+    assert parse_spec(serialize_spec(s)) == s
+
+
+def test_body_is_preserved_verbatim():
+    s = _spec()
+    parsed = parse_spec(serialize_spec(s))
+    assert parsed.body == "## Problem\n\nAgents block away from the desk.\n"
+
+
+def test_missing_frontmatter_raises():
+    with pytest.raises(SpecParseError):
+        parse_spec("# just markdown, no frontmatter\n")

--- a/tests/core/test_state.py
+++ b/tests/core/test_state.py
@@ -360,3 +360,40 @@ def test_legacy_state_without_depends_on_loads_clean(tmp_path):
     sm = StateManager(state_dir)
     state = sm.load()
     assert state.tasks["t"].depends_on == []
+
+
+def test_task_spec_id_defaults_none():
+    from datetime import datetime, timezone
+    from mship.core.state import Task
+    t = Task(
+        slug="t", description="d", phase="plan",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["a"], branch="feat/t",
+    )
+    assert t.spec_id is None
+
+
+def test_task_spec_id_round_trips(tmp_path):
+    from datetime import datetime, timezone
+    from mship.core.state import StateManager, Task, WorkspaceState
+    sm = StateManager(tmp_path)
+    sm.save(WorkspaceState(tasks={"t": Task(
+        slug="t", description="d", phase="plan",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["a"], branch="feat/t", spec_id="decision-queue",
+    )}))
+    assert sm.load().tasks["t"].spec_id == "decision-queue"
+
+
+def test_legacy_state_without_spec_id_loads(tmp_path):
+    """Old state.yaml (no spec_id key) loads cleanly (default None)."""
+    import yaml
+    from mship.core.state import StateManager
+    (tmp_path / "state.yaml").write_text(yaml.safe_dump({
+        "tasks": {"t": {
+            "slug": "t", "description": "d", "phase": "dev",
+            "created_at": "2026-04-10T00:00:00+00:00",
+            "affected_repos": ["a"], "branch": "feat/t",
+        }}
+    }))
+    assert StateManager(tmp_path).load().tasks["t"].spec_id is None

--- a/tests/core/view/test_spec_discovery.py
+++ b/tests/core/view/test_spec_discovery.py
@@ -108,3 +108,35 @@ def test_find_spec_by_name_searches_all_worktrees_when_no_task(tmp_path: Path):
 
     result = find_spec(workspace_root=tmp_path, name_or_path="found", state=state)
     assert result == specs / "found.md"
+
+
+# ---------------------------------------------------------------------------
+# specs/ directory discovery (by id and task_slug)
+# ---------------------------------------------------------------------------
+
+from mship.core.spec import Spec
+from mship.core.spec_store import SpecStore
+
+
+def _seed_spec(tmp_path: Path, spec_id: str, task_slug=None) -> Path:
+    now = datetime(2026, 6, 13, tzinfo=timezone.utc)
+    store = SpecStore(tmp_path / "specs")
+    return store.save(Spec(
+        id=spec_id, title=spec_id, status="drafting",
+        created_at=now, updated_at=now, task_slug=task_slug,
+    ))
+
+
+def test_find_spec_resolves_specs_dir_by_id(tmp_path: Path):
+    path = _seed_spec(tmp_path, "decision-queue")
+    assert find_spec(tmp_path, "decision-queue") == path
+
+
+def test_find_spec_resolves_specs_dir_by_task_slug(tmp_path: Path):
+    path = _seed_spec(tmp_path, "decision-queue", task_slug="dq")
+    state = WorkspaceState(tasks={"dq": Task(
+        slug="dq", description="d", phase="plan",
+        created_at=datetime(2026, 6, 13, tzinfo=timezone.utc),
+        affected_repos=["a"], branch="feat/dq",
+    )})
+    assert find_spec(tmp_path, None, task="dq", state=state) == path

--- a/uv.lock
+++ b/uv.lock
@@ -42,6 +42,45 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
 name = "dependency-injector"
 version = "4.49.0"
 source = { registry = "https://pypi.org/simple" }
@@ -130,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "mothership"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "dependency-injector" },
@@ -144,6 +183,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "coverage" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-tmp-files" },
@@ -162,6 +202,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "coverage", specifier = ">=7.13.5" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-tmp-files", specifier = ">=0.0.2" },


### PR DESCRIPTION
## Summary

Adds the first-class, **markdown-canonical `Spec` object** for mship (MOS-145) — the "A1" substrate the Ground Control initiative depends on:

- **`Spec` model** (`core/spec.py`): pydantic model + nested `AcceptanceCriterion`/`OpenQuestion`, an 8-state lifecycle (`captured → drafting → needs_review ⇄ needs_clarification → approved → dispatched → implemented → archived`), a transition validator (`validate_transition`, with an abandon escape to `archived`), and a derived `dispatch_ready`.
- **Frontmatter IO + registry** (`core/spec_store.py`): `parse_spec`/`serialize_spec` with verified round-trip fidelity (errors wrapped as `SpecParseError`); a `SpecStore` under `<workspace>/specs/` with atomic writes, exact-id lookup, and a path-traversal guard. `SPECS_DIRNAME` is the single source of truth for the dir name.
- **Task binding** (`core/state.py`): `Task.spec_id` pointer (back-compat default `None`).
- **Discovery** (`core/view/spec_discovery.py`): `find_spec` now resolves `specs/` by frontmatter `id` and by `task_slug`, with blessed-path precedence and all legacy fallbacks preserved.
- **CLI** (`cli/spec.py`): `mship spec new` migrated to write structured specs to `specs/` (task-optional; `--title`/`--id`/`--task`/`--force`), replacing the old blessed `.mothership/tasks/<slug>/SPEC.md` path.
- Includes the design doc and implementation plan under `docs/superpowers/`.

**Deliberately out of scope** (follow-on issues): the lifecycle verbs (`spec draft`/`review`/`questions`/`approve`), `dispatch --spec`, the `mship serve` API, and hardening the `plan→dev` gate to require an approved spec.

Linear: MOS-145.

## Test plan

- [x] `mship test` green — full suite 1277 passing.
- [x] New tests cover: the model + `dispatch_ready`, the full transition matrix (legal/abandon/illegal), frontmatter round-trip + malformed/invalid-schema handling, `SpecStore` save/list/find_by_id + unsafe-id guard + overwrite-update, `Task.spec_id` back-compat load of legacy `state.yaml`, `find_spec` resolving `specs/` by id and task_slug (no regression to blessed/legacy paths), and the migrated `spec new` (create, task prefill/bind, `--id` override, title-overrides-task, require-title, refuse-existing, `--force`, unknown-task, JSON output).
- [x] Per-task spec-compliance + code-quality review, plus a final whole-branch review (merge-ready).

Closes #140