### PR TITLE
mship capture: make active task optional (ad-hoc fallback to repo main checkout)

### DIFF
--- a/src/mship/cli/capture.py
+++ b/src/mship/cli/capture.py
@@ -1,39 +1,44 @@
 """`mship capture` — capture the running UI for an agent to inspect."""
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
 import typer
 
-from mship.cli._resolve import resolve_for_command
 from mship.cli.output import Output
 from mship.core import capture as _cap
 from mship.core.dispatch import resolve_repo
+from mship.core.task_resolver import (
+    AmbiguousTaskError,
+    NoActiveTaskError,
+    UnknownTaskError,
+    resolve_task,
+)
 
 
 def register(app: typer.Typer, get_container):
     @app.command()
     def capture(
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug (defaults to cwd-resolved)."),
-        repo: Optional[str] = typer.Option(None, "--repo", help="Which repo's worktree to capture (multi-repo tasks)."),
+        repo: Optional[str] = typer.Option(None, "--repo", help="Which repo to capture (required for an ad-hoc capture when the workspace has >1 repo)."),
         platform: Optional[str] = typer.Option(None, "--platform", help="Platform to capture (required when the repo exposes more than one)."),
         kind: str = typer.Option("all", "--kind", help="Artifact kind: image | layout | all."),
-        out: Optional[Path] = typer.Option(None, "--out", help="Output directory (default: .mothership/captures/<task>/<ts>-<platform>/)."),
+        out: Optional[Path] = typer.Option(None, "--out", help="Output directory (default: .mothership/captures/<task-or-_adhoc>/<ts>-<platform>/)."),
     ):
-        """Capture the running UI (screenshot + layout) into files to read."""
+        """Capture the running UI (screenshot + layout) into files to read.
+
+        Task-aware but not task-required: with an active task, captures run in the
+        task's worktree and are filed under the task. Without one, capture runs an
+        ad-hoc capture against a repo's main checkout — capture observes a running
+        app, not worktree source, so it shouldn't require a task.
+        """
         output = Output()
         container = get_container()
         state = container.state_manager().load()
-        resolved = resolve_for_command("capture", state, task, output)
-        t = resolved.task
-
-        try:
-            resolved_repo = resolve_repo(t, repo)
-        except ValueError as e:
-            output.error(str(e))
-            raise typer.Exit(code=1)
+        config = container.config()
 
         try:
             kinds = _cap.resolve_kinds(kind)
@@ -41,7 +46,39 @@ def register(app: typer.Typer, get_container):
             output.error(str(e))
             raise typer.Exit(code=2)
 
-        config = container.config()
+        # Resolve a task if one is anchored. No active task -> ad-hoc capture
+        # against a repo's main checkout. Ambiguous/unknown still error: the user
+        # clearly has tasks and should disambiguate rather than silently fall back.
+        try:
+            t, source = resolve_task(
+                state, cli_task=task,
+                env_task=os.environ.get("MSHIP_TASK"), cwd=Path.cwd(),
+            )
+        except NoActiveTaskError:
+            t, source = None, None
+        except (AmbiguousTaskError, UnknownTaskError) as e:
+            output.error(str(e))
+            raise typer.Exit(code=1)
+
+        if t is not None:
+            output.breadcrumb(f"→ task: {t.slug}  (resolved via {source.value})")
+            try:
+                resolved_repo = resolve_repo(t, repo)
+            except ValueError as e:
+                output.error(str(e))
+                raise typer.Exit(code=1)
+            worktree = Path(t.worktrees[resolved_repo])
+            out_bucket = t.slug
+        else:
+            try:
+                resolved_repo = _cap.resolve_adhoc_repo(list(config.repos), repo)
+            except _cap.CaptureError as e:
+                output.error(str(e))
+                raise typer.Exit(code=1)
+            # repo.path is resolved to an absolute main-checkout path at load time.
+            worktree = Path(config.repos[resolved_repo].path)
+            out_bucket = "_adhoc"
+
         repo_cfg = config.repos[resolved_repo]
         platforms = repo_cfg.capture.platforms if repo_cfg.capture else []
 
@@ -63,7 +100,6 @@ def register(app: typer.Typer, get_container):
             raise typer.Exit(code=2)
 
         actual = repo_cfg.tasks.get("capture", "capture")
-        worktree = Path(t.worktrees[resolved_repo])
 
         if out is not None:
             out_dir = out
@@ -71,7 +107,7 @@ def register(app: typer.Typer, get_container):
             ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
             workspace_root = Path(container.config_path()).parent
             label = resolved_platform or "default"
-            out_dir = workspace_root / ".mothership" / "captures" / t.slug / f"{ts}-{label}"
+            out_dir = workspace_root / ".mothership" / "captures" / out_bucket / f"{ts}-{label}"
 
         try:
             artifacts = _cap.run_capture(
@@ -95,6 +131,6 @@ def register(app: typer.Typer, get_container):
                 "platform": resolved_platform,
                 "repo": resolved_repo,
                 "artifacts": [{"kind": a.kind, "path": str(a.path)} for a in artifacts],
-                "resolved_task": resolved.task.slug,
-                "resolution_source": resolved.source,
+                "resolved_task": t.slug if t is not None else None,
+                "resolution_source": source.value if source is not None else None,
             })

--- a/src/mship/core/capture.py
+++ b/src/mship/core/capture.py
@@ -29,6 +29,27 @@ class Artifact:
     path: Path
 
 
+def resolve_adhoc_repo(repo_names: list[str], repo_flag: str | None) -> str:
+    """Pick a repo for an ad-hoc (no active task) capture.
+
+    Capture observes a running app, not worktree source, so it can run without a
+    task — against a repo's main checkout. Priority: --repo flag > sole repo >
+    CaptureError (ambiguous; caller must pass --repo).
+    """
+    if repo_flag is not None:
+        if repo_flag not in repo_names:
+            raise CaptureError(
+                f"unknown repo {repo_flag!r}. Workspace repos: {sorted(repo_names)}"
+            )
+        return repo_flag
+    if len(repo_names) == 1:
+        return repo_names[0]
+    raise CaptureError(
+        "no active task and the workspace has multiple repos; "
+        f"pass --repo <name> (one of: {sorted(repo_names)})."
+    )
+
+
 def resolve_kinds(kind_flag: str) -> list[str]:
     """Map the --kind value ('all' | a single kind) to a concrete list."""
     if kind_flag == "all":

--- a/src/mship/core/capture.py
+++ b/src/mship/core/capture.py
@@ -45,8 +45,8 @@ def resolve_adhoc_repo(repo_names: list[str], repo_flag: str | None) -> str:
     if len(repo_names) == 1:
         return repo_names[0]
     raise CaptureError(
-        "no active task and the workspace has multiple repos; "
-        f"pass --repo <name> (one of: {sorted(repo_names)})."
+        "no active task and no single repo could be selected; "
+        f"pass --repo <name> (workspace repos: {sorted(repo_names)})."
     )
 
 

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -198,6 +198,10 @@ and/or a structured layout dump (`layout`) — into files you can read, then com
 against intent and iterate. It delegates to the repo's `capture` go-task target
 (adb/simctl/etc.), so the app must already be running (`mship run`); it does not
 boot emulators/simulators. Use `--platform` when a repo targets more than one.
+It's task-aware but **not** task-required: with an active task it runs in that
+task's worktree and files captures under the task; with no task it runs an
+ad-hoc capture against the repo's main checkout (pass `--repo` if the workspace
+has more than one). Capture observes a *running app*, not worktree source.
 
 **`spawn` order:** slugify → worktree per repo → symlink `symlink_dirs` → `task setup` (unless `--skip-setup`) → save state → enter `plan`. If a repo's setup fails, the task still spawns; fix and re-run setup manually.
 

--- a/tests/cli/test_capture.py
+++ b/tests/cli/test_capture.py
@@ -61,14 +61,99 @@ class _FakeResult:
 class _FakeShell:
     def __init__(self, returncode=0, stderr="", write_image=True):
         self.returncode = returncode; self.stderr = stderr; self.write_image = write_image
-        self.calls = []
+        self.calls = []   # env dicts, one per run_task
+        self.cwds = []    # cwd Paths, one per run_task
 
     def run_task(self, task_name, actual_task_name, cwd, env_runner=None, env=None):
         self.calls.append(env)
+        self.cwds.append(cwd)
         out = Path(env["MSHIP_CAPTURE_DIR"]); out.mkdir(parents=True, exist_ok=True)
         if self.write_image:
             (out / "screen.png").write_bytes(b"PNGDATA")
         return _FakeResult(returncode=self.returncode, stderr=self.stderr)
+
+
+def _bootstrap_no_task(tmp_path: Path, repos: dict[str, list[str]]):
+    """Workspace with NO active task. `repos` maps repo name -> capture platforms."""
+    state_dir = tmp_path / ".mothership"; state_dir.mkdir()
+    lines = ["workspace: t", "repos:"]
+    for name, platforms in repos.items():
+        repo_dir = tmp_path / name; repo_dir.mkdir()
+        (repo_dir / "Taskfile.yml").write_text("version: '3'\ntasks:\n  capture:\n    cmds:\n      - echo ok\n")
+        plat = "[" + ", ".join(platforms) + "]"
+        lines += [f"  {name}:", f"    path: ./{name}", "    type: service",
+                  "    capture:", f"      platforms: {plat}"]
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text("\n".join(lines) + "\n")
+    StateManager(state_dir).save(WorkspaceState(tasks={}))
+    return cfg, state_dir
+
+
+def test_capture_no_task_adhoc_uses_main_checkout(tmp_path):
+    cfg, state_dir = _bootstrap_no_task(tmp_path, {"app": ["android"]})
+    shell = _FakeShell()
+    _override(cfg, state_dir, shell)
+    try:
+        result = runner.invoke(app, ["capture", "--repo", "app"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["platform"] == "android"
+        assert payload["resolved_task"] is None
+        assert payload["artifacts"][0]["kind"] == "image"
+        # ran in the repo's main checkout, not a worktree
+        assert shell.cwds[0] == (tmp_path / "app").resolve()
+        # output filed under the _adhoc bucket, not a task slug
+        assert "_adhoc" in payload["artifacts"][0]["path"]
+    finally:
+        _reset()
+
+
+def test_capture_no_task_requires_repo_when_multiple(tmp_path):
+    cfg, state_dir = _bootstrap_no_task(tmp_path, {"app": ["android"], "web": ["browser"]})
+    _override(cfg, state_dir, _FakeShell())
+    try:
+        result = runner.invoke(app, ["capture"])
+        assert result.exit_code != 0
+        assert "no active task" in result.output
+        assert "--repo" in result.output
+    finally:
+        _reset()
+
+
+def test_capture_no_task_with_repo_flag_picks_it(tmp_path):
+    cfg, state_dir = _bootstrap_no_task(tmp_path, {"app": ["android"], "web": ["browser"]})
+    shell = _FakeShell()
+    _override(cfg, state_dir, shell)
+    try:
+        result = runner.invoke(app, ["capture", "--repo", "web", "--platform", "browser"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["repo"] == "web"
+        assert payload["platform"] == "browser"
+        assert payload["resolved_task"] is None
+    finally:
+        _reset()
+
+
+def test_capture_ambiguous_task_still_errors(tmp_path):
+    # Two active tasks, no anchor -> ambiguous; must error, NOT fall back to adhoc.
+    cfg, state_dir = _bootstrap_no_task(tmp_path, {"app": ["android"]})
+    wt1 = tmp_path / "wt1"; wt1.mkdir()
+    wt2 = tmp_path / "wt2"; wt2.mkdir()
+    now = datetime.now(timezone.utc)
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "a": Task(slug="a", description="d", phase="dev", created_at=now,
+                  affected_repos=["app"], worktrees={"app": str(wt1)}, branch="feat/a", base_branch="main"),
+        "b": Task(slug="b", description="d", phase="dev", created_at=now,
+                  affected_repos=["app"], worktrees={"app": str(wt2)}, branch="feat/b", base_branch="main"),
+    }))
+    _override(cfg, state_dir, _FakeShell())
+    try:
+        result = runner.invoke(app, ["capture", "--repo", "app", "--platform", "android"])
+        assert result.exit_code != 0
+        assert "a" in result.output and "b" in result.output
+    finally:
+        _reset()
 
 
 def test_capture_single_platform_implicit(tmp_path):

--- a/tests/cli/test_capture.py
+++ b/tests/cli/test_capture.py
@@ -151,7 +151,21 @@ def test_capture_ambiguous_task_still_errors(tmp_path):
     try:
         result = runner.invoke(app, ["capture", "--repo", "app", "--platform", "android"])
         assert result.exit_code != 0
-        assert "a" in result.output and "b" in result.output
+        # both task slugs surface so the user can disambiguate with --task
+        assert "Multiple active tasks" in result.output
+        assert "a, b" in result.output
+    finally:
+        _reset()
+
+
+def test_capture_unknown_task_errors(tmp_path):
+    # An explicit unknown --task must error, NOT silently fall back to adhoc.
+    cfg, state_dir = _bootstrap_no_task(tmp_path, {"app": ["android"]})
+    _override(cfg, state_dir, _FakeShell())
+    try:
+        result = runner.invoke(app, ["capture", "--task", "ghost"])
+        assert result.exit_code != 0
+        assert "ghost" in result.output
     finally:
         _reset()
 
@@ -167,6 +181,10 @@ def test_capture_single_platform_implicit(tmp_path):
         assert payload["platform"] == "android"
         assert payload["artifacts"][0]["kind"] == "image"
         assert shell.calls[0]["MSHIP_CAPTURE_PLATFORM"] == "android"
+        # task mode populates the resolution fields and files under the task slug
+        assert payload["resolved_task"] == "t"
+        assert payload["resolution_source"] == "--task"
+        assert "/captures/t/" in payload["artifacts"][0]["path"]
     finally:
         _reset()
 

--- a/tests/core/test_capture.py
+++ b/tests/core/test_capture.py
@@ -8,7 +8,26 @@ import pytest
 
 from mship.core.capture import (
     Artifact, CaptureError, resolve_kinds, discover_artifacts, run_capture,
+    resolve_adhoc_repo,
 )
+
+
+def test_resolve_adhoc_repo_explicit_flag():
+    assert resolve_adhoc_repo(["app", "web"], "web") == "web"
+
+
+def test_resolve_adhoc_repo_sole_repo_implicit():
+    assert resolve_adhoc_repo(["only"], None) == "only"
+
+
+def test_resolve_adhoc_repo_unknown_flag_raises():
+    with pytest.raises(CaptureError, match="unknown repo"):
+        resolve_adhoc_repo(["app", "web"], "nope")
+
+
+def test_resolve_adhoc_repo_ambiguous_raises():
+    with pytest.raises(CaptureError, match="no active task"):
+        resolve_adhoc_repo(["app", "web"], None)
 
 
 def test_resolve_kinds_all_and_single():


### PR DESCRIPTION
## Summary

Make `mship capture` **task-optional**. It previously hard-required an active task (errored with "no active task"); now it's task-*aware* but not task-*required*.

The reasoning: `mship test` runs the worktree's *code*, so the task→worktree coupling is essential there. `mship capture` observes a *running app* — the pixels came from some build+install that's external to any worktree's filesystem at capture time — so the task only contributes the cwd (to find the `Taskfile`) and the output-dir key, neither of which actually requires a task. Requiring one also blocked a legitimate "just let me see the screen right now" use case and didn't prevent the real footgun (capture can't know what's installed regardless). This mirrors the no-active-task fallback we recently added to `mship view spec`.

### Behavior
- **Active task** → unchanged: runs in the task's worktree, captures filed under `.mothership/captures/<task>/`.
- **No active task** → ad-hoc capture against the repo's main checkout, output under `.mothership/captures/_adhoc/`. New pure helper `resolve_adhoc_repo` picks the repo: `--repo` > sole repo > error (so `--repo` is required only when the workspace has >1 repo).
- **Ambiguous / unknown task** → still errors (the user clearly has tasks; disambiguate with `--task`), matching the `view spec` fallback policy. An explicit unknown `--task` never silently falls back.
- JSON output: `resolved_task`/`resolution_source` are populated in task mode, `null` in ad-hoc mode.

## Test plan
- `tests/core/test_capture.py`: `resolve_adhoc_repo` table (flag / sole / unknown / ambiguous).
- `tests/cli/test_capture.py`: ad-hoc capture uses the main checkout + `_adhoc` bucket + null resolution fields; `--repo` required when >1 repo; `--repo` selects in ad-hoc; ambiguous task still errors; unknown `--task` errors; task-mode JSON asserts `resolved_task`/`resolution_source` + task-bucket path. Existing task-mode tests unchanged.
- TDD throughout; independent review APPROVED (no blocking/important). Full suite green via `mship test` (1616 passed).
- `working-with-mothership` skill updated to document the task-optional behavior.
