### PR TITLE
Relay serve verify: retry the public-URL health probe for ~30s before printing the relay-NOT-reachable error, so transient startup latency (tunnel route registration / on-demand cert) doesn't produce a false negative

### DIFF
--- a/src/mship/cli/serve.py
+++ b/src/mship/cli/serve.py
@@ -127,7 +127,7 @@ def _serve_with_relay(
     import uvicorn
 
     from mship.core.relay.config import RelayConfig
-    from mship.core.relay.health import verify_relay_reachable
+    from mship.core.relay.health import wait_until_reachable
     from mship.core.relay.keys import ensure_relay_key, relay_public_key
     from mship.core.relay.pairing import build_pair_link
     from mship.core.relay.token import ensure_serve_token
@@ -224,7 +224,9 @@ def _serve_with_relay(
         if not local_up:
             output.error("✗ local server didn't come up within 30s; relay not verified")
             return
-        ok, detail = verify_relay_reachable(public_url, token)
+        # The tunnel route, TLS cert, and DNS can take a few seconds after
+        # startup — retry transient failures before declaring the relay down.
+        ok, detail = wait_until_reachable(public_url, token)
         if stop_event.is_set():
             return                      # shut down while the probe was in-flight — no spurious ✗
         if ok:

--- a/src/mship/core/relay/health.py
+++ b/src/mship/core/relay/health.py
@@ -25,3 +25,37 @@ def verify_relay_reachable(public_url: str, token: str, *, get: Callable | None 
         return False, (f"relay reachable but auth failed (HTTP {r.status_code}) — "
                        "the paired phone's token is stale; re-scan the QR")
     return False, f"relay returned HTTP {r.status_code}"
+
+
+# Phrase emitted by verify_relay_reachable on a 401/403. A stale token never
+# recovers by waiting, so wait_until_reachable treats this as terminal.
+_AUTH_FAILURE_MARKER = "auth failed"
+
+
+def wait_until_reachable(public_url: str, token: str, *, get: Callable | None = None,
+                         timeout: float = 30.0, interval: float = 3.0,
+                         clock: Callable | None = None,
+                         sleep: Callable | None = None) -> tuple[bool, str]:
+    """Poll `verify_relay_reachable` until reachable or `timeout` seconds elapse.
+
+    A single post-startup probe gives false negatives: after `mship serve --relay`
+    starts, the sish route registration, on-demand TLS cert provisioning, and DNS
+    propagation each take a few seconds, so the first probe often sees a transport
+    error / 404 / 5xx that clears on its own. We retry those transient failures
+    every `interval` seconds until the deadline, then return the last detail.
+
+    A 401/403 (stale token) is terminal — retrying can't fix the wrong token — so
+    we return immediately rather than burning the whole window.
+
+    `clock`/`sleep` are injectable (default time.monotonic / time.sleep) so tests
+    can drive the deadline without real waiting.
+    """
+    import time as _time
+    clock = clock or _time.monotonic
+    sleep = sleep or _time.sleep
+    deadline = clock() + timeout
+    ok, detail = verify_relay_reachable(public_url, token, get=get)
+    while not ok and _AUTH_FAILURE_MARKER not in detail and clock() < deadline:
+        sleep(interval)
+        ok, detail = verify_relay_reachable(public_url, token, get=get)
+    return ok, detail

--- a/tests/core/relay/test_health.py
+++ b/tests/core/relay/test_health.py
@@ -1,7 +1,13 @@
-from mship.core.relay.health import verify_relay_reachable
+from mship.core.relay.health import verify_relay_reachable, wait_until_reachable
 
 class _Resp:
     def __init__(self, status): self.status_code = status
+
+class _Clock:
+    """Fake monotonic clock: sleep() advances the clock instead of blocking."""
+    def __init__(self): self.t = 0.0
+    def now(self): return self.t
+    def sleep(self, dt): self.t += dt
 
 def test_ok_when_authed_request_succeeds():
     calls = {}
@@ -21,3 +27,56 @@ def test_not_ok_on_exception_carries_reason():
     def boom(*a, **k): raise RuntimeError("name resolution failed")
     ok, detail = verify_relay_reachable("https://w.relay", "tok", get=boom)
     assert ok is False and "name resolution failed" in detail
+
+
+# --- wait_until_reachable: retry the public probe through startup latency ---
+
+def test_wait_retries_until_reachable():
+    # tunnel route not registered yet (404), then comes up (200) → succeed
+    seq = [_Resp(404), _Resp(200)]
+    calls = []
+    def get(*a, **k):
+        calls.append(1); return seq[len(calls) - 1]
+    clk = _Clock()
+    ok, detail = wait_until_reachable("https://w.relay", "tok", get=get,
+                                      timeout=30, interval=3,
+                                      clock=clk.now, sleep=clk.sleep)
+    assert ok is True and detail == "ok"
+    assert len(calls) == 2          # retried once before it came up
+
+def test_wait_retries_transport_errors():
+    # connection refused while the ssh tunnel is still being established
+    calls = []
+    def get(*a, **k):
+        calls.append(1)
+        if len(calls) < 3:
+            raise RuntimeError("connection refused")
+        return _Resp(200)
+    clk = _Clock()
+    ok, detail = wait_until_reachable("https://w.relay", "tok", get=get,
+                                      timeout=30, interval=3,
+                                      clock=clk.now, sleep=clk.sleep)
+    assert ok is True
+    assert len(calls) == 3
+
+def test_wait_times_out_returns_last_detail():
+    clk = _Clock()
+    ok, detail = wait_until_reachable("https://w.relay", "tok",
+                                      get=lambda *a, **k: _Resp(404),
+                                      timeout=10, interval=3,
+                                      clock=clk.now, sleep=clk.sleep)
+    assert ok is False and "404" in detail
+    assert clk.t >= 10              # actually waited out the deadline
+
+def test_wait_does_not_retry_on_auth_failure():
+    # a stale token never recovers — fail fast, don't burn the whole window
+    calls = []
+    def get(*a, **k):
+        calls.append(1); return _Resp(401)
+    clk = _Clock()
+    ok, detail = wait_until_reachable("https://w.relay", "tok", get=get,
+                                      timeout=30, interval=3,
+                                      clock=clk.now, sleep=clk.sleep)
+    assert ok is False and "token" in detail.lower()
+    assert len(calls) == 1          # no retry
+    assert clk.t == 0               # never slept


### PR DESCRIPTION
## Summary

Fixes a **false-negative `✗ relay NOT reachable`** that `mship serve --relay` prints right after startup.

**Root cause (hit twice while debugging the relay):** after the ssh reverse tunnel comes up, `_verify_loop` did a *single* probe of the public URL `https://<subdomain>.<relay>/health`. But the public path isn't ready the instant the tunnel connects — sish still has to register the route, on-demand TLS provisions the cert on first contact, and DNS/route propagation lags a few seconds. So the one-shot probe routinely caught a transient `404` / `5xx` / transport error and declared the relay down, even though it was reachable a few seconds later. (Observed as both an HTTP 404 and a cert-provisioning failure in practice.)

**The fix — retry transient failures, fail fast on terminal ones:**

- New `wait_until_reachable(public_url, token, *, timeout=30, interval=3, ...)` in `core/relay/health.py` polls `verify_relay_reachable` until it succeeds or the deadline elapses, retrying every 3s.
- A **401/403 (stale token)** is treated as **terminal** — it never recovers by waiting, so it returns immediately with the existing "re-scan the QR" hint instead of burning the whole 30s window.
- `_verify_loop` in `cli/serve.py` now calls `wait_until_reachable` instead of the single `verify_relay_reachable`. The existing `stop_event` shutdown guards are unchanged, so a clean Ctrl-C during the retry window still emits no spurious `✗`.
- `clock`/`sleep` are injectable so the retry/deadline logic is unit-tested without real waiting.

`verify_relay_reachable` is unchanged (still the single-probe primitive, still exported and tested). Purely additive otherwise.

Changed: `core/relay/health.py` (+`wait_until_reachable`), `cli/serve.py` (`_verify_loop` wiring). Tests: `tests/core/relay/test_health.py`.

## Test plan

- [x] `mship test --repos mothership` — full suite green (**1719 passed**). 4 new `wait_until_reachable` tests: retries a 404→200 sequence, retries transport errors, times out returning the last transient detail (asserting the fake clock actually advanced past the deadline), and **fast-fails on 401 with a single call / zero sleeps** (stale-token path).
- [ ] Manual smoke: `mship serve --relay` from a cold tunnel — the probe now prints `✓ relay reachable: <url>` once the route/cert settle (within ~30s) instead of an immediate `✗`; a genuinely wrong token still reports the stale-token `✗` promptly.

https://claude.ai/code/session_01BCH6QFgBdw9LiWBzV39Xnj
