### PR TITLE
feat(slug): preserve issue IDs past truncation boundary [MOS-178]

### DIFF
--- a/src/mship/util/slug.py
+++ b/src/mship/util/slug.py
@@ -2,6 +2,7 @@ import re
 
 MAX_SLUG_LEN = 40
 _PHRASE_SEPARATORS = ("—", ": ", ". ")
+_ISSUE_ID_RE = re.compile(r"[a-z]+-\d+")
 
 
 def slugify(text: str) -> str:
@@ -12,6 +13,9 @@ def slugify(text: str) -> str:
     result to MAX_SLUG_LEN at a word boundary. Version numbers like
     `v1.0` and URL-like strings are preserved because the heuristic
     requires whitespace after `:` and `.`.
+
+    Issue IDs (e.g. MOS-170) that fall past the truncation point are
+    re-appended so they survive in branch names and auto-link in Linear.
     """
     cut = -1
     for sep in _PHRASE_SEPARATORS:
@@ -25,7 +29,14 @@ def slugify(text: str) -> str:
     text = re.sub(r"[\s-]+", "-", text)
     text = text.strip("-")
     if len(text) > MAX_SLUG_LEN:
+        full_slug = text
         boundary = text.rfind("-", 0, MAX_SLUG_LEN + 1)
         text = text[:boundary] if boundary > 0 else text[:MAX_SLUG_LEN]
         text = text.rstrip("-")
+        # Append any issue IDs that got truncated off.
+        full_ids = _ISSUE_ID_RE.findall(full_slug)
+        kept_ids = set(_ISSUE_ID_RE.findall(text))
+        missing = [i for i in full_ids if i not in kept_ids]
+        if missing:
+            text = text + "-" + "-".join(missing)
     return text

--- a/tests/util/test_slug.py
+++ b/tests/util/test_slug.py
@@ -78,3 +78,34 @@ def test_long_single_word_hard_truncated():
 def test_short_input_unchanged_by_truncation():
     # Truncation should not affect inputs already within limits.
     assert slugify("add labels to tasks") == "add-labels-to-tasks"
+
+
+def test_multi_issue_ids_preserved_after_truncation():
+    # All issue IDs survive even when they fall past the word-boundary cut.
+    text = (
+        "long description with lots of filler words to force truncation "
+        "here MOS-170 MOS-171"
+    )
+    s = slugify(text)
+    assert "mos-170" in s
+    assert "mos-171" in s
+
+
+def test_single_issue_id_preserved_after_truncation():
+    # A trailing issue ID survives truncation of a long description.
+    text = "offboarding progress reporter surface per task offboarding MOS-170"
+    s = slugify(text)
+    assert "mos-170" in s
+
+
+def test_issue_id_already_in_truncated_slug_not_duplicated():
+    # An issue ID that fits within the truncation window is not appended again.
+    s = slugify("MOS-170 short")
+    assert s.count("mos-170") == 1
+
+
+def test_non_issue_tokens_not_preserved_past_truncation():
+    # Only tokens matching the issue-ID pattern are preserved; plain words are not.
+    text = "word " * 20 + "plain"
+    s = slugify(text)
+    assert "plain" not in s


### PR DESCRIPTION
## Summary

- `slugify` now re-appends any issue IDs (tokens matching `[a-z]+-\d+`, e.g. `mos-170`) that fall past the word-boundary truncation point.
- Existing first-phrase split and word-boundary truncation logic is unchanged — the new code only runs when truncation actually happened, and only for issue-ID tokens.
- Branch names remain lowercase alphanumeric + hyphens; the slug may exceed `MAX_SLUG_LEN` by the width of the appended IDs, which is acceptable per the spec ("reasonable length").

Refs MOS-178

## Test plan

- TDD: added 4 new tests in `tests/util/test_slug.py`:
  - `test_multi_issue_ids_preserved_after_truncation` — both `mos-170` and `mos-171` survive
  - `test_single_issue_id_preserved_after_truncation` — single trailing ID survives
  - `test_issue_id_already_in_truncated_slug_not_duplicated` — IDs that fit in the window aren't doubled
  - `test_non_issue_tokens_not_preserved_past_truncation` — plain words that get truncated stay gone
- Confirmed the two new truncation tests failed before the fix, pass after.
- All 19 slug tests green.
- No regressions: full target suite (127 tests across `test_slug`, `test_serve`, `test_spec_discovery`, `test_spec_view`, `test_spec`) green.

---
_Generated by [Claude Code](https://claude.ai/code/session_012auvaQkWnXYw9JPNZmHEuT)_