### PR TITLE
test(spec): fix stale spec-draft test left red by MOS-184

### DIFF
--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -251,10 +251,13 @@ def test_spec_draft_emits_prompt(configured_app_with_task: Path):
     assert "mship spec apply dq --from-json" in result.output
 
 
-def test_spec_draft_requires_exactly_one_source(configured_app_with_task: Path):
+def test_spec_draft_bare_emits_generic_prompt_both_sources_error(configured_app_with_task: Path):
     runner.invoke(app, ["spec", "new", "--title", "Decision queue", "--id", "dq"])
-    neither = runner.invoke(app, ["spec", "draft", "dq"])
-    assert neither.exit_code != 0
+    # Bare invocation now emits a generic drafting prompt (MOS-184).
+    bare = runner.invoke(app, ["spec", "draft", "dq"])
+    assert bare.exit_code == 0
+    assert "dq" in bare.output
+    # Supplying both sources at once is still rejected.
     both = runner.invoke(app, ["spec", "draft", "dq", "--from-text", "x", "--from-file", "f.md"])
     assert both.exit_code != 0
 


### PR DESCRIPTION
## Summary

PR #207 (MOS-184) made `mship spec draft <id>` emit a generic drafting prompt on **bare** invocation, but left `test_spec_draft_requires_exactly_one_source` asserting the old must-error behavior. This repo has **no pytest CI** (only Socket Security), so #207 merged with `main` red.

This updates the test to match the shipped behavior:
- bare `spec draft <id>` → exit 0, emits a prompt (asserts the spec id appears)
- supplying **both** `--from-text` and `--from-file` → still errors

## Test plan
- `uv run pytest tests/cli/test_spec.py` → 45 passed (was 1 failed).

Refs MOS-184