### PR TITLE
fix httpx runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "fastapi>=0.110",
     "uvicorn>=0.27",
     "segno>=1.6.6",
+    "httpx>=0.27",
 ]
 
 [project.scripts]
@@ -37,5 +38,4 @@ dev = [
     "pytest-tmp-files>=0.0.2",
     "pytest-asyncio>=0.23",
     "coverage>=7.13.5",
-    "httpx>=0.27",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -252,11 +252,12 @@ wheels = [
 
 [[package]]
 name = "mothership"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "dependency-injector" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "inquirerpy" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -270,7 +271,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
-    { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-tmp-files" },
@@ -280,6 +280,7 @@ dev = [
 requires-dist = [
     { name = "dependency-injector", specifier = ">=4.0" },
     { name = "fastapi", specifier = ">=0.110" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "inquirerpy", specifier = ">=0.3" },
     { name = "pydantic", specifier = ">=2.13" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -293,7 +294,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=7.13.5" },
-    { name = "httpx", specifier = ">=0.27" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-tmp-files", specifier = ">=0.0.2" },


### PR DESCRIPTION
## Summary

**Hotfix:** mship 0.3.0 crashes on startup when installed as a `uv tool` (or any runtime-only install):

```
ModuleNotFoundError: No module named 'httpx'
  File ".../mship/core/gh_auth.py", line 10, in <module>
    import httpx
```

MOS-187 (cloud auth) added `import httpx` to runtime code (`gh_auth.py`, imported on every invocation via `pr.py` → `container` → `cli`), but `httpx` was only declared in `[dependency-groups].dev` — not `[project.dependencies]`. `uv run` and the test suite include dev deps, so it passed everywhere in development; `uv tool install` installs only runtime deps, so the released CLI can't import.

Fix: move `httpx>=0.27` into `[project.dependencies]` (and drop the now-redundant dev entry); re-lock.

## Test plan
- **Root-cause repro/fix:** `uv run --no-dev python -c "from mship.cli import run"` (simulates the runtime-only tool install) — fails on `main`, **passes** here.
- Full suite green via `mship test`.

After merge: `uv tool upgrade mothership --reinstall` restores a working CLI.

Refs MOS-187
