### PR TITLE
docs(skills): Tier 2/3 — weave mship spec lifecycle into bundled skills

### DIFF
--- a/docs/plans/2026-06-14-skills-cli-refresh.md
+++ b/docs/plans/2026-06-14-skills-cli-refresh.md
@@ -1,0 +1,352 @@
+# Skills ↔ CLI Refresh Implementation Plan (Tier 2/3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the mship-bundled skills up to date with the current CLI — weave the `mship spec` lifecycle into the workflow skills (Approach A: one canonical description in `working-with-mothership`, thin cross-references elsewhere), fold in the Tier 3 coverage gaps, and add a configurable `docs_dir`.
+
+**Architecture:** One small additive code change (`docs_dir` on `WorkspaceConfig` + surfaced in `mship context`); the rest are documentation edits across the bundled skills under `src/mship/skills/`. A final guard test sweeps the edited skills for stale references and asserts the spec-lifecycle commands named in the docs actually exist in the CLI.
+
+**Tech Stack:** Python, pydantic v2 (`WorkspaceConfig`), Typer, pytest, `uv`. Skills are Markdown (`SKILL.md`).
+
+**Design:** [docs/specs/2026-06-14-skills-cli-refresh-design.md](../specs/2026-06-14-skills-cli-refresh-design.md)
+
+**Base note:** This branch must be spawned AFTER [#175](https://github.com/atomikpanda/mothership/pull/175) (Tier 1) merges — it edits the same skill files. Spawn from an updated `main`.
+
+---
+
+## File structure
+
+- **Modify** `src/mship/core/config.py` — add `docs_dir` field to `WorkspaceConfig`.
+- **Modify** `src/mship/cli/context.py` — surface `docs_dir` in the payload.
+- **Test** `tests/core/test_config.py`, `tests/cli/test_context.py` — config + context.
+- **Modify** `src/mship/skills/working-with-mothership/SKILL.md` — canonical Specs section + Tier 3 (serve/debug/finish).
+- **Modify** `src/mship/skills/brainstorming/SKILL.md` — dual-path output → `mship spec`.
+- **Modify** `src/mship/skills/{writing-plans,executing-plans,subagent-driven-development}/SKILL.md` — thin spec cross-refs.
+- **Modify** `src/mship/skills/{using-mothership,writing-skills}/SKILL.md` — `mship skill` coverage.
+- **Modify** `src/mship/skills/{test-driven-development,verification-before-completion,dispatching-parallel-agents}/SKILL.md` — evidence pipeline + worktree-awareness.
+- **Modify** `src/mship/skills/using-git-worktrees/SKILL.md` — drop the `~/.config/superpowers/` global fallback.
+- **Test** `tests/core/test_skills_cli_refresh.py` (new) — the guard test.
+
+---
+
+## Task 1: `docs_dir` config + `mship context` surfacing
+
+**Files:**
+- Modify: `src/mship/core/config.py` (in `WorkspaceConfig`, after `require_approved_spec` ~line 118)
+- Modify: `src/mship/cli/context.py` (after the `build_context` call, ~line 43)
+- Test: `tests/core/test_config.py`, `tests/cli/test_context.py`
+
+- [ ] **Step 1: Write the failing config tests.** Append to `tests/core/test_config.py` (they reuse the existing `workspace` fixture + `ConfigLoader.load`, exactly like `test_default_branch_pattern` / `test_custom_branch_pattern`):
+
+```python
+def test_docs_dir_defaults_to_docs(workspace: Path):
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    assert config.docs_dir == "docs"
+
+
+def test_custom_docs_dir(workspace: Path):
+    cfg = workspace / "mothership.yaml"
+    cfg.write_text(cfg.read_text() + 'docs_dir: "documentation"\n')
+    config = ConfigLoader.load(cfg)
+    assert config.docs_dir == "documentation"
+```
+
+- [ ] **Step 2: Run → fail.** `uv run pytest tests/core/test_config.py -k docs_dir -v` → FAIL (`WorkspaceConfig` has no `docs_dir`).
+
+- [ ] **Step 3: Add the field.** In `src/mship/core/config.py`, inside `WorkspaceConfig`, immediately after the `require_approved_spec` field (~line 118) and before `repos`:
+
+```python
+    # Workspace-relative directory where the bundled skills write plan docs (and,
+    # outside a workspace, fallback design docs). Plans live at `<docs_dir>/plans/`.
+    # Does NOT affect canonical mship specs (always `specs/`) or the `spec_paths`
+    # legacy spec-search default. Surfaced in `mship context` for skills.
+    docs_dir: str = "docs"
+```
+
+- [ ] **Step 4: Run → pass.** `uv run pytest tests/core/test_config.py -k docs_dir -v` → PASS.
+
+- [ ] **Step 5: Write the failing context test.** In `tests/cli/test_context.py` (mirror the existing `mship context` invocation there — a `CliRunner` invoking `["context"]` and `json.loads(result.stdout)`), add:
+
+```python
+def test_context_includes_docs_dir(configured_workspace):
+    result = runner.invoke(app, ["context"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["docs_dir"] == "docs"
+```
+
+(Use whatever configured-workspace fixture the other context tests use; if the test file has a different fixture name, match it.)
+
+- [ ] **Step 6: Run → fail.** `uv run pytest tests/cli/test_context.py -k docs_dir -v` → FAIL (`KeyError: 'docs_dir'`).
+
+- [ ] **Step 7: Surface it.** In `src/mship/cli/context.py`, right after the `payload = build_context(...)` call (~line 43, before the `resolve_task` block), add:
+
+```python
+        payload["docs_dir"] = container.config().docs_dir
+```
+
+- [ ] **Step 8: Run → pass.** `uv run pytest tests/cli/test_context.py -k docs_dir -v` → PASS. Then the whole two files: `uv run pytest tests/core/test_config.py tests/cli/test_context.py -q`.
+
+- [ ] **Step 9: Commit.**
+
+```bash
+git add src/mship/core/config.py src/mship/cli/context.py tests/core/test_config.py tests/cli/test_context.py
+git commit -m "feat(config): docs_dir (default docs); surface in mship context"
+mship journal "added docs_dir config + mship context surfacing; tests pass" --action committed
+```
+
+---
+
+## Task 2: Canonical "Specs" section in `working-with-mothership` (+ Tier 3 for that skill)
+
+**Files:**
+- Modify: `src/mship/skills/working-with-mothership/SKILL.md`
+
+This is the single source of truth (Approach A). All other skills point here.
+
+- [ ] **Step 1: Add the "Specs" section.** Insert a new section in the `plan`-phase area of `working-with-mothership/SKILL.md` (just after the phase-workflow description, before the "Delegating to subagents" section). Content:
+
+````markdown
+## Specs: the spec lifecycle (`mship spec`)
+
+In a mothership workspace the **canonical design artifact is a structured `mship spec`**, not an ad-hoc design doc. A spec is the shared communication substrate: a durable, queryable artifact that agents hand off to each other and that humans review/steer from the mobile app over `mship serve`. The `plan` phase is where a spec is authored and approved.
+
+A spec lives at `<workspace>/specs/<date>-<id>.md` — frontmatter (id, title, status, acceptance criteria, open questions, non-goals, risks, bound task) + a body with `Problem` / `User story` / `Approach` sections. Status flows:
+`captured → drafting → needs_review → needs_clarification → approved → dispatched → implemented → archived`.
+
+The lifecycle, in order:
+
+```bash
+mship spec new --title "<title>"            # create a stub (status: captured)
+mship spec draft <id>                        # emit a drafting prompt to stdout
+#   → run that prompt through an agent to produce SpecDraft JSON, then:
+mship spec apply <id> --from-json <file>     # ingest the draft (→ needs_review)
+mship spec validate <id>                     # check body structure
+mship spec review <id>                       # print the review payload (criteria, questions, context)
+mship spec verdict <id> <criterion-id> approved|flagged
+mship spec questions <id>                    # list open questions
+mship spec ask <id> "<question>"             # add a question
+mship spec answer <id> <question-id> "<answer>"
+mship spec approve <id> [--bypass-gate]      # → approved (gate: all criteria approved + questions answered)
+mship spec request-changes <id> --reason "<why>"   # → needs_clarification
+mship spec dispatch <id>                     # bind the approved spec to a task + emit a handoff
+```
+
+Review a spec without the CLI via `mship view spec [--web]`, or over HTTP via `mship serve` (the Ground Control phone path).
+
+**The approval gate.** With `require_approved_spec: true` in `mothership.yaml`, `mship phase dev` is **hard-blocked** until a bound, approved spec exists — escape with `mship phase dev --bypass-spec-gate`. **This is opt-in: the default is OFF**, so by default `phase dev` only warns when no spec is found. Spec-first is the recommended methodology regardless of the gate.
+````
+
+- [ ] **Step 2: Fix the stale "soft gates" claim.** Find the soft-gates description (it currently says `phase dev` only ever "warns if no spec is found" / "soft gates warn, don't block"). Edit it to note the spec gate is a **hard block when `require_approved_spec: true`** (default OFF), cross-referencing the Specs section. Leave the tests/uncommitted gates described as soft warnings.
+
+- [ ] **Step 3: Add Tier 3 coverage (this skill).** Make these additions:
+  - In the inspection/integration area, add `mship serve` — "read + review/approve write API over the spec + task model (`--host`/`--port 47100`, bearer `MSHIP_SERVE_TOKEN` for non-loopback). The Ground Control phone surface."
+  - In the journal/structured-logging area, add the debug thread commands and cross-ref: "`mship debug hypothesis|rule-out|resolved` record structured debugging entries (`mship test` auto-attaches to the open hypothesis). See the `systematic-debugging` skill."
+  - In the `mship finish` synopsis, add the missing flags: `--require-tests` (block, don't warn, when test evidence is missing), `--title` (override PR title), `--body-map` (per-repo bodies), and note `--force`/`-f` re-pushes new commits to an already-finished task's existing PR.
+
+- [ ] **Step 4: Verify structure + commit.** Confirm the file still has valid frontmatter and renders (eyeball headings). Then:
+
+```bash
+git add src/mship/skills/working-with-mothership/SKILL.md
+git commit -m "docs(skills): canonical mship spec lifecycle section + serve/debug/finish coverage"
+mship journal "working-with-mothership: spec lifecycle section + Tier 3 coverage" --action committed
+```
+
+---
+
+## Task 3: `brainstorming` — dual-path output (→ `mship spec` in a workspace)
+
+**Files:**
+- Modify: `src/mship/skills/brainstorming/SKILL.md`
+
+- [ ] **Step 1: Replace the design-doc output step.** The skill's checklist item 6 currently says "Write design doc — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit". Replace it (and the matching prose in the "After the Design / Documentation" section, ~line 29 and ~line 111) with a dual-path:
+
+````markdown
+6. **Capture the design** — dual-path on workspace detection (is there a `mothership.yaml` at/above cwd?):
+   - **In a mothership workspace:** the design becomes a structured **`mship spec`**, not a doc file. Run `mship spec new --title "<title>"`, then populate it (`mship spec draft <id>` → agent → `mship spec apply <id> --from-json <file>`), landing it in `needs_review`. This is the canonical artifact — it gets reviewed/approved (`mship spec review`/`verdict`/`approve`) and dispatched. See the `working-with-mothership` skill for the full lifecycle.
+   - **Outside a workspace:** write a plain design doc to `docs/specs/YYYY-MM-DD-<topic>-design.md` and commit it.
+````
+
+- [ ] **Step 2: Update the checklist + flow diagram terminal.** In the checklist and the `dot` process-flow graph, the terminal "Write design doc → … → Invoke writing-plans" path must reflect: in a workspace, the artifact is an `mship spec` that goes through review/approve before `writing-plans`. Update the "Write design doc" node label to "Capture design (mship spec in a workspace, else design doc)" and keep `writing-plans` as the terminal.
+
+- [ ] **Step 3: Update the User Review Gate wording.** The gate currently says "Spec written and committed to `<path>`…". Make it path-aware: in a workspace, "the spec is in `needs_review` (`mship spec review <id>`)"; otherwise the design-doc path.
+
+- [ ] **Step 4: Verify + commit.**
+
+```bash
+git add src/mship/skills/brainstorming/SKILL.md
+git commit -m "docs(skills): brainstorming output converges on mship spec (dual-path)"
+mship journal "brainstorming: dual-path output → mship spec" --action committed
+```
+
+---
+
+## Task 4: `writing-plans`, `executing-plans`, `subagent-driven-development` cross-refs
+
+**Files:**
+- Modify: `src/mship/skills/writing-plans/SKILL.md`
+- Modify: `src/mship/skills/executing-plans/SKILL.md`
+- Modify: `src/mship/skills/subagent-driven-development/SKILL.md`
+
+- [ ] **Step 1: `writing-plans`.** Add a short "Mothership workspace" note near the top: "In a mothership workspace, the input to a plan is an **approved `mship spec`** (reference its id in the plan header); `mship phase dev` may be gated on that approval (see `working-with-mothership`)." Change the "Save plans to" default from `docs/superpowers/plans/…` to **`<docs_dir>/plans/YYYY-MM-DD-<feature-name>.md`** (default `docs/plans/`; `docs_dir` comes from `mship context`). Outside a workspace, `docs/plans/`.
+
+- [ ] **Step 2: `executing-plans`.** In the mothership-workspace pre-flight check (where it verifies `mship status` shows an active task), add: "If `require_approved_spec: true`, the task needs a bound, approved spec before `mship phase dev` will advance — create/approve one (`mship spec …`) or pass `mship phase dev --bypass-spec-gate`. See `working-with-mothership`."
+
+- [ ] **Step 3: `subagent-driven-development`.** Near the existing `mship dispatch` guidance (the line Tier 1 corrected to include `-i`), add: "For a spec-driven kickoff, `mship spec dispatch <id>` binds an approved spec to its task and emits a handoff that includes the acceptance criteria — complementary to `mship dispatch -i`."
+
+- [ ] **Step 4: Verify + commit.**
+
+```bash
+git add src/mship/skills/writing-plans/SKILL.md src/mship/skills/executing-plans/SKILL.md src/mship/skills/subagent-driven-development/SKILL.md
+git commit -m "docs(skills): spec-aware cross-refs in writing-plans/executing-plans/subagent-driven-development"
+mship journal "writing/executing/subagent skills: spec cross-refs" --action committed
+```
+
+---
+
+## Task 5: `using-mothership` + `writing-skills` — `mship skill` coverage
+
+**Files:**
+- Modify: `src/mship/skills/using-mothership/SKILL.md`
+- Modify: `src/mship/skills/writing-skills/SKILL.md`
+
+- [ ] **Step 1: `using-mothership`.** After the "How to Access Skills" section, add a short "Installing bundled skills" note: "mship ships its skills under `src/mship/skills/`. `mship skill list` shows what's bundled; `mship skill install [--only claude,codex,gemini] [--force]` deploys them into the agent's skill directories."
+
+- [ ] **Step 2: `writing-skills`.** Where it describes skill homes (`~/.claude/skills`, `~/.agents/skills/`), add: "In mothership, bundled skills live in `src/mship/skills/<name>/SKILL.md` and are distributed with `mship skill install`." In the deployment checklist (~line 631), add a step: "In the mothership repo, run `mship skill install` after committing to propagate the skill into agent dirs."
+
+- [ ] **Step 3: Fix the self-contradicting link.** In `writing-skills/SKILL.md` (~line 556), the REFACTOR section uses `@testing-skills-with-subagents.md` — the `@` force-load syntax the skill itself prohibits (~line 286). Change it to a plain reference: `testing-skills-with-subagents.md`.
+
+- [ ] **Step 4: Verify + commit.**
+
+```bash
+git add src/mship/skills/using-mothership/SKILL.md src/mship/skills/writing-skills/SKILL.md
+git commit -m "docs(skills): mship skill list/install coverage; fix @-force-load link"
+mship journal "using-mothership + writing-skills: mship skill coverage" --action committed
+```
+
+---
+
+## Task 6: `test-driven-development`, `verification-before-completion`, `dispatching-parallel-agents`
+
+**Files:**
+- Modify: `src/mship/skills/test-driven-development/SKILL.md`
+- Modify: `src/mship/skills/verification-before-completion/SKILL.md`
+- Modify: `src/mship/skills/dispatching-parallel-agents/SKILL.md`
+
+- [ ] **Step 1: `test-driven-development`.** In the verification/debugging-integration area, add one sentence: "In a mothership workspace, run tests via `mship test` (not a bare runner) — it records the evidence that `mship finish --require-tests` checks before opening a PR."
+
+- [ ] **Step 2: `verification-before-completion`.** Add a short "mship workspace" callout: "In a mothership workspace, the verification step should use `mship test` so the result is recorded as evidence; `mship finish --require-tests` enforces that gate. See `working-with-mothership`."
+
+- [ ] **Step 3: `dispatching-parallel-agents`.** Add a "Mothership workspace" callout mirroring the one in `subagent-driven-development`: "Before dispatching parallel agents in a workspace, confirm an anchored task (`mship status`) and set each agent's working dir to its task worktree (`.resolved_task.worktrees.<repo>`) — agents that run on `main` will be blocked by the pre-commit hook."
+
+- [ ] **Step 4: Verify + commit.**
+
+```bash
+git add src/mship/skills/test-driven-development/SKILL.md src/mship/skills/verification-before-completion/SKILL.md src/mship/skills/dispatching-parallel-agents/SKILL.md
+git commit -m "docs(skills): mship test evidence pipeline + parallel-dispatch worktree awareness"
+mship journal "TDD/verification/parallel skills: evidence + worktree awareness" --action committed
+```
+
+---
+
+## Task 7: `using-git-worktrees` — drop the `~/.config/superpowers/` global fallback
+
+**Files:**
+- Modify: `src/mship/skills/using-git-worktrees/SKILL.md`
+
+- [ ] **Step 1: Remove the global-superpowers option.** The skill offers `~/.config/superpowers/worktrees/<project-name>/` as a worktree location (the "Ask User" dialog option 2 ~line 50, the "For Global Directory" section ~line 75, and the case branch ~line 97-98). Remove the global option; default the generic (non-mship) fallback to **project-local `.worktrees/`** only. Update the decision table (~line 154) accordingly.
+
+- [ ] **Step 2: Sweep for residual references.** `grep -n 'superpowers' src/mship/skills/using-git-worktrees/SKILL.md` → should be empty.
+
+- [ ] **Step 3: Verify + commit.**
+
+```bash
+git add src/mship/skills/using-git-worktrees/SKILL.md
+git commit -m "docs(skills): drop stale ~/.config/superpowers worktree fallback"
+mship journal "using-git-worktrees: dropped superpowers global fallback" --action committed
+```
+
+---
+
+## Task 8: Guard test + full suite
+
+**Files:**
+- Create: `tests/core/test_skills_cli_refresh.py`
+
+A regression guard so the skills can't silently re-drift on the things this refresh fixed.
+
+- [ ] **Step 1: Write the guard test.** Create `tests/core/test_skills_cli_refresh.py`:
+
+```python
+"""Guard tests: keep the bundled skills aligned with the CLI after the Tier 2/3 refresh."""
+from pathlib import Path
+
+import pytest
+
+SKILLS_DIR = Path(__file__).resolve().parents[2] / "src" / "mship" / "skills"
+
+# Skills edited in the refresh that must not carry the legacy upstream paths.
+EDITED_SKILLS = [
+    "working-with-mothership", "brainstorming", "writing-plans", "executing-plans",
+    "subagent-driven-development", "using-mothership", "writing-skills",
+    "test-driven-development", "verification-before-completion",
+    "dispatching-parallel-agents", "using-git-worktrees",
+]
+
+
+@pytest.mark.parametrize("skill", EDITED_SKILLS)
+def test_no_superpowers_config_path(skill):
+    text = (SKILLS_DIR / skill / "SKILL.md").read_text()
+    assert "~/.config/superpowers" not in text, f"{skill}: stale superpowers worktree path"
+
+
+def test_working_with_mothership_names_real_spec_commands():
+    """Every `mship spec <sub>` named in the canonical skill must be a real subcommand."""
+    text = (SKILLS_DIR / "working-with-mothership" / "SKILL.md").read_text()
+    real_subcommands = {
+        "new", "draft", "apply", "validate", "review", "verdict",
+        "questions", "ask", "answer", "approve", "request-changes", "dispatch",
+    }
+    import re
+    named = set(re.findall(r"mship spec ([a-z-]+)", text))
+    bogus = named - real_subcommands
+    assert not bogus, f"working-with-mothership names non-existent spec subcommands: {bogus}"
+
+
+def test_dispatch_examples_include_instruction():
+    """`mship dispatch` example invocations must include the required -i/--instruction."""
+    import re
+    for skill in ("working-with-mothership", "subagent-driven-development"):
+        text = (SKILLS_DIR / skill / "SKILL.md").read_text()
+        # any fenced example line that *invokes* dispatch must carry -i or --instruction
+        for line in text.splitlines():
+            stripped = line.strip()
+            if re.match(r"^(\$ )?mship dispatch\b", stripped):
+                assert "-i" in stripped or "--instruction" in stripped, \
+                    f"{skill}: `mship dispatch` example missing -i: {stripped!r}"
+```
+
+- [ ] **Step 2: Run → pass.** `uv run pytest tests/core/test_skills_cli_refresh.py -v`. If a case fails, the corresponding skill edit (Tasks 2–7) is incomplete — fix the skill, not the test.
+
+- [ ] **Step 3: Full suite.** `mship test` (records evidence) → green. The pre-existing skill tests (`tests/cli/test_skill.py`, `tests/core/test_skills_namespace.py`, `tests/core/test_skill_install.py`) must still pass.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add tests/core/test_skills_cli_refresh.py
+git commit -m "test(skills): guard against CLI drift (spec commands, dispatch -i, superpowers paths)"
+mship journal "added skills↔CLI drift guard test; full suite green" --action committed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §1 → Task 2 (canonical Specs section). §2 → Tasks 3 (brainstorming) + 4 (writing/executing/subagent). §3 → Tasks 2 (serve/debug/finish), 5 (skill install), 6 (evidence + parallel). §4 → Task 1 (`docs_dir` + context) + Task 7 (worktree fallback). Guard → Task 8.
+- **Placeholder scan:** code tasks (1, 8) have complete code; doc tasks specify exact files, anchors, and the actual text to insert/replace. The few "match the existing fixture" notes (config/context test harness) are deliberate — the construction boilerplate is best read from the neighbouring tests rather than guessed.
+- **Type consistency:** `WorkspaceConfig.docs_dir` (str, default `"docs"`); `payload["docs_dir"]` in `cli/context.py`; the guard test's `real_subcommands` set matches the verified `mship spec` subcommand list.
+- **Scope:** does NOT touch `spec_paths` / `SPEC_SUBDIR` (out of scope per design); does NOT migrate existing `docs/superpowers/*` files.
+
+## Execution Handoff
+
+Spawn the task AFTER #175 merges (shared skill files), then implement task-by-task. Tasks 3–7 are independent doc edits over distinct files and can be parallelized; Task 1 (code) is independent; Task 8 (guard) runs last, after the skill edits land.

--- a/docs/specs/2026-06-14-skills-cli-refresh-design.md
+++ b/docs/specs/2026-06-14-skills-cli-refresh-design.md
@@ -1,0 +1,171 @@
+# Skills ↔ CLI refresh — design (Tier 2/3)
+
+> Status: design approved 2026-06-14. Feeds `writing-plans`.
+> Follows the skills-vs-CLI audit. Tier 1 (literal command/path errors) shipped
+> separately in [#175](https://github.com/atomikpanda/mothership/pull/175) (MOS-167).
+
+## Context
+
+The mship-bundled skills (`src/mship/skills/`) are where mothership's methodology
+lives — they're a fork of superpowers, shipped + installed via `mship skill`. An
+audit of all 15 skills against the current `mship` CLI found they **predate the
+`mship spec` lifecycle (A1–A7)** and several other commands: no skill teaches the
+spec-driven workflow, and a few carry upstream-superpowers artifacts (paths, a
+self-contradicting force-load link).
+
+Tier 1 (unambiguous literal errors — `dispatch -i`, `view journal`, worktree path)
+already shipped. **This design covers Tier 2 (weave the spec lifecycle into the
+skills) + Tier 3 (the remaining coverage gaps), as one coherent refresh.**
+
+## Decisions
+
+1. **Converge on `mship spec`.** In a mothership workspace the canonical design
+   artifact is the structured `mship spec` (`<workspace>/specs/<date>-<id>.md`),
+   not a free-form design doc. Brainstorming's output flows into the spec lifecycle;
+   the structured spec is the reviewable/approvable/dispatchable contract that
+   Ground Control reads from the phone.
+   - **Why (the motivating principle):** the structured spec is the *shared
+     communication substrate*. A durable, queryable artifact that agents hand off to
+     each other and that humans review and steer from the mobile app over
+     `mship serve`. It replaces ad-hoc design docs and state held only in an agent's
+     working memory — both of which are invisible to other agents and to the phone.
+     The skills must stop producing ad-hoc docs in a workspace and instead write into
+     this shared state.
+2. **Dual-path with detection.** Skills detect the workspace (`mothership.yaml` at/
+   above cwd → mship path; else a clean generic fallback). This keeps the general
+   methodology skills usable in single-repo / non-mship contexts.
+3. **Approach A — centralized lifecycle.** `working-with-mothership` owns the single
+   canonical description of the spec lifecycle; every other skill gets a *thin*
+   mship-aware cross-reference, not a copy. This structurally prevents the
+   duplication-drift the audit just cleaned up.
+4. **Configurable docs location.** New `docs_dir` config key (default `docs`)
+   replaces the upstream `docs/superpowers/` convention with a sensible, overridable
+   default. Surfaced to agents via `mship context` so skills don't parse YAML.
+
+## §1 — Canonical "Specs" section (in `working-with-mothership`)
+
+A new section, integrated into the `plan` phase, is the single source of truth:
+
+- **What a spec is** — the structured artifact at `<workspace>/specs/<date>-<id>.md`
+  (frontmatter + `Problem`/`User story`/`Approach` body, acceptance criteria, open
+  questions, non-goals, risks) and its status lifecycle
+  (`captured → drafting → needs_review → needs_clarification → approved → dispatched
+  → implemented → archived`).
+- **The command loop, in order:** `mship spec new` → `mship spec draft` (emits a
+  drafting prompt) → run it → `mship spec apply` (ingest the `SpecDraft`,
+  → `needs_review`) → `mship spec validate` → `mship spec review` /
+  `mship spec verdict <criterion-id> approved|flagged` → `mship spec questions` /
+  `ask` / `answer` → `mship spec approve [--bypass-gate]` /
+  `mship spec request-changes --reason` → `mship spec dispatch` (binds the approved
+  spec to a task + emits the handoff).
+- **The gate** — `require_approved_spec: true` in `mothership.yaml` makes `plan→dev`
+  require an approved spec; `mship phase --bypass-spec-gate` escapes it. **Default
+  OFF.** The section presents spec-first as the *recommended methodology* while being
+  explicit the hard gate is opt-in. (This corrects the skill's current "soft gates
+  always warn, never block" claim, which is false when the gate is enabled.)
+- **Reviewing specs** — pointer to `mship view spec [--web]` and `mship serve` (the
+  Ground Control / phone review path).
+
+## §2 — Thin cross-references in the other 4 workflow skills
+
+Each gets a short mship-aware branch pointing to §1, never a copy of the lifecycle:
+
+- **`brainstorming`** — its output step changes. *In a workspace*: the design becomes
+  an `mship spec` (`spec new` → populate → `needs_review`), then review/approve, then
+  → `writing-plans`. Its checklist + process-flow diagram terminal update to match.
+  *Outside a workspace*: a plain design doc at `docs/specs/YYYY-MM-DD-<topic>-design.md`.
+- **`writing-plans`** — in a workspace the plan takes an **approved spec** as input
+  (references its id) and notes the gate; plan docs go to `<docs_dir>/plans/`.
+- **`executing-plans`** — adds the spec-gate caveat before spawning / advancing
+  `plan→dev` (check for an approved spec or `--bypass-spec-gate`).
+- **`subagent-driven-development`** — notes `mship spec dispatch` as the spec-bound
+  kickoff (complements the `mship dispatch -i` Tier 1 already corrected).
+
+## §3 — Tier 3 coverage fixes (folded in where files are already open)
+
+- **`using-mothership`** — short "installing skills" note: `mship skill list` /
+  `mship skill install [--only claude,codex,gemini] [--force]`.
+- **`writing-skills`** — the `src/mship/skills/<name>/SKILL.md` bundled-skill location
+  + `mship skill install` distribution step; fix the self-contradicting `@`-force-load
+  link (currently ~line 556) to a plain reference.
+- **`working-with-mothership`** — brief coverage of `mship serve` (read+write spec/task
+  API), `mship debug hypothesis|rule-out|resolved` (cross-ref `systematic-debugging`),
+  and the missing `mship finish` flags (`--require-tests`, `--title`, `--body-map`,
+  `--force` re-push).
+- **`test-driven-development`** + **`verification-before-completion`** — note that
+  `mship test` is the evidence-recording runner whose results feed
+  `mship finish --require-tests`.
+- **`dispatching-parallel-agents`** — a workspace/worktree-awareness callout (each
+  parallel agent works from its task worktree, not main).
+
+## §4 — Dual-path detection + `docs_dir` config
+
+- **Detection convention** (shared phrasing across skills): *"if `mothership.yaml`
+  exists at/above cwd → mship path; else generic fallback."*
+- **`docs_dir` config** — add `docs_dir: str = "docs"` to **`WorkspaceConfig`**
+  (`core/config.py`, beside `spec_paths` / `require_approved_spec`); surface it in
+  `mship context` so a skill can read it without parsing YAML, via a one-liner in
+  `cli/context.py` (`payload["docs_dir"] = container.config().docs_dir`) — no change
+  to the cached `build_context`.
+  - `docs_dir` governs **plan-doc location only** → `<docs_dir>/plans/` (default
+    `docs/plans/`). Plans have no CLI representation, so this is non-conflicting.
+  - Non-mship fallback design docs → `docs/specs/` (hardcoded default; no config
+    outside a workspace).
+  - In-workspace specs stay canonical `mship spec` files at `<workspace>/specs/`
+    (`SPECS_DIRNAME`) — **unaffected** by `docs_dir`.
+  - **Not touched:** the existing `spec_paths` config and its `SPEC_SUBDIR`
+    (`docs/superpowers/specs`) legacy free-form spec-search default. Spec discovery
+    already searches the canonical `specs/` *and* `spec_paths`, so convergence makes
+    that legacy default vestigial but harmless; changing it is separate behavioral
+    work (see Out of scope).
+- **`using-git-worktrees`** — drop the stale `~/.config/superpowers/worktrees/<project>/`
+  global option; default the generic fallback to project-local `.worktrees/`.
+
+## Architecture / units of work
+
+1. **Code:** `docs_dir: str = "docs"` on `WorkspaceConfig` (`core/config.py`, beside
+   `spec_paths`) + expose in `mship context` via the `cli/context.py` one-liner
+   (no change to the cached `build_context`). Tests: config default + override;
+   `mship context` payload includes `docs_dir`. Does NOT touch `spec_paths`/`SPEC_SUBDIR`.
+2. **Canonical doc:** the new Specs section in `working-with-mothership/SKILL.md`
+   (§1 + the §3 items that belong to that skill).
+3. **Cross-reference edits:** `brainstorming`, `writing-plans`, `executing-plans`,
+   `subagent-driven-development` (§2).
+4. **Tier 3 edits:** `using-mothership`, `writing-skills`, `test-driven-development`,
+   `verification-before-completion`, `dispatching-parallel-agents` (§3).
+5. **`using-git-worktrees`:** §4 worktree-fallback cleanup.
+
+These are mostly independent doc edits over distinct files (parallelizable), plus the
+one small code unit (1) they depend on for the `docs_dir` reference.
+
+## Migration / compat
+
+- Additive config: `docs_dir` defaults to `docs`, so unset workspaces get the new
+  default with no action.
+- Existing `docs/superpowers/*` files are left as historical, dated artifacts — no
+  migration. New docs use the `docs/` default.
+- All skill changes are documentation; the only behavioral code change is the
+  additive `docs_dir` field (no existing behavior changes when it's unset).
+
+## Testing
+
+- **Code:** `Config` parses `docs_dir` (default `docs`; override respected);
+  `mship context` includes `docs_dir`.
+- **Docs:** existing skill-namespace / install tests still pass; a sweep confirms no
+  residual `docs/superpowers/` or `~/.config/superpowers/` references remain in the
+  edited skills, and that the spec-lifecycle commands named in `working-with-mothership`
+  all exist in the CLI (guard against re-drift).
+
+## Out of scope
+
+- Migrating existing `docs/superpowers/*` files.
+- A `mship plan` CLI artifact (plans remain doc files).
+- Retroactively converting this design doc into an `mship spec` (the brainstorming→
+  spec wiring is what this designs; it doesn't exist yet).
+- Any change to the spec lifecycle commands themselves — this refresh documents the
+  CLI as it is, it doesn't extend it.
+- Reconciling the legacy `spec_paths` / `SPEC_SUBDIR` default (`docs/superpowers/specs`)
+  used by free-form spec discovery. Convergence on `mship spec` makes it vestigial,
+  but changing its default alters soft-gate / `mship view spec` search behavior for
+  unconfigured workspaces (with test impact) — a separate follow-up if the
+  `superpowers` reference should be retired everywhere.

--- a/src/mship/cli/context.py
+++ b/src/mship/cli/context.py
@@ -41,6 +41,7 @@ def register(app: typer.Typer, get_container):
             state_dir=state_dir,
             cache=ReconcileCache(state_dir),
         )
+        payload["docs_dir"] = container.config().docs_dir
         try:
             resolved_task, source = resolve_task(
                 state,

--- a/src/mship/cli/serve.py
+++ b/src/mship/cli/serve.py
@@ -17,7 +17,7 @@ def register(app: typer.Typer, get_container):
         ),
         port: int = typer.Option(47100, "--port", help="Port."),
     ):
-        """Run a read-only JSON API over the spec + task model (Ground Control)."""
+        """Run a JSON API over the spec + task model — reads plus review/approve writes (Ground Control)."""
         import os
         import uvicorn
         from mship.core.serve import create_app

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -116,6 +116,11 @@ class WorkspaceConfig(BaseModel):
     # approved spec exists (status in approved/dispatched/implemented).
     # Default False so existing configs/tests are unaffected. See MOS-151.
     require_approved_spec: bool = False
+    # Workspace-relative directory where the bundled skills write plan docs (and,
+    # outside a workspace, fallback design docs). Plans live at `<docs_dir>/plans/`.
+    # Does NOT affect canonical mship specs (always `specs/`) or the `spec_paths`
+    # legacy spec-search default. Surfaced in `mship context` for skills.
+    docs_dir: str = "docs"
     repos: dict[str, RepoConfig]
 
     @model_validator(mode="after")

--- a/src/mship/skills/brainstorming/SKILL.md
+++ b/src/mship/skills/brainstorming/SKILL.md
@@ -26,7 +26,9 @@ You MUST create a task for each of these items and complete them in order:
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+6. **Capture the design** — dual-path on workspace detection (is there a `mothership.yaml` at/above cwd?):
+   - **In a mothership workspace:** the design becomes a structured **`mship spec`**, not a doc file. Run `mship spec new --title "<title>"`, then populate it (`mship spec draft <id>` → run the emitted prompt through an agent → `mship spec apply <id> --from-json <file>`), landing it in `needs_review`. This is the canonical artifact — it gets reviewed/approved (`mship spec review` / `verdict` / `approve`) and dispatched. See the `working-with-mothership` skill for the full lifecycle.
+   - **Outside a workspace:** write a plain design doc to `docs/specs/YYYY-MM-DD-<topic>-design.md` and commit it.
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
 9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
@@ -42,7 +44,7 @@ digraph brainstorming {
     "Propose 2-3 approaches" [shape=box];
     "Present design sections" [shape=box];
     "User approves design?" [shape=diamond];
-    "Write design doc" [shape=box];
+    "Capture design\n(mship spec in a workspace, else design doc)" [shape=box];
     "Spec self-review\n(fix inline)" [shape=box];
     "User reviews spec?" [shape=diamond];
     "Invoke writing-plans skill" [shape=doublecircle];
@@ -55,10 +57,10 @@ digraph brainstorming {
     "Propose 2-3 approaches" -> "Present design sections";
     "Present design sections" -> "User approves design?";
     "User approves design?" -> "Present design sections" [label="no, revise"];
-    "User approves design?" -> "Write design doc" [label="yes"];
-    "Write design doc" -> "Spec self-review\n(fix inline)";
+    "User approves design?" -> "Capture design\n(mship spec in a workspace, else design doc)" [label="yes"];
+    "Capture design\n(mship spec in a workspace, else design doc)" -> "Spec self-review\n(fix inline)";
     "Spec self-review\n(fix inline)" -> "User reviews spec?";
-    "User reviews spec?" -> "Write design doc" [label="changes requested"];
+    "User reviews spec?" -> "Capture design\n(mship spec in a workspace, else design doc)" [label="changes requested"];
     "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
 }
 ```
@@ -108,10 +110,12 @@ digraph brainstorming {
 
 **Documentation:**
 
-- Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+Capture the design using the dual-path based on workspace detection (is there a `mothership.yaml` at/above cwd?):
+
+- **In a mothership workspace:** the design becomes a structured **`mship spec`**, not a doc file. Run `mship spec new --title "<title>"`, then populate it (`mship spec draft <id>` → run the emitted prompt through an agent → `mship spec apply <id> --from-json <file>`), landing it in `needs_review`. This is the canonical artifact — it gets reviewed/approved (`mship spec review` / `verdict` / `approve`) and dispatched. See the `working-with-mothership` skill for the full lifecycle.
+- **Outside a workspace:** write the validated design to `docs/specs/YYYY-MM-DD-<topic>-design.md` and commit it.
   - (User preferences for spec location override this default)
-- Use elements-of-style:writing-clearly-and-concisely skill if available
-- Commit the design document to git
+  - Use elements-of-style:writing-clearly-and-concisely skill if available
 
 **Spec Self-Review:**
 After writing the spec document, look at it with fresh eyes:
@@ -124,9 +128,12 @@ After writing the spec document, look at it with fresh eyes:
 Fix any issues inline. No need to re-review — just fix and move on.
 
 **User Review Gate:**
-After the spec review loop passes, ask the user to review the written spec before proceeding:
+After the spec review loop passes, ask the user to review the artifact before proceeding. The message is path-aware:
 
-> "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
+- **In a mothership workspace:** the artifact is the `mship spec` now in `needs_review` state.
+  > "Spec created and ready for review (id: `<id>`). You can review it with `mship spec review <id>` or `mship view spec` in the mobile app. Let me know if you want any changes before we start writing out the implementation plan."
+- **Outside a workspace:** the artifact is the committed design doc.
+  > "Design doc written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
 
 Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.
 

--- a/src/mship/skills/brainstorming/spec-document-reviewer-prompt.md
+++ b/src/mship/skills/brainstorming/spec-document-reviewer-prompt.md
@@ -4,7 +4,7 @@ Use this template when dispatching a spec document reviewer subagent.
 
 **Purpose:** Verify the spec is complete, consistent, and ready for implementation planning.
 
-**Dispatch after:** Spec document is written to docs/superpowers/specs/
+**Dispatch after:** the spec is captured — an `mship spec` in a workspace (review via `mship spec review <id>`), or a design doc at `docs/specs/`.
 
 ```
 Task tool (general-purpose):

--- a/src/mship/skills/dispatching-parallel-agents/SKILL.md
+++ b/src/mship/skills/dispatching-parallel-agents/SKILL.md
@@ -157,6 +157,13 @@ Agent 3 → Fix tool-approval-race-conditions.test.ts
 
 **Time saved:** 3 problems solved in parallel vs sequentially
 
+## Mothership Workspace
+
+Before dispatching parallel agents in a mothership workspace, confirm there is
+an anchored task (`mship status`) and set each agent's working directory to its
+task worktree (`.resolved_task.worktrees.<repo>`). Agents that run on `main`
+will be blocked by the pre-commit hook.
+
 ## Key Benefits
 
 1. **Parallelization** - Multiple investigations happen simultaneously

--- a/src/mship/skills/executing-plans/SKILL.md
+++ b/src/mship/skills/executing-plans/SKILL.md
@@ -19,7 +19,7 @@ Load plan, review critically, execute all tasks, report when complete.
 1. Read plan file
 2. Review critically — identify any questions or concerns about the plan
 3. If concerns: Raise them with your human partner before starting
-4. **If this is a mothership workspace** (`mothership.yaml` at any ancestor): verify `mship status` shows an active task BEFORE starting (`mship status | jq .resolved_task` should be non-null, or `.active_tasks` should contain the slug you intend to anchor). No active task → stop and tell the user to `mship spawn "<description>"` first. Then `cd` into `.resolved_task.worktrees.<repo>` and do all work and commits there. The mship pre-commit hook refuses commits from outside the worktree, so "just commit on main" is both wrong and blocked.
+4. **If this is a mothership workspace** (`mothership.yaml` at any ancestor): verify `mship status` shows an active task BEFORE starting (`mship status | jq .resolved_task` should be non-null, or `.active_tasks` should contain the slug you intend to anchor). No active task → stop and tell the user to `mship spawn "<description>"` first. Then `cd` into `.resolved_task.worktrees.<repo>` and do all work and commits there. The mship pre-commit hook refuses commits from outside the worktree, so "just commit on main" is both wrong and blocked. If `require_approved_spec: true`, the task needs a bound, approved spec before `mship phase dev` will advance — create/approve one (`mship spec …`) or pass `mship phase dev --bypass-spec-gate`. See `working-with-mothership`.
 5. If no concerns: Create TodoWrite and proceed
 
 ### Step 2: Execute Tasks

--- a/src/mship/skills/requesting-code-review/SKILL.md
+++ b/src/mship/skills/requesting-code-review/SKILL.md
@@ -58,7 +58,7 @@ HEAD_SHA=$(git rev-parse HEAD)
 
 [Dispatch code-reviewer subagent]
   WHAT_WAS_IMPLEMENTED: Verification and repair functions for conversation index
-  PLAN_OR_REQUIREMENTS: Task 2 from docs/superpowers/plans/deployment-plan.md
+  PLAN_OR_REQUIREMENTS: Task 2 from docs/plans/deployment-plan.md
   BASE_SHA: a7981ec
   HEAD_SHA: 3df7661
   DESCRIPTION: Added verifyIndex() and repairIndex() with 4 issue types

--- a/src/mship/skills/subagent-driven-development/SKILL.md
+++ b/src/mship/skills/subagent-driven-development/SKILL.md
@@ -146,7 +146,7 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 - `./spec-reviewer-prompt.md` - Dispatch spec compliance reviewer subagent
 - `./code-quality-reviewer-prompt.md` - Dispatch code quality reviewer subagent
 
-**Inside a mothership workspace:** prefer `mship dispatch --task <slug> -i "<implementer instruction>"` to build your implementer prompt. The `-i/--instruction` text is **required**; it is wrapped together with the task slug, worktree path, phase, recent journal entries, and per-repo bases into a self-contained Markdown block — handling multi-task disambiguation automatically. See `working-with-mothership` for the full decision tree on `mship dispatch` vs. `mship context`.
+**Inside a mothership workspace:** prefer `mship dispatch --task <slug> -i "<implementer instruction>"` to build your implementer prompt. The `-i/--instruction` text is **required**; it is wrapped together with the task slug, worktree path, phase, recent journal entries, and per-repo bases into a self-contained Markdown block — handling multi-task disambiguation automatically. For a spec-driven kickoff, `mship spec dispatch <id>` binds an approved spec to its task and emits a handoff that includes the acceptance criteria — complementary to `mship dispatch -i`. See `working-with-mothership` for the full decision tree on `mship dispatch` vs. `mship context`.
 
 ## Example Workflow
 

--- a/src/mship/skills/subagent-driven-development/SKILL.md
+++ b/src/mship/skills/subagent-driven-development/SKILL.md
@@ -153,7 +153,7 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 ```
 You: I'm using Subagent-Driven Development to execute this plan.
 
-[Read plan file once: docs/superpowers/plans/feature-plan.md]
+[Read plan file once: docs/plans/feature-plan.md]
 [Extract all 5 tasks with full text and context]
 [Create TodoWrite with all tasks]
 
@@ -164,7 +164,7 @@ Task 1: Hook installation script
 
 Implementer: "Before I begin - should the hook be installed at user or system level?"
 
-You: "User level (~/.config/superpowers/hooks/)"
+You: "User level (~/.claude/hooks/)"
 
 Implementer: "Got it. Implementing now..."
 [Later] Implementer:

--- a/src/mship/skills/test-driven-development/SKILL.md
+++ b/src/mship/skills/test-driven-development/SKILL.md
@@ -356,6 +356,8 @@ Never fix bugs without a test.
 
 In a mothership workspace with an open debug thread (`mship debug hypothesis`), `mship test` auto-attaches `parent=<hypothesis-id>` to the test-run journal entry — linking the failing→passing transition to the hypothesis that predicted it. See the `systematic-debugging` skill for the full hypothesis → rule-out → resolved loop.
 
+In a mothership workspace, run tests via `mship test` (not a bare runner) — it records the evidence that `mship finish --require-tests` checks before opening a PR.
+
 ## Testing Anti-Patterns
 
 When adding mocks or test utilities, read @testing-anti-patterns.md to avoid common pitfalls:

--- a/src/mship/skills/using-git-worktrees/SKILL.md
+++ b/src/mship/skills/using-git-worktrees/SKILL.md
@@ -46,8 +46,8 @@ If no directory exists and no CLAUDE.md preference:
 ```
 No worktree directory found. Where should I create worktrees?
 
-1. .worktrees/ (project-local, hidden)
-2. ~/.config/superpowers/worktrees/<project-name>/ (global location)
+1. .worktrees/ (project-local, hidden) [default]
+2. worktrees/ (project-local, visible)
 
 Which would you prefer?
 ```
@@ -72,10 +72,6 @@ Per Jesse's rule "Fix broken things immediately":
 
 **Why critical:** Prevents accidentally committing worktree contents to repository.
 
-### For Global Directory (~/.config/superpowers/worktrees)
-
-No .gitignore verification needed - outside project entirely.
-
 ## Creation Steps
 
 ### 1. Detect Project Name
@@ -89,15 +85,9 @@ project=$(basename "$(git rev-parse --show-toplevel)")
 *For non-mship workflows, create the worktree directly:*
 
 ```bash
-# Determine full path
-case $LOCATION in
-  .worktrees|worktrees)
-    path="$LOCATION/$BRANCH_NAME"
-    ;;
-  ~/.config/superpowers/worktrees/*)
-    path="~/.config/superpowers/worktrees/$project/$BRANCH_NAME"
-    ;;
-esac
+# Determine full path (default: .worktrees/)
+LOCATION="${LOCATION:-.worktrees}"
+path="$LOCATION/$BRANCH_NAME"
 
 # Create worktree with new branch
 git worktree add "$path" -b "$BRANCH_NAME"

--- a/src/mship/skills/using-mothership/SKILL.md
+++ b/src/mship/skills/using-mothership/SKILL.md
@@ -35,6 +35,10 @@ If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "alw
 
 **In other environments:** Check your platform's documentation for how skills are loaded.
 
+### Installing bundled skills
+
+mship ships its skills under `src/mship/skills/`. `mship skill list` shows what's bundled; `mship skill install` deploys them into the agent's skill directories. Available install flags: `--only <agents>` (comma-separated: claude,codex,gemini), `--force` (override safe-skip on foreign content), `--yes`/`-y` (skip per-agent confirmation prompts).
+
 ## Platform Adaptation
 
 Skills use Claude Code tool names. Non-CC platforms: see `references/copilot-tools.md` (Copilot CLI), `references/codex-tools.md` (Codex) for tool equivalents. Gemini CLI users get the tool mapping loaded automatically via GEMINI.md.

--- a/src/mship/skills/verification-before-completion/SKILL.md
+++ b/src/mship/skills/verification-before-completion/SKILL.md
@@ -130,6 +130,12 @@ From 24 failure memories:
 - Implications of success
 - ANY communication suggesting completion/correctness
 
+## Mothership Workspace
+
+In a mothership workspace, run verification via `mship test` so the result is
+recorded as evidence; `mship finish --require-tests` enforces that gate before
+a PR is opened. See `working-with-mothership`.
+
 ## The Bottom Line
 
 **No shortcuts for verification.**

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -142,7 +142,7 @@ Four phases progress linearly. Always transition explicitly with `mship phase <t
 
 | Phase | What happens here | Common per-repo skills |
 |---|---|---|
-| `plan` | Brainstorm requirements, write spec, write implementation plan | brainstorming, writing-plans (superpowers), or your team's spec process |
+| `plan` | Brainstorm requirements, author + approve an `mship spec` (see Specs above), write implementation plan | brainstorming, writing-plans, or your team's spec process |
 | `dev` | Implement, write tests, commit | TDD, subagent-driven-development, or your team's coding workflow |
 | `review` | Verify tests pass, code review, lint | code-review, verification-before-completion |
 | `run` | Start services, integration test, deploy | depends on environment |
@@ -473,7 +473,7 @@ If you realize you've been editing or committing from the main checkout instead 
 ## Integration with Other Tools
 
 Mothership pairs well with:
-- **superpowers** — methodology skills (TDD, brainstorming, code review) within each repo
+- **mship-skills** — the in-tree methodology skills (TDD, brainstorming, code review, …) bundled with mship and installed via `mship skill install`
 - **Dagger** — containerized execution, polyglot builds; receives `UPSTREAM_*` env vars from mothership
 - **gh** — required for `mship finish` PR creation
 - **Custom agent frameworks** — anything that can call shell commands and parse JSON works

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -80,6 +80,35 @@ MSHIP_TASK=other-task ./scripts/run-integration.sh
 - `mship sync` and `mship audit` operate on the workspace, not a single task — no `--task` needed (or honored).
 - Resources outside mship's state (docker containers, DB tables, shared caches) are NOT task-scoped. Share where safe; tear down where not.
 
+## Specs: the spec lifecycle (`mship spec`)
+
+In a mothership workspace the **canonical design artifact is a structured `mship spec`**, not an ad-hoc design doc. A spec is the shared communication substrate: a durable, queryable artifact that agents hand off to each other and that humans review/steer from the mobile app over `mship serve`. The `plan` phase is where a spec is authored and approved.
+
+A spec lives at `<workspace>/specs/<date>-<id>.md` — frontmatter (id, title, status, acceptance criteria, open questions, non-goals, risks, bound task) + a body with `Problem` / `User story` / `Approach` sections. Status flows:
+`captured → drafting → needs_review → needs_clarification → approved → dispatched → implemented → archived`.
+
+The lifecycle, in order:
+
+```bash
+mship spec new --title "<title>"            # create a stub (status: captured)
+mship spec draft <id>                        # emit a drafting prompt to stdout
+#   → run that prompt through an agent to produce SpecDraft JSON, then:
+mship spec apply <id> --from-json <file>     # ingest the draft (→ needs_review)
+mship spec validate <id>                     # check body structure
+mship spec review <id>                       # print the review payload (criteria, questions, context)
+mship spec verdict <id> <criterion-id> approved|flagged
+mship spec questions <id>                    # list open questions
+mship spec ask <id> "<question>"             # add a question
+mship spec answer <id> <question-id> "<answer>"
+mship spec approve <id> [--bypass-gate]      # → approved (gate: all criteria approved + questions answered)
+mship spec request-changes <id> --reason "<why>"   # → needs_clarification
+mship spec dispatch <id>                     # bind the approved spec to a task + emit a handoff
+```
+
+Review a spec without the CLI via `mship view spec [--web]`, or over HTTP via `mship serve` (the Ground Control phone path).
+
+**The approval gate.** With `require_approved_spec: true` in `mothership.yaml`, `mship phase dev` is **hard-blocked** until a bound, approved spec exists — escape with `mship phase dev --bypass-spec-gate`. **This is opt-in: the default is OFF**, so by default `phase dev` only warns when no spec is found. Spec-first is the recommended methodology regardless of the gate.
+
 ## Delegating to subagents: `mship context` and `mship dispatch`
 
 Two mship-native primitives for handing work to subagents. Use them instead of hand-rolling task context:
@@ -119,7 +148,7 @@ Four phases progress linearly. Always transition explicitly with `mship phase <t
 | `run` | Start services, integration test, deploy | depends on environment |
 
 **Soft gates** warn (don't block) when preconditions aren't met:
-- `phase dev` → warns if no spec is found
+- `phase dev` → warns if no spec is found (default); **hard-blocks when `require_approved_spec: true`** in `mothership.yaml` — escape with `--bypass-spec-gate`. See [Specs: the spec lifecycle](#specs-the-spec-lifecycle-mship-spec) above.
 - `phase review` → warns if tests haven't passed
 - `phase run` → warns if there are uncommitted changes
 
@@ -157,7 +186,7 @@ mship block "reason" | mship unblock
 mship test [--all] [--repos|--tag] [--no-diff]
 mship journal "msg" [--action X] [--open Y] [--repo R] [--test-state pass|fail|mixed]
 mship journal --show-open                 # what am I blocked on across this task?
-mship finish [--base B] [--base-map ...] [--push-only] [--handoff] [--force-audit] [--body-file F | --body TEXT] [--force]
+mship finish [--base B] [--base-map ...] [--push-only] [--handoff] [--force-audit] [--body-file F | --body TEXT] [--force] [--require-tests] [--title T] [--body-map ...]
 mship close [--yes] [--abandon] [--force] [--skip-pr-check]
 ```
 
@@ -177,7 +206,9 @@ If you don't, your edits in the shell affect the main checkout, not the feature 
 
 **Always log structured.** `--action` makes session resume actually work. `--open` flags blockers you'll come back to. `--show-open` lists them. The `repo` field is auto-inferred from `mship switch`'s active repo.
 
-**`finish`:** PR base resolves as `--base-map` entry > `--base` > `repo.base_branch` in config > gh default. Every base is verified on origin before any push; empty branches and missing bases fail fast with no partial state.
+**Structured debugging entries.** `mship debug hypothesis|rule-out|resolved` records structured debugging entries into the task journal. `mship test` auto-attaches to the open hypothesis if one exists. See the `systematic-debugging` skill for the full workflow.
+
+**`finish`:** PR base resolves as `--base-map` entry > `--base` > `repo.base_branch` in config > gh default. Every base is verified on origin before any push; empty branches and missing bases fail fast with no partial state. `--require-tests` blocks (not just warns) when no passing test evidence exists for the task. `--title` overrides the PR title; `--body-map` sets per-repo bodies when repos need different PR descriptions. `--force`/`-f` re-pushes new commits to an already-finished task's existing PR (useful when iterating post-finish without opening a new task).
 
 **`finish` PR body — write a real one.** By default the PR body is just the task description plus a `Closes #N` footer for any issue refs found in the description, journal, and commit subjects. That's a placeholder, not a body. For agent-driven finishes, pass `--body-file <path>` (or `--body '<inline>'`, or `--body -` for stdin) with a real Summary and Test plan. Empty bodies are rejected — that's deliberate. If you forgot at finish time, follow up immediately with `gh pr edit <url> --body-file <path>`. A bare task-description PR is treated as incomplete.
 
@@ -236,6 +267,8 @@ mship view status|journal|diff|spec [--watch]
 mship view spec --web                 # serves HTML on localhost
 mship graph
 mship worktrees
+mship serve [--host H] [--port 47100] # read + review/approve write API over the spec + task model;
+                                      # bearer MSHIP_SERVE_TOKEN required for non-loopback — the Ground Control phone surface
 ```
 
 **`mship pr`** iterates active tasks with `pr_urls` and shows per-PR state (`open`/`merged`/`closed`/`unknown`) and base branch. Use this instead of `gh pr view <url>` per task when you want the full cross-task picture — it's the answer to "what's merged vs. still in review across everything I have open?" TTY → table; non-TTY → JSON `{tasks: [{slug, prs: [...]}]}`.

--- a/src/mship/skills/writing-plans/SKILL.md
+++ b/src/mship/skills/writing-plans/SKILL.md
@@ -15,7 +15,10 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Context:** This should be run in a dedicated worktree (created by brainstorming skill).
 
-**Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
+**Mothership workspace:** In a mothership workspace, the input to a plan is an **approved `mship spec`** — reference its id in the plan header. `mship phase dev` may be gated on that approval (see the `working-with-mothership` skill).
+
+**Save plans to:** `<docs_dir>/plans/YYYY-MM-DD-<feature-name>.md`
+- Default `docs_dir` is `docs/plans/`; in a workspace, `docs_dir` comes from `mship context`.
 - (User preferences for plan location override this default)
 
 ## Scope Check
@@ -139,7 +142,7 @@ If you find issues, fix them inline. No need to re-review — just fix and move 
 
 After saving the plan, offer execution choice:
 
-**"Plan complete and saved to `docs/superpowers/plans/<filename>.md`. Two execution options:**
+**"Plan complete and saved to `docs/plans/<filename>.md`. Two execution options:**
 
 **1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
 

--- a/src/mship/skills/writing-skills/SKILL.md
+++ b/src/mship/skills/writing-skills/SKILL.md
@@ -9,7 +9,7 @@ description: Use when creating new skills, editing existing skills, or verifying
 
 **Writing skills IS Test-Driven Development applied to process documentation.**
 
-**Personal skills live in agent-specific directories (`~/.claude/skills` for Claude Code, `~/.agents/skills/` for Codex)** 
+**Personal skills live in agent-specific directories (`~/.claude/skills` for Claude Code, `~/.agents/skills/` for Codex). In mothership, bundled skills live in `src/mship/skills/<name>/SKILL.md` and are distributed with `mship skill install`.**
 
 You write test cases (pressure scenarios with subagents), watch them fail (baseline behavior), write the skill (documentation), watch tests pass (agents comply), and refactor (close loopholes).
 
@@ -553,7 +553,7 @@ Run same scenarios WITH skill. Agent should now comply.
 
 Agent found new rationalization? Add explicit counter. Re-test until bulletproof.
 
-**Testing methodology:** See @testing-skills-with-subagents.md for the complete testing methodology:
+**Testing methodology:** See testing-skills-with-subagents.md for the complete testing methodology:
 - How to write pressure scenarios
 - Pressure types (time, sunk cost, authority, exhaustion)
 - Plugging holes systematically
@@ -630,6 +630,7 @@ Deploying untested skills = deploying untested code. It's a violation of quality
 
 **Deployment:**
 - [ ] Commit skill to git and push to your fork (if configured)
+- [ ] In the mothership repo, run `mship skill install` after committing to propagate the skill into agent dirs
 - [ ] Consider contributing back via PR (if broadly useful)
 
 ## Discovery Workflow

--- a/tests/cli/test_context.py
+++ b/tests/cli/test_context.py
@@ -86,3 +86,21 @@ def test_context_empty_workspace(tmp_path: Path):
         assert data["cwd_matches_repo"] is None
     finally:
         _reset_container()
+
+
+def test_context_includes_docs_dir(tmp_path: Path):
+    runner = CliRunner()
+    cfg, state_dir = _bootstrap(tmp_path, [])
+
+    container.config.reset()
+    container.state_manager.reset()
+    container.log_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    try:
+        result = runner.invoke(app, ["context"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["docs_dir"] == "docs"
+    finally:
+        _reset_container()

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -698,3 +698,15 @@ def test_discover_walk_up_unchanged_when_no_env_no_marker(tmp_path, monkeypatch)
     (root / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
     nested = root / "a" / "b"; nested.mkdir(parents=True)
     assert ConfigLoader.discover(nested) == root / "mothership.yaml"
+
+
+def test_docs_dir_defaults_to_docs(workspace: Path):
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    assert config.docs_dir == "docs"
+
+
+def test_custom_docs_dir(workspace: Path):
+    cfg = workspace / "mothership.yaml"
+    cfg.write_text(cfg.read_text() + 'docs_dir: "documentation"\n')
+    config = ConfigLoader.load(cfg)
+    assert config.docs_dir == "documentation"

--- a/tests/core/test_skills_cli_refresh.py
+++ b/tests/core/test_skills_cli_refresh.py
@@ -1,0 +1,49 @@
+"""Guard tests: keep the bundled skills aligned with the CLI after the Tier 2/3 refresh."""
+import re
+from pathlib import Path
+
+import pytest
+
+SKILLS_DIR = Path(__file__).resolve().parents[2] / "src" / "mship" / "skills"
+
+EDITED_SKILLS = [
+    "working-with-mothership", "brainstorming", "writing-plans", "executing-plans",
+    "subagent-driven-development", "using-mothership", "writing-skills",
+    "test-driven-development", "verification-before-completion",
+    "dispatching-parallel-agents", "using-git-worktrees", "requesting-code-review",
+]
+
+# Stale upstream-superpowers PATHS that must not reappear in the refreshed skills.
+STALE_PATHS = ["~/.config/superpowers", "docs/superpowers/"]
+
+REAL_SPEC_SUBCOMMANDS = {
+    "new", "draft", "apply", "validate", "review", "verdict",
+    "questions", "ask", "answer", "approve", "request-changes", "dispatch",
+}
+
+
+@pytest.mark.parametrize("skill", EDITED_SKILLS)
+def test_no_stale_superpowers_paths(skill):
+    text = (SKILLS_DIR / skill / "SKILL.md").read_text()
+    for stale in STALE_PATHS:
+        assert stale not in text, f"{skill}: stale path {stale!r}"
+
+
+def test_working_with_mothership_names_real_spec_commands():
+    text = (SKILLS_DIR / "working-with-mothership" / "SKILL.md").read_text()
+    # Only match command-form usages: preceded by a backtick, or at line start
+    # (optionally after `$ `) — NOT mid-prose like "the mship spec commands".
+    named = set(re.findall(r"(?m)(?:`|^\s*(?:\$ )?)mship spec ([a-z][a-z-]+)", text))
+    bogus = named - REAL_SPEC_SUBCOMMANDS
+    assert not bogus, f"working-with-mothership names non-existent spec subcommands: {bogus}"
+
+
+def test_dispatch_examples_include_instruction():
+    """Example invocations of `mship dispatch` must carry the required -i/--instruction."""
+    for skill in ("working-with-mothership", "subagent-driven-development"):
+        text = (SKILLS_DIR / skill / "SKILL.md").read_text()
+        for line in text.splitlines():
+            stripped = line.strip()
+            if re.match(r"^(\$ )?mship dispatch\b", stripped):
+                assert "-i" in stripped or "--instruction" in stripped, \
+                    f"{skill}: `mship dispatch` example missing -i: {stripped!r}"

--- a/tests/core/test_skills_cli_refresh.py
+++ b/tests/core/test_skills_cli_refresh.py
@@ -24,9 +24,11 @@ REAL_SPEC_SUBCOMMANDS = {
 
 @pytest.mark.parametrize("skill", EDITED_SKILLS)
 def test_no_stale_superpowers_paths(skill):
-    text = (SKILLS_DIR / skill / "SKILL.md").read_text()
-    for stale in STALE_PATHS:
-        assert stale not in text, f"{skill}: stale path {stale!r}"
+    # Scan SKILL.md AND sibling files (prompt templates etc.) — drift hides there too.
+    for md in sorted((SKILLS_DIR / skill).rglob("*.md")):
+        text = md.read_text()
+        for stale in STALE_PATHS:
+            assert stale not in text, f"{md.relative_to(SKILLS_DIR)}: stale path {stale!r}"
 
 
 def test_working_with_mothership_names_real_spec_commands():


### PR DESCRIPTION
## Summary

**Tier 2/3 of the skills↔CLI audit** (Tier 1 = [#175](https://github.com/atomikpanda/mothership/pull/175)). Brings the mship-bundled skills (`src/mship/skills/`) up to date with the current CLI and weaves in the `mship spec` lifecycle.

**Motivating principle:** the structured `mship spec` is the *shared communication substrate* — the artifact agents hand off to each other and humans review/steer from the mobile app over `mship serve`. In a workspace, skills now write into that shared state instead of producing ad-hoc design docs / holding state in memory.

**Approach A (centralized):** `working-with-mothership` is the single source of truth for the spec lifecycle; every other skill carries a *thin* cross-reference, not a copy.

## What changed

- **Code:** `docs_dir: str = "docs"` on `WorkspaceConfig`, surfaced in `mship context` (one-liner; cached `build_context` untouched). Governs plan-doc location only — canonical specs stay at `specs/`, and the legacy `spec_paths`/`SPEC_SUBDIR` search is **not** touched.
- **`working-with-mothership`:** new canonical "Specs" section (full `mship spec` lifecycle + the `require_approved_spec` gate); fixed the stale "soft gates only warn" claim (it's a hard block when the gate is on); added `mship serve`, `mship debug` threads, and the missing `mship finish` flags (`--require-tests`/`--title`/`--body-map`/`--force`).
- **`brainstorming`:** dual-path output — in a workspace the design becomes an `mship spec` (`new`/`draft`/`apply` → review/approve); outside, a `docs/specs/` design doc. Checklist + flow diagram + review gate updated.
- **Cross-refs:** `writing-plans` (plan input = approved spec; plans → `<docs_dir>/plans/`), `executing-plans` (spec gate), `subagent-driven-development` (`mship spec dispatch`).
- **Tier 3:** `using-mothership` + `writing-skills` (`mship skill list/install` + `src/mship/skills/` location; fixed a self-contradicting `@`-force-load link); `test-driven-development` + `verification-before-completion` (`mship test` evidence → `finish --require-tests`); `dispatching-parallel-agents` (worktree awareness).
- **Cleanup:** dropped the stale `~/.config/superpowers/worktrees/` global fallback from `using-git-worktrees`; swept every remaining `superpowers` reference out of the skills (incl. `working-with-mothership`'s phase table/glossary and a `requesting-code-review` example path); also dropped the stale "read-only" from `mship serve`'s help (write endpoints shipped in #173).
- **Guard test** (`tests/core/test_skills_cli_refresh.py`): asserts no stale `superpowers` paths in the edited skills, that every `mship spec` subcommand named in the canonical skill exists, and that `mship dispatch` example invocations carry the required `-i`. This caught two pre-existing stale paths during execution.

## Test plan

- [x] `mship test` — full suite green (evidence recorded).
- [x] New guard test (14 cases) green; `docs_dir` config (default + override) + `mship context` surfacing tested.
- [x] Every CLI command/flag named in the new `working-with-mothership` Specs section verified against the live `--help`.

## Scope

Out: reconciling the legacy `spec_paths`/`SPEC_SUBDIR` (`docs/superpowers/specs`) search default; migrating existing `docs/superpowers/*` files.

Design + plan ride in this PR (`docs/specs/2026-06-14-skills-cli-refresh-design.md`, `docs/plans/2026-06-14-skills-cli-refresh.md`).

Linear: MOS-168.

Closes #173