### PR TITLE
low-friction phone connection sish relay and QR pairing

### DIFF
--- a/docker/relay/docker-compose.yml
+++ b/docker/relay/docker-compose.yml
@@ -1,0 +1,27 @@
+# Self-hosted sish relay for mship serve reverse tunnels.
+# Requires: a wildcard DNS record *.RELAY_DOMAIN -> this host, ports 80/443/2222 open.
+services:
+  sish:
+    image: antoniomika/sish:latest
+    restart: unless-stopped
+    ports:
+      - "2222:2222"   # SSH (clients open reverse tunnels here)
+      - "80:80"       # HTTP (ACME challenges + redirect)
+      - "443:443"     # HTTPS (public app traffic)
+    volumes:
+      - ./pubkeys:/pubkeys:ro       # allow-listed client public keys
+      - ./keys:/keys                # sish host keys (persisted)
+      - ./acme:/acme                # Let's Encrypt cert cache
+    command:
+      - --ssh-address=:2222
+      - --http-address=:80
+      - --https-address=:443
+      - --https=true
+      - --https-ondemand-certificate=true
+      - --https-ondemand-certificate-email=${ACME_EMAIL}
+      - --domain=${RELAY_DOMAIN}
+      - --authentication=true
+      - --authentication-keys-directory=/pubkeys
+      - --bind-random-subdomains=false      # honor the requested subdomain
+      - --bind-random-ports=false
+      - --idle-connection=false

--- a/docker/relay/docker-compose.yml
+++ b/docker/relay/docker-compose.yml
@@ -19,9 +19,11 @@ services:
       - --https=true
       - --https-ondemand-certificate=true
       - --https-ondemand-certificate-email=${ACME_EMAIL}
+      - --https-ondemand-certificate-accept-terms=true
       - --domain=${RELAY_DOMAIN}
       - --authentication=true
       - --authentication-keys-directory=/pubkeys
+      - --private-keys-directory=/keys
       - --bind-random-subdomains=false      # honor the requested subdomain
       - --bind-random-ports=false
       - --idle-connection=false

--- a/docs/plans/2026-06-16-low-friction-phone-connection.md
+++ b/docs/plans/2026-06-16-low-friction-phone-connection.md
@@ -1,0 +1,484 @@
+# Low-Friction Phone Connection (self-hosted sish relay + QR pairing) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `low-friction-phone-connection-to-mship` (approved) — `specs/2026-06-15-low-friction-phone-connection-to-mship.md` in the workspace.
+
+**Goal:** Connect the Ground Control phone app to any `mship serve` workspace by scanning a QR code, reachable from anywhere with no VPN — via a reverse SSH tunnel to a relay the user self-hosts (sish).
+
+**Architecture:** `mship serve` stays bound to loopback; mship opens + supervises an `ssh -R <subdomain>:80:localhost:47100` reverse tunnel to the user's sish relay, which publishes a stable `https://<workspace>.<relay-domain>` with auto-TLS. Two auth layers: SSH-key allowlist on the relay (who may expose) + bearer token on the API (who may call). Tunnel/token/key/pairing live in reusable core modules so a future auto-serve daemon can drive them with no re-pairing.
+
+**Tech Stack:** Python (mothership CLI/core), `segno` (pure-Python QR), system `ssh`/`ssh-keygen` via subprocess, sish (Docker) for the relay; Kotlin/Compose + CameraX/ML Kit (ground-control app QR scan).
+
+**Phasing:** A (relay kit) → B (mship client tunnel + token/key + CLI) → C (pairing QR in app). Each phase is independently testable; A+B give end-to-end reachability (manual URL/token), C removes the typing.
+
+**Repos:** `mothership` (Phases A, B, and the CLI side of C) and `ground-control` (the app side of C). Spawn a task scoped to both: `mship spawn "low-friction phone connection (sish relay + QR)" --repos mothership,ground-control`. Android tasks need `source ~/toolchains/android-env.sh`.
+
+---
+
+## File Structure
+
+**mothership** (new `relay` core package keeps the daemon-reusable seam — ac8):
+```
+docker/relay/docker-compose.yml          # sish relay (auto-TLS)
+scripts/relay-bootstrap.sh               # one-shot VPS bring-up
+docs/relay-hosting.md                    # DNS wildcard + key allowlist + run
+src/mship/core/relay/__init__.py
+src/mship/core/relay/config.py           # RelayConfig (mothership.yaml `relay:` block)
+src/mship/core/relay/token.py            # ensure_serve_token() persist/load
+src/mship/core/relay/keys.py             # ensure_relay_key() / relay_public_key()
+src/mship/core/relay/tunnel.py           # subdomain_for(), build_tunnel_argv(), TunnelSupervisor
+src/mship/core/relay/pairing.py          # build_pair_link(), parse_pair_link()
+src/mship/cli/relay.py                   # `mship relay setup`
+src/mship/cli/pair.py                    # `mship pair` (QR)
+# modified: src/mship/cli/serve.py       # `--relay` flag wires the above
+# modified: src/mship/core/config.py     # parse `relay:` block
+tests/core/relay/test_*.py
+```
+
+**ground-control:**
+```
+app/src/main/java/com/atomikpanda/groundcontrol/data/PairLink.kt   # parse groundcontrol://add
+app/src/main/java/com/atomikpanda/groundcontrol/ui/settings/ScanConnectionScreen.kt
+# modified: AndroidManifest.xml (intent-filter), SettingsScreen.kt (Scan button)
+app/src/test/java/com/atomikpanda/groundcontrol/PairLinkTest.kt
+```
+
+Every commit step pairs with `mship journal "<what>" --action committed` from the worktree.
+
+---
+
+# PHASE A — Relay hosting kit (mothership)
+
+## Task A1: Self-hostable sish relay (compose + bootstrap + docs)
+
+**Files:**
+- Create: `docker/relay/docker-compose.yml`, `scripts/relay-bootstrap.sh`, `docs/relay-hosting.md`
+
+No unit tests (ops artifacts); verified by config validation + shellcheck.
+
+- [ ] **Step 1: Create `docker/relay/docker-compose.yml`**
+```yaml
+# Self-hosted sish relay for mship serve reverse tunnels.
+# Requires: a wildcard DNS record *.RELAY_DOMAIN -> this host, ports 80/443/2222 open.
+services:
+  sish:
+    image: antoniomika/sish:latest
+    restart: unless-stopped
+    ports:
+      - "2222:2222"   # SSH (clients open reverse tunnels here)
+      - "80:80"       # HTTP (ACME challenges + redirect)
+      - "443:443"     # HTTPS (public app traffic)
+    volumes:
+      - ./pubkeys:/pubkeys:ro       # allow-listed client public keys
+      - ./keys:/keys                # sish host keys (persisted)
+      - ./acme:/acme                # Let's Encrypt cert cache
+    command:
+      - --ssh-address=:2222
+      - --http-address=:80
+      - --https-address=:443
+      - --https=true
+      - --https-ondemand-certificate=true
+      - --https-ondemand-certificate-email=${ACME_EMAIL}
+      - --domain=${RELAY_DOMAIN}
+      - --authentication=true
+      - --authentication-keys-directory=/pubkeys
+      - --bind-random-subdomains=false      # honor the requested subdomain
+      - --bind-random-ports=false
+      - --idle-connection=false
+```
+
+- [ ] **Step 2: Create `scripts/relay-bootstrap.sh`**
+```bash
+#!/usr/bin/env bash
+# One-shot bring-up of a self-hosted sish relay on a fresh Debian/Ubuntu VPS.
+# Usage: RELAY_DOMAIN=relay.example.com ACME_EMAIL=you@example.com ./relay-bootstrap.sh
+set -euo pipefail
+: "${RELAY_DOMAIN:?set RELAY_DOMAIN (the wildcard base, e.g. relay.example.com)}"
+: "${ACME_EMAIL:?set ACME_EMAIL (for Let's Encrypt)}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[bootstrap] installing Docker..."
+  curl -fsSL https://get.docker.com | sh
+fi
+HERE="$(cd "$(dirname "$0")/../docker/relay" && pwd)"
+mkdir -p "$HERE/pubkeys" "$HERE/keys" "$HERE/acme"
+echo "[bootstrap] add client public keys to $HERE/pubkeys/ (one file per key), then:"
+echo "  RELAY_DOMAIN=$RELAY_DOMAIN ACME_EMAIL=$ACME_EMAIL docker compose -f $HERE/docker-compose.yml up -d"
+echo "[bootstrap] DNS: point  *.$RELAY_DOMAIN  A record at this host's public IP."
+RELAY_DOMAIN="$RELAY_DOMAIN" ACME_EMAIL="$ACME_EMAIL" docker compose -f "$HERE/docker-compose.yml" up -d
+echo "[bootstrap] sish is up. Test a tunnel: ssh -p 2222 -R myws:80:localhost:8000 $RELAY_DOMAIN"
+```
+
+- [ ] **Step 3: Create `docs/relay-hosting.md`** — a concise runbook: prerequisites (a VPS, a domain), the wildcard DNS record (`*.relay.example.com A <ip>`), open ports (80/443/2222), running the bootstrap, adding client pubkeys (`mship relay setup` prints the line), and a verification `ssh -p 2222 -R test:80:localhost:8000 relay.example.com`. (Full prose — no placeholders; mirror Steps 1–2 exactly.)
+
+- [ ] **Step 4: Validate + shellcheck**
+
+Run:
+```bash
+cd /path/to/mothership/worktree
+docker compose -f docker/relay/docker-compose.yml config >/dev/null && echo "compose OK"   # if docker present
+shellcheck scripts/relay-bootstrap.sh && echo "shellcheck OK"   # if shellcheck present; else: bash -n
+chmod +x scripts/relay-bootstrap.sh
+```
+Expected: `compose OK` (or skip if no docker), `shellcheck OK` (or `bash -n` clean).
+
+- [ ] **Step 5: Commit**
+```bash
+git add docker/ scripts/relay-bootstrap.sh docs/relay-hosting.md
+git commit -m "feat(relay): self-hostable sish relay kit (compose + bootstrap + docs)"
+mship journal "relay hosting kit (sish compose + bootstrap + docs)" --action committed
+```
+
+---
+
+# PHASE B — mship client integration (mothership)
+
+## Task B1: Relay config (`relay:` block in mothership.yaml)
+
+**Files:**
+- Create: `src/mship/core/relay/__init__.py` (empty), `src/mship/core/relay/config.py`
+- Modify: `src/mship/core/config.py` (parse `relay:` into the workspace config)
+- Test: `tests/core/relay/test_config.py`
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/core/relay/test_config.py
+from mship.core.relay.config import RelayConfig
+
+def test_from_mapping_full():
+    rc = RelayConfig.from_mapping({"host": "relay.example.com", "ssh_port": 2222, "user": "tunnel"})
+    assert rc.host == "relay.example.com"
+    assert rc.ssh_port == 2222
+    assert rc.user == "tunnel"
+
+def test_from_mapping_defaults_and_none():
+    assert RelayConfig.from_mapping(None) is None           # no relay configured
+    rc = RelayConfig.from_mapping({"host": "r.example.com"})
+    assert rc.ssh_port == 2222 and rc.user is None          # defaults
+```
+
+- [ ] **Step 2: Run, verify fail** — `uv run pytest tests/core/relay/test_config.py -q` → FAIL (module missing).
+
+- [ ] **Step 3: Implement `src/mship/core/relay/config.py`**
+```python
+from __future__ import annotations
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class RelayConfig:
+    host: str
+    ssh_port: int = 2222
+    user: str | None = None       # ssh user; None → ssh default
+
+    @staticmethod
+    def from_mapping(data: dict | None) -> "RelayConfig | None":
+        if not data:
+            return None
+        host = data.get("host")
+        if not host:
+            raise ValueError("relay.host is required when a `relay:` block is present")
+        return RelayConfig(
+            host=host,
+            ssh_port=int(data.get("ssh_port", 2222)),
+            user=data.get("user"),
+        )
+```
+
+- [ ] **Step 4: Run, verify pass.** Then wire into `config.py`: where `WorkspaceConfig` is built, add `relay = RelayConfig.from_mapping(raw.get("relay"))` and expose it as an optional attribute `relay: RelayConfig | None = None`. Add a test that `ConfigLoader.load` on a yaml with a `relay:` block exposes `config.relay.host`. (Match the existing config-parsing pattern in `src/mship/core/config.py`.)
+
+- [ ] **Step 5: Commit** — `feat(relay): relay config block` + journal.
+
+## Task B2: Per-workspace serve token (auto-generate + persist)
+
+**Files:** Create `src/mship/core/relay/token.py`; Test `tests/core/relay/test_token.py`
+
+- [ ] **Step 1: Failing test**
+```python
+from pathlib import Path
+from mship.core.relay.token import ensure_serve_token
+
+def test_generates_and_persists(tmp_path: Path):
+    t1 = ensure_serve_token(tmp_path)            # tmp_path = workspace root
+    assert isinstance(t1, str) and len(t1) >= 32
+    assert (tmp_path / ".mothership" / "serve-token").read_text().strip() == t1
+    t2 = ensure_serve_token(tmp_path)            # stable across calls
+    assert t2 == t1
+
+def test_respects_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("MSHIP_SERVE_TOKEN", "explicit")
+    assert ensure_serve_token(tmp_path) == "explicit"   # env wins, no file write
+    assert not (tmp_path / ".mothership" / "serve-token").exists()
+```
+
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement `token.py`**
+```python
+from __future__ import annotations
+import os, secrets
+from pathlib import Path
+
+def ensure_serve_token(workspace_root: Path) -> str:
+    """Return the serve bearer token: env override > persisted file > freshly generated+persisted."""
+    env = os.environ.get("MSHIP_SERVE_TOKEN")
+    if env:
+        return env
+    path = workspace_root / ".mothership" / "serve-token"
+    if path.exists():
+        existing = path.read_text().strip()
+        if existing:
+            return existing
+    token = secrets.token_urlsafe(32)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(token + "\n")
+    path.chmod(0o600)
+    return token
+```
+
+- [ ] **Step 4: Verify pass.** **Step 5: Commit** `feat(relay): per-workspace serve token` + journal.
+
+## Task B3: Relay SSH key management
+
+**Files:** Create `src/mship/core/relay/keys.py`; Test `tests/core/relay/test_keys.py`
+
+Generate a dedicated ed25519 key via `ssh-keygen` if absent; expose the public key. Inject the runner for testability.
+
+- [ ] **Step 1: Failing test**
+```python
+from pathlib import Path
+from mship.core.relay.keys import ensure_relay_key, relay_public_key
+
+def test_generates_key_when_absent(tmp_path):
+    calls = []
+    def fake_run(argv):                      # stand in for subprocess
+        calls.append(argv)
+        key = tmp_path / "relay_ed25519"
+        key.write_text("PRIV"); (key.with_suffix(".pub")).write_text("ssh-ed25519 AAAA mship-relay\n")
+        return 0
+    path = ensure_relay_key(home=tmp_path, runner=fake_run)
+    assert path == tmp_path / ".mothership" / "relay_ed25519" or path.name == "relay_ed25519"
+    assert any("ssh-keygen" in a for a in calls[0])
+    assert relay_public_key(path).startswith("ssh-ed25519 ")
+
+def test_idempotent_when_present(tmp_path):
+    # pre-create the key; runner must NOT be called
+    ...
+```
+
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement `keys.py`** — `ensure_relay_key(home, runner=subprocess-based default)` computes `home/.mothership/relay_ed25519`, returns it if present, else `runner(["ssh-keygen","-t","ed25519","-f",str(path),"-N","","-C","mship-relay"])` and returns it; `relay_public_key(path)` reads `path.with_suffix(".pub")` (or `<path>.pub`). Default runner wraps `subprocess.run(..., check=True).returncode`.
+- [ ] **Step 4: Verify pass.** **Step 5: Commit** `feat(relay): dedicated relay ssh key mgmt` + journal.
+
+## Task B4: Subdomain + tunnel argv (pure)
+
+**Files:** Create `src/mship/core/relay/tunnel.py` (subdomain + argv only here; supervisor in B5); Test `tests/core/relay/test_tunnel_args.py`
+
+- [ ] **Step 1: Failing test**
+```python
+from pathlib import Path
+from mship.core.relay.config import RelayConfig
+from mship.core.relay.tunnel import subdomain_for, build_tunnel_argv
+
+def test_subdomain_slugs_workspace():
+    assert subdomain_for("Mship Workspace") == "mship-workspace"
+
+def test_build_tunnel_argv():
+    rc = RelayConfig(host="relay.example.com", ssh_port=2222, user="tunnel")
+    argv = build_tunnel_argv(rc, subdomain="mship-workspace", local_port=47100, key_path=Path("/k/relay_ed25519"))
+    assert argv[0] == "ssh"
+    assert "-R" in argv and "mship-workspace:80:localhost:47100" in argv
+    assert "-p" in argv and "2222" in argv
+    assert "-i" in argv and "/k/relay_ed25519" in argv
+    assert argv[-1] == "tunnel@relay.example.com"
+    # resilience options present
+    assert "-o" in argv and "ExitOnForwardFailure=yes" in argv and "ServerAliveInterval=30" in argv
+```
+
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement** in `tunnel.py`:
+```python
+from __future__ import annotations
+from pathlib import Path
+from mship.core.relay.config import RelayConfig
+from mship.util.slug import slugify
+
+def subdomain_for(workspace: str) -> str:
+    return slugify(workspace)
+
+def build_tunnel_argv(rc: RelayConfig, *, subdomain: str, local_port: int, key_path: Path) -> list[str]:
+    target = f"{rc.user}@{rc.host}" if rc.user else rc.host
+    return [
+        "ssh",
+        "-p", str(rc.ssh_port),
+        "-i", str(key_path),
+        "-o", "ExitOnForwardFailure=yes",
+        "-o", "ServerAliveInterval=30",
+        "-o", "ServerAliveCountMax=3",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-N",
+        "-R", f"{subdomain}:80:localhost:{local_port}",
+        target,
+    ]
+```
+
+- [ ] **Step 4: Verify pass.** **Step 5: Commit** `feat(relay): subdomain + ssh tunnel argv builder` + journal.
+
+## Task B5: TunnelSupervisor (start / supervise / stop)
+
+**Files:** Add `TunnelSupervisor` to `src/mship/core/relay/tunnel.py`; Test `tests/core/relay/test_tunnel_supervisor.py`
+
+Supervises the ssh subprocess: start, restart on unexpected exit (capped backoff), stop cleanly. Inject a process factory for testing (no real ssh).
+
+- [ ] **Step 1: Failing test**
+```python
+from mship.core.relay.tunnel import TunnelSupervisor
+
+class FakeProc:
+    def __init__(self): self._alive = True; self.terminated = False
+    def poll(self): return None if self._alive else 0
+    def terminate(self): self.terminated = True; self._alive = False
+    def wait(self, timeout=None): self._alive = False; return 0
+
+def test_start_then_stop_terminates_process():
+    procs = []
+    def factory(argv): p = FakeProc(); procs.append(p); return p
+    sup = TunnelSupervisor(argv=["ssh", "..."], proc_factory=factory)
+    sup.start()
+    assert sup.is_running() and len(procs) == 1
+    sup.stop()
+    assert procs[0].terminated and not sup.is_running()
+```
+(A second test: `restart_on_unexpected_exit` — flip the proc's poll() to a nonzero exit and assert the supervisor spawns a replacement when `tick()` is called. Keep restart logic tick-driven so it's unit-testable without threads.)
+
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement** a tick-driven `TunnelSupervisor` (start spawns via `proc_factory`; `tick()` checks `poll()` and respawns with capped backoff; `stop()` terminates + waits; `is_running()` reflects state). The CLI run loop calls `tick()` on an interval; the default `proc_factory` uses `subprocess.Popen` with process-group setup mirroring `src/mship/core/executor.py`'s background-service handling. Keep all policy in pure methods.
+- [ ] **Step 4: Verify pass.** **Step 5: Commit** `feat(relay): tunnel supervisor (reconnect/teardown)` + journal.
+
+## Task B6: Pairing link (encode/decode, shared core)
+
+**Files:** Create `src/mship/core/relay/pairing.py`; Test `tests/core/relay/test_pairing.py`
+
+- [ ] **Step 1: Failing test**
+```python
+from mship.core.relay.pairing import build_pair_link, parse_pair_link
+
+def test_round_trip():
+    link = build_pair_link(url="https://ws.relay.example.com", token="tok en/+=", workspace="ws")
+    assert link.startswith("groundcontrol://add?")
+    p = parse_pair_link(link)
+    assert p == {"url": "https://ws.relay.example.com", "token": "tok en/+=", "workspace": "ws"}
+
+def test_parse_rejects_wrong_scheme():
+    import pytest
+    with pytest.raises(ValueError):
+        parse_pair_link("https://add?url=x")
+```
+
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement `pairing.py`** using `urllib.parse` (`urlencode` with `quote_via=quote`, and `urlparse`/`parse_qs`); `parse_pair_link` validates scheme == `groundcontrol` and netloc/path == `add`, returns `{url, token, workspace}`, raising `ValueError` on mismatch or missing keys.
+- [ ] **Step 4: Verify pass.** **Step 5: Commit** `feat(relay): pairing deep-link encode/decode` + journal.
+
+## Task B7: Wire `mship serve --relay`, `mship relay setup`, `mship pair`
+
+**Files:** Modify `src/mship/cli/serve.py`; Create `src/mship/cli/relay.py`, `src/mship/cli/pair.py`; add `segno` to `pyproject.toml`; Test `tests/cli/test_relay_cli.py`
+
+- [ ] **Step 1: Add `segno` dep** — `uv add segno`; verify `uv run python -c "import segno"`.
+- [ ] **Step 2: Failing test (pairing QR command)**
+```python
+# tests/cli/test_relay_cli.py — `mship pair` prints a scannable link + QR for a configured relay
+from typer.testing import CliRunner
+from mship.cli import app
+runner = CliRunner()
+def test_pair_outputs_deeplink(relay_configured_workspace):   # fixture: workspace + relay.host + a serve token
+    r = runner.invoke(app, ["pair"])
+    assert r.exit_code == 0
+    assert "groundcontrol://add?" in r.output
+    assert "workspace=" in r.output
+```
+
+- [ ] **Step 3: Implement**
+  - `mship pair` (`src/mship/cli/pair.py`): compute `url = https://{subdomain_for(workspace)}.{rc.host}` (the sish `--domain` is the same hostname clients SSH to), `token = ensure_serve_token(workspace_root)`, `link = build_pair_link(...)`; print the link and render a QR with `segno.make(link).terminal(compact=True)`.
+  - `mship relay setup` (`src/mship/cli/relay.py`): `ensure_relay_key(home=Path.home())`, print `relay_public_key(path)` with the instruction to drop it in the relay's `pubkeys/` dir.
+  - `mship serve --relay [<host>]` (modify `serve.py`): when `--relay`/`config.relay` is set — require/auto-generate the token (`ensure_serve_token`), bind serve to loopback as today, build argv via `ensure_relay_key` + `build_tunnel_argv`, start a `TunnelSupervisor`, print the public URL + pairing QR, then run uvicorn; `tick()` the supervisor (background thread or signal-driven) and on shutdown call `sup.stop()`. Reuse the existing non-loopback/token guard.
+- [ ] **Step 4: Verify** — `uv run pytest tests/cli/test_relay_cli.py -q` green; manual: `mship serve --relay` against a real relay prints a reachable URL.
+- [ ] **Step 5: Commit** `feat(serve): --relay tunnel + mship pair/relay setup (QR)` + journal.
+
+---
+
+# PHASE C — Pairing in the Ground Control app (ground-control)
+
+> Android tasks: `source ~/toolchains/android-env.sh` before gradle.
+
+## Task C1: Deep-link parser (Kotlin, pure)
+
+**Files:** Create `app/src/main/java/com/atomikpanda/groundcontrol/data/PairLink.kt`; Test `app/src/test/java/com/atomikpanda/groundcontrol/PairLinkTest.kt`
+
+- [ ] **Step 1: Failing test**
+```kotlin
+package com.atomikpanda.groundcontrol
+import com.atomikpanda.groundcontrol.data.PairLink
+import org.junit.Assert.*
+import org.junit.Test
+
+class PairLinkTest {
+    @Test fun parses_valid_link() {
+        val c = PairLink.parse("groundcontrol://add?url=https%3A%2F%2Fws.relay.example.com&token=abc&workspace=ws")
+        assertNotNull(c)
+        assertEquals("https://ws.relay.example.com", c!!.baseUrl)
+        assertEquals("abc", c.token)
+        assertEquals("ws", c.workspaceName)
+    }
+    @Test fun rejects_wrong_scheme_or_missing_fields() {
+        assertNull(PairLink.parse("https://add?url=x"))
+        assertNull(PairLink.parse("groundcontrol://add?token=abc"))   // no url
+    }
+}
+```
+
+- [ ] **Step 2: Verify fail** — `./gradlew testDebugUnitTest --tests "*PairLinkTest"` → RED.
+- [ ] **Step 3: Implement `PairLink.kt`**
+```kotlin
+package com.atomikpanda.groundcontrol.data
+import android.net.Uri
+import java.util.UUID
+
+object PairLink {
+    /** Parse a groundcontrol://add?url=&token=&workspace= deep link into a connection, or null if invalid. */
+    fun parse(raw: String): WorkspaceConnection? {
+        val uri = runCatching { Uri.parse(raw) }.getOrNull() ?: return null
+        if (uri.scheme != "groundcontrol" || uri.host != "add") return null
+        val url = uri.getQueryParameter("url")?.takeIf { it.isNotBlank() } ?: return null
+        val token = uri.getQueryParameter("token")?.takeIf { it.isNotBlank() }
+        val ws = uri.getQueryParameter("workspace").orEmpty()
+        return WorkspaceConnection(id = UUID.randomUUID().toString(), baseUrl = url, token = token, workspaceName = ws)
+    }
+}
+```
+Note: `Uri` is available in JVM unit tests via Robolectric OR is `android.net.Uri` (not in plain JVM). If the existing test setup lacks Robolectric, parse with `java.net.URI` + manual query split instead (keep the same signature + tests). Decide based on the repo's test deps; prefer `java.net.URI` to stay pure-JVM (no Robolectric).
+
+- [ ] **Step 4: Verify pass.** **Step 5: Commit** `feat(android): pairing deep-link parser` + journal.
+
+## Task C2: Settings → Add → Scan QR + deep-link intent
+
+**Files:** Create `ui/settings/ScanConnectionScreen.kt`; Modify `AndroidManifest.xml` (intent-filter for `groundcontrol://add`), `ui/settings/SettingsScreen.kt` (Scan button), `SettingsViewModel.kt` (add-from-link). Build-verified (no unit tests for camera UI).
+
+- [ ] **Step 1: Add scanner dep** — ML Kit barcode scanning (`com.google.mlkit:barcode-scanning`) + CameraX (`androidx.camera:*`), or ZXing Android Embedded (`com.journeyapps:zxing-android-embedded`) for a simpler drop-in scanner activity. Prefer ZXing-embedded for least code.
+- [ ] **Step 2: SettingsViewModel** — add `fun addFromLink(raw: String): Boolean { val c = PairLink.parse(raw) ?: return false; viewModelScope.launch { repo.upsert(c) }; return true }`.
+- [ ] **Step 3: SettingsScreen** — add a "Scan QR" button that launches the scanner; on result, call `vm.addFromLink(result)` and toast success/failure.
+- [ ] **Step 4: AndroidManifest.xml** — add an `<intent-filter>` on MainActivity for `<data android:scheme="groundcontrol" android:host="add"/>` (VIEW/BROWSABLE) so a tapped/pasted deep link opens the app; route it to `addFromLink`.
+- [ ] **Step 5: Build** — `./gradlew assembleDebug` BUILD SUCCESSFUL; `./gradlew testDebugUnitTest` still green (PairLinkTest + the 15 prior).
+- [ ] **Step 6: Commit** `feat(android): scan QR / deep-link to add a connection` + journal.
+
+---
+
+## Acceptance Criteria → Tasks
+
+- ac1 (relay kit) → A1
+- ac2 (`serve --relay` supervised tunnel, reconnect/teardown) → B5 + B7
+- ac3 (relay host config + stable subdomain URL) → B1 + B4
+- ac4 (dedicated SSH key + surface pubkey) → B3 + `mship relay setup` (B7)
+- ac5 (token required when relaying; auto-gen/persist) → B2 + B7
+- ac6 (`serve --relay`/`pair` prints QR deep link) → B6 + B7
+- ac7 (app Scan QR / deep-link add, no typing) → C1 + C2
+- ac8 (tunnel/token/key/config/pairing as reusable core, durable pairing) → the `src/mship/core/relay/` package (B1–B6), callable independent of `serve`
+- ac9 (unit tests: payload codec both sides, token, subdomain, argv, config) → B1,B2,B3,B4,B6 tests + C1 test

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -1,0 +1,173 @@
+# Hosting Your Own mship Relay (sish)
+
+This runbook walks through standing up a self-hosted [sish](https://github.com/antoniomika/sish) relay so that `mship serve --relay` can expose your local workspace over a stable `https://<workspace>.<relay-domain>` URL from anywhere — no VPN required.
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| A VPS (Debian 12 or Ubuntu 22.04+) | 1 CPU / 512 MB RAM is sufficient. A $5/month cloud instance (Hetzner, DigitalOcean, Vultr, etc.) works. |
+| A domain you control | Example: `relay.example.com`. You only need a subdomain — the relay does not take over the root domain. |
+| SSH access to the VPS as root (or a sudo user) | To run the bootstrap script and open ports. |
+
+---
+
+## Step 1 — Point the Wildcard DNS Record at Your VPS
+
+sish routes incoming HTTP/HTTPS traffic based on the `Host` header, so every workspace needs its own subdomain. A single wildcard `A` record covers all of them.
+
+In your DNS provider, create:
+
+```
+*.relay.example.com   A   <public-ip-of-your-vps>   TTL 300
+```
+
+Replace `relay.example.com` with your actual relay base domain and `<public-ip-of-your-vps>` with the server's IPv4 address.
+
+Verify propagation before continuing:
+
+```bash
+dig +short A test.relay.example.com
+# Should return your VPS IP
+```
+
+---
+
+## Step 2 — Open Firewall Ports
+
+The relay needs three TCP ports reachable from the public internet:
+
+| Port | Protocol | Purpose |
+|---|---|---|
+| 22 **or** 2222 | TCP | SSH — mship clients open reverse tunnels here |
+| 80 | TCP | HTTP — ACME (Let's Encrypt) HTTP-01 challenge + HTTP→HTTPS redirect |
+| 443 | TCP | HTTPS — public app traffic served to clients |
+
+The compose file uses port **2222** for SSH (so it does not conflict with the host's own SSH daemon on 22). Allow it on your VPS firewall:
+
+```bash
+# ufw (Ubuntu/Debian)
+ufw allow 2222/tcp
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw reload
+```
+
+If your cloud provider has a separate security group / network firewall, add the same rules there.
+
+---
+
+## Step 3 — Run the Bootstrap Script
+
+Clone (or copy) the mothership repo to your VPS, then run the one-shot bootstrap:
+
+```bash
+git clone https://github.com/your-org/mothership.git
+cd mothership
+
+RELAY_DOMAIN=relay.example.com \
+ACME_EMAIL=you@example.com \
+./scripts/relay-bootstrap.sh
+```
+
+What the script does:
+
+1. Installs Docker Engine if it is not already present (via `https://get.docker.com`).
+2. Creates the data directories `docker/relay/pubkeys/`, `docker/relay/keys/`, and `docker/relay/acme/`.
+3. Prints a reminder to add client public keys before tunnels will be accepted.
+4. Starts the sish container with `docker compose up -d`, passing `RELAY_DOMAIN` and `ACME_EMAIL` through to the compose file for the Let's Encrypt on-demand TLS certificate workflow.
+
+The compose file (`docker/relay/docker-compose.yml`) mounts:
+
+- `./pubkeys` → `/pubkeys` (read-only) — the SSH public-key allowlist.
+- `./keys` → `/keys` — sish's own host key, persisted across container restarts.
+- `./acme` → `/acme` — Let's Encrypt certificate cache.
+
+---
+
+## Step 4 — Add Client Public Keys
+
+sish requires authentication: only clients whose public key appears in `docker/relay/pubkeys/` may open tunnels.
+
+**On the machine running mship**, generate (or surface) the dedicated relay key:
+
+```bash
+mship relay setup
+```
+
+This prints a line like:
+
+```
+ssh-ed25519 AAAA... mship-relay
+```
+
+> Note: `mship relay setup` is implemented in Phase B of this feature. Until that command is available, run `ssh-keygen -t ed25519 -f ~/.mothership/relay_ed25519 -N "" -C "mship-relay"` manually and use the contents of `~/.mothership/relay_ed25519.pub`.
+
+Copy that line to a file on the relay VPS:
+
+```bash
+# On the VPS, inside the mothership directory:
+echo "ssh-ed25519 AAAA... mship-relay" > docker/relay/pubkeys/my-laptop.pub
+```
+
+One file per key; the filename does not matter. sish reads all files in the directory on each connection attempt — no container restart needed.
+
+---
+
+## Step 5 — Verify the Relay
+
+Test that the relay is reachable and will accept a tunnel from an allowed key:
+
+```bash
+ssh -p 2222 \
+    -o StrictHostKeyChecking=accept-new \
+    -R test:80:localhost:8000 \
+    relay.example.com
+```
+
+If everything is working you will see sish output similar to:
+
+```
+Starting SSH Forwarding service for http:80
+```
+
+And `https://test.relay.example.com` will proxy to `localhost:8000` on the machine that ran the command. Press `Ctrl-C` to close the tunnel.
+
+Once this works, `mship serve --relay` will open and supervise tunnels automatically.
+
+---
+
+## Configuration Reference
+
+The relay is configured entirely through environment variables passed to `docker compose`. The bootstrap script sets them; you can also export them in a `.env` file alongside `docker-compose.yml`:
+
+| Variable | Required | Example | Description |
+|---|---|---|---|
+| `RELAY_DOMAIN` | Yes | `relay.example.com` | Base domain. Workspaces are exposed at `<subdomain>.<RELAY_DOMAIN>`. Must match the wildcard DNS record. |
+| `ACME_EMAIL` | Yes | `you@example.com` | Email registered with Let's Encrypt for certificate expiry notifications. |
+
+---
+
+## Upgrading
+
+sish uses a rolling `latest` tag. To update:
+
+```bash
+cd /path/to/mothership
+docker compose -f docker/relay/docker-compose.yml pull
+docker compose -f docker/relay/docker-compose.yml up -d
+```
+
+Data directories (`keys/`, `pubkeys/`, `acme/`) are mounted volumes and survive the upgrade.
+
+---
+
+## Troubleshooting
+
+**Tunnel connection refused** — confirm port 2222 is open (`nc -zv relay.example.com 2222`) and the client public key is in `docker/relay/pubkeys/`.
+
+**Certificate errors** — verify the wildcard DNS record resolves to the relay IP, and that port 80 is open (Let's Encrypt needs it for the HTTP-01 challenge).
+
+**sish container exits immediately** — run `docker compose -f docker/relay/docker-compose.yml logs sish` to inspect startup errors. Common causes: port already in use, or missing `RELAY_DOMAIN`/`ACME_EMAIL` environment variables.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pyyaml>=6.0",
     "fastapi>=0.110",
     "uvicorn>=0.27",
+    "segno>=1.6.6",
 ]
 
 [project.scripts]

--- a/scripts/relay-bootstrap.sh
+++ b/scripts/relay-bootstrap.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# One-shot bring-up of a self-hosted sish relay on a fresh Debian/Ubuntu VPS.
+# Usage: RELAY_DOMAIN=relay.example.com ACME_EMAIL=you@example.com ./relay-bootstrap.sh
+set -euo pipefail
+: "${RELAY_DOMAIN:?set RELAY_DOMAIN (the wildcard base, e.g. relay.example.com)}"
+: "${ACME_EMAIL:?set ACME_EMAIL (for Lets Encrypt / ACME)}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[bootstrap] installing Docker..."
+  curl -fsSL https://get.docker.com | sh
+fi
+HERE="$(cd "$(dirname "$0")/../docker/relay" && pwd)"
+mkdir -p "$HERE/pubkeys" "$HERE/keys" "$HERE/acme"
+echo "[bootstrap] add client public keys to $HERE/pubkeys/ (one file per key), then:"
+echo "  RELAY_DOMAIN=$RELAY_DOMAIN ACME_EMAIL=$ACME_EMAIL docker compose -f $HERE/docker-compose.yml up -d"
+echo "[bootstrap] DNS: point  *.$RELAY_DOMAIN  A record at this host's public IP."
+RELAY_DOMAIN="$RELAY_DOMAIN" ACME_EMAIL="$ACME_EMAIL" docker compose -f "$HERE/docker-compose.yml" up -d
+echo "[bootstrap] sish is up. Test a tunnel: ssh -p 2222 -R myws:80:localhost:8000 $RELAY_DOMAIN"

--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -85,10 +85,12 @@ from mship.cli import init as _init_mod
 from mship.cli import internal as _internal_mod
 from mship.cli import layout as _layout_mod
 from mship.cli import log as _log_mod
+from mship.cli import pair as _pair_mod
 from mship.cli import phase as _phase_mod
 from mship.cli import pr as _pr_mod
 from mship.cli import prune as _prune_mod
 from mship.cli import reconcile as _reconcile_mod
+from mship.cli import relay as _relay_mod
 from mship.cli import skill as _skill_mod
 from mship.cli import spec as _spec_mod
 from mship.cli import status as _status_mod
@@ -138,10 +140,12 @@ _init_mod.register(app, get_container)
 _internal_mod.register(app, get_container)
 _layout_mod.register(app, get_container)
 _log_mod.register(app, get_container)
+_pair_mod.register(app, get_container)
 _phase_mod.register(app, get_container)
 _pr_mod.register(app, get_container)
 _prune_mod.register(app, get_container)
 _reconcile_mod.register(app, get_container)
+_relay_mod.register(app, get_container)
 _skill_mod.register(app, get_container)
 _spec_mod.register(app, get_container)
 _status_mod.register(app, get_container)

--- a/src/mship/cli/pair.py
+++ b/src/mship/cli/pair.py
@@ -1,0 +1,44 @@
+"""`mship pair` — print a scannable pairing deep-link + QR for the Ground Control app.
+
+Resolves the workspace's relay config, computes the public URL + serve token,
+builds a `groundcontrol://add?...` deep-link, prints it, and renders a terminal
+QR code so the phone app can scan it without typing. See plan Task B7 (ac6).
+"""
+from __future__ import annotations
+
+import typer
+
+from mship.cli.output import Output
+
+
+def register(app: typer.Typer, get_container):
+    @app.command()
+    def pair():
+        """Print a pairing deep-link + QR to connect the Ground Control app to this workspace."""
+        from pathlib import Path
+
+        import segno
+
+        from mship.core.relay.pairing import build_pair_link
+        from mship.core.relay.token import ensure_serve_token
+        from mship.core.relay.tunnel import subdomain_for
+
+        output = Output()
+        container = get_container()
+        config = container.config()
+        rc = config.relay
+        if rc is None:
+            output.error(
+                "No relay configured. Add a `relay:` block (host) to mothership.yaml "
+                "to enable phone pairing. See docs/relay-hosting.md."
+            )
+            raise typer.Exit(1)
+
+        workspace = config.workspace
+        workspace_root = Path(container.config_path()).parent
+        url = f"https://{subdomain_for(workspace)}.{rc.host}"
+        token = ensure_serve_token(workspace_root)
+        link = build_pair_link(url=url, token=token, workspace=workspace)
+
+        output.print(link)
+        typer.echo(segno.make(link).terminal(compact=True))

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -1,0 +1,39 @@
+"""`mship relay` sub-app — manage the reverse-tunnel relay client side.
+
+`mship relay setup` generates (if absent) a dedicated ed25519 key used to open
+the reverse tunnel, and prints its public key for allow-listing on the relay
+host (`docker/relay/pubkeys/`). See plan Task B7 (ac4).
+"""
+from __future__ import annotations
+
+import typer
+
+from mship.cli.output import Output
+
+
+def register(parent: typer.Typer, get_container):
+    relay_app = typer.Typer(
+        name="relay",
+        help="Manage the mship reverse-tunnel relay client (keys).",
+        no_args_is_help=True,
+    )
+
+    @relay_app.command("setup")
+    def setup():
+        """Generate the relay SSH key (if absent) and print its public key to allow-list."""
+        from pathlib import Path
+
+        from mship.core.relay.keys import ensure_relay_key, relay_public_key
+
+        output = Output()
+        key_path = ensure_relay_key(home=Path.home())
+        pub = relay_public_key(key_path).strip()
+
+        output.print(pub)
+        output.print(
+            "\nAdd the line above to your relay's `docker/relay/pubkeys/` directory "
+            "(one file per key), then restart the relay, to allow this machine to "
+            "open tunnels."
+        )
+
+    parent.add_typer(relay_app)

--- a/src/mship/cli/serve.py
+++ b/src/mship/cli/serve.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional
 
 import typer
 
@@ -16,14 +17,52 @@ def register(app: typer.Typer, get_container):
                  "other devices — requires MSHIP_SERVE_TOKEN.",
         ),
         port: int = typer.Option(47100, "--port", help="Port."),
+        relay: bool = typer.Option(
+            False, "--relay",
+            help="Expose this workspace via a reverse SSH tunnel to a relay host. "
+                 "Uses config.relay.host unless --relay-host overrides it. Serve "
+                 "stays bound to loopback; a bearer token is required (auto-generated).",
+        ),
+        relay_host: Optional[str] = typer.Option(
+            None, "--relay-host",
+            metavar="HOST",
+            help="Relay host to tunnel through (implies --relay). Overrides config.relay.host.",
+            show_default=False,
+        ),
+        relay_tick: float = typer.Option(
+            1.0, "--relay-tick", hidden=True,
+            help="Seconds between tunnel-supervisor health checks.",
+        ),
     ):
         """Run a JSON API over the spec + task model — reads plus review/approve writes (Ground Control)."""
         import os
+
+        # Relaying is on if --relay is given OR a --relay-host override is supplied.
+        relay_enabled = relay or relay_host is not None
+        relay_host_override = relay_host
+
+        output = Output()
+        container = get_container()
+        workspace_root = Path(container.config_path()).parent
+        config = container.config()
+
+        if relay_enabled:
+            _serve_with_relay(
+                container=container,
+                config=config,
+                workspace_root=workspace_root,
+                output=output,
+                relay_host_override=relay_host_override,
+                port=port,
+                relay_tick=relay_tick,
+            )
+            return
+
+        # ---- existing (non-relay) behavior ----
         import uvicorn
         from mship.core.serve import create_app
         from mship.core.spec_store import SPECS_DIRNAME
 
-        output = Output()
         token = os.environ.get("MSHIP_SERVE_TOKEN")
         loopback = {"127.0.0.1", "localhost", "::1"}
         if host not in loopback and not token:
@@ -33,14 +72,12 @@ def register(app: typer.Typer, get_container):
             )
             raise typer.Exit(1)
 
-        container = get_container()
-        workspace_root = Path(container.config_path()).parent
         api = create_app(
             specs_dir=workspace_root / SPECS_DIRNAME,
             state_manager=container.state_manager(),
             log_manager=container.log_manager(),
             workspace_root=workspace_root,
-            workspace_name=container.config().workspace,
+            workspace_name=config.workspace,
             auth_token=token,
             worktree_manager=container.worktree_manager(),
         )
@@ -48,3 +85,108 @@ def register(app: typer.Typer, get_container):
         docs_note = "docs: disabled (auth)" if token else "docs: /docs"
         output.print(f"mship serve → http://{host}:{port}  ({auth_note}; {docs_note})")
         uvicorn.run(api, host=host, port=port)
+
+
+def _serve_with_relay(
+    *,
+    container,
+    config,
+    workspace_root: Path,
+    output: Output,
+    relay_host_override: Optional[str],
+    port: int,
+    relay_tick: float,
+):
+    """Run uvicorn on loopback while supervising a reverse SSH tunnel to the relay.
+
+    Token is REQUIRED when relaying (the public URL is reachable from anywhere);
+    it is taken from MSHIP_SERVE_TOKEN if set, else auto-generated + persisted.
+    uvicorn blocks in the main thread; the tunnel supervisor is ticked from a
+    background daemon thread on an interval and torn down on shutdown.
+    """
+    import threading
+
+    import segno
+    import uvicorn
+
+    from mship.core.relay.config import RelayConfig
+    from mship.core.relay.keys import ensure_relay_key
+    from mship.core.relay.pairing import build_pair_link
+    from mship.core.relay.token import ensure_serve_token
+    from mship.core.relay.tunnel import (
+        TunnelSupervisor,
+        build_tunnel_argv,
+        subdomain_for,
+    )
+    from mship.core.serve import create_app
+    from mship.core.spec_store import SPECS_DIRNAME
+
+    # Resolve the relay config: an explicit --relay <host> overrides config.relay.host;
+    # otherwise fall back to the configured relay block entirely.
+    rc = config.relay
+    if relay_host_override:
+        if rc is not None:
+            rc = RelayConfig(host=relay_host_override, ssh_port=rc.ssh_port, user=rc.user)
+        else:
+            rc = RelayConfig(host=relay_host_override)
+    if rc is None:
+        output.error(
+            "--relay requires a relay host. Pass it (`mship serve --relay relay.example.com`) "
+            "or add a `relay:` block (host) to mothership.yaml. See docs/relay-hosting.md."
+        )
+        raise typer.Exit(1)
+
+    workspace = config.workspace
+
+    # Token is REQUIRED when relaying — the public URL is reachable from anywhere.
+    token = ensure_serve_token(workspace_root)
+
+    # serve stays bound to loopback; the tunnel is what exposes it.
+    host = "127.0.0.1"
+    api = create_app(
+        specs_dir=workspace_root / SPECS_DIRNAME,
+        state_manager=container.state_manager(),
+        log_manager=container.log_manager(),
+        workspace_root=workspace_root,
+        workspace_name=workspace,
+        auth_token=token,
+        worktree_manager=container.worktree_manager(),
+    )
+
+    subdomain = subdomain_for(workspace)
+    key_path = ensure_relay_key(home=Path.home())
+    argv = build_tunnel_argv(rc, subdomain=subdomain, local_port=port, key_path=key_path)
+
+    public_url = f"https://{subdomain}.{rc.host}"
+    link = build_pair_link(url=public_url, token=token, workspace=workspace)
+
+    sup = TunnelSupervisor(argv=argv)
+    sup.start()
+
+    # Background daemon thread ticks the supervisor (reconnect on drop) while
+    # uvicorn blocks the main thread. Daemon so it never blocks interpreter exit.
+    stop_event = threading.Event()
+
+    def _tick_loop():
+        while not stop_event.wait(relay_tick):
+            try:
+                sup.tick()
+            except Exception:
+                # Never let a tick error kill the supervisor thread; next tick retries.
+                pass
+
+    ticker = threading.Thread(target=_tick_loop, name="mship-relay-tick", daemon=True)
+    ticker.start()
+
+    output.print(f"mship serve → http://{host}:{port}  (auth: bearer token; docs: disabled)")
+    output.print(f"relay → {public_url}  (tunnel via ssh -R to {rc.host})")
+    output.print(link)
+    typer.echo(segno.make(link).terminal(compact=True))
+
+    try:
+        uvicorn.run(api, host=host, port=port)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        stop_event.set()
+        sup.stop()

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -2,7 +2,9 @@ from pathlib import Path
 from typing import Literal
 
 import yaml
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, field_validator, model_validator
+
+from mship.core.relay.config import RelayConfig
 
 
 class Dependency(BaseModel):
@@ -121,7 +123,15 @@ class WorkspaceConfig(BaseModel):
     # Does NOT affect canonical mship specs (always `specs/`) or the `spec_paths`
     # legacy spec-search default. Surfaced in `mship context` for skills.
     docs_dir: str = "docs"
+    relay: RelayConfig | None = None
     repos: dict[str, RepoConfig]
+
+    @field_validator("relay", mode="before")
+    @classmethod
+    def parse_relay(cls, v) -> RelayConfig | None:
+        if isinstance(v, dict) or v is None:
+            return RelayConfig.from_mapping(v)
+        return v  # already a RelayConfig instance
 
     @model_validator(mode="after")
     def validate_default_scope(self) -> "WorkspaceConfig":

--- a/src/mship/core/relay/config.py
+++ b/src/mship/core/relay/config.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class RelayConfig:
+    host: str
+    ssh_port: int = 2222
+    user: str | None = None       # ssh user; None → ssh default
+
+    @staticmethod
+    def from_mapping(data: dict | None) -> "RelayConfig | None":
+        if not data:
+            return None
+        host = data.get("host")
+        if not host:
+            raise ValueError("relay.host is required when a `relay:` block is present")
+        return RelayConfig(
+            host=host,
+            ssh_port=int(data.get("ssh_port", 2222)),
+            user=data.get("user"),
+        )

--- a/src/mship/core/relay/keys.py
+++ b/src/mship/core/relay/keys.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+import subprocess
+from pathlib import Path
+
+
+def _default_runner(argv: list[str]) -> int:
+    return subprocess.run(argv, check=True).returncode
+
+
+def ensure_relay_key(home: Path, runner=_default_runner) -> Path:
+    """Return home/.mothership/relay_ed25519, generating it via ssh-keygen if absent."""
+    path = home / ".mothership" / "relay_ed25519"
+    if path.exists():
+        return path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    runner([
+        "ssh-keygen",
+        "-t", "ed25519",
+        "-f", str(path),
+        "-N", "",
+        "-C", "mship-relay",
+    ])
+    return path
+
+
+def relay_public_key(path: Path) -> str:
+    """Read and return the contents of the public key file at <path>.pub."""
+    pub_path = Path(str(path) + ".pub")
+    return pub_path.read_text()

--- a/src/mship/core/relay/pairing.py
+++ b/src/mship/core/relay/pairing.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+import urllib.parse
+
+
+def build_pair_link(*, url: str, token: str, workspace: str) -> str:
+    """Build a groundcontrol://add? deep-link with percent-encoded params.
+
+    Uses quote (not quote_plus) so spaces become %20, not +, and + becomes
+    %2B — this ensures round-trip fidelity for tokens containing spaces,
+    slashes, plus signs, and equals signs.
+    """
+    query = urllib.parse.urlencode(
+        {"url": url, "token": token, "workspace": workspace},
+        quote_via=urllib.parse.quote,
+    )
+    return f"groundcontrol://add?{query}"
+
+
+def parse_pair_link(link: str) -> dict:
+    """Parse a groundcontrol://add? deep-link, returning {url, token, workspace}.
+
+    Raises ValueError on wrong scheme or missing required keys.
+    """
+    parsed = urllib.parse.urlparse(link)
+    if parsed.scheme != "groundcontrol":
+        raise ValueError(f"Expected scheme 'groundcontrol', got {parsed.scheme!r}")
+    # netloc is 'add' for groundcontrol://add?...
+    host_path = (parsed.netloc + parsed.path).strip("/")
+    if host_path != "add":
+        raise ValueError(f"Expected host 'add', got {host_path!r}")
+    # parse_qs with keep_blank_values; use urllib.parse.unquote (not unquote_plus)
+    # so %20 -> space but + is left as + (we encoded with quote, not quote_plus)
+    raw_query = parsed.query
+    # parse_qsl returns (key, value) pairs; values are already unquoted by
+    # parse_qsl using unquote_plus by default, which would turn + -> space.
+    # We need unquote (not unquote_plus), so we parse manually.
+    params: dict[str, str] = {}
+    for part in raw_query.split("&"):
+        if "=" not in part:
+            continue
+        k, _, v = part.partition("=")
+        params[urllib.parse.unquote(k)] = urllib.parse.unquote(v)
+
+    required = {"url", "token", "workspace"}
+    missing = required - params.keys()
+    if missing:
+        raise ValueError(f"Missing required keys: {missing}")
+
+    return {k: params[k] for k in required}

--- a/src/mship/core/relay/token.py
+++ b/src/mship/core/relay/token.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+import os, secrets
+from pathlib import Path
+
+def ensure_serve_token(workspace_root: Path) -> str:
+    """Return the serve bearer token: env override > persisted file > freshly generated+persisted."""
+    env = os.environ.get("MSHIP_SERVE_TOKEN")
+    if env:
+        return env
+    path = workspace_root / ".mothership" / "serve-token"
+    if path.exists():
+        existing = path.read_text().strip()
+        if existing:
+            return existing
+    token = secrets.token_urlsafe(32)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(token + "\n")
+    path.chmod(0o600)
+    return token

--- a/src/mship/core/relay/tunnel.py
+++ b/src/mship/core/relay/tunnel.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from pathlib import Path
+from mship.core.relay.config import RelayConfig
+from mship.util.slug import slugify
+
+def subdomain_for(workspace: str) -> str:
+    return slugify(workspace)
+
+def build_tunnel_argv(rc: RelayConfig, *, subdomain: str, local_port: int, key_path: Path) -> list[str]:
+    target = f"{rc.user}@{rc.host}" if rc.user else rc.host
+    return [
+        "ssh",
+        "-p", str(rc.ssh_port),
+        "-i", str(key_path),
+        "-o", "ExitOnForwardFailure=yes",
+        "-o", "ServerAliveInterval=30",
+        "-o", "ServerAliveCountMax=3",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-N",
+        "-R", f"{subdomain}:80:localhost:{local_port}",
+        target,
+    ]

--- a/src/mship/core/relay/tunnel.py
+++ b/src/mship/core/relay/tunnel.py
@@ -1,15 +1,26 @@
 from __future__ import annotations
 import os
+import re
 import subprocess
+import time
 from pathlib import Path
 from typing import Callable
 
 from mship.core.relay.config import RelayConfig
-from mship.util.slug import slugify
 
 
 def subdomain_for(workspace: str) -> str:
-    return slugify(workspace)
+    """Return a DNS-label-safe slug for the given workspace name.
+
+    Rules: lowercase; runs of non-[a-z0-9] become a single '-'; leading/
+    trailing '-' stripped; capped at 63 characters (DNS label max) with any
+    trailing '-' after truncation also stripped.
+    """
+    s = workspace.lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    s = s.strip("-")
+    s = s[:63].rstrip("-")
+    return s
 
 
 def build_tunnel_argv(rc: RelayConfig, *, subdomain: str, local_port: int, key_path: Path) -> list[str]:
@@ -65,11 +76,13 @@ class TunnelSupervisor:
         proc_factory: Callable | None = None,
         backoff_delay: float = 5.0,
         max_backoff_delay: float = 60.0,
+        clock: Callable[[], float] | None = None,
     ) -> None:
         self._argv = argv
         self._proc_factory = proc_factory if proc_factory is not None else _default_proc_factory
         self._backoff_delay = backoff_delay
         self._max_backoff_delay = max_backoff_delay
+        self._clock = clock if clock is not None else time.monotonic
 
         self._proc = None
         self._stopped = False          # True once stop() has been called
@@ -84,6 +97,7 @@ class TunnelSupervisor:
     def start(self) -> None:
         """Spawn the process for the first time."""
         self._stopped = False
+        self._restart_count = 0
         self._spawn()
 
     def tick(self) -> None:
@@ -99,10 +113,21 @@ class TunnelSupervisor:
         if self._proc.poll() is None:
             # Still alive — nothing to do.
             return
-        # Process has exited unexpectedly.  Respawn (backoff is injectable to
-        # 0 for tests, so we always allow immediate respawn when backoff_delay=0).
-        self._spawn()
+        # Process has exited unexpectedly.  Check whether the backoff delay has
+        # elapsed before respawning.
+        delay = min(
+            self._backoff_delay * (2 ** self._restart_count),
+            self._max_backoff_delay,
+        )
+        now = self._clock()
+        if self._last_restart_at is None:
+            # First detected exit: record the time and wait for the backoff.
+            self._last_restart_at = now
+        if now - self._last_restart_at < delay:
+            return
+        self._last_restart_at = now
         self._restart_count += 1
+        self._spawn()
 
     def stop(self) -> None:
         """Terminate the supervised process and mark as intentionally stopped.

--- a/src/mship/core/relay/tunnel.py
+++ b/src/mship/core/relay/tunnel.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
+import os
+import subprocess
 from pathlib import Path
+from typing import Callable
+
 from mship.core.relay.config import RelayConfig
 from mship.util.slug import slugify
 
+
 def subdomain_for(workspace: str) -> str:
     return slugify(workspace)
+
 
 def build_tunnel_argv(rc: RelayConfig, *, subdomain: str, local_port: int, key_path: Path) -> list[str]:
     target = f"{rc.user}@{rc.host}" if rc.user else rc.host
@@ -20,3 +26,112 @@ def build_tunnel_argv(rc: RelayConfig, *, subdomain: str, local_port: int, key_p
         "-R", f"{subdomain}:80:localhost:{local_port}",
         target,
     ]
+
+
+def _default_proc_factory(argv: list[str]):
+    """Launch argv as a background subprocess in its own process group."""
+    kwargs: dict = dict(
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if os.name == "nt":
+        kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        kwargs["start_new_session"] = True
+    return subprocess.Popen(argv, **kwargs)
+
+
+class TunnelSupervisor:
+    """Supervises an SSH reverse-tunnel subprocess.
+
+    Policy is entirely tick-driven: the caller invokes ``tick()`` on a
+    periodic interval (e.g. from a run-loop or background thread).  No
+    threads or sleeps live inside this class, making it fully unit-testable
+    with a fake proc factory.
+
+    Args:
+        argv: The command + arguments to launch (e.g. from build_tunnel_argv).
+        proc_factory: Callable(argv) → proc-like object.  Defaults to
+            subprocess.Popen with process-group isolation.  Inject a fake for
+            tests.
+        backoff_delay: Minimum seconds between restart attempts (injectable so
+            tests can set it to 0 for instant respawn checks).
+        max_backoff_delay: Cap for the backoff counter.
+    """
+
+    def __init__(
+        self,
+        argv: list[str],
+        proc_factory: Callable | None = None,
+        backoff_delay: float = 5.0,
+        max_backoff_delay: float = 60.0,
+    ) -> None:
+        self._argv = argv
+        self._proc_factory = proc_factory if proc_factory is not None else _default_proc_factory
+        self._backoff_delay = backoff_delay
+        self._max_backoff_delay = max_backoff_delay
+
+        self._proc = None
+        self._stopped = False          # True once stop() has been called
+        self._restart_count = 0
+        # Monotonic time (seconds) of the last restart attempt; None on first start.
+        self._last_restart_at: float | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Spawn the process for the first time."""
+        self._stopped = False
+        self._spawn()
+
+    def tick(self) -> None:
+        """Check process liveness and respawn if it died unexpectedly.
+
+        Call this from a run-loop (e.g. every second).  Does nothing if
+        stop() has already been called.
+        """
+        if self._stopped:
+            return
+        if self._proc is None:
+            return
+        if self._proc.poll() is None:
+            # Still alive — nothing to do.
+            return
+        # Process has exited unexpectedly.  Respawn (backoff is injectable to
+        # 0 for tests, so we always allow immediate respawn when backoff_delay=0).
+        self._spawn()
+        self._restart_count += 1
+
+    def stop(self) -> None:
+        """Terminate the supervised process and mark as intentionally stopped.
+
+        After stop(), tick() will not respawn the process.
+        """
+        self._stopped = True
+        if self._proc is not None:
+            try:
+                self._proc.terminate()
+            except Exception:
+                pass
+            try:
+                self._proc.wait(timeout=5)
+            except Exception:
+                pass
+            self._proc = None
+
+    def is_running(self) -> bool:
+        """Return True if a live process is being supervised."""
+        if self._stopped:
+            return False
+        if self._proc is None:
+            return False
+        return self._proc.poll() is None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _spawn(self) -> None:
+        self._proc = self._proc_factory(self._argv)

--- a/tests/cli/test_relay_cli.py
+++ b/tests/cli/test_relay_cli.py
@@ -1,0 +1,208 @@
+"""Tests for the relay-facing CLI: `mship pair`, `mship relay setup`,
+and the `mship serve --relay` wiring (Task B7)."""
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+
+runner = CliRunner()
+
+
+def _override(config_path: Path, state_dir: Path):
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(config_path)
+    container.state_dir.override(state_dir)
+
+
+def _reset():
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override()
+    container.config.reset()
+    container.state_manager.reset_override()
+    container.state_manager.reset()
+
+
+@pytest.fixture
+def relay_configured_workspace(workspace: Path, monkeypatch):
+    """The standard `workspace` fixture + a `relay:` block + a seeded serve token."""
+    monkeypatch.delenv("MSHIP_SERVE_TOKEN", raising=False)
+
+    config = workspace / "mothership.yaml"
+    # Append a relay block and rename the workspace so subdomain slugging is exercised.
+    text = config.read_text().replace(
+        "workspace: test-platform",
+        "workspace: Mship Workspace\n\nrelay:\n  host: relay.example.com\n  ssh_port: 2222\n  user: tunnel",
+    )
+    config.write_text(text)
+
+    state_dir = workspace / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    # Seed a serve token so `mship pair` output is deterministic.
+    (state_dir / "serve-token").write_text("seeded-token-value\n")
+
+    _override(config, state_dir)
+    yield workspace
+    _reset()
+
+
+@pytest.fixture
+def workspace_no_relay(workspace: Path, monkeypatch):
+    """The standard `workspace` fixture with NO `relay:` block — `pair` errors cleanly."""
+    monkeypatch.delenv("MSHIP_SERVE_TOKEN", raising=False)
+    config = workspace / "mothership.yaml"
+    state_dir = workspace / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    _override(config, state_dir)
+    yield workspace
+    _reset()
+
+
+# --- mship pair ---
+
+
+def test_pair_outputs_deeplink(relay_configured_workspace):
+    r = runner.invoke(app, ["pair"])
+    assert r.exit_code == 0, r.output
+    assert "groundcontrol://add?" in r.output
+    assert "workspace=" in r.output
+
+
+def test_pair_url_uses_subdomain_and_relay_host(relay_configured_workspace):
+    """The deep-link url is https://<workspace-slug>.<relay-host>, percent-encoded."""
+    r = runner.invoke(app, ["pair"])
+    assert r.exit_code == 0, r.output
+    # workspace "Mship Workspace" → slug "mship-workspace"; host from the relay block.
+    assert "mship-workspace.relay.example.com" in r.output
+    # the seeded token rides along
+    assert "seeded-token-value" in r.output
+
+
+def test_pair_errors_without_relay(workspace_no_relay):
+    r = runner.invoke(app, ["pair"])
+    assert r.exit_code != 0
+    assert "relay" in r.output.lower()
+
+
+# --- mship relay setup ---
+
+
+def test_relay_setup_prints_public_key(tmp_path, monkeypatch):
+    """`mship relay setup` prints the relay public key (ssh-ed25519 line).
+
+    We point HOME at a tmp dir and pre-create the key so no real `ssh-keygen`
+    subprocess runs in the test.
+    """
+    fake_home = tmp_path / "home"
+    key_dir = fake_home / ".mothership"
+    key_dir.mkdir(parents=True)
+    key = key_dir / "relay_ed25519"
+    key.write_text("PRIVATE-KEY-MATERIAL\n")
+    (Path(str(key) + ".pub")).write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 mship-relay\n")
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    r = runner.invoke(app, ["relay", "setup"])
+    assert r.exit_code == 0, r.output
+    assert "ssh-ed25519 " in r.output
+    assert "pubkeys" in r.output  # the allow-list instruction
+
+
+def test_relay_setup_generates_key_when_absent(tmp_path, monkeypatch):
+    """When no key exists, `relay setup` runs the key generator and prints the pubkey.
+
+    No real `ssh-keygen` runs: we patch the keys module's subprocess.run (which the
+    default runner calls) with a fake that writes a stub key + pub file.
+    """
+    fake_home = tmp_path / "home2"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    import mship.core.relay.keys as keys_mod
+
+    class _CompletedStub:
+        returncode = 0
+
+    def fake_run(argv, *args, **kwargs):
+        # ssh-keygen -t ed25519 -f <path> -N "" -C mship-relay
+        f_idx = argv.index("-f")
+        key_path = Path(argv[f_idx + 1])
+        key_path.parent.mkdir(parents=True, exist_ok=True)
+        key_path.write_text("PRIV\n")
+        (Path(str(key_path) + ".pub")).write_text("ssh-ed25519 GENERATED mship-relay\n")
+        return _CompletedStub()
+
+    monkeypatch.setattr(keys_mod.subprocess, "run", fake_run)
+
+    r = runner.invoke(app, ["relay", "setup"])
+    assert r.exit_code == 0, r.output
+    assert "ssh-ed25519 GENERATED" in r.output
+
+
+# --- mship serve --relay (wiring) ---
+
+
+def test_serve_relay_wires_tunnel_and_loopback(relay_configured_workspace, tmp_path, monkeypatch):
+    """`serve --relay` binds uvicorn to loopback, starts+stops a supervised ssh
+    tunnel, requires the token, and prints the public URL + pairing QR.
+
+    No real uvicorn or ssh runs: uvicorn.run and TunnelSupervisor are faked.
+    """
+    # Pre-create the relay key under a fake HOME so no ssh-keygen subprocess runs.
+    fake_home = tmp_path / "home"
+    (fake_home / ".mothership").mkdir(parents=True)
+    key = fake_home / ".mothership" / "relay_ed25519"
+    key.write_text("PRIV\n")
+    (Path(str(key) + ".pub")).write_text("ssh-ed25519 AAAA mship-relay\n")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    seen: dict = {}
+    fake_sup = MagicMock()
+
+    def fake_supervisor_cls(*args, **kwargs):
+        seen["argv"] = kwargs.get("argv")
+        return fake_sup
+
+    def fake_uvicorn_run(api, host, port):
+        seen["uvicorn_host"] = host
+        seen["uvicorn_port"] = port
+        seen["start_called_before_run"] = fake_sup.start.called
+
+    with patch("uvicorn.run", fake_uvicorn_run), \
+         patch("mship.core.relay.tunnel.TunnelSupervisor", fake_supervisor_cls):
+        r = runner.invoke(
+            app,
+            ["serve", "--relay", "--port", "47100", "--relay-tick", "0.01"],
+            catch_exceptions=False,
+        )
+
+    assert r.exit_code == 0, r.output
+    # uvicorn stays on loopback even though we're relaying.
+    assert seen["uvicorn_host"] == "127.0.0.1"
+    assert seen["uvicorn_port"] == 47100
+    # Tunnel started before serving, torn down after (finally → stop()).
+    assert seen["start_called_before_run"] is True
+    assert fake_sup.stop.called is True
+    # The supervised command is an ssh reverse tunnel to the relay host.
+    argv = seen["argv"]
+    assert argv[0] == "ssh"
+    assert "tunnel@relay.example.com" in argv
+    assert any("mship-workspace:80:localhost:47100" in a for a in argv)
+    # Output advertises the public URL + scannable deep-link.
+    assert "https://mship-workspace.relay.example.com" in r.output
+    assert "groundcontrol://add?" in r.output
+
+
+def test_serve_relay_requires_host(workspace_no_relay, tmp_path, monkeypatch):
+    """`--relay` with no configured relay block and no --relay-host errors cleanly."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    r = runner.invoke(app, ["serve", "--relay"])
+    assert r.exit_code != 0
+    assert "relay" in r.output.lower()

--- a/tests/core/relay/test_config.py
+++ b/tests/core/relay/test_config.py
@@ -1,0 +1,69 @@
+# tests/core/relay/test_config.py
+from pathlib import Path
+
+import pytest
+
+from mship.core.relay.config import RelayConfig
+from mship.core.config import ConfigLoader
+
+
+def test_from_mapping_full():
+    rc = RelayConfig.from_mapping({"host": "relay.example.com", "ssh_port": 2222, "user": "tunnel"})
+    assert rc.host == "relay.example.com"
+    assert rc.ssh_port == 2222
+    assert rc.user == "tunnel"
+
+def test_from_mapping_defaults_and_none():
+    assert RelayConfig.from_mapping(None) is None           # no relay configured
+    rc = RelayConfig.from_mapping({"host": "r.example.com"})
+    assert rc.ssh_port == 2222 and rc.user is None          # defaults
+
+
+def test_config_loader_parses_relay_block(tmp_path: Path):
+    """ConfigLoader.load exposes config.relay.host when a relay: block is present."""
+    # Create a minimal repo so ConfigLoader doesn't fail path validation
+    repo_dir = tmp_path / "myrepo"
+    repo_dir.mkdir()
+    (repo_dir / "Taskfile.yml").write_text("version: '3'\ntasks:\n  test:\n    cmds:\n      - echo ok\n")
+
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        """\
+workspace: test-relay
+relay:
+  host: relay.example.com
+  ssh_port: 2222
+  user: tunnel
+repos:
+  myrepo:
+    path: ./myrepo
+    type: service
+"""
+    )
+
+    config = ConfigLoader.load(cfg)
+    assert config.relay is not None
+    assert config.relay.host == "relay.example.com"
+    assert config.relay.ssh_port == 2222
+    assert config.relay.user == "tunnel"
+
+
+def test_config_loader_relay_none_when_absent(tmp_path: Path):
+    """WorkspaceConfig.relay is None when no relay: block is in mothership.yaml."""
+    repo_dir = tmp_path / "myrepo"
+    repo_dir.mkdir()
+    (repo_dir / "Taskfile.yml").write_text("version: '3'\ntasks:\n  test:\n    cmds:\n      - echo ok\n")
+
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        """\
+workspace: test-no-relay
+repos:
+  myrepo:
+    path: ./myrepo
+    type: service
+"""
+    )
+
+    config = ConfigLoader.load(cfg)
+    assert config.relay is None

--- a/tests/core/relay/test_keys.py
+++ b/tests/core/relay/test_keys.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from mship.core.relay.keys import ensure_relay_key, relay_public_key
+
+def test_generates_key_when_absent(tmp_path):
+    calls = []
+    def fake_run(argv):                      # stand in for subprocess
+        calls.append(argv)
+        key = tmp_path / ".mothership" / "relay_ed25519"
+        key.write_text("PRIV"); (Path(str(key) + ".pub")).write_text("ssh-ed25519 AAAA mship-relay\n")
+        return 0
+    path = ensure_relay_key(home=tmp_path, runner=fake_run)
+    assert path == tmp_path / ".mothership" / "relay_ed25519" or path.name == "relay_ed25519"
+    assert any("ssh-keygen" in a for a in calls[0])
+    assert relay_public_key(path).startswith("ssh-ed25519 ")
+
+def test_idempotent_when_present(tmp_path):
+    # pre-create the key; runner must NOT be called
+    mothership_dir = tmp_path / ".mothership"
+    mothership_dir.mkdir(parents=True, exist_ok=True)
+    key_path = mothership_dir / "relay_ed25519"
+    key_path.write_text("PRIV")
+    pub_path = Path(str(key_path) + ".pub")
+    pub_path.write_text("ssh-ed25519 BBBB mship-relay\n")
+
+    calls = []
+    def fake_run(argv):
+        calls.append(argv)
+        return 0
+
+    path = ensure_relay_key(home=tmp_path, runner=fake_run)
+    assert len(calls) == 0, "runner must NOT be called when key already exists"
+    assert path == key_path

--- a/tests/core/relay/test_pairing.py
+++ b/tests/core/relay/test_pairing.py
@@ -1,0 +1,12 @@
+from mship.core.relay.pairing import build_pair_link, parse_pair_link
+
+def test_round_trip():
+    link = build_pair_link(url="https://ws.relay.example.com", token="tok en/+=", workspace="ws")
+    assert link.startswith("groundcontrol://add?")
+    p = parse_pair_link(link)
+    assert p == {"url": "https://ws.relay.example.com", "token": "tok en/+=", "workspace": "ws"}
+
+def test_parse_rejects_wrong_scheme():
+    import pytest
+    with pytest.raises(ValueError):
+        parse_pair_link("https://add?url=x")

--- a/tests/core/relay/test_token.py
+++ b/tests/core/relay/test_token.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from mship.core.relay.token import ensure_serve_token
+
+def test_generates_and_persists(tmp_path: Path):
+    t1 = ensure_serve_token(tmp_path)            # tmp_path = workspace root
+    assert isinstance(t1, str) and len(t1) >= 32
+    assert (tmp_path / ".mothership" / "serve-token").read_text().strip() == t1
+    t2 = ensure_serve_token(tmp_path)            # stable across calls
+    assert t2 == t1
+
+def test_respects_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("MSHIP_SERVE_TOKEN", "explicit")
+    assert ensure_serve_token(tmp_path) == "explicit"   # env wins, no file write
+    assert not (tmp_path / ".mothership" / "serve-token").exists()

--- a/tests/core/relay/test_tunnel_args.py
+++ b/tests/core/relay/test_tunnel_args.py
@@ -5,6 +5,12 @@ from mship.core.relay.tunnel import subdomain_for, build_tunnel_argv
 def test_subdomain_slugs_workspace():
     assert subdomain_for("Mship Workspace") == "mship-workspace"
 
+def test_subdomain_no_phrase_heuristic_colon():
+    assert subdomain_for("team: alpha") == "team-alpha"
+
+def test_subdomain_no_phrase_heuristic_dot():
+    assert subdomain_for("My.Cool Workspace") == "my-cool-workspace"
+
 def test_build_tunnel_argv():
     rc = RelayConfig(host="relay.example.com", ssh_port=2222, user="tunnel")
     argv = build_tunnel_argv(rc, subdomain="mship-workspace", local_port=47100, key_path=Path("/k/relay_ed25519"))

--- a/tests/core/relay/test_tunnel_args.py
+++ b/tests/core/relay/test_tunnel_args.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from mship.core.relay.config import RelayConfig
+from mship.core.relay.tunnel import subdomain_for, build_tunnel_argv
+
+def test_subdomain_slugs_workspace():
+    assert subdomain_for("Mship Workspace") == "mship-workspace"
+
+def test_build_tunnel_argv():
+    rc = RelayConfig(host="relay.example.com", ssh_port=2222, user="tunnel")
+    argv = build_tunnel_argv(rc, subdomain="mship-workspace", local_port=47100, key_path=Path("/k/relay_ed25519"))
+    assert argv[0] == "ssh"
+    assert "-R" in argv and "mship-workspace:80:localhost:47100" in argv
+    assert "-p" in argv and "2222" in argv
+    assert "-i" in argv and "/k/relay_ed25519" in argv
+    assert argv[-1] == "tunnel@relay.example.com"
+    # resilience options present
+    assert "-o" in argv and "ExitOnForwardFailure=yes" in argv and "ServerAliveInterval=30" in argv

--- a/tests/core/relay/test_tunnel_supervisor.py
+++ b/tests/core/relay/test_tunnel_supervisor.py
@@ -1,0 +1,37 @@
+from mship.core.relay.tunnel import TunnelSupervisor
+
+
+class FakeProc:
+    def __init__(self): self._alive = True; self.terminated = False
+    def poll(self): return None if self._alive else 0
+    def terminate(self): self.terminated = True; self._alive = False
+    def wait(self, timeout=None): self._alive = False; return 0
+
+
+def test_start_then_stop_terminates_process():
+    procs = []
+    def factory(argv): p = FakeProc(); procs.append(p); return p
+    sup = TunnelSupervisor(argv=["ssh", "..."], proc_factory=factory)
+    sup.start()
+    assert sup.is_running() and len(procs) == 1
+    sup.stop()
+    assert procs[0].terminated and not sup.is_running()
+
+
+def test_restart_on_unexpected_exit():
+    """tick() respawns the process when it exits unexpectedly (not via stop())."""
+    procs = []
+    def factory(argv): p = FakeProc(); procs.append(p); return p
+
+    sup = TunnelSupervisor(argv=["ssh", "..."], proc_factory=factory, backoff_delay=0)
+    sup.start()
+    assert len(procs) == 1 and sup.is_running()
+
+    # Simulate unexpected process exit (non-None poll return = process died)
+    procs[0]._alive = False
+
+    # tick() should detect the exit and spawn a replacement
+    sup.tick()
+
+    assert len(procs) == 2, "supervisor should have spawned a replacement proc"
+    assert sup.is_running(), "supervisor should report running after respawn"

--- a/tests/core/relay/test_tunnel_supervisor.py
+++ b/tests/core/relay/test_tunnel_supervisor.py
@@ -35,3 +35,35 @@ def test_restart_on_unexpected_exit():
 
     assert len(procs) == 2, "supervisor should have spawned a replacement proc"
     assert sup.is_running(), "supervisor should report running after respawn"
+
+
+def test_backoff_gates_respawn():
+    """tick() must NOT respawn until the backoff delay has elapsed."""
+    procs = []
+    def factory(argv): p = FakeProc(); procs.append(p); return p
+
+    t = [0.0]
+    def fake_clock(): return t[0]
+
+    sup = TunnelSupervisor(
+        argv=["ssh", "..."],
+        proc_factory=factory,
+        backoff_delay=1.0,
+        clock=fake_clock,
+    )
+    sup.start()
+    assert len(procs) == 1
+
+    # Kill the process
+    procs[0]._alive = False
+
+    # tick() at t=0: delay=1.0, elapsed=0.0 → must NOT respawn
+    t[0] = 0.0
+    sup.tick()
+    assert len(procs) == 1, "should NOT have respawned before backoff delay elapsed"
+
+    # Advance clock past the backoff delay
+    t[0] = 1.5
+    sup.tick()
+    assert len(procs) == 2, "should have respawned after backoff delay elapsed"
+    assert sup.is_running()

--- a/uv.lock
+++ b/uv.lock
@@ -261,6 +261,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "segno" },
     { name = "textual" },
     { name = "typer" },
     { name = "uvicorn" },
@@ -283,6 +284,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
+    { name = "segno", specifier = ">=1.6.6" },
     { name = "textual", specifier = ">=0.80" },
     { name = "typer", specifier = ">=0.15" },
     { name = "uvicorn", specifier = ">=0.27" },
@@ -498,6 +500,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "segno"
+version = "1.6.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/2e/b396f750c53f570055bf5a9fc1ace09bed2dff013c73b7afec5702a581ba/segno-1.6.6.tar.gz", hash = "sha256:e60933afc4b52137d323a4434c8340e0ce1e58cec71439e46680d4db188f11b3", size = 1628586, upload-time = "2025-03-12T22:12:53.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/02/12c73fd423eb9577b97fc1924966b929eff7074ae6b2e15dd3d30cb9e4ae/segno-1.6.6-py3-none-any.whl", hash = "sha256:28c7d081ed0cf935e0411293a465efd4d500704072cdb039778a2ab8736190c7", size = 76503, upload-time = "2025-03-12T22:12:48.106Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Low-friction phone ↔ `mship serve` connection: reach your serves from anywhere with **no VPN**, via a **self-hosted sish relay**, and pair the Ground Control app by **scanning a QR** (no typing URLs or tokens). Spans two repos (`mothership` + `ground-control`) as one feature; see the coordination block for merge order.

Spec: `low-friction-phone-connection-to-mship` (approved). Refs MOS issues for the Ground Control epic.

### Phase A — relay hosting kit (`mothership`)
- `docker/relay/docker-compose.yml` (sish, auto-TLS via Let's Encrypt on-demand + accept-terms, SSH-key allowlist, persistent host key), `scripts/relay-bootstrap.sh`, `docs/relay-hosting.md` (wildcard DNS + key allowlist runbook). All BYO — nothing points at vendor infra.

### Phase B — mship client integration (`mothership`)
- New reusable core package `src/mship/core/relay/` (no CLI coupling — the daemon seam): `config` (`relay:` block), `token` (auto-gen + persist, 0600), `keys` (dedicated `~/.mothership/relay_ed25519`), `tunnel` (`subdomain_for`, `build_tunnel_argv`, `TunnelSupervisor` with capped backoff), `pairing` (`groundcontrol://add` deep-link codec).
- `mship serve --relay [/--relay-host]`: binds uvicorn to loopback, supervises an `ssh -R` reverse tunnel, **requires an API bearer token whenever relaying** (auto-generated if unset), prints the public `https://<workspace>.<relay>` URL + a pairing QR.
- `mship pair` (QR via `segno`) and `mship relay setup` (prints the pubkey to allow-list).

### Phase C — pairing in the app (`ground-control`)
- `PairLink.parse` (pure-JVM) decodes the `groundcontrol://add?url&token&workspace` link; Settings → **Scan QR** (ZXing) + a `groundcontrol://add` deep-link intent-filter add a connection with no typing. Re-pairing the same workspace updates in place (dedupe by `baseUrl`, no duplicates).

## Test plan
- TDD throughout. `mothership`: relay core + CLI tests (token, keys, subdomain+argv, supervisor backoff, pairing codec, config, `pair`/`relay setup`/`serve --relay` wiring incl. the "no tunnel without token" + loopback-bind assertions). **Full mothership suite: 1430 passed.**
- `ground-control`: `PairLink` unit tests incl. a **cross-compat test** locking the exact Python↔Kotlin encoding (`tok%20en%2F%2B%3D` ↔ `tok en/+=`); pairing upsert-by-baseUrl tests. `./gradlew assembleDebug` + **21 unit tests green** (no emulator → UI is build-verified).

## Known v0 limitations (accepted)
- Truly proving end-to-end reachability requires you to self-host the relay (VPS + wildcard DNS + TLS) once — by design.
- `--relay` / `--relay-host` split (Typer can't express a value-optional flag cleanly).
- App deep links handled at cold-start `onCreate` (not `onNewIntent` when already running).
- `ssh-keygen` prints its usual output on first key generation.
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `low-friction-phone-connection-sish-relay`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/2 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/187 | this PR |

⚠ Merge in order: ground-control → mothership