### PR TITLE
MOS-190 runtime-only deps import guard

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,9 +7,38 @@ tasks:
       - uv sync
 
   test:
-    desc: Run the test suite
+    desc: Run the test suite (runtime-deps guard, then pytest)
     cmds:
+      - task: check-runtime-deps
       - uv run pytest -q
+
+  check-runtime-deps:
+    desc: Import the CLI with runtime-only deps to catch a dev-only dep used at runtime (MOS-190)
+    # A `uv tool install` ships only `[project.dependencies]`, so a module-level
+    # `import <pkg>` of a dev-only dependency crashes the CLI for users on
+    # startup (MOS-187: `import httpx` in gh_auth.py while httpx was dev-only,
+    # fixed reactively in #219). pytest can't catch this — it always runs in the
+    # dev environment, so the dev dep is present.
+    #
+    # This builds + installs the project into a throwaway venv (exactly what
+    # `uv tool install` / `uv pip install` produce: runtime deps only, no dev
+    # group) and imports mship.cli, which walks the full runtime graph
+    # (cli -> container -> pr -> gh_auth -> import httpx). Any runtime module
+    # importing an undeclared dependency fails here with ModuleNotFoundError.
+    #
+    # Why a throwaway venv and not `uv run --no-dev`: a plain `uv run --no-dev`
+    # does a non-pruning sync, so a dev dep left in a warm .venv masks the
+    # regression; `uv run --no-dev --exact` fixes that but churns the dev's
+    # .venv on every run; `uv run --no-project --with .` reuses a stale built
+    # wheel and silently passes. A fresh venv is reliable AND leaves .venv alone.
+    cmds:
+      - |
+        set -eu
+        tmp="$(mktemp -d)"
+        trap 'rm -rf "$tmp"' EXIT
+        uv venv "$tmp/venv" >/dev/null
+        uv pip install --python "$tmp/venv/bin/python" --quiet .
+        "$tmp/venv/bin/python" -c "import mship.cli"
 
   lint:
     desc: Static checks (no linter wired yet)


### PR DESCRIPTION
## Summary

mship 0.3.0 shipped broken: `gh_auth.py` does a module-level `import httpx` (reached on every invocation via `pr.py` → `container` → `cli`), but `httpx` was declared only in the `dev` dependency-group, not `[project.dependencies]`. Every dev-side check passed — `uv run`, the full pytest suite, even multi-stage review all run *with* dev deps — so a `uv tool install` (which installs only `[project.dependencies]`) crashed on startup with `ModuleNotFoundError: No module named 'httpx'`. Fixed reactively in #219; nothing prevented the next dev-only-import-at-runtime regression (MOS-187).

This adds a deterministic guard that exercises the **runtime-only** dependency set.

## What changed

A new `check-runtime-deps` task in the mothership `Taskfile.yml`, wired as the **first** step of `task test` (so it runs locally on every `mship test` and fails fast before pytest):

```yaml
check-runtime-deps:
  cmds:
    - |
      set -eu
      tmp="$(mktemp -d)"
      trap 'rm -rf "$tmp"' EXIT
      uv venv "$tmp/venv" >/dev/null
      uv pip install --python "$tmp/venv/bin/python" --quiet .
      "$tmp/venv/bin/python" -c "import mship.cli"
```

It builds + installs the project into a throwaway venv (exactly what `uv tool install` produces: runtime deps only, no dev group) and imports `mship.cli`, walking the full runtime graph (`cli → container → pr → gh_auth → import httpx`). Any runtime module importing an undeclared dependency now fails here with `ModuleNotFoundError` instead of in users' hands.

The repo has no GitHub Actions today, so this lands as a `task` target (the issue's accepted fallback). A CI job, when added, can simply run `task test` and inherit the guard.

## Why a throwaway venv (design notes, verified empirically)

The issue proposed `uv run --no-dev python -c "import mship.cli"`. I found that command **unreliable** and the alternatives each have a flaw:

| Approach | Catches regression? | Notes |
|---|---|---|
| `uv run --no-dev` | ❌ no | non-pruning sync — a dev dep lingering in a warm `.venv` masks it |
| `uv run --no-dev --exact` | ✅ yes | works, but **churns the dev's `.venv`** (prunes dev deps) on every run |
| `uv run --no-project --with .` | ❌ no | reuses a **stale built wheel** for the path dep; passes even with `--refresh` |
| **fresh venv + `uv pip install .`** | ✅ yes | reliable **and** leaves `.venv` untouched; mirrors `uv tool install` exactly |

## Test plan

- **Reproduced the regression**: temporarily moved `httpx` from `[project.dependencies]` to the `dev` group → `task check-runtime-deps` exits non-zero with `ModuleNotFoundError: No module named 'httpx'`; deterministic across warm-cache re-runs. Reverted.
- **Passes on the fixed state**: `task check-runtime-deps` → exit 0.
- **`task test` fails fast** on the regression — 0 pytest lines run (guard aborts before pytest).
- **`.venv` not mutated** by the guard (pytest still importable afterward).
- **Full suite via `mship test`** (now guard → pytest) → **1617 passed**, 0 failed.

Closes MOS-190.
