### PR TITLE
journal json jsonl exporter MOS-101

### DIFF
--- a/src/mship/cli/log.py
+++ b/src/mship/cli/log.py
@@ -84,6 +84,12 @@ def register(app: typer.Typer, get_container):
         if fmt is not None and fmt not in ("json", "jsonl"):
             output.error("Invalid --format: use 'json' or 'jsonl'.")
             raise typer.Exit(code=1)
+        # --json/--format are read-only exporters; combining them with a message
+        # (a write) is contradictory — fail loud rather than silently dropping
+        # the flag (#101 review).
+        if message is not None and export_mode:
+            output.error("--json / --format are read-only and cannot be combined with a message (a write).")
+            raise typer.Exit(code=1)
 
         # Structured-flag validation (#108): `mship journal --test-state pass`
         # (or --action / --open) without a message silently dropped the flag
@@ -171,18 +177,21 @@ def register(app: typer.Typer, get_container):
                 })
             return
 
-        # Read path (no message argument)
-        entries = log_mgr.read(t.slug, last=last)
-
-        # Read filters (#101): action / repo / since narrow the entries.
+        # Read path (no message argument). Read the FULL history once, apply
+        # filters, THEN apply --last to the filtered result so `--last N
+        # --action X` returns up to N *matching* entries (#101 review). The
+        # full list also resolves `--since last-phase-change`, so the cutoff is
+        # computed before action/repo filtering and no second read is needed.
+        entries = log_mgr.read(t.slug)
+        cutoff = _resolve_since_cutoff(since, entries) if since is not None else None
         if action is not None:
             entries = [e for e in entries if e.action == action]
         if repo is not None:
             entries = [e for e in entries if e.repo == repo]
-        if since is not None:
-            cutoff = _resolve_since_cutoff(since, log_mgr.read(t.slug))
-            if cutoff is not None:
-                entries = [e for e in entries if e.timestamp >= cutoff]
+        if cutoff is not None:
+            entries = [e for e in entries if e.timestamp >= cutoff]
+        if last is not None:
+            entries = entries[-last:]
 
         # Export (#101): --json → a JSON array; --format jsonl → one object/line.
         if export_mode:

--- a/src/mship/cli/log.py
+++ b/src/mship/cli/log.py
@@ -6,11 +6,48 @@ from mship.cli._resolve import resolve_for_command
 from mship.cli.output import Output
 
 
+def _entry_to_dict(e) -> dict:
+    """Stable JSON view of a LogEntry — all known kv fields (#101)."""
+    return {
+        "timestamp": e.timestamp.isoformat(),
+        "message": e.message,
+        "action": e.action,
+        "repo": e.repo,
+        "iteration": e.iteration,
+        "test_state": e.test_state,
+        "open_question": e.open_question,
+        "id": e.id,
+        "parent": e.parent,
+        "evidence": e.evidence,
+        "category": e.category,
+    }
+
+
+def _resolve_since_cutoff(value: str, entries: list):
+    """Resolve a `--since` value to a cutoff datetime (#101).
+
+    `last-phase-change` → timestamp of the most recent "Phase transition:"
+    entry, or None if there is none (no filtering). Otherwise an ISO-8601
+    timestamp (trailing `Z` accepted).
+    """
+    from datetime import datetime
+
+    if value == "last-phase-change":
+        for e in reversed(entries):
+            if e.message.startswith("Phase transition:"):
+                return e.timestamp
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
 def register(app: typer.Typer, get_container):
     @app.command(name="journal")
     def log_cmd(
         message: Optional[str] = typer.Argument(None, help="Message to append to task journal"),
         last: Optional[int] = typer.Option(None, "--last", help="Show only last N entries"),
+        json_out: bool = typer.Option(False, "--json", help="Read: emit entries as a JSON array"),
+        fmt: Optional[str] = typer.Option(None, "--format", help="Read: output format — json | jsonl"),
+        since: Optional[str] = typer.Option(None, "--since", help="Read: only entries at/after an ISO timestamp or 'last-phase-change'"),
         action: Optional[str] = typer.Option(None, "--action", help="Structured: what you were doing"),
         open_question: Optional[str] = typer.Option(None, "--open", help="Structured: blocking question"),
         test_state: Optional[str] = typer.Option(None, "--test-state", help="Structured: pass|fail|mixed"),
@@ -40,12 +77,21 @@ def register(app: typer.Typer, get_container):
         if t.active_repo is not None and t.active_repo in t.worktrees:
             cwd_warn = format_cwd_warning(_P.cwd(), _P(t.worktrees[t.active_repo]))
 
+        # Export mode (#101): --json / --format turn the read path into a
+        # machine-readable exporter. In that mode --action / --repo / --since
+        # are read filters, not write-intent flags.
+        export_mode = json_out or fmt is not None
+        if fmt is not None and fmt not in ("json", "jsonl"):
+            output.error("Invalid --format: use 'json' or 'jsonl'.")
+            raise typer.Exit(code=1)
+
         # Structured-flag validation (#108): `mship journal --test-state pass`
         # (or --action / --open) without a message silently dropped the flag
         # and fell through to read mode. That made `--test-state pass`
         # ineffective as test-evidence — the unified reader (#81) had nothing
-        # to read. Fail loud instead.
-        if message is None and not show_open and (
+        # to read. Fail loud instead. (Skipped in export mode, where these
+        # narrow the read instead of writing.)
+        if message is None and not show_open and not export_mode and (
             test_state is not None or action is not None or open_question is not None
         ):
             output.error(
@@ -127,6 +173,28 @@ def register(app: typer.Typer, get_container):
 
         # Read path (no message argument)
         entries = log_mgr.read(t.slug, last=last)
+
+        # Read filters (#101): action / repo / since narrow the entries.
+        if action is not None:
+            entries = [e for e in entries if e.action == action]
+        if repo is not None:
+            entries = [e for e in entries if e.repo == repo]
+        if since is not None:
+            cutoff = _resolve_since_cutoff(since, log_mgr.read(t.slug))
+            if cutoff is not None:
+                entries = [e for e in entries if e.timestamp >= cutoff]
+
+        # Export (#101): --json → a JSON array; --format jsonl → one object/line.
+        if export_mode:
+            import json as _json
+            dicts = [_entry_to_dict(e) for e in entries]
+            if fmt == "jsonl":
+                for d in dicts:
+                    typer.echo(_json.dumps(d))
+            else:
+                typer.echo(_json.dumps(dicts))
+            return
+
         if not entries:
             output.print("No journal entries")
             return

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -305,3 +305,85 @@ def test_journal_no_args_still_reads(configured_app_with_task: Path):
     result = runner.invoke(app, ["journal", "--task", "add-labels"])
     assert result.exit_code == 0, result.output
     assert "first entry" in result.output
+
+
+# --- MOS-101: --json / --format jsonl exporter + filters ---
+
+import json as _json
+from datetime import datetime as _dt, timezone as _tz
+
+
+def test_journal_json_emits_array(configured_app_with_task: Path):
+    runner.invoke(app, ["journal", "first", "--task", "add-labels"])
+    runner.invoke(app, ["journal", "second", "--task", "add-labels", "--action", "ran tests"])
+    result = runner.invoke(app, ["journal", "--task", "add-labels", "--json"])
+    assert result.exit_code == 0, result.output
+    data = _json.loads(result.output)
+    assert isinstance(data, list)
+    msgs = [e["message"] for e in data]
+    assert "first" in msgs and "second" in msgs
+    expected = {"timestamp", "message", "action", "repo", "iteration",
+                "test_state", "open_question", "id", "parent", "evidence", "category"}
+    assert expected.issubset(data[0].keys())
+
+
+def test_journal_jsonl_one_object_per_line(configured_app_with_task: Path):
+    runner.invoke(app, ["journal", "a", "--task", "add-labels"])
+    runner.invoke(app, ["journal", "b", "--task", "add-labels"])
+    result = runner.invoke(app, ["journal", "--task", "add-labels", "--format", "jsonl"])
+    assert result.exit_code == 0, result.output
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    assert len(lines) >= 2
+    for ln in lines:
+        _json.loads(ln)  # each line is a valid JSON object
+
+
+def test_journal_json_filters_by_action(configured_app_with_task: Path):
+    runner.invoke(app, ["journal", "plain", "--task", "add-labels"])
+    runner.invoke(app, ["journal", "tested", "--task", "add-labels", "--action", "ran tests"])
+    result = runner.invoke(app, ["journal", "--task", "add-labels", "--action", "ran tests", "--json"])
+    assert result.exit_code == 0, result.output
+    data = _json.loads(result.output)
+    assert [e["message"] for e in data] == ["tested"]
+    assert all(e["action"] == "ran tests" for e in data)
+
+
+def test_journal_invalid_format_errors(configured_app_with_task: Path):
+    result = runner.invoke(app, ["journal", "--task", "add-labels", "--format", "yaml"])
+    assert result.exit_code != 0
+    assert "format" in result.output.lower()
+
+
+def test_resolve_since_cutoff_iso():
+    from mship.cli.log import _resolve_since_cutoff
+    assert _resolve_since_cutoff("2026-06-16T12:00:05Z", []) == _dt(2026, 6, 16, 12, 0, 5, tzinfo=_tz.utc)
+
+
+def test_resolve_since_cutoff_last_phase_change():
+    from mship.cli.log import _resolve_since_cutoff
+    from mship.core.log import LogEntry
+    entries = [
+        LogEntry(timestamp=_dt(2026, 6, 16, 12, 0, 0, tzinfo=_tz.utc), message="old"),
+        LogEntry(timestamp=_dt(2026, 6, 16, 12, 0, 5, tzinfo=_tz.utc), message="Phase transition: plan → dev"),
+        LogEntry(timestamp=_dt(2026, 6, 16, 12, 0, 9, tzinfo=_tz.utc), message="new"),
+    ]
+    assert _resolve_since_cutoff("last-phase-change", entries) == _dt(2026, 6, 16, 12, 0, 5, tzinfo=_tz.utc)
+
+
+def test_resolve_since_cutoff_no_phase_change_returns_none():
+    from mship.cli.log import _resolve_since_cutoff
+    from mship.core.log import LogEntry
+    entries = [LogEntry(timestamp=_dt(2026, 6, 16, 12, 0, 0, tzinfo=_tz.utc), message="x")]
+    assert _resolve_since_cutoff("last-phase-change", entries) is None
+
+
+def test_entry_to_dict_includes_all_fields():
+    from mship.cli.log import _entry_to_dict
+    from mship.core.log import LogEntry
+    e = LogEntry(timestamp=_dt(2026, 6, 16, 12, 0, 0, tzinfo=_tz.utc), message="m",
+                 action="a", id="x1", evidence="f.py:1-2", category="c", parent="p1")
+    d = _entry_to_dict(e)
+    assert d["message"] == "m" and d["action"] == "a" and d["id"] == "x1"
+    assert d["evidence"] == "f.py:1-2" and d["category"] == "c" and d["parent"] == "p1"
+    assert set(d) == {"timestamp", "message", "action", "repo", "iteration",
+                      "test_state", "open_question", "id", "parent", "evidence", "category"}

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -387,3 +387,25 @@ def test_entry_to_dict_includes_all_fields():
     assert d["evidence"] == "f.py:1-2" and d["category"] == "c" and d["parent"] == "p1"
     assert set(d) == {"timestamp", "message", "action", "repo", "iteration",
                       "test_state", "open_question", "id", "parent", "evidence", "category"}
+
+
+def test_journal_last_applies_after_filters(configured_app_with_task: Path):
+    # Interleave matching (ran tests) and non-matching entries.
+    runner.invoke(app, ["journal", "t1", "--task", "add-labels", "--action", "ran tests"])
+    runner.invoke(app, ["journal", "p1", "--task", "add-labels"])
+    runner.invoke(app, ["journal", "t2", "--task", "add-labels", "--action", "ran tests"])
+    runner.invoke(app, ["journal", "p2", "--task", "add-labels"])
+    runner.invoke(app, ["journal", "t3", "--task", "add-labels", "--action", "ran tests"])
+    # Filter first, THEN --last → the 2 most-recent *matching* entries (not <2).
+    result = runner.invoke(
+        app, ["journal", "--task", "add-labels", "--action", "ran tests", "--last", "2", "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    assert [e["message"] for e in _json.loads(result.output)] == ["t2", "t3"]
+
+
+def test_journal_json_with_message_errors(configured_app_with_task: Path):
+    # Export flags are read-only; combining with a message (write) is an error.
+    result = runner.invoke(app, ["journal", "hello", "--task", "add-labels", "--json"])
+    assert result.exit_code != 0
+    assert "read-only" in result.output.lower()


### PR DESCRIPTION
## Summary

Add a read-time JSON/JSONL exporter to `mship journal` (the markdown journal stays authoritative; this is a view).

- `--json` → all entries as a JSON array; `--format jsonl` → one JSON object per line.
- Each entry is the full `LogEntry` schema: `timestamp, message, action, repo, iteration, test_state, open_question, id, parent, evidence, category`.
- Filters (export mode): `--action <value>`, `--repo <value>`, `--since <iso-timestamp | last-phase-change>`.
- The existing write-footgun guard (`--action`/`--test-state`/`--open` without a message errors) is **preserved** outside export mode; inside export mode those become read filters — so `mship journal --action hypothesis --json` works while `mship journal --action x` still errors.
- Pure helpers `_entry_to_dict` / `_resolve_since_cutoff` are extracted and unit-tested deterministically (avoids the second-precision-timestamp flakiness of testing `--since` end-to-end).

No new on-disk files; single task at a time (per the issue's scope).

## Test plan
- TDD red→green in `tests/cli/test_log.py`: JSON array, JSONL one-object-per-line, `--action` filter, invalid `--format` error; helper unit tests for `--since` ISO, `--since last-phase-change`, no-phase-change → None, and the entry-to-dict field set.
- Full `test_log.py` green (24), including the preserved write-guard tests.

> ⚠️ The full repo suite shows **one pre-existing unrelated failure** — the #195 stale `test_spec_non_watch_no_task_exits_1`, **fixed in open PR #196**. Merge #196 first for a fully green suite.

Refs MOS-101
