### PR TITLE
fix(view spec): no-active-task falls back to newest structured spec [MOS-175]

### DIFF
--- a/src/mship/cli/view/spec.py
+++ b/src/mship/cli/view/spec.py
@@ -291,10 +291,23 @@ def register(app: typer.Typer, get_container):
         if name_or_path is None:
             if watch:
                 cli_task_for_view = task
-            else:
+            elif task is not None:
+                # Explicit --task: resolve or exit on unknown/ambiguous.
                 from mship.cli._resolve import resolve_or_exit
                 t = resolve_or_exit(state, task)
                 resolved_task_slug = t.slug
+            else:
+                # No explicit --task: try to resolve the active task, but fall
+                # back to newest spec in workspace if none is active (MOS-175).
+                try:
+                    t, _ = resolve_task(
+                        state, cli_task=None,
+                        env_task=os.environ.get("MSHIP_TASK"),
+                        cwd=_P.cwd(),
+                    )
+                    resolved_task_slug = t.slug
+                except (NoActiveTaskError, AmbiguousTaskError, UnknownTaskError):
+                    resolved_task_slug = None
 
         # --web still requires a resolvable spec path at request time.
         if web:

--- a/src/mship/core/view/spec_discovery.py
+++ b/src/mship/core/view/spec_discovery.py
@@ -87,6 +87,11 @@ def find_spec(
     search_roots = _resolve_search_roots(workspace_root, task, state, spec_paths)
 
     if name_or_path is None:
+        if task is None:
+            # Also search the structured specs/ dir for newest-mtime lookup.
+            extra = workspace_root / SPECS_DIR
+            if extra not in search_roots:
+                search_roots = search_roots + [extra]
         return _newest_across(search_roots, task)
 
     # Try specs/ dir by frontmatter id before the legacy search-roots name loop.

--- a/tests/cli/view/test_spec_view.py
+++ b/tests/cli/view/test_spec_view.py
@@ -414,3 +414,33 @@ def test_spec_cli_non_tty_does_not_construct_specview(tmp_path, monkeypatch):
         assert constructed == [], "SpecView must not be constructed in non-TTY mode"
     finally:
         _reset_overrides()
+
+
+# --- MOS-175: no-active-task fallback to newest structured spec ---
+
+
+def test_spec_cli_non_tty_no_active_task_renders_newest_structured_spec(tmp_path):
+    """Non-TTY, no active task: fall back to newest spec in <workspace>/specs/. MOS-175."""
+    runner = CliRunner()
+    _setup_workspace(tmp_path)
+    specs_dir = tmp_path / "specs"
+    specs_dir.mkdir()
+    (specs_dir / "my-spec.md").write_text("# My Spec\n\nStructured spec body.\n")
+    try:
+        result = runner.invoke(app, ["view", "spec"])
+        assert result.exit_code == 0, result.output
+        assert "Structured spec body" in result.output
+    finally:
+        _reset_overrides()
+
+
+def test_spec_cli_explicit_task_still_exits_on_unknown(tmp_path):
+    """--task <unknown> still errors even with MOS-175 fallback in place."""
+    runner = CliRunner()
+    _setup_workspace(tmp_path)
+    try:
+        result = runner.invoke(app, ["view", "spec", "--task", "nope"])
+        assert result.exit_code != 0
+        assert "nope" in result.output
+    finally:
+        _reset_overrides()

--- a/tests/core/view/test_spec_discovery.py
+++ b/tests/core/view/test_spec_discovery.py
@@ -140,3 +140,24 @@ def test_find_spec_resolves_specs_dir_by_task_slug(tmp_path: Path):
         affected_repos=["a"], branch="feat/dq",
     )})
     assert find_spec(tmp_path, None, task="dq", state=state) == path
+
+
+def test_find_spec_newest_structured_specs_dir_no_task(tmp_path: Path):
+    """find_spec(name=None, task=None) returns the newest spec from <workspace>/specs/."""
+    path = _seed_spec(tmp_path, "structured-newest")
+    result = find_spec(workspace_root=tmp_path, name_or_path=None, task=None)
+    assert result == path
+
+
+def test_find_spec_newest_prefers_higher_mtime_across_dirs(tmp_path: Path):
+    """When both legacy and structured dirs exist, newest mtime wins."""
+    legacy = tmp_path / "docs" / "superpowers" / "specs"
+    legacy.mkdir(parents=True)
+    older = legacy / "old-legacy.md"
+    older.write_text("# old\n")
+    import os as _os, time as _time
+    _os.utime(older, (_time.time() - 200, _time.time() - 200))
+
+    path = _seed_spec(tmp_path, "newer-structured")
+    result = find_spec(workspace_root=tmp_path, name_or_path=None, task=None)
+    assert result == path


### PR DESCRIPTION
## Summary

Fixes two root causes that made `mship view spec` (bare, no name) unusable without an active task:

**1. CLI exits instead of falling back (`src/mship/cli/view/spec.py`)**

When `name_or_path` is `None` and `--watch` is not set, the code called `resolve_or_exit(state, task)` unconditionally — which hard-exits with "no active task" even though the command docstring promises "newest by default". Fix: when `--task` is *not* explicitly provided, catch `NoActiveTaskError`/`AmbiguousTaskError`/`UnknownTaskError` and proceed with `task=None`. An explicit `--task <slug>` still resolves-or-exits as before, preserving `test_spec_cli_rejects_unknown_task` behaviour.

**2. `find_spec(name=None, task=None)` misses `specs/` dir (`src/mship/core/view/spec_discovery.py`)**

`_resolve_search_roots` only included `docs/superpowers/specs` (legacy) and worktree paths; the structured `<workspace>/specs/` directory was never searched in the newest-mtime path. Fix: when `name_or_path=None` and `task=None`, append `workspace_root / SPECS_DIR` to the search roots before calling `_newest_across`. The existing name-based lookup via `_find_in_specs_dir` is unchanged.

`mship view spec <id>` (with explicit name) was already task-independent and is not regressed.

Refs MOS-175

## Test plan

TDD — tests written and confirmed failing before implementation, passing after:

- `tests/core/view/test_spec_discovery.py`:
  - `test_find_spec_newest_structured_specs_dir_no_task` — `find_spec(name=None, task=None)` returns the newest file from `<workspace>/specs/`
  - `test_find_spec_newest_prefers_higher_mtime_across_dirs` — when both legacy and structured dirs exist, highest mtime wins

- `tests/cli/view/test_spec_view.py`:
  - `test_spec_cli_non_tty_no_active_task_renders_newest_structured_spec` — non-TTY `mship view spec` with empty task state, structured spec in `specs/` → exit 0, content printed
  - `test_spec_cli_explicit_task_still_exits_on_unknown` — `--task nope` still errors (no regression)

Full target suite: **127 passed**, 1 pre-existing git-sandbox error, 0 regressions.

---
_Generated by [Claude Code](https://claude.ai/code/session_012auvaQkWnXYw9JPNZmHEuT)_