### PR TITLE
serve auth tailnet B2

### DIFF
--- a/docs/mship-serve-tailscale.md
+++ b/docs/mship-serve-tailscale.md
@@ -1,0 +1,92 @@
+# Reaching `mship serve` from your phone (Tailscale)
+
+`mship serve` exposes a read-only JSON API over your specs + tasks. By default it
+binds to `127.0.0.1` with no auth. To reach it from another device, bind to your
+tailnet IP and set a bearer token.
+
+## One-time setup
+
+1. Install + start Tailscale on the host and the phone, on the same tailnet:
+   ```
+   tailscale up
+   ```
+2. Find the host's tailnet IP:
+   ```
+   tailscale ip -4   # e.g. 100.x.y.z
+   ```
+
+## Run the server
+
+```bash
+export MSHIP_SERVE_TOKEN="$(openssl rand -hex 32)"
+mship serve --host <tailnet-ip>      # e.g. --host 100.x.y.z  (or 0.0.0.0)
+```
+
+`mship serve` **refuses to bind a non-loopback host without `MSHIP_SERVE_TOKEN`** —
+this prevents accidentally exposing your specs unauthenticated. The exact error:
+
+```
+Error: Refusing to bind to non-loopback host '100.x.y.z' without auth.
+       Set MSHIP_SERVE_TOKEN to expose the API safely.
+```
+
+Default port is `47100`. Override with `--port`.
+
+## Call it from the phone
+
+```
+GET http://<tailnet-ip>:47100/specs
+Authorization: Bearer <your MSHIP_SERVE_TOKEN>
+```
+
+Every endpoint requires the token; a missing or wrong token returns `401 Unauthorized`.
+
+Available endpoints:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Server health + workspace name |
+| GET | `/specs` | List all specs (id, title, status, task_slug) |
+| GET | `/specs/{id}` | Full spec detail |
+| GET | `/specs/{id}/review` | Spec review data |
+| GET | `/tasks` | List all tasks |
+| GET | `/tasks/{slug}` | Single task detail |
+| GET | `/journal/{slug}` | Last 50 journal entries for a task |
+
+## Interactive docs
+
+When a token is set, the interactive docs (`/docs`, `/redoc`, `/openapi.json`) are
+disabled — no unauthenticated schema surface is exposed. To browse `/docs` during
+development, run a local `mship serve` without a token (loopback only):
+
+```bash
+mship serve   # binds 127.0.0.1:47100, no token required, /docs available
+```
+
+## Security notes
+
+- The token is read from the environment at startup; it is never written to
+  `mothership.yaml` or any on-disk state file.
+- Only your tailnet peers can route to the tailnet IP. The bearer token is a second
+  layer on top of Tailscale's network-level access control.
+- More locked-down alternative: keep `mship serve` on `127.0.0.1` and front it with
+  Tailscale's HTTPS proxy, which terminates TLS and restricts access to tailnet peers:
+  ```
+  tailscale serve https / http://127.0.0.1:47100
+  ```
+
+## Verify locally
+
+```bash
+# Start with auth on loopback
+MSHIP_SERVE_TOKEN=secret mship serve --host 127.0.0.1 &
+
+# Authenticated request — should return {"status":"ok",...}
+curl -s -H "Authorization: Bearer secret" http://127.0.0.1:47100/health
+
+# Unauthenticated request — should return 401
+curl -s http://127.0.0.1:47100/health
+
+# Kill the background server when done
+kill %1
+```

--- a/docs/superpowers/plans/2026-06-14-mship-serve-auth.md
+++ b/docs/superpowers/plans/2026-06-14-mship-serve-auth.md
@@ -1,0 +1,189 @@
+# `mship serve` auth + `--host` — Implementation Plan (B2 / MOS-153)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: subagent-driven-development. Steps use checkbox (`- [ ]`).
+
+**Goal:** Make `mship serve` reachable beyond loopback (`--host`) and gate it with a `MSHIP_SERVE_TOKEN` bearer token, with a safety interlock that refuses to bind a non-loopback host without a token. Plus a Tailscale setup doc.
+
+**Architecture:** `create_app(..., auth_token)` adds an app-level FastAPI auth dependency (constant-time bearer check) when a token is set. `cli/serve.py` gains `--host`, reads the token from env, runs the interlock before `uvicorn.run`. Design: [docs/superpowers/specs/2026-06-14-mship-serve-auth-design.md](../specs/2026-06-14-mship-serve-auth-design.md).
+
+**Tech Stack:** FastAPI, uvicorn, Typer, pytest. Builds on B1 (`core/serve.py`, `cli/serve.py`, in `main`).
+
+---
+
+## File structure
+- **Modify** `src/mship/core/serve.py` (`auth_token` param + auth dependency).
+- **Modify** `src/mship/cli/serve.py` (`--host` + token + interlock).
+- **Create** `docs/mship-serve-tailscale.md` (setup guide).
+- **Test** `tests/core/test_serve.py` (auth), `tests/cli/test_serve.py` (interlock).
+
+---
+
+## Task 1: bearer-token auth in `create_app`
+
+**Files:** `src/mship/core/serve.py`; `tests/core/test_serve.py`.
+
+- [ ] **Step 1: Failing tests** (append to `tests/core/test_serve.py`):
+
+```python
+def _auth_app(tmp_path: Path, token: str | None):
+    _seed_spec(tmp_path)  # from Task 2 of B1 — a spec to GET
+    state = StateManager(tmp_path / ".mothership")
+    return create_app(
+        specs_dir=tmp_path / "specs", state_manager=state, log_manager=None,
+        workspace_root=tmp_path, workspace_name="test-ws", auth_token=token,
+    )
+
+
+def test_auth_required_when_token_set(tmp_path):
+    client = TestClient(_auth_app(tmp_path, "secret"))
+    assert client.get("/specs").status_code == 401                       # no header
+    assert client.get("/specs", headers={"Authorization": "Bearer wrong"}).status_code == 401
+    ok = client.get("/specs", headers={"Authorization": "Bearer secret"})
+    assert ok.status_code == 200
+
+
+def test_open_when_no_token(tmp_path):
+    # auth_token=None preserves B1 behavior (no auth).
+    assert TestClient(_auth_app(tmp_path, None)).get("/specs").status_code == 200
+```
+
+- [ ] **Step 2: Run → fail** (`uv run pytest tests/core/test_serve.py -k auth -v` → `create_app` has no `auth_token`).
+
+- [ ] **Step 3: Implement** — in `src/mship/core/serve.py`:
+  - Add `auth_token: str | None = None` to `create_app`'s signature.
+  - Add a module-level (or in-factory) dependency factory + wire it as an app-level dependency:
+
+```python
+def _make_auth_dependency(token: str):
+    import hmac
+    from fastapi import Header, HTTPException
+
+    def _require_token(authorization: str | None = Header(default=None)):
+        expected = f"Bearer {token}"
+        if authorization is None or not hmac.compare_digest(authorization, expected):
+            raise HTTPException(status_code=401, detail="missing or invalid bearer token")
+
+    return _require_token
+```
+
+  - Change the app construction (currently `app = FastAPI(title="mship serve", version="0")`) to:
+
+```python
+    from fastapi import Depends, FastAPI, HTTPException
+
+    dependencies = [Depends(_make_auth_dependency(auth_token))] if auth_token else []
+    app = FastAPI(title="mship serve", version="0", dependencies=dependencies)
+```
+
+  (App-level `dependencies` apply to every route — including `/health` and `/docs` — when a token is set. That's intended.)
+
+- [ ] **Step 4: Run → pass.** Also run the whole `tests/core/test_serve.py` (the existing no-auth tests still pass since `_app()` passes no `auth_token`).
+
+- [ ] **Step 5: Commit** `feat(serve): bearer-token auth on create_app (constant-time)` + `mship journal`.
+
+---
+
+## Task 2: `--host` + env token + safety interlock (CLI)
+
+**Files:** `src/mship/cli/serve.py`; `tests/cli/test_serve.py`.
+
+- [ ] **Step 1: Failing tests** (append to `tests/cli/test_serve.py`). Use the B1 `configured_app_with_task` fixture for the pass path; monkeypatch `uvicorn.run` to avoid blocking:
+
+```python
+def test_serve_refuses_nonloopback_without_token(monkeypatch):
+    monkeypatch.delenv("MSHIP_SERVE_TOKEN", raising=False)
+    result = runner.invoke(app, ["serve", "--host", "0.0.0.0"])
+    assert result.exit_code != 0
+    assert "MSHIP_SERVE_TOKEN" in result.output
+
+
+def test_serve_binds_nonloopback_with_token(configured_app_with_task, monkeypatch):
+    monkeypatch.setenv("MSHIP_SERVE_TOKEN", "secret")
+    called = {}
+    import uvicorn
+    monkeypatch.setattr(uvicorn, "run", lambda *a, **k: called.setdefault("host", k.get("host")))
+    result = runner.invoke(app, ["serve", "--host", "0.0.0.0"])
+    assert result.exit_code == 0, result.output
+    assert called["host"] == "0.0.0.0"
+```
+
+  (`configured_app_with_task` is in `tests/cli/test_spec.py`; if it isn't importable from `test_serve.py`, replicate its container-override setup or move it to `conftest.py`. Simplest: add a minimal local fixture in `test_serve.py` that overrides `container.config_path`/`state_dir` like `configured_app_with_task` does.)
+
+- [ ] **Step 2: Run → fail** (no `--host`).
+
+- [ ] **Step 3: Implement** — rewrite the `serve` command in `src/mship/cli/serve.py`:
+
+```python
+    @app.command()
+    def serve(
+        host: str = typer.Option(
+            "127.0.0.1", "--host",
+            help="Bind address. Use your tailnet IP (or 0.0.0.0) to reach it from "
+                 "other devices — requires MSHIP_SERVE_TOKEN.",
+        ),
+        port: int = typer.Option(47100, "--port", help="Port."),
+    ):
+        """Run a read-only JSON API over the spec + task model (Ground Control)."""
+        import os
+        import uvicorn
+        from mship.core.serve import create_app
+        from mship.core.spec_store import SPECS_DIRNAME
+
+        output = Output()
+        token = os.environ.get("MSHIP_SERVE_TOKEN")
+        loopback = {"127.0.0.1", "localhost", "::1"}
+        if host not in loopback and not token:
+            output.error(
+                f"Refusing to bind to non-loopback host {host!r} without auth. "
+                f"Set MSHIP_SERVE_TOKEN to expose the API safely."
+            )
+            raise typer.Exit(1)
+
+        container = get_container()
+        workspace_root = Path(container.config_path()).parent
+        api = create_app(
+            specs_dir=workspace_root / SPECS_DIRNAME,
+            state_manager=container.state_manager(),
+            log_manager=container.log_manager(),
+            workspace_root=workspace_root,
+            workspace_name=container.config().workspace,
+            auth_token=token,
+        )
+        auth_note = "auth: bearer token" if token else "auth: none (loopback only)"
+        output.print(f"mship serve → http://{host}:{port}  ({auth_note}; docs: /docs)")
+        uvicorn.run(api, host=host, port=port)
+```
+
+  (Interlock runs BEFORE `get_container`, so the refuse-path test doesn't need a configured workspace.)
+
+- [ ] **Step 4: Run → pass.** Run the whole `tests/cli/test_serve.py` (the B1 `serve --help` smoke still passes).
+
+- [ ] **Step 5: Commit** `feat(serve): --host + MSHIP_SERVE_TOKEN + non-loopback safety interlock` + journal.
+
+---
+
+## Task 3: Tailscale setup doc + full suite
+
+**Files:** `docs/mship-serve-tailscale.md`; (verification).
+
+- [ ] **Step 1: Write the doc** `docs/mship-serve-tailscale.md` — concise setup guide:
+  - **Goal:** reach `mship serve` from your phone over Tailscale.
+  - **Steps:** (1) `tailscale up` on the host (+ the phone); (2) get the host's tailnet IP (`tailscale ip -4`); (3) `export MSHIP_SERVE_TOKEN=$(openssl rand -hex 32)`; (4) `mship serve --host <tailnet-ip>`; (5) from the phone, hit `http://<tailnet-ip>:47100/specs` with header `Authorization: Bearer $MSHIP_SERVE_TOKEN`.
+  - **Security notes:** the interlock refuses non-loopback binding without the token; the token is read from env, never committed; everything (incl. `/health`, `/docs`) requires the token when set; `tailscale serve` (TLS-terminating proxy to `127.0.0.1:47100`) is a more locked-down alternative.
+  - **Verify locally:** `MSHIP_SERVE_TOKEN=secret mship serve --host 127.0.0.1` then `curl -H "Authorization: Bearer secret" localhost:47100/health`.
+
+- [ ] **Step 2: Full suite.** `mship test` (or `uv run pytest`) → green.
+
+- [ ] **Step 3: Commit** `docs(serve): Tailscale + auth setup guide` + journal.
+
+---
+
+## Self-Review
+- **Coverage:** token auth (T1) + 401/200/wrong/None-open tests; `--host` + interlock (T2) + refuse/pass tests; doc + full suite (T3).
+- **Placeholders:** none — complete code; the one fixture caveat (reuse vs. replicate `configured_app_with_task`) is called out.
+- **Security:** constant-time compare; interlock prevents open non-loopback exposure; token from env not config; auth covers all routes when set.
+- **Compat:** default `--host 127.0.0.1` + no token = exactly B1.
+- **Type consistency:** `create_app(..., auth_token)`, `_make_auth_dependency(token)`; reuses the B1 app + `_seed_spec`/`configured_app_with_task` test helpers.
+
+## Execution Handoff
+Commit this plan + design to `main`, then `mship spawn` MOS-153.

--- a/docs/superpowers/specs/2026-06-14-mship-serve-auth-design.md
+++ b/docs/superpowers/specs/2026-06-14-mship-serve-auth-design.md
@@ -1,0 +1,74 @@
+# `mship serve` auth + tailnet reachability — design (B2 / MOS-153)
+
+> Status: design approved 2026-06-14. Feeds `writing-plans`.
+> Part of **Ground Control** (epic MOS-144). Adds the auth + reachability layer on
+> top of B1's read-only `mship serve` (merged, #170).
+
+## Context
+
+B1 serves the spec/task API on `127.0.0.1` with no auth (localhost = trusted,
+single-user). B2 makes it reachable from a phone over **Tailscale** and gates it
+with a **bearer token** — so the API is safe once it leaves loopback. Tailscale
+itself is the user's infra (a `tailscale up` device on the tailnet); mship provides
+the bindable host + auth + setup docs.
+
+## Decisions
+
+1. **`mship serve --host <addr>`** — new flag (default `127.0.0.1`). Set it to the
+   device's tailnet IP (or `0.0.0.0`) so tailnet peers can reach it directly.
+2. **Static bearer token via env `MSHIP_SERVE_TOKEN`.** When set, every endpoint
+   requires `Authorization: Bearer <token>` → `401` otherwise. Read from the env
+   (never `mothership.yaml` — it's a secret). Transport-agnostic.
+3. **🔒 Safety interlock (the backbone):** `mship serve` **refuses to start** when
+   binding to a **non-loopback** host (`--host` not in `{127.0.0.1, localhost, ::1}`)
+   **without** `MSHIP_SERVE_TOKEN` set — exits non-zero with a clear message. This
+   makes accidental open exposure of the spec/task data impossible.
+4. **Auth applies to *all* endpoints (incl. `/health`) when a token is set.**
+   Simplest + most secure; the single-user app holds the token anyway. (No
+   unauthenticated liveness probe in v0 — add one later if needed.)
+5. **Localhost + no token stays open** — preserves B1 behavior (loopback dev use).
+6. **Tailscale = documented, not automated.** A setup doc covers `tailscale up`,
+   finding the tailnet IP, `mship serve --host <tailnet-ip>`, and setting the token.
+   (`tailscale serve` proxy is mentioned as an alternative but `--host` is the
+   chosen path.)
+
+## Architecture
+
+- **`core/serve.py`** — `create_app(..., auth_token: str | None = None)`. When
+  `auth_token` is set, the app gets an **app-level dependency** that checks the
+  `Authorization` header against `Bearer <auth_token>` and raises `401` on
+  mismatch; when `None`, no dependency (open, B1 behavior). A small
+  `_make_auth_dependency(token)` factory returns the dependency.
+- **`cli/serve.py`** — add `--host` (default `127.0.0.1`); read
+  `token = os.environ.get("MSHIP_SERVE_TOKEN")`; run the interlock (non-loopback +
+  no token → `output.error` + `Exit(1)`); `create_app(..., auth_token=token)`;
+  `uvicorn.run(api, host=host, port=port)`. Print whether auth is on.
+
+## Auth contract
+
+`Authorization: Bearer <MSHIP_SERVE_TOKEN>` on every request. Missing/wrong →
+`401 {"detail": "..."}`. Constant-time compare (`hmac.compare_digest`) to avoid a
+timing side-channel on the token.
+
+## Testing
+
+- **create_app auth** (`TestClient`): with `auth_token="secret"` — `GET /specs`
+  with no header → `401`; with `Authorization: Bearer secret` → `200`; wrong token
+  → `401`. With `auth_token=None` — open (`200` no header), proving B1 compat.
+- **CLI interlock** (`CliRunner`): `serve --host 0.0.0.0` with `MSHIP_SERVE_TOKEN`
+  unset → exits non-zero, message names the env var (this path returns *before*
+  `uvicorn.run`, so no hang). With the token set + `uvicorn.run` monkeypatched to a
+  no-op → exits `0` (interlock passes, app built with the token). Loopback default
+  (no token) is not invoked via the runner (it would block on `uvicorn.run`).
+
+## Scope (B2)
+
+In: `--host`, the bearer-token auth dependency + the safety interlock, the
+constant-time compare, and the Tailscale setup doc. Out: Tailscale identity-header
+trust (follow-on), TLS termination in mship (Tailscale/`tailscale serve` owns TLS),
+write endpoints (separate), multi-user auth.
+
+## Migration / compat
+
+Additive. Default `--host 127.0.0.1` + no token = exactly B1's behavior. The
+interlock only triggers on an explicit non-loopback `--host`.

--- a/src/mship/cli/serve.py
+++ b/src/mship/cli/serve.py
@@ -44,5 +44,6 @@ def register(app: typer.Typer, get_container):
             auth_token=token,
         )
         auth_note = "auth: bearer token" if token else "auth: none (loopback only)"
-        output.print(f"mship serve → http://{host}:{port}  ({auth_note}; docs: /docs)")
+        docs_note = "docs: disabled (auth)" if token else "docs: /docs"
+        output.print(f"mship serve → http://{host}:{port}  ({auth_note}; {docs_note})")
         uvicorn.run(api, host=host, port=port)

--- a/src/mship/cli/serve.py
+++ b/src/mship/cli/serve.py
@@ -10,12 +10,28 @@ from mship.cli.output import Output
 def register(app: typer.Typer, get_container):
     @app.command()
     def serve(
-        port: int = typer.Option(47100, "--port", help="Port to bind on 127.0.0.1."),
+        host: str = typer.Option(
+            "127.0.0.1", "--host",
+            help="Bind address. Use your tailnet IP (or 0.0.0.0) to reach it from "
+                 "other devices — requires MSHIP_SERVE_TOKEN.",
+        ),
+        port: int = typer.Option(47100, "--port", help="Port."),
     ):
         """Run a read-only JSON API over the spec + task model (Ground Control)."""
+        import os
         import uvicorn
         from mship.core.serve import create_app
         from mship.core.spec_store import SPECS_DIRNAME
+
+        output = Output()
+        token = os.environ.get("MSHIP_SERVE_TOKEN")
+        loopback = {"127.0.0.1", "localhost", "::1"}
+        if host not in loopback and not token:
+            output.error(
+                f"Refusing to bind to non-loopback host {host!r} without auth. "
+                f"Set MSHIP_SERVE_TOKEN to expose the API safely."
+            )
+            raise typer.Exit(1)
 
         container = get_container()
         workspace_root = Path(container.config_path()).parent
@@ -25,6 +41,8 @@ def register(app: typer.Typer, get_container):
             log_manager=container.log_manager(),
             workspace_root=workspace_root,
             workspace_name=container.config().workspace,
+            auth_token=token,
         )
-        Output().print(f"mship serve → http://127.0.0.1:{port}  (docs: /docs)")
-        uvicorn.run(api, host="127.0.0.1", port=port)
+        auth_note = "auth: bearer token" if token else "auth: none (loopback only)"
+        output.print(f"mship serve → http://{host}:{port}  ({auth_note}; docs: /docs)")
+        uvicorn.run(api, host=host, port=port)

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -3,20 +3,34 @@ from __future__ import annotations
 from pathlib import Path
 
 
+def _make_auth_dependency(token: str):
+    import hmac
+    from fastapi import Header, HTTPException
+
+    def _require_token(authorization: str | None = Header(default=None)):
+        expected = f"Bearer {token}"
+        if authorization is None or not hmac.compare_digest(authorization, expected):
+            raise HTTPException(status_code=401, detail="missing or invalid bearer token")
+
+    return _require_token
+
+
 def create_app(
     specs_dir: Path,
     state_manager,
     log_manager,
     workspace_root: Path,
     workspace_name: str = "mothership",
+    auth_token: str | None = None,
 ):
     """Build the read-only mship serve FastAPI app. Sync handlers call the core
     directly; FastAPI serializes the returns (pydantic models, dicts, dataclasses)."""
-    from fastapi import FastAPI, HTTPException
+    from fastapi import Depends, FastAPI, HTTPException
 
     from mship.core.spec_store import SpecStore
 
-    app = FastAPI(title="mship serve", version="0")
+    dependencies = [Depends(_make_auth_dependency(auth_token))] if auth_token else []
+    app = FastAPI(title="mship serve", version="0", dependencies=dependencies)
     store = SpecStore(specs_dir)
 
     @app.get("/health")

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -7,9 +7,11 @@ def _make_auth_dependency(token: str):
     import hmac
     from fastapi import Header, HTTPException
 
+    expected = f"Bearer {token}".encode("utf-8")
+
     def _require_token(authorization: str | None = Header(default=None)):
-        expected = f"Bearer {token}"
-        if authorization is None or not hmac.compare_digest(authorization, expected):
+        provided = (authorization or "").encode("utf-8")
+        if not hmac.compare_digest(provided, expected):
             raise HTTPException(status_code=401, detail="missing or invalid bearer token")
 
     return _require_token
@@ -29,8 +31,16 @@ def create_app(
 
     from mship.core.spec_store import SpecStore
 
-    dependencies = [Depends(_make_auth_dependency(auth_token))] if auth_token else []
-    app = FastAPI(title="mship serve", version="0", dependencies=dependencies)
+    if auth_token:
+        dependencies = [Depends(_make_auth_dependency(auth_token))]
+        # Auth covers user routes but NOT FastAPI's built-in docs/openapi routes,
+        # so disable them when exposed behind auth (no unauthenticated schema surface).
+        app = FastAPI(
+            title="mship serve", version="0", dependencies=dependencies,
+            docs_url=None, redoc_url=None, openapi_url=None,
+        )
+    else:
+        app = FastAPI(title="mship serve", version="0")
     store = SpecStore(specs_dir)
 
     @app.get("/health")

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -1,10 +1,50 @@
+from pathlib import Path
+
+import pytest
 from typer.testing import CliRunner
-from mship.cli import app
+
+from mship.cli import app, container
 
 runner = CliRunner()
+
+
+@pytest.fixture
+def _configured(workspace: Path):
+    state_dir = workspace / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(workspace / "mothership.yaml")
+    container.state_dir.override(state_dir)
+
+    yield workspace
+
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override()
+    container.config.reset()
+    container.state_manager.reset_override()
+    container.state_manager.reset()
 
 
 def test_serve_command_registered():
     result = runner.invoke(app, ["serve", "--help"])
     assert result.exit_code == 0
     assert "127.0.0.1" in result.output
+
+
+def test_serve_refuses_nonloopback_without_token(monkeypatch):
+    monkeypatch.delenv("MSHIP_SERVE_TOKEN", raising=False)
+    result = runner.invoke(app, ["serve", "--host", "0.0.0.0"])
+    assert result.exit_code != 0
+    assert "MSHIP_SERVE_TOKEN" in result.output
+
+
+def test_serve_binds_nonloopback_with_token(_configured, monkeypatch):
+    monkeypatch.setenv("MSHIP_SERVE_TOKEN", "secret")
+    import uvicorn
+    seen = {}
+    monkeypatch.setattr(uvicorn, "run", lambda *a, **k: seen.update(k))
+    result = runner.invoke(app, ["serve", "--host", "0.0.0.0"])
+    assert result.exit_code == 0, result.output
+    assert seen.get("host") == "0.0.0.0"

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -104,3 +104,23 @@ def test_post_is_405(tmp_path):
 
 def test_unknown_path_404(tmp_path):
     assert TestClient(_app(tmp_path)).get("/nope").status_code == 404
+
+
+def _auth_app(tmp_path: Path, token):
+    _seed_spec(tmp_path)
+    state = StateManager(tmp_path / ".mothership")
+    return create_app(
+        specs_dir=tmp_path / "specs", state_manager=state, log_manager=None,
+        workspace_root=tmp_path, workspace_name="test-ws", auth_token=token,
+    )
+
+
+def test_auth_required_when_token_set(tmp_path):
+    client = TestClient(_auth_app(tmp_path, "secret"))
+    assert client.get("/specs").status_code == 401
+    assert client.get("/specs", headers={"Authorization": "Bearer wrong"}).status_code == 401
+    assert client.get("/specs", headers={"Authorization": "Bearer secret"}).status_code == 200
+
+
+def test_open_when_no_token(tmp_path):
+    assert TestClient(_auth_app(tmp_path, None)).get("/specs").status_code == 200

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -124,3 +124,24 @@ def test_auth_required_when_token_set(tmp_path):
 
 def test_open_when_no_token(tmp_path):
     assert TestClient(_auth_app(tmp_path, None)).get("/specs").status_code == 200
+
+
+def test_docs_disabled_when_token_set(tmp_path):
+    client = TestClient(_auth_app(tmp_path, "secret"))
+    # No unauthenticated schema/docs surface when exposed behind auth.
+    assert client.get("/openapi.json").status_code == 404
+    assert client.get("/docs").status_code == 404
+
+
+def test_docs_available_when_no_token(tmp_path):
+    client = TestClient(_auth_app(tmp_path, None))
+    assert client.get("/openapi.json").status_code == 200
+
+
+def test_non_ascii_token_still_401_not_500(tmp_path):
+    client = TestClient(_auth_app(tmp_path, "tøken-✓"))
+    r = client.get("/specs")          # missing header
+    assert r.status_code == 401       # fail-closed, not 500
+    # Positive case (correct non-ascii token) omitted: httpx/TestClient encodes
+    # header values as ASCII and raises UnicodeEncodeError before the request
+    # reaches the server, so we cannot test the success path via TestClient.


### PR DESCRIPTION
## Summary

B2 / MOS-153 — **auth + tailnet reachability** for `mship serve` (on top of B1's read-only API).

- **`mship serve --host <addr>`** (default `127.0.0.1`) — bind to your tailnet IP (or `0.0.0.0`) to reach it from your phone.
- **Bearer token** from env **`MSHIP_SERVE_TOKEN`** → `Authorization: Bearer …` required on **every** endpoint (`401` otherwise), **constant-time** (`hmac.compare_digest` on bytes).
- **🔒 Safety interlock:** `mship serve` *refuses to start* when binding a **non-loopback** host **without** a token — so the spec/task API can't be exposed open by accident.
- **No unauthenticated surface under auth:** `/docs`, `/redoc`, `/openapi.json` are disabled when a token is set (they stay available for localhost dev with no token).
- **Tailscale setup doc:** `docs/mship-serve-tailscale.md`.
- **B1 compat:** default `127.0.0.1` + no token = exactly B1 (open localhost; `/docs` available).

## 🔒 Security

This is the first auth/network-exposure code, so it got a dedicated adversarial review:
- Caught + fixed an **auth-bypass** — `/docs`/`/redoc`/`/openapi.json` were reachable unauthenticated under a token (FastAPI registers them outside the app-level dependency) → now disabled under auth. **Re-reviewed: no unauthenticated route remains when a token is set** (HEAD/OPTIONS/trailing-slash-redirect probed — no data/schema leak).
- Fixed a non-ASCII-token `500` (now fail-closed `401` via byte-compare).
- Token read from env only — never written to / read from `mothership.yaml`; never logged.

## Test plan

- [x] `mship test` green — full suite.
- [x] `TestClient`: no/wrong token → `401`, correct → `200`, `auth_token=None` → open (B1 compat); `/docs`+`/openapi.json` → `404` under auth, `200` without; non-ASCII token → `401` (not `500`).
- [x] CLI: non-loopback `--host` without token → exits non-zero naming `MSHIP_SERVE_TOKEN` (before binding); with token → binds (uvicorn mocked).
- [x] Per-feature spec+quality review + an **adversarial security review with re-review** + a holistic final review (all merge-ready).

## Scope

Out: Tailscale identity-header trust (follow-on), TLS termination in mship (Tailscale owns it), write endpoints, multi-user auth.

Linear: MOS-153.
