### PR TITLE
feat(serve): include affected_repos in GET /specs response [MOS-179]

### DIFF
--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -97,7 +97,7 @@ def create_app(
     @app.get("/specs")
     def list_specs():
         return [
-            {"id": s.id, "title": s.title, "status": s.status, "task_slug": s.task_slug}
+            {"id": s.id, "title": s.title, "status": s.status, "task_slug": s.task_slug, "affected_repos": s.affected_repos}
             for s in store.list()
         ]
 

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -43,7 +43,7 @@ def test_list_specs(tmp_path):
     _seed_spec(tmp_path)
     r = TestClient(_app(tmp_path)).get("/specs")
     assert r.status_code == 200
-    assert r.json() == [{"id": "dq", "title": "Decision queue", "status": "needs_review", "task_slug": "dq"}]
+    assert r.json() == [{"id": "dq", "title": "Decision queue", "status": "needs_review", "task_slug": "dq", "affected_repos": []}]
 
 
 def test_get_spec_and_404(tmp_path):


### PR DESCRIPTION
## Summary

- `GET /specs` now returns `affected_repos` alongside `id`, `title`, `status`, and `task_slug` for each spec.
- One-line change in `src/mship/core/serve.py`: added `"affected_repos": s.affected_repos` to the `list_specs()` response dict.

Refs MOS-179

## Test plan

- TDD: updated `tests/core/test_serve.py::test_list_specs` to assert the new `affected_repos` key (seeded spec has `[]`). Confirmed it failed before the fix, passes after.
- Full `tests/core/test_serve.py` suite (35 tests) green — no regressions.

---
_Generated by [Claude Code](https://claude.ai/code/session_012auvaQkWnXYw9JPNZmHEuT)_