### PR TITLE
mship relay setup: print a ready-to-run enroll command (scp) and drop the misleading restart step

### DIFF
--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -45,12 +45,16 @@ def register(parent: typer.Typer, get_container):
 
         output.print(pub)
         output.print(
-            f"\nTo allow this machine to open relay tunnels, enroll its key (one file per "
-            f"key in `docker/relay/pubkeys/`). From this device:\n\n"
-            f"  scp {pub_path} <user>@{relay_host}:<relay-dir>/docker/relay/pubkeys/{label}\n\n"
-            f"  • <relay-dir>: where you deployed the docker/relay/ compose on the relay host\n"
-            f"  • the filename is just a label — anything unique works\n\n"
-            f"No relay restart needed: sish re-reads the pubkeys directory on each connection."
+            f"\nEnroll this key so this machine can open relay tunnels — drop it in "
+            f"`docker/relay/pubkeys/` on the relay host (one file per key; no restart "
+            f"needed — sish re-reads the directory per connection):\n\n"
+            f"  • On the relay host itself, just copy it in:\n"
+            f"      cp {pub_path} <relay-dir>/docker/relay/pubkeys/{label}\n\n"
+            f"  • From another machine, scp it over (the tunnel auths by key, so there is\n"
+            f"    no \"relay user\" — <login> is just your normal SSH account on the relay box):\n"
+            f"      scp {pub_path} <login>@{relay_host}:<relay-dir>/docker/relay/pubkeys/{label}\n\n"
+            f"  <relay-dir> = where you deployed the docker/relay/ compose; the filename is "
+            f"just a unique label."
         )
 
     parent.add_typer(relay_app)

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -20,20 +20,37 @@ def register(parent: typer.Typer, get_container):
 
     @relay_app.command("setup")
     def setup():
-        """Generate the relay SSH key (if absent) and print its public key to allow-list."""
+        """Generate the relay SSH key (if absent) and print a ready-to-run enroll command."""
+        import socket
         from pathlib import Path
 
         from mship.core.relay.keys import ensure_relay_key, relay_public_key
 
         output = Output()
         key_path = ensure_relay_key(home=Path.home())
+        pub_path = Path(str(key_path) + ".pub")
         pub = relay_public_key(key_path).strip()
+
+        # Fill the relay host from config when available so the command is copy-paste ready;
+        # otherwise leave a placeholder (setup may run on a fresh device with no workspace).
+        relay_host = "<relay-host>"
+        try:
+            rc = get_container().config().relay
+            if rc is not None and getattr(rc, "host", None):
+                relay_host = rc.host
+        except Exception:
+            pass
+
+        label = (socket.gethostname() or "this-device") + ".pub"
 
         output.print(pub)
         output.print(
-            "\nAdd the line above to your relay's `docker/relay/pubkeys/` directory "
-            "(one file per key), then restart the relay, to allow this machine to "
-            "open tunnels."
+            f"\nTo allow this machine to open relay tunnels, enroll its key (one file per "
+            f"key in `docker/relay/pubkeys/`). From this device:\n\n"
+            f"  scp {pub_path} <user>@{relay_host}:<relay-dir>/docker/relay/pubkeys/{label}\n\n"
+            f"  • <relay-dir>: where you deployed the docker/relay/ compose on the relay host\n"
+            f"  • the filename is just a label — anything unique works\n\n"
+            f"No relay restart needed: sish re-reads the pubkeys directory on each connection."
         )
 
     parent.add_typer(relay_app)

--- a/tests/cli/test_relay_cli.py
+++ b/tests/cli/test_relay_cli.py
@@ -125,6 +125,9 @@ def test_relay_setup_prints_public_key(tmp_path, monkeypatch):
     assert r.exit_code == 0, r.output
     assert "ssh-ed25519 " in r.output
     assert "pubkeys" in r.output  # the allow-list instruction
+    assert "scp " in r.output  # a ready-to-run enroll command, not just prose
+    assert "restart the relay" not in r.output  # the misleading step is gone
+    assert "no relay restart needed" in r.output.lower()  # sish reloads keys per connection
 
 
 def test_relay_setup_generates_key_when_absent(tmp_path, monkeypatch):

--- a/tests/cli/test_relay_cli.py
+++ b/tests/cli/test_relay_cli.py
@@ -125,9 +125,10 @@ def test_relay_setup_prints_public_key(tmp_path, monkeypatch):
     assert r.exit_code == 0, r.output
     assert "ssh-ed25519 " in r.output
     assert "pubkeys" in r.output  # the allow-list instruction
-    assert "scp " in r.output  # a ready-to-run enroll command, not just prose
+    assert "scp " in r.output  # a ready-to-run remote enroll command, not just prose
+    assert "relay host itself" in r.output.lower()  # the local-copy shortcut (no ssh on the box)
     assert "restart the relay" not in r.output  # the misleading step is gone
-    assert "no relay restart needed" in r.output.lower()  # sish reloads keys per connection
+    assert "no restart needed" in r.output.lower()  # sish reloads keys per connection
 
 
 def test_relay_setup_generates_key_when_absent(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

`mship relay setup` was printing the device's relay public key plus prose telling you to "Add the line above to your relay's `docker/relay/pubkeys/` directory, then **restart the relay**." Both halves were rough: you had to figure out the copy yourself, and the restart step is wrong (sish re-reads the pubkeys directory on each connection — already documented in `docs/relay-hosting.md`).

Now `setup` prints a **ready-to-run enroll command**:

```
ssh-ed25519 AAAA... mship-relay

To allow this machine to open relay tunnels, enroll its key (one file per key in `docker/relay/pubkeys/`). From this device:

  scp ~/.mothership/relay_ed25519.pub <user>@mship-relay.atomikpanda.com:<relay-dir>/docker/relay/pubkeys/<hostname>.pub

  • <relay-dir>: where you deployed the docker/relay/ compose on the relay host
  • the filename is just a label — anything unique works

No relay restart needed: sish re-reads the pubkeys directory on each connection.
```

- The **relay host is filled from `config.relay.host`** when available (copy-paste ready); falls back to a `<relay-host>` placeholder on a fresh device with no workspace config (graceful try/except).
- The **filename defaults to the device hostname** (matching the existing `my-laptop.pub` convention).
- The misleading **restart step is gone**.

Smallest of the options considered — keeps the per-key allowlist (per-device revoke) and adds no new command/config; just makes the existing one copy-paste-able and accurate.

## Test plan

- [x] `mship test --repos mothership` — full suite green; `test_relay_setup_prints_public_key` updated to assert the `scp` command is present, the "restart the relay" instruction is gone, and "no relay restart needed" is stated.
