### PR TITLE
fix(spec): allow bare mship spec draft <id> to emit a generic prompt (MOS-184)

### DIFF
--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -87,14 +87,18 @@ def register(parent: typer.Typer, get_container):
         from_text: Optional[str] = typer.Option(None, "--from-text", help="Inline intent text."),
         from_file: Optional[str] = typer.Option(None, "--from-file", help="Read intent from a file."),
     ):
-        """Emit a drafting prompt for `<id>` to stdout (run it through your agent, then `spec apply`)."""
+        """Emit a drafting prompt for `<id>` to stdout (run it through your agent, then `spec apply`).
+
+        Without --from-text / --from-file a generic drafting prompt is emitted.
+        Supply one of those options to embed your intent directly in the prompt.
+        """
         from pathlib import Path
         from mship.core.spec_store import SpecStore, SPECS_DIRNAME
         from mship.core.spec_draft import build_draft_prompt
 
         output = Output()
-        if (from_text is None) == (from_file is None):
-            output.error("Provide exactly one of --from-text or --from-file.")
+        if from_text is not None and from_file is not None:
+            output.error("Provide only one of --from-text or --from-file, not both.")
             raise typer.Exit(1)
 
         container = get_container()
@@ -106,12 +110,17 @@ def register(parent: typer.Typer, get_container):
 
         if from_text is not None:
             intent = from_text
-        else:
+        elif from_file is not None:
             try:
                 intent = Path(from_file).read_text()
             except OSError as e:
                 output.error(f"Cannot read --from-file {from_file!r}: {e}")
                 raise typer.Exit(1)
+        else:
+            intent = (
+                "<Describe your intent here: the problem to solve, who benefits, "
+                "and any constraints. Pass --from-text or --from-file to embed it automatically.>"
+            )
         typer.echo(build_draft_prompt(spec_id, intent))
 
     @spec_app.command("apply")

--- a/src/mship/skills/brainstorming/SKILL.md
+++ b/src/mship/skills/brainstorming/SKILL.md
@@ -27,7 +27,7 @@ You MUST create a task for each of these items and complete them in order:
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
 6. **Capture the design** — dual-path on workspace detection (is there a `mothership.yaml` at/above cwd?):
-   - **In a mothership workspace:** the design becomes a structured **`mship spec`**, not a doc file. Run `mship spec new --title "<title>"`, then populate it (`mship spec draft <id>` → run the emitted prompt through an agent → `mship spec apply <id> --from-json <file>`), landing it in `needs_review`. This is the canonical artifact — it gets reviewed/approved (`mship spec review` / `verdict` / `approve`) and dispatched. See the `working-with-mothership` skill for the full lifecycle.
+   - **In a mothership workspace:** the design becomes a structured **`mship spec`**, not a doc file. Run `mship spec new --title "<title>"`, then populate it (`mship spec draft <id> [--from-text "..."]` → run the emitted prompt through an agent → `mship spec apply <id> --from-json <file>`), landing it in `needs_review`. This is the canonical artifact — it gets reviewed/approved (`mship spec review` / `verdict` / `approve`) and dispatched. See the `working-with-mothership` skill for the full lifecycle.
    - **Outside a workspace:** write a plain design doc to `docs/specs/YYYY-MM-DD-<topic>-design.md` and commit it.
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
@@ -112,7 +112,7 @@ digraph brainstorming {
 
 Capture the design using the dual-path based on workspace detection (is there a `mothership.yaml` at/above cwd?):
 
-- **In a mothership workspace:** the design becomes a structured **`mship spec`**, not a doc file. Run `mship spec new --title "<title>"`, then populate it (`mship spec draft <id>` → run the emitted prompt through an agent → `mship spec apply <id> --from-json <file>`), landing it in `needs_review`. This is the canonical artifact — it gets reviewed/approved (`mship spec review` / `verdict` / `approve`) and dispatched. See the `working-with-mothership` skill for the full lifecycle.
+- **In a mothership workspace:** the design becomes a structured **`mship spec`**, not a doc file. Run `mship spec new --title "<title>"`, then populate it (`mship spec draft <id> [--from-text "..."]` → run the emitted prompt through an agent → `mship spec apply <id> --from-json <file>`), landing it in `needs_review`. This is the canonical artifact — it gets reviewed/approved (`mship spec review` / `verdict` / `approve`) and dispatched. See the `working-with-mothership` skill for the full lifecycle.
 - **Outside a workspace:** write the validated design to `docs/specs/YYYY-MM-DD-<topic>-design.md` and commit it.
   - (User preferences for spec location override this default)
   - Use elements-of-style:writing-clearly-and-concisely skill if available

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -91,7 +91,8 @@ The lifecycle, in order:
 
 ```bash
 mship spec new --title "<title>"            # create a stub (status: captured)
-mship spec draft <id>                        # emit a drafting prompt to stdout
+mship spec draft <id> [--from-text "..."|--from-file <path>]  # emit a drafting prompt to stdout
+#   bare `spec draft <id>` emits a generic prompt; supply intent via --from-text or --from-file
 #   → run that prompt through an agent to produce SpecDraft JSON, then:
 mship spec apply <id> --from-json <file>     # ingest the draft (→ needs_review)
 mship spec validate <id>                     # check body structure

--- a/tests/cli/test_spec_draft_cli.py
+++ b/tests/cli/test_spec_draft_cli.py
@@ -1,0 +1,80 @@
+"""Tests for MOS-184: bare `mship spec draft <id>` invocation."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+from mship.core.spec_draft import new_spec
+from mship.core.spec_store import SpecStore
+
+
+def _make_store(tmp_path: Path) -> tuple[SpecStore, str]:
+    specs_dir = tmp_path / "specs"
+    specs_dir.mkdir()
+    store = SpecStore(specs_dir)
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    spec = new_spec("My Feature", now=now)
+    store.save(spec)
+    return store, spec.id
+
+
+def _app(tmp_path: Path) -> typer.Typer:
+    from mship.cli.spec import register
+
+    class FakeContainer:
+        def config_path(self):
+            return str(tmp_path / "mothership.yaml")
+
+    app = typer.Typer()
+    register(app, lambda: FakeContainer())
+    return app
+
+
+def test_draft_bare_emits_prompt_without_options(tmp_path):
+    """Bare `spec draft <id>` (no --from-text / --from-file) must succeed and emit a prompt."""
+    _make_store(tmp_path)
+    app = _app(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(app, ["spec", "draft", "my-feature"])
+    assert result.exit_code == 0, result.output
+    assert "my-feature" in result.output
+    assert "acceptance_criteria" in result.output  # JSON schema shape present
+
+
+def test_draft_bare_prompt_contains_placeholder_hint(tmp_path):
+    """The emitted prompt should guide the user to supply intent."""
+    _make_store(tmp_path)
+    app = _app(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(app, ["spec", "draft", "my-feature"])
+    assert result.exit_code == 0
+    lower = result.output.lower()
+    assert "intent" in lower or "--from-text" in lower or "describe" in lower
+
+
+def test_draft_both_options_errors(tmp_path):
+    """Supplying both --from-text and --from-file is an error."""
+    _make_store(tmp_path)
+    intent_file = tmp_path / "intent.txt"
+    intent_file.write_text("some intent")
+    app = _app(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["spec", "draft", "my-feature", "--from-text", "x", "--from-file", str(intent_file)]
+    )
+    assert result.exit_code != 0
+    output_lower = result.output.lower()
+    assert any(k in output_lower for k in ("one of", "mutually exclusive", "both", "only one"))
+
+
+def test_draft_from_text_still_works(tmp_path):
+    """--from-text still embeds the provided intent in the prompt."""
+    _make_store(tmp_path)
+    app = _app(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(app, ["spec", "draft", "my-feature", "--from-text", "build a rocket"])
+    assert result.exit_code == 0, result.output
+    assert "build a rocket" in result.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,25 @@
 import os
 import subprocess
+import sys
+import typing
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 import yaml
+
+# pydantic 2.13 calls typing._eval_type(prefer_fwd_module=True) which doesn't
+# exist until Python 3.14 final (rc2 lacks it). Shim the kwarg away.
+if sys.version_info >= (3, 14):
+    _orig_eval_type = typing._eval_type  # type: ignore[attr-defined]
+
+    def _patched_eval_type(t, globalns, localns, type_params=None, **kwargs):  # type: ignore[misc]
+        kwargs.pop("prefer_fwd_module", None)
+        if type_params is None:
+            return _orig_eval_type(t, globalns, localns, **kwargs)
+        return _orig_eval_type(t, globalns, localns, type_params, **kwargs)
+
+    typing._eval_type = _patched_eval_type  # type: ignore[attr-defined]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- `mship spec draft <id>` without `--from-text` / `--from-file` now emits a generic intent placeholder instead of erroring with "Provide exactly one of --from-text or --from-file"
- Both options provided at once still errors
- Skill docs updated to reflect the new optional flag syntax

## Test plan

- [ ] `uv run pytest tests/cli/test_spec_draft_cli.py -v` — 4 tests, all pass
- [ ] `mship spec draft <id>` bare invocation emits a prompt to stdout
- [ ] `mship spec draft <id> --from-text "foo"` still works
- [ ] `mship spec draft <id> --from-text "a" --from-file b` still errors

Refs MOS-184