### PR TITLE
serve write endpoints B1.5

### DIFF
--- a/docs/superpowers/plans/2026-06-14-serve-writes.md
+++ b/docs/superpowers/plans/2026-06-14-serve-writes.md
@@ -1,0 +1,240 @@
+# `mship serve` write endpoints (review → approve) — Plan (B1.5 / MOS-166)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: subagent-driven-development. Steps use checkbox (`- [ ]`).
+
+**Goal:** Add the review→approve POST endpoints to `mship serve`, each a thin wrapper over an existing core write helper, gated by the B2 token, returning the fresh `build_review` payload.
+
+**Architecture:** Module-level pydantic request models in `core/serve.py`; POST routes added inside `create_app` (after the GET routes), using `_load_or_404` + `_save` closures; core errors mapped to HTTP (404/400/409). Design: [docs/superpowers/specs/2026-06-14-serve-writes-design.md](../specs/2026-06-14-serve-writes-design.md).
+
+**Tech Stack:** FastAPI, pydantic, pytest. Builds on B1/B2 (`core/serve.py`) + the A1–A5 core helpers (all in `main`).
+
+---
+
+## File structure
+- **Modify** `src/mship/core/serve.py` (request models + POST routes + helpers).
+- **Test** `tests/core/test_serve.py` (TestClient write tests).
+
+Reuses existing test helpers in `test_serve.py`: `_app(tmp_path)`, `_auth_app(tmp_path, token)`, `_seed_spec(tmp_path)` (seeds spec `dq`: `ac1` verdict `approved`, `q1` unanswered).
+
+---
+
+## Task 1: request models + verdict / questions / answer endpoints
+
+**Files:** `src/mship/core/serve.py`; `tests/core/test_serve.py`.
+
+- [ ] **Step 1: Failing tests** (append to `tests/core/test_serve.py`):
+
+```python
+def test_post_verdict(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs/dq/verdict", json={"criterion_id": "ac1", "verdict": "flagged"})
+    assert r.status_code == 200
+    assert r.json()["acceptance_criteria"][0]["verdict"] == "flagged"   # build_review payload
+    assert client.post("/specs/dq/verdict", json={"criterion_id": "ac1", "verdict": "bogus"}).status_code == 400
+    assert client.post("/specs/dq/verdict", json={"criterion_id": "nope", "verdict": "approved"}).status_code == 400
+    assert client.post("/specs/none/verdict", json={"criterion_id": "ac1", "verdict": "approved"}).status_code == 404
+
+
+def test_post_question_and_answer(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    add = client.post("/specs/dq/questions", json={"text": "Tablets too?"})
+    assert add.status_code == 200
+    assert [q["id"] for q in add.json()["open_questions"]] == ["q1", "q2"]
+    ans = client.post("/specs/dq/questions/q1/answer", json={"answer": "yes"})
+    assert ans.status_code == 200
+    assert ans.json()["open_questions"][0]["answer"] == "yes"
+    assert client.post("/specs/dq/questions/q99/answer", json={"answer": "x"}).status_code == 400
+```
+
+- [ ] **Step 2: Run → fail** (`uv run pytest tests/core/test_serve.py -k "verdict or question" -v` → 405/404, no POST routes).
+
+- [ ] **Step 3: Implement.** Add module-level request models at the top of `src/mship/core/serve.py` (pydantic is already a dep; add `from pydantic import BaseModel`):
+
+```python
+from pydantic import BaseModel
+
+
+class VerdictBody(BaseModel):
+    criterion_id: str
+    verdict: str
+
+
+class QuestionBody(BaseModel):
+    text: str
+
+
+class AnswerBody(BaseModel):
+    answer: str
+
+
+class ApproveBody(BaseModel):
+    bypass_gate: bool = False
+
+
+class ReasonBody(BaseModel):
+    reason: str
+```
+
+Inside `create_app`, after the GET routes (and after the existing lazy `from fastapi import ...` — ensure `HTTPException` is imported there), add the helpers + 3 routes:
+
+```python
+    from datetime import datetime, timezone
+    from mship.core.spec_review import set_criterion_verdict  # build_review already imported above
+    from mship.core.spec_questions import add_question, answer_question
+
+    def _load_or_404(spec_id: str):
+        spec = store.find_by_id(spec_id)
+        if spec is None:
+            raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
+        return spec
+
+    def _save_and_review(spec):
+        spec.updated_at = datetime.now(timezone.utc)
+        store.save(spec)
+        return build_review(spec)
+
+    @app.post("/specs/{spec_id}/verdict")
+    def post_verdict(spec_id: str, body: VerdictBody):
+        spec = _load_or_404(spec_id)
+        try:
+            set_criterion_verdict(spec, body.criterion_id, body.verdict)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        return _save_and_review(spec)
+
+    @app.post("/specs/{spec_id}/questions")
+    def post_question(spec_id: str, body: QuestionBody):
+        spec = _load_or_404(spec_id)
+        add_question(spec, body.text)
+        return _save_and_review(spec)
+
+    @app.post("/specs/{spec_id}/questions/{qid}/answer")
+    def post_answer(spec_id: str, qid: str, body: AnswerBody):
+        spec = _load_or_404(spec_id)
+        try:
+            answer_question(spec, qid, body.answer)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        return _save_and_review(spec)
+```
+
+(`build_review` is imported in the GET section from Task-2-of-B1; if it isn't in scope where these handlers are defined, add `from mship.core.spec_review import build_review` here too.)
+
+- [ ] **Step 4: Run → pass.** Then the whole `tests/core/test_serve.py`.
+- [ ] **Step 5: Commit** `feat(serve): write endpoints — verdict, add/answer question` + journal.
+
+---
+
+## Task 2: approve / request-changes endpoints
+
+**Files:** `src/mship/core/serve.py`; `tests/core/test_serve.py`.
+
+- [ ] **Step 1: Failing tests** (append):
+
+```python
+def test_post_approve_gate_and_success(tmp_path):
+    _seed_spec(tmp_path)   # ac1 approved, q1 unanswered → blocked on q1
+    client = TestClient(_app(tmp_path))
+    blocked = client.post("/specs/dq/approve", json={})
+    assert blocked.status_code == 409
+    client.post("/specs/dq/questions/q1/answer", json={"answer": "yes"})   # clear the blocker
+    ok = client.post("/specs/dq/approve", json={})
+    assert ok.status_code == 200
+    assert ok.json()["status"] == "approved"
+    # re-approve from approved → illegal transition → 409
+    assert client.post("/specs/dq/approve", json={}).status_code == 409
+
+
+def test_post_approve_bypass(tmp_path):
+    _seed_spec(tmp_path)   # still blocked (q1 unanswered)
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs/dq/approve", json={"bypass_gate": True})
+    assert r.status_code == 200
+    assert r.json()["status"] == "approved"
+
+
+def test_post_request_changes(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs/dq/request-changes", json={"reason": "tighten scope"})
+    assert r.status_code == 200
+    assert r.json()["status"] == "needs_clarification"
+```
+
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** — inside `create_app`, after the Task 1 routes:
+
+```python
+    from mship.core.spec import InvalidTransition, validate_transition
+    from mship.core.spec_approve import approval_blockers
+
+    @app.post("/specs/{spec_id}/approve")
+    def post_approve(spec_id: str, body: ApproveBody):
+        spec = _load_or_404(spec_id)
+        if not body.bypass_gate:
+            blockers = approval_blockers(spec)
+            if blockers:
+                raise HTTPException(status_code=409, detail={"blocked": blockers})
+        try:
+            validate_transition(spec.status, "approved")
+        except InvalidTransition as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        spec.status = "approved"
+        return _save_and_review(spec)
+
+    @app.post("/specs/{spec_id}/request-changes")
+    def post_request_changes(spec_id: str, body: ReasonBody):
+        spec = _load_or_404(spec_id)
+        try:
+            validate_transition(spec.status, "needs_clarification")
+        except InvalidTransition as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        spec.status = "needs_clarification"
+        review = _save_and_review(spec)
+        if log_manager is not None:
+            try:
+                log_manager.append(spec.id, f"spec request-changes (api): {body.reason}")
+            except Exception:
+                pass
+        return review
+```
+
+- [ ] **Step 4: Run → pass.** Then the whole `tests/core/test_serve.py`.
+- [ ] **Step 5: Commit** `feat(serve): write endpoints — approve + request-changes (gate, 409 on conflict)` + journal.
+
+---
+
+## Task 3: writes inherit auth + full suite
+
+**Files:** `tests/core/test_serve.py`; (verification).
+
+- [ ] **Step 1: Test** — writes are gated by the B2 token (inherited app-level dependency):
+
+```python
+def test_writes_require_auth(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_auth_app(tmp_path, "secret"))
+    # No Authorization header → 401 even for a write.
+    assert client.post("/specs/dq/verdict", json={"criterion_id": "ac1", "verdict": "approved"}).status_code == 401
+    # With the token → allowed.
+    ok = client.post("/specs/dq/verdict", json={"criterion_id": "ac1", "verdict": "approved"},
+                     headers={"Authorization": "Bearer secret"})
+    assert ok.status_code == 200
+```
+
+- [ ] **Step 2: Run → pass** (auth dependency already applies to all routes; this confirms it covers POSTs).
+- [ ] **Step 3: Full suite.** `mship test` (or `uv run pytest`) → green.
+- [ ] **Step 4: Commit** `test(serve): confirm write endpoints inherit bearer auth; full suite green` + journal.
+
+---
+
+## Self-Review
+- **Coverage:** verdict / add-question / answer (T1); approve + gate + 409 / request-changes (T2); auth-gating + full suite (T3). Each returns `build_review`.
+- **Error mapping:** spec 404; domain `ValueError` → 400; `InvalidTransition` + gate-blocked → 409; malformed body → 422 (FastAPI). All tested.
+- **Placeholders:** none — complete code. The one in-scope note (ensure `build_review`/`HTTPException` in scope where the POST handlers are defined) is called out.
+- **Type consistency:** request models (`VerdictBody`/`QuestionBody`/`AnswerBody`/`ApproveBody`/`ReasonBody`); reuses `set_criterion_verdict`, `add_question`, `answer_question`, `approval_blockers`, `validate_transition`, `InvalidTransition`, `build_review`, `SpecStore`.
+
+## Execution Handoff
+Commit this plan + design to `main`, then `mship spawn` MOS-166.

--- a/docs/superpowers/specs/2026-06-14-serve-writes-design.md
+++ b/docs/superpowers/specs/2026-06-14-serve-writes-design.md
@@ -1,0 +1,58 @@
+# `mship serve` write endpoints (review → approve) — design (B1.5 / MOS-166)
+
+> Status: design approved 2026-06-14. Feeds `writing-plans`.
+> Part of **Ground Control** (epic MOS-144). Adds the review/approve write loop to
+> the `mship serve` API (B1 read-only + B2 auth, both merged).
+
+## Context
+
+B1 serves read-only; B2 gates it. B1.5 adds the **POST** endpoints the C4 review
+cards drive — submit verdicts, manage questions, approve / request-changes — so a
+reviewer can act from their phone. Each is a thin wrapper over an existing core
+write helper (no logic fork from the CLI).
+
+## Decisions
+
+1. **Endpoints (all POST, all on the existing app):**
+   | Endpoint | Body | Core call |
+   |----------|------|-----------|
+   | `POST /specs/{id}/verdict` | `{criterion_id, verdict}` | `set_criterion_verdict` |
+   | `POST /specs/{id}/questions` | `{text}` | `add_question` |
+   | `POST /specs/{id}/questions/{qid}/answer` | `{answer}` | `answer_question` |
+   | `POST /specs/{id}/approve` | `{bypass_gate=false}` | `approval_blockers` + `validate_transition` |
+   | `POST /specs/{id}/request-changes` | `{reason}` | `validate_transition` |
+2. **Request bodies are pydantic models** (FastAPI validates + schemas them; malformed body → `422` automatically).
+3. **Every write returns `build_review(spec)`** — the fresh review payload (status + criteria + questions + summary), so the app refreshes its cards in one round-trip.
+4. **Each handler:** `find_by_id` (→ `404` if absent) → call the core helper → bump `updated_at` → `SpecStore.save` → return `build_review`. (Same load→mutate→save the CLI does.) `request-changes` also best-effort journals the reason via `log_manager` (if present).
+5. **Error → HTTP mapping:**
+   - spec not found → **404**
+   - core `ValueError` (bad verdict value, unknown criterion/question id, prose-unit id) → **400** (message passed through)
+   - `InvalidTransition` (approve/request-changes from the wrong status) → **409**
+   - approval gate blocked (not bypassed) → **409**, body lists the blockers
+   - malformed JSON body → **422** (FastAPI default)
+6. **Auth: inherited.** Writes are routes on the same app, so the B2 app-level bearer dependency already gates them — no extra auth code. (A test asserts a write `401`s without the token.)
+
+## Scope (B1.5)
+
+In: the 5 review/approve write endpoints + their request models + error mapping.
+Out: capture writes (`POST /specs`, `/draft`, `/apply`), `dispatch` over HTTP
+(spawn follow-up), idempotency keys, optimistic-concurrency (single-user; SpecStore
+atomic writes suffice).
+
+## Migration / compat
+
+Additive — new POST routes on the existing read-only app; GET behavior, auth, and
+the docs-disabled-under-auth behavior unchanged.
+
+## Testing
+
+- **verdict:** sets a criterion's verdict (response `build_review` reflects it); bad
+  verdict value → `400`; unknown criterion → `400`; unknown spec → `404`.
+- **questions:** add → review shows the new `q`; answer → review shows the answer;
+  unknown `qid` → `400`.
+- **approve:** blocked (unreviewed criterion / unanswered question) → `409` with
+  blockers; after verdict+answer → `200`, status `approved`; `bypass_gate=true` →
+  `200`; wrong status (re-approve) → `409`.
+- **request-changes:** → `200`, status `needs_clarification`.
+- **auth:** with `auth_token` set, a write with no `Authorization` header → `401`
+  (confirms writes inherit the B2 gate).

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -2,6 +2,29 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from pydantic import BaseModel
+
+
+class VerdictBody(BaseModel):
+    criterion_id: str
+    verdict: str
+
+
+class QuestionBody(BaseModel):
+    text: str
+
+
+class AnswerBody(BaseModel):
+    answer: str
+
+
+class ApproveBody(BaseModel):
+    bypass_gate: bool = False
+
+
+class ReasonBody(BaseModel):
+    reason: str
+
 
 def _make_auth_dependency(token: str):
     import hmac
@@ -91,5 +114,79 @@ def create_app(
         if slug not in state.tasks:
             raise HTTPException(status_code=404, detail=f"no task {slug!r}")
         return jsonable_encoder(log_manager.read(slug, last=50))
+
+    # --- write endpoints ---
+
+    from datetime import datetime, timezone
+    from mship.core.spec_review import set_criterion_verdict
+    from mship.core.spec_questions import add_question, answer_question
+
+    def _load_or_404(spec_id: str):
+        spec = store.find_by_id(spec_id)
+        if spec is None:
+            raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
+        return spec
+
+    def _save_and_review(spec):
+        spec.updated_at = datetime.now(timezone.utc)
+        store.save(spec)
+        return build_review(spec)
+
+    @app.post("/specs/{spec_id}/verdict")
+    def post_verdict(spec_id: str, body: VerdictBody):
+        spec = _load_or_404(spec_id)
+        try:
+            set_criterion_verdict(spec, body.criterion_id, body.verdict)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        return _save_and_review(spec)
+
+    @app.post("/specs/{spec_id}/questions")
+    def post_question(spec_id: str, body: QuestionBody):
+        spec = _load_or_404(spec_id)
+        add_question(spec, body.text)
+        return _save_and_review(spec)
+
+    @app.post("/specs/{spec_id}/questions/{qid}/answer")
+    def post_answer(spec_id: str, qid: str, body: AnswerBody):
+        spec = _load_or_404(spec_id)
+        try:
+            answer_question(spec, qid, body.answer)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        return _save_and_review(spec)
+
+    from mship.core.spec import InvalidTransition, validate_transition
+    from mship.core.spec_approve import approval_blockers
+
+    @app.post("/specs/{spec_id}/approve")
+    def post_approve(spec_id: str, body: ApproveBody):
+        spec = _load_or_404(spec_id)
+        if not body.bypass_gate:
+            blockers = approval_blockers(spec)
+            if blockers:
+                raise HTTPException(status_code=409, detail={"blocked": blockers})
+        try:
+            validate_transition(spec.status, "approved")
+        except InvalidTransition as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        spec.status = "approved"
+        return _save_and_review(spec)
+
+    @app.post("/specs/{spec_id}/request-changes")
+    def post_request_changes(spec_id: str, body: ReasonBody):
+        spec = _load_or_404(spec_id)
+        try:
+            validate_transition(spec.status, "needs_clarification")
+        except InvalidTransition as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        spec.status = "needs_clarification"
+        review = _save_and_review(spec)
+        if log_manager is not None:
+            try:
+                log_manager.append(spec.id, f"spec request-changes (api): {body.reason}")
+            except Exception:
+                pass
+        return review
 
     return app

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -48,8 +48,8 @@ def create_app(
     workspace_name: str = "mothership",
     auth_token: str | None = None,
 ):
-    """Build the read-only mship serve FastAPI app. Sync handlers call the core
-    directly; FastAPI serializes the returns (pydantic models, dicts, dataclasses)."""
+    """Build the mship serve FastAPI app (read + review/approve write endpoints).
+    Sync handlers call the core directly; FastAPI serializes the returns."""
     from fastapi import Depends, FastAPI, HTTPException
 
     from mship.core.spec_store import SpecStore
@@ -165,7 +165,7 @@ def create_app(
         if not body.bypass_gate:
             blockers = approval_blockers(spec)
             if blockers:
-                raise HTTPException(status_code=409, detail={"blocked": blockers})
+                raise HTTPException(status_code=409, detail="cannot approve: " + "; ".join(blockers))
         try:
             validate_transition(spec.status, "approved")
         except InvalidTransition as e:

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -169,3 +169,27 @@ def test_post_question_and_answer(tmp_path):
     assert ans.status_code == 200
     assert ans.json()["open_questions"][0]["answer"] == "yes"
     assert client.post("/specs/dq/questions/q99/answer", json={"answer": "x"}).status_code == 400
+
+
+def test_post_approve_gate_and_success(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    assert client.post("/specs/dq/approve", json={}).status_code == 409          # q1 unanswered
+    client.post("/specs/dq/questions/q1/answer", json={"answer": "yes"})
+    ok = client.post("/specs/dq/approve", json={})
+    assert ok.status_code == 200 and ok.json()["status"] == "approved"
+    assert client.post("/specs/dq/approve", json={}).status_code == 409           # re-approve illegal
+
+
+def test_post_approve_bypass(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs/dq/approve", json={"bypass_gate": True})
+    assert r.status_code == 200 and r.json()["status"] == "approved"
+
+
+def test_post_request_changes(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs/dq/request-changes", json={"reason": "tighten scope"})
+    assert r.status_code == 200 and r.json()["status"] == "needs_clarification"

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 from mship.core.serve import create_app
-from mship.core.spec import AcceptanceCriterion, Spec
+from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec
 from mship.core.spec_body import render_body
 from mship.core.spec_store import SpecStore
 from mship.core.state import StateManager, Task, WorkspaceState
@@ -28,6 +28,7 @@ def _seed_spec(tmp_path: Path):
         created_at=now, updated_at=now, task_slug="dq",
         body=render_body("the problem", "as a user", "the approach"),
         acceptance_criteria=[AcceptanceCriterion(id="ac1", text="view questions", verdict="approved")],
+        open_questions=[OpenQuestion(id="q1", text="Mobile too?")],
     ))
 
 
@@ -145,3 +146,26 @@ def test_non_ascii_token_still_401_not_500(tmp_path):
     # Positive case (correct non-ascii token) omitted: httpx/TestClient encodes
     # header values as ASCII and raises UnicodeEncodeError before the request
     # reaches the server, so we cannot test the success path via TestClient.
+
+
+def test_post_verdict(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs/dq/verdict", json={"criterion_id": "ac1", "verdict": "flagged"})
+    assert r.status_code == 200
+    assert r.json()["acceptance_criteria"][0]["verdict"] == "flagged"
+    assert client.post("/specs/dq/verdict", json={"criterion_id": "ac1", "verdict": "bogus"}).status_code == 400
+    assert client.post("/specs/dq/verdict", json={"criterion_id": "nope", "verdict": "approved"}).status_code == 400
+    assert client.post("/specs/none/verdict", json={"criterion_id": "ac1", "verdict": "approved"}).status_code == 404
+
+
+def test_post_question_and_answer(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    add = client.post("/specs/dq/questions", json={"text": "Tablets too?"})
+    assert add.status_code == 200
+    assert [q["id"] for q in add.json()["open_questions"]] == ["q1", "q2"]
+    ans = client.post("/specs/dq/questions/q1/answer", json={"answer": "yes"})
+    assert ans.status_code == 200
+    assert ans.json()["open_questions"][0]["answer"] == "yes"
+    assert client.post("/specs/dq/questions/q99/answer", json={"answer": "x"}).status_code == 400

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -199,3 +199,15 @@ def test_post_request_changes(tmp_path):
     client = TestClient(_app(tmp_path))
     r = client.post("/specs/dq/request-changes", json={"reason": "tighten scope"})
     assert r.status_code == 200 and r.json()["status"] == "needs_clarification"
+
+
+def test_writes_require_auth(tmp_path):
+    client = TestClient(_auth_app(tmp_path, "secret"))
+    # No Authorization header → 401 even for a write.
+    assert client.post("/specs/dq/verdict", json={"criterion_id": "ac1", "verdict": "approved"}).status_code == 401
+    # With the token → allowed.
+    ok = client.post(
+        "/specs/dq/verdict", json={"criterion_id": "ac1", "verdict": "approved"},
+        headers={"Authorization": "Bearer secret"},
+    )
+    assert ok.status_code == 200

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -171,10 +171,16 @@ def test_post_question_and_answer(tmp_path):
     assert client.post("/specs/dq/questions/q99/answer", json={"answer": "x"}).status_code == 400
 
 
+def test_post_question_unknown_spec_404(tmp_path):
+    assert TestClient(_app(tmp_path)).post("/specs/none/questions", json={"text": "x"}).status_code == 404
+
+
 def test_post_approve_gate_and_success(tmp_path):
     _seed_spec(tmp_path)
     client = TestClient(_app(tmp_path))
-    assert client.post("/specs/dq/approve", json={}).status_code == 409          # q1 unanswered
+    blocked = client.post("/specs/dq/approve", json={})
+    assert blocked.status_code == 409          # q1 unanswered
+    assert isinstance(blocked.json()["detail"], str)   # uniform string shape
     client.post("/specs/dq/questions/q1/answer", json={"answer": "yes"})
     ok = client.post("/specs/dq/approve", json={})
     assert ok.status_code == 200 and ok.json()["status"] == "approved"


### PR DESCRIPTION
## Summary

B1.5 / MOS-166 — the **review → approve write loop** for `mship serve`, on top of B1 (read-only API) + B2 (bearer auth). These are the POST endpoints the Ground Control review cards drive, so a reviewer can act from their phone.

5 write endpoints, each a thin wrapper over an existing core helper, each returning the fresh `build_review(spec)` payload so the client refreshes its cards in one round-trip:

| Endpoint | Body | Core call |
|----------|------|-----------|
| `POST /specs/{id}/verdict` | `{criterion_id, verdict}` | `set_criterion_verdict` |
| `POST /specs/{id}/questions` | `{text}` | `add_question` |
| `POST /specs/{id}/questions/{qid}/answer` | `{answer}` | `answer_question` |
| `POST /specs/{id}/approve` | `{bypass_gate=false}` | `approval_blockers` + `validate_transition` |
| `POST /specs/{id}/request-changes` | `{reason}` | `validate_transition` (best-effort journals the reason) |

## Behavior

- **Same load→mutate→save the CLI does:** `find_by_id` → core helper → bump `updated_at` → `SpecStore.save` → return `build_review`.
- **Error → HTTP mapping:** spec not found → `404`; core `ValueError` (bad verdict value, unknown criterion/question id, prose-unit id) → `400`; `InvalidTransition` + approval-gate-blocked → `409` (uniform **string** detail on both approve paths); malformed body → `422` (FastAPI/pydantic).
- **Approve gate** honors `bypass_gate`; the structured blocker breakdown stays available via `GET /specs/{id}/review`.
- **🔒 Auth: inherited.** Writes are routes on the same app, so the B2 app-level bearer dependency already gates them — a write with no `Authorization` header → `401` (tested). No write route escapes the gate.

## Test plan

- [x] `mship test` green — **full suite 1359/1359**.
- [x] `TestClient`: every endpoint's happy + error paths — verdict (bad value / unknown criterion / unknown spec), add/answer question (unknown qid / unknown spec), approve (gate-blocked `409` / success / re-approve `409` / `bypass_gate`), request-changes; writes inherit auth (`401` without token, `200` with).
- [x] Per-feature spec+quality review + a holistic whole-branch review (both merge-ready).

## Scope

Out (follow-ons): capture writes (`POST /specs`, `/draft`, `/apply`), `dispatch` over HTTP, idempotency keys, optimistic-concurrency (single-user; `SpecStore` atomic writes suffice).

Linear: MOS-166.
