### PR TITLE
Cloud auth: GH_TOKEN passthrough for mship bootstrap and finish

### DIFF
--- a/docs/plans/2026-06-18-cloud-auth.md
+++ b/docs/plans/2026-06-18-cloud-auth.md
@@ -1,0 +1,686 @@
+# Cloud auth (GH_TOKEN passthrough) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `cloud-auth` (MOS-187) — approved. Read it at `specs/2026-06-17-cloud-auth.md` in the workspace metarepo.
+
+**Goal:** Make `mship bootstrap` and `mship finish` work in a cloud session with no git creds / no `gh`, by auto-configuring auth from an env-injected token (precedence `--token` > `GH_TOKEN` > `GITHUB_TOKEN`), with a clear actionable error when none is present.
+
+**Architecture:** A new single-purpose `core/gh_auth.py` turns a token into (a) a non-persistent, github.com-scoped `git -c credential.helper` (token passed via subprocess env, never argv/disk) for clone+push, and (b) a gh-independent httpx PR-creation path. `bootstrap` splices the cred args onto `git clone`; `finish` (`core/pr.py` + the finish CLI) splices them onto `git push` and routes PR creation to `gh pr create` when gh is usable, else to the httpx path. Reuses the existing `_parse_github_slug` for owner/repo (satisfies the spec's `parse_owner_repo` criterion).
+
+**Tech Stack:** Python 3.14, Typer, httpx (already a dep, `httpx>=0.27`), pytest, `uv`. Git/gh via `ShellRunner` (`run(command, cwd, env=None)` merges `env` over `os.environ`).
+
+**Where to work:** all paths are relative to the `mothership` worktree:
+`/home/bailey/development/repos/mship-workspace/.worktrees/cloud-auth/mothership`. `cd` there; task slug `cloud-auth`, branch `feat/cloud-auth`. Targeted tests: `uv run pytest …`; full suite: `mship test`.
+
+---
+
+## Key facts from the codebase (verified)
+
+- `bootstrap._clone_one` clones via `shell.run(f"git clone {shlex.quote(url)} {shlex.quote(str(path))}", cwd=workspace_root)` (`src/mship/core/bootstrap.py:51`).
+- `PRManager` (`src/mship/core/pr.py`) is a DI `providers.Factory(PRManager, shell=shell)` — obtained as `container.pr_manager()`; do NOT add a `token` constructor arg (the factory only passes `shell`). Thread the token through method params instead.
+- `PRManager.push_branch(repo_path, branch)` runs `git push -u origin <branch>`.
+- `PRManager.create_pr(repo_path, branch, title, body, base=None)` runs `gh pr create …` (with a gh-api REST fallback that still needs `gh`, only for GraphQL rate-limits).
+- `PRManager.check_gh_available()` runs `gh auth status`; returncode `127` = gh not installed, non-zero = not authed.
+- `_parse_github_slug(remote_url) -> tuple[str,str] | None` already handles `https`, `https…​.git`, and `git@github.com:o/r.git`, returns `None` for non-github. **Reuse it.**
+- Finish CLI (`src/mship/cli/worktree.py`): `check_gh_available()` guard at ~`:1082`; `push_branch` calls at ~`:1050`, `:1275`, `:1295`; `create_pr` call at ~`:1354`. The `finish` command def is at ~`:802`. The `bootstrap` CLI is `src/mship/cli/bootstrap.py`.
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `src/mship/core/gh_auth.py` (new) | `resolve_token`, `git_cred_args`, `create_pr_via_httpx`, `get_default_branch_via_httpx` | 1,2 |
+| `src/mship/core/bootstrap.py` | resolve token, splice cred args onto `git clone`, actionable no-token error | 3 |
+| `src/mship/cli/bootstrap.py` | `--token` option | 3 |
+| `src/mship/core/pr.py` | `gh_usable()`, token on `push_branch`/`create_pr`, httpx branch | 4 |
+| `src/mship/cli/worktree.py` | resolve token in `finish`, token-aware gh guard, thread token to push/create, `--token` | 4 |
+| `tests/core/test_gh_auth.py` (new) | unit tests for all of gh_auth | 1,2 |
+| `tests/core/test_bootstrap.py` | bootstrap token-wiring tests | 3 |
+| `tests/core/test_pr.py` | PRManager token/gh-vs-httpx tests | 4 |
+
+---
+
+## Task 1: `gh_auth.py` — token resolution + git credential args
+
+**Files:**
+- Create: `src/mship/core/gh_auth.py`
+- Test: `tests/core/test_gh_auth.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/core/test_gh_auth.py`:
+
+```python
+import pytest
+
+from mship.core.gh_auth import resolve_token, git_cred_args
+
+
+def test_resolve_token_precedence(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "gh_env")
+    monkeypatch.setenv("GITHUB_TOKEN", "github_env")
+    assert resolve_token("explicit") == "explicit"          # flag wins
+    assert resolve_token(None) == "gh_env"                   # GH_TOKEN next
+    monkeypatch.delenv("GH_TOKEN")
+    assert resolve_token(None) == "github_env"               # GITHUB_TOKEN last
+    monkeypatch.delenv("GITHUB_TOKEN")
+    assert resolve_token(None) is None                       # none
+
+
+def test_resolve_token_blank_is_none(monkeypatch):
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    assert resolve_token("   ") is None                      # blank flag ignored
+
+
+def test_git_cred_args_token_only_in_env_not_args():
+    args, env = git_cred_args("secret-tok")
+    # token is carried only in the env dict, never in the args
+    assert "secret-tok" not in " ".join(args)
+    assert env["MSHIP_GH_TOKEN"] == "secret-tok"
+    # the helper config is scoped to github.com and is a -c override
+    assert args[0] == "-c"
+    assert args[1].startswith('credential.https://github.com.helper=')
+    # the helper reads the token from the env var, not a literal
+    assert "$MSHIP_GH_TOKEN" in args[1]
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/core/test_gh_auth.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'mship.core.gh_auth'`.
+
+- [ ] **Step 3: Implement**
+
+Create `src/mship/core/gh_auth.py`:
+
+```python
+"""Configure git/gh auth from an environment token for cloud sessions (MOS-187).
+
+The token is passed to git only via a subprocess env var read by a github.com-
+scoped credential helper — never written to disk, never placed in argv.
+"""
+from __future__ import annotations
+
+import os
+
+# Credential helper: on a `get` request, emit username/password reading the
+# token from the env var git inherits. Single-quote-safe (uses double quotes
+# internally) so callers can shlex.quote the whole `-c` value.
+_CRED_HELPER = (
+    '!f() { test "$1" = get && '
+    'printf "username=x-access-token\\npassword=%s\\n" "$MSHIP_GH_TOKEN"; }; f'
+)
+_TOKEN_ENV_VAR = "MSHIP_GH_TOKEN"
+
+
+def resolve_token(explicit: str | None) -> str | None:
+    """Token precedence: explicit (--token) > GH_TOKEN > GITHUB_TOKEN. Blank → None."""
+    for candidate in (explicit, os.environ.get("GH_TOKEN"), os.environ.get("GITHUB_TOKEN")):
+        if candidate and candidate.strip():
+            return candidate.strip()
+    return None
+
+
+def git_cred_args(token: str) -> tuple[list[str], dict[str, str]]:
+    """Return (`-c` args for a github.com-scoped credential helper, env carrying
+    the token). Splice the args into a `git` invocation and pass the env to it.
+    The token appears only in the env, never in the args."""
+    keyval = f"credential.https://github.com.helper={_CRED_HELPER}"
+    return ["-c", keyval], {_TOKEN_ENV_VAR: token}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/core/test_gh_auth.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/gh_auth.py tests/core/test_gh_auth.py
+git commit -m "feat(gh_auth): token resolution + github-scoped git credential args (MOS-187)"
+mship journal "gh_auth: resolve_token precedence + git_cred_args (token in env, not argv); tests passing" --action committed
+```
+
+---
+
+## Task 2: `gh_auth.py` — httpx PR creation (gh-independent)
+
+**Files:**
+- Modify: `src/mship/core/gh_auth.py`
+- Test: `tests/core/test_gh_auth.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/core/test_gh_auth.py`:
+
+```python
+import json
+import httpx
+
+from mship.core.gh_auth import create_pr_via_httpx, get_default_branch_via_httpx
+
+
+def test_create_pr_via_httpx_posts_and_returns_html_url():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["auth"] = request.headers.get("authorization")
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(201, json={"html_url": "https://github.com/o/r/pull/7"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    url = create_pr_via_httpx(
+        "tok", "o", "r", head="feat/x", base="main",
+        title="T", body="B", client=client,
+    )
+    assert url == "https://github.com/o/r/pull/7"
+    assert captured["url"] == "https://api.github.com/repos/o/r/pulls"
+    assert captured["auth"] == "Bearer tok"
+    assert captured["body"] == {"title": "T", "head": "feat/x", "base": "main", "body": "B"}
+
+
+def test_create_pr_via_httpx_raises_on_error_status():
+    def handler(request):
+        return httpx.Response(422, json={"message": "Validation Failed"})
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    import pytest
+    with pytest.raises(RuntimeError):
+        create_pr_via_httpx("tok", "o", "r", head="h", base="main",
+                            title="T", body="B", client=client)
+
+
+def test_get_default_branch_via_httpx():
+    def handler(request):
+        assert str(request.url) == "https://api.github.com/repos/o/r"
+        return httpx.Response(200, json={"default_branch": "trunk"})
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    assert get_default_branch_via_httpx("tok", "o", "r", client=client) == "trunk"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/core/test_gh_auth.py -k httpx -v`
+Expected: FAIL — `ImportError` (functions don't exist yet).
+
+- [ ] **Step 3: Implement** — append to `src/mship/core/gh_auth.py`:
+
+```python
+import httpx
+
+_API = "https://api.github.com"
+_API_HEADERS = {"Accept": "application/vnd.github+json"}
+
+
+def _client(token: str, client: httpx.Client | None) -> tuple[httpx.Client, bool]:
+    if client is not None:
+        return client, False
+    return httpx.Client(timeout=30.0), True
+
+
+def create_pr_via_httpx(
+    token: str, owner: str, repo: str, *, head: str, base: str,
+    title: str, body: str, client: httpx.Client | None = None,
+) -> str:
+    """Open a PR via the GitHub REST API (no gh dependency). Returns html_url."""
+    c, owns = _client(token, client)
+    try:
+        resp = c.post(
+            f"{_API}/repos/{owner}/{repo}/pulls",
+            json={"title": title, "head": head, "base": base, "body": body},
+            headers={**_API_HEADERS, "Authorization": f"Bearer {token}"},
+        )
+    finally:
+        if owns:
+            c.close()
+    if resp.status_code >= 300:
+        raise RuntimeError(
+            f"GitHub PR creation failed ({resp.status_code}): {resp.text[:300]}"
+        )
+    url = resp.json().get("html_url")
+    if not isinstance(url, str) or not url:
+        raise RuntimeError("GitHub PR created but response had no html_url")
+    return url
+
+
+def get_default_branch_via_httpx(
+    token: str, owner: str, repo: str, *, client: httpx.Client | None = None,
+) -> str:
+    """Fetch the repo's default branch (used when no base is given)."""
+    c, owns = _client(token, client)
+    try:
+        resp = c.get(
+            f"{_API}/repos/{owner}/{repo}",
+            headers={**_API_HEADERS, "Authorization": f"Bearer {token}"},
+        )
+    finally:
+        if owns:
+            c.close()
+    if resp.status_code >= 300:
+        raise RuntimeError(
+            f"Could not fetch default branch ({resp.status_code}): {resp.text[:200]}"
+        )
+    return resp.json().get("default_branch") or "main"
+```
+
+Move the `import httpx` to the top of the file with the other imports (don't leave it mid-file).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/core/test_gh_auth.py -v`
+Expected: PASS (all 6).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/gh_auth.py tests/core/test_gh_auth.py
+git commit -m "feat(gh_auth): httpx PR creation + default-branch lookup (MOS-187)"
+mship journal "gh_auth: create_pr_via_httpx + get_default_branch_via_httpx with MockTransport tests; passing" --action committed
+```
+
+---
+
+## Task 3: Wire token into `mship bootstrap`
+
+**Files:**
+- Modify: `src/mship/core/bootstrap.py`, `src/mship/cli/bootstrap.py`
+- Test: `tests/core/test_bootstrap.py`
+
+- [ ] **Step 1: Write the failing tests** — add to `tests/core/test_bootstrap.py`:
+
+```python
+def test_bootstrap_clone_includes_cred_args_when_token(tmp_path, monkeypatch):
+    # Capture the git clone command instead of really cloning.
+    from mship.core import bootstrap as bmod
+    calls = []
+
+    class FakeShell:
+        def run(self, command, cwd, env=None):
+            calls.append((command, env))
+            from mship.util.shell import ShellResult
+            # pretend the clone produced a dir + Taskfile so later steps no-op
+            return ShellResult(returncode=0, stdout="", stderr="")
+        def run_task(self, *a, **k):
+            from mship.util.shell import ShellResult
+            return ShellResult(returncode=0, stdout="", stderr="")
+
+    ws = tmp_path / "ws"; ws.mkdir(); (ws / ".mothership").mkdir()
+    (ws / "mothership.yaml").write_text(
+        "workspace: w\nrepos:\n  lib:\n    path: lib\n    type: library\n"
+        "    url: https://github.com/o/lib\n"
+    )
+    bmod.bootstrap(ws / "mothership.yaml", FakeShell(),
+                   state_dir=ws / ".mothership", token="tok123")
+    clone = next((c, e) for c, e in calls if "git" in c and "clone" in c)
+    cmd, env = clone
+    assert "credential.https://github.com.helper" in cmd
+    assert "tok123" not in cmd                 # token never in argv
+    assert env and env.get("MSHIP_GH_TOKEN") == "tok123"
+
+
+def test_bootstrap_clone_no_cred_args_without_token(tmp_path):
+    from mship.core import bootstrap as bmod
+    calls = []
+
+    class FakeShell:
+        def run(self, command, cwd, env=None):
+            calls.append((command, env))
+            from mship.util.shell import ShellResult
+            return ShellResult(returncode=0, stdout="", stderr="")
+        def run_task(self, *a, **k):
+            from mship.util.shell import ShellResult
+            return ShellResult(returncode=0, stdout="", stderr="")
+
+    ws = tmp_path / "ws2"; ws.mkdir(); (ws / ".mothership").mkdir()
+    (ws / "mothership.yaml").write_text(
+        "workspace: w\nrepos:\n  lib:\n    path: lib\n    type: library\n"
+        "    url: https://github.com/o/lib\n"
+    )
+    bmod.bootstrap(ws / "mothership.yaml", FakeShell(),
+                   state_dir=ws / ".mothership")  # no token
+    clone = next(c for c, e in calls if "git" in c and "clone" in c)
+    assert "credential.https://github.com.helper" not in clone
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/core/test_bootstrap.py -k "cred_args" -v`
+Expected: FAIL — `bootstrap()` has no `token` kwarg (TypeError).
+
+- [ ] **Step 3: Implement** — in `src/mship/core/bootstrap.py`:
+
+Add the import near the top:
+```python
+from mship.core.gh_auth import resolve_token, git_cred_args
+```
+
+Change the `bootstrap` signature to accept `token`:
+```python
+def bootstrap(
+    config_path: Path,
+    shell: ShellRunner,
+    *,
+    state_dir: Path,
+    repos: list[str] | None = None,
+    token: str | None = None,
+) -> BootstrapReport:
+```
+
+Just after `config = ConfigLoader.load(config_path, require_paths=False)`, resolve once and thread to `_clone_one`:
+```python
+    resolved_token = resolve_token(token)
+```
+Update the `_clone_one(...)` call in the list comprehension to pass it:
+```python
+    results: list[MemberResult] = [
+        _clone_one(n, config.repos[n], config.default_remote, workspace_root, shell,
+                   resolved_token)
+        for n in names
+    ]
+```
+
+Update `_clone_one` to splice cred args onto the clone:
+```python
+def _clone_one(
+    name: str, repo: RepoConfig, default_remote: str | None,
+    workspace_root: Path, shell: ShellRunner, token: str | None = None,
+) -> MemberResult:
+    path = Path(repo.path)
+    if os.path.lexists(path):
+        return MemberResult(name, "present", f"already present at {path}")
+
+    url = resolve_clone_url(name, repo, default_remote)
+    if url is None:
+        return MemberResult(
+            name, "error",
+            "no resolvable url — set `url` on the member or `default_remote` "
+            "on the workspace",
+        )
+
+    if token:
+        cred_args, cred_env = git_cred_args(token)
+        prefix = " ".join(shlex.quote(a) for a in cred_args) + " "
+    else:
+        prefix, cred_env = "", None
+    res = shell.run(
+        f"git {prefix}clone {shlex.quote(url)} {shlex.quote(str(path))}",
+        cwd=workspace_root, env=cred_env,
+    )
+    if res.returncode != 0:
+        hint = ""
+        if token is None and _looks_like_auth_failure(res.stderr):
+            hint = (" — authentication failed and no GH_TOKEN/GITHUB_TOKEN found; "
+                    "set a token with repo scope or pass --token")
+        return MemberResult(
+            name, "error",
+            f"clone failed: {res.stderr.strip()[:200] or 'unknown'}{hint}",
+        )
+    # ... (checkout expected/base branch — unchanged from current code) ...
+```
+
+Add a small helper near the top of the module:
+```python
+def _looks_like_auth_failure(stderr: str) -> bool:
+    s = stderr.lower()
+    return any(k in s for k in (
+        "authentication failed", "could not read username",
+        "terminal prompts disabled", "permission denied", "403", "fatal: could not read",
+    ))
+```
+
+(Keep the existing branch-checkout block after the clone success exactly as it is now.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/core/test_bootstrap.py -v`
+Expected: PASS (all — the new two plus the existing bootstrap tests, which pass `token=None` by default).
+
+- [ ] **Step 5: Add `--token` to the CLI** — in `src/mship/cli/bootstrap.py`, add the option and pass it through:
+
+```python
+    def bootstrap(
+        repos: Optional[str] = typer.Option(
+            None, "--repos", help="Comma-separated repo names (default: all)."
+        ),
+        token: Optional[str] = typer.Option(
+            None, "--token", help="GitHub token for cloning private members "
+            "(else GH_TOKEN / GITHUB_TOKEN).",
+        ),
+    ):
+```
+and update the core call:
+```python
+        report = run_bootstrap(config_path, shell, state_dir=state_dir,
+                               repos=names, token=token)
+```
+(Keep the existing `try/except ValueError` wrapper around it.)
+
+- [ ] **Step 6: Verify CLI wiring**
+
+Run: `uv run mship bootstrap --help`
+Expected: shows `--token`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/mship/core/bootstrap.py src/mship/cli/bootstrap.py tests/core/test_bootstrap.py
+git commit -m "feat(bootstrap): token-authed git clone for private members (MOS-187)"
+mship journal "bootstrap: splices github-scoped cred args onto git clone when a token resolves; --token added; tests passing" --action committed
+```
+
+---
+
+## Task 4: Wire token into `mship finish` (push + gh-or-httpx PR)
+
+**Files:**
+- Modify: `src/mship/core/pr.py`, `src/mship/cli/worktree.py`
+- Test: `tests/core/test_pr.py`
+
+- [ ] **Step 1: Write the failing tests** — add to `tests/core/test_pr.py` (create the file if it doesn't exist; mirror its existing import style if it does):
+
+```python
+from pathlib import Path
+
+from mship.core.pr import PRManager
+from mship.util.shell import ShellResult
+
+
+class _Shell:
+    def __init__(self, gh_returncode=0):
+        self.calls = []
+        self._gh_rc = gh_returncode
+    def run(self, command, cwd, env=None):
+        self.calls.append((command, env))
+        if command.startswith("gh auth status"):
+            return ShellResult(returncode=self._gh_rc, stdout="", stderr="")
+        if command.startswith("git remote get-url"):
+            return ShellResult(returncode=0, stdout="https://github.com/o/r\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+
+def test_push_branch_includes_cred_args_with_token():
+    sh = _Shell()
+    PRManager(sh).push_branch(Path("/x"), "feat/y", token="tok")
+    push = next((c, e) for c, e in sh.calls if "git" in c and "push" in c)
+    cmd, env = push
+    assert "credential.https://github.com.helper" in cmd
+    assert "tok" not in cmd
+    assert env and env["MSHIP_GH_TOKEN"] == "tok"
+
+
+def test_gh_usable_true_when_status_zero():
+    assert PRManager(_Shell(gh_returncode=0)).gh_usable() is True
+
+
+def test_gh_usable_false_when_not_installed():
+    assert PRManager(_Shell(gh_returncode=127)).gh_usable() is False
+
+
+def test_create_pr_uses_httpx_when_gh_absent(monkeypatch):
+    sh = _Shell(gh_returncode=127)
+    sent = {}
+    def fake_httpx(token, owner, repo, *, head, base, title, body, client=None):
+        sent.update(owner=owner, repo=repo, head=head, base=base, token=token)
+        return "https://github.com/o/r/pull/9"
+    monkeypatch.setattr("mship.core.pr.create_pr_via_httpx", fake_httpx)
+    url = PRManager(sh).create_pr(Path("/x"), "feat/y", "T", "B", base="main", token="tok")
+    assert url == "https://github.com/o/r/pull/9"
+    assert sent == {"owner": "o", "repo": "r", "head": "feat/y", "base": "main", "token": "tok"}
+
+
+def test_create_pr_uses_gh_when_available():
+    sh = _Shell(gh_returncode=0)
+    # gh pr create returns a URL on stdout
+    real_run = sh.run
+    def run(command, cwd, env=None):
+        if command.startswith("gh pr create"):
+            return ShellResult(returncode=0, stdout="https://github.com/o/r/pull/3\n", stderr="")
+        return real_run(command, cwd, env)
+    sh.run = run
+    url = PRManager(sh).create_pr(Path("/x"), "feat/y", "T", "B", base="main", token="tok")
+    assert url == "https://github.com/o/r/pull/3"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/core/test_pr.py -k "cred_args or gh_usable or httpx or uses_gh" -v`
+Expected: FAIL — `push_branch`/`create_pr` have no `token` kwarg and `gh_usable` doesn't exist.
+
+- [ ] **Step 3: Implement** — in `src/mship/core/pr.py`:
+
+Add the import at the top:
+```python
+from mship.core.gh_auth import git_cred_args, create_pr_via_httpx, get_default_branch_via_httpx
+```
+
+Add `gh_usable` to `PRManager`:
+```python
+    def gh_usable(self) -> bool:
+        """True if gh is installed and authenticated (returncode 0)."""
+        return self._shell.run("gh auth status", cwd=Path(".")).returncode == 0
+```
+
+Update `push_branch` to splice cred args when a token is given:
+```python
+    def push_branch(self, repo_path: Path, branch: str, token: str | None = None) -> None:
+        prefix, env = "", None
+        if token:
+            args, env = git_cred_args(token)
+            prefix = " ".join(shlex.quote(a) for a in args) + " "
+        result = self._shell.run(
+            f"git {prefix}push -u origin {shlex.quote(branch)}",
+            cwd=repo_path, env=env,
+        )
+        if result.returncode != 0:
+            hint = ""
+            if token is None and "could not read" in result.stderr.lower():
+                hint = " — set GH_TOKEN/GITHUB_TOKEN or pass --token"
+            raise RuntimeError(
+                f"Failed to push branch '{branch}': {result.stderr.strip()}{hint}"
+            )
+```
+
+Update `create_pr` to route to httpx when gh isn't usable and a token is present. Add `token` param and a branch at the top of the method:
+```python
+    def create_pr(
+        self, repo_path: Path, branch: str, title: str, body: str,
+        base: str | None = None, token: str | None = None,
+    ) -> str:
+        if not self.gh_usable():
+            if not token:
+                raise RuntimeError(
+                    "gh CLI not available and no GH_TOKEN/GITHUB_TOKEN found. "
+                    "Install gh, or set a token (repo scope) / pass --token."
+                )
+            remote = self._shell.run("git remote get-url origin", cwd=repo_path)
+            slug = _parse_github_slug(remote.stdout) if remote.returncode == 0 else None
+            if slug is None:
+                raise RuntimeError(
+                    "Could not determine owner/repo from origin remote for REST PR creation."
+                )
+            owner, repo = slug
+            effective_base = base or get_default_branch_via_httpx(token, owner, repo)
+            return create_pr_via_httpx(
+                token, owner, repo, head=branch, base=effective_base,
+                title=title, body=body,
+            )
+        # --- existing gh pr create path (unchanged) ---
+        safe_title = shlex.quote(title)
+        # ... rest of the current method body stays exactly as-is ...
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/core/test_pr.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Thread the token through the finish CLI** — in `src/mship/cli/worktree.py`:
+
+Add the option to the `finish` command (near the other finish options, ~`:802`):
+```python
+        token: Optional[str] = typer.Option(
+            None, "--token", help="GitHub token for push + PR creation in "
+            "credential-less environments (else GH_TOKEN / GITHUB_TOKEN).",
+        ),
+```
+
+Resolve it once early in `finish` (after `pr_mgr = container.pr_manager()` is obtained):
+```python
+        from mship.core.gh_auth import resolve_token
+        gh_token = resolve_token(token)
+```
+
+Make the gh guard token-aware — replace the unconditional `pr_mgr.check_gh_available()` (~`:1082`) with:
+```python
+        if gh_token is None:
+            pr_mgr.check_gh_available()
+        # else: a token is present; the httpx PR path covers gh absence.
+```
+
+Pass `token=gh_token` at every `push_branch` call (~`:1050`, `:1275`, `:1295`):
+```python
+                    pr_mgr.push_branch(repo_path, task.branch, token=gh_token)
+```
+and at the `create_pr` call (~`:1354`):
+```python
+                    pr_url = pr_mgr.create_pr(
+                        ...,                       # existing args unchanged
+                        token=gh_token,
+                    )
+```
+(Find each exact call and add the `token=gh_token` kwarg; don't change the other args.)
+
+- [ ] **Step 6: Verify + full suite**
+
+Run: `uv run mship finish --help` → shows `--token`.
+Run: `mship test` (full suite). Expected: green (modulo the known MOS-188 serve test if run from a bare checkout).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/mship/core/pr.py src/mship/cli/worktree.py tests/core/test_pr.py
+git commit -m "feat(finish): token-authed push + gh-or-httpx PR creation (MOS-187)"
+mship journal "finish: push uses token cred args; create_pr falls back to httpx when gh absent; --token added + threaded; tests passing" --action committed
+```
+
+---
+
+## Final verification
+
+- [ ] `mship test` — full suite green (only the pre-existing MOS-188 serve test may fail from a bare checkout).
+- [ ] `uv run mship bootstrap --help` and `uv run mship finish --help` both show `--token`.
+- [ ] Manual/cloud note: true end-to-end (private clone + tokenless→token, gh-absent PR) requires a cloud session — call it out in the PR as the one path not covered by local unit tests.
+
+Then `mship phase review` → `mship finish --require-tests --body-file <body>` (PR body: gh_auth module, bootstrap/finish token wiring, gh-or-httpx PR path, security notes; `Refs MOS-187`).
+
+---
+
+## Self-Review (by plan author)
+
+**Spec coverage:** ac1 resolve_token → Task 1. ac2 git_cred_args token-in-env → Task 1. ac3 owner/repo parse → reuse `_parse_github_slug` (Task 4 uses it; already tested in the repo — add a case if coverage is thin). ac4 create_pr_via_httpx POST+html_url → Task 2. ac5 finish gh-vs-REST selection → Task 4 (`test_create_pr_uses_httpx_when_gh_absent` / `_uses_gh_when_available`). ac6 bootstrap splices cred args iff token → Task 3. ac7 no-token auth-failure actionable error → Task 3 (`_looks_like_auth_failure` hint) + Task 4 (create_pr raise, push hint). ac8 `--token` on both commands → Task 3 Step 5, Task 4 Step 5. ac9 token never in argv/disk → Task 1 `test_git_cred_args_token_only_in_env_not_args` + Task 3/4 command-capture asserts. ✓ all covered.
+
+**Placeholder scan:** none — every code step has complete code and an exact command + expected result. The one "unchanged from current code" reference (the clone's branch-checkout block, and the gh `create_pr` body) is intentional: those blocks already exist verbatim in the files and must be preserved, not rewritten.
+
+**Type consistency:** `resolve_token(explicit) -> str | None`, `git_cred_args(token) -> (list[str], dict[str,str])`, `create_pr_via_httpx(token, owner, repo, *, head, base, title, body, client=None) -> str`, `get_default_branch_via_httpx(token, owner, repo, *, client=None) -> str`, `gh_usable() -> bool`, `push_branch(..., token=None)`, `create_pr(..., token=None)` — used identically across tasks.

--- a/src/mship/cli/bootstrap.py
+++ b/src/mship/cli/bootstrap.py
@@ -11,6 +11,10 @@ def register(app: typer.Typer, get_container):
         repos: Optional[str] = typer.Option(
             None, "--repos", help="Comma-separated repo names (default: all)."
         ),
+        token: Optional[str] = typer.Option(
+            None, "--token", help="GitHub token for cloning private members "
+            "(else GH_TOKEN / GITHUB_TOKEN).",
+        ),
     ):
         """Clone missing workspace members so a fresh clone becomes a full workspace."""
         from mship.core.bootstrap import bootstrap as run_bootstrap
@@ -26,7 +30,8 @@ def register(app: typer.Typer, get_container):
         )
 
         try:
-            report = run_bootstrap(config_path, shell, state_dir=state_dir, repos=names)
+            report = run_bootstrap(config_path, shell, state_dir=state_dir,
+                                   repos=names, token=token)
         except ValueError as e:
             output.error(str(e))
             raise typer.Exit(code=1)

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -842,6 +842,10 @@ def register(app: typer.Typer, get_container):
                  "Multi-repo tasks use the same title for every PR. See #45.",
         ),
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),
+        token: Optional[str] = typer.Option(
+            None, "--token", help="GitHub token for push + PR creation in "
+            "credential-less environments (else GH_TOKEN / GITHUB_TOKEN).",
+        ),
     ):
         """Create PRs across repos in dependency order."""
         from pathlib import Path
@@ -1033,6 +1037,8 @@ def register(app: typer.Typer, get_container):
 
         # PR creation flow
         pr_mgr = container.pr_manager()
+        from mship.core.gh_auth import resolve_token
+        gh_token = resolve_token(token)
 
         # --push-only: push branches, stamp finished_at, skip gh entirely.
         if push_only:
@@ -1047,7 +1053,7 @@ def register(app: typer.Typer, get_container):
                     if wt_path.exists():
                         repo_path = wt_path
                 try:
-                    pr_mgr.push_branch(repo_path, task.branch)
+                    pr_mgr.push_branch(repo_path, task.branch, token=gh_token)
                 except RuntimeError as e:
                     output.error(f"{repo_name}: {e}")
                     raise typer.Exit(code=1)
@@ -1078,11 +1084,13 @@ def register(app: typer.Typer, get_container):
                 output.print("Branch pushed. After merge/review, run `mship close` to clean up.")
             return
 
-        try:
-            pr_mgr.check_gh_available()
-        except RuntimeError as e:
-            output.error(str(e))
-            raise typer.Exit(code=1)
+        if gh_token is None:
+            try:
+                pr_mgr.check_gh_available()
+            except RuntimeError as e:
+                output.error(str(e))
+                raise typer.Exit(code=1)
+        # else: a token is present; the httpx PR path covers gh absence.
 
         # --- Resolve + verify PR base branches up front ---
         from mship.core.base_resolver import (
@@ -1272,7 +1280,7 @@ def register(app: typer.Typer, get_container):
             # --- --force re-push path: branch exists on origin, push new commits.
             if all_members_have_url and force:
                 try:
-                    pr_mgr.push_branch(group.rep_path, task.branch)
+                    pr_mgr.push_branch(group.rep_path, task.branch, token=gh_token)
                 except RuntimeError as e:
                     output.error(f"{group.rep_name}: {e}")
                     raise typer.Exit(code=1)
@@ -1292,7 +1300,7 @@ def register(app: typer.Typer, get_container):
 
             # --- Fresh path: push, ensure_upstream, find-or-create PR.
             try:
-                pr_mgr.push_branch(group.rep_path, task.branch)
+                pr_mgr.push_branch(group.rep_path, task.branch, token=gh_token)
             except RuntimeError as e:
                 output.error(f"{group.rep_name}: {e}")
                 raise typer.Exit(code=1)
@@ -1357,6 +1365,7 @@ def register(app: typer.Typer, get_container):
                         title=title if title else task.description,
                         body=pr_body,
                         base=group.base,
+                        token=gh_token,
                     )
                 except RuntimeError as e:
                     output.error(f"{group.rep_name}: {e}")

--- a/src/mship/core/bootstrap.py
+++ b/src/mship/core/bootstrap.py
@@ -10,7 +10,17 @@ from pathlib import Path
 
 from mship.core.clone_url import resolve_clone_url
 from mship.core.config import ConfigLoader, RepoConfig, unique_git_roots
+from mship.core.gh_auth import resolve_token, git_cred_args
 from mship.util.shell import ShellRunner
+
+
+def _looks_like_auth_failure(stderr: str) -> bool:
+    s = stderr.lower()
+    return any(k in s for k in (
+        "authentication failed", "could not read username",
+        "terminal prompts disabled", "permission denied", "403",
+        "fatal: could not read",
+    ))
 
 
 @dataclass(frozen=True)
@@ -32,7 +42,7 @@ class BootstrapReport:
 
 def _clone_one(
     name: str, repo: RepoConfig, default_remote: str | None,
-    workspace_root: Path, shell: ShellRunner,
+    workspace_root: Path, shell: ShellRunner, token: str | None = None,
 ) -> MemberResult:
     path = Path(repo.path)
     # No-clobber: lexists() is True for an existing dir OR a (possibly broken)
@@ -48,10 +58,23 @@ def _clone_one(
             "on the workspace",
         )
 
-    res = shell.run(f"git clone {shlex.quote(url)} {shlex.quote(str(path))}", cwd=workspace_root)
+    if token:
+        cred_args, cred_env = git_cred_args(token)
+        prefix = " ".join(shlex.quote(a) for a in cred_args) + " "
+    else:
+        prefix, cred_env = "", None
+    res = shell.run(
+        f"git {prefix}clone {shlex.quote(url)} {shlex.quote(str(path))}",
+        cwd=workspace_root, env=cred_env,
+    )
     if res.returncode != 0:
+        hint = ""
+        if token is None and _looks_like_auth_failure(res.stderr):
+            hint = (" — authentication failed and no GH_TOKEN/GITHUB_TOKEN found; "
+                    "set a token with repo scope or pass --token")
         return MemberResult(
-            name, "error", f"clone failed: {res.stderr.strip()[:200] or 'unknown'}"
+            name, "error",
+            f"clone failed: {res.stderr.strip()[:200] or 'unknown'}{hint}",
         )
 
     target = repo.expected_branch or repo.base_branch
@@ -74,10 +97,12 @@ def bootstrap(
     *,
     state_dir: Path,
     repos: list[str] | None = None,
+    token: str | None = None,
 ) -> BootstrapReport:
     config_path = Path(config_path)
     workspace_root = config_path.parent
     config = ConfigLoader.load(config_path, require_paths=False)
+    resolved_token = resolve_token(token)
 
     names = repos or list(config.repos.keys())
     unknown = [n for n in names if n not in config.repos]
@@ -90,7 +115,8 @@ def bootstrap(
     # are materialized when the parent is cloned, never cloned independently.
     names = [n for n in names if config.repos[n].git_root is None]
     results: list[MemberResult] = [
-        _clone_one(n, config.repos[n], config.default_remote, workspace_root, shell)
+        _clone_one(n, config.repos[n], config.default_remote, workspace_root, shell,
+                   resolved_token)
         for n in names
     ]
 

--- a/src/mship/core/gh_auth.py
+++ b/src/mship/core/gh_auth.py
@@ -11,7 +11,8 @@ import os
 # token from the env var git inherits. Single-quote-safe (uses double quotes
 # internally) so callers can shlex.quote the whole `-c` value.
 _CRED_HELPER = (
-    '!f() { test "$1" = get && '
+    '!f() { test "$1" = get || exit 0; '
+    '[ -n "$MSHIP_GH_TOKEN" ] || { echo "MSHIP_GH_TOKEN unset" >&2; exit 1; }; '
     'printf "username=x-access-token\\npassword=%s\\n" "$MSHIP_GH_TOKEN"; }; f'
 )
 _TOKEN_ENV_VAR = "MSHIP_GH_TOKEN"

--- a/src/mship/core/gh_auth.py
+++ b/src/mship/core/gh_auth.py
@@ -74,6 +74,11 @@ def create_pr_via_httpx(
         if not isinstance(url, str) or not url:
             raise RuntimeError("GitHub PR created but response had no html_url")
         return url
+    except httpx.HTTPError as e:
+        # Network/connectivity failures (ConnectError, TimeoutException, …) are
+        # httpx.HTTPError, not RuntimeError — re-raise so the finish caller's
+        # `except RuntimeError` handles them cleanly instead of crashing.
+        raise RuntimeError(f"GitHub PR creation request failed: {e}") from e
     finally:
         if owns:
             c.close()
@@ -108,6 +113,8 @@ def get_default_branch_via_httpx(
             f"{_API}/repos/{owner}/{repo}",
             headers={**_API_HEADERS, "Authorization": f"Bearer {token}"},
         )
+    except httpx.HTTPError as e:
+        raise RuntimeError(f"Could not fetch default branch: {e}") from e
     finally:
         if owns:
             c.close()

--- a/src/mship/core/gh_auth.py
+++ b/src/mship/core/gh_auth.py
@@ -40,7 +40,7 @@ _API = "https://api.github.com"
 _API_HEADERS = {"Accept": "application/vnd.github+json"}
 
 
-def _client(token: str, client: httpx.Client | None) -> tuple[httpx.Client, bool]:
+def _make_client(client: httpx.Client | None) -> tuple[httpx.Client, bool]:
     if client is not None:
         return client, False
     return httpx.Client(timeout=30.0), True
@@ -51,7 +51,7 @@ def create_pr_via_httpx(
     title: str, body: str, client: httpx.Client | None = None,
 ) -> str:
     """Open a PR via the GitHub REST API (no gh dependency). Returns html_url."""
-    c, owns = _client(token, client)
+    c, owns = _make_client(client)
     try:
         resp = c.post(
             f"{_API}/repos/{owner}/{repo}/pulls",
@@ -75,7 +75,7 @@ def get_default_branch_via_httpx(
     token: str, owner: str, repo: str, *, client: httpx.Client | None = None,
 ) -> str:
     """Fetch the repo's default branch (used when no base is given)."""
-    c, owns = _client(token, client)
+    c, owns = _make_client(client)
     try:
         resp = c.get(
             f"{_API}/repos/{owner}/{repo}",
@@ -88,4 +88,9 @@ def get_default_branch_via_httpx(
         raise RuntimeError(
             f"Could not fetch default branch ({resp.status_code}): {resp.text[:200]}"
         )
-    return resp.json().get("default_branch") or "main"
+    branch = resp.json().get("default_branch")
+    if not isinstance(branch, str) or not branch:
+        raise RuntimeError(
+            f"GitHub repo response for {owner}/{repo} had no default_branch"
+        )
+    return branch

--- a/src/mship/core/gh_auth.py
+++ b/src/mship/core/gh_auth.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import os
 
+import httpx
+
 # Credential helper: on a `get` request, emit username/password reading the
 # token from the env var git inherits. Single-quote-safe (uses double quotes
 # internally) so callers can shlex.quote the whole `-c` value.
@@ -32,3 +34,58 @@ def git_cred_args(token: str) -> tuple[list[str], dict[str, str]]:
     The token appears only in the env, never in the args."""
     keyval = f"credential.https://github.com.helper={_CRED_HELPER}"
     return ["-c", keyval], {_TOKEN_ENV_VAR: token}
+
+
+_API = "https://api.github.com"
+_API_HEADERS = {"Accept": "application/vnd.github+json"}
+
+
+def _client(token: str, client: httpx.Client | None) -> tuple[httpx.Client, bool]:
+    if client is not None:
+        return client, False
+    return httpx.Client(timeout=30.0), True
+
+
+def create_pr_via_httpx(
+    token: str, owner: str, repo: str, *, head: str, base: str,
+    title: str, body: str, client: httpx.Client | None = None,
+) -> str:
+    """Open a PR via the GitHub REST API (no gh dependency). Returns html_url."""
+    c, owns = _client(token, client)
+    try:
+        resp = c.post(
+            f"{_API}/repos/{owner}/{repo}/pulls",
+            json={"title": title, "head": head, "base": base, "body": body},
+            headers={**_API_HEADERS, "Authorization": f"Bearer {token}"},
+        )
+    finally:
+        if owns:
+            c.close()
+    if resp.status_code >= 300:
+        raise RuntimeError(
+            f"GitHub PR creation failed ({resp.status_code}): {resp.text[:300]}"
+        )
+    url = resp.json().get("html_url")
+    if not isinstance(url, str) or not url:
+        raise RuntimeError("GitHub PR created but response had no html_url")
+    return url
+
+
+def get_default_branch_via_httpx(
+    token: str, owner: str, repo: str, *, client: httpx.Client | None = None,
+) -> str:
+    """Fetch the repo's default branch (used when no base is given)."""
+    c, owns = _client(token, client)
+    try:
+        resp = c.get(
+            f"{_API}/repos/{owner}/{repo}",
+            headers={**_API_HEADERS, "Authorization": f"Bearer {token}"},
+        )
+    finally:
+        if owns:
+            c.close()
+    if resp.status_code >= 300:
+        raise RuntimeError(
+            f"Could not fetch default branch ({resp.status_code}): {resp.text[:200]}"
+        )
+    return resp.json().get("default_branch") or "main"

--- a/src/mship/core/gh_auth.py
+++ b/src/mship/core/gh_auth.py
@@ -1,0 +1,33 @@
+"""Configure git/gh auth from an environment token for cloud sessions (MOS-187).
+
+The token is passed to git only via a subprocess env var read by a github.com-
+scoped credential helper — never written to disk, never placed in argv.
+"""
+from __future__ import annotations
+
+import os
+
+# Credential helper: on a `get` request, emit username/password reading the
+# token from the env var git inherits. Single-quote-safe (uses double quotes
+# internally) so callers can shlex.quote the whole `-c` value.
+_CRED_HELPER = (
+    '!f() { test "$1" = get && '
+    'printf "username=x-access-token\\npassword=%s\\n" "$MSHIP_GH_TOKEN"; }; f'
+)
+_TOKEN_ENV_VAR = "MSHIP_GH_TOKEN"
+
+
+def resolve_token(explicit: str | None) -> str | None:
+    """Token precedence: explicit (--token) > GH_TOKEN > GITHUB_TOKEN. Blank → None."""
+    for candidate in (explicit, os.environ.get("GH_TOKEN"), os.environ.get("GITHUB_TOKEN")):
+        if candidate and candidate.strip():
+            return candidate.strip()
+    return None
+
+
+def git_cred_args(token: str) -> tuple[list[str], dict[str, str]]:
+    """Return (`-c` args for a github.com-scoped credential helper, env carrying
+    the token). Splice the args into a `git` invocation and pass the env to it.
+    The token appears only in the env, never in the args."""
+    keyval = f"credential.https://github.com.helper={_CRED_HELPER}"
+    return ["-c", keyval], {_TOKEN_ENV_VAR: token}

--- a/src/mship/core/gh_auth.py
+++ b/src/mship/core/gh_auth.py
@@ -50,7 +50,11 @@ def create_pr_via_httpx(
     token: str, owner: str, repo: str, *, head: str, base: str,
     title: str, body: str, client: httpx.Client | None = None,
 ) -> str:
-    """Open a PR via the GitHub REST API (no gh dependency). Returns html_url."""
+    """Open a PR via the GitHub REST API (no gh dependency). Returns html_url.
+
+    Idempotent: if a PR already exists for the branch (GitHub 422), recover and
+    return the existing PR's URL instead of raising — so retrying `mship finish`
+    after a partial cloud run succeeds (mirrors the gh path)."""
     c, owns = _make_client(client)
     try:
         resp = c.post(
@@ -58,17 +62,40 @@ def create_pr_via_httpx(
             json={"title": title, "head": head, "base": base, "body": body},
             headers={**_API_HEADERS, "Authorization": f"Bearer {token}"},
         )
+        if resp.status_code == 422 and "already exist" in resp.text.lower():
+            existing = _find_open_pr_url(c, token, owner, repo, head)
+            if existing:
+                return existing
+        if resp.status_code >= 300:
+            raise RuntimeError(
+                f"GitHub PR creation failed ({resp.status_code}): {resp.text[:300]}"
+            )
+        url = resp.json().get("html_url")
+        if not isinstance(url, str) or not url:
+            raise RuntimeError("GitHub PR created but response had no html_url")
+        return url
     finally:
         if owns:
             c.close()
+
+
+def _find_open_pr_url(
+    client: httpx.Client, token: str, owner: str, repo: str, head: str,
+) -> str | None:
+    """Return the html_url of the open PR for `head` (same-repo branch), or None."""
+    resp = client.get(
+        f"{_API}/repos/{owner}/{repo}/pulls",
+        params={"head": f"{owner}:{head}", "state": "open"},
+        headers={**_API_HEADERS, "Authorization": f"Bearer {token}"},
+    )
     if resp.status_code >= 300:
-        raise RuntimeError(
-            f"GitHub PR creation failed ({resp.status_code}): {resp.text[:300]}"
-        )
-    url = resp.json().get("html_url")
-    if not isinstance(url, str) or not url:
-        raise RuntimeError("GitHub PR created but response had no html_url")
-    return url
+        return None
+    items = resp.json()
+    if isinstance(items, list) and items:
+        url = items[0].get("html_url")
+        if isinstance(url, str) and url:
+            return url
+    return None
 
 
 def get_default_branch_via_httpx(

--- a/src/mship/core/pr.py
+++ b/src/mship/core/pr.py
@@ -78,6 +78,7 @@ class PRManager:
 
     def __init__(self, shell: ShellRunner) -> None:
         self._shell = shell
+        self._gh_usable_cache: bool | None = None
 
     def check_gh_available(self) -> None:
         result = self._shell.run("gh auth status", cwd=Path("."))
@@ -91,8 +92,13 @@ class PRManager:
             )
 
     def gh_usable(self) -> bool:
-        """True if gh is installed and authenticated (gh auth status returncode 0)."""
-        return self._shell.run("gh auth status", cwd=Path(".")).returncode == 0
+        """True if gh is installed and authenticated. Cached per instance —
+        gh availability does not change within a single mship invocation."""
+        if self._gh_usable_cache is None:
+            self._gh_usable_cache = (
+                self._shell.run("gh auth status", cwd=Path(".")).returncode == 0
+            )
+        return self._gh_usable_cache
 
     def push_branch(self, repo_path: Path, branch: str, token: str | None = None) -> None:
         prefix, env = "", None

--- a/src/mship/core/pr.py
+++ b/src/mship/core/pr.py
@@ -90,6 +90,9 @@ class PRManager:
             raise RuntimeError(
                 "gh CLI not authenticated. Run `gh auth login` first."
             )
+        # Seed the cache so a later gh_usable() (e.g. in create_pr) doesn't
+        # re-run `gh auth status` in the no-token path.
+        self._gh_usable_cache = True
 
     def gh_usable(self) -> bool:
         """True if gh is installed and authenticated. Cached per instance —

--- a/src/mship/core/pr.py
+++ b/src/mship/core/pr.py
@@ -4,6 +4,7 @@ import shlex
 from pathlib import Path
 from typing import NamedTuple
 
+from mship.core.gh_auth import git_cred_args, create_pr_via_httpx, get_default_branch_via_httpx
 from mship.util.shell import ShellRunner
 
 
@@ -89,14 +90,25 @@ class PRManager:
                 "gh CLI not authenticated. Run `gh auth login` first."
             )
 
-    def push_branch(self, repo_path: Path, branch: str) -> None:
+    def gh_usable(self) -> bool:
+        """True if gh is installed and authenticated (gh auth status returncode 0)."""
+        return self._shell.run("gh auth status", cwd=Path(".")).returncode == 0
+
+    def push_branch(self, repo_path: Path, branch: str, token: str | None = None) -> None:
+        prefix, env = "", None
+        if token:
+            args, env = git_cred_args(token)
+            prefix = " ".join(shlex.quote(a) for a in args) + " "
         result = self._shell.run(
-            f"git push -u origin {shlex.quote(branch)}",
-            cwd=repo_path,
+            f"git {prefix}push -u origin {shlex.quote(branch)}",
+            cwd=repo_path, env=env,
         )
         if result.returncode != 0:
+            hint = ""
+            if token is None and "could not read" in result.stderr.lower():
+                hint = " — set GH_TOKEN/GITHUB_TOKEN or pass --token"
             raise RuntimeError(
-                f"Failed to push branch '{branch}': {result.stderr.strip()}"
+                f"Failed to push branch '{branch}': {result.stderr.strip()}{hint}"
             )
 
     def ensure_upstream(self, repo_path: Path, branch: str) -> None:
@@ -124,8 +136,27 @@ class PRManager:
 
     def create_pr(
         self, repo_path: Path, branch: str, title: str, body: str,
-        base: str | None = None,
+        base: str | None = None, token: str | None = None,
     ) -> str:
+        if not self.gh_usable():
+            if not token:
+                raise RuntimeError(
+                    "gh CLI not available and no GH_TOKEN/GITHUB_TOKEN found. "
+                    "Install gh, or set a token (repo scope) / pass --token."
+                )
+            remote = self._shell.run("git remote get-url origin", cwd=repo_path)
+            slug = _parse_github_slug(remote.stdout) if remote.returncode == 0 else None
+            if slug is None:
+                raise RuntimeError(
+                    "Could not determine owner/repo from origin remote for REST PR creation."
+                )
+            owner, repo = slug
+            effective_base = base or get_default_branch_via_httpx(token, owner, repo)
+            return create_pr_via_httpx(
+                token, owner, repo, head=branch, base=effective_base,
+                title=title, body=body,
+            )
+        # --- existing gh pr create path stays here, unchanged ---
         safe_title = shlex.quote(title)
         safe_body = shlex.quote(body)
         cmd = (

--- a/tests/core/test_bootstrap.py
+++ b/tests/core/test_bootstrap.py
@@ -171,5 +171,6 @@ def test_bootstrap_clone_no_cred_args_without_token(tmp_path):
     )
     bmod.bootstrap(ws / "mothership.yaml", FakeShell(),
                    state_dir=ws / ".mothership")  # no token
-    clone = next(c for c, e in calls if "git" in c and "clone" in c)
+    clone, clone_env = next((c, e) for c, e in calls if "git" in c and "clone" in c)
     assert "credential.https://github.com.helper" not in clone
+    assert clone_env is None  # no token => no injected env at all

--- a/tests/core/test_bootstrap.py
+++ b/tests/core/test_bootstrap.py
@@ -125,3 +125,51 @@ def test_bootstrap_unknown_repo_filter_raises(tmp_path):
     with pytest.raises(ValueError, match="Unknown repo"):
         bootstrap(ws / "mothership.yaml", ShellRunner(),
                   state_dir=ws / ".mothership", repos=["typo"])
+
+
+def test_bootstrap_clone_includes_cred_args_when_token(tmp_path):
+    from mship.core import bootstrap as bmod
+    from mship.util.shell import ShellResult
+    calls = []
+
+    class FakeShell:
+        def run(self, command, cwd, env=None):
+            calls.append((command, env))
+            return ShellResult(returncode=0, stdout="", stderr="")
+        def run_task(self, *a, **k):
+            return ShellResult(returncode=0, stdout="", stderr="")
+
+    ws = tmp_path / "ws"; ws.mkdir(); (ws / ".mothership").mkdir()
+    (ws / "mothership.yaml").write_text(
+        "workspace: w\nrepos:\n  lib:\n    path: lib\n    type: library\n"
+        "    url: https://github.com/o/lib\n"
+    )
+    bmod.bootstrap(ws / "mothership.yaml", FakeShell(),
+                   state_dir=ws / ".mothership", token="tok123")
+    cmd, env = next((c, e) for c, e in calls if "git" in c and "clone" in c)
+    assert "credential.https://github.com.helper" in cmd
+    assert "tok123" not in cmd                 # token never in argv
+    assert env and env.get("MSHIP_GH_TOKEN") == "tok123"
+
+
+def test_bootstrap_clone_no_cred_args_without_token(tmp_path):
+    from mship.core import bootstrap as bmod
+    from mship.util.shell import ShellResult
+    calls = []
+
+    class FakeShell:
+        def run(self, command, cwd, env=None):
+            calls.append((command, env))
+            return ShellResult(returncode=0, stdout="", stderr="")
+        def run_task(self, *a, **k):
+            return ShellResult(returncode=0, stdout="", stderr="")
+
+    ws = tmp_path / "ws2"; ws.mkdir(); (ws / ".mothership").mkdir()
+    (ws / "mothership.yaml").write_text(
+        "workspace: w\nrepos:\n  lib:\n    path: lib\n    type: library\n"
+        "    url: https://github.com/o/lib\n"
+    )
+    bmod.bootstrap(ws / "mothership.yaml", FakeShell(),
+                   state_dir=ws / ".mothership")  # no token
+    clone = next(c for c, e in calls if "git" in c and "clone" in c)
+    assert "credential.https://github.com.helper" not in clone

--- a/tests/core/test_gh_auth.py
+++ b/tests/core/test_gh_auth.py
@@ -1,0 +1,29 @@
+import pytest
+
+from mship.core.gh_auth import resolve_token, git_cred_args
+
+
+def test_resolve_token_precedence(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "gh_env")
+    monkeypatch.setenv("GITHUB_TOKEN", "github_env")
+    assert resolve_token("explicit") == "explicit"          # flag wins
+    assert resolve_token(None) == "gh_env"                   # GH_TOKEN next
+    monkeypatch.delenv("GH_TOKEN")
+    assert resolve_token(None) == "github_env"               # GITHUB_TOKEN last
+    monkeypatch.delenv("GITHUB_TOKEN")
+    assert resolve_token(None) is None                       # none
+
+
+def test_resolve_token_blank_is_none(monkeypatch):
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    assert resolve_token("   ") is None                      # blank flag ignored
+
+
+def test_git_cred_args_token_only_in_env_not_args():
+    args, env = git_cred_args("secret-tok")
+    assert "secret-tok" not in " ".join(args)
+    assert env["MSHIP_GH_TOKEN"] == "secret-tok"
+    assert args[0] == "-c"
+    assert args[1].startswith('credential.https://github.com.helper=')
+    assert "$MSHIP_GH_TOKEN" in args[1]

--- a/tests/core/test_gh_auth.py
+++ b/tests/core/test_gh_auth.py
@@ -1,6 +1,8 @@
+import json
+import httpx
 import pytest
 
-from mship.core.gh_auth import resolve_token, git_cred_args
+from mship.core.gh_auth import resolve_token, git_cred_args, create_pr_via_httpx, get_default_branch_via_httpx
 
 
 def test_resolve_token_precedence(monkeypatch):
@@ -27,3 +29,40 @@ def test_git_cred_args_token_only_in_env_not_args():
     assert args[0] == "-c"
     assert args[1].startswith('credential.https://github.com.helper=')
     assert "$MSHIP_GH_TOKEN" in args[1]
+
+
+def test_create_pr_via_httpx_posts_and_returns_html_url():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["auth"] = request.headers.get("authorization")
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(201, json={"html_url": "https://github.com/o/r/pull/7"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    url = create_pr_via_httpx(
+        "tok", "o", "r", head="feat/x", base="main",
+        title="T", body="B", client=client,
+    )
+    assert url == "https://github.com/o/r/pull/7"
+    assert captured["url"] == "https://api.github.com/repos/o/r/pulls"
+    assert captured["auth"] == "Bearer tok"
+    assert captured["body"] == {"title": "T", "head": "feat/x", "base": "main", "body": "B"}
+
+
+def test_create_pr_via_httpx_raises_on_error_status():
+    def handler(request):
+        return httpx.Response(422, json={"message": "Validation Failed"})
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    with pytest.raises(RuntimeError):
+        create_pr_via_httpx("tok", "o", "r", head="h", base="main",
+                            title="T", body="B", client=client)
+
+
+def test_get_default_branch_via_httpx():
+    def handler(request):
+        assert str(request.url) == "https://api.github.com/repos/o/r"
+        return httpx.Response(200, json={"default_branch": "trunk"})
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    assert get_default_branch_via_httpx("tok", "o", "r", client=client) == "trunk"

--- a/tests/core/test_gh_auth.py
+++ b/tests/core/test_gh_auth.py
@@ -100,6 +100,25 @@ def test_create_pr_via_httpx_422_non_existing_still_raises():
                             title="T", body="B", client=client)
 
 
+def test_create_pr_via_httpx_network_error_becomes_runtimeerror():
+    # Network failures (httpx.HTTPError) must surface as RuntimeError so the
+    # finish caller's `except RuntimeError` handles them, not as a traceback.
+    def handler(request):
+        raise httpx.ConnectError("connection refused")
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    with pytest.raises(RuntimeError):
+        create_pr_via_httpx("tok", "o", "r", head="h", base="main",
+                            title="T", body="B", client=client)
+
+
+def test_get_default_branch_via_httpx_network_error_becomes_runtimeerror():
+    def handler(request):
+        raise httpx.ConnectError("connection refused")
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    with pytest.raises(RuntimeError):
+        get_default_branch_via_httpx("tok", "o", "r", client=client)
+
+
 def test_get_default_branch_via_httpx():
     def handler(request):
         assert str(request.url) == "https://api.github.com/repos/o/r"

--- a/tests/core/test_gh_auth.py
+++ b/tests/core/test_gh_auth.py
@@ -70,6 +70,36 @@ def test_create_pr_via_httpx_raises_when_no_html_url():
                             title="T", body="B", client=client)
 
 
+def test_create_pr_via_httpx_recovers_existing_on_422_already_exists():
+    # Idempotency: GitHub returns 422 when a PR already exists for the branch;
+    # the httpx path must recover the existing PR URL (mirrors the gh path).
+    def handler(request):
+        if request.method == "POST":
+            return httpx.Response(422, json={
+                "message": "Validation Failed",
+                "errors": [{"message": "A pull request already exists for o:feat/x."}],
+            })
+        assert request.method == "GET"  # lookup of the existing open PR
+        return httpx.Response(200, json=[{"html_url": "https://github.com/o/r/pull/5"}])
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    url = create_pr_via_httpx("tok", "o", "r", head="feat/x", base="main",
+                              title="T", body="B", client=client)
+    assert url == "https://github.com/o/r/pull/5"
+
+
+def test_create_pr_via_httpx_422_non_existing_still_raises():
+    def handler(request):
+        return httpx.Response(422, json={
+            "message": "Validation Failed",
+            "errors": [{"message": "base is invalid"}],
+        })
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    with pytest.raises(RuntimeError):
+        create_pr_via_httpx("tok", "o", "r", head="h", base="bad",
+                            title="T", body="B", client=client)
+
+
 def test_get_default_branch_via_httpx():
     def handler(request):
         assert str(request.url) == "https://api.github.com/repos/o/r"

--- a/tests/core/test_gh_auth.py
+++ b/tests/core/test_gh_auth.py
@@ -1,4 +1,5 @@
 import json
+
 import httpx
 import pytest
 
@@ -60,9 +61,19 @@ def test_create_pr_via_httpx_raises_on_error_status():
                             title="T", body="B", client=client)
 
 
+def test_create_pr_via_httpx_raises_when_no_html_url():
+    def handler(request):
+        return httpx.Response(201, json={"number": 7})  # 2xx but no html_url
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    with pytest.raises(RuntimeError):
+        create_pr_via_httpx("tok", "o", "r", head="h", base="main",
+                            title="T", body="B", client=client)
+
+
 def test_get_default_branch_via_httpx():
     def handler(request):
         assert str(request.url) == "https://api.github.com/repos/o/r"
+        assert request.headers.get("authorization") == "Bearer tok"
         return httpx.Response(200, json={"default_branch": "trunk"})
     client = httpx.Client(transport=httpx.MockTransport(handler))
     assert get_default_branch_via_httpx("tok", "o", "r", client=client) == "trunk"

--- a/tests/core/test_pr.py
+++ b/tests/core/test_pr.py
@@ -62,7 +62,10 @@ def test_create_pr(mock_shell: MagicMock):
 
 
 def test_create_pr_failure(mock_shell: MagicMock):
-    mock_shell.run.return_value = ShellResult(returncode=1, stdout="", stderr="error")
+    mock_shell.run.side_effect = [
+        ShellResult(returncode=0, stdout="", stderr=""),   # gh auth status → gh_usable=True
+        ShellResult(returncode=1, stdout="", stderr="error"),  # gh pr create fails
+    ]
     mgr = PRManager(mock_shell)
     with pytest.raises(RuntimeError, match="Failed to create PR"):
         mgr.create_pr(Path("/tmp/repo"), "feat/test", "title", "body")
@@ -343,6 +346,7 @@ def test_list_pr_for_branch_returns_none_on_gh_failure(mock_shell: MagicMock):
 def test_create_pr_duplicate_harvests_existing_url(mock_shell: MagicMock):
     from mship.core.pr import PRManager
     mock_shell.run.side_effect = [
+        ShellResult(returncode=0, stdout="", stderr=""),  # gh auth status → gh_usable=True
         ShellResult(
             returncode=1,
             stdout="",
@@ -360,13 +364,14 @@ def test_create_pr_duplicate_harvests_existing_url(mock_shell: MagicMock):
         title="t", body="b", base="main",
     )
     assert url == "https://github.com/org/repo/pull/17"
-    assert "gh pr create" in mock_shell.run.call_args_list[0].args[0]
-    assert "gh pr list" in mock_shell.run.call_args_list[1].args[0]
+    assert "gh pr create" in mock_shell.run.call_args_list[1].args[0]
+    assert "gh pr list" in mock_shell.run.call_args_list[2].args[0]
 
 
 def test_create_pr_duplicate_but_list_fails_raises(mock_shell: MagicMock):
     from mship.core.pr import PRManager
     mock_shell.run.side_effect = [
+        ShellResult(returncode=0, stdout="", stderr=""),  # gh auth status → gh_usable=True
         ShellResult(returncode=1, stdout="", stderr="a pull request already exists"),
         ShellResult(returncode=1, stdout="", stderr="gh auth error"),
     ]
@@ -381,9 +386,10 @@ def test_create_pr_duplicate_but_list_fails_raises(mock_shell: MagicMock):
 def test_create_pr_non_duplicate_error_still_raises(mock_shell: MagicMock):
     """Regression: non-duplicate rc=1 errors still raise (existing behavior)."""
     from mship.core.pr import PRManager
-    mock_shell.run.return_value = ShellResult(
-        returncode=1, stdout="", stderr="fatal: some other error",
-    )
+    mock_shell.run.side_effect = [
+        ShellResult(returncode=0, stdout="", stderr=""),  # gh auth status → gh_usable=True
+        ShellResult(returncode=1, stdout="", stderr="fatal: some other error"),
+    ]
     pr_mgr = PRManager(mock_shell)
     with pytest.raises(RuntimeError, match="some other error"):
         pr_mgr.create_pr(
@@ -397,6 +403,8 @@ def test_create_pr_falls_back_to_rest_on_graphql_rate_limit(mock_shell: MagicMoc
     from mship.core.pr import PRManager
     import json
     mock_shell.run.side_effect = [
+        # 0. gh auth status → gh_usable=True
+        ShellResult(returncode=0, stdout="", stderr=""),
         # 1. gh pr create hits the rate limit.
         ShellResult(
             returncode=1, stdout="",
@@ -431,6 +439,7 @@ def test_create_pr_falls_back_on_secondary_rate_limit(mock_shell: MagicMock):
     from mship.core.pr import PRManager
     import json
     mock_shell.run.side_effect = [
+        ShellResult(returncode=0, stdout="", stderr=""),  # gh auth status → gh_usable=True
         ShellResult(
             returncode=1, stdout="",
             stderr="You have exceeded a secondary rate limit.",
@@ -454,6 +463,7 @@ def test_create_pr_rest_fallback_fails_surfaces_original_error(mock_shell: Magic
     """If REST also fails, surface the original GraphQL error, not the REST error."""
     from mship.core.pr import PRManager
     mock_shell.run.side_effect = [
+        ShellResult(returncode=0, stdout="", stderr=""),  # gh auth status → gh_usable=True
         ShellResult(
             returncode=1, stdout="",
             stderr="GraphQL: API rate limit already exceeded for user ID 1.",
@@ -476,6 +486,7 @@ def test_create_pr_rest_fallback_parses_ssh_remote_url(mock_shell: MagicMock):
     from mship.core.pr import PRManager
     import json
     mock_shell.run.side_effect = [
+        ShellResult(returncode=0, stdout="", stderr=""),  # gh auth status → gh_usable=True
         ShellResult(returncode=1, stdout="", stderr="GraphQL: API rate limit exceeded"),
         ShellResult(returncode=0, stdout="git@github.com:owner/repo.git\n", stderr=""),
         ShellResult(
@@ -499,6 +510,7 @@ def test_create_pr_rest_fallback_parses_https_without_git_suffix(mock_shell: Mag
     from mship.core.pr import PRManager
     import json
     mock_shell.run.side_effect = [
+        ShellResult(returncode=0, stdout="", stderr=""),  # gh auth status → gh_usable=True
         ShellResult(returncode=1, stdout="", stderr="GraphQL: API rate limit exceeded"),
         ShellResult(returncode=0, stdout="https://github.com/a/b\n", stderr=""),
         ShellResult(
@@ -574,3 +586,66 @@ def test_check_pr_state_unknown_rate_limit_surfaces_reason(mock_shell):
     result = PRManager(mock_shell).check_pr_state("https://x/1")
     assert result.state == "unknown"
     assert result.reason == "rate limited"
+
+
+# --- Task 4: token-authed push + gh-or-httpx PR (MOS-187) ---
+
+
+class _Shell:
+    def __init__(self, gh_returncode=0):
+        self.calls = []
+        self._gh_rc = gh_returncode
+    def run(self, command, cwd, env=None):
+        self.calls.append((command, env))
+        if command.startswith("gh auth status"):
+            return ShellResult(returncode=self._gh_rc, stdout="", stderr="")
+        if command.startswith("git remote get-url"):
+            return ShellResult(returncode=0, stdout="https://github.com/o/r\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+
+def test_push_branch_includes_cred_args_with_token():
+    sh = _Shell()
+    PRManager(sh).push_branch(Path("/x"), "feat/y", token="ghp_supersecrettoken99")
+    cmd, env = next((c, e) for c, e in sh.calls if "git" in c and "push" in c)
+    assert "credential.https://github.com.helper" in cmd
+    assert "ghp_supersecrettoken99" not in cmd
+    assert env and env["MSHIP_GH_TOKEN"] == "ghp_supersecrettoken99"
+
+
+def test_gh_usable_true_when_status_zero():
+    assert PRManager(_Shell(gh_returncode=0)).gh_usable() is True
+
+
+def test_gh_usable_false_when_not_installed():
+    assert PRManager(_Shell(gh_returncode=127)).gh_usable() is False
+
+
+def test_create_pr_uses_httpx_when_gh_absent(monkeypatch):
+    sh = _Shell(gh_returncode=127)
+    sent = {}
+    def fake_httpx(token, owner, repo, *, head, base, title, body, client=None):
+        sent.update(owner=owner, repo=repo, head=head, base=base, token=token)
+        return "https://github.com/o/r/pull/9"
+    monkeypatch.setattr("mship.core.pr.create_pr_via_httpx", fake_httpx)
+    url = PRManager(sh).create_pr(Path("/x"), "feat/y", "T", "B", base="main", token="tok")
+    assert url == "https://github.com/o/r/pull/9"
+    assert sent == {"owner": "o", "repo": "r", "head": "feat/y", "base": "main", "token": "tok"}
+
+
+def test_create_pr_uses_gh_when_available():
+    sh = _Shell(gh_returncode=0)
+    real_run = sh.run
+    def run(command, cwd, env=None):
+        if command.startswith("gh pr create"):
+            return ShellResult(returncode=0, stdout="https://github.com/o/r/pull/3\n", stderr="")
+        return real_run(command, cwd, env)
+    sh.run = run
+    url = PRManager(sh).create_pr(Path("/x"), "feat/y", "T", "B", base="main", token="tok")
+    assert url == "https://github.com/o/r/pull/3"
+
+
+def test_create_pr_no_gh_no_token_raises():
+    import pytest
+    with pytest.raises(RuntimeError):
+        PRManager(_Shell(gh_returncode=127)).create_pr(Path("/x"), "feat/y", "T", "B", base="main")

--- a/tests/core/test_pr.py
+++ b/tests/core/test_pr.py
@@ -643,9 +643,10 @@ def test_create_pr_uses_gh_when_available():
     sh.run = run
     url = PRManager(sh).create_pr(Path("/x"), "feat/y", "T", "B", base="main", token="tok")
     assert url == "https://github.com/o/r/pull/3"
+    assert any("gh auth status" in c for c, _ in sh.calls)
 
 
 def test_create_pr_no_gh_no_token_raises():
     import pytest
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="gh CLI not available"):
         PRManager(_Shell(gh_returncode=127)).create_pr(Path("/x"), "feat/y", "T", "B", base="main")

--- a/tests/core/test_pr.py
+++ b/tests/core/test_pr.py
@@ -650,3 +650,14 @@ def test_create_pr_no_gh_no_token_raises():
     import pytest
     with pytest.raises(RuntimeError, match="gh CLI not available"):
         PRManager(_Shell(gh_returncode=127)).create_pr(Path("/x"), "feat/y", "T", "B", base="main")
+
+
+def test_check_gh_available_populates_cache():
+    # check_gh_available() runs `gh auth status`; it should seed the cache so a
+    # later gh_usable() (e.g. inside create_pr) doesn't run it a second time.
+    sh = _Shell(gh_returncode=0)
+    mgr = PRManager(sh)
+    mgr.check_gh_available()
+    assert mgr.gh_usable() is True
+    gh_calls = [c for c, _ in sh.calls if c.startswith("gh auth status")]
+    assert len(gh_calls) == 1


### PR DESCRIPTION
## Summary

Makes `mship bootstrap` and `mship finish` work in cloud Claude Code sessions that have **no git credentials and no usable `gh`**, by auto-configuring auth from an environment-injected token. Implements spec `cloud-auth` (MOS-187). This is what makes the native bootstrap → work → finish workflow viable for cloud/CI agents (the gap surfaced dogfooding `mship bootstrap` overnight; see MOS-186/187).

### What's new
- **`core/gh_auth.py`** (new, single responsibility):
  - `resolve_token(explicit)` — precedence `--token` > `GH_TOKEN` > `GITHUB_TOKEN`.
  - `git_cred_args(token)` — a **non-persistent, github.com-scoped** `-c credential.helper` whose token is read from a subprocess **env var** (`MSHIP_GH_TOKEN`). The token never appears in argv, never touches disk; the helper fails loud if the env var is unset.
  - `create_pr_via_httpx` + `get_default_branch_via_httpx` — a genuinely **gh-independent** PR path via httpx (already a dep). (The existing `_create_pr_via_rest` shells `gh api`, so it's useless when gh is absent.)
- **`bootstrap`**: resolves a token and splices the credential args onto each `git clone` (private members clone over HTTPS); clear actionable error when a clone auth-fails with no token. `--token` flag added.
- **`finish`**: `push` uses the same token credential helper; PR creation uses `gh pr create` when gh is usable (today's path, fully preserved — already-exists dedup + rate-limit REST fallback intact), else falls back to the httpx path. `gh_usable()` is memoized (one `gh auth status` per run, not per repo). The gh preflight is skipped when a token is present (the httpx path covers gh absence). `--token` flag added and threaded through every push/create call site.

### Security
Token is passed only via subprocess env (never argv, never written to disk); the credential helper is scoped to `https://github.com` so a non-github remote can't harvest it; no token in logs or error messages.

## Test plan
TDD throughout. Unit-tested entirely offline:
- `test_gh_auth.py`: token precedence, token-only-in-env (not argv), httpx PR POST/Bearer/body/html_url + error + missing-field guards (httpx `MockTransport`), default-branch lookup.
- `test_bootstrap.py`: clone includes cred args + env when token (token not in argv), no injected env without token.
- `test_pr.py`: `push_branch` cred args; `gh_usable` true/false; `create_pr` routes to httpx when gh absent, uses gh when present, raises when neither; the existing gh-path tests preserved (adjusted only for the new `gh_usable` preflight, not weakened).
- Full suite green via `mship test` at the final commit.

**Not covered by local tests** (flagged for cloud verification): true end-to-end — a private clone and a gh-absent PR creation in an actual cloud session with a real token.

Known follow-up polish (non-blocking): a no-client httpx smoke test; reuse `_looks_like_auth_failure` for the `push_branch` no-token hint (currently narrower than bootstrap's).

Refs MOS-187
