### PR TITLE
fix mship view spec TUI: fall back to newest spec when no active task (non-watch)

### DIFF
--- a/src/mship/cli/view/spec.py
+++ b/src/mship/cli/view/spec.py
@@ -102,10 +102,14 @@ class SpecView(ViewApp):
 
         state = self._current_state()
 
-        # Per-tick resolver: only active when state_manager is set (watch
-        # mode wired with the new API). Legacy callers that pass state= and
-        # task= directly bypass this path.
-        if self._state_manager is not None:
+        # Per-tick resolver: only active in watch mode, where a task may be
+        # spawned/changed while the view is open and the "waiting for a task"
+        # placeholder is the right thing to show. In non-watch mode the command
+        # already resolved the task once (with the MOS-175 fall-back-to-newest
+        # when none is active), so trust `self._task_filter` and never override
+        # it with the placeholder. Legacy callers that pass state=/task= directly
+        # (state_manager is None) also bypass this path.
+        if self._state_manager is not None and self._watch:
             try:
                 slug_for_tick = self._resolve_task_slug(state)
             except (NoActiveTaskError, AmbiguousTaskError, UnknownTaskError) as err:

--- a/tests/cli/view/test_spec_view.py
+++ b/tests/cli/view/test_spec_view.py
@@ -337,6 +337,33 @@ async def test_spec_view_watch_transitions_to_fallback_when_task_appears(tmp_pat
         assert "My task description" in text or "No spec yet for task" in text
 
 
+# --- Non-watch TUI: no-active-task falls back to newest spec (MOS-175) ---
+
+
+@pytest.mark.asyncio
+async def test_spec_view_non_watch_no_active_task_renders_newest_spec(tmp_path):
+    """A plain (non-watch) `mship view spec` with no active task must fall back
+    to the newest spec — the watch-only 'No active task' placeholder is wrong
+    here. Regression for the interactive TUI path that bypassed MOS-175."""
+    specs_dir = tmp_path / "specs"
+    specs_dir.mkdir()
+    (specs_dir / "newest.md").write_text("# Newest Spec\n\nStructured spec body here.\n")
+    view = SpecView(
+        workspace_root=tmp_path,
+        name_or_path=None,
+        state_manager=_MutableSpecStateMgr(tasks_dict={}),
+        cli_task=None,
+        cwd=tmp_path,
+        watch=False,
+        interval=0.5,
+    )
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        text = view.rendered_text()
+        assert "No active task" not in text
+        assert "Structured spec body here." in text
+
+
 # --- Non-TTY short-circuit tests (#124) ---
 
 


### PR DESCRIPTION
## Summary

Fix `mship view spec` showing **"No active task. Run `mship spawn`…"** instead of the spec, when run in an interactive terminal with no active task.

The MOS-175 *fall-back-to-newest-spec-when-no-active-task* behavior was wired into the outer `view spec` command and the non-TTY short-circuit, but **not** the interactive TUI: `SpecView._refresh_content` re-resolved the active task every tick and rendered the watch-only placeholder on `NoActiveTaskError`. So a plain `mship view spec` in a real terminal hit the placeholder, while the same command piped/redirected (non-TTY) correctly fell back to the newest spec.

Fix: restrict the per-tick resolver (and its placeholder) to **watch mode**, where a task may be spawned/changed while the view is open and "waiting for a task" is the right message. In non-watch mode the command has already resolved the task once (with the MOS-175 fallback baked in), so the view trusts that slug — `None` → newest spec.

One-line behavioral change (`and self._watch`) plus a regression test.

## Test plan
- New `test_spec_view_non_watch_no_active_task_renders_newest_spec` — non-watch TUI, empty state, a spec on disk → renders the spec body, asserts the placeholder is gone. **Fails before, passes after.**
- Watch-mode placeholder tests (`…watch_no_active_task_shows_placeholder`, ambiguous, unknown-slug, transitions) unchanged and still green.
- Full suite green via `mship test` (exit 0).
