### PR TITLE
spec body additional sections MOS-176

### DIFF
--- a/src/mship/core/spec.py
+++ b/src/mship/core/spec.py
@@ -88,6 +88,12 @@ def validate_transition(current: str, target: str) -> None:
         raise InvalidTransition(f"illegal spec transition: {current} -> {target}")
 
 
+class BodySection(BaseModel):
+    """An extra spec body section beyond the canonical three (e.g. Architecture, Testing)."""
+    heading: str
+    body: str
+
+
 class SpecDraft(BaseModel):
     """The draftable subset a model produces; ingested by `mship spec apply`.
 
@@ -101,3 +107,4 @@ class SpecDraft(BaseModel):
     affected_repos: list[str] = []
     acceptance_criteria: list[str] = []
     open_questions: list[str] = []
+    additional_sections: list[BodySection] = []

--- a/src/mship/core/spec_body.py
+++ b/src/mship/core/spec_body.py
@@ -3,12 +3,22 @@ from __future__ import annotations
 REQUIRED_SECTIONS: tuple[str, ...] = ("Problem", "User story", "Approach")
 
 
-def render_body(problem: str, user_story: str, approach: str) -> str:
-    return (
+def render_body(
+    problem: str,
+    user_story: str,
+    approach: str,
+    additional_sections: list[tuple[str, str]] | None = None,
+) -> str:
+    """Render the canonical three sections, then append any extra (heading, body)
+    sections after Approach — for design-heavy specs (Architecture, Testing, …)."""
+    body = (
         f"## Problem\n\n{problem.strip()}\n\n"
         f"## User story\n\n{user_story.strip()}\n\n"
         f"## Approach\n\n{approach.strip()}\n"
     )
+    for heading, text in additional_sections or []:
+        body += f"\n## {heading.strip()}\n\n{text.strip()}\n"
+    return body
 
 
 def parse_body_sections(body: str) -> dict[str, str]:

--- a/src/mship/core/spec_draft.py
+++ b/src/mship/core/spec_draft.py
@@ -70,7 +70,8 @@ object matching this shape — no prose, no markdown fence:
   "risks": ["<known risk>"],
   "affected_repos": ["<repo>"],
   "acceptance_criteria": ["<testable, user-visible outcome>"],
-  "open_questions": ["<must be resolved before approval>"]
+  "open_questions": ["<must be resolved before approval>"],
+  "additional_sections": [{{"heading": "<optional extra section, e.g. Architecture | Testing | Security>", "body": "<prose; include only for design-heavy specs>"}}]
 }}
 
 ## Intent
@@ -93,7 +94,10 @@ def apply_draft(spec: Spec, draft: SpecDraft) -> Spec:
     """Merge a SpecDraft into `spec` in place: render the canonical body, set the
     structured fields, and assign deterministic `ac`/`q` ids. Does NOT change
     status/updated_at — the caller owns the lifecycle transition + persistence."""
-    spec.body = render_body(draft.problem, draft.user_story, draft.approach)
+    spec.body = render_body(
+        draft.problem, draft.user_story, draft.approach,
+        additional_sections=[(s.heading, s.body) for s in draft.additional_sections],
+    )
     spec.non_goals = list(draft.non_goals)
     spec.risks = list(draft.risks)
     spec.affected_repos = list(draft.affected_repos)

--- a/tests/cli/view/test_view_cli.py
+++ b/tests/cli/view/test_view_cli.py
@@ -82,11 +82,14 @@ def test_journal_watch_with_unknown_task_constructs_view_without_exit(empty_work
     assert view._cli_task == "missing"
 
 
-def test_spec_non_watch_no_task_exits_1(empty_workspace):
+def test_spec_non_watch_no_task_empty_workspace_exits_1(empty_workspace):
+    # MOS-175 (#195): `view spec` with no active task no longer errors "no active
+    # task" — it falls back to the newest spec. In an empty workspace (no specs)
+    # that fallback finds nothing, so it exits 1 with a "no specs" message.
     runner = CliRunner()
     result = runner.invoke(app, ["view", "spec"])
     assert result.exit_code == 1
-    assert "no active task" in (result.output or "").lower()
+    assert "no specs" in (result.output or "").lower()
 
 
 def _force_tty(monkeypatch):

--- a/tests/core/test_spec_body.py
+++ b/tests/core/test_spec_body.py
@@ -34,3 +34,22 @@ def test_extra_headings_do_not_break_validation():
     from mship.core.spec_body import render_body, validate_body_structure
     body = render_body("p", "u", "a") + "\n## Extra\n\nbonus section\n"
     assert validate_body_structure(body) == []   # all required still present
+
+
+def test_render_body_appends_additional_sections_after_approach():
+    from mship.core.spec_body import render_body, parse_body_sections, validate_body_structure
+    body = render_body("p", "u", "a", additional_sections=[
+        ("Architecture", "the arch"),
+        ("Testing", "the tests"),
+    ])
+    sections = parse_body_sections(body)
+    assert sections["Problem"] == "p"
+    assert sections["Architecture"] == "the arch"
+    assert sections["Testing"] == "the tests"
+    assert validate_body_structure(body) == []                        # required gate still holds
+    assert body.index("## Approach") < body.index("## Architecture")  # extras come after Approach
+
+
+def test_render_body_without_additional_sections_unchanged():
+    from mship.core.spec_body import render_body
+    assert render_body("p", "u", "a") == render_body("p", "u", "a", additional_sections=[])

--- a/tests/core/test_spec_draft.py
+++ b/tests/core/test_spec_draft.py
@@ -72,3 +72,25 @@ def test_new_spec_unslugifiable_title_raises():
     now = datetime(2026, 6, 14, tzinfo=timezone.utc)
     with pytest.raises(ValueError):
         new_spec("!!!", now=now)             # slug collapses to empty
+
+
+def test_specdraft_accepts_additional_sections():
+    d = SpecDraft(problem="P", user_story="U", approach="A",
+                  additional_sections=[{"heading": "Architecture", "body": "arch"}])
+    assert d.additional_sections[0].heading == "Architecture"
+    assert d.additional_sections[0].body == "arch"
+
+
+def test_apply_draft_renders_additional_sections():
+    from mship.core.spec_body import parse_body_sections, validate_body_structure
+    spec = _spec()
+    draft = SpecDraft(problem="P", user_story="U", approach="A",
+                      additional_sections=[{"heading": "Testing", "body": "the tests"}])
+    out = apply_draft(spec, draft)
+    sections = parse_body_sections(out.body)
+    assert sections["Testing"] == "the tests"
+    assert validate_body_structure(out.body) == []   # required still present
+
+
+def test_build_draft_prompt_mentions_additional_sections():
+    assert "additional_sections" in build_draft_prompt("x", "intent")


### PR DESCRIPTION
## Summary

**MOS-176 — richer spec bodies.** A spec can now carry **additional sections** beyond the canonical Problem / User story / Approach, so design-heavy specs (Architecture, Testing, Security, …) keep first-class structure instead of being flattened into Approach prose.

- `SpecDraft` gains `additional_sections: list[BodySection]` (each `{heading, body}`).
- `render_body(..., additional_sections=...)` appends `## {heading}` blocks **after** Approach.
- `apply_draft` passes them through; `build_draft_prompt` advertises the optional field so the drafting agent can emit them.
- The required-three validation gate is **unchanged** — `validate_body_structure` already only checks the three are present, and `parse_body_sections` already round-trips arbitrary `##` headings.

**Folded-in fix (MOS-175 / #195 follow-up).** #195 changed `view spec` with no active task to fall back to the newest spec, but left a stale CLI test (`test_spec_non_watch_no_task_exits_1`) asserting the old `"no active task"` message — which was **failing on `main`**. Updated it to assert the new behavior (empty workspace → exit 1 with a "no specs" message) and renamed it accordingly.

## Test plan

- TDD (RED→GREEN):
  - `tests/core/test_spec_body.py` — `render_body` appends extras after Approach; no-extras output unchanged.
  - `tests/core/test_spec_draft.py` — `SpecDraft` accepts `additional_sections`; `apply_draft` renders them and the body still validates; `build_draft_prompt` mentions the field.
- `tests/cli/view/test_view_cli.py` — stale no-task test updated to the post-#195 behavior; green.
- **Full mothership suite green via `mship test`** (exit 0).

Refs MOS-176
Refs MOS-175

Closes #195