### PR TITLE
complete spec lifecycle A4-A7

### DIFF
--- a/docs/superpowers/plans/2026-06-14-spec-lifecycle.md
+++ b/docs/superpowers/plans/2026-06-14-spec-lifecycle.md
@@ -1,0 +1,145 @@
+# Complete the Spec Lifecycle — Implementation Plan (A4–A7)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: subagent-driven-development. One combined branch/PR. Order: A4 → A5 → A7 → A6 (A6 last — highest integration risk). Steps use checkbox (`- [ ]`).
+
+**Goal:** Finish the `mship spec` CLI lifecycle: `questions` (A4), `approve`/`request-changes` (A5), harden the `plan→dev` gate (A7), and `spec dispatch` (A6).
+
+**Architecture:** Thin core helpers per feature + Typer commands on the existing `spec` sub-app; reuse A1–A3 primitives (`Spec`, `validate_transition`, `SpecStore`, `parse_body_sections`). Design + 🟡 judgment calls: [docs/superpowers/specs/2026-06-14-spec-lifecycle-design.md](../specs/2026-06-14-spec-lifecycle-design.md).
+
+**Tech Stack:** Python, pydantic v2, Typer, pytest. Builds on A1–A3 (merged).
+
+---
+
+## File structure
+- **Create** `core/spec_questions.py` (A4), `core/spec_approve.py` (A5).
+- **Modify** `cli/spec.py` (A4/A5/A6 commands), `core/phase.py` + `cli/phase.py` (A7 gate), `core/state.py` already has `Task.spec_id` (A1).
+- **Test** `tests/core/test_spec_questions.py`, `tests/core/test_spec_approve.py`, `tests/cli/test_spec.py` (extend), `tests/core/test_phase.py` (extend), `tests/cli/test_spec_dispatch.py` (A6, git-fixture).
+
+Per-task: `uv run pytest <path>`; full suite via `mship test` at the end.
+
+---
+
+## Task A4 — `spec questions` / `ask` / `answer`
+
+**Files:** Create `src/mship/core/spec_questions.py`; modify `cli/spec.py`; test `tests/core/test_spec_questions.py` + `tests/cli/test_spec.py`.
+
+- [ ] **Core helpers (TDD).** `src/mship/core/spec_questions.py`:
+
+```python
+from __future__ import annotations
+from mship.core.spec import OpenQuestion, Spec
+
+
+def add_question(spec: Spec, text: str) -> OpenQuestion:
+    """Append a question with the next q<n> id (max existing + 1)."""
+    nums = [int(q.id[1:]) for q in spec.open_questions if q.id.startswith("q") and q.id[1:].isdigit()]
+    q = OpenQuestion(id=f"q{(max(nums) + 1) if nums else 1}", text=text)
+    spec.open_questions.append(q)
+    return q
+
+
+def answer_question(spec: Spec, q_id: str, answer: str) -> Spec:
+    for q in spec.open_questions:
+        if q.id == q_id:
+            q.answer = answer
+            return spec
+    valid = ", ".join(q.id for q in spec.open_questions) or "(none)"
+    raise ValueError(f"no open question {q_id!r}; valid ids: {valid}")
+
+
+def list_questions(spec: Spec) -> list[dict]:
+    return [{"id": q.id, "text": q.text, "answer": q.answer} for q in spec.open_questions]
+```
+
+Tests (`tests/core/test_spec_questions.py`): `add_question` assigns `q1` then `q2` (and `q<max+1>` when a draft already seeded `q1`); `answer_question` sets the answer and raises `ValueError` on unknown id; `list_questions` shape.
+
+- [ ] **CLI (TDD).** In `cli/spec.py` `register`, add three commands following the established pattern (`get_container` → `SpecStore` → load → mutate → `updated_at` → save; TTY vs `output.json`):
+  - `spec questions <id>` → `output.json(list_questions(spec))` / TTY readable. Unknown spec id errors.
+  - `spec ask <id> <text>` → `add_question`, save; emit the new q-id.
+  - `spec answer <id> <q-id> <answer>` → `answer_question` (catch `ValueError` → `output.error` + Exit 1), save.
+
+  Tests (`tests/cli/test_spec.py`): after `new`+`apply` (which seeds `q1`), `ask dq "..."` → `q2`; `answer dq q1 "yes"` then `review dq` shows the answer; unknown q-id errors. (Answering does NOT change status — assert status unchanged.)
+
+- [ ] **Commit** (one per sub-step or combined): `feat(spec): spec questions (ask/answer/list)` + `mship journal`.
+
+---
+
+## Task A5 — `spec approve` / `request-changes`
+
+**Files:** Create `src/mship/core/spec_approve.py`; modify `cli/spec.py`; test `tests/core/test_spec_approve.py` + `tests/cli/test_spec.py`.
+
+- [ ] **Core helper (TDD).** `src/mship/core/spec_approve.py`:
+
+```python
+from __future__ import annotations
+from mship.core.spec import Spec
+
+
+def approval_blockers(spec: Spec) -> list[str]:
+    """Reasons a spec can't be approved (empty list == approvable)."""
+    blockers: list[str] = []
+    bad = [c.id for c in spec.acceptance_criteria if c.verdict != "approved"]
+    if bad:
+        blockers.append(f"acceptance criteria not approved: {', '.join(bad)}")
+    unanswered = [q.id for q in spec.open_questions if q.answer is None]
+    if unanswered:
+        blockers.append(f"open questions unanswered: {', '.join(unanswered)}")
+    if not spec.acceptance_criteria:
+        blockers.append("no acceptance criteria")
+    return blockers
+```
+
+Tests (`tests/core/test_spec_approve.py`): flagged/unreviewed criterion → blocked; unanswered question → blocked; no criteria → blocked; all-approved + all-answered → `[]`.
+
+- [ ] **CLI (TDD).** In `cli/spec.py`:
+  - `spec approve <id> [--bypass-gate]` → if `not bypass_gate` and `approval_blockers(spec)` non-empty → print blockers, Exit 1. Else `validate_transition(spec.status, "approved")` (catch `InvalidTransition` → Exit 1 with the message), set `status="approved"`, `updated_at`, save.
+  - `spec request-changes <id> --reason <reason>` → `validate_transition(spec.status, "needs_clarification")`, set status, `updated_at`, save; echo + `mship journal` the reason (🟡 not persisted on the spec — see design).
+
+  Tests (`tests/cli/test_spec.py`): approve refused while a criterion is unreviewed (lists it); after `verdict dq ac1 approved` (+ answering q1) approve succeeds → status `approved`; `--bypass-gate` approves despite blockers; approve from a non-`needs_review` status errors; `request-changes dq --reason x` → status `needs_clarification`.
+
+- [ ] **Commit:** `feat(spec): spec approve + request-changes with approval gate` + journal.
+
+---
+
+## Task A7 — harden `plan → dev` gate
+
+**Files:** Modify `src/mship/core/phase.py` (+ `src/mship/cli/phase.py` to thread the bypass flag); test `tests/core/test_phase.py` + the existing `tests/cli/test_spec.py` gate tests.
+
+- [ ] **Read first:** `core/phase.py` `transition` + `_check_gates` + `_gate_dev` (currently warning-only), and `cli/phase.py` (how `transition` is invoked + how warnings are surfaced).
+- [ ] **TDD.** Add a HARD requirement for `plan→dev`: there must be a bound, approved spec (a spec with `task_slug == task_slug` and `status` in `{approved, dispatched, implemented}`), unless bypassed.
+  - Add `bypass_spec_gate: bool = False` to `PhaseManager.transition` (and a `--bypass-spec-gate` option on `cli/phase.py`'s phase command, threaded through).
+  - Implement a helper `_has_approved_spec(task_slug) -> bool` in `phase.py` that scans `<workspace_root>/specs` via `SpecStore` for a spec with matching `task_slug` and an approved-or-later status. (Reuse `SpecStore` + `SPECS_DIRNAME`.)
+  - In `transition`, when `current=="plan"` and `target=="dev"` and `not bypass_spec_gate` and `not _has_approved_spec(task_slug)` → raise a `SpecGateError` (new, or reuse an existing phase error type) with a clear message naming `--bypass-spec-gate`.
+  - 🟡 The existing soft "no spec found" *warning* (`_gate_dev`) stays for the bypass path / informational; the new behavior is the hard block. Adjust the two existing gate tests (`test_gate_dev_satisfied_by_blessed_path`, `test_gate_dev_hint_mentions_spec_new`) to pass `--bypass-spec-gate` (or seed an approved spec) so they still exercise the warning path without the new block.
+  - Tests: `plan→dev` raises without an approved bound spec; succeeds with one seeded (`SpecStore.save` a spec with `task_slug` + `status="approved"`); succeeds with `--bypass-spec-gate`.
+- [ ] **Commit:** `feat(spec): require an approved spec for plan→dev (--bypass-spec-gate)` + journal.
+
+---
+
+## Task A6 — `mship spec dispatch` 🟡 (integration-risk)
+
+**Files:** Modify `cli/spec.py`; test `tests/cli/test_spec_dispatch.py` (uses a git-backed workspace fixture from `tests/conftest.py`, e.g. `workspace_with_git` / `audit_workspace`).
+
+- [ ] **Read first:** `WorktreeManager.spawn(description, repos, slug, workspace_root, ...) -> SpawnResult` (`core/worktree.py:396`); `build_dispatch_prompt(task, repo, instruction, journal_entries, base_sha_info, agents_md_path, pkg_skills_source, state)` and how `cli/dispatch.py` calls it; the `container.worktree_manager()` + `container.state_manager()` providers.
+- [ ] **Implement `spec dispatch <id>`** (TDD):
+  1. Load spec; require `spec.status == "approved"` (else error "approve it first").
+  2. `result = container.worktree_manager().spawn(description=spec.title, repos=(spec.affected_repos or None), slug=spec.id, workspace_root=Path(container.config_path()).parent)`.
+  3. State mutate: set the new task's `spec_id = spec.id`. Set `spec.status = "dispatched"` (`validate_transition`), `spec.task_slug = result.task.slug` (or the spawned slug), save the spec.
+  4. Emit a handoff prompt via `build_dispatch_prompt` seeded with `instruction = spec problem + acceptance criteria` (build the instruction string from `parse_body_sections(spec.body)["Problem"]` + the criteria texts). Print to stdout.
+  - Tests (git fixture): from an approved spec → `spec dispatch dq` exits 0, a task exists with `spec_id == dq`, `spec.status == "dispatched"`, output contains an acceptance-criterion text; dispatching an unapproved spec errors.
+- [ ] **🟡 Fallback (if the full spawn integration proves too entangled to test cleanly):** implement `spec dispatch <id>` to require an *already-spawned* task whose `slug == spec.id` (or `--task`), bind `task.spec_id`/`spec.status=dispatched`, and emit the prompt — **no auto-spawn**. Document this fallback prominently in the PR body if taken.
+- [ ] **Commit:** `feat(spec): spec dispatch (approved spec → task + handoff prompt)` + journal.
+
+---
+
+## Final steps
+- [ ] **Full suite:** `mship test` → green.
+- [ ] Final whole-branch review (per subagent-driven-development), then `mship finish` → one PR.
+
+## Self-Review
+- **Coverage:** A4 (questions) → core+CLI; A5 (approve/request-changes) → `approval_blockers` + CLI; A7 (gate) → `transition` hard-block + bypass; A6 (dispatch) → spawn + bind + prompt (or fallback).
+- **Placeholders:** A4/A5/A7 have complete code/contracts; A6 is directed (read-then-mirror the spawn machinery) by necessity (integration), with an explicit fallback — flagged, not a hidden gap.
+- **Type consistency:** reuses `Spec`/`OpenQuestion`/`AcceptanceCriterion`/`validate_transition`/`InvalidTransition`/`SpecStore`/`SPECS_DIRNAME`/`parse_body_sections`/`build_dispatch_prompt`/`WorktreeManager.spawn`. New: `add_question`/`answer_question`/`list_questions`, `approval_blockers`, `_has_approved_spec`.
+
+## Execution Handoff
+Combined branch; commit this plan + design to `main`, then `mship spawn` MOS-148–151 as one task.

--- a/docs/superpowers/specs/2026-06-14-spec-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-06-14-spec-lifecycle-design.md
@@ -1,0 +1,108 @@
+# Complete the spec lifecycle — design (A4–A7: MOS-148/149/150/151)
+
+> Status: design 2026-06-14. Autonomous combined effort (one PR). Design calls made
+> by the agent and documented here for PR review (no interactive brainstorm — the
+> reviewer evaluates the whole PR). Builds on A1–A3 (Spec model, draft/apply,
+> review/verdict — all merged).
+> **⚠️ Judgment calls flagged inline with 🟡 for reviewer attention.**
+
+Completes the `mship spec` lifecycle: `new → draft → apply → review/verdict →
+**questions → approve → dispatch** → (gate)`.
+
+---
+
+## A4 — `spec questions` (MOS-148)
+
+Manage the open questions on a spec (the model already has
+`open_questions: [{id, text, answer}]`).
+
+- **`mship spec questions <id>`** — list open questions (non-TTY JSON / TTY readable).
+- **`mship spec ask <id> "<text>"`** — append a question; assign the next `q<n>` id
+  (max existing + 1); save; bump `updated_at`.
+- **`mship spec answer <id> <q-id> "<answer>"`** — set a question's `answer`;
+  unknown `q-id` errors (lists valid ids); save.
+- 🟡 **Answering does not auto-transition status** (a question is an annotation;
+  A5's `approve`/`request-changes` own status). Keeps A4 a pure CRUD layer.
+- Core helpers in `core/spec_questions.py`: `add_question(spec, text)`,
+  `answer_question(spec, q_id, answer)`, `list_questions(spec) -> list[dict]`.
+
+## A5 — `spec approve` / `request-changes` (MOS-149)
+
+- **`mship spec approve <id> [--bypass-gate]`** — the approval gate. Refuses unless
+  **every acceptance criterion verdict == `approved`** AND **every open question is
+  answered** (`answer is not None`); on failure, prints exactly what's blocking and
+  exits non-zero. With the gate satisfied (or `--bypass-gate`),
+  `validate_transition(status, "approved")` → set `approved`, save. (Legal only from
+  `needs_review` per the A1 map.)
+- **`mship spec request-changes <id> --reason "<why>"`** —
+  `validate_transition(status, "needs_clarification")` → set `needs_clarification`,
+  save. 🟡 **The `--reason` is echoed + journaled (`mship journal`), not persisted on
+  the spec** — avoids a model field this version; a `change_requests[]` field is a
+  clean follow-on if reviewers want the reason on the artifact.
+- Gate logic in `core/spec_approve.py`: `approval_blockers(spec) -> list[str]`
+  (empty == approvable), reused by the CLI.
+
+## A6 — dispatch an approved spec (MOS-150) 🟡 **(integration-risk — review closely)**
+
+🟡 **Command shape:** `mship spec dispatch <id>` (a new subcommand under `spec`),
+**not** an overload of the existing `mship dispatch`. Rationale: `mship dispatch`
+today emits a prompt for an *existing* task (`--instruction` required); making it
+*also create* a task from a spec would overload its contract and risk regressions.
+A dedicated `spec dispatch` keeps that boundary clean. (The MOS-150 title says
+`dispatch --spec`; this is the same intent, cleaner surface — flagged for the
+reviewer to confirm.)
+
+Behavior:
+1. Require `spec.status == approved` (else error: "approve it first"). 🟡 ungated by
+   `--bypass` here — dispatch from an unapproved spec defeats the lifecycle; can add
+   a bypass later if needed.
+2. **Reuse the existing spawn machinery** to create a task for `spec.affected_repos`,
+   slug derived from `spec.id` (worktrees + branch, exactly like `mship spawn`).
+3. Bind both directions: `task.spec_id = spec.id`; `spec.status = dispatched`
+   (`validate_transition`), `spec.task_slug = task.slug`; save both.
+4. Emit the standard handoff prompt (`build_dispatch_prompt`) seeded from the spec —
+   instruction = the spec's problem + acceptance criteria.
+
+🟡 **Risk:** this touches task-creation + worktree side effects, so its tests need a
+git-backed workspace fixture (conftest `workspace_with_git` / `audit_workspace`).
+If the spawn integration proves too entangled to do cleanly in one task, the
+fallback is a **lighter A6**: bind the spec to an *already-spawned* task + emit the
+prompt (no auto-spawn), and the auto-spawn becomes a follow-on. This fallback will
+be called out in the PR if taken.
+
+## A7 — harden the `plan → dev` gate (MOS-151)
+
+- `mship phase` `plan → dev` requires a **bound, approved** spec (a spec with
+  `task_slug == <task>` and `status` in {`approved`, `dispatched`, `implemented`}).
+  Today the gate only *warns* when no spec file exists; this upgrades it to *require*
+  an approved spec.
+- **`--bypass-spec-gate`** overrides (per the `--bypass-…` naming convention).
+- 🟡 Implemented additively in `core/phase.py`'s dev-gate: keep the existing
+  spec-existence warning, add the approved-spec requirement. Old workspaces with no
+  specs at all still need the bypass — documented.
+
+---
+
+## Scope / out of scope
+
+In: the four commands + their core helpers + the gate change. Out: per-prose-card
+verdicts (A3 follow-on), the serve API (B1), the GC app (C), persisting the
+request-changes reason (flagged follow-on).
+
+## Migration / compat
+
+A4/A5/A6 are additive (new commands). A7 changes `phase plan→dev` behavior — the
+`--bypass-spec-gate` escape hatch preserves the workflow for spec-less tasks; the
+change is covered by updated gate tests.
+
+## Testing
+
+- A4: ask assigns sequential `q` ids; answer sets/【unknown-id errors】; list/JSON shape.
+- A5: `approval_blockers` (flagged criterion → blocked; unanswered question → blocked;
+  all-clear → empty); `approve` refuses when blocked, succeeds when clear / bypassed,
+  rejects from non-`needs_review` status; `request-changes` → `needs_clarification`.
+- A6: dispatch from approved spec creates a task (git fixture), binds `task.spec_id`
+  + `spec.status == dispatched`, emits a prompt containing the acceptance criteria;
+  refuses an unapproved spec.
+- A7: `plan→dev` refused without an approved bound spec; allowed with one; allowed
+  with `--bypass-spec-gate`; existing gate tests adjusted.

--- a/docs/superpowers/specs/2026-06-14-spec-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-06-14-spec-lifecycle-design.md
@@ -72,14 +72,23 @@ be called out in the PR if taken.
 
 ## A7 — harden the `plan → dev` gate (MOS-151)
 
-- `mship phase` `plan → dev` requires a **bound, approved** spec (a spec with
+- `mship phase` `plan → dev` **optionally** requires a **bound, approved** spec (a spec with
   `task_slug == <task>` and `status` in {`approved`, `dispatched`, `implemented`}).
-  Today the gate only *warns* when no spec file exists; this upgrades it to *require*
-  an approved spec.
-- **`--bypass-spec-gate`** overrides (per the `--bypass-…` naming convention).
-- 🟡 Implemented additively in `core/phase.py`'s dev-gate: keep the existing
-  spec-existence warning, add the approved-spec requirement. Old workspaces with no
-  specs at all still need the bypass — documented.
+  The gate is **config-gated and off by default** via `require_approved_spec: true` in
+  `mothership.yaml`. This avoids breaking the existing `spawn → phase dev` workflow
+  for workspaces that have not yet adopted the spec lifecycle. Workspaces that opt in
+  get the hard block; all others keep the existing soft warning.
+- **`--bypass-spec-gate`** overrides the hard block for one-off exceptions
+  (per the `--bypass-…` naming convention).
+- Implemented additively in `core/phase.py`: keep the existing spec-existence warning
+  (still fires as a soft gate when `require_approved_spec` is False), and add the
+  hard-block on top when the flag is True. The `SpecGateError` is raised before
+  any state mutation, so partial transitions cannot occur.
+
+**Why default-off?** A hard-on default would block every existing `plan→dev`
+transition that lacks an approved spec, breaking all current workspaces and tests.
+The blast radius is too large for a v1 gate. Workspaces can opt in when they have
+integrated the spec workflow end-to-end.
 
 ---
 
@@ -91,9 +100,10 @@ request-changes reason (flagged follow-on).
 
 ## Migration / compat
 
-A4/A5/A6 are additive (new commands). A7 changes `phase plan→dev` behavior — the
-`--bypass-spec-gate` escape hatch preserves the workflow for spec-less tasks; the
-change is covered by updated gate tests.
+A4/A5/A6 are additive (new commands). A7 adds a config-gated gate to `phase plan→dev` —
+default-off means zero impact on existing workspaces. Workspaces that set
+`require_approved_spec: true` get the hard block; `--bypass-spec-gate` provides an
+escape hatch. The gate is covered by new tests.
 
 ## Testing
 

--- a/src/mship/cli/phase.py
+++ b/src/mship/cli/phase.py
@@ -4,7 +4,7 @@ import typer
 
 from mship.cli._resolve import resolve_for_command
 from mship.cli.output import Output
-from mship.core.phase import PHASE_ORDER, FinishedTaskError
+from mship.core.phase import PHASE_ORDER, FinishedTaskError, SpecGateError
 
 
 def register(app: typer.Typer, get_container):
@@ -13,6 +13,7 @@ def register(app: typer.Typer, get_container):
         target: str,
         force: bool = typer.Option(False, "--force", "-f", help="Force transition even if task is blocked or finished"),
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),
+        bypass_spec_gate: bool = typer.Option(False, "--bypass-spec-gate", help="Skip the approved-spec requirement for plan→dev (requires require_approved_spec: true in mothership.yaml)."),
     ):
         """Transition a task to a new phase."""
         container = get_container()
@@ -50,8 +51,12 @@ def register(app: typer.Typer, get_container):
                 target,
                 force_unblock=force,
                 force_finished=force,
+                bypass_spec_gate=bypass_spec_gate,
             )
         except FinishedTaskError as e:
+            output.error(str(e))
+            raise typer.Exit(code=1)
+        except SpecGateError as e:
             output.error(str(e))
             raise typer.Exit(code=1)
 

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -352,4 +352,75 @@ def register(parent: typer.Typer, get_container):
         else:
             output.json({"id": spec.id, "question_id": q_id})
 
+    @spec_app.command("approve")
+    def approve(
+        spec_id: str = typer.Argument(...),
+        bypass_gate: bool = typer.Option(False, "--bypass-gate", help="Approve despite unmet review gate."),
+    ):
+        """Approve a spec (gate: all criteria approved + all questions answered)."""
+        from datetime import datetime, timezone
+        from pathlib import Path
+        from mship.core.spec import InvalidTransition, validate_transition
+        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
+        from mship.core.spec_approve import approval_blockers
+        output = Output()
+        container = get_container()
+        store = SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
+        spec = store.find_by_id(spec_id)
+        if spec is None:
+            output.error(f"No spec with id {spec_id!r}.")
+            raise typer.Exit(1)
+        if not bypass_gate:
+            blockers = approval_blockers(spec)
+            if blockers:
+                output.error("Cannot approve — " + "; ".join(blockers) + ". Use --bypass-gate to override.")
+                raise typer.Exit(1)
+        try:
+            validate_transition(spec.status, "approved")
+        except InvalidTransition as e:
+            output.error(str(e))
+            raise typer.Exit(1)
+        spec.status = "approved"
+        spec.updated_at = datetime.now(timezone.utc)
+        path = store.save(spec)
+        if output.is_tty:
+            output.success(f"Approved: {path}")
+        else:
+            output.json({"id": spec.id, "status": spec.status})
+
+    @spec_app.command("request-changes")
+    def request_changes(
+        spec_id: str = typer.Argument(...),
+        reason: str = typer.Option(..., "--reason", help="What needs to change."),
+    ):
+        """Send a spec back for changes (→ needs_clarification)."""
+        from datetime import datetime, timezone
+        from pathlib import Path
+        from mship.core.spec import InvalidTransition, validate_transition
+        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
+        output = Output()
+        container = get_container()
+        store = SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
+        spec = store.find_by_id(spec_id)
+        if spec is None:
+            output.error(f"No spec with id {spec_id!r}.")
+            raise typer.Exit(1)
+        try:
+            validate_transition(spec.status, "needs_clarification")
+        except InvalidTransition as e:
+            output.error(str(e))
+            raise typer.Exit(1)
+        spec.status = "needs_clarification"
+        spec.updated_at = datetime.now(timezone.utc)
+        store.save(spec)
+        # Reason is echoed + journaled, not persisted on the spec (see design A5).
+        try:
+            container.log_manager().append(spec.id, f"spec request-changes: {reason}")
+        except Exception:
+            pass
+        if output.is_tty:
+            output.success(f"Requested changes ({spec.status}): {reason}")
+        else:
+            output.json({"id": spec.id, "status": spec.status, "reason": reason})
+
     parent.add_typer(spec_app)

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -388,6 +388,107 @@ def register(parent: typer.Typer, get_container):
         else:
             output.json({"id": spec.id, "status": spec.status})
 
+    @spec_app.command("dispatch")
+    def dispatch(
+        spec_id: str = typer.Argument(..., help="Spec id to dispatch (must be approved)."),
+    ):
+        """Bind an approved spec to its pre-existing task and emit a handoff prompt.
+
+        FALLBACK implementation (A6): requires an already-existing task whose
+        slug == spec.id (create it first with `mship spawn`). Transitions the spec
+        to 'dispatched', sets task.spec_id, and prints an instruction block
+        containing the acceptance criteria + worktree paths.
+
+        TODO(auto-spawn): upgrade to auto-spawn (PRIMARY) when the git/worktree
+        mocking story is cleaner — see MOS-150 A6 spec for details.
+        """
+        from datetime import datetime, timezone
+        from pathlib import Path
+        from mship.core.spec import InvalidTransition, validate_transition
+        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
+        from mship.core.spec_body import parse_body_sections
+
+        output = Output()
+        container = get_container()
+        workspace_root = Path(container.config_path()).parent
+        store = SpecStore(workspace_root / SPECS_DIRNAME)
+        spec = store.find_by_id(spec_id)
+        if spec is None:
+            output.error(f"No spec with id {spec_id!r}.")
+            raise typer.Exit(1)
+
+        # Gate: spec must be approved
+        if spec.status != "approved":
+            output.error(
+                f"Spec {spec_id!r} is {spec.status!r} — approve the spec first "
+                f"(mship spec approve {spec_id})."
+            )
+            raise typer.Exit(1)
+
+        # FALLBACK: require a pre-existing task whose slug == spec.id
+        state = container.state_manager().load()
+        if spec_id not in state.tasks:
+            output.error(
+                f"No task with slug {spec_id!r}. "
+                f"Create one first with `mship spawn` (use the same slug as the spec id), "
+                f"then re-run `mship spec dispatch {spec_id}`."
+            )
+            raise typer.Exit(1)
+
+        task = state.tasks[spec_id]
+
+        # Validate the spec→dispatched transition
+        try:
+            validate_transition(spec.status, "dispatched")
+        except InvalidTransition as e:
+            output.error(str(e))
+            raise typer.Exit(1)
+
+        # Bind: task.spec_id = spec.id (mutate under lock)
+        container.state_manager().mutate(
+            lambda s: setattr(s.tasks[spec_id], "spec_id", spec.id)
+            if spec_id in s.tasks else None
+        )
+
+        # Bind: spec.status = "dispatched", spec.task_slug = slug
+        spec.status = "dispatched"
+        spec.task_slug = spec_id
+        spec.updated_at = datetime.now(timezone.utc)
+        store.save(spec)
+
+        # Emit handoff prompt
+        sections = parse_body_sections(spec.body)
+        problem = sections.get("Problem", "").strip()
+        criteria_lines = "\n".join(
+            f"  - [{ac.id}] {ac.text}" for ac in spec.acceptance_criteria
+        )
+        worktrees_lines = "\n".join(
+            f"  - {repo}: {path}" for repo, path in task.worktrees.items()
+        ) or "  (no worktrees registered yet)"
+
+        prompt = f"""\
+# Spec dispatch: {spec.title}
+
+**spec id:** {spec.id}
+**task slug:** {task.slug}
+**branch:** {task.branch}
+
+## Problem
+
+{problem or "(see spec body)"}
+
+## Acceptance criteria
+
+{criteria_lines or "  (none)"}
+
+## Worktrees
+
+{worktrees_lines}
+
+Run `mship dispatch --task {task.slug} --instruction "<your instruction>"` to emit a full subagent prompt.
+"""
+        typer.echo(prompt)
+
     @spec_app.command("request-changes")
     def request_changes(
         spec_id: str = typer.Argument(...),

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -293,4 +293,63 @@ def register(parent: typer.Typer, get_container):
         else:
             output.json({"id": spec_id, "valid": True})
 
+    @spec_app.command("questions")
+    def questions(spec_id: str = typer.Argument(..., help="Spec id.")):
+        """List a spec's open questions."""
+        from pathlib import Path
+        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
+        from mship.core.spec_questions import list_questions
+        output = Output(); container = get_container()
+        store = SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
+        spec = store.find_by_id(spec_id)
+        if spec is None:
+            output.error(f"No spec with id {spec_id!r}."); raise typer.Exit(1)
+        qs = list_questions(spec)
+        if output.is_tty:
+            for q in qs:
+                output.print(f"  {q['id']}: {q['text']}" + (f"  → {q['answer']}" if q['answer'] else "  (unanswered)"))
+        else:
+            output.json(qs)
+
+    @spec_app.command("ask")
+    def ask(spec_id: str = typer.Argument(...), text: str = typer.Argument(..., help="Question text.")):
+        """Add an open question to a spec."""
+        from datetime import datetime, timezone
+        from pathlib import Path
+        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
+        from mship.core.spec_questions import add_question
+        output = Output(); container = get_container()
+        store = SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
+        spec = store.find_by_id(spec_id)
+        if spec is None:
+            output.error(f"No spec with id {spec_id!r}."); raise typer.Exit(1)
+        q = add_question(spec, text)
+        spec.updated_at = datetime.now(timezone.utc); store.save(spec)
+        if output.is_tty:
+            output.success(f"Added {q.id}: {text}")
+        else:
+            output.json({"id": spec.id, "question_id": q.id})
+
+    @spec_app.command("answer")
+    def answer(spec_id: str = typer.Argument(...), q_id: str = typer.Argument(...), answer_text: str = typer.Argument(..., metavar="ANSWER")):
+        """Answer an open question (does not change status)."""
+        from datetime import datetime, timezone
+        from pathlib import Path
+        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
+        from mship.core.spec_questions import answer_question
+        output = Output(); container = get_container()
+        store = SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
+        spec = store.find_by_id(spec_id)
+        if spec is None:
+            output.error(f"No spec with id {spec_id!r}."); raise typer.Exit(1)
+        try:
+            answer_question(spec, q_id, answer_text)
+        except ValueError as e:
+            output.error(str(e)); raise typer.Exit(1)
+        spec.updated_at = datetime.now(timezone.utc); store.save(spec)
+        if output.is_tty:
+            output.success(f"{q_id} answered.")
+        else:
+            output.json({"id": spec.id, "question_id": q_id})
+
     parent.add_typer(spec_app)

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -112,6 +112,10 @@ class WorkspaceConfig(BaseModel):
     # which matches the bundled `brainstorming` / `writing-plans` skill
     # convention. See #113.
     spec_paths: list[str] | None = None
+    # When True, `mship phase dev` hard-blocks plan→dev unless a bound,
+    # approved spec exists (status in approved/dispatched/implemented).
+    # Default False so existing configs/tests are unaffected. See MOS-151.
+    require_approved_spec: bool = False
     repos: dict[str, RepoConfig]
 
     @model_validator(mode="after")

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -17,6 +17,10 @@ class FinishedTaskError(RuntimeError):
     """Raised when transitioning a finished task to plan/dev/review without --force."""
 
 
+class SpecGateError(RuntimeError):
+    """Raised when plan→dev requires an approved spec and none is bound to the task."""
+
+
 @dataclass
 class PhaseTransition:
     new_phase: Phase
@@ -44,6 +48,7 @@ class PhaseManager:
         target: Phase,
         force_unblock: bool = False,
         force_finished: bool = False,
+        bypass_spec_gate: bool = False,
     ) -> PhaseTransition:
         # Read-only preflight: compute soft-gate warnings from current state.
         # These read repo state (specs, tests, uncommitted files) and mship
@@ -59,6 +64,21 @@ class PhaseManager:
                 f"Task '{task_slug}' is finished. Transitioning to {target} "
                 f"probably means you want `mship close` then `mship spawn` for "
                 f"the next task. Use --force to override."
+            )
+
+        # Approved-spec gate: opt-in via require_approved_spec in mothership.yaml.
+        if (
+            task.phase == "plan"
+            and target == "dev"
+            and self._config is not None
+            and self._config.require_approved_spec
+            and not bypass_spec_gate
+            and not self._has_approved_spec(task_slug)
+        ):
+            raise SpecGateError(
+                f"Task '{task_slug}' has no bound approved spec. "
+                f"Create and approve one (`mship spec approve`) or pass "
+                f"--bypass-spec-gate to skip this check."
             )
 
         old_phase = task.phase
@@ -150,6 +170,24 @@ class PhaseManager:
         except SpecNotFoundError:
             return [warn]
         return []
+
+    def _has_approved_spec(self, task_slug: str) -> bool:
+        """Return True if a spec bound to task_slug has an approved-or-beyond status."""
+        if self._workspace_root is None:
+            return False
+        # Import inside method to avoid potential import cycles at module load.
+        from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+
+        specs_dir = self._workspace_root / SPECS_DIRNAME
+        try:
+            specs = SpecStore(specs_dir).list()
+        except Exception:
+            return False
+        approved_statuses = {"approved", "dispatched", "implemented"}
+        return any(
+            s.task_slug == task_slug and s.status in approved_statuses
+            for s in specs
+        )
 
     def _gate_review(self, task) -> list[str]:
         # Unified reader honors both task.test_results and journal

--- a/src/mship/core/spec_approve.py
+++ b/src/mship/core/spec_approve.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+from mship.core.spec import Spec
+
+
+def approval_blockers(spec: Spec) -> list[str]:
+    """Reasons a spec can't be approved (empty list == approvable)."""
+    blockers: list[str] = []
+    if not spec.acceptance_criteria:
+        blockers.append("no acceptance criteria")
+    bad = [c.id for c in spec.acceptance_criteria if c.verdict != "approved"]
+    if bad:
+        blockers.append(f"acceptance criteria not approved: {', '.join(bad)}")
+    unanswered = [q.id for q in spec.open_questions if q.answer is None]
+    if unanswered:
+        blockers.append(f"open questions unanswered: {', '.join(unanswered)}")
+    return blockers

--- a/src/mship/core/spec_questions.py
+++ b/src/mship/core/spec_questions.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from mship.core.spec import OpenQuestion, Spec
+
+
+def add_question(spec: Spec, text: str) -> OpenQuestion:
+    """Append a question with the next q<n> id (max existing + 1)."""
+    nums = [int(q.id[1:]) for q in spec.open_questions
+            if q.id.startswith("q") and q.id[1:].isdigit()]
+    q = OpenQuestion(id=f"q{(max(nums) + 1) if nums else 1}", text=text)
+    spec.open_questions.append(q)
+    return q
+
+
+def answer_question(spec: Spec, q_id: str, answer: str) -> Spec:
+    for q in spec.open_questions:
+        if q.id == q_id:
+            q.answer = answer
+            return spec
+    valid = ", ".join(q.id for q in spec.open_questions) or "(none)"
+    raise ValueError(f"no open question {q_id!r}; valid ids: {valid}")
+
+
+def list_questions(spec: Spec) -> list[dict]:
+    return [{"id": q.id, "text": q.text, "answer": q.answer} for q in spec.open_questions]

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -398,3 +398,31 @@ def test_spec_verdict_rejects_unknown_criterion(configured_app_with_task: Path, 
     result = runner.invoke(app, ["spec", "verdict", "dq", "ac99", "approved"])
     assert result.exit_code != 0
     assert "ac99" in result.output
+
+
+# --- spec ask / answer / questions (#148) ---
+
+
+def test_spec_ask_adds_question(configured_app_with_task: Path, tmp_path):
+    _apply_dq(tmp_path)  # seeds q1 (from _draft_json open_questions)
+    result = runner.invoke(app, ["spec", "ask", "dq", "Should we support tablets?"])
+    assert result.exit_code == 0, result.output
+    qs = _json.loads(runner.invoke(app, ["spec", "questions", "dq"]).output)
+    assert [q["id"] for q in qs] == ["q1", "q2"]
+
+
+def test_spec_answer_sets_and_status_unchanged(configured_app_with_task: Path, tmp_path):
+    _apply_dq(tmp_path)
+    runner.invoke(app, ["spec", "answer", "dq", "q1", "yes"])
+    review = _json.loads(runner.invoke(app, ["spec", "review", "dq"]).output)
+    assert review["open_questions"][0]["answer"] == "yes"
+    assert review["status"] == "needs_review"  # answering didn't transition status
+    qs = _json.loads(runner.invoke(app, ["spec", "questions", "dq"]).output)
+    assert qs[0]["answer"] == "yes"
+
+
+def test_spec_answer_unknown_question_errors(configured_app_with_task: Path, tmp_path):
+    _apply_dq(tmp_path)
+    result = runner.invoke(app, ["spec", "answer", "dq", "q99", "x"])
+    assert result.exit_code != 0
+    assert "q99" in result.output

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -468,3 +468,71 @@ def test_spec_request_changes(configured_app_with_task: Path, tmp_path):
     result = runner.invoke(app, ["spec", "request-changes", "dq", "--reason", "tighten scope"])
     assert result.exit_code == 0, result.output
     assert _store(configured_app_with_task).find_by_id("dq").status == "needs_clarification"
+
+
+# --- spec dispatch (A6) ---
+# FALLBACK implementation: requires an already-existing task whose slug == spec.id.
+# The spec must be approved; the task binds spec_id; spec transitions to "dispatched".
+
+
+def _approve_add_labels(workspace: Path, tmp_path: Path) -> None:
+    """Create, apply, and approve a spec with id='add-labels' (matches the seeded task)."""
+    runner.invoke(app, ["spec", "new", "--title", "Add labels to tasks", "--id", "add-labels"])
+    jf = tmp_path / "al_draft.json"
+    jf.write_text(_draft_json())
+    runner.invoke(app, ["spec", "apply", "add-labels", "--from-json", str(jf)])
+    runner.invoke(app, ["spec", "verdict", "add-labels", "ac1", "approved"])
+    runner.invoke(app, ["spec", "answer", "add-labels", "q1", "yes"])
+    runner.invoke(app, ["spec", "approve", "add-labels"])
+
+
+def test_spec_dispatch_exits_zero_and_sets_dispatched(configured_app_with_task: Path, tmp_path: Path):
+    """Happy path: approved spec + matching task → status=dispatched, task.spec_id set, output has AC text."""
+    _approve_add_labels(configured_app_with_task, tmp_path)
+    result = runner.invoke(app, ["spec", "dispatch", "add-labels"])
+    assert result.exit_code == 0, result.output
+    spec = _store(configured_app_with_task).find_by_id("add-labels")
+    assert spec.status == "dispatched"
+    assert spec.task_slug == "add-labels"
+    # Output should contain the acceptance criterion text from _draft_json
+    assert "view questions" in result.output
+
+
+def test_spec_dispatch_binds_spec_id_on_task(configured_app_with_task: Path, tmp_path: Path):
+    """spec dispatch must set task.spec_id = spec.id in workspace state."""
+    _approve_add_labels(configured_app_with_task, tmp_path)
+    runner.invoke(app, ["spec", "dispatch", "add-labels"])
+    state_dir = configured_app_with_task / ".mothership"
+    mgr = StateManager(state_dir)
+    state = mgr.load()
+    assert state.tasks["add-labels"].spec_id == "add-labels"
+
+
+def test_spec_dispatch_requires_approved_status(configured_app_with_task: Path, tmp_path: Path):
+    """Dispatching a spec that is not approved must exit non-zero."""
+    # Create spec but only apply (status=needs_review, not approved)
+    runner.invoke(app, ["spec", "new", "--title", "Add labels to tasks", "--id", "add-labels"])
+    jf = tmp_path / "al_draft.json"
+    jf.write_text(_draft_json())
+    runner.invoke(app, ["spec", "apply", "add-labels", "--from-json", str(jf)])
+    result = runner.invoke(app, ["spec", "dispatch", "add-labels"])
+    assert result.exit_code != 0
+    assert "approve" in result.output.lower()
+
+
+def test_spec_dispatch_requires_matching_task(configured_app_with_task: Path, tmp_path: Path):
+    """If no task with slug==spec.id exists, dispatch must exit non-zero with helpful hint."""
+    # Create a spec with id "dq" — no matching task in state
+    _apply_dq(tmp_path)
+    # Approve it manually (bypass gate to skip verdict/answer steps)
+    runner.invoke(app, ["spec", "approve", "dq", "--bypass-gate"])
+    result = runner.invoke(app, ["spec", "dispatch", "dq"])
+    assert result.exit_code != 0
+    assert "mship spawn" in result.output or "spawn" in result.output.lower()
+
+
+def test_spec_dispatch_unknown_id_errors(configured_app_with_task: Path):
+    """Dispatching a non-existent spec id must exit non-zero."""
+    result = runner.invoke(app, ["spec", "dispatch", "no-such-spec"])
+    assert result.exit_code != 0
+    assert "no-such-spec" in result.output

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -426,3 +426,45 @@ def test_spec_answer_unknown_question_errors(configured_app_with_task: Path, tmp
     result = runner.invoke(app, ["spec", "answer", "dq", "q99", "x"])
     assert result.exit_code != 0
     assert "q99" in result.output
+
+
+# --- spec approve / request-changes (A5) ---
+
+
+def test_spec_approve_refused_while_unreviewed(configured_app_with_task: Path, tmp_path):
+    _apply_dq(tmp_path)  # ac1 unreviewed, q1 unanswered
+    result = runner.invoke(app, ["spec", "approve", "dq"])
+    assert result.exit_code != 0
+    assert "ac1" in result.output
+
+
+def test_spec_approve_succeeds_when_clear(configured_app_with_task: Path, tmp_path):
+    _apply_dq(tmp_path)
+    runner.invoke(app, ["spec", "verdict", "dq", "ac1", "approved"])
+    runner.invoke(app, ["spec", "answer", "dq", "q1", "yes"])
+    result = runner.invoke(app, ["spec", "approve", "dq"])
+    assert result.exit_code == 0, result.output
+    assert _store(configured_app_with_task).find_by_id("dq").status == "approved"
+
+
+def test_spec_approve_bypass_gate(configured_app_with_task: Path, tmp_path):
+    _apply_dq(tmp_path)  # still blocked
+    result = runner.invoke(app, ["spec", "approve", "dq", "--bypass-gate"])
+    assert result.exit_code == 0, result.output
+    assert _store(configured_app_with_task).find_by_id("dq").status == "approved"
+
+
+def test_spec_approve_rejected_from_wrong_status(configured_app_with_task: Path, tmp_path):
+    _apply_dq(tmp_path)
+    runner.invoke(app, ["spec", "verdict", "dq", "ac1", "approved"])
+    runner.invoke(app, ["spec", "answer", "dq", "q1", "yes"])
+    runner.invoke(app, ["spec", "approve", "dq"])              # -> approved
+    again = runner.invoke(app, ["spec", "approve", "dq"])      # approved -> approved illegal
+    assert again.exit_code != 0
+
+
+def test_spec_request_changes(configured_app_with_task: Path, tmp_path):
+    _apply_dq(tmp_path)
+    result = runner.invoke(app, ["spec", "request-changes", "dq", "--reason", "tighten scope"])
+    assert result.exit_code == 0, result.output
+    assert _store(configured_app_with_task).find_by_id("dq").status == "needs_clarification"

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from mship.core.log import LogManager
-from mship.core.phase import FinishedTaskError, PhaseManager, PhaseTransition
+from mship.core.phase import FinishedTaskError, PhaseManager, PhaseTransition, SpecGateError
 from mship.core.state import StateManager, Task, TestResult, WorkspaceState
 
 
@@ -276,3 +276,108 @@ def test_transition_to_run_on_finished_task_allowed_without_force(phase_env):
     sm.save(state)
     result = pm.transition("t", "run")
     assert result.new_phase == "run"
+
+
+# ---------------------------------------------------------------------------
+# A7 — require_approved_spec gate (MOS-151)
+# ---------------------------------------------------------------------------
+
+def _make_phase_manager_with_approved_spec_gate(
+    state_mgr: StateManager,
+    workspace_root: Path,
+    require_approved_spec: bool = True,
+) -> PhaseManager:
+    """Build a PhaseManager with require_approved_spec toggled."""
+    from mship.core.config import WorkspaceConfig, RepoConfig
+    config = WorkspaceConfig(
+        workspace="test",
+        repos={"shared": RepoConfig(path=Path("./shared"), type="library")},
+        require_approved_spec=require_approved_spec,
+    )
+    return PhaseManager(
+        state_mgr,
+        MagicMock(spec=LogManager),
+        config=config,
+        workspace_root=workspace_root,
+    )
+
+
+def _seed_approved_spec(workspace_root: Path, task_slug: str) -> None:
+    """Write a minimal approved spec bound to task_slug into the specs dir."""
+    from datetime import datetime, timezone
+    from mship.core.spec import Spec
+    from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+
+    now = datetime.now(timezone.utc)
+    spec = Spec(
+        id=f"{task_slug}-spec",
+        title=f"Spec for {task_slug}",
+        status="approved",
+        created_at=now,
+        updated_at=now,
+        task_slug=task_slug,
+    )
+    SpecStore(workspace_root / SPECS_DIRNAME).save(spec)
+
+
+def test_a7_plan_to_dev_blocked_when_require_approved_spec_and_no_spec(
+    state_with_task: StateManager, tmp_path: Path
+):
+    """require_approved_spec=True + no bound approved spec → SpecGateError."""
+    pm = _make_phase_manager_with_approved_spec_gate(state_with_task, tmp_path)
+    with pytest.raises(SpecGateError):
+        pm.transition("add-labels", "dev")
+
+
+def test_a7_plan_to_dev_allowed_when_approved_spec_exists(
+    state_with_task: StateManager, tmp_path: Path
+):
+    """require_approved_spec=True + bound approved spec → transition succeeds."""
+    _seed_approved_spec(tmp_path, "add-labels")
+    pm = _make_phase_manager_with_approved_spec_gate(state_with_task, tmp_path)
+    result = pm.transition("add-labels", "dev")
+    assert result.new_phase == "dev"
+
+
+def test_a7_plan_to_dev_allowed_with_bypass_spec_gate(
+    state_with_task: StateManager, tmp_path: Path
+):
+    """require_approved_spec=True + no spec + bypass_spec_gate=True → succeeds."""
+    pm = _make_phase_manager_with_approved_spec_gate(state_with_task, tmp_path)
+    result = pm.transition("add-labels", "dev", bypass_spec_gate=True)
+    assert result.new_phase == "dev"
+
+
+def test_a7_plan_to_dev_default_off_no_spec_still_succeeds(
+    state_with_task: StateManager, tmp_path: Path
+):
+    """Default config (require_approved_spec=False) + no spec → plan→dev succeeds (backward compat)."""
+    pm = _make_phase_manager_with_approved_spec_gate(
+        state_with_task, tmp_path, require_approved_spec=False
+    )
+    result = pm.transition("add-labels", "dev")
+    assert result.new_phase == "dev"
+
+
+def test_a7_dispatched_spec_also_satisfies_gate(
+    state_with_task: StateManager, tmp_path: Path
+):
+    """A spec with status='dispatched' should also satisfy the gate."""
+    from datetime import datetime, timezone
+    from mship.core.spec import Spec
+    from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+
+    now = datetime.now(timezone.utc)
+    spec = Spec(
+        id="add-labels-dispatched",
+        title="Dispatched spec",
+        status="dispatched",
+        created_at=now,
+        updated_at=now,
+        task_slug="add-labels",
+    )
+    SpecStore(tmp_path / SPECS_DIRNAME).save(spec)
+
+    pm = _make_phase_manager_with_approved_spec_gate(state_with_task, tmp_path)
+    result = pm.transition("add-labels", "dev")
+    assert result.new_phase == "dev"

--- a/tests/core/test_spec_approve.py
+++ b/tests/core/test_spec_approve.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timezone
+from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec
+from mship.core.spec_approve import approval_blockers
+
+
+def _spec(criteria=None, questions=None):
+    now = datetime(2026, 6, 14, tzinfo=timezone.utc)
+    return Spec(id="dq", title="DQ", status="needs_review", created_at=now, updated_at=now,
+                acceptance_criteria=criteria or [], open_questions=questions or [])
+
+
+def test_blockers_flag_unapproved_criteria():
+    s = _spec(criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="flagged")])
+    assert any("ac1" in b for b in approval_blockers(s))
+
+
+def test_blockers_flag_unanswered_questions():
+    s = _spec(criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
+              questions=[OpenQuestion(id="q1", text="?")])
+    assert any("q1" in b for b in approval_blockers(s))
+
+
+def test_blockers_flag_no_criteria():
+    assert approval_blockers(_spec()) != []
+
+
+def test_no_blockers_when_all_clear():
+    s = _spec(criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
+              questions=[OpenQuestion(id="q1", text="?", answer="yes")])
+    assert approval_blockers(s) == []

--- a/tests/core/test_spec_questions.py
+++ b/tests/core/test_spec_questions.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timezone
+import pytest
+from mship.core.spec import OpenQuestion, Spec
+from mship.core.spec_questions import add_question, answer_question, list_questions
+
+
+def _spec(qs=None):
+    now = datetime(2026, 6, 14, tzinfo=timezone.utc)
+    return Spec(id="dq", title="DQ", status="needs_review", created_at=now, updated_at=now,
+                open_questions=qs or [])
+
+
+def test_add_question_assigns_sequential_ids():
+    s = _spec()
+    assert add_question(s, "first").id == "q1"
+    assert add_question(s, "second").id == "q2"
+
+
+def test_add_question_continues_after_existing():
+    s = _spec([OpenQuestion(id="q1", text="seeded")])
+    assert add_question(s, "next").id == "q2"
+
+
+def test_answer_question_sets_and_rejects_unknown():
+    s = _spec([OpenQuestion(id="q1", text="?")])
+    answer_question(s, "q1", "yes")
+    assert s.open_questions[0].answer == "yes"
+    with pytest.raises(ValueError):
+        answer_question(s, "q9", "x")
+
+
+def test_list_questions_shape():
+    s = _spec([OpenQuestion(id="q1", text="?", answer="a")])
+    assert list_questions(s) == [{"id": "q1", "text": "?", "answer": "a"}]


### PR DESCRIPTION
## Summary

Completes the **`mship spec` lifecycle** (Ground Control workstream A4–A7) in one PR. The CLI now spans the full flow: `new → draft → apply → review/verdict → **questions → approve → dispatch**` (+ an opt-in `plan→dev` gate).

- **A4 — [MOS-148](https://linear.app/atomik-panda-labs/issue/MOS-148) `spec questions` / `ask` / `answer`** — manage a spec's open questions (sequential `q<n>` ids; answering does **not** change status — it's an annotation).
- **A5 — [MOS-149](https://linear.app/atomik-panda-labs/issue/MOS-149) `spec approve` / `request-changes`** — approval **gate** via `approval_blockers` (refuses unless every acceptance criterion is `approved` and every open question is answered; `--bypass-gate` overrides); `request-changes` → `needs_clarification`.
- **A6 — [MOS-150](https://linear.app/atomik-panda-labs/issue/MOS-150) `spec dispatch`** — dispatch an approved spec: bind `task.spec_id`, move spec → `dispatched`, emit a handoff prompt seeded with the spec's problem + acceptance criteria.
- **A7 — [MOS-151](https://linear.app/atomik-panda-labs/issue/MOS-151) `plan→dev` gate** — opt-in requirement for a bound, approved spec; `--bypass-spec-gate`.

Reuses the A1–A3 primitives (`Spec`, `validate_transition`, `SpecStore`, `parse_body_sections`) throughout. New core helpers: `spec_questions.py`, `spec_approve.py`.

## ⚠️ Judgment calls to review (made autonomously — please confirm)

1. **A6 took the FALLBACK (no auto-spawn).** `spec dispatch <id>` requires a task **already spawned** with `slug == spec.id` (it binds + dispatches + emits the prompt) rather than auto-spawning the worktrees. Reason: `WorktreeManager.spawn` needs a real git workspace + mutates state internally, making clean unit-testing of auto-spawn impractical here. There's a `TODO(auto-spawn)` in `cli/spec.py` for the upgrade. **Focus your review on `cli/spec.py` `dispatch`** — confirm the fallback contract is OK for v1, and note the two non-atomic writes (task mutate + spec save).
2. **A7 is config-gated, default OFF** (refined from the design's "hard requirement"). A hard default would break the basic `spawn → dev` flow + every existing test. Instead: `require_approved_spec: false` in `mothership.yaml`; teams opt in. Gate is provably inert when off (verified by a backward-compat test). Bypass: `--bypass-spec-gate`.
3. **`request-changes --reason` is journaled, not persisted on the spec** — avoids a model field this PR; a `change_requests[]` field is a clean follow-on if you want the reason on the artifact.

Design + rationale: `docs/superpowers/specs/2026-06-14-spec-lifecycle-design.md` (🟡-flagged inline).

## Test plan

- [x] `mship test` green — **full suite 1336 passing**.
- [x] New tests: `spec_questions` (id sequencing, answer/unknown-id, status-unchanged), `spec_approve` (all blocker conditions + refuse/succeed/bypass/wrong-status/request-changes), A7 gate (blocked / allowed-with-approved-spec / bypass / **default-off backward-compat**), A6 dispatch (approved-required / missing-task / unknown-id / binding).
- [x] Per-feature spec+quality reviews + a final whole-branch review (merge-ready; A7 gate confirmed inert-when-off by reading the condition).

## Scope

A4–A7 only. Out: per-prose-card verdicts, the serve API (B1), the GC app (C), A6 auto-spawn (TODO), persisting the request-changes reason.
