### PR TITLE
relay enroll unit run as owner

### DIFF
--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -124,7 +124,7 @@ mship relay enroll-server \
 
 > **Important — keep the enroll-server supervised.** The enroll-server backs Caddy's on-demand TLS `ask` endpoint, which gates cert issuance **and renewal** for every relay subdomain — not just new enrollment requests. If the enroll-server is down, Caddy cannot renew existing certs and will refuse to issue new ones for serve subdomains. Unlike sish and Caddy (which Docker Compose restarts automatically), the enroll-server runs outside the compose stack and **must run under a supervisor so it survives reboots**.
 >
-> The bootstrap script installs a systemd unit automatically when run as root. To install it manually:
+> The bootstrap script installs a systemd unit automatically when run as root (it runs the service as the user that owns the relay dir, so `mship relay approve` can still read the pending store). To install it manually, set `User=` to the operator who owns `<relay-dir>` and runs `mship relay approve` — not root:
 >
 > ```ini
 > # /etc/systemd/system/mship-relay-enroll.service
@@ -134,6 +134,7 @@ mship relay enroll-server \
 > Wants=network-online.target
 >
 > [Service]
+> User=<relay-owner>
 > ExecStart=<MSHIP_BIN> relay enroll-server --relay-domain <RELAY_DOMAIN> --pubkeys-dir <relay-dir>/pubkeys --store-dir <relay-dir>/pending-store
 > Restart=always
 > RestartSec=2

--- a/scripts/relay-bootstrap.sh
+++ b/scripts/relay-bootstrap.sh
@@ -17,8 +17,13 @@ echo "[bootstrap] DNS: point  *.$RELAY_DOMAIN  A record at this host's public IP
 RELAY_DOMAIN="$RELAY_DOMAIN" ACME_EMAIL="$ACME_EMAIL" docker compose -f "$HERE/docker-compose.yml" up -d
 # Supervise the enroll-server: it backs Caddy's on-demand TLS `ask`, so it gates
 # cert issuance/renewal for EVERY relay subdomain, not just enrollment — keep it up.
-if [ "$(id -u)" = 0 ] && command -v systemctl >/dev/null 2>&1 && command -v mship >/dev/null 2>&1; then
-  MSHIP_BIN="$(command -v mship)"
+# Run it as the user who owns the relay dir (the operator who also runs
+# `mship relay approve`), so the pending store stays readable by that user — not root.
+RELAY_USER="$(stat -c '%U' "$HERE")"
+# Locate mship in the relay user's login PATH (handles a ~/.local/bin user install),
+# falling back to root's PATH.
+MSHIP_BIN="$(sudo -u "$RELAY_USER" sh -lc 'command -v mship' 2>/dev/null || command -v mship 2>/dev/null || true)"
+if [ "$(id -u)" = 0 ] && command -v systemctl >/dev/null 2>&1 && [ -n "$MSHIP_BIN" ]; then
   cat >/etc/systemd/system/mship-relay-enroll.service <<UNIT
 [Unit]
 Description=mship relay enroll-server (device enrollment + Caddy on-demand TLS ask)
@@ -26,6 +31,7 @@ After=network-online.target docker.service
 Wants=network-online.target
 
 [Service]
+User=$RELAY_USER
 ExecStart=$MSHIP_BIN relay enroll-server --relay-domain $RELAY_DOMAIN --pubkeys-dir $HERE/pubkeys --store-dir $HERE/pending-store
 Restart=always
 RestartSec=2
@@ -35,7 +41,7 @@ WantedBy=multi-user.target
 UNIT
   systemctl daemon-reload
   systemctl enable --now mship-relay-enroll.service
-  echo "[bootstrap] enroll-server supervised via systemd (mship-relay-enroll.service)."
+  echo "[bootstrap] enroll-server supervised via systemd as user '$RELAY_USER' (mship-relay-enroll.service)."
 else
   echo "[bootstrap] IMPORTANT: supervise the enroll-server — it backs Caddy's on-demand TLS ask"
   echo "[bootstrap]   (gates ALL relay cert issuance/renewal). Run it under systemd or equivalent:"


### PR DESCRIPTION
## Summary

Follow-up to #240. The bootstrap-generated `mship-relay-enroll.service` ran the enroll-server **as root**, which has two problems:

1. **`mship relay approve` breaks.** The enroll-server creates the pending store; as root, those files are root-owned, so `mship relay approve` (run by the operator) can't read the request it's trying to approve.
2. **Least privilege.** The enroll-server is reachable (via Caddy) and gates all relay TLS issuance — no reason to run it as root.

**Fix:** run the unit as the user who owns the relay dir.
- `scripts/relay-bootstrap.sh`: derive `RELAY_USER="$(stat -c '%U' "$HERE")"` and emit `User=$RELAY_USER` in the unit. Also locate `mship` via that user's login PATH (`sudo -u "$RELAY_USER" sh -lc 'command -v mship'`, falling back to root's PATH) so a `~/.local/bin` user install is found — not just a system-wide one — and gate the auto-install on that binary being resolvable.
- `docs/relay-hosting.md`: the manual systemd template now shows `User=<relay-owner>` with a note explaining why (so `mship relay approve` can read the store; not root).

No code/behavior change to the enroll-server itself — purely how the supervised unit is generated/documented.

## Test plan

- [x] `bash -n scripts/relay-bootstrap.sh` — parses clean.
- [x] No Python touched (shell + docs only), so the mothership suite is unaffected.
- [ ] On a host: run the bootstrap as root from a repo owned by a non-root operator → `systemctl cat mship-relay-enroll.service` shows `User=<operator>` and `ExecStart` pointing at that operator's `mship`; the service starts; `mship relay approve <id>` (as the operator) reads a request created by the service.

https://claude.ai/code/session_01BCH6QFgBdw9LiWBzV39Xnj
