### PR TITLE
MOS-188 serve token test cwd-independent

### DIFF
--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -33,7 +33,12 @@ def test_serve_command_registered():
     assert "127.0.0.1" in result.output
 
 
-def test_serve_refuses_nonloopback_without_token(monkeypatch):
+def test_serve_refuses_nonloopback_without_token(_configured, monkeypatch):
+    # _configured overrides config_path so get_container() skips cwd-based
+    # workspace discovery (see mship.cli.get_container). Without it, serve hits
+    # "No mothership.yaml found" before the token check when pytest runs from a
+    # bare checkout with no workspace above cwd, masking the security assertion
+    # below (MOS-188).
     monkeypatch.delenv("MSHIP_SERVE_TOKEN", raising=False)
     result = runner.invoke(app, ["serve", "--host", "0.0.0.0"])
     assert result.exit_code != 0


### PR DESCRIPTION
## Summary

`tests/cli/test_serve.py::test_serve_refuses_nonloopback_without_token` failed when pytest ran from a **bare mothership checkout** (no `mothership.yaml` discoverable above cwd). The test invoked `mship serve --host 0.0.0.0` expecting a `MSHIP_SERVE_TOKEN` refusal, but `get_container()` does cwd-based config discovery first and raised `No mothership.yaml found in any parent directory` before the token check could fire:

```
AssertionError: assert 'MSHIP_SERVE_TOKEN' in 'Error: No mothership.yaml found in any parent directory\n'
```

It passed only when run from inside a workspace (CI, task worktrees, the cloud agent's bootstrapped checkout), so it went unnoticed — and became reproducible once `mothership/mothership.yaml` was consolidated into the workspace, leaving a bare clone with no discoverable config.

## Fix (test-only, no behavior change)

Add the existing `_configured` fixture to the test. It overrides `container.config_path`, and `get_container()` only runs `ConfigLoader.discover(Path.cwd())` when `config_path` is **not** overridden — so discovery is skipped entirely and `serve` reaches the non-loopback token check regardless of cwd. The test still genuinely asserts that `serve --host 0.0.0.0` without `MSHIP_SERVE_TOKEN` is refused (non-zero exit + `MSHIP_SERVE_TOKEN` in output). This mirrors how `test_serve_binds_nonloopback_with_token` already uses the fixture.

## Test plan

- **Reproduced the failure first** from an empty temp cwd (no `mothership.yaml` ancestor): `cd $(mktemp -d) && uv run --project <repo> pytest tests/cli/test_serve.py` → 1 failed with the exact assertion above.
- **After the fix**, same bare-cwd invocation → `3 passed`.
- From inside the worktree (where it always passed) → `3 passed`.
- Full suite via `mship test` → **1617 passed**, 0 failed.

Closes MOS-188.
