### PR TITLE
Ground Control Tasks tab: monitor in-flight work (enrich TaskSummary + tasks list/detail + journal)

### DIFF
--- a/docs/plans/2026-06-22-tasks-tab.md
+++ b/docs/plans/2026-06-22-tasks-tab.md
@@ -1,0 +1,610 @@
+# Ground Control Tasks tab Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Spec:** `ground-control-tasks-tab` (approved) — workspace `specs/2026-06-22-ground-control-tasks-tab.md`.
+
+**Goal:** A read-only Tasks tab in Ground Control that monitors in-flight work — phase, per-repo test status, blocked reason, tap-through PR links, and the journal timeline — closing the dispatch→watch loop. Plus a small mothership change widening `TaskSummary` so the app has the fields to show.
+
+**Architecture:** mothership widens `TaskSummary` (additive). ground-control adds DTOs + API calls + a fan-out repository + two screens (list + detail), all mirroring the existing spec inbox/detail (`ui/specs`, `ui/specdetail`) — MVVM + StateFlow, reusing `mshipDefaults` error mapping, the `connectionId` nav carry, `runBlockingSnapshot` connection-resolve, and the pull-to-refresh pattern. JVM unit tests only (no emulator); Compose screens are build-verified.
+
+**This task spans TWO repos:**
+- mothership worktree: `.worktrees/ground-control-tasks-tab/mothership` (Task 1)
+- ground-control worktree: `.worktrees/ground-control-tasks-tab/ground-control` (Tasks 2–4)
+- Task 5 verifies both.
+
+**dev-binary note:** run mothership tests via `uv run pytest …`.
+
+---
+
+<!-- mship:task id=1 -->
+### Task 1 (mothership): widen TaskSummary
+
+**Files:**
+- Modify: `src/mship/core/view/task_index.py`
+- Test: `tests/core/view/test_task_index.py`
+
+Work in the **mothership** worktree.
+
+- [ ] **Step 1: Write the failing test** — append to `tests/core/view/test_task_index.py` (it already imports `Task, WorkspaceState, TestResult`, has the `_task(slug, **over)` helper, and tests `build_task_index`):
+
+```python
+def test_build_task_index_includes_enriched_fields(tmp_path: Path):
+    from mship.core.state import DependencyEdge
+    now = datetime.now(timezone.utc)
+    t = _task(
+        "a",
+        description="Add the thing",
+        pr_urls={"mothership": "https://github.com/x/mothership/pull/1"},
+        test_results={"mothership": TestResult(status="pass", at=now)},
+        depends_on=[DependencyEdge(upstream_slug="up", created_at=now)],
+    )
+    state = WorkspaceState(tasks={"a": t})
+    [s] = build_task_index(state, tmp_path)
+    assert s.description == "Add the thing"
+    assert s.pr_urls == {"mothership": "https://github.com/x/mothership/pull/1"}
+    assert s.test_results == {"mothership": "pass"}
+    assert s.depends_on == ["up"]
+```
+
+> If `DependencyEdge` lives elsewhere or has a different field name, confirm via `grep -n "class DependencyEdge" src/mship/core/state.py` and adjust the import/kwargs — but `upstream_slug` is the expected field.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/core/view/test_task_index.py -q`
+Expected: FAIL — `TaskSummary` has no `description`/`pr_urls`/`test_results`/`depends_on`.
+
+- [ ] **Step 3: Widen the dataclass + `_summarize`**
+
+In `src/mship/core/view/task_index.py`, change the import to include `field`:
+```python
+from dataclasses import dataclass, field
+```
+add the four fields to `TaskSummary` (with defaults so any direct construction stays valid — they must come after the existing no-default fields):
+```python
+@dataclass(frozen=True)
+class TaskSummary:
+    slug: str
+    phase: str
+    branch: str
+    affected_repos: list[str]
+    worktrees: dict[str, Path]
+    finished_at: datetime | None
+    blocked_reason: str | None
+    created_at: datetime
+    spec_count: int
+    orphan: bool
+    tests_failing: bool
+    description: str = ""
+    pr_urls: dict[str, str] = field(default_factory=dict)
+    test_results: dict[str, str] = field(default_factory=dict)
+    depends_on: list[str] = field(default_factory=list)
+```
+and populate them in `_summarize`'s `return TaskSummary(...)` (add these kwargs):
+```python
+        description=task.description,
+        pr_urls=dict(task.pr_urls),
+        test_results={repo: tr.status for repo, tr in task.test_results.items()},
+        depends_on=[e.upstream_slug for e in task.depends_on],
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/core/view/test_task_index.py tests/core/test_serve.py -q`
+Expected: PASS (new test + existing task_index + serve tests; `jsonable_encoder` serializes the new fields automatically, so `GET /tasks` shape tests still pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/view/task_index.py tests/core/view/test_task_index.py
+git commit -m "feat(view): widen TaskSummary with description, pr_urls, test_results, depends_on"
+mship journal "widened TaskSummary (description/pr_urls/test_results/depends_on) for Ground Control Tasks tab; tests green" --action committed
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=2 -->
+### Task 2 (ground-control): Task DTOs + API + repository
+
+**Files:**
+- Create: `android/app/src/main/java/com/atomikpanda/groundcontrol/data/dto/TaskDtos.kt`
+- Modify: `android/app/src/main/java/com/atomikpanda/groundcontrol/data/MshipClient.kt`
+- Create: `android/app/src/main/java/com/atomikpanda/groundcontrol/data/TasksRepository.kt`
+- Test: `android/app/src/test/java/com/atomikpanda/groundcontrol/TaskDtosTest.kt`, `TasksApiTest.kt`, `TasksRepositoryTest.kt`
+
+Work in the **ground-control** worktree. Source the toolchain before gradle: `source ~/toolchains/android-env.sh`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`TaskDtosTest.kt`:
+```kotlin
+package com.atomikpanda.groundcontrol
+
+import com.atomikpanda.groundcontrol.data.buildJson
+import com.atomikpanda.groundcontrol.data.dto.JournalEntry
+import com.atomikpanda.groundcontrol.data.dto.TaskSummary
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TaskDtosTest {
+    private val json = buildJson()
+
+    @Test fun parses_task_summary_with_maps_and_unknown_keys() {
+        val raw = """
+        {"slug":"t1","description":"Do it","phase":"dev","branch":"feat/t1",
+         "affected_repos":["mothership"],"pr_urls":{"mothership":"https://x/pull/1"},
+         "test_results":{"mothership":"pass"},"blocked_reason":null,"depends_on":["up"],
+         "spec_count":1,"orphan":false,"tests_failing":false,
+         "finished_at":null,"created_at":"2026-06-22T00:00:00Z","worktrees":{"mothership":"/x"}}
+        """.trimIndent()
+        val t = json.decodeFromString(TaskSummary.serializer(), raw)
+        assertEquals("t1", t.slug)
+        assertEquals("Do it", t.description)
+        assertEquals("dev", t.phase)
+        assertEquals("https://x/pull/1", t.prUrls["mothership"])
+        assertEquals("pass", t.testResults["mothership"])
+        assertEquals(listOf("up"), t.dependsOn)
+        assertNull(t.finishedAt)
+    }
+
+    @Test fun parses_journal_entry_with_optional_fields() {
+        val raw = """{"timestamp":"2026-06-22T00:00:00Z","message":"ran tests","repo":"mothership",
+                     "action":"ran tests","test_state":"pass","open_question":null,"iteration":2}"""
+        val e = json.decodeFromString(JournalEntry.serializer(), raw.trimIndent())
+        assertEquals("ran tests", e.message)
+        assertEquals("pass", e.testState)
+        assertEquals(2, e.iteration)
+        assertNull(e.openQuestion)
+    }
+}
+```
+
+`TasksApiTest.kt`:
+```kotlin
+package com.atomikpanda.groundcontrol
+
+import com.atomikpanda.groundcontrol.data.SpecApi
+import com.atomikpanda.groundcontrol.data.WorkspaceConnection
+import com.atomikpanda.groundcontrol.data.mshipDefaults
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TasksApiTest {
+    private val conn = WorkspaceConnection("1", "http://h:47100", "secret", "ws")
+    private val jsonHdr = headersOf(HttpHeaders.ContentType, "application/json")
+    private fun client(h: io.ktor.client.engine.mock.MockRequestHandler) =
+        HttpClient(MockEngine(h)) { mshipDefaults() }
+
+    @Test fun list_tasks_hits_tasks_path_with_bearer() = runTest {
+        var url: String? = null; var auth: String? = null
+        val api = SpecApi(client { req ->
+            url = req.url.toString(); auth = req.headers[HttpHeaders.Authorization]
+            respond("""[{"slug":"t1","phase":"dev","branch":"feat/t1"}]""", HttpStatusCode.OK, jsonHdr)
+        })
+        val tasks = api.listTasks(conn)
+        assertEquals(1, tasks.size); assertEquals("t1", tasks[0].slug)
+        assertTrue(url!!.endsWith("/tasks")); assertEquals("Bearer secret", auth)
+    }
+
+    @Test fun get_journal_hits_journal_path() = runTest {
+        var url: String? = null
+        val api = SpecApi(client { req ->
+            url = req.url.toString()
+            respond("""[{"timestamp":"t","message":"m"}]""", HttpStatusCode.OK, jsonHdr)
+        })
+        val j = api.getJournal(conn, "t1")
+        assertEquals(1, j.size); assertTrue(url!!.endsWith("/journal/t1"))
+    }
+
+    @Test(expected = com.atomikpanda.groundcontrol.data.NotFoundException::class)
+    fun get_task_maps_404() = runTest {
+        val api = SpecApi(client { respond("""{"detail":"no task"}""", HttpStatusCode.NotFound, jsonHdr) })
+        api.getTask(conn, "missing")
+    }
+}
+```
+
+`TasksRepositoryTest.kt`:
+```kotlin
+package com.atomikpanda.groundcontrol
+
+import com.atomikpanda.groundcontrol.data.SpecApi
+import com.atomikpanda.groundcontrol.data.TasksRepository
+import com.atomikpanda.groundcontrol.data.WorkspaceConnection
+import com.atomikpanda.groundcontrol.data.buildJson
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TasksRepositoryTest {
+    private val jsonHdr = headersOf(HttpHeaders.ContentType, "application/json")
+
+    @Test fun aggregates_and_isolates_failures() = runTest {
+        val ok = WorkspaceConnection("1", "http://ok:47100", null, "ws-ok")
+        val bad = WorkspaceConnection("2", "http://bad:47100", null, "ws-bad")
+        val api = SpecApi(HttpClient(MockEngine { req ->
+            if (req.url.host == "ok") respond("""[{"slug":"t1","phase":"dev","branch":"b"}]""", HttpStatusCode.OK, jsonHdr)
+            else respond("boom", HttpStatusCode.InternalServerError)
+        }) { install(ContentNegotiation) { json(buildJson()) } })
+        val results = TasksRepository(api).listAllTasks(listOf(ok, bad))
+        assertEquals(2, results.size)
+        assertTrue(results.first { it.connection.id == "1" }.tasks.isSuccess)
+        assertTrue(results.first { it.connection.id == "2" }.tasks.isFailure)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd android && ./gradlew testDebugUnitTest --tests "com.atomikpanda.groundcontrol.Task*"`
+Expected: FAIL — unresolved DTOs / `listTasks` / `TasksRepository`.
+
+- [ ] **Step 3: Implement**
+
+Create `data/dto/TaskDtos.kt`:
+```kotlin
+package com.atomikpanda.groundcontrol.data.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TaskSummary(
+    val slug: String,
+    val description: String = "",
+    val phase: String,
+    val branch: String,
+    @SerialName("affected_repos") val affectedRepos: List<String> = emptyList(),
+    @SerialName("pr_urls") val prUrls: Map<String, String> = emptyMap(),
+    @SerialName("test_results") val testResults: Map<String, String> = emptyMap(),
+    @SerialName("blocked_reason") val blockedReason: String? = null,
+    @SerialName("depends_on") val dependsOn: List<String> = emptyList(),
+    @SerialName("spec_count") val specCount: Int = 0,
+    val orphan: Boolean = false,
+    @SerialName("tests_failing") val testsFailing: Boolean = false,
+    @SerialName("finished_at") val finishedAt: String? = null,
+    @SerialName("created_at") val createdAt: String? = null,
+)
+
+@Serializable
+data class JournalEntry(
+    val timestamp: String,
+    val message: String,
+    val repo: String? = null,
+    val action: String? = null,
+    @SerialName("test_state") val testState: String? = null,
+    @SerialName("open_question") val openQuestion: String? = null,
+    val category: String? = null,
+    val iteration: Int? = null,
+)
+```
+
+In `data/MshipClient.kt`, add imports for `TaskSummary` and `JournalEntry`, and add to `SpecApi`:
+```kotlin
+    suspend fun listTasks(conn: WorkspaceConnection): List<TaskSummary> =
+        client.get("${conn.baseUrl}/tasks") { auth(conn) }.body()
+
+    suspend fun getTask(conn: WorkspaceConnection, slug: String): TaskSummary =
+        client.get("${conn.baseUrl}/tasks/$slug") { auth(conn) }.body()
+
+    suspend fun getJournal(conn: WorkspaceConnection, slug: String): List<JournalEntry> =
+        client.get("${conn.baseUrl}/journal/$slug") { auth(conn) }.body()
+```
+
+Create `data/TasksRepository.kt`:
+```kotlin
+package com.atomikpanda.groundcontrol.data
+
+import com.atomikpanda.groundcontrol.data.dto.TaskSummary
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+
+data class WorkspaceTasks(
+    val connection: WorkspaceConnection,
+    val tasks: Result<List<TaskSummary>>,
+)
+
+class TasksRepository(private val api: SpecApi) {
+    suspend fun listAllTasks(connections: List<WorkspaceConnection>): List<WorkspaceTasks> =
+        coroutineScope {
+            connections.map { conn ->
+                async { WorkspaceTasks(conn, runCatching { api.listTasks(conn) }) }
+            }.awaitAll()
+        }
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd android && ./gradlew testDebugUnitTest --tests "com.atomikpanda.groundcontrol.Task*"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add android/app/src/main/java/com/atomikpanda/groundcontrol/data/dto/TaskDtos.kt \
+        android/app/src/main/java/com/atomikpanda/groundcontrol/data/MshipClient.kt \
+        android/app/src/main/java/com/atomikpanda/groundcontrol/data/TasksRepository.kt \
+        android/app/src/test/java/com/atomikpanda/groundcontrol/TaskDtosTest.kt \
+        android/app/src/test/java/com/atomikpanda/groundcontrol/TasksApiTest.kt \
+        android/app/src/test/java/com/atomikpanda/groundcontrol/TasksRepositoryTest.kt
+git commit -m "feat(gc): Task/Journal DTOs + listTasks/getTask/getJournal + TasksRepository"
+mship journal "added Task DTOs, tasks/journal API calls, fan-out TasksRepository; tests green" --action committed --repo ground-control
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=3 -->
+### Task 3 (ground-control): Tasks list — ViewModel, screen, nav
+
+**Files:**
+- Create: `android/app/src/main/java/com/atomikpanda/groundcontrol/ui/tasks/TasksViewModel.kt`
+- Create: `android/app/src/main/java/com/atomikpanda/groundcontrol/ui/tasks/TasksScreen.kt`
+- Modify: `android/app/src/main/java/com/atomikpanda/groundcontrol/GroundControlApp.kt`
+- Test: `android/app/src/test/java/com/atomikpanda/groundcontrol/TasksViewModelTest.kt`
+
+Work in the **ground-control** worktree. This mirrors `ui/specs/SpecInboxViewModel.kt` + `SpecInboxScreen.kt` (read them first).
+
+- [ ] **Step 1: Write the failing test**
+
+`TasksViewModelTest.kt`:
+```kotlin
+package com.atomikpanda.groundcontrol
+
+import com.atomikpanda.groundcontrol.data.SpecApi
+import com.atomikpanda.groundcontrol.data.TasksRepository
+import com.atomikpanda.groundcontrol.data.WorkspaceConnection
+import com.atomikpanda.groundcontrol.data.buildJson
+import com.atomikpanda.groundcontrol.ui.tasks.TaskGroup
+import com.atomikpanda.groundcontrol.ui.tasks.TasksUiState
+import com.atomikpanda.groundcontrol.ui.tasks.TasksViewModel
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class TasksViewModelTest {
+    @Before fun setUp() = Dispatchers.setMain(StandardTestDispatcher())
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private val jsonHdr = headersOf(HttpHeaders.ContentType, "application/json")
+    private fun repo() = TasksRepository(SpecApi(HttpClient(MockEngine {
+        respond("""[{"slug":"act","phase":"dev","branch":"b","finished_at":null},
+                    {"slug":"done","phase":"review","branch":"b","finished_at":"2026-06-22T00:00:00Z"}]""",
+            HttpStatusCode.OK, jsonHdr)
+    }) { install(ContentNegotiation) { json(buildJson()) } }))
+
+    @Test fun groups_workspace_then_active_finished() = runTest {
+        val vm = TasksViewModel(repo(), {
+            listOf(WorkspaceConnection("1", "http://h:47100", null, "ws-a"))
+        }, this)
+        vm.refresh()?.join()
+        val content = vm.state.value as TasksUiState.Content
+        val sec = content.sections[0]
+        assertEquals("ws-a", sec.workspaceName)
+        assertEquals("1", sec.connectionId)
+        val groups = sec.groups.getOrThrow()
+        assertEquals(listOf(TaskGroup.ACTIVE, TaskGroup.FINISHED), groups.map { it.group })
+        assertEquals(listOf("act"), groups[0].tasks.map { it.slug })
+        assertEquals(listOf("done"), groups[1].tasks.map { it.slug })
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails** — `cd android && ./gradlew testDebugUnitTest --tests "com.atomikpanda.groundcontrol.TasksViewModelTest"` → FAIL (unresolved).
+
+- [ ] **Step 3: Implement the ViewModel** — `ui/tasks/TasksViewModel.kt` (mirrors `SpecInboxViewModel`):
+```kotlin
+package com.atomikpanda.groundcontrol.ui.tasks
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.atomikpanda.groundcontrol.data.TasksRepository
+import com.atomikpanda.groundcontrol.data.WorkspaceConnection
+import com.atomikpanda.groundcontrol.data.dto.TaskSummary
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+enum class TaskGroup(val label: String) { ACTIVE("Active"), FINISHED("Finished") }
+
+fun taskGroupFor(t: TaskSummary): TaskGroup =
+    if (t.finishedAt == null) TaskGroup.ACTIVE else TaskGroup.FINISHED
+
+data class TaskGroupBlock(val group: TaskGroup, val tasks: List<TaskSummary>)
+
+data class TasksSection(
+    val workspaceName: String,
+    val connectionId: String,
+    val groups: Result<List<TaskGroupBlock>>,
+)
+
+sealed interface TasksUiState {
+    data object Loading : TasksUiState
+    data object EmptyConfig : TasksUiState
+    data class Content(val sections: List<TasksSection>) : TasksUiState
+}
+
+class TasksViewModel(
+    private val repo: TasksRepository,
+    private val connectionsProvider: () -> List<WorkspaceConnection>,
+    private val testScope: CoroutineScope? = null,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<TasksUiState>(TasksUiState.Loading)
+    val state: StateFlow<TasksUiState> = _state.asStateFlow()
+
+    fun refresh(): Job? {
+        val connections = connectionsProvider()
+        if (connections.isEmpty()) { _state.value = TasksUiState.EmptyConfig; return null }
+        _state.value = TasksUiState.Loading
+        return (testScope ?: viewModelScope).launch {
+            val results = repo.listAllTasks(connections)
+            _state.value = TasksUiState.Content(
+                results.map { ws ->
+                    TasksSection(
+                        workspaceName = ws.connection.workspaceName.ifBlank { ws.connection.baseUrl },
+                        connectionId = ws.connection.id,
+                        groups = ws.tasks.map { tasks -> toGroupBlocks(tasks) },
+                    )
+                }
+            )
+        }
+    }
+
+    private fun toGroupBlocks(tasks: List<TaskSummary>): List<TaskGroupBlock> {
+        val byGroup = tasks.groupBy { taskGroupFor(it) }
+        return TaskGroup.entries.mapNotNull { g ->
+            byGroup[g]?.takeIf { it.isNotEmpty() }?.let { TaskGroupBlock(g, it) }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes** — same `--tests TasksViewModelTest` → PASS.
+
+- [ ] **Step 5: Write the screen (build-verified)** — `ui/tasks/TasksScreen.kt`, mirroring `SpecInboxScreen.kt` (same pull-to-refresh + section/group rendering + error chip). Render each task row with `ListItem`: headline = `task.description.ifBlank { task.slug }`; supporting = a line with the phase, a per-repo test summary (e.g. `task.testResults` rendered as `repo:status`), a `⚠ blocked` marker when `task.blockedReason != null`, and a `PR` marker when `task.prUrls.isNotEmpty()`. Row `Modifier.clickable { onTaskClick(section.connectionId, task.slug) }`. Signature: `fun TasksScreen(vm: TasksViewModel, onTaskClick: (connectionId: String, slug: String) -> Unit)`. Empty-config state: "Add a workspace in Settings." (Keep it close to `SpecInboxScreen` — copy its structure and swap spec→task fields.)
+
+- [ ] **Step 6: Wire nav in `GroundControlApp.kt`** — add `val tasksRepo = remember { TasksRepository(api) }`; replace `composable(Section.TASKS.route) { PlaceholderScreen("Tasks", "C7") }` with:
+```kotlin
+            composable(Section.TASKS.route) {
+                val vm = viewModel {
+                    TasksViewModel(tasksRepo, connectionsProvider = { runBlockingSnapshot(connRepo) })
+                }
+                TasksScreen(vm) { connId, slug -> nav.navigate("taskDetail/$connId/$slug") }
+            }
+```
+(Add imports for `TasksRepository`, `TasksScreen`, `TasksViewModel`. The `taskDetail` route is added in Task 4.)
+
+- [ ] **Step 7: Build** — `cd android && ./gradlew assembleDebug` → BUILD SUCCESSFUL. (The `taskDetail` route doesn't exist yet, but `nav.navigate` to an unknown route only fails at runtime, not compile — Task 4 adds it. If you prefer, implement Task 4's route now; otherwise the build is green.)
+
+- [ ] **Step 8: Commit**
+```bash
+git add android/app/src/main/java/com/atomikpanda/groundcontrol/ui/tasks/TasksViewModel.kt \
+        android/app/src/main/java/com/atomikpanda/groundcontrol/ui/tasks/TasksScreen.kt \
+        android/app/src/main/java/com/atomikpanda/groundcontrol/GroundControlApp.kt \
+        android/app/src/test/java/com/atomikpanda/groundcontrol/TasksViewModelTest.kt
+git commit -m "feat(gc): Tasks tab list (workspace -> active/finished) + nav"
+mship journal "added Tasks list screen + VM (grouped workspace/active-finished), swapped into Tasks nav; tests + build green" --action committed --repo ground-control
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=4 -->
+### Task 4 (ground-control): Task detail + journal
+
+**Files:**
+- Create: `android/app/src/main/java/com/atomikpanda/groundcontrol/ui/tasks/TaskDetailViewModel.kt`
+- Create: `android/app/src/main/java/com/atomikpanda/groundcontrol/ui/tasks/TaskDetailScreen.kt`
+- Modify: `android/app/src/main/java/com/atomikpanda/groundcontrol/GroundControlApp.kt`
+- Test: `android/app/src/test/java/com/atomikpanda/groundcontrol/TaskDetailViewModelTest.kt`
+
+Work in the **ground-control** worktree. Mirrors `ui/specdetail/SpecDetailViewModel.kt` + `SpecDetailScreen.kt` (load + error states), minus any writes.
+
+- [ ] **Step 1: Write the failing tests** (`TaskDetailViewModelTest.kt`) — cover: load success builds Content with the task + journal; 404 → NOT_FOUND; 401 → AUTH. Mirror `SpecDetailViewModelTest`'s structure (StandardTestDispatcher, MockEngine `vm(scope, handler)` helper). The handler returns the task JSON for `/tasks/{slug}` and the journal JSON for `/journal/{slug}` (branch on `req.url.encodedPath`):
+```kotlin
+    private fun vm(scope: kotlinx.coroutines.CoroutineScope, handler: io.ktor.client.engine.mock.MockRequestHandler) =
+        TaskDetailViewModel(
+            com.atomikpanda.groundcontrol.data.TasksRepository(
+                com.atomikpanda.groundcontrol.data.SpecApi(
+                    io.ktor.client.HttpClient(io.ktor.client.engine.mock.MockEngine(handler)) {
+                        com.atomikpanda.groundcontrol.data.mshipDefaults()
+                    })),
+            conn, "t1", testScope = scope,
+        )
+    // load_success: handler returns task for paths ending /tasks/t1 and journal list for /journal/t1
+    // assert Content.task.slug == "t1" and Content.journal has the entries
+    // 404 on /tasks/t1 -> Error(NOT_FOUND); 401 -> Error(AUTH)
+```
+(Write the concrete tests following `SpecDetailViewModelTest` — task load is a single `getTask` + `getJournal`; assert the merged Content and the error kinds.)
+
+- [ ] **Step 2: Run to verify they fail** → unresolved `TaskDetailViewModel`.
+
+- [ ] **Step 3: Implement the ViewModel** — `ui/tasks/TaskDetailViewModel.kt`: `StateFlow<TaskDetailUiState>` = `Loading | Error(kind: ErrorKind, message) | Content(task: TaskSummary, journal: List<JournalEntry>)`. Reuse `ErrorKind` from `ui.specdetail` (import it) or define a local one. `load()` launches, fetches `repo.getTask(conn, slug)` and `repo.getJournal(conn, slug)` (sequential or `async` both), maps `AuthException→AUTH`, `NotFoundException→NOT_FOUND`, else `NETWORK`. Constructor `(repo: TasksRepository, conn: WorkspaceConnection, slug: String, testScope: CoroutineScope? = null)`. Add `getTask`/`getJournal` pass-throughs to `TasksRepository` (mirror `SpecDetailRepository`) OR call `api` via the repo — add to `TasksRepository`:
+```kotlin
+    suspend fun getTask(conn: WorkspaceConnection, slug: String) = api.getTask(conn, slug)
+    suspend fun getJournal(conn: WorkspaceConnection, slug: String) = api.getJournal(conn, slug)
+```
+(make `api` accessible — it's already the constructor param).
+
+- [ ] **Step 4: Run to verify they pass.**
+
+- [ ] **Step 5: Write the screen (build-verified)** — `ui/tasks/TaskDetailScreen.kt`, mirroring `SpecDetailScreen`'s scaffold (top bar + back + pull-to-refresh + Loading/Error/Content). Content renders: header (description, phase, branch, blocked banner when `blockedReason`); affected repos; **per-repo test results** (`task.testResults` → `repo: status` rows); **PR links** — for each `(repo, url)` in `task.prUrls`, a clickable row that opens the browser:
+```kotlin
+import androidx.compose.ui.platform.LocalUriHandler
+// inside Content:
+val uriHandler = LocalUriHandler.current
+task.prUrls.forEach { (repo, url) ->
+    Text("$repo PR ↗", modifier = Modifier.clickable { uriHandler.openUri(url) }.padding(16.dp, 4.dp),
+        color = MaterialTheme.colorScheme.primary)
+}
+```
+`depends_on` as a bullet list of upstream slugs; then the **journal timeline** (each `JournalEntry`: timestamp + message, with `action`/`testState`/`repo` shown as small labels and `openQuestion` highlighted). Signature `fun TaskDetailScreen(vm: TaskDetailViewModel, title: String, onBack: () -> Unit)`; show `(state as? Content)?.task?.description ?: title` in the top bar (the title-from-state pattern from the detail screen).
+
+- [ ] **Step 6: Add the nav route in `GroundControlApp.kt`** — after the Tasks route, add the `taskDetail/{connectionId}/{slug}` composable, mirroring the existing `specDetail/{connectionId}/{specId}` route (resolve the connection via `runBlockingSnapshot(connRepo)`, null fallback, build `TaskDetailViewModel(tasksRepo, conn, slug)`, render `TaskDetailScreen(vm, title = slug, onBack = { nav.popBackStack() })`). Add the `TaskDetailScreen`/`TaskDetailViewModel` imports.
+
+- [ ] **Step 7: Build** — `cd android && ./gradlew assembleDebug` → BUILD SUCCESSFUL.
+
+- [ ] **Step 8: Commit**
+```bash
+git add android/app/src/main/java/com/atomikpanda/groundcontrol/ui/tasks/TaskDetailViewModel.kt \
+        android/app/src/main/java/com/atomikpanda/groundcontrol/ui/tasks/TaskDetailScreen.kt \
+        android/app/src/main/java/com/atomikpanda/groundcontrol/data/TasksRepository.kt \
+        android/app/src/main/java/com/atomikpanda/groundcontrol/GroundControlApp.kt \
+        android/app/src/test/java/com/atomikpanda/groundcontrol/TaskDetailViewModelTest.kt
+git commit -m "feat(gc): Task detail + journal timeline (per-repo tests, PR tap-through, depends_on)"
+mship journal "added Task detail screen + VM (getTask+getJournal, PR links via LocalUriHandler, journal timeline); build + tests green" --action committed --repo ground-control
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=5 -->
+### Task 5: full verification + phase transition
+
+**Files:** none.
+
+- [ ] **Step 1: mothership** (mothership worktree): `uv run pytest -q` → green.
+- [ ] **Step 2: ground-control** (ground-control worktree): `mship test` (or `source ~/toolchains/android-env.sh && cd android && ./gradlew assembleDebug testDebugUnitTest`) → green.
+- [ ] **Step 3: Confirm acceptance criteria** against `specs/2026-06-22-ground-control-tasks-tab.md` (ac1→T1; ac2→T2; ac3/ac4→T3; ac5→T4; ac6 errors→T4; ac7 tests→all). Note any gap.
+- [ ] **Step 4:** `mship journal "Tasks tab implemented across mothership + ground-control; suites green" --action completed --test-state pass` then `mship phase review`.
+
+> Then `mship finish --body-file <path>` to open the PR(s).
+<!-- /mship:task -->
+
+---
+
+## Non-goals (from the spec)
+
+Task actions from the phone (read-only monitor) · live updates/SSE · dependency-graph viz · time-in-phase · notifications · iOS · Compose/instrumentation tests.

--- a/src/mship/core/view/task_index.py
+++ b/src/mship/core/view/task_index.py
@@ -1,7 +1,7 @@
 """Task-index data layer for the cross-task `mship view` God view."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
@@ -21,6 +21,10 @@ class TaskSummary:
     spec_count: int
     orphan: bool
     tests_failing: bool
+    description: str = ""
+    pr_urls: dict[str, str] = field(default_factory=dict)
+    test_results: dict[str, str] = field(default_factory=dict)
+    depends_on: list[str] = field(default_factory=list)
 
 
 def _summarize(task: Task) -> TaskSummary:
@@ -44,6 +48,10 @@ def _summarize(task: Task) -> TaskSummary:
         spec_count=spec_count,
         orphan=orphan,
         tests_failing=tests_failing,
+        description=task.description,
+        pr_urls=dict(task.pr_urls),
+        test_results={repo: tr.status for repo, tr in task.test_results.items()},
+        depends_on=[e.upstream_slug for e in task.depends_on],
     )
 
 

--- a/tests/core/view/test_task_index.py
+++ b/tests/core/view/test_task_index.py
@@ -142,3 +142,21 @@ def test_find_all_specs_sorted_flat_by_mtime_desc_across_tasks(tmp_path: Path):
     specs = find_all_specs(state, tmp_path)
     names = [s.path.name for s in specs]
     assert names.index("newer.md") < names.index("older.md")
+
+
+def test_build_task_index_includes_enriched_fields(tmp_path: Path):
+    from mship.core.state import DependencyEdge
+    now = datetime.now(timezone.utc)
+    t = _task(
+        "a",
+        description="Add the thing",
+        pr_urls={"mothership": "https://github.com/x/mothership/pull/1"},
+        test_results={"mothership": TestResult(status="pass", at=now)},
+        depends_on=[DependencyEdge(upstream_slug="up", created_at=now)],
+    )
+    state = WorkspaceState(tasks={"a": t})
+    [s] = build_task_index(state, tmp_path)
+    assert s.description == "Add the thing"
+    assert s.pr_urls == {"mothership": "https://github.com/x/mothership/pull/1"}
+    assert s.test_results == {"mothership": "pass"}
+    assert s.depends_on == ["up"]


### PR DESCRIPTION
## Summary

Adds a read-only **Tasks tab** to Ground Control, closing the dispatch→watch loop — after you approve + dispatch a spec from your phone, you can now watch the task run (phase, per-repo tests, PR, journal) instead of going blind. Implements spec `ground-control-tasks-tab`.

- **mothership:** widen `TaskSummary` (`core/view/task_index.py`) with `description`, `pr_urls`, per-repo `test_results`, and `depends_on` — additive, so `GET /tasks` and `/tasks/{slug}` gain the fields the app needs without touching existing consumers.
- **ground-control:** Task/Journal DTOs + `listTasks`/`getTask`/`getJournal` (reusing the existing `mshipDefaults` bearer auth + 401/404/409 mapping); a fan-out `TasksRepository`; the **Tasks list** (aggregated workspace → Active/Finished, per-repo test status, blocked + PR markers, partial-failure resilience, pull-to-refresh); and the **Task detail** (per-repo test results, **tap-through PR links** via `LocalUriHandler`, blocked reason, `depends_on`, and the **journal timeline**). Reuses the spec inbox/detail patterns (connectionId carry, connection-resolve, error states).

## Test plan

- [x] mothership `uv run pytest -q` — **1655 passed**, no regressions.
- [x] ground-control `./gradlew assembleDebug testDebugUnitTest` — green: Task DTO deserialization (maps + `ignoreUnknownKeys`), API paths/auth + 404 mapping, repository parallel aggregation + failure isolation, list grouping (workspace → active/finished), and the detail+journal ViewModel (load + AUTH/NOT_FOUND/NETWORK).
- [ ] Manual: dispatch a task, open the Tasks tab on a device, confirm phase/tests/PR/journal render and PR links open in the browser (no emulator in this environment).

## Notes

Read-only monitor — acting on tasks from the phone (unblock/finish/dispatch-more) is a deliberate non-goal for v1. Built via subagent-driven development with per-task + final review (all read-only agents). Plan: `docs/plans/2026-06-22-tasks-tab.md`.
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `ground-control-tasks-tab`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/7 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/231 | this PR |

⚠ Merge in order: ground-control → mothership