### PR TITLE
non-tty pure json output MOS-177

### DIFF
--- a/src/mship/cli/output.py
+++ b/src/mship/cli/output.py
@@ -30,7 +30,11 @@ class Output:
         if self.is_tty:
             self._console.print(f"[yellow]WARNING:[/yellow] {message}")
         else:
-            self._stream.write(f"WARNING: {message}\n")
+            # Non-TTY: warnings go to stderr so they never corrupt the JSON
+            # payload on stdout (e.g. `mship phase dev | jq`). JSON-mode
+            # consumers that need the warnings get them in-band via the
+            # payload's `warnings` field. (MOS-177)
+            self._err_stream.write(f"WARNING: {message}\n")
 
     def error(self, message: str) -> None:
         if self.is_tty:

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -47,11 +47,23 @@ def test_format_json():
     assert result["status"] == "ok"
 
 
-def test_format_warning():
-    fake_stdout = StringIO()
-    output = Output(stream=fake_stdout)
+def test_warning_to_stderr_in_non_tty():
+    # MOS-177: in non-TTY mode warnings go to stderr so they never corrupt the
+    # JSON payload on stdout (e.g. `mship phase dev | jq`).
+    out, err = StringIO(), StringIO()
+    output = Output(stream=out, err_stream=err)
     output.warning("Tests not passing")
-    assert "Tests not passing" in fake_stdout.getvalue()
+    assert "Tests not passing" in err.getvalue()
+    assert out.getvalue() == ""
+
+
+def test_warning_to_stdout_on_tty():
+    # On a TTY (human), the warning still renders on stdout.
+    out = _TTYStream()
+    err = _TTYStream()
+    output = Output(stream=out, err_stream=err)
+    output.warning("careful")
+    assert "careful" in out.getvalue()
 
 
 def test_format_error():

--- a/tests/cli/test_phase.py
+++ b/tests/cli/test_phase.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -47,8 +48,23 @@ def test_phase_transition(configured_app_with_task, workspace: Path):
 
 
 def test_phase_shows_warnings(configured_app_with_task):
+    # Non-TTY: warnings are carried in the JSON payload's `warnings` field, not
+    # printed onto stdout (MOS-177).
     result = runner.invoke(app, ["phase", "dev", "--task", "add-labels"])
-    assert "WARNING" in result.output or "spec" in result.output.lower()
+    data = json.loads(result.stdout)
+    assert data["warnings"]
+
+
+def test_phase_non_tty_stdout_is_pure_json_despite_warnings(configured_app_with_task):
+    # MOS-177: `mship phase dev | jq` must work even when the transition emits
+    # warnings (e.g. no spec found). stdout must be parseable JSON with the
+    # warnings carried in-band, and no "WARNING:" prefix leaking onto stdout
+    # (the warning text goes to stderr instead).
+    result = runner.invoke(app, ["phase", "dev", "--task", "add-labels"])
+    data = json.loads(result.stdout)
+    assert data["warnings"]
+    assert "WARNING" not in result.stdout
+    assert "WARNING" in result.stderr
 
 
 def test_phase_no_task(workspace: Path):


### PR DESCRIPTION
## Summary

Non-TTY `mship` output was not guaranteed to be pure JSON: `Output.warning()` wrote to **stdout** in non-TTY mode. Commands that emit warnings before their JSON payload — notably `mship phase dev` when no spec is found — prepended `WARNING: …` to stdout, so `mship phase dev | jq` failed to parse.

This routes non-TTY warnings to **stderr**, matching `error` and `breadcrumb`. No information is lost for JSON consumers: the `mship phase` JSON payload already carries the same warnings in-band via its `warnings` field. On a TTY, warnings still render on stdout (human-facing) — unchanged.

Scope is intentionally narrow (the `warning` method). `error`/`breadcrumb` already go to stderr; `success`/`print` go to stdout in non-TTY but are not on any JSON-emitting path.

## Test plan

TDD red→green:
- `tests/cli/test_output.py`: `test_warning_to_stderr_in_non_tty` (non-TTY warning → stderr, stdout empty) and `test_warning_to_stdout_on_tty` (TTY warning still on stdout).
- `tests/cli/test_phase.py`: `test_phase_shows_warnings` (warnings carried in the JSON `warnings` field) and `test_phase_non_tty_stdout_is_pure_json_despite_warnings` (`json.loads(result.stdout)` succeeds, `warnings` non-empty, no `WARNING` on stdout, warning present on stderr).
- Full repo suite green via `mship test` (1 iteration, exit 0).

Refs MOS-177
