### PR TITLE
mship bootstrap: materialize a workspace from a fresh clone

### DIFF
--- a/examples/mothership.yaml
+++ b/examples/mothership.yaml
@@ -19,11 +19,17 @@
 
 workspace: example-workspace
 
+# Base prefix used to resolve a member's clone URL when its `url` is a bare repo
+# name or omitted (so `mship bootstrap` can clone missing members). Host-agnostic:
+# a member on a different host can instead give a full `url` (https://… or git@…).
+default_remote: https://github.com/your-org
+
 repos:
   # A shared library other repos compile against.
   shared:
     path: shared
     type: library
+    # url omitted -> default_remote/shared (i.e. https://github.com/your-org/shared)
     base_branch: main
     expected_branch: main
 
@@ -32,6 +38,7 @@ repos:
   api:
     path: api
     type: service
+    url: your-org/api   # owner/repo -> https://github.com/your-org/api (a full https://… or git@… URL also works)
     base_branch: main
     expected_branch: main
     depends_on: [shared]

--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -73,6 +73,7 @@ def get_container(required: bool = True) -> "Container | None":
 # Register command modules
 from mship.cli import audit as _audit_mod
 from mship.cli import bind as _bind_mod
+from mship.cli import bootstrap as _bootstrap_mod
 from mship.cli import block as _block_mod
 from mship.cli import commit as _commit_mod
 from mship.cli import context as _context_mod
@@ -128,6 +129,7 @@ def run() -> None:
 
 _audit_mod.register(app, get_container)
 _bind_mod.register(app, get_container)
+_bootstrap_mod.register(app, get_container)
 _block_mod.register(app, get_container)
 _commit_mod.register(app, get_container)
 _context_mod.register(app, get_container)

--- a/src/mship/cli/bootstrap.py
+++ b/src/mship/cli/bootstrap.py
@@ -1,0 +1,52 @@
+from typing import Optional
+
+import typer
+
+from mship.cli.output import Output
+
+
+def register(app: typer.Typer, get_container):
+    @app.command()
+    def bootstrap(
+        repos: Optional[str] = typer.Option(
+            None, "--repos", help="Comma-separated repo names (default: all)."
+        ),
+    ):
+        """Clone missing workspace members so a fresh clone becomes a full workspace."""
+        from mship.core.bootstrap import bootstrap as run_bootstrap
+
+        container = get_container()
+        output = Output()
+        config_path = container.config_path()
+        shell = container.shell()
+        state_dir = container.state_dir()
+
+        names = (
+            [n.strip() for n in repos.split(",") if n.strip()] if repos else None
+        )
+
+        report = run_bootstrap(config_path, shell, state_dir=state_dir, repos=names)
+
+        if output.is_tty:
+            for m in report.members:
+                if m.status == "cloned":
+                    output.print(f"  [green]{m.name}[/green]: {m.message}")
+                elif m.status == "present":
+                    output.print(f"  {m.name}: {m.message}")
+                else:
+                    output.print(f"  [red]{m.name}[/red]: {m.message}")
+            if report.doctor_ok is False:
+                output.warning("doctor reported issues — run `mship doctor`")
+            elif report.doctor_ok is None and not report.has_errors:
+                output.warning("doctor was not run")
+        else:
+            output.json({
+                "members": [
+                    {"name": m.name, "status": m.status, "message": m.message}
+                    for m in report.members
+                ],
+                "doctor_ok": report.doctor_ok,
+                "errors": sum(1 for m in report.members if m.status == "error"),
+            })
+
+        raise typer.Exit(code=1 if report.has_errors else 0)

--- a/src/mship/cli/bootstrap.py
+++ b/src/mship/cli/bootstrap.py
@@ -27,6 +27,12 @@ def register(app: typer.Typer, get_container):
 
         report = run_bootstrap(config_path, shell, state_dir=state_dir, repos=names)
 
+        warnings: list[str] = []
+        if report.doctor_ok is False:
+            warnings.append("doctor reported issues — run `mship doctor`")
+        elif report.doctor_ok is None and not report.has_errors:
+            warnings.append("doctor was not run")
+
         if output.is_tty:
             for m in report.members:
                 if m.status == "cloned":
@@ -35,10 +41,8 @@ def register(app: typer.Typer, get_container):
                     output.print(f"  {m.name}: {m.message}")
                 else:
                     output.print(f"  [red]{m.name}[/red]: {m.message}")
-            if report.doctor_ok is False:
-                output.warning("doctor reported issues — run `mship doctor`")
-            elif report.doctor_ok is None and not report.has_errors:
-                output.warning("doctor was not run")
+            for w in warnings:
+                output.warning(w)
         else:
             output.json({
                 "members": [
@@ -46,6 +50,7 @@ def register(app: typer.Typer, get_container):
                     for m in report.members
                 ],
                 "doctor_ok": report.doctor_ok,
+                "warnings": warnings,
                 "errors": sum(1 for m in report.members if m.status == "error"),
             })
 

--- a/src/mship/cli/bootstrap.py
+++ b/src/mship/cli/bootstrap.py
@@ -25,7 +25,11 @@ def register(app: typer.Typer, get_container):
             [n.strip() for n in repos.split(",") if n.strip()] if repos else None
         )
 
-        report = run_bootstrap(config_path, shell, state_dir=state_dir, repos=names)
+        try:
+            report = run_bootstrap(config_path, shell, state_dir=state_dir, repos=names)
+        except ValueError as e:
+            output.error(str(e))
+            raise typer.Exit(code=1)
 
         warnings: list[str] = []
         if report.doctor_ok is False:

--- a/src/mship/cli/init.py
+++ b/src/mship/cli/init.py
@@ -4,18 +4,8 @@ from typing import Optional
 import typer
 
 from mship.cli.output import Output
+from mship.core.config import unique_git_roots
 from mship.core.init import WorkspaceInitializer, DetectedRepo
-
-
-def _unique_git_roots(config) -> list[Path]:
-    """Return deduplicated effective git roots for all repos in config."""
-    roots: set[Path] = set()
-    for name, repo in config.repos.items():
-        if repo.git_root is not None and repo.git_root in config.repos:
-            roots.add(Path(config.repos[repo.git_root].path).resolve())
-        else:
-            roots.add(Path(repo.path).resolve())
-    return sorted(roots)
 
 
 def register(app: typer.Typer, get_container):
@@ -46,7 +36,7 @@ def register(app: typer.Typer, get_container):
             config = container.config()
             installed_results: list[tuple[Path, dict[str, InstallOutcome]]] = []
             failed: list[tuple[Path, str]] = []
-            for root in _unique_git_roots(config):
+            for root in unique_git_roots(config):
                 try:
                     outcomes = install_hook(root)
                     installed_results.append((root, outcomes))
@@ -129,7 +119,7 @@ def register(app: typer.Typer, get_container):
 
         # Install pre-commit hooks on each effective git root
         from mship.core.hooks import install_hook
-        for root in _unique_git_roots(config):
+        for root in unique_git_roots(config):
             try:
                 install_hook(root)
             except Exception as e:
@@ -297,7 +287,7 @@ def _run_interactive(
 
     # Install pre-commit hooks on each effective git root
     from mship.core.hooks import install_hook
-    for root in _unique_git_roots(config):
+    for root in unique_git_roots(config):
         try:
             install_hook(root)
         except Exception as e:

--- a/src/mship/core/bootstrap.py
+++ b/src/mship/core/bootstrap.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from mship.core.clone_url import resolve_clone_url
-from mship.core.config import ConfigLoader, WorkspaceConfig, unique_git_roots
+from mship.core.config import ConfigLoader, RepoConfig, unique_git_roots
 from mship.util.shell import ShellRunner
 
 
@@ -31,7 +31,7 @@ class BootstrapReport:
 
 
 def _clone_one(
-    name: str, repo, default_remote: str | None,
+    name: str, repo: RepoConfig, default_remote: str | None,
     workspace_root: Path, shell: ShellRunner,
 ) -> MemberResult:
     path = Path(repo.path)

--- a/src/mship/core/bootstrap.py
+++ b/src/mship/core/bootstrap.py
@@ -3,12 +3,13 @@ up, install git hooks, then run doctor. See spec mship-bootstrap (MOS-180)."""
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
 from mship.core.clone_url import resolve_clone_url
-from mship.core.config import ConfigLoader, WorkspaceConfig
+from mship.core.config import ConfigLoader, WorkspaceConfig, unique_git_roots
 from mship.util.shell import ShellRunner
 
 
@@ -29,19 +30,6 @@ class BootstrapReport:
         return any(m.status == "error" for m in self.members)
 
 
-def _unique_git_roots(config: WorkspaceConfig, names: list[str]) -> list[Path]:
-    roots: list[Path] = []
-    seen: set[Path] = set()
-    for name in names:
-        repo = config.repos[name]
-        root = config.repos[repo.git_root].path if repo.git_root else repo.path
-        root = Path(root).resolve()
-        if root not in seen:
-            seen.add(root)
-            roots.append(root)
-    return roots
-
-
 def _clone_one(
     name: str, repo, default_remote: str | None,
     workspace_root: Path, shell: ShellRunner,
@@ -60,7 +48,7 @@ def _clone_one(
             "on the workspace",
         )
 
-    res = shell.run(f"git clone {url} {path}", cwd=workspace_root)
+    res = shell.run(f"git clone {shlex.quote(url)} {shlex.quote(str(path))}", cwd=workspace_root)
     if res.returncode != 0:
         return MemberResult(
             name, "error", f"clone failed: {res.stderr.strip()[:200] or 'unknown'}"
@@ -70,7 +58,7 @@ def _clone_one(
     if target:
         cur = shell.run("git rev-parse --abbrev-ref HEAD", cwd=path).stdout.strip()
         if cur != target:
-            co = shell.run(f"git checkout {target}", cwd=path)
+            co = shell.run(f"git checkout {shlex.quote(target)}", cwd=path)
             if co.returncode != 0:
                 return MemberResult(
                     name, "cloned",
@@ -99,7 +87,9 @@ def bootstrap(
 
     cloned = [r.name for r in results if r.status == "cloned"]
 
-    # task setup for freshly-cloned members (best-effort; failures are warnings).
+    # task setup for freshly-cloned members (best-effort; a failure only annotates
+    # the message — it must NOT change the member's "cloned" status).
+    setup_failures: dict[str, str] = {}
     if cloned and shutil.which("task") is not None:
         for name in cloned:
             repo = config.repos[name]
@@ -111,19 +101,20 @@ def bootstrap(
                 env_runner=repo.env_runner or config.env_runner,
             )
             if setup.returncode != 0:
-                results = [
-                    MemberResult(r.name, r.status,
-                                 f"{r.message}; setup failed: "
-                                 f"{setup.stderr.strip()[:120]}")
-                    if r.name == name else r
-                    for r in results
-                ]
+                setup_failures[name] = setup.stderr.strip()[:120]
+    if setup_failures:
+        results = [
+            MemberResult(r.name, r.status,
+                         f"{r.message}; setup failed: {setup_failures[r.name]}")
+            if r.name in setup_failures else r
+            for r in results
+        ]
 
     # Install git hooks on each unique git root that is now present.
     present = [r.name for r in results if r.status in ("cloned", "present")]
     if present:
         from mship.core.hooks import install_hook
-        for root in _unique_git_roots(config, present):
+        for root in unique_git_roots(config, present):
             try:
                 install_hook(root)
             except Exception:

--- a/src/mship/core/bootstrap.py
+++ b/src/mship/core/bootstrap.py
@@ -1,0 +1,145 @@
+"""Materialize a workspace from a fresh clone: clone missing members, set them
+up, install git hooks, then run doctor. See spec mship-bootstrap (MOS-180)."""
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from mship.core.clone_url import resolve_clone_url
+from mship.core.config import ConfigLoader, WorkspaceConfig
+from mship.util.shell import ShellRunner
+
+
+@dataclass(frozen=True)
+class MemberResult:
+    name: str
+    status: str  # "present" | "cloned" | "error"
+    message: str
+
+
+@dataclass(frozen=True)
+class BootstrapReport:
+    members: tuple[MemberResult, ...]
+    doctor_ok: bool | None  # None when doctor was not run (clone errors / load failed)
+
+    @property
+    def has_errors(self) -> bool:
+        return any(m.status == "error" for m in self.members)
+
+
+def _unique_git_roots(config: WorkspaceConfig, names: list[str]) -> list[Path]:
+    roots: list[Path] = []
+    seen: set[Path] = set()
+    for name in names:
+        repo = config.repos[name]
+        root = config.repos[repo.git_root].path if repo.git_root else repo.path
+        root = Path(root).resolve()
+        if root not in seen:
+            seen.add(root)
+            roots.append(root)
+    return roots
+
+
+def _clone_one(
+    name: str, repo, default_remote: str | None,
+    workspace_root: Path, shell: ShellRunner,
+) -> MemberResult:
+    path = Path(repo.path)
+    # No-clobber: lexists() is True for an existing dir OR a (possibly broken)
+    # symlink, so neither is ever re-pointed, reset, or overwritten.
+    if os.path.lexists(path):
+        return MemberResult(name, "present", f"already present at {path}")
+
+    url = resolve_clone_url(name, repo, default_remote)
+    if url is None:
+        return MemberResult(
+            name, "error",
+            "no resolvable url — set `url` on the member or `default_remote` "
+            "on the workspace",
+        )
+
+    res = shell.run(f"git clone {url} {path}", cwd=workspace_root)
+    if res.returncode != 0:
+        return MemberResult(
+            name, "error", f"clone failed: {res.stderr.strip()[:200] or 'unknown'}"
+        )
+
+    target = repo.expected_branch or repo.base_branch
+    if target:
+        cur = shell.run("git rev-parse --abbrev-ref HEAD", cwd=path).stdout.strip()
+        if cur != target:
+            co = shell.run(f"git checkout {target}", cwd=path)
+            if co.returncode != 0:
+                return MemberResult(
+                    name, "cloned",
+                    f"cloned from {url}; could not checkout {target}: "
+                    f"{co.stderr.strip()[:120]}",
+                )
+    return MemberResult(name, "cloned", f"cloned from {url}")
+
+
+def bootstrap(
+    config_path: Path,
+    shell: ShellRunner,
+    *,
+    state_dir: Path,
+    repos: list[str] | None = None,
+) -> BootstrapReport:
+    config_path = Path(config_path)
+    workspace_root = config_path.parent
+    config = ConfigLoader.load(config_path, require_paths=False)
+
+    names = repos or list(config.repos.keys())
+    results: list[MemberResult] = [
+        _clone_one(n, config.repos[n], config.default_remote, workspace_root, shell)
+        for n in names
+    ]
+
+    cloned = [r.name for r in results if r.status == "cloned"]
+
+    # task setup for freshly-cloned members (best-effort; failures are warnings).
+    if cloned and shutil.which("task") is not None:
+        for name in cloned:
+            repo = config.repos[name]
+            if "setup" in repo.not_applicable:
+                continue
+            actual = repo.tasks.get("setup", "setup")
+            setup = shell.run_task(
+                "setup", actual, cwd=Path(repo.path),
+                env_runner=repo.env_runner or config.env_runner,
+            )
+            if setup.returncode != 0:
+                results = [
+                    MemberResult(r.name, r.status,
+                                 f"{r.message}; setup failed: "
+                                 f"{setup.stderr.strip()[:120]}")
+                    if r.name == name else r
+                    for r in results
+                ]
+
+    # Install git hooks on each unique git root that is now present.
+    present = [r.name for r in results if r.status in ("cloned", "present")]
+    if present:
+        from mship.core.hooks import install_hook
+        for root in _unique_git_roots(config, present):
+            try:
+                install_hook(root)
+            except Exception:
+                pass  # hook install is best-effort; doctor will flag if missing
+
+    # Doctor — only meaningful once every member is present (strict load works).
+    doctor_ok: bool | None = None
+    if not any(r.status == "error" for r in results):
+        try:
+            strict = ConfigLoader.load(config_path, require_paths=True)
+            from mship.core.doctor import DoctorChecker
+            report = DoctorChecker(
+                strict, shell, state_dir=state_dir, workspace_root=workspace_root
+            ).run()
+            doctor_ok = report.ok
+        except Exception:
+            doctor_ok = None
+
+    return BootstrapReport(members=tuple(results), doctor_ok=doctor_ok)

--- a/src/mship/core/bootstrap.py
+++ b/src/mship/core/bootstrap.py
@@ -80,6 +80,15 @@ def bootstrap(
     config = ConfigLoader.load(config_path, require_paths=False)
 
     names = repos or list(config.repos.keys())
+    unknown = [n for n in names if n not in config.repos]
+    if unknown:
+        raise ValueError(
+            f"Unknown repo name(s): {sorted(unknown)}. "
+            f"Valid repos: {sorted(config.repos)}"
+        )
+    # git_root repos are subdirectories of their parent repo's checkout — they
+    # are materialized when the parent is cloned, never cloned independently.
+    names = [n for n in names if config.repos[n].git_root is None]
     results: list[MemberResult] = [
         _clone_one(n, config.repos[n], config.default_remote, workspace_root, shell)
         for n in names

--- a/src/mship/core/clone_url.py
+++ b/src/mship/core/clone_url.py
@@ -1,0 +1,34 @@
+"""Resolve a workspace member's clone URL from its config + default_remote.
+
+Pure, no I/O. Rules (see spec mship-bootstrap / MOS-180):
+  - `url` with a scheme ("://") or a "git@" prefix -> used as-is (any host/SSH).
+  - `url` as "owner/repo" (contains "/", no scheme) -> https://github.com/owner/repo.
+    github.com is the assumed host for this shorthand; other hosts (and local
+    paths) must use a full URL, e.g. file:///path or https://gitlab.com/g/r.
+  - `url` as a bare "repo" (no "/") -> {default_remote}/repo.
+  - `url` omitted -> {default_remote}/{member_name}.
+  - bare/omitted with no default_remote -> None (caller emits a per-member error).
+"""
+from __future__ import annotations
+
+from mship.core.config import RepoConfig
+
+_GITHUB = "https://github.com"
+
+
+def resolve_clone_url(
+    name: str, repo: RepoConfig, default_remote: str | None
+) -> str | None:
+    base = default_remote.rstrip("/") if default_remote else None
+    url = repo.url.strip() if repo.url else None
+
+    if url:
+        if "://" in url or url.startswith("git@"):
+            return url
+        if "/" in url:
+            return f"{_GITHUB}/{url}"
+        # bare repo name
+        return f"{base}/{url}" if base else None
+
+    # url omitted -> default_remote/member_name
+    return f"{base}/{name}" if base else None

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -46,8 +46,18 @@ class RepoConfig(BaseModel):
     healthcheck: Healthcheck | None = None
     base_branch: str | None = None
     expected_branch: str | None = None
+    url: str | None = None
     allow_dirty: bool = False
     allow_extra_worktrees: bool = False
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if not v.strip():
+            raise ValueError("url must be a non-empty string when provided")
+        return v
 
     @model_validator(mode="before")
     @classmethod
@@ -123,6 +133,11 @@ class WorkspaceConfig(BaseModel):
     # Does NOT affect canonical mship specs (always `specs/`) or the `spec_paths`
     # legacy spec-search default. Surfaced in `mship context` for skills.
     docs_dir: str = "docs"
+    # Host-agnostic base prefix used to resolve a member's clone URL when its
+    # `url` is a bare repo name or omitted (e.g. "https://github.com/atomikpanda").
+    # Deliberately not named after GitHub: non-GitHub members use a full `url`.
+    # See spec mship-bootstrap (MOS-180).
+    default_remote: str | None = None
     relay: RelayConfig | None = None
     repos: dict[str, RepoConfig]
 

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -320,3 +320,24 @@ class ConfigLoader:
                     "No mothership.yaml found in any parent directory"
                 )
             current = parent
+
+
+def unique_git_roots(
+    config: "WorkspaceConfig", names: list[str] | None = None
+) -> list[Path]:
+    """Resolved git-root path for each selected repo, de-duplicated, order-preserving.
+
+    A repo's git root is its parent repo's path when `git_root` is set (subdir
+    service), else its own path. `names=None` means all repos.
+    """
+    selected = names if names is not None else list(config.repos.keys())
+    roots: list[Path] = []
+    seen: set[Path] = set()
+    for name in selected:
+        repo = config.repos[name]
+        root = config.repos[repo.git_root].path if repo.git_root else repo.path
+        root = Path(root).resolve()
+        if root not in seen:
+            seen.add(root)
+            roots.append(root)
+    return roots

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -243,7 +243,7 @@ class ConfigLoader:
     """Loads and validates mothership.yaml."""
 
     @staticmethod
-    def load(path: Path) -> WorkspaceConfig:
+    def load(path: Path, *, require_paths: bool = True) -> WorkspaceConfig:
         with open(path) as f:
             raw = yaml.safe_load(f)
 
@@ -251,33 +251,35 @@ class ConfigLoader:
 
         config = WorkspaceConfig(**raw)
 
-        # First pass: resolve paths and validate for repos WITHOUT git_root
+        # First pass: resolve paths and (when required) validate existence.
         for name, repo in config.repos.items():
             if repo.git_root is not None:
                 continue
             resolved = (workspace_root / repo.path).resolve()
             repo.path = resolved
-            if not resolved.is_dir():
-                raise ValueError(f"Repo '{name}' path does not exist: {resolved}")
-            if not (resolved / "Taskfile.yml").exists():
-                raise ValueError(
-                    f"Repo '{name}' at {resolved} has no Taskfile.yml"
-                )
+            if require_paths:
+                if not resolved.is_dir():
+                    raise ValueError(f"Repo '{name}' path does not exist: {resolved}")
+                if not (resolved / "Taskfile.yml").exists():
+                    raise ValueError(
+                        f"Repo '{name}' at {resolved} has no Taskfile.yml"
+                    )
 
-        # Second pass: validate git_root repos against their parent's resolved path
+        # Second pass: git_root repos validated against their parent's path.
         for name, repo in config.repos.items():
             if repo.git_root is None:
                 continue
             parent = config.repos[repo.git_root]
             effective = (parent.path / repo.path).resolve()
-            if not effective.is_dir():
-                raise ValueError(
-                    f"Repo '{name}' subdirectory does not exist: {effective}"
-                )
-            if not (effective / "Taskfile.yml").exists():
-                raise ValueError(
-                    f"Repo '{name}' at {effective} has no Taskfile.yml"
-                )
+            if require_paths:
+                if not effective.is_dir():
+                    raise ValueError(
+                        f"Repo '{name}' subdirectory does not exist: {effective}"
+                    )
+                if not (effective / "Taskfile.yml").exists():
+                    raise ValueError(
+                        f"Repo '{name}' at {effective} has no Taskfile.yml"
+                    )
 
         return config
 

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -55,9 +55,11 @@ class RepoConfig(BaseModel):
     def validate_url(cls, v: str | None) -> str | None:
         if v is None:
             return v
-        if not v.strip():
+        stripped = v.strip()
+        if not stripped:
             raise ValueError("url must be a non-empty string when provided")
-        return v
+        # Normalize at parse time so any reader of repo.url sees the trimmed value.
+        return stripped
 
     @model_validator(mode="before")
     @classmethod

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -50,7 +50,7 @@ class RepoConfig(BaseModel):
     allow_dirty: bool = False
     allow_extra_worktrees: bool = False
 
-    @field_validator("url")
+    @field_validator("url", mode="after")
     @classmethod
     def validate_url(cls, v: str | None) -> str | None:
         if v is None:

--- a/tests/cli/test_bootstrap.py
+++ b/tests/cli/test_bootstrap.py
@@ -72,5 +72,7 @@ def test_bootstrap_exit_nonzero_on_member_error(tmp_path):
         data = json.loads(result.stdout)
         assert data["members"][0]["status"] == "error"
         assert result.exit_code == 1
+        assert data["errors"] == 1
+        assert data["warnings"] == []
     finally:
         _reset()

--- a/tests/cli/test_bootstrap.py
+++ b/tests/cli/test_bootstrap.py
@@ -1,0 +1,76 @@
+import json
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+
+runner = CliRunner()
+
+
+def _git(args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, check=True,
+                   capture_output=True, text=True)
+
+
+def _source_repo(root: Path) -> Path:
+    src = root / "src"
+    src.mkdir()
+    _git(["init", "-q", "-b", "main"], src)
+    (src / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    _git(["add", "."], src)
+    _git(["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "i"], src)
+    return src
+
+
+def _ws(root: Path, body: str) -> Path:
+    ws = root / "ws"
+    ws.mkdir()
+    (ws / "mothership.yaml").write_text(body)
+    (ws / ".mothership").mkdir()
+    return ws
+
+
+def _configure(ws: Path):
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(ws / "mothership.yaml")
+    container.state_dir.override(ws / ".mothership")
+
+
+def _reset():
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset()
+    container.state_manager.reset()
+
+
+def test_bootstrap_non_tty_is_pure_json(tmp_path):
+    src = _source_repo(tmp_path)
+    ws = _ws(tmp_path,
+             "workspace: w\nrepos:\n  lib:\n    path: lib\n    type: library\n"
+             f"    url: file://{src}\n")
+    _configure(ws)
+    try:
+        result = runner.invoke(app, ["bootstrap"])
+        data = json.loads(result.stdout)  # must be pure JSON
+        assert any(m["name"] == "lib" and m["status"] == "cloned"
+                   for m in data["members"])
+        assert result.exit_code == 0
+        assert (ws / "lib" / "Taskfile.yml").exists()
+    finally:
+        _reset()
+
+
+def test_bootstrap_exit_nonzero_on_member_error(tmp_path):
+    ws = _ws(tmp_path,
+             "workspace: w\nrepos:\n  bad:\n    path: bad\n    type: library\n")
+    _configure(ws)
+    try:
+        result = runner.invoke(app, ["bootstrap"])
+        data = json.loads(result.stdout)
+        assert data["members"][0]["status"] == "error"
+        assert result.exit_code == 1
+    finally:
+        _reset()

--- a/tests/cli/test_bootstrap.py
+++ b/tests/cli/test_bootstrap.py
@@ -76,3 +76,19 @@ def test_bootstrap_exit_nonzero_on_member_error(tmp_path):
         assert data["warnings"] == []
     finally:
         _reset()
+
+
+def test_bootstrap_unknown_repo_filter_errors_cleanly(tmp_path):
+    src = _source_repo(tmp_path)
+    ws = _ws(tmp_path,
+             "workspace: w\nrepos:\n  lib:\n    path: lib\n    type: library\n"
+             f"    url: file://{src}\n")
+    _configure(ws)
+    try:
+        result = runner.invoke(app, ["bootstrap", "--repos", "typo,lib"])
+        # Actionable error, not a raw KeyError traceback.
+        assert result.exit_code == 1
+        assert "typo" in result.output
+        assert "Unknown repo" in result.output
+    finally:
+        _reset()

--- a/tests/core/test_bootstrap.py
+++ b/tests/core/test_bootstrap.py
@@ -1,4 +1,3 @@
-import json
 import os
 import subprocess
 from pathlib import Path

--- a/tests/core/test_bootstrap.py
+++ b/tests/core/test_bootstrap.py
@@ -1,0 +1,99 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from mship.core.bootstrap import bootstrap
+from mship.util.shell import ShellRunner
+
+
+def _git(args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, check=True,
+                   capture_output=True, text=True)
+
+
+def _make_source_repo(root: Path) -> Path:
+    """A real git repo with a Taskfile.yml, usable as a file:// clone source."""
+    src = root / "src-lib"
+    src.mkdir()
+    _git(["init", "-q", "-b", "main"], src)
+    (src / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    _git(["add", "."], src)
+    _git(["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init"], src)
+    return src
+
+
+def _workspace(root: Path, url: str, *, member="lib") -> Path:
+    ws = root / "ws"
+    ws.mkdir()
+    (ws / "mothership.yaml").write_text(
+        "workspace: w\n"
+        "repos:\n"
+        f"  {member}:\n"
+        f"    path: {member}\n"
+        "    type: library\n"
+        f"    url: {url}\n"
+    )
+    (ws / ".mothership").mkdir()
+    return ws
+
+
+def test_bootstrap_clones_missing_member(tmp_path):
+    src = _make_source_repo(tmp_path)
+    ws = _workspace(tmp_path, f"file://{src}")
+    report = bootstrap(ws / "mothership.yaml", ShellRunner(),
+                       state_dir=ws / ".mothership")
+    statuses = {m.name: m.status for m in report.members}
+    assert statuses["lib"] == "cloned"
+    assert (ws / "lib" / "Taskfile.yml").exists()
+    assert not report.has_errors
+
+
+def test_bootstrap_skips_existing_dir(tmp_path):
+    src = _make_source_repo(tmp_path)
+    ws = _workspace(tmp_path, f"file://{src}")
+    (ws / "lib").mkdir()  # already present
+    report = bootstrap(ws / "mothership.yaml", ShellRunner(),
+                       state_dir=ws / ".mothership")
+    assert {m.name: m.status for m in report.members}["lib"] == "present"
+
+
+def test_bootstrap_skips_symlink(tmp_path):
+    src = _make_source_repo(tmp_path)
+    ws = _workspace(tmp_path, f"file://{src}")
+    os.symlink(src, ws / "lib")  # symlink must never be re-pointed
+    report = bootstrap(ws / "mothership.yaml", ShellRunner(),
+                       state_dir=ws / ".mothership")
+    assert {m.name: m.status for m in report.members}["lib"] == "present"
+    assert (ws / "lib").is_symlink()  # untouched
+
+
+def test_bootstrap_unresolvable_url_errors_but_others_proceed(tmp_path):
+    src = _make_source_repo(tmp_path)
+    ws = tmp_path / "ws2"
+    ws.mkdir()
+    (ws / ".mothership").mkdir()
+    # `bad` has no url and there is no default_remote -> unresolvable.
+    # `lib` has a file:// url -> clones fine.
+    (ws / "mothership.yaml").write_text(
+        "workspace: w\n"
+        "repos:\n"
+        "  bad:\n    path: bad\n    type: library\n"
+        f"  lib:\n    path: lib\n    type: library\n    url: file://{src}\n"
+    )
+    report = bootstrap(ws / "mothership.yaml", ShellRunner(),
+                       state_dir=ws / ".mothership")
+    statuses = {m.name: m.status for m in report.members}
+    assert statuses["bad"] == "error"
+    assert statuses["lib"] == "cloned"
+    assert report.has_errors is True
+    # doctor is skipped while a member errored
+    assert report.doctor_ok is None
+
+
+def test_bootstrap_repos_filter(tmp_path):
+    src = _make_source_repo(tmp_path)
+    ws = _workspace(tmp_path, f"file://{src}", member="lib")
+    report = bootstrap(ws / "mothership.yaml", ShellRunner(),
+                       state_dir=ws / ".mothership", repos=["lib"])
+    assert [m.name for m in report.members] == ["lib"]

--- a/tests/core/test_bootstrap.py
+++ b/tests/core/test_bootstrap.py
@@ -96,3 +96,32 @@ def test_bootstrap_repos_filter(tmp_path):
     report = bootstrap(ws / "mothership.yaml", ShellRunner(),
                        state_dir=ws / ".mothership", repos=["lib"])
     assert [m.name for m in report.members] == ["lib"]
+
+
+def test_bootstrap_skips_git_root_repos(tmp_path):
+    # A git_root repo is a subdirectory of its parent's checkout — it is
+    # materialized when the parent is cloned, never cloned independently.
+    src = _make_source_repo(tmp_path)
+    ws = tmp_path / "wsg"
+    ws.mkdir()
+    (ws / ".mothership").mkdir()
+    (ws / "mothership.yaml").write_text(
+        "workspace: w\n"
+        "repos:\n"
+        f"  svc:\n    path: svc\n    type: service\n    url: file://{src}\n"
+        "  svc_sub:\n    path: sub\n    type: library\n    git_root: svc\n"
+    )
+    report = bootstrap(ws / "mothership.yaml", ShellRunner(),
+                       state_dir=ws / ".mothership")
+    names = {m.name for m in report.members}
+    assert "svc" in names              # parent is cloned
+    assert "svc_sub" not in names      # git_root subdir is skipped, not cloned
+
+
+def test_bootstrap_unknown_repo_filter_raises(tmp_path):
+    src = _make_source_repo(tmp_path)
+    ws = _workspace(tmp_path, f"file://{src}", member="lib")
+    import pytest
+    with pytest.raises(ValueError, match="Unknown repo"):
+        bootstrap(ws / "mothership.yaml", ShellRunner(),
+                  state_dir=ws / ".mothership", repos=["typo"])

--- a/tests/core/test_clone_url.py
+++ b/tests/core/test_clone_url.py
@@ -11,11 +11,12 @@ def _repo(url=None):
 @pytest.mark.parametrize("url, default_remote, expected", [
     # full URL / SSH → as-is
     ("https://example.com/o/r.git", None, "https://example.com/o/r.git"),
+    ("  https://example.com/o/r.git  ", None, "https://example.com/o/r.git"),  # leading/trailing whitespace stripped
     ("git@github.com:o/r.git", None, "git@github.com:o/r.git"),
     ("file:///tmp/src", None, "file:///tmp/src"),
     # owner/repo → github
     ("atomikpanda/mothership", None, "https://github.com/atomikpanda/mothership"),
-    ("atomikpanda/mothership", "https://github.com/other", "https://github.com/atomikpanda/mothership"),
+    ("atomikpanda/mothership", "https://github.com/other", "https://github.com/atomikpanda/mothership"),  # default_remote ignored for owner/repo
     # bare repo → default_remote/repo
     ("mothership", "https://github.com/atomikpanda", "https://github.com/atomikpanda/mothership"),
     # trailing slash on default_remote normalized

--- a/tests/core/test_clone_url.py
+++ b/tests/core/test_clone_url.py
@@ -1,0 +1,37 @@
+import pytest
+
+from mship.core.clone_url import resolve_clone_url
+from mship.core.config import RepoConfig
+
+
+def _repo(url=None):
+    return RepoConfig(path="x", type="library", url=url)
+
+
+@pytest.mark.parametrize("url, default_remote, expected", [
+    # full URL / SSH → as-is
+    ("https://example.com/o/r.git", None, "https://example.com/o/r.git"),
+    ("git@github.com:o/r.git", None, "git@github.com:o/r.git"),
+    ("file:///tmp/src", None, "file:///tmp/src"),
+    # owner/repo → github
+    ("atomikpanda/mothership", None, "https://github.com/atomikpanda/mothership"),
+    ("atomikpanda/mothership", "https://github.com/other", "https://github.com/atomikpanda/mothership"),
+    # bare repo → default_remote/repo
+    ("mothership", "https://github.com/atomikpanda", "https://github.com/atomikpanda/mothership"),
+    # trailing slash on default_remote normalized
+    ("mothership", "https://github.com/atomikpanda/", "https://github.com/atomikpanda/mothership"),
+    # bare repo, no default_remote → None
+    ("mothership", None, None),
+])
+def test_resolve_with_url(url, default_remote, expected):
+    assert resolve_clone_url("name-ignored", _repo(url), default_remote) == expected
+
+
+def test_resolve_omitted_uses_member_name():
+    assert resolve_clone_url(
+        "ground-control", _repo(None), "https://github.com/atomikpanda"
+    ) == "https://github.com/atomikpanda/ground-control"
+
+
+def test_resolve_omitted_no_default_remote_is_none():
+    assert resolve_clone_url("lib", _repo(None), None) is None

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -712,8 +712,7 @@ def test_custom_docs_dir(workspace: Path):
     assert config.docs_dir == "documentation"
 
 
-def test_repo_url_and_default_remote_parse(tmp_path):
-    from mship.core.config import WorkspaceConfig
+def test_repo_url_and_default_remote_parse():
     cfg = WorkspaceConfig(
         workspace="w",
         default_remote="https://github.com/atomikpanda",
@@ -728,8 +727,6 @@ def test_repo_url_and_default_remote_parse(tmp_path):
 
 
 def test_repo_url_rejects_blank():
-    from mship.core.config import WorkspaceConfig
-    import pytest
     with pytest.raises(ValueError):
         WorkspaceConfig(
             workspace="w",

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -710,3 +710,28 @@ def test_custom_docs_dir(workspace: Path):
     cfg.write_text(cfg.read_text() + 'docs_dir: "documentation"\n')
     config = ConfigLoader.load(cfg)
     assert config.docs_dir == "documentation"
+
+
+def test_repo_url_and_default_remote_parse(tmp_path):
+    from mship.core.config import WorkspaceConfig
+    cfg = WorkspaceConfig(
+        workspace="w",
+        default_remote="https://github.com/atomikpanda",
+        repos={
+            "lib": {"path": "lib", "type": "library", "url": "atomikpanda/lib"},
+            "svc": {"path": "svc", "type": "service"},  # url omitted is allowed
+        },
+    )
+    assert cfg.default_remote == "https://github.com/atomikpanda"
+    assert cfg.repos["lib"].url == "atomikpanda/lib"
+    assert cfg.repos["svc"].url is None
+
+
+def test_repo_url_rejects_blank():
+    from mship.core.config import WorkspaceConfig
+    import pytest
+    with pytest.raises(ValueError):
+        WorkspaceConfig(
+            workspace="w",
+            repos={"lib": {"path": "lib", "type": "library", "url": "   "}},
+        )

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -732,3 +732,37 @@ def test_repo_url_rejects_blank():
             workspace="w",
             repos={"lib": {"path": "lib", "type": "library", "url": "   "}},
         )
+
+
+def test_load_lenient_skips_missing_paths(tmp_path):
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: w\n"
+        "default_remote: https://github.com/atomikpanda\n"
+        "repos:\n"
+        "  lib:\n"
+        "    path: lib\n"
+        "    type: library\n"
+    )
+    cfg = ConfigLoader.load(tmp_path / "mothership.yaml", require_paths=False)
+    assert "lib" in cfg.repos
+    assert cfg.repos["lib"].path == (tmp_path / "lib").resolve()  # still resolved
+
+
+def test_load_lenient_still_raises_on_schema_error(tmp_path):
+    # Dependency cycle is a pure schema error — must raise even when lenient.
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: w\n"
+        "repos:\n"
+        "  a:\n    path: a\n    type: library\n    depends_on: [b]\n"
+        "  b:\n    path: b\n    type: library\n    depends_on: [a]\n"
+    )
+    with pytest.raises(ValueError):
+        ConfigLoader.load(tmp_path / "mothership.yaml", require_paths=False)
+
+
+def test_load_strict_still_raises_on_missing_path(tmp_path):
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: w\nrepos:\n  lib:\n    path: lib\n    type: library\n"
+    )
+    with pytest.raises(ValueError):
+        ConfigLoader.load(tmp_path / "mothership.yaml")  # default require_paths=True

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -734,6 +734,14 @@ def test_repo_url_rejects_blank():
         )
 
 
+def test_repo_url_is_stripped_at_parse():
+    cfg = WorkspaceConfig(
+        workspace="w",
+        repos={"lib": {"path": "lib", "type": "library", "url": "  atomikpanda/lib  "}},
+    )
+    assert cfg.repos["lib"].url == "atomikpanda/lib"
+
+
 def test_load_lenient_skips_missing_paths(tmp_path):
     (tmp_path / "mothership.yaml").write_text(
         "workspace: w\n"

--- a/tests/core/test_example_config.py
+++ b/tests/core/test_example_config.py
@@ -23,3 +23,10 @@ def test_example_declares_a_compile_dependency():
     deps = config.repos["api"].depends_on
     names = [(d.repo if hasattr(d, "repo") else d) for d in deps]
     assert "shared" in names
+
+
+def test_example_declares_default_remote_and_member_url():
+    raw = yaml.safe_load(EXAMPLE.read_text())
+    config = WorkspaceConfig(**raw)
+    assert config.default_remote                       # a non-empty base prefix is set
+    assert any(r.url for r in config.repos.values())   # at least one member has a url


### PR DESCRIPTION
## Summary

Adds **`mship bootstrap`** so a cloud/CI agent can turn a fresh clone of the workspace metarepo into a fully materialized, doctor-clean workspace and then drive the native mship workflow (`spawn`/`test`/`finish`) — instead of falling back to raw `git`/`gh`. Implements spec `mship-bootstrap` (MOS-180).

### What's new
- **Self-describing config:** `RepoConfig.url` (per-member clone source) and `WorkspaceConfig.default_remote` (a host-agnostic base prefix — deliberately *not* named after GitHub; non-GitHub members use a full `url`).
- **`resolve_clone_url`** (pure helper): full `https://…`/`git@…`/`file://…` → as-is; `owner/repo` → `https://github.com/owner/repo`; bare `repo` → `{default_remote}/repo`; omitted → `{default_remote}/{member}`; bare/omitted with no `default_remote` → a clear per-member error.
- **`ConfigLoader.load(*, require_paths=True)`:** lenient mode skips only the path-exists / `Taskfile.yml` checks (so bootstrap can read the config before members exist) while still running every pure schema validator. Every existing caller keeps the strict default.
- **`mship bootstrap`:** lenient-load → **no-clobber** (`os.path.lexists`, so an existing dir *or* symlink is never re-pointed) → `git clone` absent members (args `shlex`-quoted) → checkout `expected/base` branch → best-effort `task setup` → `mship init --install-hooks` → `mship doctor`. Per-member errors are isolated (others proceed); exit 1 if any member errored. Non-TTY stdout is a pure-JSON envelope with `warnings` carried in-band (per the MOS-177 contract).
- **`sync` unchanged** — still strictly fetch + ff-only, never clones.
- Shared `unique_git_roots` helper (de-dups the previous copy in `init.py`); example config demonstrates the new fields.

## Test plan
TDD red→green throughout. Full feature suite green (`tests/core/test_config.py`, `test_clone_url.py`, `test_bootstrap.py`, `test_example_config.py`, `tests/cli/test_bootstrap.py`) plus full repo suite via `mship test` (exit 0, no regressions — incl. `init` tests after the shared-helper refactor):
- `resolve_clone_url` resolution table (all forms incl. whitespace-strip + `None` cases).
- Lenient load skips missing paths but still raises on schema errors; strict still raises on missing paths.
- bootstrap integration against a **local `file://` repo** (no network): clones absent member; skips existing dir; skips symlink (untouched); unresolvable-url isolation (one errors, others proceed, doctor skipped); `--repos` filter.
- CLI: non-TTY stdout parses as pure JSON; exit 1 on member error (asserts `errors`/`warnings` envelope).

## Notes
- **Credentials:** the cloud env must have git auth for each member it clones; failures are reported clearly per-member without aborting the others.
- Out of scope (own follow-ups): `sync --clone-missing`, dispatch self-bootstrap mode.

Refs MOS-180
