### PR TITLE
fix(skills): Tier 1 literal CLI drift

### DIFF
--- a/src/mship/skills/subagent-driven-development/SKILL.md
+++ b/src/mship/skills/subagent-driven-development/SKILL.md
@@ -146,7 +146,7 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 - `./spec-reviewer-prompt.md` - Dispatch spec compliance reviewer subagent
 - `./code-quality-reviewer-prompt.md` - Dispatch code quality reviewer subagent
 
-**Inside a mothership workspace:** prefer `mship dispatch --task <slug>` as the source of your implementer prompt's task context. It emits a self-contained Markdown block with the task slug, worktree path, phase, recent journal entries, and per-repo bases — handling multi-task disambiguation automatically. See `working-with-mothership` for the full decision tree on `mship dispatch` vs. `mship context`.
+**Inside a mothership workspace:** prefer `mship dispatch --task <slug> -i "<implementer instruction>"` to build your implementer prompt. The `-i/--instruction` text is **required**; it is wrapped together with the task slug, worktree path, phase, recent journal entries, and per-repo bases into a self-contained Markdown block — handling multi-task disambiguation automatically. See `working-with-mothership` for the full decision tree on `mship dispatch` vs. `mship context`.
 
 ## Example Workflow
 

--- a/src/mship/skills/using-git-worktrees/SKILL.md
+++ b/src/mship/skills/using-git-worktrees/SKILL.md
@@ -188,10 +188,10 @@ You: I'm using the using-git-worktrees skill to set up an isolated workspace.
 
 [Detect: mothership.yaml found at /abs/workspace — routing through mship spawn]
 [Run: mship spawn "implement auth middleware" --repos auth-service]
-[mship creates worktree at .worktrees/feat/implement-auth-middleware, runs task setup]
+[mship creates worktree at .worktrees/implement-auth-middleware/auth-service, runs task setup]
 [Run: mship test (baseline check)]
 
-Worktree ready at /abs/workspace/.worktrees/feat/implement-auth-middleware
+Worktree ready at /abs/workspace/.worktrees/implement-auth-middleware/auth-service
 Tests passing (47 tests, 0 failures)
 Ready to implement auth middleware
 ```

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -42,7 +42,7 @@ Mothership supports multiple active tasks simultaneously. Typical reasons:
 - Two unrelated investigations in flight; one can progress while the other is idle.
 - Long-running `mship finish` / CI on task A while beginning new work on task B.
 
-Each task has its own worktree at `.worktrees/feat/<slug>/`; they coexist cleanly.
+Each task gets a worktree per affected repo at `.worktrees/<slug>/<repo>/` (the branch is `feat/<slug>`); they coexist cleanly.
 
 ### How mship resolves which task a command targets
 
@@ -50,7 +50,7 @@ In order of precedence:
 
 1. **`--task <slug>` flag** — explicit; wins over everything else. Use for one-off commands from any pwd.
 2. **`MSHIP_TASK=<slug>` env var** — shell/tab-level default. Useful when you want every `mship` command in a shell to target one task.
-3. **cwd-based inference** — if pwd is inside `.worktrees/feat/<slug>/`, mship picks `<slug>`. This is the most ergonomic: `cd` into a worktree and every command defaults to that task.
+3. **cwd-based inference** — if pwd is inside `.worktrees/<slug>/<repo>/`, mship picks `<slug>`. This is the most ergonomic: `cd` into a worktree and every command defaults to that task.
 
 Zero anchors (no `--task`, no `MSHIP_TASK`, pwd outside any worktree) + two active tasks → `AmbiguousTaskError` with a clear message listing the options.
 
@@ -61,7 +61,7 @@ Zero anchors (no `--task`, no `MSHIP_TASK`, pwd outside any worktree) + two acti
 mship worktrees
 
 # Open a new terminal tab → enter a different task's worktree:
-cd .worktrees/feat/other-task
+cd .worktrees/other-task/<repo>
 
 # Every mship command in this tab now targets `other-task`:
 mship status
@@ -84,10 +84,10 @@ MSHIP_TASK=other-task ./scripts/run-integration.sh
 
 Two mship-native primitives for handing work to subagents. Use them instead of hand-rolling task context:
 
-- **`mship dispatch`** — emits a self-contained Markdown prompt for a subagent. Output includes task slug, worktree path, phase, recent journal entries, affected repos, and per-repo bases. Pipe stdout directly as the `prompt` field of a Claude Code `Task` tool dispatch (or analogous mechanism in Codex / other agent platforms).
+- **`mship dispatch`** — wraps your instruction (`-i/--instruction`, **required**) in a self-contained Markdown prompt for a subagent. Output includes your instruction plus the task slug, worktree path, phase, recent journal entries, affected repos, and per-repo bases. Pipe stdout directly as the `prompt` field of a Claude Code `Task` tool dispatch (or analogous mechanism in Codex / other agent platforms).
 
   ```bash
-  mship dispatch --task my-task   # prints a ready-to-use prompt to stdout
+  mship dispatch --task my-task -i "implement the parser changes"   # prints a ready-to-use prompt to stdout
   ```
 
 - **`mship context`** — emits structured JSON for programmatic consumers. Use when feeding state into a non-Claude-Code LLM, logging for audit, or scripting decisions. `jq`-friendly.
@@ -232,7 +232,7 @@ For larger changes — new features, significant refactors — spawn a new task 
 mship status                          # task, phase, branch, drift, last log, finished warning
 mship audit [--repos r] [--json]
 mship pr                              # aggregate PR state across all active tasks
-mship view status|logs|diff|spec [--watch]
+mship view status|journal|diff|spec [--watch]
 mship view spec --web                 # serves HTML on localhost
 mship graph
 mship worktrees


### PR DESCRIPTION
## Summary

**Tier 1 of a skills-vs-CLI drift audit** — corrects the *verified literal errors* in the mship-bundled skills (`src/mship/skills/`), where a skill's `mship …` example or path no longer matches the current CLI. Doc-only.

| Skill | Was | Now (verified against the CLI) |
|-------|-----|-------------------------------|
| `working-with-mothership` | `mship dispatch --task my-task` | `mship dispatch --task my-task -i "…"` — `-i/--instruction` is **`[required]`**; the example would have errored |
| `working-with-mothership` | `mship view status\|logs\|diff\|spec` | `mship view status\|journal\|diff\|spec` — there is no `logs` subcommand |
| `working-with-mothership` (×3) | worktree at `.worktrees/feat/<slug>/` | `.worktrees/<slug>/<repo>/` — the branch is `feat/<slug>`; the path has no `feat/` prefix and includes the repo (per `worktree.py:449` `hub = workspace_root / ".worktrees" / slug`) |
| `subagent-driven-development` | `mship dispatch --task <slug>` | `mship dispatch --task <slug> -i "…"` — same required-instruction fix |
| `using-git-worktrees` | example path `.worktrees/feat/implement-auth-middleware` | `.worktrees/implement-auth-middleware/auth-service` (`<slug>/<repo>`) |

## What this is NOT

This PR is only the unambiguous literal corrections. The larger findings from the audit — weaving the new `mship spec` lifecycle into the workflow skills, the `~/.config/superpowers/` → mship rebranding, `mship serve`/`debug`/`finish --require-tests` coverage — are a separate spec'd effort (Tier 2/3), since those are methodology-design decisions rather than factual fixes.

## Test plan

- [x] `mship test` — full suite green (exit 0), evidence recorded.
- [x] Swept all 15 skills for residual `.worktrees/feat/`, `view … logs`, and `mship dispatch` examples missing `-i` — none remain (prose references to the command name by itself are intentionally left).
