### PR TITLE
mship build command MOS-32

### DIFF
--- a/src/mship/cli/exec.py
+++ b/src/mship/cli/exec.py
@@ -433,6 +433,93 @@ def register(app: typer.Typer, get_container):
 
         output.print("All background services have exited")
 
+    @app.command(name="build")
+    def build_cmd(
+        run_all: bool = typer.Option(False, "--all", help="Build all repos even if one fails"),
+        repos: Optional[str] = typer.Option(None, "--repos", help="Comma-separated repo names to filter"),
+        tag: Optional[list[str]] = typer.Option(None, "--tag", help="Filter repos by tag"),
+        task: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),
+    ):
+        """Build artifacts across repos in dependency order (runs `task build`)."""
+        import os as _os
+        from pathlib import Path as _P
+        from mship.core.task_resolver import (
+            AmbiguousTaskError,
+            NoActiveTaskError,
+            UnknownTaskError,
+            resolve_task,
+        )
+
+        container = get_container()
+        output = Output()
+        state_mgr = container.state_manager()
+        state = state_mgr.load()
+        config = container.config()
+
+        # Scope repos to a task if one resolves (cwd / MSHIP_TASK / --task);
+        # otherwise build the whole workspace. Mirrors `run`'s graceful
+        # fallback — an explicit unknown --task is still an error.
+        task_slug: str | None
+        fallback_repos: list[str]
+        try:
+            t, _ = resolve_task(
+                state, cli_task=task,
+                env_task=_os.environ.get("MSHIP_TASK"), cwd=_P.cwd(),
+            )
+            fallback_repos = t.affected_repos
+            task_slug = t.slug
+        except UnknownTaskError as e:
+            known = ", ".join(sorted(state.tasks.keys())) or "(none)"
+            output.error(f"Unknown task: {e.slug}. Known: {known}.")
+            raise typer.Exit(1)
+        except (NoActiveTaskError, AmbiguousTaskError):
+            fallback_repos = list(config.repos.keys())
+            task_slug = None
+
+        try:
+            target_repos = _resolve_repos(config, fallback_repos, repos, tag)
+        except ValueError as e:
+            output.error(str(e))
+            raise typer.Exit(code=1)
+
+        executor = container.executor()
+        result = executor.execute(
+            "build", repos=target_repos, run_all=run_all, task_slug=task_slug,
+        )
+
+        def _status(r) -> str:
+            return "skip" if r.skipped else ("pass" if r.success else "fail")
+
+        if output.is_tty:
+            output.print("[bold]Build[/bold]")
+            for r in sorted(result.results, key=lambda r: r.repo):
+                st = _status(r)
+                color = "green" if st == "pass" else "yellow" if st == "skip" else "red"
+                output.print(f"  {r.repo}: [{color}]{st}[/{color}]  ({r.duration_ms / 1000:.1f}s)")
+                if st == "fail":
+                    for line in (r.shell_result.stderr or "").splitlines()[-20:]:
+                        output.print(f"      {line}")
+            if result.success:
+                output.print("")
+                output.success("Build succeeded")
+        else:
+            output.json({
+                "command": "build",
+                "repos": {
+                    r.repo: {
+                        "status": _status(r),
+                        "duration_ms": r.duration_ms,
+                        "exit_code": r.shell_result.returncode,
+                    }
+                    for r in result.results
+                },
+                "success": result.success,
+                "resolved_task": task_slug,
+            })
+
+        if not result.success:
+            raise typer.Exit(code=1)
+
     @app.command()
     def logs(
         service: Optional[str] = typer.Argument(None, help="Service name (omit with --all)"),

--- a/tests/cli/test_exec.py
+++ b/tests/cli/test_exec.py
@@ -1024,3 +1024,67 @@ def test_mship_logs_aliased_target_via_mship_yaml(workspace: Path):
         container.state_manager.reset_override()
         container.state_manager.reset()
         container.shell.reset_override()
+
+
+# ---------------------------------------------------------------------------
+# mship build (MOS-32): dependency-ordered `task build` per repo
+# ---------------------------------------------------------------------------
+
+
+def test_mship_build(configured_exec_app):
+    workspace, mock_shell = configured_exec_app
+    result = runner.invoke(app, ["build", "--task", "test-task"])
+    assert result.exit_code == 0, result.output
+    assert mock_shell.run_task.call_count == 2
+
+
+def test_mship_build_fail_fast(configured_exec_app):
+    workspace, mock_shell = configured_exec_app
+    # shared (tier 1) fails → auth-service (tier 2) never runs.
+    mock_shell.run_task.side_effect = [
+        ShellResult(returncode=1, stdout="", stderr="boom"),
+        ShellResult(returncode=0, stdout="ok", stderr=""),
+    ]
+    result = runner.invoke(app, ["build", "--task", "test-task"])
+    assert result.exit_code != 0
+    assert mock_shell.run_task.call_count == 1
+
+
+def test_mship_build_all_flag_continues_past_failure(configured_exec_app):
+    workspace, mock_shell = configured_exec_app
+    mock_shell.run_task.side_effect = [
+        ShellResult(returncode=1, stdout="", stderr="boom"),
+        ShellResult(returncode=0, stdout="ok", stderr=""),
+    ]
+    result = runner.invoke(app, ["build", "--all", "--task", "test-task"])
+    assert mock_shell.run_task.call_count == 2
+
+
+def test_mship_build_repos_filter(configured_exec_app):
+    workspace, mock_shell = configured_exec_app
+    result = runner.invoke(app, ["build", "--repos", "shared", "--task", "test-task"])
+    assert result.exit_code == 0
+    assert mock_shell.run_task.call_count == 1
+
+
+def test_mship_build_works_without_active_task(workspace: Path):
+    """build falls back to all repos when no task is active (workspace-scoped, like run)."""
+    state_dir = workspace / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(workspace / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok\n", stderr="")
+    container.shell.override(mock_shell)
+    try:
+        result = runner.invoke(app, ["build", "--repos", "shared"])
+        assert result.exit_code == 0, result.output
+        assert mock_shell.run_task.call_count == 1
+    finally:
+        container.shell.reset_override()
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()


### PR DESCRIPTION
## Summary

Add a first-class **`mship build`** command that runs `task build` per repo in **dependency order** — mirroring `mship test` / `mship run`.

- Deps build before dependents; **fails fast** (blocking) unless `--all`.
- Supports `--repos` / `--tag` / `--task`; honors `tasks.build` aliasing and `not_applicable: [build]`.
- Scopes to a task when one resolves (cwd / `MSHIP_TASK` / `--task`), else builds the whole workspace (graceful fallback like `run`).
- No executor change needed — the executor already runs arbitrary named tasks generically.

Out of scope (the issue's v2 open questions): the optional `run.build_first` auto-build, and `mship run --build`.

## Test plan
- `tests/cli/test_exec.py` (TDD red→green): per-repo build (2 invocations), fail-fast (1 invocation + exit≠0), `--all` continues past failure (2), `--repos` filter (1), no-active-task → all repos. Full `test_exec.py` suite green (41).
- `mship build --help` present.

> ⚠️ The full repo suite currently shows **one pre-existing, unrelated failure** — `test_spec_non_watch_no_task_exits_1`, the #195 stale test **already fixed in open PR #196**. Merge #196 first for a fully green suite.

Refs MOS-32
