### PR TITLE
mship serve read-only API B1

### DIFF
--- a/docs/superpowers/plans/2026-06-14-mship-serve.md
+++ b/docs/superpowers/plans/2026-06-14-mship-serve.md
@@ -1,0 +1,332 @@
+# `mship serve` (read-only FastAPI) — Implementation Plan (B1 / MOS-152)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: subagent-driven-development. Steps use checkbox (`- [ ]`).
+
+**Goal:** A persistent, read-only JSON API over the spec + task model for Ground Control, built with FastAPI, calling the mship core directly.
+
+**Architecture:** `core/serve.py` exposes `create_app(specs_dir, state_manager, log_manager, workspace_root, workspace_name) -> FastAPI` with sync GET handlers that call the core (`SpecStore`, `build_review`, `build_task_index`, `LogManager`) — FastAPI serializes the returns. `cli/serve.py` runs it via `uvicorn` on `127.0.0.1`. Tested with FastAPI `TestClient` (no socket). Design: [docs/superpowers/specs/2026-06-14-mship-serve-design.md](../specs/2026-06-14-mship-serve-design.md).
+
+**Tech Stack:** Python, FastAPI, uvicorn, pydantic v2, Typer, pytest. Reuses A1–A7 core (in `main`).
+
+---
+
+## File structure
+- **Create** `src/mship/core/serve.py` (`create_app` factory).
+- **Create** `src/mship/cli/serve.py` (`mship serve` command).
+- **Modify** `pyproject.toml` (add `fastapi`, `uvicorn`), `uv.lock` (via `uv sync`), `src/mship/cli/__init__.py` (register).
+- **Test** `tests/core/test_serve.py` (TestClient), `tests/cli/test_serve.py` (command smoke).
+
+---
+
+## Task 1: deps + app skeleton + `/health` + command wiring
+
+**Files:** `pyproject.toml`, `src/mship/core/serve.py`, `src/mship/cli/serve.py`, `src/mship/cli/__init__.py`, `tests/core/test_serve.py`.
+
+- [ ] **Step 1: Add deps + install.** In `pyproject.toml` `[project].dependencies`, add `"fastapi>=0.110"` and `"uvicorn>=0.27"`. Then run `uv sync` (updates `uv.lock` + the worktree venv) so `import fastapi` works under `uv run`. Verify: `uv run python -c "import fastapi, uvicorn; print('ok')"`.
+
+- [ ] **Step 2: Failing test** (`tests/core/test_serve.py`):
+
+```python
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+from mship.core.serve import create_app
+from mship.core.state import StateManager
+
+
+def _app(tmp_path: Path):
+    state = StateManager(tmp_path / ".mothership")
+    return create_app(
+        specs_dir=tmp_path / "specs",
+        state_manager=state,
+        log_manager=None,
+        workspace_root=tmp_path,
+        workspace_name="test-ws",
+    )
+
+
+def test_health(tmp_path):
+    client = TestClient(_app(tmp_path))
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok", "workspace": "test-ws"}
+```
+
+- [ ] **Step 3: Run → fail** (`uv run pytest tests/core/test_serve.py -v` → ImportError / no create_app).
+
+- [ ] **Step 4: Implement** (`src/mship/core/serve.py`):
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def create_app(
+    specs_dir: Path,
+    state_manager,
+    log_manager,
+    workspace_root: Path,
+    workspace_name: str = "mothership",
+):
+    """Build the read-only mship serve FastAPI app. Sync handlers call the core
+    directly; FastAPI serializes the returns (pydantic models, dicts, dataclasses)."""
+    from fastapi import FastAPI, HTTPException
+
+    from mship.core.spec_store import SpecStore
+
+    app = FastAPI(title="mship serve", version="0")
+    store = SpecStore(specs_dir)
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok", "workspace": workspace_name}
+
+    return app
+```
+
+- [ ] **Step 5: Run → pass.** Then register the command. In `src/mship/cli/serve.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from mship.cli.output import Output
+
+
+def register(app: typer.Typer, get_container):
+    @app.command()
+    def serve(
+        port: int = typer.Option(47100, "--port", help="Port to bind on 127.0.0.1."),
+    ):
+        """Run a read-only JSON API over the spec + task model (Ground Control)."""
+        import uvicorn
+        from mship.core.serve import create_app
+        from mship.core.spec_store import SPECS_DIRNAME
+
+        container = get_container()
+        workspace_root = Path(container.config_path()).parent
+        api = create_app(
+            specs_dir=workspace_root / SPECS_DIRNAME,
+            state_manager=container.state_manager(),
+            log_manager=container.log_manager(),
+            workspace_root=workspace_root,
+            workspace_name=container.config().workspace,
+        )
+        Output().print(f"mship serve → http://127.0.0.1:{port}  (docs: /docs)")
+        uvicorn.run(api, host="127.0.0.1", port=port)
+```
+
+  In `src/mship/cli/__init__.py`: add `from mship.cli import serve as _serve_mod` (with the other imports) and `_serve_mod.register(app, get_container)` (with the other register calls).
+
+- [ ] **Step 6: CLI smoke test** (`tests/cli/test_serve.py`):
+
+```python
+from typer.testing import CliRunner
+from mship.cli import app
+
+runner = CliRunner()
+
+
+def test_serve_command_registered():
+    result = runner.invoke(app, ["serve", "--help"])
+    assert result.exit_code == 0
+    assert "127.0.0.1" in result.output
+```
+
+- [ ] **Step 7: Commit** `feat(serve): mship serve skeleton (FastAPI app + /health + command)` + `mship journal`.
+
+---
+
+## Task 2: spec endpoints (`/specs`, `/specs/{id}`, `/specs/{id}/review`)
+
+**Files:** `src/mship/core/serve.py`; `tests/core/test_serve.py`.
+
+- [ ] **Step 1: Failing tests** (append; add a helper that seeds a spec via `SpecStore`):
+
+```python
+from datetime import datetime, timezone
+from mship.core.spec import AcceptanceCriterion, Spec
+from mship.core.spec_store import SpecStore
+from mship.core.spec_body import render_body
+
+
+def _seed_spec(tmp_path: Path):
+    now = datetime(2026, 6, 14, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(
+        id="dq", title="Decision queue", status="needs_review",
+        created_at=now, updated_at=now, task_slug="dq",
+        body=render_body("the problem", "as a user", "the approach"),
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="view questions", verdict="approved")],
+    ))
+
+
+def test_list_specs(tmp_path):
+    _seed_spec(tmp_path)
+    r = TestClient(_app(tmp_path)).get("/specs")
+    assert r.status_code == 200
+    assert r.json() == [{"id": "dq", "title": "Decision queue", "status": "needs_review", "task_slug": "dq"}]
+
+
+def test_get_spec_and_404(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    assert client.get("/specs/dq").json()["id"] == "dq"
+    assert client.get("/specs/nope").status_code == 404
+
+
+def test_get_review(tmp_path):
+    _seed_spec(tmp_path)
+    r = TestClient(_app(tmp_path)).get("/specs/dq/review")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["acceptance_criteria"][0]["id"] == "ac1"
+    assert body["summary"]["approved"] == 1
+```
+
+- [ ] **Step 2: Run → fail** (404s, routes not registered).
+
+- [ ] **Step 3: Implement** — inside `create_app`, after `/health`:
+
+```python
+    from mship.core.spec_review import build_review
+
+    @app.get("/specs")
+    def list_specs():
+        return [
+            {"id": s.id, "title": s.title, "status": s.status, "task_slug": s.task_slug}
+            for s in store.list()
+        ]
+
+    @app.get("/specs/{spec_id}")
+    def get_spec(spec_id: str):
+        spec = store.find_by_id(spec_id)
+        if spec is None:
+            raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
+        return spec.model_dump(mode="json")
+
+    @app.get("/specs/{spec_id}/review")
+    def get_review(spec_id: str):
+        spec = store.find_by_id(spec_id)
+        if spec is None:
+            raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
+        return build_review(spec)
+```
+
+- [ ] **Step 4: Run → pass.** **Step 5: Commit** `feat(serve): /specs, /specs/{id}, /specs/{id}/review` + journal.
+
+---
+
+## Task 3: task + journal endpoints (`/tasks`, `/tasks/{slug}`, `/journal/{slug}`)
+
+**Files:** `src/mship/core/serve.py`; `tests/core/test_serve.py`.
+
+- [ ] **Step 1: Failing tests** (append; seed a task into state + a journal entry):
+
+```python
+from mship.core.state import Task, WorkspaceState
+from mship.core.log import LogManager
+
+
+def _seed_task(tmp_path: Path):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    sm = StateManager(state_dir)
+    sm.save(WorkspaceState(tasks={"dq": Task(
+        slug="dq", description="d", phase="dev",
+        created_at=datetime(2026, 6, 14, tzinfo=timezone.utc),
+        affected_repos=["mothership"], branch="feat/dq",
+    )}))
+    log = LogManager(state_dir / "logs")
+    log.append("dq", "spawned")
+    return sm, log
+
+
+def _app_with(tmp_path, sm, log):
+    return create_app(specs_dir=tmp_path / "specs", state_manager=sm,
+                      log_manager=log, workspace_root=tmp_path, workspace_name="test-ws")
+
+
+def test_list_and_get_task(tmp_path):
+    sm, log = _seed_task(tmp_path)
+    client = TestClient(_app_with(tmp_path, sm, log))
+    assert any(t["slug"] == "dq" for t in client.get("/tasks").json())
+    assert client.get("/tasks/dq").json()["slug"] == "dq"
+    assert client.get("/tasks/nope").status_code == 404
+
+
+def test_journal(tmp_path):
+    sm, log = _seed_task(tmp_path)
+    client = TestClient(_app_with(tmp_path, sm, log))
+    entries = client.get("/journal/dq").json()
+    assert any("spawned" in e["message"] for e in entries)
+    assert client.get("/journal/nope").status_code == 404
+```
+
+- [ ] **Step 2: Run → fail.** **Step 3: Implement** — inside `create_app`:
+
+```python
+    from mship.core.view.task_index import build_task_index
+
+    @app.get("/tasks")
+    def list_tasks():
+        return build_task_index(state_manager.load(), workspace_root)
+
+    @app.get("/tasks/{slug}")
+    def get_task(slug: str):
+        state = state_manager.load()
+        if slug not in state.tasks:
+            raise HTTPException(status_code=404, detail=f"no task {slug!r}")
+        by_slug = {t.slug: t for t in build_task_index(state, workspace_root)}
+        return by_slug[slug]
+
+    @app.get("/journal/{slug}")
+    def get_journal(slug: str):
+        state = state_manager.load()
+        if slug not in state.tasks:
+            raise HTTPException(status_code=404, detail=f"no task {slug!r}")
+        return log_manager.read(slug, last=50)
+```
+
+  (FastAPI runs `jsonable_encoder` on returns, handling the `TaskSummary`/`LogEntry` dataclasses + their `Path`/`datetime` fields. If a field fails to encode, wrap the return in `from fastapi.encoders import jsonable_encoder` explicitly — but verify the plain return works first.)
+
+- [ ] **Step 4: Run → pass.** **Step 5: Commit** `feat(serve): /tasks, /tasks/{slug}, /journal/{slug}` + journal.
+
+---
+
+## Task 4: read-only guard + full suite
+
+**Files:** `tests/core/test_serve.py`; `tests/cli/test_serve.py`.
+
+- [ ] **Step 1: Tests** — confirm read-only + unknown-path behavior (FastAPI defaults):
+
+```python
+def test_post_is_405(tmp_path):
+    # No write routes registered → POST to a GET path is 405 (Method Not Allowed).
+    r = TestClient(_app(tmp_path)).post("/specs/dq/review")
+    assert r.status_code == 405
+
+
+def test_unknown_path_404(tmp_path):
+    assert TestClient(_app(tmp_path)).get("/nope").status_code == 404
+```
+
+- [ ] **Step 2: Run → pass.** If `POST /specs/dq/review` returns 404 rather than 405 (path templating nuance), adjust the test to POST a concrete GET path that exists for GET (e.g. `/health`) — confirm 405 there; the point is "no writes accepted."
+
+- [ ] **Step 3: Full suite.** `mship test` (or `uv run pytest`) → green. Confirm the new `fastapi`/`uvicorn` deps didn't perturb anything; `uv.lock` is updated + committed.
+
+- [ ] **Step 4: Commit** `test(serve): read-only guard + unknown-path; full suite green` + journal.
+
+---
+
+## Self-Review
+- **Coverage:** `/health` (T1), `/specs` + `/specs/{id}` + `/review` (T2), `/tasks` + `/tasks/{slug}` + `/journal/{slug}` (T3), read-only 405 + 404 (T4). `create_app` factory + `mship serve` command + registration + deps (T1).
+- **Placeholders:** none — complete code. The one runtime check (does the plain dataclass return serialize, else `jsonable_encoder`) is called out, not hidden.
+- **Decisions honored:** core-direct (handlers call core, no CLI subprocess); FastAPI + uvicorn (deps added); read-only (no write routes); localhost bind; sync handlers.
+- **Type consistency:** `create_app(specs_dir, state_manager, log_manager, workspace_root, workspace_name)`; reuses `SpecStore`, `build_review`, `build_task_index`, `LogManager.read`, `Spec.model_dump`, `SPECS_DIRNAME`.
+
+## Execution Handoff
+Commit this plan + design to `main`, then `mship spawn` MOS-152. Note T1 runs `uv sync` to install the new deps in the worktree before tests can import FastAPI.

--- a/docs/superpowers/specs/2026-06-14-mship-serve-design.md
+++ b/docs/superpowers/specs/2026-06-14-mship-serve-design.md
@@ -1,0 +1,90 @@
+# `mship serve` — read-only JSON API — design (B1 / MOS-152)
+
+> Status: design approved 2026-06-14. Feeds `writing-plans`.
+> Part of **Ground Control** (epic MOS-144). The persistent surface the GC app
+> reads from. Builds on the A1–A7 spec lifecycle (all merged).
+
+## Context
+
+Ground Control needs a persistent endpoint a phone client can read. Today only an
+*ephemeral* `mship view spec --web` server exists (stdlib `http.server`, one spec
+at a time). B1 is a long-lived JSON API over the whole spec + task model.
+
+## Decisions
+
+1. **Core-library-direct (NOT CLI-wrapping).** `serve` imports the core
+   (`SpecStore`, `build_review`, `StateManager` / `build_task_index`, `LogManager`)
+   and serializes models to JSON itself. No subprocess, no parsing CLI output.
+   **This removes the MOS-103 dependency** — the API shape is owned by `serve`, not
+   by the CLI's TTY detection.
+2. **FastAPI + uvicorn** (two new deps — deliberate). Reuses mship's pydantic v2
+   models as response schemas, auto-generates OpenAPI/Swagger docs (a
+   self-documenting contract for the GC app developer), gives clean path-param
+   routing + validation, and sets up cleanly for the write endpoints (follow-on)
+   and B2 auth (FastAPI dependencies/middleware). Route handlers are plain `def`
+   (sync) — FastAPI runs them in a worker thread, so the sync core (`SpecStore`,
+   `StateManager`) needs **no async rewrite**.
+3. **Read-only (v0).** GET endpoints only. Writes (verdict / answer / approve /
+   dispatch) are a tight follow-on (the core helpers already exist) — POST/PUT
+   return `405` with a "writes not yet supported" body.
+4. **Bind `127.0.0.1`, no auth.** B2 (MOS-153) adds Tailscale reachability +
+   single-user auth. B1 is localhost-only.
+5. **Testable via FastAPI `TestClient`.** Tests exercise the app with Starlette's
+   `TestClient` (httpx-based, no real socket) — full request/response coverage
+   without binding a port.
+
+## Architecture
+
+- **`src/mship/core/serve.py`** — `create_app(specs_dir, state_manager, log_manager,
+  workspace_root) -> FastAPI`: builds the app and registers the GET routes; each
+  handler calls the core and returns a pydantic model / dict (FastAPI serializes +
+  schemas it). Workspace context is captured via the factory closure. This factory
+  is the unit-tested surface (`TestClient(create_app(...))`).
+- **`src/mship/cli/serve.py`** — the `mship serve [--port]` command: build the app
+  from the container, then `uvicorn.run(app, host="127.0.0.1", port=port)`.
+  Registered in `cli/__init__.py`. `fastapi`/`uvicorn` are imported **inside** the
+  command (lazy) so the rest of the CLI doesn't pay their import cost.
+
+## Endpoints (v0, all GET → JSON)
+
+| Path | Returns |
+|------|---------|
+| `GET /health` | `{"status":"ok","workspace":<name>}` |
+| `GET /specs` | list of `{id, title, status, task_slug}` (from `SpecStore.list()`) |
+| `GET /specs/<id>` | the full spec (`spec.model_dump(mode="json")`), `404` if absent |
+| `GET /specs/<id>/review` | `build_review(spec)` (the C4 review-card payload), `404` if absent |
+| `GET /tasks` | `build_task_index(state, workspace_root)` summaries |
+| `GET /tasks/<slug>` | that task's detail (status envelope), `404` if absent |
+| `GET /journal/<slug>` | recent journal entries (`LogManager.read(slug)`), `404` if task absent |
+
+- Any other path → `404 {"error": "..."}`. Non-GET → `405 {"error":"read-only; writes not yet supported"}`.
+- Content-Type `application/json`; bodies are `json.dumps`'d.
+- Spec id / task slug parsed from the path; unsafe/unknown → `404`.
+
+## Scope (B1 v0)
+
+In: the `SpecApi` router + the GET endpoints + the `mship serve` command + a default
+port (`47100`, `--port` to override). Out: write endpoints (follow-on), auth +
+Tailscale (B2), the app (C), MOS-103 (decoupled).
+
+## Migration / compat
+
+Additive — a new command + new modules; no change to existing behavior. Adds two
+runtime dependencies (`fastapi`, `uvicorn`) to `pyproject.toml` — the first
+web-framework deps in the repo.
+
+## Testing
+
+- `TestClient(create_app(...))` (no socket): `/health`; `/specs` lists seeded specs;
+  `/specs/<id>` → spec / `404` for unknown; `/specs/<id>/review` → a
+  `build_review`-shaped payload; `/tasks` + `/tasks/<slug>` (seeded state) + `404`;
+  `/journal/<slug>`; unknown path → `404`; `POST /specs/<id>/...` → `405` (no write
+  route registered). `TestClient` exercises the real ASGI app end-to-end, so no
+  separate socket test is needed.
+
+## Follow-ons
+
+- **Writes** (verdict / answer / approve / request-changes / dispatch) over POST —
+  thin wrappers on the existing core helpers; the next increment.
+- **B2 (MOS-153)** — Tailscale bind + single-user auth on top of this server.
+- **MOS-103** — still worth doing for CLI/CI determinism, but no longer blocks B1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "InquirerPy>=0.3",
     "dependency-injector>=4.0",
     "pyyaml>=6.0",
+    "fastapi>=0.110",
+    "uvicorn>=0.27",
 ]
 
 [project.scripts]
@@ -34,4 +36,5 @@ dev = [
     "pytest-tmp-files>=0.0.2",
     "pytest-asyncio>=0.23",
     "coverage>=7.13.5",
+    "httpx>=0.27",
 ]

--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -93,6 +93,7 @@ from mship.cli import skill as _skill_mod
 from mship.cli import spec as _spec_mod
 from mship.cli import status as _status_mod
 from mship.cli import switch as _switch_mod
+from mship.cli import serve as _serve_mod
 from mship.cli import sync as _sync_mod
 from mship.cli import view as _view_mod
 from mship.cli import worktree as _worktree_mod
@@ -145,6 +146,7 @@ _skill_mod.register(app, get_container)
 _spec_mod.register(app, get_container)
 _status_mod.register(app, get_container)
 _switch_mod.register(app, get_container)
+_serve_mod.register(app, get_container)
 _sync_mod.register(app, get_container)
 _view_mod.register(app, get_container)
 _worktree_mod.register(app, get_container)

--- a/src/mship/cli/serve.py
+++ b/src/mship/cli/serve.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from mship.cli.output import Output
+
+
+def register(app: typer.Typer, get_container):
+    @app.command()
+    def serve(
+        port: int = typer.Option(47100, "--port", help="Port to bind on 127.0.0.1."),
+    ):
+        """Run a read-only JSON API over the spec + task model (Ground Control)."""
+        import uvicorn
+        from mship.core.serve import create_app
+        from mship.core.spec_store import SPECS_DIRNAME
+
+        container = get_container()
+        workspace_root = Path(container.config_path()).parent
+        api = create_app(
+            specs_dir=workspace_root / SPECS_DIRNAME,
+            state_manager=container.state_manager(),
+            log_manager=container.log_manager(),
+            workspace_root=workspace_root,
+            workspace_name=container.config().workspace,
+        )
+        Output().print(f"mship serve → http://127.0.0.1:{port}  (docs: /docs)")
+        uvicorn.run(api, host="127.0.0.1", port=port)

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -12,15 +12,38 @@ def create_app(
 ):
     """Build the read-only mship serve FastAPI app. Sync handlers call the core
     directly; FastAPI serializes the returns (pydantic models, dicts, dataclasses)."""
-    from fastapi import FastAPI, HTTPException  # noqa: F401  (HTTPException used in later tasks)
+    from fastapi import FastAPI, HTTPException
 
     from mship.core.spec_store import SpecStore
 
     app = FastAPI(title="mship serve", version="0")
-    store = SpecStore(specs_dir)  # noqa: F841  (used in later tasks)
+    store = SpecStore(specs_dir)
 
     @app.get("/health")
     def health():
         return {"status": "ok", "workspace": workspace_name}
+
+    from mship.core.spec_review import build_review
+
+    @app.get("/specs")
+    def list_specs():
+        return [
+            {"id": s.id, "title": s.title, "status": s.status, "task_slug": s.task_slug}
+            for s in store.list()
+        ]
+
+    @app.get("/specs/{spec_id}")
+    def get_spec(spec_id: str):
+        spec = store.find_by_id(spec_id)
+        if spec is None:
+            raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
+        return spec.model_dump(mode="json")
+
+    @app.get("/specs/{spec_id}/review")
+    def get_review(spec_id: str):
+        spec = store.find_by_id(spec_id)
+        if spec is None:
+            raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
+        return build_review(spec)
 
     return app

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def create_app(
+    specs_dir: Path,
+    state_manager,
+    log_manager,
+    workspace_root: Path,
+    workspace_name: str = "mothership",
+):
+    """Build the read-only mship serve FastAPI app. Sync handlers call the core
+    directly; FastAPI serializes the returns (pydantic models, dicts, dataclasses)."""
+    from fastapi import FastAPI, HTTPException  # noqa: F401  (HTTPException used in later tasks)
+
+    from mship.core.spec_store import SpecStore
+
+    app = FastAPI(title="mship serve", version="0")
+    store = SpecStore(specs_dir)  # noqa: F841  (used in later tasks)
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok", "workspace": workspace_name}
+
+    return app

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -46,4 +46,26 @@ def create_app(
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
         return build_review(spec)
 
+    from fastapi.encoders import jsonable_encoder
+    from mship.core.view.task_index import build_task_index
+
+    @app.get("/tasks")
+    def list_tasks():
+        return jsonable_encoder(build_task_index(state_manager.load(), workspace_root))
+
+    @app.get("/tasks/{slug}")
+    def get_task(slug: str):
+        state = state_manager.load()
+        if slug not in state.tasks:
+            raise HTTPException(status_code=404, detail=f"no task {slug!r}")
+        by_slug = {t.slug: t for t in build_task_index(state, workspace_root)}
+        return jsonable_encoder(by_slug[slug])
+
+    @app.get("/journal/{slug}")
+    def get_journal(slug: str):
+        state = state_manager.load()
+        if slug not in state.tasks:
+            raise HTTPException(status_code=404, detail=f"no task {slug!r}")
+        return jsonable_encoder(log_manager.read(slug, last=50))
+
     return app

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -1,0 +1,10 @@
+from typer.testing import CliRunner
+from mship.cli import app
+
+runner = CliRunner()
+
+
+def test_serve_command_registered():
+    result = runner.invoke(app, ["serve", "--help"])
+    assert result.exit_code == 0
+    assert "127.0.0.1" in result.output

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -1,7 +1,11 @@
+from datetime import datetime, timezone
 from pathlib import Path
 from fastapi.testclient import TestClient
 
 from mship.core.serve import create_app
+from mship.core.spec import AcceptanceCriterion, Spec
+from mship.core.spec_body import render_body
+from mship.core.spec_store import SpecStore
 from mship.core.state import StateManager
 
 
@@ -16,8 +20,41 @@ def _app(tmp_path: Path):
     )
 
 
+def _seed_spec(tmp_path: Path):
+    now = datetime(2026, 6, 14, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(
+        id="dq", title="Decision queue", status="needs_review",
+        created_at=now, updated_at=now, task_slug="dq",
+        body=render_body("the problem", "as a user", "the approach"),
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="view questions", verdict="approved")],
+    ))
+
+
 def test_health(tmp_path):
     client = TestClient(_app(tmp_path))
     r = client.get("/health")
     assert r.status_code == 200
     assert r.json() == {"status": "ok", "workspace": "test-ws"}
+
+
+def test_list_specs(tmp_path):
+    _seed_spec(tmp_path)
+    r = TestClient(_app(tmp_path)).get("/specs")
+    assert r.status_code == 200
+    assert r.json() == [{"id": "dq", "title": "Decision queue", "status": "needs_review", "task_slug": "dq"}]
+
+
+def test_get_spec_and_404(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    assert client.get("/specs/dq").json()["id"] == "dq"
+    assert client.get("/specs/nope").status_code == 404
+
+
+def test_get_review(tmp_path):
+    _seed_spec(tmp_path)
+    r = TestClient(_app(tmp_path)).get("/specs/dq/review")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["acceptance_criteria"][0]["id"] == "ac1"
+    assert body["summary"]["approved"] == 1

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -94,3 +94,13 @@ def test_journal(tmp_path):
     entries = client.get("/journal/dq").json()
     assert any("spawned" in e["message"] for e in entries)
     assert client.get("/journal/nope").status_code == 404
+
+
+def test_post_is_405(tmp_path):
+    # No write routes registered → POST to a GET path is 405 (Method Not Allowed).
+    r = TestClient(_app(tmp_path)).post("/specs/dq/review")
+    assert r.status_code == 405
+
+
+def test_unknown_path_404(tmp_path):
+    assert TestClient(_app(tmp_path)).get("/nope").status_code == 404

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -6,7 +6,8 @@ from mship.core.serve import create_app
 from mship.core.spec import AcceptanceCriterion, Spec
 from mship.core.spec_body import render_body
 from mship.core.spec_store import SpecStore
-from mship.core.state import StateManager
+from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.log import LogManager
 
 
 def _app(tmp_path: Path):
@@ -58,3 +59,38 @@ def test_get_review(tmp_path):
     body = r.json()
     assert body["acceptance_criteria"][0]["id"] == "ac1"
     assert body["summary"]["approved"] == 1
+
+
+def _seed_task(tmp_path: Path):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    sm = StateManager(state_dir)
+    sm.save(WorkspaceState(tasks={"dq": Task(
+        slug="dq", description="d", phase="dev",
+        created_at=datetime(2026, 6, 14, tzinfo=timezone.utc),
+        affected_repos=["mothership"], branch="feat/dq",
+    )}))
+    log = LogManager(state_dir / "logs")
+    log.append("dq", "spawned")
+    return sm, log
+
+
+def _app_with(tmp_path, sm, log):
+    return create_app(specs_dir=tmp_path / "specs", state_manager=sm,
+                      log_manager=log, workspace_root=tmp_path, workspace_name="test-ws")
+
+
+def test_list_and_get_task(tmp_path):
+    sm, log = _seed_task(tmp_path)
+    client = TestClient(_app_with(tmp_path, sm, log))
+    assert any(t["slug"] == "dq" for t in client.get("/tasks").json())
+    assert client.get("/tasks/dq").json()["slug"] == "dq"
+    assert client.get("/tasks/nope").status_code == 404
+
+
+def test_journal(tmp_path):
+    sm, log = _seed_task(tmp_path)
+    client = TestClient(_app_with(tmp_path, sm, log))
+    entries = client.get("/journal/dq").json()
+    assert any("spawned" in e["message"] for e in entries)
+    assert client.get("/journal/nope").status_code == 404

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+from mship.core.serve import create_app
+from mship.core.state import StateManager
+
+
+def _app(tmp_path: Path):
+    state = StateManager(tmp_path / ".mothership")
+    return create_app(
+        specs_dir=tmp_path / "specs",
+        state_manager=state,
+        log_manager=None,
+        workspace_root=tmp_path,
+        workspace_name="test-ws",
+    )
+
+
+def test_health(tmp_path):
+    client = TestClient(_app(tmp_path))
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok", "workspace": "test-ws"}

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,27 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -93,6 +114,68 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/6f/f74fee9629528f0879295b9f89a5c751d3ad931eca0c78407f715e5472a6/dependency_injector-4.49.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b5d2f1be2dc971db47b1305a83b5a8c24d0eba7fb4cea7845679f9c9f24a0a9", size = 1843223, upload-time = "2026-03-22T21:19:23.356Z" },
     { url = "https://files.pythonhosted.org/packages/c5/f0/45948c7c933f063039a44afb4bd61747a7bafd50693e6ccdc972fac0839c/dependency_injector-4.49.0-cp310-abi3-win32.whl", hash = "sha256:0593c8aaade651a5a88ff8ba1271a8364773e76d3aa2efbeacc3be4969cafd1c", size = 1546172, upload-time = "2026-03-22T21:19:25.392Z" },
     { url = "https://files.pythonhosted.org/packages/e2/b5/1d8e5627137cb9a6812ecaa468eaf39154f6605c5088da4749e5a8579483/dependency_injector-4.49.0-cp310-abi3-win_amd64.whl", hash = "sha256:fa4b587158b0d65a1f9681ca648da3f9bf90f312f68c2f2e73cc58296ec2bf45", size = 1674743, upload-time = "2026-03-22T21:19:27.018Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.137.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/fe/fb25c287ff7e0f79fc6acf2e8b812725dad28d2a1446c0410bab1422ac90/fastapi-0.137.0.tar.gz", hash = "sha256:d0565d551f65a803ecff245390840867186f456ef98971f750724eed16e1541c", size = 408023, upload-time = "2026-06-14T12:51:30.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/f1/b38481428e50131e5345b535414d11d196f14990122fe69c9020c64e5683/fastapi-0.137.0-py3-none-any.whl", hash = "sha256:6dcbde8d464f92117c1accb9e42720f8e423fa9b86cb563b1f5862f785a06498", size = 121777, upload-time = "2026-06-14T12:51:29.067Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -173,17 +256,20 @@ version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "dependency-injector" },
+    { name = "fastapi" },
     { name = "inquirerpy" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "textual" },
     { name = "typer" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-tmp-files" },
@@ -192,17 +278,20 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dependency-injector", specifier = ">=4.0" },
+    { name = "fastapi", specifier = ">=0.110" },
     { name = "inquirerpy", specifier = ">=0.3" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "textual", specifier = ">=0.80" },
     { name = "typer", specifier = ">=0.15" },
+    { name = "uvicorn", specifier = ">=0.27" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=7.13.5" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-tmp-files", specifier = ">=0.0.2" },
@@ -430,6 +519,18 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
 name = "textual"
 version = "8.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -489,6 +590,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

B1 / MOS-152 — **`mship serve`**, a read-only **FastAPI** JSON API over the spec + task model. The persistent surface the Ground Control app reads from.

- **`core/serve.py` `create_app(...)`** — the FastAPI app; sync handlers call the mship **core directly** (`SpecStore`, `build_review`, `build_task_index`, `LogManager`) — no CLI subprocess, no logic fork.
- **`cli/serve.py` `mship serve [--port]`** — runs `uvicorn` on `127.0.0.1:47100` (fastapi/uvicorn lazy-imported in the command).
- **Endpoints (all GET):** `/health`, `/specs`, `/specs/{id}`, `/specs/{id}/review`, `/tasks`, `/tasks/{slug}`, `/journal/{slug}` — plus FastAPI's auto **`/docs` (Swagger)** + `/openapi.json` (a live contract for the GC app build).
- **Read-only:** no write routes → writes get `405`. **Localhost bind, no auth** — B2 (MOS-153) adds Tailscale + single-user auth.

## ⚠️ For your review

1. **First web-framework deps in the repo** — `fastapi` + `uvicorn` in `[project].dependencies` (+ `httpx` dev-only for `TestClient`); `uv.lock` updated + committed. (You requested FastAPI — flagging since it's the one durable decision here.)
2. **`mship serve` is core-direct, so it's no longer blocked by MOS-103** — I re-pointed that relation from *blocks* to *related*.
3. **Follow-up (not fixed here):** `GET /tasks/{slug}` rebuilds the full task index for a single lookup (O(n) FS walks). Negligible at single-user/localhost scale, and the clean fix touches the shared `task_index` module — deferred deliberately.

## Test plan

- [x] `mship test` green — **full suite 1345 passing**; new deps caused no regressions.
- [x] FastAPI `TestClient` tests (no socket) for every endpoint: `/health`, `/specs` list/get/review (+404), `/tasks` list/get (+404), `/journal` (+404), read-only `405`, unknown-path `404`; plus a `serve --help` CLI smoke test.
- [x] Per-task spec+quality reviews + a final whole-branch review (merge-ready; lazy-import hygiene + 404-guard-before-access + `jsonable_encoder` on Path/datetime returns all confirmed).

## Scope

Read-only v0. Out: write endpoints (verdict/answer/approve/dispatch over POST — next increment), auth + Tailscale (B2), MOS-103 (decoupled).

Linear: MOS-152.
