### PR TITLE
B3 B4 serve write endpoints MOS-170 MOS-171

### DIFF
--- a/src/mship/cli/serve.py
+++ b/src/mship/cli/serve.py
@@ -42,6 +42,7 @@ def register(app: typer.Typer, get_container):
             workspace_root=workspace_root,
             workspace_name=container.config().workspace,
             auth_token=token,
+            worktree_manager=container.worktree_manager(),
         )
         auth_note = "auth: bearer token" if token else "auth: none (loopback only)"
         docs_note = "docs: disabled (auth)" if token else "docs: /docs"

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -12,21 +12,6 @@ import typer
 from mship.cli.output import Output
 
 
-SPEC_BODY_TEMPLATE = """\
-## Problem
-
-_What problem does this solve? Why now?_
-
-## User story
-
-_As a <user>, I want <capability>, so that <benefit>._
-
-## Approach
-
-_How will it work? Key decisions._
-"""
-
-
 def register(parent: typer.Typer, get_container):
     spec_app = typer.Typer(
         name="spec",
@@ -44,9 +29,8 @@ def register(parent: typer.Typer, get_container):
         """Create a structured spec at `<workspace>/specs/YYYY-MM-DD-<id>.md`."""
         from datetime import datetime, timezone
         from pathlib import Path
-        from mship.core.spec import Spec
+        from mship.core.spec_draft import new_spec
         from mship.core.spec_store import SpecStore, SPECS_DIRNAME
-        from mship.util.slug import slugify
 
         container = get_container()
         output = Output()
@@ -72,19 +56,16 @@ def register(parent: typer.Typer, get_container):
         if title is None:
             output.error("Provide --title (or --task to derive it).")
             raise typer.Exit(1)
-        if spec_id is None:
-            spec_id = slugify(title)
-        if not spec_id:
-            output.error("Could not derive a spec id from the title; pass --id explicitly.")
-            raise typer.Exit(1)
 
         now = datetime.now(timezone.utc)
-        spec = Spec(
-            id=spec_id, title=title, status="drafting",
-            created_at=now, updated_at=now,
-            affected_repos=affected_repos, task_slug=task_slug,
-            body=SPEC_BODY_TEMPLATE,
-        )
+        try:
+            spec = new_spec(
+                title, now=now, spec_id=spec_id,
+                affected_repos=affected_repos, task_slug=task_slug,
+            )
+        except ValueError:
+            output.error("Could not derive a spec id from the title; pass --id explicitly.")
+            raise typer.Exit(1)
         path = store.path_for(spec)
         if path.exists() and not force:
             output.error(f"Spec already exists: {path}\n  Pass --force to overwrite.")
@@ -392,21 +373,17 @@ def register(parent: typer.Typer, get_container):
     def dispatch(
         spec_id: str = typer.Argument(..., help="Spec id to dispatch (must be approved)."),
     ):
-        """Bind an approved spec to its pre-existing task and emit a handoff prompt.
+        """Dispatch an approved spec to its task.
 
-        FALLBACK implementation (A6): requires an already-existing task whose
-        slug == spec.id (create it first with `mship spawn`). Transitions the spec
-        to 'dispatched', sets task.spec_id, and prints an instruction block
-        containing the acceptance criteria + worktree paths.
-
-        TODO(auto-spawn): upgrade to auto-spawn (PRIMARY) when the git/worktree
-        mocking story is cleaner — see MOS-150 A6 spec for details.
+        Binds the spec to a task whose slug == spec.id, auto-spawning that task
+        (worktrees per the spec's `affected_repos`) when none exists yet.
+        Transitions the spec to 'dispatched', sets task.spec_id, and prints a
+        handoff prompt with acceptance criteria + worktree paths.
         """
         from datetime import datetime, timezone
         from pathlib import Path
-        from mship.core.spec import InvalidTransition, validate_transition
         from mship.core.spec_store import SpecStore, SPECS_DIRNAME
-        from mship.core.spec_body import parse_body_sections
+        from mship.core.spec_dispatch import DispatchError, dispatch_spec
 
         output = Output()
         container = get_container()
@@ -417,77 +394,32 @@ def register(parent: typer.Typer, get_container):
             output.error(f"No spec with id {spec_id!r}.")
             raise typer.Exit(1)
 
-        # Gate: spec must be approved
-        if spec.status != "approved":
-            output.error(
-                f"Spec {spec_id!r} is {spec.status!r} — approve the spec first "
-                f"(mship spec approve {spec_id})."
-            )
-            raise typer.Exit(1)
+        def _spawn(s):
+            return container.worktree_manager().spawn(
+                description=s.title,
+                repos=list(s.affected_repos),
+                slug=s.id,
+                workspace_root=workspace_root,
+            ).task
 
-        # FALLBACK: require a pre-existing task whose slug == spec.id
-        state = container.state_manager().load()
-        if spec_id not in state.tasks:
-            output.error(
-                f"No task with slug {spec_id!r}. "
-                f"Create one first with `mship spawn` (use the same slug as the spec id), "
-                f"then re-run `mship spec dispatch {spec_id}`."
-            )
-            raise typer.Exit(1)
-
-        task = state.tasks[spec_id]
-
-        # Validate the spec→dispatched transition
         try:
-            validate_transition(spec.status, "dispatched")
-        except InvalidTransition as e:
+            result = dispatch_spec(
+                spec,
+                state_manager=container.state_manager(),
+                store=store,
+                spawn_fn=_spawn,
+                now=datetime.now(timezone.utc),
+            )
+        except DispatchError as e:
             output.error(str(e))
             raise typer.Exit(1)
 
-        # Bind: task.spec_id = spec.id (mutate under lock)
-        container.state_manager().mutate(
-            lambda s: setattr(s.tasks[spec_id], "spec_id", spec.id)
-            if spec_id in s.tasks else None
-        )
-
-        # Bind: spec.status = "dispatched", spec.task_slug = slug
-        spec.status = "dispatched"
-        spec.task_slug = spec_id
-        spec.updated_at = datetime.now(timezone.utc)
-        store.save(spec)
-
-        # Emit handoff prompt
-        sections = parse_body_sections(spec.body)
-        problem = sections.get("Problem", "").strip()
-        criteria_lines = "\n".join(
-            f"  - [{ac.id}] {ac.text}" for ac in spec.acceptance_criteria
-        )
-        worktrees_lines = "\n".join(
-            f"  - {repo}: {path}" for repo, path in task.worktrees.items()
-        ) or "  (no worktrees registered yet)"
-
-        prompt = f"""\
-# Spec dispatch: {spec.title}
-
-**spec id:** {spec.id}
-**task slug:** {task.slug}
-**branch:** {task.branch}
-
-## Problem
-
-{problem or "(see spec body)"}
-
-## Acceptance criteria
-
-{criteria_lines or "  (none)"}
-
-## Worktrees
-
-{worktrees_lines}
-
-Run `mship dispatch --task {task.slug} --instruction "<your instruction>"` to emit a full subagent prompt.
-"""
-        typer.echo(prompt)
+        if output.is_tty and result.spawned:
+            output.success(
+                f"Auto-spawned task {result.task.slug!r} "
+                f"({', '.join(result.task.affected_repos)})."
+            )
+        typer.echo(result.handoff)
 
     @spec_app.command("request-changes")
     def request_changes(

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -4,10 +4,28 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
+from mship.core.spec import SpecDraft
+
 
 class VerdictBody(BaseModel):
     criterion_id: str
     verdict: str
+
+
+class NewSpecBody(BaseModel):
+    title: str
+    id: str | None = None
+    affected_repos: list[str] = []
+    task_slug: str | None = None
+
+
+class DraftIntentBody(BaseModel):
+    intent: str
+
+
+class ApplyDraftBody(BaseModel):
+    draft: SpecDraft
+    bypass_status_gate: bool = False
 
 
 class QuestionBody(BaseModel):
@@ -47,9 +65,13 @@ def create_app(
     workspace_root: Path,
     workspace_name: str = "mothership",
     auth_token: str | None = None,
+    worktree_manager=None,
 ):
     """Build the mship serve FastAPI app (read + review/approve write endpoints).
-    Sync handlers call the core directly; FastAPI serializes the returns."""
+    Sync handlers call the core directly; FastAPI serializes the returns.
+
+    `worktree_manager` (optional) enables the dispatch endpoint to auto-spawn a
+    task when none exists; without it, dispatch can only bind a pre-existing task."""
     from fastapi import Depends, FastAPI, HTTPException
 
     from mship.core.spec_store import SpecStore
@@ -188,5 +210,75 @@ def create_app(
             except Exception:
                 pass
         return review
+
+    # --- capture-write endpoints (B3): the phone Capture path over HTTP ---
+
+    from mship.core.spec_draft import apply_draft, build_draft_prompt, new_spec
+
+    @app.post("/specs")
+    def post_create_spec(body: NewSpecBody):
+        now = datetime.now(timezone.utc)
+        try:
+            spec = new_spec(
+                body.title, now=now, spec_id=body.id,
+                affected_repos=body.affected_repos, task_slug=body.task_slug,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        if store.find_by_id(spec.id) is not None:
+            raise HTTPException(status_code=409, detail=f"spec {spec.id!r} already exists")
+        store.save(spec)
+        return spec.model_dump(mode="json")
+
+    @app.post("/specs/{spec_id}/draft")
+    def post_draft(spec_id: str, body: DraftIntentBody):
+        _load_or_404(spec_id)
+        return {"prompt": build_draft_prompt(spec_id, body.intent)}
+
+    @app.post("/specs/{spec_id}/apply")
+    def post_apply(spec_id: str, body: ApplyDraftBody):
+        spec = _load_or_404(spec_id)
+        if not body.bypass_status_gate:
+            try:
+                validate_transition(spec.status, "needs_review")
+            except InvalidTransition as e:
+                raise HTTPException(status_code=409, detail=str(e))
+        apply_draft(spec, body.draft)
+        spec.status = "needs_review"
+        spec.updated_at = datetime.now(timezone.utc)
+        store.save(spec)
+        return spec.model_dump(mode="json")
+
+    # --- dispatch endpoint (B4): close the dispatch-from-phone loop ---
+
+    from mship.core.spec_dispatch import DispatchError, dispatch_spec
+
+    def _serve_spawn(s):
+        if worktree_manager is None:
+            raise DispatchError(
+                "auto-spawn unavailable: this server has no worktree manager; "
+                f"spawn a task named {s.id!r} first, then dispatch."
+            )
+        return worktree_manager.spawn(
+            description=s.title, repos=list(s.affected_repos),
+            slug=s.id, workspace_root=workspace_root,
+        ).task
+
+    @app.post("/specs/{spec_id}/dispatch")
+    def post_dispatch(spec_id: str):
+        spec = _load_or_404(spec_id)
+        try:
+            result = dispatch_spec(
+                spec, state_manager=state_manager, store=store,
+                spawn_fn=_serve_spawn, now=datetime.now(timezone.utc),
+            )
+        except DispatchError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        return {
+            "spec": result.spec.model_dump(mode="json"),
+            "task_slug": result.task.slug,
+            "spawned": result.spawned,
+            "handoff": result.handoff,
+        }
 
     return app

--- a/src/mship/core/spec_dispatch.py
+++ b/src/mship/core/spec_dispatch.py
@@ -1,0 +1,116 @@
+"""Dispatch an approved spec to a task (the A6/B4 dispatch path).
+
+`dispatch_spec` is the shared core behind `mship spec dispatch` (CLI) and the
+`POST /specs/{id}/dispatch` serve endpoint. It auto-spawns a task when none
+exists yet, via an injected `spawn_fn` — real callers pass a thunk over
+`WorktreeManager.spawn` (real git + state mutation); tests pass a fake. Keeping
+the spawn dependency injected is what makes this unit-testable, which is exactly
+what blocked auto-spawn in the original A6 fallback (see MOS-150 / MOS-171).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable
+
+from mship.core.spec import Spec
+from mship.core.spec_body import parse_body_sections
+from mship.core.state import Task
+
+
+class DispatchError(Exception):
+    """Spec is not in a dispatchable state (not approved, or un-spawnable)."""
+
+
+@dataclass
+class DispatchResult:
+    spec: Spec
+    task: Task
+    spawned: bool       # True if a task was auto-spawned during this dispatch
+    handoff: str        # the subagent handoff prompt
+
+
+def build_dispatch_handoff(spec: Spec, task: Task) -> str:
+    """Render the handoff prompt printed/returned after a successful dispatch."""
+    sections = parse_body_sections(spec.body)
+    problem = sections.get("Problem", "").strip()
+    criteria_lines = "\n".join(
+        f"  - [{ac.id}] {ac.text}" for ac in spec.acceptance_criteria
+    )
+    worktrees_lines = "\n".join(
+        f"  - {repo}: {path}" for repo, path in task.worktrees.items()
+    ) or "  (no worktrees registered yet)"
+    return f"""\
+# Spec dispatch: {spec.title}
+
+**spec id:** {spec.id}
+**task slug:** {task.slug}
+**branch:** {task.branch}
+
+## Problem
+
+{problem or "(see spec body)"}
+
+## Acceptance criteria
+
+{criteria_lines or "  (none)"}
+
+## Worktrees
+
+{worktrees_lines}
+
+Run `mship dispatch --task {task.slug} --instruction "<your instruction>"` to emit a full subagent prompt.
+"""
+
+
+def dispatch_spec(
+    spec: Spec,
+    *,
+    state_manager,
+    store,
+    spawn_fn: Callable[[Spec], Task],
+    now: datetime,
+) -> DispatchResult:
+    """Bind an approved spec to its task (auto-spawning one if needed).
+
+    - Requires `spec.status == "approved"` (else `DispatchError`).
+    - If a task with slug `spec.id` exists, binds to it; otherwise calls
+      `spawn_fn(spec)` to create the task + worktrees (requires non-empty
+      `affected_repos`).
+    - Sets `task.spec_id = spec.id`, transitions the spec to `dispatched`,
+      stamps `task_slug`/`updated_at`, and persists the spec.
+    """
+    if spec.status != "approved":
+        raise DispatchError(
+            f"spec {spec.id!r} is {spec.status!r} — approve it first "
+            f"(mship spec approve {spec.id})."
+        )
+
+    state = state_manager.load()
+    if spec.id in state.tasks:
+        task = state.tasks[spec.id]
+        spawned = False
+    else:
+        if not spec.affected_repos:
+            raise DispatchError(
+                f"spec {spec.id!r} has no affected_repos; cannot auto-spawn a task. "
+                f"Add repos to the spec or spawn a task named {spec.id!r} first."
+            )
+        task = spawn_fn(spec)
+        spawned = True
+
+    # Bind the task to the spec under the state lock.
+    def _bind(s):
+        if spec.id in s.tasks:
+            s.tasks[spec.id].spec_id = spec.id
+    state_manager.mutate(_bind)
+
+    spec.status = "dispatched"
+    spec.task_slug = spec.id
+    spec.updated_at = now
+    store.save(spec)
+
+    return DispatchResult(
+        spec=spec, task=task, spawned=spawned,
+        handoff=build_dispatch_handoff(spec, task),
+    )

--- a/src/mship/core/spec_draft.py
+++ b/src/mship/core/spec_draft.py
@@ -1,7 +1,57 @@
 from __future__ import annotations
 
+from datetime import datetime
+
 from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec, SpecDraft
 from mship.core.spec_body import render_body
+from mship.util.slug import slugify
+
+
+SPEC_BODY_TEMPLATE = """\
+## Problem
+
+_What problem does this solve? Why now?_
+
+## User story
+
+_As a <user>, I want <capability>, so that <benefit>._
+
+## Approach
+
+_How will it work? Key decisions._
+"""
+
+
+def new_spec(
+    title: str,
+    *,
+    now: datetime,
+    spec_id: str | None = None,
+    affected_repos: list[str] | None = None,
+    task_slug: str | None = None,
+) -> Spec:
+    """Construct a fresh spec in `drafting` with the canonical empty body.
+
+    Pure: builds and returns the `Spec` but does NOT persist it — callers own
+    save + collision handling. `spec_id` defaults to a slug of the title;
+    raises `ValueError` if the title yields an empty slug and no id is given.
+    """
+    if spec_id is None:
+        spec_id = slugify(title)
+    if not spec_id:
+        raise ValueError(
+            f"could not derive a spec id from title {title!r}; pass spec_id explicitly"
+        )
+    return Spec(
+        id=spec_id,
+        title=title,
+        status="drafting",
+        created_at=now,
+        updated_at=now,
+        affected_repos=list(affected_repos or []),
+        task_slug=task_slug,
+        body=SPEC_BODY_TEMPLATE,
+    )
 
 
 def build_draft_prompt(spec_id: str, intent_text: str) -> str:

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -41,6 +41,25 @@ def configured_app_with_task(workspace: Path):
     container.state_manager.reset()
 
 
+@pytest.fixture
+def configured_app_git_no_task(workspace_with_git: Path):
+    """Git-backed workspace with no tasks — for exercising real auto-spawn."""
+    state_dir = workspace_with_git / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(workspace_with_git / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    StateManager(state_dir).save(WorkspaceState(tasks={}))
+    yield workspace_with_git
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override()
+    container.config.reset()
+    container.state_manager.reset_override()
+    container.state_manager.reset()
+
+
 def _store(workspace: Path) -> SpecStore:
     return SpecStore(workspace / "specs")
 
@@ -470,9 +489,9 @@ def test_spec_request_changes(configured_app_with_task: Path, tmp_path):
     assert _store(configured_app_with_task).find_by_id("dq").status == "needs_clarification"
 
 
-# --- spec dispatch (A6) ---
-# FALLBACK implementation: requires an already-existing task whose slug == spec.id.
+# --- spec dispatch (A6 + B4 auto-spawn) ---
 # The spec must be approved; the task binds spec_id; spec transitions to "dispatched".
+# When no task exists, dispatch auto-spawns one (worktrees per affected_repos).
 
 
 def _approve_add_labels(workspace: Path, tmp_path: Path) -> None:
@@ -520,15 +539,43 @@ def test_spec_dispatch_requires_approved_status(configured_app_with_task: Path, 
     assert "approve" in result.output.lower()
 
 
-def test_spec_dispatch_requires_matching_task(configured_app_with_task: Path, tmp_path: Path):
-    """If no task with slug==spec.id exists, dispatch must exit non-zero with helpful hint."""
-    # Create a spec with id "dq" — no matching task in state
-    _apply_dq(tmp_path)
-    # Approve it manually (bypass gate to skip verdict/answer steps)
+def test_spec_dispatch_auto_spawns_when_no_task(configured_app_git_no_task: Path, tmp_path: Path):
+    """No matching task → dispatch auto-spawns one (real worktrees) and dispatches."""
+    runner.invoke(app, ["spec", "new", "--title", "Cap feature", "--id", "capfeat"])
+    draft = _json.dumps({
+        "problem": "P", "user_story": "U", "approach": "A",
+        "acceptance_criteria": ["view"], "open_questions": [], "affected_repos": ["shared"],
+    })
+    jf = tmp_path / "cap.json"
+    jf.write_text(draft)
+    runner.invoke(app, ["spec", "apply", "capfeat", "--from-json", str(jf)])
+    runner.invoke(app, ["spec", "approve", "capfeat", "--bypass-gate"])
+
+    result = runner.invoke(app, ["spec", "dispatch", "capfeat"])
+    assert result.exit_code == 0, result.output
+
+    state = StateManager(configured_app_git_no_task / ".mothership").load()
+    assert "capfeat" in state.tasks                       # task auto-created
+    assert state.tasks["capfeat"].spec_id == "capfeat"    # bound
+    # real worktree materialized
+    assert (configured_app_git_no_task / ".worktrees" / "capfeat" / "shared").exists()
+    assert _store(configured_app_git_no_task).find_by_id("capfeat").status == "dispatched"
+
+
+def test_spec_dispatch_auto_spawn_refused_without_affected_repos(configured_app_with_task: Path, tmp_path: Path):
+    """No task + spec has no affected_repos → dispatch refuses (can't auto-spawn)."""
+    runner.invoke(app, ["spec", "new", "--title", "Decision queue", "--id", "dq"])
+    draft = _json.dumps({
+        "problem": "P", "user_story": "U", "approach": "A",
+        "acceptance_criteria": ["x"], "open_questions": [], "affected_repos": [],
+    })
+    jf = tmp_path / "dq.json"
+    jf.write_text(draft)
+    runner.invoke(app, ["spec", "apply", "dq", "--from-json", str(jf)])
     runner.invoke(app, ["spec", "approve", "dq", "--bypass-gate"])
     result = runner.invoke(app, ["spec", "dispatch", "dq"])
     assert result.exit_code != 0
-    assert "mship spawn" in result.output or "spawn" in result.output.lower()
+    assert "affected_repos" in result.output
 
 
 def test_spec_dispatch_unknown_id_errors(configured_app_with_task: Path):

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -211,3 +211,176 @@ def test_writes_require_auth(tmp_path):
         headers={"Authorization": "Bearer secret"},
     )
     assert ok.status_code == 200
+
+
+# --- B3: capture-write endpoints (create / draft / apply) ---
+
+
+def test_post_create_spec(tmp_path):
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs", json={"title": "Decision Queue", "affected_repos": ["mothership"]})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["id"] == "decision-queue"     # slugified title
+    assert body["status"] == "drafting"
+    assert body["affected_repos"] == ["mothership"]
+    # persisted → shows up in the list
+    assert any(s["id"] == "decision-queue" for s in client.get("/specs").json())
+
+
+def test_post_create_spec_explicit_id(tmp_path):
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs", json={"title": "Anything", "id": "custom"})
+    assert r.status_code == 200 and r.json()["id"] == "custom"
+
+
+def test_post_create_spec_collision_409(tmp_path):
+    client = TestClient(_app(tmp_path))
+    assert client.post("/specs", json={"title": "Dup"}).status_code == 200
+    assert client.post("/specs", json={"title": "Dup"}).status_code == 409
+
+
+def test_post_create_spec_unslugifiable_title_400(tmp_path):
+    client = TestClient(_app(tmp_path))
+    assert client.post("/specs", json={"title": "!!!"}).status_code == 400
+
+
+def test_post_draft_returns_prompt_no_mutation(tmp_path):
+    client = TestClient(_app(tmp_path))
+    client.post("/specs", json={"title": "DQ", "id": "dq"})
+    r = client.post("/specs/dq/draft", json={"intent": "I want a decision queue"})
+    assert r.status_code == 200
+    prompt = r.json()["prompt"]
+    assert "I want a decision queue" in prompt          # the intent
+    assert "acceptance_criteria" in prompt              # the draft JSON shape
+    # draft is read-only: status unchanged
+    assert client.get("/specs/dq").json()["status"] == "drafting"
+
+
+def test_post_draft_unknown_spec_404(tmp_path):
+    assert TestClient(_app(tmp_path)).post("/specs/none/draft", json={"intent": "x"}).status_code == 404
+
+
+def test_post_apply_advances_to_needs_review(tmp_path):
+    client = TestClient(_app(tmp_path))
+    client.post("/specs", json={"title": "DQ", "id": "dq"})   # drafting
+    r = client.post("/specs/dq/apply", json={"draft": {
+        "problem": "P", "user_story": "U", "approach": "A",
+        "acceptance_criteria": ["view questions"], "open_questions": ["android?"],
+        "affected_repos": ["mothership"],
+    }})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "needs_review"
+    assert [c["id"] for c in body["acceptance_criteria"]] == ["ac1"]
+    assert body["affected_repos"] == ["mothership"]
+
+
+def test_post_apply_unknown_spec_404(tmp_path):
+    r = TestClient(_app(tmp_path)).post(
+        "/specs/none/apply", json={"draft": {"problem": "P", "user_story": "U", "approach": "A"}}
+    )
+    assert r.status_code == 404
+
+
+def test_post_apply_illegal_transition_409_and_bypass(tmp_path):
+    _seed_spec(tmp_path)   # status needs_review already
+    client = TestClient(_app(tmp_path))
+    draft = {"draft": {"problem": "P", "user_story": "U", "approach": "A"}}
+    assert client.post("/specs/dq/apply", json=draft).status_code == 409      # needs_review → needs_review illegal
+    ok = client.post("/specs/dq/apply", json={**draft, "bypass_status_gate": True})
+    assert ok.status_code == 200 and ok.json()["status"] == "needs_review"
+
+
+def test_capture_writes_require_auth(tmp_path):
+    client = TestClient(_auth_app(tmp_path, "secret"))
+    assert client.post("/specs", json={"title": "X"}).status_code == 401
+    ok = client.post("/specs", json={"title": "X"}, headers={"Authorization": "Bearer secret"})
+    assert ok.status_code == 200
+
+
+# --- B4: dispatch endpoint + auto-spawn ---
+
+from types import SimpleNamespace
+
+
+def _seed_approved_spec(tmp_path: Path, spec_id="dq", repos=("mothership",)):
+    now = datetime(2026, 6, 14, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(
+        id=spec_id, title="Decision queue", status="approved",
+        created_at=now, updated_at=now, affected_repos=list(repos),
+        body=render_body("the problem", "as a user", "the approach"),
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="view questions", verdict="approved")],
+    ))
+
+
+class _FakeWorktreeManager:
+    """Stands in for WorktreeManager.spawn — registers a task, no real git."""
+
+    def __init__(self, sm):
+        self._sm = sm
+
+    def spawn(self, *, description, repos, slug, workspace_root):
+        task = Task(
+            slug=slug, description=description, phase="plan",
+            created_at=datetime(2026, 6, 14, tzinfo=timezone.utc),
+            affected_repos=list(repos), branch=f"feat/{slug}",
+            worktrees={r: Path(f"/wt/{slug}/{r}") for r in repos},
+        )
+        self._sm.mutate(lambda s: s.tasks.__setitem__(slug, task))
+        return SimpleNamespace(task=task)
+
+
+def _empty_state(tmp_path: Path) -> StateManager:
+    (tmp_path / ".mothership").mkdir(exist_ok=True)
+    sm = StateManager(tmp_path / ".mothership")
+    sm.save(WorkspaceState(tasks={}))
+    return sm
+
+
+def test_post_dispatch_binds_existing_task(tmp_path):
+    sm, log = _seed_task(tmp_path)        # task "dq", affected_repos=["mothership"]
+    _seed_approved_spec(tmp_path)         # approved spec "dq"
+    client = TestClient(_app_with(tmp_path, sm, log))
+    r = client.post("/specs/dq/dispatch")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["spawned"] is False
+    assert body["spec"]["status"] == "dispatched"
+    assert body["task_slug"] == "dq"
+    assert "view questions" in body["handoff"]
+    assert sm.load().tasks["dq"].spec_id == "dq"
+
+
+def test_post_dispatch_auto_spawns(tmp_path):
+    sm = _empty_state(tmp_path)
+    _seed_approved_spec(tmp_path, spec_id="cap", repos=["shared"])
+    app = create_app(
+        specs_dir=tmp_path / "specs", state_manager=sm, log_manager=None,
+        workspace_root=tmp_path, workspace_name="t",
+        worktree_manager=_FakeWorktreeManager(sm),
+    )
+    r = TestClient(app).post("/specs/cap/dispatch")
+    assert r.status_code == 200, r.text
+    assert r.json()["spawned"] is True
+    assert sm.load().tasks["cap"].spec_id == "cap"
+
+
+def test_post_dispatch_not_approved_409(tmp_path):
+    _seed_spec(tmp_path)                  # status needs_review
+    assert TestClient(_app(tmp_path)).post("/specs/dq/dispatch").status_code == 409
+
+
+def test_post_dispatch_unknown_spec_404(tmp_path):
+    assert TestClient(_app(tmp_path)).post("/specs/none/dispatch").status_code == 404
+
+
+def test_post_dispatch_auto_spawn_unavailable_409(tmp_path):
+    # approved spec, no task, no worktree_manager configured → cannot auto-spawn
+    sm = _empty_state(tmp_path)
+    _seed_approved_spec(tmp_path, spec_id="cap", repos=["shared"])
+    app = create_app(
+        specs_dir=tmp_path / "specs", state_manager=sm, log_manager=None,
+        workspace_root=tmp_path, workspace_name="t",
+    )
+    assert TestClient(app).post("/specs/cap/dispatch").status_code == 409

--- a/tests/core/test_spec_dispatch.py
+++ b/tests/core/test_spec_dispatch.py
@@ -1,0 +1,111 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from mship.core.spec import AcceptanceCriterion, Spec
+from mship.core.spec_body import render_body
+from mship.core.spec_store import SpecStore
+from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.spec_dispatch import DispatchError, build_dispatch_handoff, dispatch_spec
+
+
+NOW = datetime(2026, 6, 14, tzinfo=timezone.utc)
+
+
+def _approved_spec(**over) -> Spec:
+    data = dict(
+        id="dq", title="Decision Queue", status="approved",
+        created_at=NOW, updated_at=NOW, affected_repos=["mothership"],
+        body=render_body("the problem", "as a user", "the approach"),
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="view questions", verdict="approved")],
+    )
+    data.update(over)
+    return Spec(**data)
+
+
+def _store(tmp_path) -> SpecStore:
+    return SpecStore(tmp_path / "specs")
+
+
+def _sm(tmp_path) -> StateManager:
+    d = tmp_path / ".mothership"
+    d.mkdir(exist_ok=True)
+    return StateManager(d)
+
+
+def _task(slug="dq", repos=("mothership",)) -> Task:
+    return Task(
+        slug=slug, description="d", phase="plan", created_at=NOW,
+        affected_repos=list(repos), branch=f"feat/{slug}",
+        worktrees={r: Path(f"/wt/{slug}/{r}") for r in repos},
+    )
+
+
+def test_build_dispatch_handoff_contains_key_facts():
+    out = build_dispatch_handoff(_approved_spec(), _task())
+    assert "Decision Queue" in out                 # title
+    assert "dq" in out                             # spec id / task slug
+    assert "feat/dq" in out                        # branch
+    assert "the problem" in out                    # Problem section from body
+    assert "ac1" in out and "view questions" in out  # acceptance criteria
+    assert "/wt/dq/mothership" in out              # worktree path
+    assert "mship dispatch --task dq" in out       # next-step command
+
+
+def test_dispatch_spec_binds_existing_task_without_spawning(tmp_path):
+    sm, store = _sm(tmp_path), _store(tmp_path)
+    sm.save(WorkspaceState(tasks={"dq": _task()}))
+    spec = _approved_spec()
+    store.save(spec)
+
+    def spawn_fn(_s):
+        raise AssertionError("must not auto-spawn when the task already exists")
+
+    result = dispatch_spec(spec, state_manager=sm, store=store, spawn_fn=spawn_fn, now=NOW)
+
+    assert result.spawned is False
+    assert result.spec.status == "dispatched"
+    assert result.spec.task_slug == "dq"
+    assert store.find_by_id("dq").status == "dispatched"   # persisted
+    assert sm.load().tasks["dq"].spec_id == "dq"           # task bound to spec
+
+
+def test_dispatch_spec_auto_spawns_when_no_task(tmp_path):
+    sm, store = _sm(tmp_path), _store(tmp_path)
+    sm.save(WorkspaceState(tasks={}))
+    spec = _approved_spec()
+    store.save(spec)
+
+    calls = []
+
+    def spawn_fn(s):
+        calls.append((s.id, tuple(s.affected_repos)))
+        task = _task(slug=s.id, repos=s.affected_repos)
+        sm.mutate(lambda st: st.tasks.__setitem__(s.id, task))
+        return task
+
+    result = dispatch_spec(spec, state_manager=sm, store=store, spawn_fn=spawn_fn, now=NOW)
+
+    assert result.spawned is True
+    assert calls == [("dq", ("mothership",))]              # spawn_fn got the spec
+    assert result.task.slug == "dq"
+    assert sm.load().tasks["dq"].spec_id == "dq"
+    assert store.find_by_id("dq").status == "dispatched"
+
+
+def test_dispatch_spec_requires_approved(tmp_path):
+    sm, store = _sm(tmp_path), _store(tmp_path)
+    spec = _approved_spec(status="needs_review")
+    store.save(spec)
+    with pytest.raises(DispatchError):
+        dispatch_spec(spec, state_manager=sm, store=store, spawn_fn=lambda s: None, now=NOW)
+
+
+def test_dispatch_spec_auto_spawn_requires_affected_repos(tmp_path):
+    sm, store = _sm(tmp_path), _store(tmp_path)
+    sm.save(WorkspaceState(tasks={}))
+    spec = _approved_spec(affected_repos=[])
+    store.save(spec)
+    with pytest.raises(DispatchError):
+        dispatch_spec(spec, state_manager=sm, store=store, spawn_fn=lambda s: None, now=NOW)

--- a/tests/core/test_spec_draft.py
+++ b/tests/core/test_spec_draft.py
@@ -41,3 +41,34 @@ def test_apply_draft_merges_fields_and_assigns_ids():
     assert [q.id for q in out.open_questions] == ["q1"]
     assert out.open_questions[0].answer is None
     assert out.id == "dq" and out.task_slug == "dq"         # identity preserved
+
+
+import pytest
+
+from mship.core.spec_draft import new_spec, SPEC_BODY_TEMPLATE
+
+
+def test_new_spec_defaults_id_from_title():
+    now = datetime(2026, 6, 14, tzinfo=timezone.utc)
+    spec = new_spec("Decision Queue", now=now)
+    assert spec.id == "decision-queue"          # slugified title
+    assert spec.title == "Decision Queue"
+    assert spec.status == "drafting"            # fresh specs start drafting
+    assert spec.created_at == now and spec.updated_at == now
+    assert spec.body == SPEC_BODY_TEMPLATE      # canonical empty body
+    assert spec.affected_repos == [] and spec.task_slug is None
+
+
+def test_new_spec_honors_explicit_id_repos_and_task():
+    now = datetime(2026, 6, 14, tzinfo=timezone.utc)
+    spec = new_spec("Anything", now=now, spec_id="custom",
+                    affected_repos=["a", "b"], task_slug="t")
+    assert spec.id == "custom"
+    assert spec.affected_repos == ["a", "b"]
+    assert spec.task_slug == "t"
+
+
+def test_new_spec_unslugifiable_title_raises():
+    now = datetime(2026, 6, 14, tzinfo=timezone.utc)
+    with pytest.raises(ValueError):
+        new_spec("!!!", now=now)             # slug collapses to empty


### PR DESCRIPTION
## Summary

Completes the Ground Control backend (B3 + B4) — the remaining `mship serve`
write endpoints that the mobile app's Capture and Dispatch flows depend on.

**B3 — capture-write endpoints (MOS-170):** the phone Capture path over HTTP,
mirroring the B1.5 thin-wrapper-over-core + inherited bearer-auth pattern.
- `POST /specs` — create a spec (`drafting`)
- `POST /specs/{id}/draft` — return the drafting prompt for intent text (read-only)
- `POST /specs/{id}/apply` — ingest a `SpecDraft` → `needs_review`
- Extracted core `new_spec()` + `SPEC_BODY_TEMPLATE`; refactored CLI `spec new`
  onto the shared helper (no behavior change).

**B4 — dispatch + auto-spawn (MOS-171):** closes the dispatch-from-phone loop and
completes the auto-spawn that A6 deferred.
- New core `spec_dispatch.dispatch_spec()` takes an injected `spawn_fn`, which makes
  the auto-spawn path unit-testable (the original A6 blocker). Real callers pass
  `WorktreeManager.spawn`.
- CLI `spec dispatch` now auto-spawns a task + worktrees per `affected_repos` when
  none exists (the fallback TODO is removed).
- `POST /specs/{id}/dispatch` — `create_app` gains an optional `worktree_manager`.

All new endpoints inherit the existing app-wide bearer auth.

## Test plan

TDD throughout (red → green for every endpoint and core function):
- `tests/core/test_serve.py` — happy + error (400/404/409) + auth paths for all new endpoints.
- `tests/core/test_spec_dispatch.py` — new core: existing-task bind, auto-spawn, not-approved, no-affected-repos.
- `tests/core/test_spec_draft.py` — `new_spec()` defaults / explicit id / unslugifiable title.
- `tests/cli/test_spec.py` — real git-backed auto-spawn integration test + no-repos refusal; existing dispatch suite updated for the new behavior.
- Full `mothership` suite green via `mship test` (exit 0).

Refs MOS-170, MOS-171.

Closes #180
Closes #181
