### PR TITLE
Relay enrollment with approval (v1): public enroll-server creating pending requests (30min TTL), mship relay requests/approve/deny on the host, requester mship relay enroll with polling

### DIFF
--- a/docs/plans/2026-06-25-relay-enroll-approval.md
+++ b/docs/plans/2026-06-25-relay-enroll-approval.md
@@ -1,0 +1,529 @@
+# Relay Enrollment with Owner Approval (v1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `relay-enroll-approval` (mship spec). v1 = the secure core with CLI approve/deny on the relay host; phone (Ground Control) approval is v2.
+
+**Goal:** Let a device that can't touch the relay box *request* relay access (public endpoint), have the request sit **pending** (never auto-enrolled), and let the owner **approve/deny** it from the relay host. Pending requests **expire after 30 min**.
+
+**Architecture:** Security-critical logic is pure and unit-tested. `core/relay/enroll.py` holds pubkey validation, fingerprinting, traversal-proof label sanitization, and a filesystem `RequestStore` (create → pending; approve writes into the allowlist; deny/expire resolve) with an injectable clock + atomic writes. `core/relay/enroll_app.py` is a thin FastAPI wrapper (`POST /enroll`, `GET /status/{id}`). `cli/relay.py` adds `enroll-server`, `requests`, `approve`, `deny`, `enroll`. No sish change — approve just drops a file into the existing `pubkeys/` allowlist (sish re-reads it per connection).
+
+**Tech Stack:** Python 3, FastAPI + uvicorn (already deps), httpx (requester), pytest (+ FastAPI `TestClient`). Injectable clock for TTL; no network in tests.
+
+---
+
+## Decisions (from spec open questions)
+- **Store layout:** `pending/<id>.json` → moved to `resolved/<id>.json` (with a `status`) on approve/deny/expire. Atomic temp-file+rename. `/status` reads both.
+- **Config:** CLI flags with defaults mirroring `docker/relay/` — `--pubkeys-dir ./pubkeys`, `--store-dir ./pending-store`, `--port 47180`, `--ttl 1800`.
+- **Deployment:** a documented `mship relay enroll-server` host process for v1.
+- **Anti-abuse:** open requests (approval is the gate) + a global pending cap (`MAX_PENDING=50`) + the 30-min TTL sweeping stale entries.
+
+## Files
+
+| File | Change |
+|---|---|
+| `src/mship/core/relay/enroll.py` (create) | `validate_pubkey`, `fingerprint`, `sanitize_label`, `RequestStore`, exceptions. |
+| `src/mship/core/relay/enroll_app.py` (create) | `build_enroll_app(store)` → FastAPI. |
+| `src/mship/cli/relay.py` (modify) | `enroll-server`, `requests`, `approve`, `deny`, `enroll`. |
+| `tests/core/relay/test_enroll.py`, `tests/core/relay/test_enroll_app.py`, `tests/cli/test_relay_cli.py` | unit + app + CLI tests. |
+
+Work in `.worktrees/relay-enrollment-with-approval-v1/mothership`, branch `feat/relay-enrollment-with-approval-v1`. Tests: `uv run pytest` / `mship test --repos mothership`.
+
+---
+
+<!-- mship:task id=1 -->
+### Task 1: Pure helpers — validate / fingerprint / sanitize
+
+**Files:** Create `src/mship/core/relay/enroll.py` (helpers only); Test `tests/core/relay/test_enroll.py`.
+
+- [ ] **Step 1: failing tests**
+
+```python
+# tests/core/relay/test_enroll.py
+from mship.core.relay.enroll import validate_pubkey, fingerprint, sanitize_label
+
+_PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host"
+
+def test_validate_accepts_ssh_key():
+    assert validate_pubkey(_PUB)
+    assert validate_pubkey("ssh-rsa AAAAB3NzaC1yc2EAAAAD host")
+
+def test_validate_rejects_junk():
+    assert not validate_pubkey("not a key")
+    assert not validate_pubkey("")
+    assert not validate_pubkey("ssh-ed25519 !!!notbase64!!!")
+    assert not validate_pubkey("rm -rf /")
+
+def test_fingerprint_is_stable_sha256():
+    fp = fingerprint(_PUB)
+    assert fp.startswith("SHA256:")
+    assert fp == fingerprint(_PUB + "  different-comment")  # body only
+
+def test_sanitize_label_is_traversal_proof():
+    assert sanitize_label("../../etc/passwd") == "etc-passwd"
+    assert sanitize_label("My Laptop!") == "my-laptop"
+    assert sanitize_label("") == "device"
+    s = sanitize_label("a/" * 100)
+    assert "/" not in s and ".." not in s and len(s) <= 40
+```
+
+- [ ] **Step 2: run → fail** — `uv run pytest tests/core/relay/test_enroll.py -q` → FAIL (module missing).
+
+- [ ] **Step 3: implement**
+
+```python
+# src/mship/core/relay/enroll.py
+from __future__ import annotations
+import base64
+import hashlib
+import re
+
+
+def validate_pubkey(s: str) -> bool:
+    """True if `s` is a single ssh public-key line (key-type + valid base64 body)."""
+    parts = s.strip().split()
+    if len(parts) < 2:
+        return False
+    ktype, body = parts[0], parts[1]
+    if not ktype.startswith(("ssh-", "ecdsa-", "sk-")):
+        return False
+    try:
+        base64.b64decode(body, validate=True)
+    except Exception:
+        return False
+    return len(body) >= 20
+
+
+def fingerprint(pubkey: str) -> str:
+    """ssh-keygen-style SHA256 fingerprint of the key body: `SHA256:<base64-no-pad>`."""
+    body = pubkey.strip().split()[1]
+    digest = hashlib.sha256(base64.b64decode(body)).digest()
+    return "SHA256:" + base64.b64encode(digest).decode().rstrip("=")
+
+
+def sanitize_label(hostname: str) -> str:
+    """A safe pubkeys-filename stem from a hostname: lowercase [a-z0-9-], no traversal, ≤40."""
+    s = re.sub(r"[^a-z0-9]+", "-", (hostname or "").lower()).strip("-")[:40].strip("-")
+    return s or "device"
+```
+
+- [ ] **Step 4: run → pass** — `uv run pytest tests/core/relay/test_enroll.py -q` → PASS (4).
+
+- [ ] **Step 5: commit + journal**
+```bash
+git add src/mship/core/relay/enroll.py tests/core/relay/test_enroll.py
+git commit -m "feat(relay): enroll helpers — validate_pubkey/fingerprint/sanitize_label"
+mship journal "enroll: pure helpers; 4 tests" --action committed
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=2 -->
+### Task 2: RequestStore — pending → approve/deny/expire (the heart)
+
+**Files:** Modify `src/mship/core/relay/enroll.py` (append the store); Test `tests/core/relay/test_enroll.py`.
+
+- [ ] **Step 1: failing tests**
+
+```python
+# append to tests/core/relay/test_enroll.py
+import pytest
+from mship.core.relay.enroll import RequestStore, PendingCapReached, NotPending
+
+class _Clock:
+    def __init__(self, t=1000.0): self.t = t
+    def __call__(self): return self.t
+
+def _store(tmp_path, ttl=1800, clock=None, cap=50):
+    return RequestStore(tmp_path / "store", ttl_seconds=ttl, max_pending=cap, clock=clock or _Clock())
+
+def test_create_then_pending_then_approve_writes_allowlist(tmp_path):
+    pubkeys = tmp_path / "pubkeys"; pubkeys.mkdir()
+    s = _store(tmp_path)
+    rid = s.create(_PUB, "my-laptop")
+    assert s.get(rid) == "pending"
+    assert [r["id"] for r in s.list_pending()] == [rid]
+    s.approve(rid, pubkeys)
+    assert s.get(rid) == "approved"
+    written = list(pubkeys.glob("*.pub"))
+    assert len(written) == 1 and written[0].read_text().strip() == _PUB.strip()
+    assert s.list_pending() == []  # no longer pending
+
+def test_deny_resolves_without_touching_allowlist(tmp_path):
+    pubkeys = tmp_path / "pubkeys"; pubkeys.mkdir()
+    s = _store(tmp_path)
+    rid = s.create(_PUB, "h")
+    s.deny(rid)
+    assert s.get(rid) == "denied"
+    assert list(pubkeys.glob("*.pub")) == []
+
+def test_expiry_after_ttl(tmp_path):
+    clock = _Clock(1000.0)
+    s = _store(tmp_path, ttl=1800, clock=clock)
+    rid = s.create(_PUB, "h")
+    clock.t = 1000.0 + 1801  # past TTL
+    assert s.list_pending() == []
+    assert s.get(rid) == "expired"
+    with pytest.raises(NotPending):
+        s.approve(rid, tmp_path)
+
+def test_pending_cap_enforced(tmp_path):
+    s = _store(tmp_path, cap=2)
+    s.create(_PUB, "a"); s.create(_PUB, "b")
+    with pytest.raises(PendingCapReached):
+        s.create(_PUB, "c")
+
+def test_same_hostname_does_not_clobber(tmp_path):
+    pubkeys = tmp_path / "pubkeys"; pubkeys.mkdir()
+    s = _store(tmp_path)
+    r1 = s.create(_PUB, "laptop"); s.approve(r1, pubkeys)
+    r2 = s.create(_PUB, "laptop"); s.approve(r2, pubkeys)
+    assert len(list(pubkeys.glob("*.pub"))) == 2  # unique filenames
+```
+
+- [ ] **Step 2: run → fail**
+
+- [ ] **Step 3: implement (append to `enroll.py`)**
+
+```python
+import json
+import secrets
+import time
+from pathlib import Path
+from typing import Callable
+
+
+class PendingCapReached(Exception):
+    """Too many simultaneously-pending requests."""
+
+
+class NotPending(Exception):
+    """No pending request with that id (unknown, already resolved, or expired)."""
+
+
+class RequestStore:
+    """Filesystem-backed enroll requests: pending/<id>.json, moved to resolved/ on
+    approve/deny/expire. Atomic writes; lazy TTL expiry on every read/mutate."""
+
+    def __init__(self, base_dir, ttl_seconds: int = 1800, max_pending: int = 50,
+                 clock: Callable[[], float] = time.time) -> None:
+        self._pending = Path(base_dir) / "pending"
+        self._resolved = Path(base_dir) / "resolved"
+        self._pending.mkdir(parents=True, exist_ok=True)
+        self._resolved.mkdir(parents=True, exist_ok=True)
+        self._ttl = ttl_seconds
+        self._max_pending = max_pending
+        self._clock = clock
+
+    def _write_atomic(self, path: Path, rec: dict) -> None:
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(rec))
+        tmp.replace(path)
+
+    def _resolve(self, p: Path, rec: dict, status: str) -> None:
+        rec["status"] = status
+        self._write_atomic(self._resolved / p.name, rec)
+        p.unlink(missing_ok=True)
+
+    def _sweep(self) -> None:
+        now = self._clock()
+        for p in self._pending.glob("*.json"):
+            rec = json.loads(p.read_text())
+            if now - rec["created_at"] >= self._ttl:
+                self._resolve(p, rec, "expired")
+
+    def create(self, pubkey: str, hostname: str) -> str:
+        self._sweep()
+        if len(list(self._pending.glob("*.json"))) >= self._max_pending:
+            raise PendingCapReached()
+        rid = secrets.token_hex(4)
+        self._write_atomic(self._pending / f"{rid}.json", {
+            "id": rid, "pubkey": pubkey.strip(), "hostname": hostname,
+            "fingerprint": fingerprint(pubkey), "created_at": self._clock(),
+            "status": "pending",
+        })
+        return rid
+
+    def list_pending(self) -> list[dict]:
+        self._sweep()
+        return [json.loads(p.read_text()) for p in sorted(self._pending.glob("*.json"))]
+
+    def get(self, rid: str) -> str:
+        self._sweep()
+        if (self._pending / f"{rid}.json").exists():
+            return "pending"
+        r = self._resolved / f"{rid}.json"
+        if r.exists():
+            return json.loads(r.read_text())["status"]
+        return "unknown"
+
+    def approve(self, rid: str, pubkeys_dir) -> None:
+        self._sweep()
+        p = self._pending / f"{rid}.json"
+        if not p.exists():
+            raise NotPending(rid)
+        rec = json.loads(p.read_text())
+        dest = _unique_pub_path(Path(pubkeys_dir), sanitize_label(rec["hostname"]))
+        dest.write_text(rec["pubkey"] + "\n")
+        self._resolve(p, rec, "approved")
+
+    def deny(self, rid: str) -> None:
+        p = self._pending / f"{rid}.json"
+        if not p.exists():
+            raise NotPending(rid)
+        self._resolve(p, json.loads(p.read_text()), "denied")
+
+
+def _unique_pub_path(pubkeys_dir: Path, stem: str) -> Path:
+    pubkeys_dir.mkdir(parents=True, exist_ok=True)
+    cand = pubkeys_dir / f"{stem}.pub"
+    i = 2
+    while cand.exists():
+        cand = pubkeys_dir / f"{stem}-{i}.pub"
+        i += 1
+    return cand
+```
+
+- [ ] **Step 4: run → pass** (5 new tests + Task 1's 4).
+- [ ] **Step 5: commit + journal**
+```bash
+git add src/mship/core/relay/enroll.py tests/core/relay/test_enroll.py
+git commit -m "feat(relay): RequestStore — pending/approve/deny/expire with TTL + cap"
+mship journal "enroll: RequestStore lifecycle + TTL + cap; tests green" --action committed
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=3 -->
+### Task 3: FastAPI enroll app
+
+**Files:** Create `src/mship/core/relay/enroll_app.py`; Test `tests/core/relay/test_enroll_app.py`.
+
+- [ ] **Step 1: failing tests**
+
+```python
+# tests/core/relay/test_enroll_app.py
+from fastapi.testclient import TestClient
+from mship.core.relay.enroll import RequestStore
+from mship.core.relay.enroll_app import build_enroll_app
+
+_PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host"
+
+def _client(tmp_path, cap=50):
+    store = RequestStore(tmp_path / "s", max_pending=cap)
+    return TestClient(build_enroll_app(store)), store
+
+def test_enroll_creates_pending_and_status(tmp_path):
+    c, _ = _client(tmp_path)
+    r = c.post("/enroll", json={"pubkey": _PUB, "hostname": "laptop"})
+    assert r.status_code == 200
+    rid = r.json()["id"]
+    assert c.get(f"/status/{rid}").json()["status"] == "pending"
+
+def test_enroll_rejects_bad_key(tmp_path):
+    c, _ = _client(tmp_path)
+    assert c.post("/enroll", json={"pubkey": "garbage", "hostname": "x"}).status_code == 400
+
+def test_enroll_over_cap_429(tmp_path):
+    c, _ = _client(tmp_path, cap=1)
+    c.post("/enroll", json={"pubkey": _PUB, "hostname": "a"})
+    assert c.post("/enroll", json={"pubkey": _PUB, "hostname": "b"}).status_code == 429
+
+def test_status_unknown(tmp_path):
+    c, _ = _client(tmp_path)
+    assert c.get("/status/deadbeef").json()["status"] == "unknown"
+```
+
+- [ ] **Step 2: run → fail**
+
+- [ ] **Step 3: implement**
+
+```python
+# src/mship/core/relay/enroll_app.py
+from __future__ import annotations
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from mship.core.relay.enroll import RequestStore, PendingCapReached, validate_pubkey
+
+
+class _EnrollBody(BaseModel):
+    pubkey: str
+    hostname: str = ""
+
+
+def build_enroll_app(store: RequestStore) -> FastAPI:
+    app = FastAPI(title="mship relay enroll")
+
+    @app.post("/enroll")
+    def enroll(body: _EnrollBody):
+        if not validate_pubkey(body.pubkey):
+            raise HTTPException(status_code=400, detail="invalid ssh public key")
+        try:
+            rid = store.create(body.pubkey, body.hostname)
+        except PendingCapReached:
+            raise HTTPException(status_code=429, detail="too many pending requests; try later")
+        return {"id": rid, "status": "pending"}
+
+    @app.get("/status/{rid}")
+    def status(rid: str):
+        return {"id": rid, "status": store.get(rid)}
+
+    return app
+```
+
+- [ ] **Step 4: run → pass** (4).
+- [ ] **Step 5: commit + journal**
+```bash
+git add src/mship/core/relay/enroll_app.py tests/core/relay/test_enroll_app.py
+git commit -m "feat(relay): FastAPI enroll app (POST /enroll, GET /status)"
+mship journal "enroll: FastAPI app + TestClient tests" --action committed
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=4 -->
+### Task 4: CLI — enroll-server / requests / approve / deny / enroll
+
+**Files:** Modify `src/mship/cli/relay.py`; Test `tests/cli/test_relay_cli.py` (host-side commands + requester poll).
+
+Host-side commands operate a `RequestStore` directly (the owner is on the box); `enroll` (requester) POSTs + polls via httpx (injectable for tests). Read the existing `cli/relay.py` `register(parent, get_container)` shape first.
+
+- [ ] **Step 1: tests for the host commands + requester (TDD where pure)**
+
+```python
+# append to tests/cli/test_relay_cli.py
+from mship.core.relay.enroll import RequestStore
+
+def test_relay_requests_approve_deny_roundtrip(tmp_path, monkeypatch):
+    store_dir = tmp_path / "store"; pubkeys = tmp_path / "pubkeys"; pubkeys.mkdir()
+    s = RequestStore(store_dir)
+    rid = s.create("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAA host", "laptop")
+    base = ["relay", "--store-dir", str(store_dir), "--pubkeys-dir", str(pubkeys)]
+    r = runner.invoke(app, base + ["requests"])
+    assert r.exit_code == 0 and rid in r.output and "laptop" in r.output
+    r = runner.invoke(app, base + ["approve", rid])
+    assert r.exit_code == 0
+    assert len(list(pubkeys.glob("*.pub"))) == 1  # key enrolled
+    assert RequestStore(store_dir).get(rid) == "approved"
+```
+
+(The exact flag wiring — whether `--store-dir`/`--pubkeys-dir` are options on the `relay` group or per-command — is the implementer's call; match the codebase's typer conventions. The behavioral assertions above are the contract: `requests` lists, `approve` enrolls the key + resolves, `deny` resolves without enrolling.)
+
+- [ ] **Step 2: implement the commands in `cli/relay.py`**
+
+Add (sketch — adapt to the existing typer style):
+
+```python
+    @relay_app.command("enroll-server")
+    def enroll_server(
+        pubkeys_dir: str = typer.Option("./pubkeys", "--pubkeys-dir"),
+        store_dir: str = typer.Option("./pending-store", "--store-dir"),
+        port: int = typer.Option(47180, "--port"),
+        host: str = typer.Option("0.0.0.0", "--host"),
+        ttl: int = typer.Option(1800, "--ttl", help="pending request TTL seconds (default 30m)"),
+    ):
+        """Run the public enroll endpoint on the relay host (devices POST their key here)."""
+        import uvicorn
+        from pathlib import Path
+        from mship.core.relay.enroll import RequestStore
+        from mship.core.relay.enroll_app import build_enroll_app
+        store = RequestStore(Path(store_dir), ttl_seconds=ttl)
+        # approve happens out-of-band via `mship relay approve`; the server only creates pending.
+        Output().print(f"enroll-server → http://{host}:{port}  (pubkeys: {pubkeys_dir}, ttl: {ttl}s)")
+        uvicorn.run(build_enroll_app(store), host=host, port=port)
+
+    @relay_app.command("requests")
+    def requests_cmd(store_dir: str = typer.Option("./pending-store", "--store-dir")):
+        """List pending enroll requests (id · hostname · fingerprint · age)."""
+        from pathlib import Path
+        from mship.core.relay.enroll import RequestStore
+        out = Output()
+        for r in RequestStore(Path(store_dir)).list_pending():
+            out.print(f"{r['id']}  {r['hostname'] or '-'}  {r['fingerprint']}")
+
+    @relay_app.command("approve")
+    def approve_cmd(rid: str = typer.Argument(...),
+                    store_dir: str = typer.Option("./pending-store", "--store-dir"),
+                    pubkeys_dir: str = typer.Option("./pubkeys", "--pubkeys-dir")):
+        """Approve a pending request: add its key to the allowlist (sish picks it up, no restart)."""
+        from pathlib import Path
+        from mship.core.relay.enroll import RequestStore, NotPending
+        try:
+            RequestStore(Path(store_dir)).approve(rid, Path(pubkeys_dir))
+            Output().success(f"approved {rid} — enrolled into {pubkeys_dir}")
+        except NotPending:
+            Output().error(f"no pending request {rid!r} (unknown, already resolved, or expired)")
+            raise typer.Exit(1)
+
+    @relay_app.command("deny")
+    def deny_cmd(rid: str = typer.Argument(...),
+                 store_dir: str = typer.Option("./pending-store", "--store-dir")):
+        """Deny a pending request (does not touch the allowlist)."""
+        from pathlib import Path
+        from mship.core.relay.enroll import RequestStore, NotPending
+        try:
+            RequestStore(Path(store_dir)).deny(rid)
+            Output().print(f"denied {rid}")
+        except NotPending:
+            Output().error(f"no pending request {rid!r}"); raise typer.Exit(1)
+
+    @relay_app.command("enroll")
+    def enroll_cmd(
+        enroll_url: str = typer.Option(..., "--enroll-url", help="http://<relay-host>:47180"),
+        wait: bool = typer.Option(True, "--wait/--no-wait"),
+    ):
+        """From a NEW device: request relay access; the relay owner approves/denies."""
+        import socket, time
+        from pathlib import Path
+        import httpx
+        from mship.core.relay.keys import ensure_relay_key, relay_public_key
+        out = Output()
+        pub = relay_public_key(ensure_relay_key(home=Path.home())).strip()
+        r = httpx.post(enroll_url.rstrip("/") + "/enroll",
+                       json={"pubkey": pub, "hostname": socket.gethostname()}, timeout=10)
+        if r.status_code != 200:
+            out.error(f"enroll request failed: HTTP {r.status_code} {r.text}"); raise typer.Exit(1)
+        rid = r.json()["id"]
+        out.print(f"requested (id {rid}) — ask the relay owner to `mship relay approve {rid}`.")
+        if not wait:
+            return
+        deadline = time.monotonic() + 1800
+        while time.monotonic() < deadline:
+            st = httpx.get(enroll_url.rstrip("/") + f"/status/{rid}", timeout=10).json()["status"]
+            if st == "approved":
+                out.success("✓ approved — you can now run `mship serve --relay`."); return
+            if st in ("denied", "expired"):
+                out.error(f"✗ {st}."); raise typer.Exit(1)
+            time.sleep(3)
+        out.error("✗ timed out waiting for approval."); raise typer.Exit(1)
+```
+
+> Note the `--store-dir`/`--pubkeys-dir` test flags: if typer makes per-command options awkward to invoke as in the test, expose them as options on the `relay` sub-app callback (shared) and adjust the test invocation to match. The contract (the behavioral assertions) is what matters.
+
+- [ ] **Step 3: build + suite** — `uv run python -c "import mship.cli.relay"` then `mship test --repos mothership` (green; the requester `enroll` poll is integration — keep its logic thin; the host commands are covered by the roundtrip test).
+
+- [ ] **Step 4: commit + journal**
+```bash
+git add src/mship/cli/relay.py tests/cli/test_relay_cli.py
+git commit -m "feat(relay): enroll-server + requests/approve/deny + requester enroll"
+mship journal "enroll: CLI commands wired; roundtrip test green" --action committed
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=5 -->
+### Task 5: Verification + docs + finish
+
+- [ ] **Step 1: full suite** — `mship test --repos mothership` → all green (Tasks 1–4 + existing).
+- [ ] **Step 2: docs** — add a short "Enrolling a device that can't reach the relay box" section to `docs/relay-hosting.md`: owner runs `mship relay enroll-server` on the relay host; new device runs `mship relay enroll --enroll-url http://<relay-host>:47180`; owner `mship relay requests` + `approve <id>`. Note the 30-min TTL + that requests only become keys on approval.
+- [ ] **Step 3:** `mship journal "relay enroll-approval v1 complete; suite green" --action verified --test-state pass` then `mship phase review`.
+<!-- /mship:task -->
+
+---
+
+## Self-Review
+
+**Coverage:** AC1/AC2 → Task 3 (enroll endpoint + bad-key 400 + cap 429) over Task 2's store. AC3 (30-min TTL) → Task 2 (`test_expiry_after_ttl`). AC4 (`requests`) / AC5 (`approve` enrolls + resolves, refuses expired) / AC6 (`deny`) → Tasks 2+4. AC7 (`enroll` requester, no box access) → Task 4. AC8 (sanitize, no traversal/clobber) → Task 1 (`sanitize_label`) + Task 2 (`_unique_pub_path`, `test_same_hostname_does_not_clobber`). AC9 (pure cores + app + requester tested) → Tasks 1–4 tests.
+
+**Security check:** `POST /enroll` only ever creates a pending record (never writes pubkeys/); the allowlist is touched only by `approve` (owner, on the box). Bad keys 400; cap 429; TTL sweeps. Filenames go through `sanitize_label` + `_unique_pub_path` (traversal-proof, non-clobbering). Plain HTTP carries only a non-secret pubkey.
+
+**Placeholder scan:** none — concrete code/commands; Task 4 flags the one typer-style adaptation (per-command vs group option) explicitly with the behavioral contract pinned by tests.
+
+**Type consistency:** `validate_pubkey`/`fingerprint`/`sanitize_label` (T1) used by `RequestStore` (T2) + `build_enroll_app` (T3); `RequestStore`/`PendingCapReached`/`NotPending` (T2) used by T3 + T4; `build_enroll_app` (T3) used by `enroll-server` (T4). `ensure_relay_key`/`relay_public_key` match `keys.py`.

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -114,6 +114,34 @@ echo "ssh-ed25519 AAAA... mship-relay" > docker/relay/pubkeys/my-laptop.pub
 
 One file per key; the filename does not matter. sish reads all files in the directory on each connection attempt — no container restart needed.
 
+### Enrolling a device that can't reach the relay box
+
+The manual copy above assumes you can write to `docker/relay/pubkeys/` on the relay host. When a *new device* (a laptop you can't SSH from into the relay box) needs access, use the **request → approve** flow instead — no shared secret, and a request can never enroll itself:
+
+**On the relay host**, run the enroll endpoint (public, beside sish; reads/writes a pending store, not the allowlist):
+
+```bash
+mship relay enroll-server --pubkeys-dir docker/relay/pubkeys --store-dir docker/relay/enroll-store
+# serves http://0.0.0.0:47180 ; pending requests expire after 30 min
+```
+
+**On the new device**, request access (it only needs the relay's public address — no filesystem/SSH access to the box):
+
+```bash
+mship relay enroll --enroll-url http://<relay-host>:47180
+# → requested (id a1c2…); waits for the owner to approve, then prints "✓ approved"
+```
+
+**Back on the relay host**, review and grant (or deny):
+
+```bash
+mship relay requests                 # id · hostname · key fingerprint
+mship relay approve a1c2 --store-dir docker/relay/enroll-store --pubkeys-dir docker/relay/pubkeys
+# writes the key into pubkeys/ → sish picks it up (no restart). `deny <id>` discards it.
+```
+
+A request only ever creates a *pending* entry — nothing reaches the allowlist until you `approve` it, and pending requests auto-expire after 30 minutes. The device can then `mship serve --relay`.
+
 ---
 
 ## Step 5 — Verify the Relay

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -47,7 +47,9 @@ def register(parent: typer.Typer, get_container):
     @relay_app.command("enroll-server")
     def enroll_server(
         pubkeys_dir: str = typer.Option("./pubkeys", "--pubkeys-dir",
-                                        help="Directory where approved keys are written (sish pubkeys/)."),
+                                        help="Allowlist dir used by 'mship relay approve' "
+                                             "(this server only creates pending requests; "
+                                             "it never writes keys)."),
         store_dir: str = typer.Option("./pending-store", "--store-dir",
                                       help="Directory for pending enroll request state."),
         port: int = typer.Option(47180, "--port", help="Port to listen on."),
@@ -155,11 +157,18 @@ def register(parent: typer.Typer, get_container):
         out = Output()
         pub = relay_public_key(ensure_relay_key(home=Path.home())).strip()
         base = enroll_url.rstrip("/")
-        r = httpx.post(
-            f"{base}/enroll",
-            json={"pubkey": pub, "hostname": socket.gethostname()},
-            timeout=10,
-        )
+        # The requester runs on a remote device hitting a public endpoint, so
+        # connection-refused / DNS / timeout are LIKELY: surface them cleanly
+        # rather than dumping an httpx traceback.
+        try:
+            r = httpx.post(
+                f"{base}/enroll",
+                json={"pubkey": pub, "hostname": socket.gethostname()},
+                timeout=10,
+            )
+        except httpx.RequestError as exc:
+            out.error(f"could not reach enroll server at {base}: {exc}")
+            raise typer.Exit(1)
         if r.status_code != 200:
             out.error(f"enroll request failed: HTTP {r.status_code} {r.text}")
             raise typer.Exit(1)
@@ -168,16 +177,30 @@ def register(parent: typer.Typer, get_container):
         if not wait:
             return
         deadline = time.monotonic() + 1800
-        while time.monotonic() < deadline:
-            resp = httpx.get(f"{base}/status/{rid}", timeout=10)
-            st = resp.json()["status"]
-            if st == "approved":
-                out.success("approved — you can now run `mship serve --relay`.")
-                return
-            if st in ("denied", "expired"):
-                out.error(f"{st}.")
-                raise typer.Exit(1)
-            time.sleep(3)
+        try:
+            while time.monotonic() < deadline:
+                # A transient blip or a non-JSON proxy page (e.g. a 502 error
+                # page) shouldn't kill the wait — back off and retry; the
+                # deadline still bounds the loop.
+                try:
+                    resp = httpx.get(f"{base}/status/{rid}", timeout=10)
+                    st = resp.json().get("status", "pending")
+                except (httpx.RequestError, ValueError):  # ValueError covers JSON decode
+                    time.sleep(3)
+                    continue
+                if st == "approved":
+                    out.success("approved — you can now run `mship serve --relay`.")
+                    return
+                if st in ("denied", "expired"):
+                    out.error(f"{st}.")
+                    raise typer.Exit(1)
+                time.sleep(3)
+        except KeyboardInterrupt:
+            out.print(
+                f"cancelled — your request {rid} is still pending; "
+                "the owner can still approve it."
+            )
+            raise typer.Exit(1)
         out.error("timed out waiting for approval.")
         raise typer.Exit(1)
 

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -3,6 +3,10 @@
 `mship relay setup` generates (if absent) a dedicated ed25519 key used to open
 the reverse tunnel, and prints its public key for allow-listing on the relay
 host (`docker/relay/pubkeys/`). See plan Task B7 (ac4).
+
+`mship relay enroll-server` runs the public enroll HTTP endpoint on the relay
+host; `mship relay requests/approve/deny` manage pending enroll requests
+(owner-side); `mship relay enroll` is the requester path (new device).
 """
 from __future__ import annotations
 
@@ -35,5 +39,146 @@ def register(parent: typer.Typer, get_container):
             "(one file per key), then restart the relay, to allow this machine to "
             "open tunnels."
         )
+
+    # -------------------------------------------------------------------------
+    # Owner-side: enroll-server
+    # -------------------------------------------------------------------------
+
+    @relay_app.command("enroll-server")
+    def enroll_server(
+        pubkeys_dir: str = typer.Option("./pubkeys", "--pubkeys-dir",
+                                        help="Directory where approved keys are written (sish pubkeys/)."),
+        store_dir: str = typer.Option("./pending-store", "--store-dir",
+                                      help="Directory for pending enroll request state."),
+        port: int = typer.Option(47180, "--port", help="Port to listen on."),
+        host: str = typer.Option("0.0.0.0", "--host", help="Interface to bind."),
+        ttl: int = typer.Option(1800, "--ttl",
+                                help="Pending request TTL in seconds (default 30 min)."),
+    ):
+        """Run the public enroll endpoint on the relay host (devices POST their key here)."""
+        import uvicorn
+        from pathlib import Path
+
+        from mship.core.relay.enroll import RequestStore
+        from mship.core.relay.enroll_app import build_enroll_app
+
+        out = Output()
+        store = RequestStore(Path(store_dir), ttl_seconds=ttl)
+        out.print(
+            f"enroll-server → http://{host}:{port}  "
+            f"(pubkeys: {pubkeys_dir}, store: {store_dir}, ttl: {ttl}s)"
+        )
+        uvicorn.run(build_enroll_app(store), host=host, port=port)
+
+    # -------------------------------------------------------------------------
+    # Owner-side: list / approve / deny
+    # -------------------------------------------------------------------------
+
+    @relay_app.command("requests")
+    def requests_cmd(
+        store_dir: str = typer.Option("./pending-store", "--store-dir",
+                                      help="Directory for pending enroll request state."),
+    ):
+        """List pending enroll requests (id · hostname · fingerprint)."""
+        from pathlib import Path
+
+        from mship.core.relay.enroll import RequestStore
+
+        out = Output()
+        pending = RequestStore(Path(store_dir)).list_pending()
+        if not pending:
+            out.print("no pending requests")
+            return
+        for rec in pending:
+            out.print(f"{rec['id']}  {rec['hostname'] or '-'}  {rec['fingerprint']}")
+
+    @relay_app.command("approve")
+    def approve_cmd(
+        rid: str = typer.Argument(..., help="Request ID to approve."),
+        store_dir: str = typer.Option("./pending-store", "--store-dir",
+                                      help="Directory for pending enroll request state."),
+        pubkeys_dir: str = typer.Option("./pubkeys", "--pubkeys-dir",
+                                        help="Directory where approved keys are written (sish pubkeys/)."),
+    ):
+        """Approve a pending request: add its key to the allowlist (sish picks it up, no restart)."""
+        from pathlib import Path
+
+        from mship.core.relay.enroll import NotPending, RequestStore
+
+        out = Output()
+        try:
+            RequestStore(Path(store_dir)).approve(rid, Path(pubkeys_dir))
+            out.success(f"approved {rid} — key enrolled into {pubkeys_dir}")
+        except NotPending:
+            out.error(f"no pending request {rid!r} (unknown, already resolved, or expired)")
+            raise typer.Exit(1)
+
+    @relay_app.command("deny")
+    def deny_cmd(
+        rid: str = typer.Argument(..., help="Request ID to deny."),
+        store_dir: str = typer.Option("./pending-store", "--store-dir",
+                                      help="Directory for pending enroll request state."),
+    ):
+        """Deny a pending request (does not touch the allowlist)."""
+        from pathlib import Path
+
+        from mship.core.relay.enroll import NotPending, RequestStore
+
+        out = Output()
+        try:
+            RequestStore(Path(store_dir)).deny(rid)
+            out.print(f"denied {rid}")
+        except NotPending:
+            out.error(f"no pending request {rid!r} (unknown, already resolved, or expired)")
+            raise typer.Exit(1)
+
+    # -------------------------------------------------------------------------
+    # Requester-side: enroll (new device)
+    # -------------------------------------------------------------------------
+
+    @relay_app.command("enroll")
+    def enroll_cmd(
+        enroll_url: str = typer.Option(..., "--enroll-url",
+                                       help="Base URL of the relay enroll server, e.g. http://<host>:47180."),
+        wait: bool = typer.Option(True, "--wait/--no-wait",
+                                  help="Poll until approved/denied (default) or return immediately."),
+    ):
+        """From a NEW device: request relay access; the relay owner approves/denies."""
+        import socket
+        import time
+        from pathlib import Path
+
+        import httpx
+
+        from mship.core.relay.keys import ensure_relay_key, relay_public_key
+
+        out = Output()
+        pub = relay_public_key(ensure_relay_key(home=Path.home())).strip()
+        base = enroll_url.rstrip("/")
+        r = httpx.post(
+            f"{base}/enroll",
+            json={"pubkey": pub, "hostname": socket.gethostname()},
+            timeout=10,
+        )
+        if r.status_code != 200:
+            out.error(f"enroll request failed: HTTP {r.status_code} {r.text}")
+            raise typer.Exit(1)
+        rid = r.json()["id"]
+        out.print(f"requested (id {rid}) — ask the relay owner to run: mship relay approve {rid}")
+        if not wait:
+            return
+        deadline = time.monotonic() + 1800
+        while time.monotonic() < deadline:
+            resp = httpx.get(f"{base}/status/{rid}", timeout=10)
+            st = resp.json()["status"]
+            if st == "approved":
+                out.success("approved — you can now run `mship serve --relay`.")
+                return
+            if st in ("denied", "expired"):
+                out.error(f"{st}.")
+                raise typer.Exit(1)
+            time.sleep(3)
+        out.error("timed out waiting for approval.")
+        raise typer.Exit(1)
 
     parent.add_typer(relay_app)

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -172,7 +172,11 @@ def register(parent: typer.Typer, get_container):
         if r.status_code != 200:
             out.error(f"enroll request failed: HTTP {r.status_code} {r.text}")
             raise typer.Exit(1)
-        rid = r.json()["id"]
+        try:
+            rid = r.json()["id"]
+        except (ValueError, KeyError):
+            out.error("enroll server returned an unexpected response (no request id)")
+            raise typer.Exit(1)
         out.print(f"requested (id {rid}) — ask the relay owner to run: mship relay approve {rid}")
         if not wait:
             return

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 import base64
 import hashlib
+import json
 import re
+import secrets
+import time
+from pathlib import Path
+from typing import Callable
 
 
 def _b64decode_strict(body: str) -> bytes:
@@ -50,3 +55,122 @@ def sanitize_label(hostname: str) -> str:
     """A safe pubkeys-filename stem from a hostname: lowercase [a-z0-9-], no traversal, ≤40."""
     s = re.sub(r"[^a-z0-9]+", "-", (hostname or "").lower()).strip("-")[:40].strip("-")
     return s or "device"
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class PendingCapReached(Exception):
+    """Too many simultaneously-pending requests."""
+
+
+class NotPending(Exception):
+    """No pending request with that id (unknown, already resolved, or expired)."""
+
+
+# ---------------------------------------------------------------------------
+# RequestStore
+# ---------------------------------------------------------------------------
+
+
+class RequestStore:
+    """Filesystem-backed enroll requests: pending/<id>.json, moved to resolved/ on
+    approve/deny/expire. Atomic writes; lazy TTL expiry on every read/mutate."""
+
+    def __init__(
+        self,
+        base_dir,
+        ttl_seconds: int = 1800,
+        max_pending: int = 50,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._pending = Path(base_dir) / "pending"
+        self._resolved = Path(base_dir) / "resolved"
+        self._pending.mkdir(parents=True, exist_ok=True)
+        self._resolved.mkdir(parents=True, exist_ok=True)
+        self._ttl = ttl_seconds
+        self._max_pending = max_pending
+        self._clock = clock
+
+    def _write_atomic(self, path: Path, rec: dict) -> None:
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(rec))
+        tmp.replace(path)
+
+    def _resolve(self, p: Path, rec: dict, status: str) -> None:
+        rec = dict(rec)
+        rec["status"] = status
+        self._write_atomic(self._resolved / p.name, rec)
+        p.unlink(missing_ok=True)
+
+    def _sweep(self) -> None:
+        now = self._clock()
+        for p in list(self._pending.glob("*.json")):
+            rec = json.loads(p.read_text())
+            if now - rec["created_at"] >= self._ttl:
+                self._resolve(p, rec, "expired")
+
+    def create(self, pubkey: str, hostname: str) -> str:
+        self._sweep()
+        if len(list(self._pending.glob("*.json"))) >= self._max_pending:
+            raise PendingCapReached()
+        rid = secrets.token_hex(4)
+        self._write_atomic(
+            self._pending / f"{rid}.json",
+            {
+                "id": rid,
+                "pubkey": pubkey.strip(),
+                "hostname": hostname,
+                "fingerprint": fingerprint(pubkey),
+                "created_at": self._clock(),
+                "status": "pending",
+            },
+        )
+        return rid
+
+    def list_pending(self) -> list[dict]:
+        self._sweep()
+        return [json.loads(p.read_text()) for p in sorted(self._pending.glob("*.json"))]
+
+    def get(self, rid: str) -> str:
+        self._sweep()
+        if (self._pending / f"{rid}.json").exists():
+            return "pending"
+        r = self._resolved / f"{rid}.json"
+        if r.exists():
+            return json.loads(r.read_text())["status"]
+        return "unknown"
+
+    def approve(self, rid: str, pubkeys_dir) -> None:
+        self._sweep()
+        p = self._pending / f"{rid}.json"
+        if not p.exists():
+            raise NotPending(rid)
+        rec = json.loads(p.read_text())
+        dest = _unique_pub_path(Path(pubkeys_dir), sanitize_label(rec["hostname"]))
+        dest.write_text(rec["pubkey"] + "\n")
+        self._resolve(p, rec, "approved")
+
+    def deny(self, rid: str) -> None:
+        p = self._pending / f"{rid}.json"
+        if not p.exists():
+            raise NotPending(rid)
+        self._resolve(p, json.loads(p.read_text()), "denied")
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _unique_pub_path(pubkeys_dir: Path, stem: str) -> Path:
+    """Return a Path that doesn't yet exist in pubkeys_dir, using stem with a counter suffix."""
+    pubkeys_dir.mkdir(parents=True, exist_ok=True)
+    cand = pubkeys_dir / f"{stem}.pub"
+    i = 2
+    while cand.exists():
+        cand = pubkeys_dir / f"{stem}-{i}.pub"
+        i += 1
+    return cand

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import os
 import re
 import secrets
 import time
@@ -185,7 +186,9 @@ class RequestStore:
         p = self._pending / f"{rid}.json"
         if not p.exists():
             raise NotPending(rid)
-        rec = json.loads(p.read_text())
+        rec = self._read_rec(p)
+        if rec is None:                       # corrupt/truncated → quarantined, treat as gone
+            raise NotPending(rid)
         dest = _unique_pub_path(Path(pubkeys_dir), sanitize_label(rec["hostname"]))
         # Atomic key write: sish re-reads pubkeys/ per connection and must never observe
         # a half-written key file mid-write.
@@ -203,7 +206,10 @@ class RequestStore:
         p = self._pending / f"{rid}.json"
         if not p.exists():
             raise NotPending(rid)
-        self._resolve(p, json.loads(p.read_text()), "denied")
+        rec = self._read_rec(p)
+        if rec is None:                       # corrupt/truncated → quarantined, treat as gone
+            raise NotPending(rid)
+        self._resolve(p, rec, "denied")
 
 
 # ---------------------------------------------------------------------------
@@ -212,13 +218,20 @@ class RequestStore:
 
 
 def _unique_pub_path(pubkeys_dir: Path, stem: str) -> Path:
-    """Return a Path that doesn't yet exist in pubkeys_dir, using stem with a counter suffix."""
+    """Atomically reserve a not-yet-existing `<stem>[-N].pub` in pubkeys_dir.
+
+    Uses O_CREAT|O_EXCL to claim the filename race-free — two concurrent approvals
+    for the same hostname get distinct files and neither silently overwrites the
+    other (an exists()-then-write check would have a TOCTOU window). The caller
+    overwrites the empty reserved file with the key content via tmp+replace."""
     pubkeys_dir.mkdir(parents=True, exist_ok=True)
-    cand = pubkeys_dir / f"{stem}.pub"
-    i = 2
-    while cand.exists():
-        if i > 1000:
-            raise RuntimeError("too many key files for this label")
-        cand = pubkeys_dir / f"{stem}-{i}.pub"
-        i += 1
-    return cand
+    i = 1
+    while True:
+        cand = pubkeys_dir / (f"{stem}.pub" if i == 1 else f"{stem}-{i}.pub")
+        try:
+            os.close(os.open(cand, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
+            return cand
+        except FileExistsError:
+            i += 1
+            if i > 1000:
+                raise RuntimeError("too many key files for this label")

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -12,8 +12,18 @@ def _b64decode_strict(body: str) -> bytes:
 
 
 def validate_pubkey(s: str) -> bool:
-    """True if `s` is a single ssh public-key line (key-type + valid base64 body)."""
-    parts = s.strip().split()
+    """True if `s` is a single ssh public-key line (key-type + decodable base64 body).
+
+    Checks *shape* only — a recognized key-type prefix plus a base64-decodable body
+    on a single line. It does not parse the SSH wire format or verify cryptographic
+    key structure; the real security boundary for enrollment is owner approval, not
+    this function. The single-line guard rejects multi-line / CRLF input so a crafted
+    second line cannot be smuggled into the authorized_keys allowlist on approval.
+    """
+    s = s.strip()
+    if "\n" in s or "\r" in s:  # reject multi-line / CRLF authorized_keys injection
+        return False
+    parts = s.split()
     if len(parts) < 2:
         return False
     ktype, body = parts[0], parts[1]
@@ -28,7 +38,10 @@ def validate_pubkey(s: str) -> bool:
 
 def fingerprint(pubkey: str) -> str:
     """ssh-keygen-style SHA256 fingerprint of the key body: `SHA256:<base64-no-pad>`."""
-    body = pubkey.strip().split()[1]
+    parts = pubkey.strip().split()
+    if len(parts) < 2:
+        raise ValueError("not an ssh public key")
+    body = parts[1]
     digest = hashlib.sha256(_b64decode_strict(body)).digest()
     return "SHA256:" + base64.b64encode(digest).decode().rstrip("=")
 

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -105,18 +105,43 @@ class RequestStore:
         self._write_atomic(self._resolved / p.name, rec)
         p.unlink(missing_ok=True)
 
+    def _read_rec(self, p: Path) -> dict | None:
+        """Load a pending record, quarantining a corrupt/truncated file instead of raising.
+
+        A hand-edited or partially-written `pending/*.json` must not brick the whole
+        store (one bad file would otherwise poison every sweep/list/get). On failure the
+        file is moved aside to `*.json.corrupt` and skipped."""
+        try:
+            rec = json.loads(p.read_text())
+            if "created_at" not in rec:
+                raise ValueError("missing created_at")
+            return rec
+        except (json.JSONDecodeError, OSError, ValueError):
+            try:
+                p.replace(p.with_suffix(".json.corrupt"))
+            except OSError:
+                p.unlink(missing_ok=True)
+            return None
+
     def _sweep(self) -> None:
         now = self._clock()
         for p in list(self._pending.glob("*.json")):
-            rec = json.loads(p.read_text())
+            rec = self._read_rec(p)
+            if rec is None:
+                continue
             if now - rec["created_at"] >= self._ttl:
                 self._resolve(p, rec, "expired")
 
     def create(self, pubkey: str, hostname: str) -> str:
+        # The store is the security boundary, not just the HTTP layer: self-protect.
+        # validate_pubkey rejects multi-line/CRLF input, so a crafted second line can't
+        # be smuggled in here and later written into the pubkeys allowlist on approve.
+        if not validate_pubkey(pubkey):
+            raise ValueError("invalid pubkey")
         self._sweep()
         if len(list(self._pending.glob("*.json"))) >= self._max_pending:
             raise PendingCapReached()
-        rid = secrets.token_hex(4)
+        rid = secrets.token_hex(16)
         self._write_atomic(
             self._pending / f"{rid}.json",
             {
@@ -132,7 +157,12 @@ class RequestStore:
 
     def list_pending(self) -> list[dict]:
         self._sweep()
-        return [json.loads(p.read_text()) for p in sorted(self._pending.glob("*.json"))]
+        out = []
+        for p in sorted(self._pending.glob("*.json")):
+            rec = self._read_rec(p)
+            if rec is not None:
+                out.append(rec)
+        return out
 
     def get(self, rid: str) -> str:
         self._sweep()
@@ -150,10 +180,17 @@ class RequestStore:
             raise NotPending(rid)
         rec = json.loads(p.read_text())
         dest = _unique_pub_path(Path(pubkeys_dir), sanitize_label(rec["hostname"]))
-        dest.write_text(rec["pubkey"] + "\n")
+        # Atomic key write: sish re-reads pubkeys/ per connection and must never observe
+        # a half-written key file mid-write.
+        tmp = dest.with_suffix(".pub.tmp")
+        tmp.write_text(rec["pubkey"] + "\n")
+        tmp.replace(dest)
         self._resolve(p, rec, "approved")
 
     def deny(self, rid: str) -> None:
+        # Sweep first so denying an already-expired request resolves it as `expired`,
+        # consistent with the other methods.
+        self._sweep()
         p = self._pending / f"{rid}.json"
         if not p.exists():
             raise NotPending(rid)
@@ -171,6 +208,8 @@ def _unique_pub_path(pubkeys_dir: Path, stem: str) -> Path:
     cand = pubkeys_dir / f"{stem}.pub"
     i = 2
     while cand.exists():
+        if i > 1000:
+            raise RuntimeError("too many key files for this label")
         cand = pubkeys_dir / f"{stem}-{i}.pub"
         i += 1
     return cand

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import base64
+import hashlib
+import re
+
+
+def _b64decode_strict(body: str) -> bytes:
+    """Decode base64, adding padding if needed, rejecting non-base64 characters."""
+    padding = (4 - len(body) % 4) % 4
+    padded = body + "=" * padding
+    return base64.b64decode(padded, validate=True)
+
+
+def validate_pubkey(s: str) -> bool:
+    """True if `s` is a single ssh public-key line (key-type + valid base64 body)."""
+    parts = s.strip().split()
+    if len(parts) < 2:
+        return False
+    ktype, body = parts[0], parts[1]
+    if not ktype.startswith(("ssh-", "ecdsa-", "sk-")):
+        return False
+    try:
+        _b64decode_strict(body)
+    except Exception:
+        return False
+    return len(body) >= 20
+
+
+def fingerprint(pubkey: str) -> str:
+    """ssh-keygen-style SHA256 fingerprint of the key body: `SHA256:<base64-no-pad>`."""
+    body = pubkey.strip().split()[1]
+    digest = hashlib.sha256(_b64decode_strict(body)).digest()
+    return "SHA256:" + base64.b64encode(digest).decode().rstrip("=")
+
+
+def sanitize_label(hostname: str) -> str:
+    """A safe pubkeys-filename stem from a hostname: lowercase [a-z0-9-], no traversal, ≤40."""
+    s = re.sub(r"[^a-z0-9]+", "-", (hostname or "").lower()).strip("-")[:40].strip("-")
+    return s or "device"

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -70,6 +70,11 @@ class NotPending(Exception):
     """No pending request with that id (unknown, already resolved, or expired)."""
 
 
+# Request ids are secrets.token_hex(16). Reject anything else before it touches a
+# filesystem path — defense-in-depth against a crafted id like "../../evil".
+_RID_RE = re.compile(r"\A[0-9a-f]{1,64}\Z")
+
+
 # ---------------------------------------------------------------------------
 # RequestStore
 # ---------------------------------------------------------------------------
@@ -165,15 +170,17 @@ class RequestStore:
         return out
 
     def get(self, rid: str) -> str:
+        if not _RID_RE.match(rid):
+            return "unknown"
         self._sweep()
         if (self._pending / f"{rid}.json").exists():
             return "pending"
-        r = self._resolved / f"{rid}.json"
-        if r.exists():
-            return json.loads(r.read_text())["status"]
-        return "unknown"
+        rec = self._read_rec(self._resolved / f"{rid}.json")
+        return rec.get("status", "unknown") if rec else "unknown"
 
     def approve(self, rid: str, pubkeys_dir) -> None:
+        if not _RID_RE.match(rid):
+            raise NotPending(rid)
         self._sweep()
         p = self._pending / f"{rid}.json"
         if not p.exists():
@@ -188,6 +195,8 @@ class RequestStore:
         self._resolve(p, rec, "approved")
 
     def deny(self, rid: str) -> None:
+        if not _RID_RE.match(rid):
+            raise NotPending(rid)
         # Sweep first so denying an already-expired request resolves it as `expired`,
         # consistent with the other methods.
         self._sweep()

--- a/src/mship/core/relay/enroll_app.py
+++ b/src/mship/core/relay/enroll_app.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from mship.core.relay.enroll import RequestStore, PendingCapReached, validate_pubkey
+
+
+class _EnrollBody(BaseModel):
+    pubkey: str
+    hostname: str = ""
+
+
+def build_enroll_app(store: RequestStore) -> FastAPI:
+    app = FastAPI(title="mship relay enroll")
+
+    @app.post("/enroll")
+    def enroll(body: _EnrollBody):
+        if not validate_pubkey(body.pubkey):
+            raise HTTPException(status_code=400, detail="invalid ssh public key")
+        try:
+            rid = store.create(body.pubkey, body.hostname)
+        except PendingCapReached:
+            raise HTTPException(status_code=429, detail="too many pending requests; try later")
+        return {"id": rid, "status": "pending"}
+
+    @app.get("/status/{rid}")
+    def status(rid: str):
+        return {"id": rid, "status": store.get(rid)}
+
+    return app

--- a/src/mship/core/relay/enroll_app.py
+++ b/src/mship/core/relay/enroll_app.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from mship.core.relay.enroll import RequestStore, PendingCapReached, validate_pubkey
 
 
 class _EnrollBody(BaseModel):
-    pubkey: str
-    hostname: str = ""
+    # Bound the body: this endpoint is public, so cap the payload before we
+    # read+hash+store it. 1024 covers any real ssh key; 253 is the DNS hostname
+    # max. Over-length input is rejected by pydantic with a 422.
+    pubkey: str = Field(max_length=1024)
+    hostname: str = Field(default="", max_length=253)
 
 
 def build_enroll_app(store: RequestStore) -> FastAPI:
@@ -21,6 +24,10 @@ def build_enroll_app(store: RequestStore) -> FastAPI:
             rid = store.create(body.pubkey, body.hostname)
         except PendingCapReached:
             raise HTTPException(status_code=429, detail="too many pending requests; try later")
+        except ValueError:
+            # Store self-validates (belt-and-suspenders); surface its rejection
+            # as a clean 400 rather than letting it bubble up as a 500.
+            raise HTTPException(status_code=400, detail="invalid ssh public key")
         return {"id": rid, "status": "pending"}
 
     @app.get("/status/{rid}")

--- a/tests/cli/test_relay_cli.py
+++ b/tests/cli/test_relay_cli.py
@@ -229,3 +229,95 @@ def test_serve_relay_requires_host(workspace_no_relay, tmp_path, monkeypatch):
     r = runner.invoke(app, ["serve", "--relay"])
     assert r.exit_code != 0
     assert "relay" in r.output.lower()
+
+
+# --- mship relay requests / approve / deny ---
+
+
+def test_relay_requests_approve_deny_roundtrip(tmp_path):
+    """Host-side roundtrip: create a pending request, list it, approve it.
+
+    Flags are per-command (not on the relay group), so --store-dir/--pubkeys-dir
+    are passed after the subcommand name.
+    """
+    from mship.core.relay.enroll import RequestStore
+
+    store_dir = tmp_path / "store"
+    pubkeys = tmp_path / "pubkeys"
+    pubkeys.mkdir()
+
+    # Seed a pending request directly via the store (simulates a device POSTing /enroll).
+    s = RequestStore(store_dir)
+    rid = s.create(
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAA host",
+        "laptop",
+    )
+
+    # `mship relay requests --store-dir <dir>` should list the pending request.
+    r = runner.invoke(app, ["relay", "requests", "--store-dir", str(store_dir)])
+    assert r.exit_code == 0, r.output
+    assert rid in r.output
+    assert "laptop" in r.output
+
+    # `mship relay approve <id> --store-dir <dir> --pubkeys-dir <dir>` should
+    # write the key into pubkeys/ and mark the request as approved.
+    r = runner.invoke(
+        app,
+        ["relay", "approve", rid, "--store-dir", str(store_dir), "--pubkeys-dir", str(pubkeys)],
+    )
+    assert r.exit_code == 0, r.output
+    assert len(list(pubkeys.glob("*.pub"))) == 1  # key enrolled
+    assert RequestStore(store_dir).get(rid) == "approved"
+
+
+def test_relay_deny_resolves_without_enrolling(tmp_path):
+    """deny removes the request from pending but writes no key file."""
+    from mship.core.relay.enroll import RequestStore
+
+    store_dir = tmp_path / "store"
+    pubkeys = tmp_path / "pubkeys"
+    pubkeys.mkdir()
+
+    s = RequestStore(store_dir)
+    rid = s.create(
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAA host",
+        "phone",
+    )
+
+    r = runner.invoke(app, ["relay", "deny", rid, "--store-dir", str(store_dir)])
+    assert r.exit_code == 0, r.output
+    assert len(list(pubkeys.glob("*.pub"))) == 0  # no key enrolled
+    assert RequestStore(store_dir).get(rid) == "denied"
+
+
+def test_relay_approve_unknown_id_exits_nonzero(tmp_path):
+    """approve on a non-existent id exits 1 with a clean error (no traceback)."""
+    store_dir = tmp_path / "store"
+    pubkeys = tmp_path / "pubkeys"
+    pubkeys.mkdir()
+
+    r = runner.invoke(
+        app,
+        ["relay", "approve", "doesnotexist", "--store-dir", str(store_dir), "--pubkeys-dir", str(pubkeys)],
+    )
+    assert r.exit_code == 1
+    # Output should mention the id, not a Python traceback.
+    assert "doesnotexist" in r.output
+
+
+def test_relay_deny_unknown_id_exits_nonzero(tmp_path):
+    """deny on a non-existent id exits 1 with a clean error (no traceback)."""
+    store_dir = tmp_path / "store"
+
+    r = runner.invoke(app, ["relay", "deny", "nope", "--store-dir", str(store_dir)])
+    assert r.exit_code == 1
+    assert "nope" in r.output
+
+
+def test_relay_requests_empty(tmp_path):
+    """`mship relay requests` with no pending requests exits 0 and says so."""
+    store_dir = tmp_path / "store"
+
+    r = runner.invoke(app, ["relay", "requests", "--store-dir", str(store_dir)])
+    assert r.exit_code == 0, r.output
+    assert "no pending" in r.output

--- a/tests/cli/test_relay_cli.py
+++ b/tests/cli/test_relay_cli.py
@@ -321,3 +321,122 @@ def test_relay_requests_empty(tmp_path):
     r = runner.invoke(app, ["relay", "requests", "--store-dir", str(store_dir)])
     assert r.exit_code == 0, r.output
     assert "no pending" in r.output
+
+
+# --- mship relay enroll (requester) ---
+
+
+def _stub_relay_key(tmp_path, monkeypatch):
+    """Point HOME at a tmp dir with a pre-created relay key so `enroll` reads a
+    real pubkey without spawning ssh-keygen."""
+    fake_home = tmp_path / "home"
+    (fake_home / ".mothership").mkdir(parents=True)
+    key = fake_home / ".mothership" / "relay_ed25519"
+    key.write_text("PRIV\n")
+    (Path(str(key) + ".pub")).write_text("ssh-ed25519 AAAA mship-relay\n")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+
+def test_enroll_post_connection_error_is_clean(tmp_path, monkeypatch):
+    """A connection error on the initial POST exits 1 with a clean message, not a traceback."""
+    import httpx
+
+    _stub_relay_key(tmp_path, monkeypatch)
+
+    def boom(*args, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(httpx, "post", boom)
+
+    r = runner.invoke(app, ["relay", "enroll", "--enroll-url", "http://relay.example:47180"])
+    assert r.exit_code == 1
+    assert "could not reach enroll server" in r.output
+    # No traceback leaked.
+    assert "Traceback" not in r.output
+
+
+def test_enroll_poll_survives_transient_blip_then_approved(tmp_path, monkeypatch):
+    """A transient RequestError mid-poll is retried; the loop then sees 'approved' and exits 0."""
+    import httpx
+
+    _stub_relay_key(tmp_path, monkeypatch)
+
+    class _Resp:
+        status_code = 200
+
+        def __init__(self, payload):
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: _Resp({"id": "rid123", "status": "pending"}))
+
+    calls = {"n": 0}
+
+    def fake_get(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ConnectError("blip")  # transient — should be retried
+        return _Resp({"status": "approved"})
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    # No real sleeping between poll iterations.
+    import time as _time
+    monkeypatch.setattr(_time, "sleep", lambda *a, **k: None)
+
+    r = runner.invoke(app, ["relay", "enroll", "--enroll-url", "http://relay.example:47180"])
+    assert r.exit_code == 0, r.output
+    assert "approved" in r.output
+    assert calls["n"] == 2  # first call blipped, second succeeded
+
+
+def test_enroll_poll_denied_exits_nonzero(tmp_path, monkeypatch):
+    """A 'denied' status during polling exits 1 cleanly."""
+    import httpx
+
+    _stub_relay_key(tmp_path, monkeypatch)
+
+    class _Resp:
+        status_code = 200
+
+        def __init__(self, payload):
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: _Resp({"id": "rid123", "status": "pending"}))
+    monkeypatch.setattr(httpx, "get", lambda *a, **k: _Resp({"status": "denied"}))
+    import time as _time
+    monkeypatch.setattr(_time, "sleep", lambda *a, **k: None)
+
+    r = runner.invoke(app, ["relay", "enroll", "--enroll-url", "http://relay.example:47180"])
+    assert r.exit_code == 1
+    assert "denied" in r.output
+
+
+def test_enroll_no_wait_returns_after_post(tmp_path, monkeypatch):
+    """--no-wait POSTs and returns 0 without polling."""
+    import httpx
+
+    _stub_relay_key(tmp_path, monkeypatch)
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"id": "rid123", "status": "pending"}
+
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: _Resp())
+
+    def fail_get(*a, **k):
+        raise AssertionError("should not poll when --no-wait")
+
+    monkeypatch.setattr(httpx, "get", fail_get)
+
+    r = runner.invoke(
+        app, ["relay", "enroll", "--enroll-url", "http://relay.example:47180", "--no-wait"]
+    )
+    assert r.exit_code == 0, r.output
+    assert "rid123" in r.output

--- a/tests/core/relay/test_enroll.py
+++ b/tests/core/relay/test_enroll.py
@@ -112,3 +112,47 @@ def test_same_hostname_does_not_clobber(tmp_path):
     r2 = s.create(_PUB, "laptop")
     s.approve(r2, pubkeys)
     assert len(list(pubkeys.glob("*.pub"))) == 2  # unique filenames
+
+
+# ---------------------------------------------------------------------------
+# Task 2 hardening (security review of commit 5886872)
+# ---------------------------------------------------------------------------
+
+
+def test_create_rejects_multiline_pubkey_and_writes_nothing(tmp_path):
+    # The store is the security boundary: a multi-line pubkey must be rejected at
+    # create() so a crafted second line can never reach the pubkeys allowlist.
+    pubkeys = tmp_path / "pubkeys"
+    pubkeys.mkdir()
+    s = _store(tmp_path)
+    evil = _PUB + "\n" + _PUB.replace("host", "evil")
+    with pytest.raises(ValueError):
+        s.create(evil, "h")
+    assert s.list_pending() == []
+    assert list((tmp_path / "store" / "pending").glob("*.json")) == []
+    assert list(pubkeys.glob("*.pub")) == []
+
+
+def test_deny_sweeps_so_expired_resolves_as_expired(tmp_path):
+    clock = _Clock(1000.0)
+    s = _store(tmp_path, ttl=1800, clock=clock)
+    rid = s.create(_PUB, "h")
+    clock.t = 1000.0 + 1801  # past TTL
+    with pytest.raises(NotPending):
+        s.deny(rid)
+    assert s.get(rid) == "expired"  # not "denied"
+
+
+def test_corrupt_pending_file_does_not_brick_store(tmp_path):
+    pubkeys = tmp_path / "pubkeys"
+    pubkeys.mkdir()
+    s = _store(tmp_path)
+    good = s.create(_PUB, "good")
+    pending_dir = tmp_path / "store" / "pending"
+    (pending_dir / "deadbeef.json").write_text("{ truncated not json")
+    # A corrupt sibling must not raise from list/get/approve; it is quarantined.
+    assert [r["id"] for r in s.list_pending()] == [good]
+    assert s.get(good) == "pending"
+    s.approve(good, pubkeys)
+    assert s.get(good) == "approved"
+    assert list(pending_dir.glob("*.json.corrupt"))  # bad file moved aside

--- a/tests/core/relay/test_enroll.py
+++ b/tests/core/relay/test_enroll.py
@@ -156,3 +156,22 @@ def test_corrupt_pending_file_does_not_brick_store(tmp_path):
     s.approve(good, pubkeys)
     assert s.get(good) == "approved"
     assert list(pending_dir.glob("*.json.corrupt"))  # bad file moved aside
+
+
+def test_approve_and_deny_on_corrupt_own_record_raise_cleanly(tmp_path):
+    """A truncated/corrupt pending file at approve/deny time → NotPending, not a traceback."""
+    pubkeys = tmp_path / "pubkeys"
+    pubkeys.mkdir()
+    s = _store(tmp_path)
+    pending_dir = tmp_path / "store" / "pending"
+
+    rid = s.create(_PUB, "laptop")
+    (pending_dir / f"{rid}.json").write_text("{ truncated")
+    with pytest.raises(NotPending):
+        s.approve(rid, pubkeys)
+    assert list(pubkeys.glob("*.pub")) == []  # nothing written to the allowlist
+
+    rid2 = s.create(_PUB, "laptop2")
+    (pending_dir / f"{rid2}.json").write_text("not json at all")
+    with pytest.raises(NotPending):
+        s.deny(rid2)

--- a/tests/core/relay/test_enroll.py
+++ b/tests/core/relay/test_enroll.py
@@ -1,0 +1,29 @@
+from mship.core.relay.enroll import validate_pubkey, fingerprint, sanitize_label
+
+_PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host"
+
+
+def test_validate_accepts_ssh_key():
+    assert validate_pubkey(_PUB)
+    assert validate_pubkey("ssh-rsa AAAAB3NzaC1yc2EAAAAD host")
+
+
+def test_validate_rejects_junk():
+    assert not validate_pubkey("not a key")
+    assert not validate_pubkey("")
+    assert not validate_pubkey("ssh-ed25519 !!!notbase64!!!")
+    assert not validate_pubkey("rm -rf /")
+
+
+def test_fingerprint_is_stable_sha256():
+    fp = fingerprint(_PUB)
+    assert fp.startswith("SHA256:")
+    assert fp == fingerprint(_PUB + "  different-comment")  # body only
+
+
+def test_sanitize_label_is_traversal_proof():
+    assert sanitize_label("../../etc/passwd") == "etc-passwd"
+    assert sanitize_label("My Laptop!") == "my-laptop"
+    assert sanitize_label("") == "device"
+    s = sanitize_label("a/" * 100)
+    assert "/" not in s and ".." not in s and len(s) <= 40

--- a/tests/core/relay/test_enroll.py
+++ b/tests/core/relay/test_enroll.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mship.core.relay.enroll import validate_pubkey, fingerprint, sanitize_label
 
 _PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host"
@@ -15,10 +17,21 @@ def test_validate_rejects_junk():
     assert not validate_pubkey("rm -rf /")
 
 
+def test_validate_rejects_multiline_injection():
+    # A crafted second line must not be smuggled into the authorized_keys allowlist.
+    assert not validate_pubkey(_PUB + "\n" + _PUB.replace("host", "evil"))
+    assert not validate_pubkey(_PUB + "\r\n" + _PUB.replace("host", "evil"))
+
+
 def test_fingerprint_is_stable_sha256():
     fp = fingerprint(_PUB)
     assert fp.startswith("SHA256:")
     assert fp == fingerprint(_PUB + "  different-comment")  # body only
+
+
+def test_fingerprint_rejects_non_key():
+    with pytest.raises(ValueError):
+        fingerprint("ssh-ed25519")
 
 
 def test_sanitize_label_is_traversal_proof():

--- a/tests/core/relay/test_enroll.py
+++ b/tests/core/relay/test_enroll.py
@@ -1,6 +1,7 @@
 import pytest
 
 from mship.core.relay.enroll import validate_pubkey, fingerprint, sanitize_label
+from mship.core.relay.enroll import RequestStore, PendingCapReached, NotPending
 
 _PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host"
 
@@ -40,3 +41,74 @@ def test_sanitize_label_is_traversal_proof():
     assert sanitize_label("") == "device"
     s = sanitize_label("a/" * 100)
     assert "/" not in s and ".." not in s and len(s) <= 40
+
+
+# ---------------------------------------------------------------------------
+# Task 2: RequestStore tests
+# ---------------------------------------------------------------------------
+
+
+class _Clock:
+    def __init__(self, t=1000.0):
+        self.t = t
+
+    def __call__(self):
+        return self.t
+
+
+def _store(tmp_path, ttl=1800, clock=None, cap=50):
+    return RequestStore(tmp_path / "store", ttl_seconds=ttl, max_pending=cap, clock=clock or _Clock())
+
+
+def test_create_then_pending_then_approve_writes_allowlist(tmp_path):
+    pubkeys = tmp_path / "pubkeys"
+    pubkeys.mkdir()
+    s = _store(tmp_path)
+    rid = s.create(_PUB, "my-laptop")
+    assert s.get(rid) == "pending"
+    assert [r["id"] for r in s.list_pending()] == [rid]
+    s.approve(rid, pubkeys)
+    assert s.get(rid) == "approved"
+    written = list(pubkeys.glob("*.pub"))
+    assert len(written) == 1 and written[0].read_text().strip() == _PUB.strip()
+    assert s.list_pending() == []  # no longer pending
+
+
+def test_deny_resolves_without_touching_allowlist(tmp_path):
+    pubkeys = tmp_path / "pubkeys"
+    pubkeys.mkdir()
+    s = _store(tmp_path)
+    rid = s.create(_PUB, "h")
+    s.deny(rid)
+    assert s.get(rid) == "denied"
+    assert list(pubkeys.glob("*.pub")) == []
+
+
+def test_expiry_after_ttl(tmp_path):
+    clock = _Clock(1000.0)
+    s = _store(tmp_path, ttl=1800, clock=clock)
+    rid = s.create(_PUB, "h")
+    clock.t = 1000.0 + 1801  # past TTL
+    assert s.list_pending() == []
+    assert s.get(rid) == "expired"
+    with pytest.raises(NotPending):
+        s.approve(rid, tmp_path)
+
+
+def test_pending_cap_enforced(tmp_path):
+    s = _store(tmp_path, cap=2)
+    s.create(_PUB, "a")
+    s.create(_PUB, "b")
+    with pytest.raises(PendingCapReached):
+        s.create(_PUB, "c")
+
+
+def test_same_hostname_does_not_clobber(tmp_path):
+    pubkeys = tmp_path / "pubkeys"
+    pubkeys.mkdir()
+    s = _store(tmp_path)
+    r1 = s.create(_PUB, "laptop")
+    s.approve(r1, pubkeys)
+    r2 = s.create(_PUB, "laptop")
+    s.approve(r2, pubkeys)
+    assert len(list(pubkeys.glob("*.pub"))) == 2  # unique filenames

--- a/tests/core/relay/test_enroll_app.py
+++ b/tests/core/relay/test_enroll_app.py
@@ -1,0 +1,34 @@
+from fastapi.testclient import TestClient
+from mship.core.relay.enroll import RequestStore
+from mship.core.relay.enroll_app import build_enroll_app
+
+_PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host"
+
+
+def _client(tmp_path, cap=50):
+    store = RequestStore(tmp_path / "s", max_pending=cap)
+    return TestClient(build_enroll_app(store)), store
+
+
+def test_enroll_creates_pending_and_status(tmp_path):
+    c, _ = _client(tmp_path)
+    r = c.post("/enroll", json={"pubkey": _PUB, "hostname": "laptop"})
+    assert r.status_code == 200
+    rid = r.json()["id"]
+    assert c.get(f"/status/{rid}").json()["status"] == "pending"
+
+
+def test_enroll_rejects_bad_key(tmp_path):
+    c, _ = _client(tmp_path)
+    assert c.post("/enroll", json={"pubkey": "garbage", "hostname": "x"}).status_code == 400
+
+
+def test_enroll_over_cap_429(tmp_path):
+    c, _ = _client(tmp_path, cap=1)
+    c.post("/enroll", json={"pubkey": _PUB, "hostname": "a"})
+    assert c.post("/enroll", json={"pubkey": _PUB, "hostname": "b"}).status_code == 429
+
+
+def test_status_unknown(tmp_path):
+    c, _ = _client(tmp_path)
+    assert c.get("/status/deadbeef").json()["status"] == "unknown"

--- a/tests/core/relay/test_enroll_app.py
+++ b/tests/core/relay/test_enroll_app.py
@@ -32,3 +32,12 @@ def test_enroll_over_cap_429(tmp_path):
 def test_status_unknown(tmp_path):
     c, _ = _client(tmp_path)
     assert c.get("/status/deadbeef").json()["status"] == "unknown"
+
+
+def test_enroll_rejects_oversized_pubkey(tmp_path):
+    c, _ = _client(tmp_path)
+    # A valid key-type prefix + an absurdly long body: the body bound must reject
+    # this before we read+hash+store it. 4xx (pydantic 422 or our 400), never 2xx/5xx.
+    oversized = "ssh-ed25519 " + "A" * 4096 + " host"
+    r = c.post("/enroll", json={"pubkey": oversized, "hostname": "x"})
+    assert 400 <= r.status_code < 500


### PR DESCRIPTION
## Summary

Lets a device that **can't reach the relay box** get onto the sish allowlist via a **request → owner-approve** flow — no shared secret, and a request can never enroll itself. Implements spec `relay-enroll-approval` (v1; phone-approval is v2). Closes the gap where per-key enrollment required filesystem/SSH access to the relay host that a remote device doesn't have.

**Flow:**
```
 new device:  mship relay enroll --enroll-url http://<relay-host>:47180
   → POST {pubkey, hostname} ──────────────▶ relay enroll-server: PENDING (never the allowlist)
                                              30-min TTL
 owner (on relay host):  mship relay requests        # id · hostname · fingerprint
                         mship relay approve <id>     # writes pubkeys/<host>.pub → sish picks it up
                         mship relay deny <id>        # discards
 new device: (polls) → ✓ approved → mship serve --relay
```

**Security model — "anyone can ask, only you grant":**
- `POST /enroll` only ever creates a **pending** record; the allowlist is written **only** by `RequestStore.approve` (owner, on the box). A stranger's POST can't enroll itself.
- **`authorized_keys` injection closed at two layers:** `validate_pubkey` rejects multi-line/CRLF, enforced both in the HTTP handler *and* re-checked inside `RequestStore.create` (so the store self-protects even if called directly).
- **Path-traversal-proof:** hostnames are sanitized to a safe `[a-z0-9-]` filename stem; request ids are validated to hex before touching any path; approve writes a unique file (never clobbers an existing key) atomically (sish never sees a half-written key).
- **Abuse bounded:** open requests but a global pending **cap** (429), a **body-size bound** (422), and the **30-min TTL** sweeping stale entries. Corrupt request files are quarantined, not fatal.
- The requester handles network errors / timeouts / non-JSON cleanly (no tracebacks) and always terminates.

**New:** `core/relay/enroll.py` (validate/fingerprint/sanitize + `RequestStore`), `core/relay/enroll_app.py` (FastAPI). **Modified:** `cli/relay.py` (+`enroll-server`/`requests`/`approve`/`deny`/`enroll`), `docs/relay-hosting.md` (the enroll section). Purely additive — `setup`/`pair` and the existing relay code untouched. No sish change.

Built subagent-driven with a security-first two-stage review per task — which **caught and closed two confirmed `authorized_keys` injection paths** (ET1 multi-line accept, ET2 `create()` not re-validating) plus a public-endpoint DoS surface and the requester's network-error handling. A final adversarial whole-branch review confirmed the core invariant (no key without owner approval) and AC1–AC9, then flagged 3 robustness minors (no 500s/tracebacks) which are fixed here.

## Test plan

- [x] `mship test --repos mothership` — full suite green; **35 new relay tests** (helpers incl. injection/traversal, `RequestStore` lifecycle + TTL via injectable clock + cap + corrupt-file resilience, FastAPI `TestClient` for 400/429/422, requester poll resilience) + the 27 pre-existing setup/pair/tunnel tests.
- [ ] Manual smoke: on the relay host `mship relay enroll-server`; from another machine `mship relay enroll --enroll-url …` → owner `mship relay requests` + `approve <id>` → the device's key lands in `pubkeys/` and `mship serve --relay` works; a request left for >30 min reports `expired`.
