### PR TITLE
dispatch implementer mode: mship dispatch defaults to report-back framing (no PR), --mode standalone restores PR-opening (#234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For details, see `mship spawn --help`, [`docs/cli.md`](docs/cli.md), and the `wo
 
 **A phase lifecycle that keeps the whole feature honest.** `plan → dev → review → run` with soft gates on each transition — warns on moving to dev without a spec, to review with failing tests *in any affected repo*, to run with uncommitted changes *anywhere in the task*. The lifecycle is task-scoped, not repo-scoped, so a feature across five repos has one phase, not five.
 
-**A dispatch primitive for session handoff.** `mship dispatch --task <slug> -i "<instruction>"` prints a self-contained subagent prompt — cd directive, branch state, recent journal entries, finish contract — so a fresh agent session can pick up a multi-repo task without parent-held context.
+**A dispatch primitive for session handoff.** `mship dispatch --task <slug> -i "<instruction>"` prints a self-contained subagent prompt — cd directive, branch state, recent journal entries, and a closing contract — so a fresh agent session can pick up a multi-repo task without parent-held context. By default it emits **implementer** framing: scope to the single task, report back, don't open a PR (the orchestrator finishes). Pass `--mode standalone` for the older "finish and open the PR yourself" contract.
 
 ## How it works
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,7 +30,8 @@ mship close [--yes] [--abandon] [--force] [--skip-pr-check] [--bypass-reconcile]
 ```bash
 mship status                                        # task, phase, branch, drift, last log, finished warning
 mship context                                       # one-shot agent-readable JSON snapshot of workspace state
-mship dispatch --task <slug> -i "<instruction>"     # emit self-contained subagent prompt to stdout
+mship dispatch --task <slug> -i "<instruction>"     # emit self-contained subagent prompt to stdout (default: implementer framing — report back, no PR)
+mship dispatch --task <slug> --mode standalone -i "<instruction>"  # standalone framing — subagent finishes and opens its own PR
 mship audit [--repos r] [--json]
 mship reconcile [--json] [--ignore SLUG] [--clear-ignores] [--refresh]
 mship view status|logs|diff|spec [--watch]

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -32,6 +32,15 @@ def register(app: typer.Typer, get_container):
             None, "--plan-task",
             help="Anchor id in --plan to use as the instruction (mutually exclusive with --instruction).",
         ),
+        mode: str = typer.Option(
+            "implementer", "--mode",
+            help=(
+                "Closing framing. 'implementer' (default): scope to a single task, "
+                "report back, do not open a PR — for per-task execution under an "
+                "orchestrator that owns finishing. 'standalone': finish the work and "
+                "open the PR via `mship finish`."
+            ),
+        ),
     ):
         """Emit a self-contained markdown subagent prompt to stdout.
 
@@ -39,6 +48,12 @@ def register(app: typer.Typer, get_container):
         stdin `--instruction -`, or `--plan-task <id>` (with `--plan <path>`).
         """
         output = Output()
+
+        if mode not in _d.DISPATCH_MODES:
+            output.error(
+                f"--mode must be one of: {', '.join(_d.DISPATCH_MODES)} (got {mode!r})."
+            )
+            raise typer.Exit(code=2)
 
         # --- resolve the instruction source (exactly one of) ---
         if (instruction is not None) == (plan_task is not None):
@@ -107,6 +122,7 @@ def register(app: typer.Typer, get_container):
             agents_md_path=agents_md_path,
             pkg_skills_source=pkg_skills_source(),
             state=state,
+            mode=mode,
         )
         # Print directly to stdout (NOT via Output.json — this is meant to be piped).
         print(prompt)

--- a/src/mship/core/dispatch.py
+++ b/src/mship/core/dispatch.py
@@ -181,14 +181,28 @@ def _summarize_base_sha(
     return "; ".join(parts) if parts else "unknown"
 
 
-_CONVENTIONS_RECAP = """\
-These are strictly enforced in this workspace:
-
-- **Use `mship finish --body-file <path>` to open the PR.** Empty bodies are rejected by design. Write a real Summary and Test plan.
-- **Don't edit from the main checkout.** Only the worktree path above. The pre-commit hook refuses otherwise.
-- **Prefer `--bypass-<check>` over `--force-<check>`** on any mship command that takes one (e.g., `--bypass-reconcile`, `--bypass-audit`). Different flag name if you see `--force-<something>` in older docs; the bypass form is canonical."""
+DISPATCH_MODES: tuple[str, ...] = ("implementer", "standalone")
 
 
+_CONVENTIONS_INTRO = "These are strictly enforced in this workspace:"
+
+_CONV_NO_MAIN_CHECKOUT = "- **Don't edit from the main checkout.** Only the worktree path above. The pre-commit hook refuses otherwise."
+
+_CONV_BYPASS = "- **Prefer `--bypass-<check>` over `--force-<check>`** on any mship command that takes one (e.g., `--bypass-reconcile`, `--bypass-audit`). Different flag name if you see `--force-<something>` in older docs; the bypass form is canonical."
+
+# Standalone dispatches own their own finish: the subagent opens the PR.
+_CONV_OPEN_PR = "- **Use `mship finish --body-file <path>` to open the PR.** Empty bodies are rejected by design. Write a real Summary and Test plan."
+
+# Implementer dispatches hand back to an orchestrator that integrates and finishes.
+_CONV_NO_PR = "- **Don't open a PR or run `mship finish`.** The orchestrator integrates, reviews, and finishes after your hand-off — report back instead (see below)."
+
+
+def _conventions_recap(mode: str) -> str:
+    finish_bullet = _CONV_OPEN_PR if mode == "standalone" else _CONV_NO_PR
+    return "\n".join([_CONVENTIONS_INTRO, "", finish_bullet, _CONV_NO_MAIN_CHECKOUT, _CONV_BYPASS])
+
+
+# Standalone: the subagent finishes and opens the PR itself.
 _FINISH_CONTRACT = """\
 When the work is done:
 
@@ -199,6 +213,29 @@ When the work is done:
 
 If you get stuck or find the task is wrong-shaped, stop and report back with what you tried and where you're blocked. Don't guess.
 """
+
+
+# Implementer: scoped to a single task, hands control back without opening a PR.
+# This is the default — per-task implementers in an orchestrated flow let the
+# orchestrator own integration and PR creation (#234).
+_REPORT_CONTRACT = """\
+You are a **per-task implementer**: implement exactly the one task described above, then hand control back to the orchestrator. The orchestrator — not you — integrates, reviews, and opens the PR (`mship finish`). **Do not open a PR yourself.**
+
+1. **Before coding**, ask any clarifying questions if the task is ambiguous or underspecified — don't guess at intent.
+2. Implement only this one task. Don't pick up adjacent work or the rest of a plan.
+3. Run `mship test` until green (or confirm no test suite applies).
+4. Self-review your change against the instruction above.
+5. **Return a status report** as your final message: what changed (files/functions), what you verified (tests/commands run), and anything left or uncertain.
+
+If you get stuck or the task is wrong-shaped, stop and report what you tried and where you're blocked. Don't guess.
+"""
+
+
+def _closing_section(mode: str) -> tuple[str, str]:
+    """Return the (heading, body) for the prompt's closing section."""
+    if mode == "standalone":
+        return "How to finish", _FINISH_CONTRACT
+    return "Report back (do not open a PR)", _REPORT_CONTRACT
 
 
 def _render_base_sha_block(info: BaseShaInfo, base_branch: str) -> str:
@@ -263,14 +300,27 @@ def build_dispatch_prompt(
     agents_md_path: Path | None,
     pkg_skills_source: Path,
     state=None,
+    mode: str = "implementer",
 ) -> str:
-    """Return the full markdown dispatch prompt for a fresh subagent."""
+    """Return the full markdown dispatch prompt for a fresh subagent.
+
+    `mode` selects the closing framing (#234):
+    - "implementer" (default): scope to a single task, report back, do NOT open
+      a PR — for per-task execution where an orchestrator owns finishing.
+    - "standalone": the subagent finishes the work and opens its own PR.
+    """
+    if mode not in DISPATCH_MODES:
+        raise ValueError(
+            f"unknown dispatch mode {mode!r}; choose one of {', '.join(DISPATCH_MODES)}"
+        )
     worktree = task.worktrees[repo]
     base_branch = task.base_branch or "main"
     skills_block = _render_skills(canonical_skills(pkg_skills_source))
     journal_block = _render_journal(journal_entries)
     base_block = _render_base_sha_block(base_sha_info, base_branch)
     dependencies_block = _format_dependencies_section(task, state=state)
+    conventions_recap = _conventions_recap(mode)
+    closing_heading, closing_body = _closing_section(mode)
     agents_line = f"\nFull doc: `{agents_md_path}`." if agents_md_path else ""
 
     return f"""\
@@ -306,7 +356,7 @@ This is a git worktree checked out on branch `{task.branch}`. Every edit, test r
 
 ## Conventions (recap)
 
-{_CONVENTIONS_RECAP}{agents_line}
+{conventions_recap}{agents_line}
 
 ## Read these skills before starting
 
@@ -314,6 +364,6 @@ Invoke via your platform's skill tool if it has one. Direct read paths (always v
 
 {skills_block}
 
-## How to finish
+## {closing_heading}
 
-{_FINISH_CONTRACT}"""
+{closing_body}"""

--- a/src/mship/skills/subagent-driven-development/SKILL.md
+++ b/src/mship/skills/subagent-driven-development/SKILL.md
@@ -152,6 +152,11 @@ stdout as the subagent's prompt — the anchored task block from the plan become
 the instruction, wrapped with the worktree path, slug, phase, recent journal,
 and per-repo bases. (Use `-i "<text>"` or `-i -` for stdin when you need an
 ad-hoc instruction not in a plan; exactly one instruction source is allowed.)
+`mship dispatch` defaults to **implementer** framing — it scopes the subagent to
+the single task and tells it to report back, NOT open a PR. That's exactly what
+you want here: you (the orchestrator) own integration and run `mship finish`
+after reviewing. Don't reach for `--mode standalone` (which restores the
+open-your-own-PR contract) for plan-task execution.
 Dispatched subagents MUST run `mship test` (not a bare runner) so
 `mship finish` finds the passing-test evidence it gates on. For a spec-driven
 kickoff, `mship spec dispatch <id> [--task <slug>]` binds an approved spec to a

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -120,6 +120,8 @@ Two mship-native primitives for handing work to subagents. Use them instead of h
   mship dispatch --task my-task -i "implement the parser changes"   # prints a ready-to-use prompt to stdout
   ```
 
+  **Modes (`--mode`).** By default (`implementer`) the prompt scopes the subagent to the single task, tells it to ask clarifying questions, self-review, and report back — and explicitly **not** to open a PR, because the orchestrator owns integration and runs `mship finish` after review. This is what you want for per-task execution under an orchestrator. Pass `--mode standalone` for the alternative contract where the subagent finishes the work and opens its own PR (use it only for genuinely standalone, one-off dispatches).
+
 - **`mship context`** — emits structured JSON for programmatic consumers. Use when feeding state into a non-Claude-Code LLM, logging for audit, or scripting decisions. `jq`-friendly.
 
   ```bash

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -207,6 +207,47 @@ def test_dispatch_instruction_dash_reads_stdin(tmp_path: Path):
         _reset()
 
 
+def test_dispatch_default_mode_reports_back_no_pr(tmp_path: Path):
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing"])
+        assert result.exit_code == 0, result.output
+        assert "Report back" in result.output
+        assert "status report" in result.output.lower()
+        assert "How to finish" not in result.output
+        assert "mship finish --body-file" not in result.output
+    finally:
+        _reset()
+
+
+def test_dispatch_standalone_mode_has_finish_contract(tmp_path: Path):
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "standalone", "-i", "x"])
+        assert result.exit_code == 0, result.output
+        assert "How to finish" in result.output
+        assert "mship finish --body-file" in result.output
+    finally:
+        _reset()
+
+
+def test_dispatch_invalid_mode_errors(tmp_path: Path):
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "bogus", "-i", "x"])
+        assert result.exit_code == 2
+        assert "implementer" in result.output
+        assert "standalone" in result.output
+    finally:
+        _reset()
+
+
 def test_dispatch_prompt_includes_dependencies_section(tmp_path: Path):
     now = datetime.now(timezone.utc)
     wt_a = tmp_path / "wt-a"; wt_a.mkdir()

--- a/tests/core/test_dispatch.py
+++ b/tests/core/test_dispatch.py
@@ -291,16 +291,38 @@ def test_build_prompt_journal_renders_bulleted_list(tmp_path: Path):
     assert "2026-04-17T18:00:00" in out
 
 
-def test_build_prompt_contains_three_convention_bullets(tmp_path: Path):
+def test_build_prompt_conventions_common_bullets(tmp_path: Path):
+    """The main-checkout and bypass conventions appear in every mode."""
     task = _task({"repo": tmp_path / "wt"})
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="x",
         journal_entries=[], base_sha_info=_info_clean(),
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
-    assert "mship finish --body-file" in out
     assert "main checkout" in out
     assert "--bypass-" in out
+
+
+def test_build_prompt_standalone_conventions_have_finish_bullet(tmp_path: Path):
+    task = _task({"repo": tmp_path / "wt"})
+    out = build_dispatch_prompt(
+        task=task, repo="repo", instruction="x", mode="standalone",
+        journal_entries=[], base_sha_info=_info_clean(),
+        agents_md_path=None, pkg_skills_source=tmp_path / "skills",
+    )
+    assert "mship finish --body-file" in out
+
+
+def test_build_prompt_implementer_conventions_drop_finish_bullet(tmp_path: Path):
+    """Default (implementer) conventions never tell the subagent to open a PR."""
+    task = _task({"repo": tmp_path / "wt"})
+    out = build_dispatch_prompt(
+        task=task, repo="repo", instruction="x",
+        journal_entries=[], base_sha_info=_info_clean(),
+        agents_md_path=None, pkg_skills_source=tmp_path / "skills",
+    )
+    assert "mship finish --body-file" not in out
+    assert "orchestrator" in out.lower()
 
 
 def test_build_prompt_lists_canonical_skills_with_paths(tmp_path: Path):
@@ -339,10 +361,10 @@ def test_build_prompt_omits_agents_md_line_when_absent(tmp_path: Path):
     assert "Full doc:" not in out
 
 
-def test_build_prompt_contains_finish_contract(tmp_path: Path):
+def test_build_prompt_standalone_mode_has_finish_contract(tmp_path: Path):
     task = _task({"repo": tmp_path / "wt"})
     out = build_dispatch_prompt(
-        task=task, repo="repo", instruction="x",
+        task=task, repo="repo", instruction="x", mode="standalone",
         journal_entries=[], base_sha_info=_info_clean(),
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
@@ -350,3 +372,47 @@ def test_build_prompt_contains_finish_contract(tmp_path: Path):
     assert "mship test" in out
     assert "--body-file" in out
     assert "PR URL" in out
+
+
+def test_build_prompt_default_mode_is_implementer_report_back(tmp_path: Path):
+    """Default output reports back, scopes to one task, and never opens a PR."""
+    task = _task({"repo": tmp_path / "wt"})
+    out = build_dispatch_prompt(
+        task=task, repo="repo", instruction="x",
+        journal_entries=[], base_sha_info=_info_clean(),
+        agents_md_path=None, pkg_skills_source=tmp_path / "skills",
+    )
+    lower = out.lower()
+    # Reports back instead of finishing.
+    assert "report back" in lower
+    assert "status report" in lower
+    assert "clarifying question" in lower
+    assert "mship test" in out
+    # Single-task scope is stated explicitly.
+    assert "exactly the one task" in lower
+    # Does NOT instruct the subagent to open a PR.
+    assert "do not open a pr" in lower
+    assert "How to finish" not in out
+    assert "mship finish --body-file" not in out
+    assert "PR URL" not in out
+
+
+def test_build_prompt_implementer_mode_matches_default(tmp_path: Path):
+    """Explicit mode='implementer' is identical to the default."""
+    task = _task({"repo": tmp_path / "wt"})
+    common = dict(
+        task=task, repo="repo", instruction="x",
+        journal_entries=[], base_sha_info=_info_clean(),
+        agents_md_path=None, pkg_skills_source=tmp_path / "skills",
+    )
+    assert build_dispatch_prompt(**common, mode="implementer") == build_dispatch_prompt(**common)
+
+
+def test_build_prompt_unknown_mode_raises(tmp_path: Path):
+    task = _task({"repo": tmp_path / "wt"})
+    with pytest.raises(ValueError, match="mode"):
+        build_dispatch_prompt(
+            task=task, repo="repo", instruction="x", mode="bogus",
+            journal_entries=[], base_sha_info=_info_clean(),
+            agents_md_path=None, pkg_skills_source=tmp_path / "skills",
+        )


### PR DESCRIPTION
## Summary

Fixes #234. `mship dispatch` no longer tells the subagent to open a PR by default.

- **New default — implementer framing.** The dispatch prompt now scopes the subagent to **exactly one task** and instructs it to: ask clarifying questions before coding, implement only that task, run `mship test`, self-review, and **return a status report** instead of finishing. It explicitly does **not** open a PR — the orchestrator owns integration and runs `mship finish` after review. The "Conventions (recap)" section drops the "open the PR" bullet in this mode and replaces it with a "don't open a PR / the orchestrator finishes" bullet.
- **`--mode standalone`** restores the previous behavior: the "How to finish" contract where the subagent finishes the work and opens its own PR. Reach for it only for genuinely standalone, one-off dispatches.
- **Validation.** An invalid `--mode` value exits 2 with a message naming both valid modes (`implementer`, `standalone`). The core builder also raises `ValueError` for unknown modes (defense in depth for programmatic callers).
- **Docs.** README, `docs/cli.md`, and the `working-with-mothership` + `subagent-driven-development` skills now describe the new default and the `--mode` flag.

Standalone mode reproduces the old prompt byte-for-byte (same conventions bullets in the same order, same "How to finish" contract), so existing standalone use is unchanged. The `mship spec dispatch` / `serve` handoff path shells out to `mship dispatch`, so it inherits the new implementer default automatically with no edits.

### Acceptance criteria (from #234)

- [x] Output, by default, does not tell the subagent to open a PR.
- [x] Output instructs the subagent to ask questions, self-review, and return a status report.
- [x] Output scopes the subagent to a single task.
- [x] Standalone/PR-opening behavior is still reachable (`--mode standalone`).

## Test plan

- [x] TDD: added/updated unit tests in `tests/core/test_dispatch.py` (mode-aware conventions + closing section, default == implementer, unknown-mode raises) and CLI tests in `tests/cli/test_dispatch.py` (default reports back / no PR, `--mode standalone` has finish contract, invalid mode exits 2). Watched them fail before implementing.
- [x] Full suite green via `mship test`: **1749 passed**.
- [x] Manually rendered both modes (`uv run mship dispatch` default vs `--mode standalone`) and the invalid-mode error path; confirmed the prose reads correctly and the standalone output matches the pre-change prompt.

Closes #234