### PR TITLE
relay caddy front

### DIFF
--- a/docker/relay/Caddyfile
+++ b/docker/relay/Caddyfile
@@ -1,0 +1,44 @@
+{
+	on_demand_tls {
+		ask http://127.0.0.1:47180/tls-check
+	}
+	email {$ACME_EMAIL}
+}
+
+# Enrollment — public but edge-hardened (only POST /enroll, GET /status/*).
+enroll.{$RELAY_DOMAIN} {
+	tls {
+		on_demand
+	}
+	@enroll {
+		method POST
+		path /enroll
+	}
+	@status {
+		method GET
+		path /status/*
+	}
+	handle @enroll {
+		request_body {
+			max_size 4KB
+		}
+		reverse_proxy 127.0.0.1:47180
+	}
+	handle @status {
+		reverse_proxy 127.0.0.1:47180
+	}
+	handle {
+		respond "not found" 404
+	}
+}
+
+# Per-device serve subdomains -> sish (Host preserved). The more-specific
+# enroll.<domain> site above takes precedence over this wildcard.
+*.{$RELAY_DOMAIN} {
+	tls {
+		on_demand
+	}
+	reverse_proxy 127.0.0.1:8080 {
+		header_up Host {host}
+	}
+}

--- a/docker/relay/docker-compose.yml
+++ b/docker/relay/docker-compose.yml
@@ -1,25 +1,21 @@
 # Self-hosted sish relay for mship serve reverse tunnels.
+# Caddy owns public :80/:443 (on-demand TLS, enroll route hardened).
+# sish handles SSH tunnels (:2222) and serves HTTP internally (:8080 loopback).
 # Requires: a wildcard DNS record *.RELAY_DOMAIN -> this host, ports 80/443/2222 open.
 services:
   sish:
     image: antoniomika/sish:latest
     restart: unless-stopped
     ports:
-      - "2222:2222"   # SSH (clients open reverse tunnels here)
-      - "80:80"       # HTTP (ACME challenges + redirect)
-      - "443:443"     # HTTPS (public app traffic)
+      - "2222:2222"               # SSH (clients open reverse tunnels here)
+      - "127.0.0.1:8080:8080"    # HTTP internal (Caddy proxies to here)
     volumes:
       - ./pubkeys:/pubkeys:ro       # allow-listed client public keys
       - ./keys:/keys                # sish host keys (persisted)
-      - ./acme:/acme                # Let's Encrypt cert cache
     command:
       - --ssh-address=:2222
-      - --http-address=:80
-      - --https-address=:443
-      - --https=true
-      - --https-ondemand-certificate=true
-      - --https-ondemand-certificate-email=${ACME_EMAIL}
-      - --https-ondemand-certificate-accept-terms=true
+      - --http-address=:8080
+      - --https=false
       - --domain=${RELAY_DOMAIN}
       - --authentication=true
       - --authentication-keys-directory=/pubkeys
@@ -27,3 +23,15 @@ services:
       - --bind-random-subdomains=false      # honor the requested subdomain
       - --bind-random-ports=false
       - --idle-connection=false
+
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    network_mode: host          # owns host :80/:443; reaches enroll-server + sish on 127.0.0.1
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./caddy-data:/data
+      - ./caddy-config:/config
+    environment:
+      - RELAY_DOMAIN=${RELAY_DOMAIN}
+      - ACME_EMAIL=${ACME_EMAIL}

--- a/docs/plans/2026-06-26-relay-caddy-front.md
+++ b/docs/plans/2026-06-26-relay-caddy-front.md
@@ -1,0 +1,494 @@
+# Relay Caddy Front Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `relay-caddy-front` (approved) — `specs/2026-06-26-relay-caddy-front.md`
+
+**Goal:** Put the relay's device-enrollment endpoint behind the relay's existing 443 via a Caddy reverse proxy with on-demand TLS, so there's no side port / firewall hole, certs issue only for relay-owned hosts, the enroll surface is edge-hardened, and the operator supplies only the relay host.
+
+**Architecture:** Caddy becomes the sole public web ingress (80/443, `network_mode: host`); sish moves behind it (`--https=false`, internal `127.0.0.1:8080`, keeps 2222 for SSH tunnels). Caddy host-routes `enroll.<relay>` → the enroll-server (now `127.0.0.1:47180`) and `*.<relay>` → sish. TLS is Caddy on-demand gated by an `ask` endpoint backed by a pure predicate `tls_ask_allowed(domain, relay_domain)` that allows only `enroll.<relay>` and `<slug>-<6hex>.<relay>` serve subdomains. The enroll-server gains the ask route and binds loopback; the `mship relay enroll` CLI derives `https://enroll.<relay-host>` from `--relay-host`.
+
+**Tech Stack:** Python (FastAPI, typer, pytest), Caddy 2, docker-compose, sish.
+
+---
+
+<!-- mship:task id=1 -->
+### Task 1: `tls_ask_allowed` — the cert allowlist predicate (pure core)
+
+The security-critical heart: Caddy will only provision a TLS cert for a hostname this returns `True` for. It must allow exactly `enroll.<relay_domain>` and the serve per-device shape `<base>-<6hex>.<relay_domain>` (see `device_subdomain` in `core/relay/tunnel.py`: base is `[a-z0-9-]`, id is `[0-9a-f]{6}`, whole label ≤63), and reject everything else — the bare apex, foreign domains, extra subdomain levels, lookalikes, and whitespace/empty input.
+
+**Files:**
+- Create: `src/mship/core/relay/tls_ask.py`
+- Test: `tests/core/relay/test_tls_ask.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/core/relay/test_tls_ask.py
+from mship.core.relay.tls_ask import tls_ask_allowed
+
+RELAY = "mship-relay.atomikpanda.com"
+
+def test_allows_enroll_host():
+    assert tls_ask_allowed(f"enroll.{RELAY}", RELAY) is True
+
+def test_allows_serve_subdomains():
+    # device_subdomain output: <slug>-<6hex>
+    assert tls_ask_allowed(f"mship-workspace-92bbb7.{RELAY}", RELAY) is True
+    assert tls_ask_allowed(f"x-000000.{RELAY}", RELAY) is True
+
+def test_rejects_bare_apex():
+    assert tls_ask_allowed(RELAY, RELAY) is False
+
+def test_rejects_foreign_domain():
+    assert tls_ask_allowed("example.com", RELAY) is False
+    assert tls_ask_allowed(f"mship-workspace-92bbb7.evil.com", RELAY) is False
+
+def test_rejects_lookalike_and_extra_levels():
+    assert tls_ask_allowed(f"enroll.{RELAY}.evil.com", RELAY) is False
+    assert tls_ask_allowed(f"a.enroll.{RELAY}", RELAY) is False          # extra level
+    assert tls_ask_allowed(f"x.mship-workspace-92bbb7.{RELAY}", RELAY) is False
+
+def test_rejects_non_serve_label():
+    assert tls_ask_allowed(f"random.{RELAY}", RELAY) is False            # no -<6hex>
+    assert tls_ask_allowed(f"foo-92bbbz.{RELAY}", RELAY) is False        # z not hex
+
+def test_rejects_blank_and_whitespace():
+    assert tls_ask_allowed("", RELAY) is False
+    assert tls_ask_allowed("   ", RELAY) is False
+    assert tls_ask_allowed(f"enroll.{RELAY}", "") is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/core/relay/test_tls_ask.py -q`
+Expected: FAIL — `ModuleNotFoundError: mship.core.relay.tls_ask`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# src/mship/core/relay/tls_ask.py
+from __future__ import annotations
+import re
+
+# A serve per-device subdomain LABEL: <base>-<6 hex>, where base is the
+# DNS-safe workspace slug ([a-z0-9-]). Mirrors device_subdomain() in tunnel.py.
+_SERVE_LABEL = re.compile(r"[a-z0-9-]+-[0-9a-f]{6}")
+
+
+def tls_ask_allowed(domain: str, relay_domain: str) -> bool:
+    """Whether Caddy may provision an on-demand TLS cert for `domain`.
+
+    True only for the enroll host and serve per-device subdomains under
+    `relay_domain`; False for the bare apex, foreign domains, extra subdomain
+    levels, lookalikes, and blank input. This is the cert allowlist — keep it
+    tight; a loose match reopens the "mint a cert for any host" surface.
+    """
+    domain = (domain or "").strip().lower()
+    relay_domain = (relay_domain or "").strip().lower()
+    if not domain or not relay_domain:
+        return False
+    suffix = "." + relay_domain
+    if not domain.endswith(suffix):
+        return False
+    label = domain[: -len(suffix)]
+    if not label or "." in label:        # no nested subdomain levels
+        return False
+    if label == "enroll":
+        return True
+    return len(label) <= 63 and _SERVE_LABEL.fullmatch(label) is not None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/core/relay/test_tls_ask.py -q`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit (pair with `mship journal`)**
+
+```bash
+git add src/mship/core/relay/tls_ask.py tests/core/relay/test_tls_ask.py
+git commit -m "relay: add tls_ask_allowed cert allowlist predicate"
+mship journal "tls_ask_allowed predicate + allow/deny matrix tests" --action committed --test-state pass
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=2 -->
+### Task 2: Mount the on-demand `ask` route on the enroll app
+
+Caddy's on-demand TLS calls `GET /tls-check?domain=<sni>` over loopback and issues a cert only on a 2xx. Add that route to the enroll app, backed by `tls_ask_allowed`. The app now needs to know the relay domain, so thread it through `build_enroll_app`.
+
+**Files:**
+- Modify: `src/mship/core/relay/enroll_app.py`
+- Test: `tests/core/relay/test_enroll_app.py` (add cases)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/core/relay/test_enroll_app.py
+from fastapi.testclient import TestClient
+from mship.core.relay.enroll import RequestStore
+from mship.core.relay.enroll_app import build_enroll_app
+
+RELAY = "mship-relay.atomikpanda.com"
+
+def _client(tmp_path):
+    return TestClient(build_enroll_app(RequestStore(tmp_path / "store"), relay_domain=RELAY))
+
+def test_tls_check_allows_relay_owned_host(tmp_path):
+    c = _client(tmp_path)
+    assert c.get("/tls-check", params={"domain": f"enroll.{RELAY}"}).status_code == 200
+    assert c.get("/tls-check", params={"domain": f"w-92bbb7.{RELAY}"}).status_code == 200
+
+def test_tls_check_rejects_foreign_host(tmp_path):
+    c = _client(tmp_path)
+    assert c.get("/tls-check", params={"domain": "evil.com"}).status_code == 403
+
+def test_tls_check_requires_domain(tmp_path):
+    c = _client(tmp_path)
+    assert c.get("/tls-check").status_code in (400, 422)
+```
+
+(If existing tests call `build_enroll_app(store)` with no `relay_domain`, update them to pass `relay_domain=RELAY` — keep the param keyword-only with no default so the wiring is explicit.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/core/relay/test_enroll_app.py -q`
+Expected: FAIL — `build_enroll_app() got an unexpected keyword argument 'relay_domain'` / 404 on `/tls-check`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# src/mship/core/relay/enroll_app.py  — change the builder signature + add the route
+from fastapi import FastAPI, HTTPException, Query, Response
+from mship.core.relay.tls_ask import tls_ask_allowed
+# ... existing imports ...
+
+def build_enroll_app(store: RequestStore, *, relay_domain: str) -> FastAPI:
+    app = FastAPI(title="mship relay enroll")
+
+    # ... existing /enroll and /status routes unchanged ...
+
+    @app.get("/tls-check")
+    def tls_check(domain: str = Query(..., max_length=253)):
+        # Caddy on-demand TLS ask endpoint: 2xx => issue a cert for `domain`.
+        if not tls_ask_allowed(domain, relay_domain):
+            raise HTTPException(status_code=403, detail="host not allowed")
+        return Response(status_code=200)
+
+    return app
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/core/relay/test_enroll_app.py -q`
+Expected: PASS (new + existing, after updating existing calls to pass `relay_domain`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/core/relay/enroll_app.py tests/core/relay/test_enroll_app.py
+git commit -m "relay: enroll app serves Caddy on-demand /tls-check ask route"
+mship journal "added /tls-check ask route; build_enroll_app takes relay_domain" --action committed --test-state pass
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=3 -->
+### Task 3: enroll-server binds loopback + takes `--relay-domain`
+
+The server is now reached only via Caddy on loopback, so it should bind `127.0.0.1` (not `0.0.0.0`) — that's what actually closes the firewall hole. It also needs the relay domain to answer `/tls-check`.
+
+**Files:**
+- Modify: `src/mship/cli/relay.py` (the `enroll-server` command)
+- Test: `tests/cli/test_relay_enroll_server.py` (create, or add to the existing relay CLI test module)
+
+- [ ] **Step 1: Write the failing test**
+
+The launch is `uvicorn.run(...)`; assert wiring by monkeypatching `uvicorn.run` and `build_enroll_app` and invoking the command via typer's `CliRunner`.
+
+```python
+# tests/cli/test_relay_enroll_server.py
+import mship.cli.relay as relay_mod
+
+def test_enroll_server_binds_loopback_and_passes_relay_domain(monkeypatch, tmp_path):
+    calls = {}
+    monkeypatch.setattr(relay_mod, "_run_uvicorn", lambda app, host, port: calls.update(host=host, port=port))
+    captured = {}
+    import mship.core.relay.enroll_app as ea
+    monkeypatch.setattr(ea, "build_enroll_app",
+                        lambda store, *, relay_domain: captured.update(relay_domain=relay_domain) or "APP")
+    relay_mod._enroll_server_impl(  # pure helper the command delegates to
+        store_dir=str(tmp_path / "s"), pubkeys_dir=str(tmp_path / "p"),
+        port=47180, host="127.0.0.1", ttl=1800, relay_domain="r.example.com",
+    )
+    assert calls["host"] == "127.0.0.1"
+    assert captured["relay_domain"] == "r.example.com"
+```
+
+(Refactor note: extract the command body into a testable `_enroll_server_impl(...)` and a thin `_run_uvicorn(app, host, port)` seam so the test never starts a server. The `@relay_app.command("enroll-server")` function just parses options and calls `_enroll_server_impl`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/cli/test_relay_enroll_server.py -q`
+Expected: FAIL — `_enroll_server_impl` / `_run_uvicorn` don't exist yet
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# src/mship/cli/relay.py
+import os
+
+def _run_uvicorn(app, host, port):   # seam so tests don't boot a server
+    import uvicorn
+    uvicorn.run(app, host=host, port=port)
+
+def _enroll_server_impl(*, store_dir, pubkeys_dir, port, host, ttl, relay_domain):
+    from pathlib import Path
+    from mship.core.relay.enroll import RequestStore
+    from mship.core.relay.enroll_app import build_enroll_app
+    if not relay_domain:
+        raise typer.BadParameter("relay domain required: pass --relay-domain or set RELAY_DOMAIN")
+    store = RequestStore(Path(store_dir), ttl_seconds=ttl)
+    Output().print(f"enroll-server → http://{host}:{port}  (relay: {relay_domain}, "
+                   f"pubkeys: {pubkeys_dir}, store: {store_dir}, ttl: {ttl}s)")
+    _run_uvicorn(build_enroll_app(store, relay_domain=relay_domain), host=host, port=port)
+
+@relay_app.command("enroll-server")
+def enroll_server(
+    pubkeys_dir: str = typer.Option("./pubkeys", "--pubkeys-dir", help="..."),
+    store_dir: str = typer.Option("./pending-store", "--store-dir", help="..."),
+    port: int = typer.Option(47180, "--port", help="Port to listen on."),
+    host: str = typer.Option("127.0.0.1", "--host", help="Interface to bind (loopback; Caddy fronts it)."),
+    ttl: int = typer.Option(1800, "--ttl", help="Pending request TTL in seconds."),
+    relay_domain: str = typer.Option(lambda: os.environ.get("RELAY_DOMAIN", ""), "--relay-domain",
+                                     help="Relay domain for the on-demand TLS ask (default $RELAY_DOMAIN)."),
+):
+    """Run the enroll endpoint on the relay host (behind Caddy; loopback by default)."""
+    _enroll_server_impl(store_dir=store_dir, pubkeys_dir=pubkeys_dir, port=port,
+                        host=host, ttl=ttl, relay_domain=relay_domain)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/cli/test_relay_enroll_server.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/cli/relay.py tests/cli/test_relay_enroll_server.py
+git commit -m "relay: enroll-server binds loopback + takes --relay-domain for the ask route"
+mship journal "enroll-server 127.0.0.1 default + --relay-domain wired to build_enroll_app" --action committed --test-state pass
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=4 -->
+### Task 4: `mship relay enroll` derives `https://enroll.<relay-host>`
+
+The device side: operator passes only the relay host. Encode the URL precedence in a pure helper so it's testable without httpx.
+
+**Files:**
+- Modify: `src/mship/cli/relay.py` (the `enroll` command + a new pure helper)
+- Test: `tests/cli/test_relay_enroll_url.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/cli/test_relay_enroll_url.py
+import pytest
+from mship.cli.relay import enroll_base_url
+
+def test_explicit_enroll_url_wins():
+    assert enroll_base_url(enroll_url="http://h:47180", relay_host="r.example.com",
+                           config_host="c.example.com") == "http://h:47180"
+
+def test_relay_host_derives_https_enroll_subdomain():
+    assert enroll_base_url(enroll_url=None, relay_host="r.example.com",
+                           config_host=None) == "https://enroll.r.example.com"
+
+def test_falls_back_to_config_host():
+    assert enroll_base_url(enroll_url=None, relay_host=None,
+                           config_host="c.example.com") == "https://enroll.c.example.com"
+
+def test_errors_when_nothing_given():
+    with pytest.raises(ValueError):
+        enroll_base_url(enroll_url=None, relay_host=None, config_host=None)
+
+def test_strips_trailing_slash_on_override():
+    assert enroll_base_url(enroll_url="http://h:47180/", relay_host=None,
+                           config_host=None) == "http://h:47180"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/cli/test_relay_enroll_url.py -q`
+Expected: FAIL — `cannot import name 'enroll_base_url'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# src/mship/cli/relay.py
+def enroll_base_url(*, enroll_url: str | None, relay_host: str | None,
+                    config_host: str | None) -> str:
+    """Resolve the enroll endpoint base URL. Precedence:
+    explicit --enroll-url  >  --relay-host  >  configured relay.host.
+    A relay host derives https://enroll.<host>."""
+    if enroll_url:
+        return enroll_url.rstrip("/")
+    host = relay_host or config_host
+    if not host:
+        raise ValueError("provide --relay-host (or configure relay.host)")
+    return f"https://enroll.{host.strip().rstrip('.')}"
+```
+
+Then change the `enroll` command to use it. `--enroll-url` becomes optional; add `--relay-host`; read the configured host best-effort from the container/config (e.g. `RelayConfig.from_mapping(...)` if a `relay:` block is present, else `None`):
+
+```python
+@relay_app.command("enroll")
+def enroll_cmd(
+    relay_host: str = typer.Option(None, "--relay-host",
+                                   help="Relay host, e.g. mship-relay.example.com (enroll URL is derived)."),
+    enroll_url: str = typer.Option(None, "--enroll-url",
+                                   help="Explicit enroll base URL (overrides --relay-host)."),
+    wait: bool = typer.Option(True, "--wait/--no-wait", help="..."),
+):
+    out = Output()
+    try:
+        base = enroll_base_url(enroll_url=enroll_url, relay_host=relay_host,
+                               config_host=_configured_relay_host(get_container))
+    except ValueError as e:
+        out.error(str(e)); raise typer.Exit(2)
+    # ... existing httpx POST {base}/enroll + poll loop unchanged ...
+```
+
+Add a small `_configured_relay_host(get_container) -> str | None` that returns the workspace's `relay.host` if configured, else `None` (wrap in try/except so a non-workspace device just gets `None`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/cli/test_relay_enroll_url.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mship/cli/relay.py tests/cli/test_relay_enroll_url.py
+git commit -m "relay: enroll derives https://enroll.<relay-host>; --enroll-url now optional override"
+mship journal "enroll_base_url precedence helper + --relay-host UX" --action committed --test-state pass
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=5 -->
+### Task 5: Caddy front — Caddyfile + docker-compose
+
+Config (no unit test). Caddy owns 80/443 (`network_mode: host`), gates on-demand TLS via the ask endpoint, hardens the enroll route, and proxies everything else to sish. sish stops terminating TLS and publishes HTTP only on loopback.
+
+**Files:**
+- Create: `docker/relay/Caddyfile`
+- Modify: `docker/relay/docker-compose.yml`
+
+- [ ] **Step 1: Write `docker/relay/Caddyfile`**
+
+```
+{
+    on_demand_tls {
+        ask http://127.0.0.1:47180/tls-check
+    }
+    email {$ACME_EMAIL}
+}
+
+# Enrollment — public but edge-hardened (only POST /enroll, GET /status/*).
+enroll.{$RELAY_DOMAIN} {
+    tls { on_demand }
+    @enroll  { method POST  path /enroll }
+    @status  { method GET   path /status/* }
+    handle @enroll {
+        request_body { max_size 4KB }
+        reverse_proxy 127.0.0.1:47180
+    }
+    handle @status {
+        reverse_proxy 127.0.0.1:47180
+    }
+    handle { respond "not found" 404 }
+}
+
+# Per-device serve subdomains → sish (Host preserved). More-specific
+# enroll.<domain> above takes precedence over this wildcard.
+*.{$RELAY_DOMAIN} {
+    tls { on_demand }
+    reverse_proxy 127.0.0.1:8080 {
+        header_up Host {host}
+    }
+}
+```
+
+- [ ] **Step 2: Edit `docker/relay/docker-compose.yml`**
+
+sish service: drop `- "80:80"` and `- "443:443"`; add `- "127.0.0.1:8080:8080"`; keep `- "2222:2222"`. In `command`: replace `--http-address=:80` with `--http-address=:8080`, set `--https=false`, and remove the `--https-address`, `--https=true`, and all `--https-ondemand-certificate*` flags (Caddy does TLS now). Keep `--domain`, `--authentication*`, `--private-keys-directory`, `--bind-random-*`, `--idle-connection`.
+
+Add the Caddy service:
+
+```yaml
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    network_mode: host          # owns host :80/:443; reaches enroll-server + sish on 127.0.0.1
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./caddy-data:/data
+      - ./caddy-config:/config
+    environment:
+      - RELAY_DOMAIN=${RELAY_DOMAIN}
+      - ACME_EMAIL=${ACME_EMAIL}
+```
+
+- [ ] **Step 3: Validate the compose + Caddyfile render**
+
+Run:
+```bash
+cd docker/relay && RELAY_DOMAIN=example.com ACME_EMAIL=x@example.com docker compose config >/dev/null && echo "compose OK"
+docker run --rm -v "$PWD/Caddyfile":/etc/caddy/Caddyfile:ro caddy:2 caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+```
+Expected: `compose OK` and Caddy reports the config valid. (If docker isn't available in the build env, note it and defer to the manual smoke step in Task 6.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker/relay/Caddyfile docker/relay/docker-compose.yml
+git commit -m "relay: front sish with Caddy (on-demand TLS ask, enroll behind 443, loopback enroll-server)"
+mship journal "Caddyfile + compose: Caddy host-net front, sish internal :8080, enroll route hardened" --action committed
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=6 -->
+### Task 6: Docs + run the full suite
+
+**Files:**
+- Modify: `docs/relay-hosting.md`
+
+- [ ] **Step 1: Update `docs/relay-hosting.md`**
+
+Document: Caddy is the public web front (80/443); sish runs behind it on internal `:8080` with `--https=false` (keeps 2222); the device-facing enroll URL is now `https://enroll.<relay-domain>` (no port); `mship relay enroll --relay-host <host>` derives it; the enroll-server binds `127.0.0.1` and takes `--relay-domain`; on-demand TLS is gated by `/tls-check` so certs issue only for `enroll.<relay>` and serve subdomains. Add the manual smoke steps below. Note the deferred items: rate-limit plugin, wildcard DNS-01 as an alternative.
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `mship test --repos mothership`
+Expected: green; new tests (tls_ask matrix, /tls-check route, enroll-server wiring, enroll URL derivation) included.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/relay-hosting.md
+git commit -m "docs: relay Caddy front + https://enroll.<host> enroll flow"
+mship journal "docs updated; full suite green" --action committed --test-state pass
+```
+
+- [ ] **Manual smoke (out-of-band, on the relay host):** `docker compose up -d` (sish+caddy); `mship relay enroll-server --relay-domain <relay> --store-dir <abs> --pubkeys-dir <abs>` (loopback); from another device `mship relay enroll --relay-host <relay>` reaches `https://enroll.<relay>`; owner `mship relay approve <id>`; an existing `mship serve --relay` subdomain still loads through Caddy; port 47180 is not reachable from outside.
+<!-- /mship:task -->
+
+---
+
+## Self-Review
+
+- **Spec coverage:** ac1 → Task 5 (Caddy service + sish internal). ac2 → Task 5 (host routing). ac3 → Task 1 (predicate) + Task 2 (ask route). ac4 → Task 5 (Caddyfile method/path + body cap). ac5 → Task 3 (loopback bind) + Task 5. ac6 → Task 4 (CLI derivation). ac7 → Task 6 (suite + docs) and the per-task tests. All seven covered.
+- **Deployment note:** `network_mode: host` for Caddy is what lets a loopback-only enroll-server (ac5) stay reachable; sish publishes HTTP on `127.0.0.1:8080` so Caddy reaches it on loopback. This is the topology that satisfies "no public 47180" without containerizing the enroll-server.
+- **Ordering:** 1→2 (predicate before the route that uses it), 3 independent, 4 independent, 5 after 2/3 (Caddy points at the ask route + loopback server), 6 last.

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -122,6 +122,33 @@ mship relay enroll-server \
 
 `--relay-domain` can also be set via the `RELAY_DOMAIN` environment variable. The enroll-server is reached from the internet only through Caddy at `https://enroll.<relay>` — the raw `:47180` port is not accessible externally.
 
+> **Important — keep the enroll-server supervised.** The enroll-server backs Caddy's on-demand TLS `ask` endpoint, which gates cert issuance **and renewal** for every relay subdomain — not just new enrollment requests. If the enroll-server is down, Caddy cannot renew existing certs and will refuse to issue new ones for serve subdomains. Unlike sish and Caddy (which Docker Compose restarts automatically), the enroll-server runs outside the compose stack and **must run under a supervisor so it survives reboots**.
+>
+> The bootstrap script installs a systemd unit automatically when run as root. To install it manually:
+>
+> ```ini
+> # /etc/systemd/system/mship-relay-enroll.service
+> [Unit]
+> Description=mship relay enroll-server (device enrollment + Caddy on-demand TLS ask)
+> After=network-online.target docker.service
+> Wants=network-online.target
+>
+> [Service]
+> ExecStart=<MSHIP_BIN> relay enroll-server --relay-domain <RELAY_DOMAIN> --pubkeys-dir <relay-dir>/pubkeys --store-dir <relay-dir>/pending-store
+> Restart=always
+> RestartSec=2
+>
+> [Install]
+> WantedBy=multi-user.target
+> ```
+>
+> Enable and start it:
+>
+> ```bash
+> systemctl daemon-reload
+> systemctl enable --now mship-relay-enroll.service
+> ```
+
 ---
 
 ## Step 5 — Add Client Public Keys

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -251,4 +251,4 @@ Data directories (`keys/`, `pubkeys/`, `caddy-data/`, `caddy-config/`) are mount
 
 **Caddy container exits immediately** — check `docker compose logs caddy`. A malformed `Caddyfile` or a missing `RELAY_DOMAIN`/`ACME_EMAIL` variable is the usual cause.
 
-**Enroll request times out** — confirm the enroll-server process is running on the relay host (`curl http://127.0.0.1:47180/health` from the host should respond). Also check that Caddy is running and that `enroll.<relay>` resolves to the relay IP.
+**Enroll request times out** — confirm the enroll-server process is running on the relay host (`curl http://127.0.0.1:47180/status/x` from the host should return a JSON status). Also check that Caddy is running and that `enroll.<relay>` resolves to the relay IP.

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -1,6 +1,20 @@
-# Hosting Your Own mship Relay (sish)
+# Hosting Your Own mship Relay (sish + Caddy)
 
 This runbook walks through standing up a self-hosted [sish](https://github.com/antoniomika/sish) relay so that `mship serve --relay` can expose your local workspace over a stable `https://<workspace>.<relay-domain>` URL from anywhere — no VPN required.
+
+**Architecture overview.** Caddy is the public web front (ports 80 and 443). It terminates TLS using Let's Encrypt **on-demand** TLS, gated by a `ask` endpoint so certificates are only issued for `enroll.<relay>` and per-device serve subdomains (`<slug>-<6hex>.<relay>`). sish runs behind Caddy — it owns SSH (`:2222`) and serves HTTP internally on `127.0.0.1:8080`; it never sees TLS. The enroll-server binds loopback (`127.0.0.1:47180`) and is reached exclusively through Caddy; no external firewall hole is needed for it.
+
+```
+internet
+  │
+  ├─ :2222 (TCP) ───────────────────────────────────── sish (SSH tunnels)
+  │
+  └─ :80 / :443 (TCP) ──── Caddy (TLS termination)
+                               │
+                               ├─ enroll.<relay> ──── enroll-server (127.0.0.1:47180)
+                               │
+                               └─ *.<relay> ──────── sish HTTP (127.0.0.1:8080)
+```
 
 ---
 
@@ -16,7 +30,7 @@ This runbook walks through standing up a self-hosted [sish](https://github.com/a
 
 ## Step 1 — Point the Wildcard DNS Record at Your VPS
 
-sish routes incoming HTTP/HTTPS traffic based on the `Host` header, so every workspace needs its own subdomain. A single wildcard `A` record covers all of them.
+Caddy routes incoming HTTPS traffic based on the `Host` header, so every workspace needs its own subdomain. A single wildcard `A` record covers all of them (including `enroll.<relay>`).
 
 In your DNS provider, create:
 
@@ -43,9 +57,9 @@ The relay needs three TCP ports reachable from the public internet:
 |---|---|---|
 | 22 **or** 2222 | TCP | SSH — mship clients open reverse tunnels here |
 | 80 | TCP | HTTP — ACME (Let's Encrypt) HTTP-01 challenge + HTTP→HTTPS redirect |
-| 443 | TCP | HTTPS — public app traffic served to clients |
+| 443 | TCP | HTTPS — public app traffic and enroll endpoint (TLS terminated by Caddy) |
 
-The compose file uses port **2222** for SSH (so it does not conflict with the host's own SSH daemon on 22). Allow it on your VPS firewall:
+The compose file uses port **2222** for SSH (so it does not conflict with the host's own SSH daemon on 22). The enroll-server port `:47180` is loopback-only and does **not** need an external firewall rule.
 
 ```bash
 # ufw (Ubuntu/Debian)
@@ -75,19 +89,42 @@ ACME_EMAIL=you@example.com \
 What the script does:
 
 1. Installs Docker Engine if it is not already present (via `https://get.docker.com`).
-2. Creates the data directories `docker/relay/pubkeys/`, `docker/relay/keys/`, and `docker/relay/acme/`.
+2. Creates the data directories `docker/relay/pubkeys/`, `docker/relay/keys/`, `docker/relay/caddy-data/`, and `docker/relay/caddy-config/`.
 3. Prints a reminder to add client public keys before tunnels will be accepted.
-4. Starts the sish container with `docker compose up -d`, passing `RELAY_DOMAIN` and `ACME_EMAIL` through to the compose file for the Let's Encrypt on-demand TLS certificate workflow.
+4. Starts the sish and Caddy containers with `docker compose up -d`.
 
-The compose file (`docker/relay/docker-compose.yml`) mounts:
+The compose file (`docker/relay/docker-compose.yml`) starts two services:
 
-- `./pubkeys` → `/pubkeys` (read-only) — the SSH public-key allowlist.
-- `./keys` → `/keys` — sish's own host key, persisted across container restarts.
-- `./acme` → `/acme` — Let's Encrypt certificate cache.
+- **sish** — `--https=false`, HTTP on internal `127.0.0.1:8080`, SSH on `:2222`. Mounts `./pubkeys` (read-only key allowlist) and `./keys` (sish host key).
+- **caddy** — `network_mode: host` so it can bind `:80`/`:443` directly and reach the sish and enroll-server loopback addresses. Mounts `./Caddyfile`, `./caddy-data`, and `./caddy-config`.
+
+The `Caddyfile` (`docker/relay/Caddyfile`) wires:
+
+- `enroll.{$RELAY_DOMAIN}` → `127.0.0.1:47180` (enroll-server; only `POST /enroll` and `GET /status/*` are forwarded — everything else returns 404).
+- `*.{$RELAY_DOMAIN}` → `127.0.0.1:8080` (sish HTTP, `Host` header preserved).
+
+On-demand TLS is gated by the enroll-server's `/tls-check` ask endpoint, so Caddy only issues certificates for known hostnames.
 
 ---
 
-## Step 4 — Add Client Public Keys
+## Step 4 — Start the Enroll Server
+
+The enroll-server is not part of the Docker compose stack — it runs as a long-lived process on the relay host (e.g. under systemd or tmux):
+
+```bash
+mship relay enroll-server \
+  --relay-domain relay.example.com \
+  --store-dir /path/to/docker/relay/enroll-store \
+  --pubkeys-dir /path/to/docker/relay/pubkeys
+# Binds 127.0.0.1:47180 by default; Caddy proxies public traffic to it.
+# pending requests expire after 30 min.
+```
+
+`--relay-domain` can also be set via the `RELAY_DOMAIN` environment variable. The enroll-server is reached from the internet only through Caddy at `https://enroll.<relay>` — the raw `:47180` port is not accessible externally.
+
+---
+
+## Step 5 — Add Client Public Keys
 
 sish requires authentication: only clients whose public key appears in `docker/relay/pubkeys/` may open tunnels.
 
@@ -103,7 +140,7 @@ This prints a line like:
 ssh-ed25519 AAAA... mship-relay
 ```
 
-> Note: `mship relay setup` is implemented in Phase B of this feature. Until that command is available, run `ssh-keygen -t ed25519 -f ~/.mothership/relay_ed25519 -N "" -C "mship-relay"` manually and use the contents of `~/.mothership/relay_ed25519.pub`.
+> Note: until `mship relay setup` is available, run `ssh-keygen -t ed25519 -f ~/.mothership/relay_ed25519 -N "" -C "mship-relay"` manually and use the contents of `~/.mothership/relay_ed25519.pub`.
 
 Copy that line to a file on the relay VPS:
 
@@ -116,54 +153,57 @@ One file per key; the filename does not matter. sish reads all files in the dire
 
 ### Enrolling a device that can't reach the relay box
 
-The manual copy above assumes you can write to `docker/relay/pubkeys/` on the relay host. When a *new device* (a laptop you can't SSH from into the relay box) needs access, use the **request → approve** flow instead — no shared secret, and a request can never enroll itself:
+When a *new device* (a laptop you can't SSH into the relay box from) needs access, use the **request → approve** flow — no shared secret, and a request can never enroll itself:
 
-**On the relay host**, run the enroll endpoint (public, beside sish; reads/writes a pending store, not the allowlist):
+**On the new device**, request access using the relay hostname (not a full URL):
 
 ```bash
-mship relay enroll-server --pubkeys-dir docker/relay/pubkeys --store-dir docker/relay/enroll-store
-# serves http://0.0.0.0:47180 ; pending requests expire after 30 min
+mship relay enroll --relay-host relay.example.com
+# Derives https://enroll.relay.example.com automatically.
+# Prints: "requested (id a1c2…); waiting for owner approval…"
+# Polls and prints "approved" once the owner approves.
 ```
 
-**On the new device**, request access (it only needs the relay's public address — no filesystem/SSH access to the box):
+You can also pass an explicit URL if you need to override the derived address:
 
 ```bash
-mship relay enroll --enroll-url http://<relay-host>:47180
-# → requested (id a1c2…); waits for the owner to approve, then prints "✓ approved"
+mship relay enroll --enroll-url https://enroll.relay.example.com
 ```
 
 **Back on the relay host**, review and grant (or deny):
 
 ```bash
 mship relay requests                 # id · hostname · key fingerprint
-mship relay approve a1c2 --store-dir docker/relay/enroll-store --pubkeys-dir docker/relay/pubkeys
-# writes the key into pubkeys/ → sish picks it up (no restart). `deny <id>` discards it.
+mship relay approve a1c2 \
+  --store-dir docker/relay/enroll-store \
+  --pubkeys-dir docker/relay/pubkeys
+# writes the key into pubkeys/ → sish picks it up (no restart needed).
+# `mship relay deny <id>` discards it.
 ```
 
 A request only ever creates a *pending* entry — nothing reaches the allowlist until you `approve` it, and pending requests auto-expire after 30 minutes. The device can then `mship serve --relay`.
 
 ---
 
-## Step 5 — Verify the Relay
+## Step 6 — Manual Smoke Test
 
-Test that the relay is reachable and will accept a tunnel from an allowed key:
+After the stack is running, verify each layer:
 
-```bash
-ssh -p 2222 \
-    -o StrictHostKeyChecking=accept-new \
-    -R test:80:localhost:8000 \
-    relay.example.com
-```
+1. **Containers up**: `docker compose -f docker/relay/docker-compose.yml ps` — both `sish` and `caddy` should be `Up`.
 
-If everything is working you will see sish output similar to:
+2. **SSH reachable**: `nc -zv relay.example.com 2222` should connect.
 
-```
-Starting SSH Forwarding service for http:80
-```
+3. **Enroll server visible through Caddy**: from *another device*, run:
+   ```bash
+   mship relay enroll --relay-host relay.example.com
+   ```
+   It should print a request ID and enter polling. `:47180` should **not** be reachable directly from outside the relay host.
 
-And `https://test.relay.example.com` will proxy to `localhost:8000` on the machine that ran the command. Press `Ctrl-C` to close the tunnel.
+4. **Approve and confirm**: on the relay host, `mship relay approve <id>` — the device should print `approved`.
 
-Once this works, `mship serve --relay` will open and supervise tunnels automatically.
+5. **Serve subdomain**: run `mship serve --relay` from an enrolled device and confirm the printed URL (`https://<slug>-<6hex>.relay.example.com`) loads through Caddy (look for a valid TLS certificate issued by Let's Encrypt).
+
+6. **Port 47180 closed externally**: `nc -zv relay.example.com 47180` should time out or refuse — it is loopback-only.
 
 ---
 
@@ -176,11 +216,20 @@ The relay is configured entirely through environment variables passed to `docker
 | `RELAY_DOMAIN` | Yes | `relay.example.com` | Base domain. Workspaces are exposed at `<subdomain>.<RELAY_DOMAIN>`. Must match the wildcard DNS record. |
 | `ACME_EMAIL` | Yes | `you@example.com` | Email registered with Let's Encrypt for certificate expiry notifications. |
 
+The `mship relay enroll-server` command also respects `RELAY_DOMAIN` if `--relay-domain` is not passed explicitly.
+
+---
+
+## Deferred / Future Work
+
+- **Rate limiting on the enroll endpoint** — a custom Caddy image with a rate-limit plugin will protect `POST /enroll` against abuse. The current `request_body max_size 4KB` limit is a lightweight guard only.
+- **Wildcard DNS-01 TLS as an alternative** — for providers that support a Caddy ACME DNS plugin, a single wildcard certificate (`*.relay.example.com`) via DNS-01 challenge is a cleaner TLS strategy and avoids per-subdomain on-demand issuance.
+
 ---
 
 ## Upgrading
 
-sish uses a rolling `latest` tag. To update:
+sish and Caddy both use the `latest` tag. To update:
 
 ```bash
 cd /path/to/mothership
@@ -188,7 +237,7 @@ docker compose -f docker/relay/docker-compose.yml pull
 docker compose -f docker/relay/docker-compose.yml up -d
 ```
 
-Data directories (`keys/`, `pubkeys/`, `acme/`) are mounted volumes and survive the upgrade.
+Data directories (`keys/`, `pubkeys/`, `caddy-data/`, `caddy-config/`) are mounted volumes and survive the upgrade.
 
 ---
 
@@ -196,6 +245,10 @@ Data directories (`keys/`, `pubkeys/`, `acme/`) are mounted volumes and survive 
 
 **Tunnel connection refused** — confirm port 2222 is open (`nc -zv relay.example.com 2222`) and the client public key is in `docker/relay/pubkeys/`.
 
-**Certificate errors** — verify the wildcard DNS record resolves to the relay IP, and that port 80 is open (Let's Encrypt needs it for the HTTP-01 challenge).
+**Certificate errors** — verify the wildcard DNS record resolves to the relay IP, and that ports 80 and 443 are open. Caddy writes ACME state to `docker/relay/caddy-data/`; check `docker compose logs caddy` for ACME errors.
 
-**sish container exits immediately** — run `docker compose -f docker/relay/docker-compose.yml logs sish` to inspect startup errors. Common causes: port already in use, or missing `RELAY_DOMAIN`/`ACME_EMAIL` environment variables.
+**sish container exits immediately** — run `docker compose -f docker/relay/docker-compose.yml logs sish` to inspect startup errors. Common causes: port already in use, or missing `RELAY_DOMAIN` environment variable.
+
+**Caddy container exits immediately** — check `docker compose logs caddy`. A malformed `Caddyfile` or a missing `RELAY_DOMAIN`/`ACME_EMAIL` variable is the usual cause.
+
+**Enroll request times out** — confirm the enroll-server process is running on the relay host (`curl http://127.0.0.1:47180/health` from the host should respond). Also check that Caddy is running and that `enroll.<relay>` resolves to the relay IP.

--- a/scripts/relay-bootstrap.sh
+++ b/scripts/relay-bootstrap.sh
@@ -10,9 +10,11 @@ if ! command -v docker >/dev/null 2>&1; then
   curl -fsSL https://get.docker.com | sh
 fi
 HERE="$(cd "$(dirname "$0")/../docker/relay" && pwd)"
-mkdir -p "$HERE/pubkeys" "$HERE/keys" "$HERE/acme"
+mkdir -p "$HERE/pubkeys" "$HERE/keys" "$HERE/caddy-data" "$HERE/caddy-config"
 echo "[bootstrap] add client public keys to $HERE/pubkeys/ (one file per key), then:"
 echo "  RELAY_DOMAIN=$RELAY_DOMAIN ACME_EMAIL=$ACME_EMAIL docker compose -f $HERE/docker-compose.yml up -d"
 echo "[bootstrap] DNS: point  *.$RELAY_DOMAIN  A record at this host's public IP."
 RELAY_DOMAIN="$RELAY_DOMAIN" ACME_EMAIL="$ACME_EMAIL" docker compose -f "$HERE/docker-compose.yml" up -d
-echo "[bootstrap] sish is up. Test a tunnel: ssh -p 2222 -R myws:80:localhost:8000 $RELAY_DOMAIN"
+echo "[bootstrap] sish + Caddy are up. Per-device subdomains come from 'mship serve --relay'."
+echo "[bootstrap] To enroll devices, run the enroll-server (loopback) on this host:"
+echo "  RELAY_DOMAIN=$RELAY_DOMAIN mship relay enroll-server --pubkeys-dir $HERE/pubkeys --store-dir $HERE/pending-store"

--- a/scripts/relay-bootstrap.sh
+++ b/scripts/relay-bootstrap.sh
@@ -15,6 +15,29 @@ echo "[bootstrap] add client public keys to $HERE/pubkeys/ (one file per key), t
 echo "  RELAY_DOMAIN=$RELAY_DOMAIN ACME_EMAIL=$ACME_EMAIL docker compose -f $HERE/docker-compose.yml up -d"
 echo "[bootstrap] DNS: point  *.$RELAY_DOMAIN  A record at this host's public IP."
 RELAY_DOMAIN="$RELAY_DOMAIN" ACME_EMAIL="$ACME_EMAIL" docker compose -f "$HERE/docker-compose.yml" up -d
-echo "[bootstrap] sish + Caddy are up. Per-device subdomains come from 'mship serve --relay'."
-echo "[bootstrap] To enroll devices, run the enroll-server (loopback) on this host:"
-echo "  RELAY_DOMAIN=$RELAY_DOMAIN mship relay enroll-server --pubkeys-dir $HERE/pubkeys --store-dir $HERE/pending-store"
+# Supervise the enroll-server: it backs Caddy's on-demand TLS `ask`, so it gates
+# cert issuance/renewal for EVERY relay subdomain, not just enrollment — keep it up.
+if [ "$(id -u)" = 0 ] && command -v systemctl >/dev/null 2>&1 && command -v mship >/dev/null 2>&1; then
+  MSHIP_BIN="$(command -v mship)"
+  cat >/etc/systemd/system/mship-relay-enroll.service <<UNIT
+[Unit]
+Description=mship relay enroll-server (device enrollment + Caddy on-demand TLS ask)
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+ExecStart=$MSHIP_BIN relay enroll-server --relay-domain $RELAY_DOMAIN --pubkeys-dir $HERE/pubkeys --store-dir $HERE/pending-store
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+  systemctl daemon-reload
+  systemctl enable --now mship-relay-enroll.service
+  echo "[bootstrap] enroll-server supervised via systemd (mship-relay-enroll.service)."
+else
+  echo "[bootstrap] IMPORTANT: supervise the enroll-server — it backs Caddy's on-demand TLS ask"
+  echo "[bootstrap]   (gates ALL relay cert issuance/renewal). Run it under systemd or equivalent:"
+  echo "[bootstrap]   RELAY_DOMAIN=$RELAY_DOMAIN mship relay enroll-server --pubkeys-dir $HERE/pubkeys --store-dir $HERE/pending-store"
+fi

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -82,6 +82,8 @@ def register(parent: typer.Typer, get_container):
         import uvicorn
         from pathlib import Path
 
+        import os
+
         from mship.core.relay.enroll import RequestStore
         from mship.core.relay.enroll_app import build_enroll_app
 
@@ -91,7 +93,7 @@ def register(parent: typer.Typer, get_container):
             f"enroll-server → http://{host}:{port}  "
             f"(pubkeys: {pubkeys_dir}, store: {store_dir}, ttl: {ttl}s)"
         )
-        uvicorn.run(build_enroll_app(store), host=host, port=port)
+        uvicorn.run(build_enroll_app(store, relay_domain=os.environ.get("RELAY_DOMAIN", "")), host=host, port=port)
 
     # -------------------------------------------------------------------------
     # Owner-side: list / approve / deny

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -10,9 +10,30 @@ host; `mship relay requests/approve/deny` manage pending enroll requests
 """
 from __future__ import annotations
 
+import os
+
 import typer
 
 from mship.cli.output import Output
+
+
+def _run_uvicorn(app, host, port):   # seam so tests don't boot a server
+    import uvicorn
+    uvicorn.run(app, host=host, port=port)
+
+
+def _enroll_server_impl(*, store_dir, pubkeys_dir, port, host, ttl, relay_domain):
+    from pathlib import Path
+
+    from mship.core.relay.enroll import RequestStore
+    from mship.core.relay.enroll_app import build_enroll_app
+
+    if not relay_domain:
+        raise typer.BadParameter("relay domain required: pass --relay-domain or set RELAY_DOMAIN")
+    store = RequestStore(Path(store_dir), ttl_seconds=ttl)
+    Output().print(f"enroll-server → http://{host}:{port}  (relay: {relay_domain}, "
+                   f"pubkeys: {pubkeys_dir}, store: {store_dir}, ttl: {ttl}s)")
+    _run_uvicorn(build_enroll_app(store, relay_domain=relay_domain), host=host, port=port)
 
 
 def register(parent: typer.Typer, get_container):
@@ -74,26 +95,16 @@ def register(parent: typer.Typer, get_container):
         store_dir: str = typer.Option("./pending-store", "--store-dir",
                                       help="Directory for pending enroll request state."),
         port: int = typer.Option(47180, "--port", help="Port to listen on."),
-        host: str = typer.Option("0.0.0.0", "--host", help="Interface to bind."),
+        host: str = typer.Option("127.0.0.1", "--host",
+                                 help="Interface to bind (loopback; Caddy fronts it)."),
         ttl: int = typer.Option(1800, "--ttl",
                                 help="Pending request TTL in seconds (default 30 min)."),
+        relay_domain: str = typer.Option(lambda: os.environ.get("RELAY_DOMAIN", ""), "--relay-domain",
+                                         help="Relay domain for the on-demand TLS ask (default $RELAY_DOMAIN)."),
     ):
         """Run the public enroll endpoint on the relay host (devices POST their key here)."""
-        import uvicorn
-        from pathlib import Path
-
-        import os
-
-        from mship.core.relay.enroll import RequestStore
-        from mship.core.relay.enroll_app import build_enroll_app
-
-        out = Output()
-        store = RequestStore(Path(store_dir), ttl_seconds=ttl)
-        out.print(
-            f"enroll-server → http://{host}:{port}  "
-            f"(pubkeys: {pubkeys_dir}, store: {store_dir}, ttl: {ttl}s)"
-        )
-        uvicorn.run(build_enroll_app(store, relay_domain=os.environ.get("RELAY_DOMAIN", "")), host=host, port=port)
+        _enroll_server_impl(store_dir=store_dir, pubkeys_dir=pubkeys_dir,
+                            port=port, host=host, ttl=ttl, relay_domain=relay_domain)
 
     # -------------------------------------------------------------------------
     # Owner-side: list / approve / deny

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -17,6 +17,27 @@ import typer
 from mship.cli.output import Output
 
 
+def enroll_base_url(*, enroll_url, relay_host, config_host):
+    """Resolve the enroll endpoint base URL. Precedence:
+    explicit --enroll-url  >  --relay-host  >  configured relay.host.
+    A relay host derives https://enroll.<host>."""
+    if enroll_url:
+        return enroll_url.rstrip("/")
+    host = relay_host or config_host
+    if not host:
+        raise ValueError("provide --relay-host (or configure relay.host)")
+    return f"https://enroll.{host.strip().rstrip('.')}"
+
+
+def _configured_relay_host(get_container):
+    """Best-effort: the workspace's configured relay.host, or None outside a workspace."""
+    try:
+        rc = get_container().config().relay
+        return rc.host if rc else None
+    except Exception:
+        return None
+
+
 def _run_uvicorn(app, host, port):   # seam so tests don't boot a server
     import uvicorn
     uvicorn.run(app, host=host, port=port)
@@ -174,8 +195,10 @@ def register(parent: typer.Typer, get_container):
 
     @relay_app.command("enroll")
     def enroll_cmd(
-        enroll_url: str = typer.Option(..., "--enroll-url",
-                                       help="Base URL of the relay enroll server, e.g. http://<host>:47180."),
+        enroll_url: str = typer.Option(None, "--enroll-url",
+                                       help="Explicit enroll base URL (overrides --relay-host)."),
+        relay_host: str = typer.Option(None, "--relay-host",
+                                       help="Relay host, e.g. mship-relay.example.com (enroll URL is derived)."),
         wait: bool = typer.Option(True, "--wait/--no-wait",
                                   help="Poll until approved/denied (default) or return immediately."),
     ):
@@ -190,7 +213,11 @@ def register(parent: typer.Typer, get_container):
 
         out = Output()
         pub = relay_public_key(ensure_relay_key(home=Path.home())).strip()
-        base = enroll_url.rstrip("/")
+        try:
+            base = enroll_base_url(enroll_url=enroll_url, relay_host=relay_host,
+                                   config_host=_configured_relay_host(get_container))
+        except ValueError as e:
+            out.error(str(e)); raise typer.Exit(2)
         # The requester runs on a remote device hitting a public endpoint, so
         # connection-refused / DNS / timeout are LIKELY: surface them cleanly
         # rather than dumping an httpx traceback.

--- a/src/mship/core/relay/enroll_app.py
+++ b/src/mship/core/relay/enroll_app.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query, Response
 from pydantic import BaseModel, Field
 
 from mship.core.relay.enroll import RequestStore, PendingCapReached, validate_pubkey
+from mship.core.relay.tls_ask import tls_ask_allowed
 
 
 class _EnrollBody(BaseModel):
@@ -13,7 +14,7 @@ class _EnrollBody(BaseModel):
     hostname: str = Field(default="", max_length=253)
 
 
-def build_enroll_app(store: RequestStore) -> FastAPI:
+def build_enroll_app(store: RequestStore, *, relay_domain: str) -> FastAPI:
     app = FastAPI(title="mship relay enroll")
 
     @app.post("/enroll")
@@ -33,5 +34,12 @@ def build_enroll_app(store: RequestStore) -> FastAPI:
     @app.get("/status/{rid}")
     def status(rid: str):
         return {"id": rid, "status": store.get(rid)}
+
+    @app.get("/tls-check")
+    def tls_check(domain: str = Query(..., max_length=253)):
+        # Caddy on-demand TLS ask endpoint: 2xx => issue a cert for `domain`.
+        if not tls_ask_allowed(domain, relay_domain):
+            raise HTTPException(status_code=403, detail="host not allowed")
+        return Response(status_code=200)
 
     return app

--- a/src/mship/core/relay/tls_ask.py
+++ b/src/mship/core/relay/tls_ask.py
@@ -3,7 +3,7 @@ import re
 
 # A serve per-device subdomain LABEL: <base>-<6 hex>, where base is the
 # DNS-safe workspace slug ([a-z0-9-]). Mirrors device_subdomain() in tunnel.py.
-_SERVE_LABEL = re.compile(r"[a-z0-9-]+-[0-9a-f]{6}")
+_SERVE_LABEL = re.compile(r"[a-z0-9][a-z0-9-]*-[0-9a-f]{6}")
 
 
 def tls_ask_allowed(domain: str, relay_domain: str) -> bool:

--- a/src/mship/core/relay/tls_ask.py
+++ b/src/mship/core/relay/tls_ask.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+import re
+
+# A serve per-device subdomain LABEL: <base>-<6 hex>, where base is the
+# DNS-safe workspace slug ([a-z0-9-]). Mirrors device_subdomain() in tunnel.py.
+_SERVE_LABEL = re.compile(r"[a-z0-9-]+-[0-9a-f]{6}")
+
+
+def tls_ask_allowed(domain: str, relay_domain: str) -> bool:
+    """Whether Caddy may provision an on-demand TLS cert for `domain`.
+
+    True only for the enroll host and serve per-device subdomains under
+    `relay_domain`; False for the bare apex, foreign domains, extra subdomain
+    levels, lookalikes, and blank input. This is the cert allowlist — keep it
+    tight; a loose match reopens the "mint a cert for any host" surface.
+    """
+    domain = (domain or "").strip().lower()
+    relay_domain = (relay_domain or "").strip().lower()
+    if not domain or not relay_domain:
+        return False
+    suffix = "." + relay_domain
+    if not domain.endswith(suffix):
+        return False
+    label = domain[: -len(suffix)]
+    if not label or "." in label:        # no nested subdomain levels
+        return False
+    if label == "enroll":
+        return True
+    return len(label) <= 63 and _SERVE_LABEL.fullmatch(label) is not None

--- a/tests/cli/test_relay_enroll_server.py
+++ b/tests/cli/test_relay_enroll_server.py
@@ -1,0 +1,49 @@
+"""Tests for `mship relay enroll-server` CLI command (Task 3).
+
+Verifies:
+  - loopback (127.0.0.1) is the default bind host
+  - --relay-domain flag is passed through to build_enroll_app
+  - RELAY_DOMAIN env var provides the default when --relay-domain is omitted
+
+These tests use module-level monkeypatching seams (_run_uvicorn, build_enroll_app)
+so no real server is started.
+"""
+from __future__ import annotations
+
+import typer
+from typer.testing import CliRunner
+
+import mship.cli.relay as relay_mod
+import mship.core.relay.enroll_app as ea
+
+
+def _app(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(relay_mod, "_run_uvicorn",
+                        lambda app, host, port: captured.update(host=host, port=port, app=app))
+    monkeypatch.setattr(ea, "build_enroll_app",
+                        lambda store, *, relay_domain: captured.update(relay_domain=relay_domain) or "APP")
+    app = typer.Typer()
+    relay_mod.register(app, lambda: None)
+    return app, captured
+
+
+def test_enroll_server_defaults_to_loopback(monkeypatch, tmp_path):
+    app, captured = _app(monkeypatch)
+    res = CliRunner().invoke(app, ["relay", "enroll-server",
+                                   "--store-dir", str(tmp_path / "s"),
+                                   "--pubkeys-dir", str(tmp_path / "p"),
+                                   "--relay-domain", "r.example.com"])
+    assert res.exit_code == 0, res.output
+    assert captured["host"] == "127.0.0.1"          # loopback default (ac5)
+    assert captured["relay_domain"] == "r.example.com"
+
+
+def test_enroll_server_relay_domain_defaults_from_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("RELAY_DOMAIN", "env.example.com")
+    app, captured = _app(monkeypatch)
+    res = CliRunner().invoke(app, ["relay", "enroll-server",
+                                   "--store-dir", str(tmp_path / "s"),
+                                   "--pubkeys-dir", str(tmp_path / "p")])
+    assert res.exit_code == 0, res.output
+    assert captured["relay_domain"] == "env.example.com"

--- a/tests/cli/test_relay_enroll_url.py
+++ b/tests/cli/test_relay_enroll_url.py
@@ -1,0 +1,22 @@
+import pytest
+from mship.cli.relay import enroll_base_url
+
+def test_explicit_enroll_url_wins():
+    assert enroll_base_url(enroll_url="http://h:47180", relay_host="r.example.com",
+                           config_host="c.example.com") == "http://h:47180"
+
+def test_relay_host_derives_https_enroll_subdomain():
+    assert enroll_base_url(enroll_url=None, relay_host="r.example.com",
+                           config_host=None) == "https://enroll.r.example.com"
+
+def test_falls_back_to_config_host():
+    assert enroll_base_url(enroll_url=None, relay_host=None,
+                           config_host="c.example.com") == "https://enroll.c.example.com"
+
+def test_errors_when_nothing_given():
+    with pytest.raises(ValueError):
+        enroll_base_url(enroll_url=None, relay_host=None, config_host=None)
+
+def test_strips_trailing_slash_on_override():
+    assert enroll_base_url(enroll_url="http://h:47180/", relay_host=None,
+                           config_host=None) == "http://h:47180"

--- a/tests/core/relay/test_enroll_app.py
+++ b/tests/core/relay/test_enroll_app.py
@@ -3,11 +3,16 @@ from mship.core.relay.enroll import RequestStore
 from mship.core.relay.enroll_app import build_enroll_app
 
 _PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host"
+RELAY = "mship-relay.atomikpanda.com"
 
 
 def _client(tmp_path, cap=50):
     store = RequestStore(tmp_path / "s", max_pending=cap)
-    return TestClient(build_enroll_app(store)), store
+    return TestClient(build_enroll_app(store, relay_domain=RELAY)), store
+
+
+def _ask_client(tmp_path):
+    return TestClient(build_enroll_app(RequestStore(tmp_path / "store"), relay_domain=RELAY))
 
 
 def test_enroll_creates_pending_and_status(tmp_path):
@@ -41,3 +46,19 @@ def test_enroll_rejects_oversized_pubkey(tmp_path):
     oversized = "ssh-ed25519 " + "A" * 4096 + " host"
     r = c.post("/enroll", json={"pubkey": oversized, "hostname": "x"})
     assert 400 <= r.status_code < 500
+
+
+def test_tls_check_allows_relay_owned_host(tmp_path):
+    c = _ask_client(tmp_path)
+    assert c.get("/tls-check", params={"domain": f"enroll.{RELAY}"}).status_code == 200
+    assert c.get("/tls-check", params={"domain": f"w-92bbb7.{RELAY}"}).status_code == 200
+
+
+def test_tls_check_rejects_foreign_host(tmp_path):
+    c = _ask_client(tmp_path)
+    assert c.get("/tls-check", params={"domain": "evil.com"}).status_code == 403
+
+
+def test_tls_check_requires_domain(tmp_path):
+    c = _ask_client(tmp_path)
+    assert c.get("/tls-check").status_code in (400, 422)

--- a/tests/core/relay/test_tls_ask.py
+++ b/tests/core/relay/test_tls_ask.py
@@ -29,3 +29,19 @@ def test_rejects_blank_and_whitespace():
     assert tls_ask_allowed("", RELAY) is False
     assert tls_ask_allowed("   ", RELAY) is False
     assert tls_ask_allowed(f"enroll.{RELAY}", "") is False
+
+def test_rejects_relay_as_suffix_without_label_boundary():
+    # the critical vector: relay_domain as a bare suffix with NO dot boundary
+    assert tls_ask_allowed(f"evil{RELAY}", RELAY) is False
+
+def test_rejects_trailing_dot_fqdn():
+    assert tls_ask_allowed(f"enroll.{RELAY}.", RELAY) is False
+    assert tls_ask_allowed(f"x-000000.{RELAY}.", RELAY) is False
+
+def test_uppercase_host_is_normalized_and_allowed():
+    # hostnames are case-insensitive; the predicate lowercases, so these match
+    assert tls_ask_allowed(f"ENROLL.{RELAY}", RELAY) is True
+    assert tls_ask_allowed(f"X-ABCDEF.{RELAY.upper()}", RELAY) is True
+
+def test_rejects_leading_hyphen_label():
+    assert tls_ask_allowed(f"-abcdef.{RELAY}", RELAY) is False

--- a/tests/core/relay/test_tls_ask.py
+++ b/tests/core/relay/test_tls_ask.py
@@ -1,0 +1,31 @@
+from mship.core.relay.tls_ask import tls_ask_allowed
+
+RELAY = "mship-relay.atomikpanda.com"
+
+def test_allows_enroll_host():
+    assert tls_ask_allowed(f"enroll.{RELAY}", RELAY) is True
+
+def test_allows_serve_subdomains():
+    assert tls_ask_allowed(f"mship-workspace-92bbb7.{RELAY}", RELAY) is True
+    assert tls_ask_allowed(f"x-000000.{RELAY}", RELAY) is True
+
+def test_rejects_bare_apex():
+    assert tls_ask_allowed(RELAY, RELAY) is False
+
+def test_rejects_foreign_domain():
+    assert tls_ask_allowed("example.com", RELAY) is False
+    assert tls_ask_allowed(f"mship-workspace-92bbb7.evil.com", RELAY) is False
+
+def test_rejects_lookalike_and_extra_levels():
+    assert tls_ask_allowed(f"enroll.{RELAY}.evil.com", RELAY) is False
+    assert tls_ask_allowed(f"a.enroll.{RELAY}", RELAY) is False
+    assert tls_ask_allowed(f"x.mship-workspace-92bbb7.{RELAY}", RELAY) is False
+
+def test_rejects_non_serve_label():
+    assert tls_ask_allowed(f"random.{RELAY}", RELAY) is False
+    assert tls_ask_allowed(f"foo-92bbbz.{RELAY}", RELAY) is False
+
+def test_rejects_blank_and_whitespace():
+    assert tls_ask_allowed("", RELAY) is False
+    assert tls_ask_allowed("   ", RELAY) is False
+    assert tls_ask_allowed(f"enroll.{RELAY}", "") is False

--- a/tests/core/relay/test_tls_ask.py
+++ b/tests/core/relay/test_tls_ask.py
@@ -45,3 +45,7 @@ def test_uppercase_host_is_normalized_and_allowed():
 
 def test_rejects_leading_hyphen_label():
     assert tls_ask_allowed(f"-abcdef.{RELAY}", RELAY) is False
+
+def test_rejects_double_leading_hyphen_label():
+    # base must start alphanumeric; a lone-hyphen base must not slip through
+    assert tls_ask_allowed(f"--abcdef.{RELAY}", RELAY) is False


### PR DESCRIPTION
## Summary

Puts the relay's device-enrollment endpoint **behind the relay's existing 443** via a Caddy reverse proxy, replacing the raw `:47180` port (and its manual firewall hole). Implements the approved spec `relay-caddy-front`. The request→approve enrollment model and `RequestStore` internals are **unchanged** — this is purely the ingress + device UX.

**Before:** `mship relay enroll-server` ran as a public HTTP service on `:47180` (open the port, plaintext, device types a full `http://<host>:47180` URL). sish terminated TLS itself and would mint an on-demand cert for **any** requested hostname.

**After:**
- **Caddy is the sole public web ingress** (80/443, `network_mode: host`). sish moves behind it: `--https=false`, internal `127.0.0.1:8080`, still owns SSH `:2222`.
- **Host routing:** `enroll.<relay>` → the enroll-server (now bound **`127.0.0.1`** — no public port, firewall hole gone); `*.<relay>` → sish (Host preserved, so every per-device serve subdomain still works).
- **On-demand TLS gated by an `ask` endpoint** — a pure predicate `tls_ask_allowed(domain, relay_domain)` issues certs **only** for `enroll.<relay>` and serve subdomains (`<slug>-<6hex>.<relay>`), closing sish's "cert for any host" surface. Adversarially reviewed; no bypass (the `"." + relay_domain` suffix forces a label boundary, `relay_domain` is never compiled as regex).
- **Edge-hardened enroll route:** request-body size cap + method/path allowlist (only `POST /enroll`, `GET /status/*`) in the Caddyfile.
- **Device UX:** `mship relay enroll --relay-host <relay>` derives `https://enroll.<relay>` itself — operator supplies only the relay host. `--enroll-url` remains an optional explicit override.

New: `core/relay/tls_ask.py`, `docker/relay/Caddyfile`. Changed: `core/relay/enroll_app.py` (the `/tls-check` ask route), `cli/relay.py` (enroll-server loopback + `--relay-domain`; enroll `--relay-host` derivation), `docker/relay/docker-compose.yml` (Caddy service, sish reconfig), `docs/relay-hosting.md`, `scripts/relay-bootstrap.sh`. Plan: `docs/plans/2026-06-26-relay-caddy-front.md`.

Built subagent-driven (implementer + spec/quality review per task). A final **whole-branch review** caught the one integration gap the per-task reviews couldn't: `scripts/relay-bootstrap.sh` still created the removed `acme/` volume and omitted the `caddy-data/`/`caddy-config/` dirs the docs promise — fixed here, along with a troubleshooting `curl` pointing at a `/health` route the enroll-app doesn't expose.

**Deferred (documented):** a rate-limit plugin (custom Caddy image) and wildcard DNS-01 as an alternative TLS strategy.

## Test plan

- [x] `mship test --repos mothership` — full suite green (**1740 passed**). New unit tests: `tls_ask_allowed` allow/deny matrix + bypass-critical regressions (suffix-boundary, trailing-dot FQDN, case, leading hyphen); the `/tls-check` route (allow/deny/missing-domain via TestClient); enroll-server loopback default + `--relay-domain` env fallback (CliRunner); `enroll_base_url` precedence (`--enroll-url` > `--relay-host` > config `relay.host`).
- [x] `docker compose config` validates with the new Caddy service + reconfigured sish.
- [ ] **Caddy config validation could not run in CI** (no `caddy` binary; docker daemon not accessible in the build env) — the Caddyfile was reviewed by hand; validate on the host with `caddy validate --config docker/relay/Caddyfile --adapter caddyfile`.
- [ ] **Manual smoke (on the relay host):** `docker compose up -d` (sish + caddy); `RELAY_DOMAIN=<relay> mship relay enroll-server --pubkeys-dir … --store-dir …` (binds `127.0.0.1`); from another device `mship relay enroll --relay-host <relay>` reaches `https://enroll.<relay>`; owner `mship relay approve <id>`; confirm an existing `mship serve --relay` subdomain still loads through Caddy; confirm `:47180` is **not** reachable externally.

https://claude.ai/code/session_01BCH6QFgBdw9LiWBzV39Xnj
