### PR TITLE
example two-repo mothership.yaml MOS-174

### DIFF
--- a/examples/mothership.yaml
+++ b/examples/mothership.yaml
@@ -1,0 +1,37 @@
+# Example two-repo mship workspace — a teaching artifact.
+#
+# Copy this to your workspace root as `mothership.yaml` and adjust the names,
+# paths, and URLs. This is illustrative and intentionally separate from the
+# live mship-workspace config.
+#
+# Layout: members live as gitignored subdirectories cloned into the workspace
+# (each is its own git repo). On a machine that already has a member checked
+# out elsewhere, that member directory may instead be a symlink to the existing
+# checkout — mship treats either the same.
+#
+#   my-workspace/
+#     mothership.yaml      <- this file
+#     api/                 <- gitignored member repo (clone or symlink)
+#     shared/              <- gitignored member repo (clone or symlink)
+#
+# `mship` coordinates the members from the workspace root: spawn worktrees,
+# run tests/builds in dependency order, and open a PR per repo on finish.
+
+workspace: example-workspace
+
+repos:
+  # A shared library other repos compile against.
+  shared:
+    path: shared
+    type: library
+    base_branch: main
+    expected_branch: main
+
+  # A service that depends on `shared` at build time. Dependency ordering means
+  # `mship test` / `mship build` run `shared` before `api`.
+  api:
+    path: api
+    type: service
+    base_branch: main
+    expected_branch: main
+    depends_on: [shared]

--- a/tests/core/test_example_config.py
+++ b/tests/core/test_example_config.py
@@ -1,0 +1,25 @@
+"""The shipped example workspace config (examples/mothership.yaml) must stay valid."""
+from pathlib import Path
+
+import yaml
+
+from mship.core.config import WorkspaceConfig
+
+EXAMPLE = Path(__file__).resolve().parents[2] / "examples" / "mothership.yaml"
+
+
+def test_example_two_repo_config_parses():
+    raw = yaml.safe_load(EXAMPLE.read_text())
+    config = WorkspaceConfig(**raw)          # schema validation (no filesystem checks)
+    assert config.workspace
+    assert set(config.repos) == {"api", "shared"}
+    assert config.repos["api"].type == "service"
+    assert config.repos["shared"].type == "library"
+
+
+def test_example_declares_a_compile_dependency():
+    raw = yaml.safe_load(EXAMPLE.read_text())
+    config = WorkspaceConfig(**raw)
+    deps = config.repos["api"].depends_on
+    names = [(d.repo if hasattr(d, "repo") else d) for d in deps]
+    assert "shared" in names


### PR DESCRIPTION
## Summary

Ship an example two-repo `mothership.yaml` under `examples/` as a teaching artifact: a library + a service with a compile dependency, plus comments documenting the gitignored-subdir / symlink-an-existing-checkout layout. A test asserts the example stays schema-valid.

## Test plan
- `tests/core/test_example_config.py` (TDD red→green): the example parses into `WorkspaceConfig`, exposes the two repos with correct `type`s, and the compile dependency is present.
- This PR adds only `examples/` + a passing test.

> ⚠️ The full suite currently shows **one pre-existing failure unrelated to this change** — `tests/cli/view/test_view_cli.py::test_spec_non_watch_no_task_exits_1`, a stale test left by #195 (MOS-175) and **already fixed in open PR #196**. Merge #196 first and the suite is green here.

Refs MOS-174
