### PR TITLE
Stop-hook inbox drain: live agent answers phone messages at turn boundaries (#239 slice 1)

### DIFF
--- a/docs/plans/2026-06-30-stop-hook-inbox-drain.md
+++ b/docs/plans/2026-06-30-stop-hook-inbox-drain.md
@@ -1,0 +1,410 @@
+# Stop-Hook Inbox Drain Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `stop-hook-inbox-drain` (approved). Slice 1 of issue #239. Idle-session wake (`mship inbox wait` + read cursor) is Spec 2 and explicitly out of scope here.
+
+**Goal:** A Claude Code `Stop` hook that drains this workspace's message inbox at each turn boundary, so a live agent answers pending phone messages with no manual `mship inbox`.
+
+**Architecture:** A new hidden `mship _drain` reads the Stop event JSON from stdin and inspects the cwd-resolved workspace's `MessageStore`; if threads await an agent it blocks the stop and injects them, else it allows the stop (also allows on `stop_hook_active` for loop safety, and on any error to fail open). An `install_stop_hook` (third caller of the existing `_install_hook_entry`) wires it into `.claude/settings.json` via `mship init --install-hooks`.
+
+**Tech Stack:** Python 3.14, typer, pytest + `typer.testing.CliRunner` (Click 8.3.2 — stdout in `result.output`, stderr in `result.stderr`). Run tests with `uv run pytest`.
+
+**Stop-hook contract:** a Claude Code `Stop` hook reads event JSON on stdin (`{stop_hook_active: bool, ...}`). To BLOCK the turn from ending, it prints `{"decision": "block", "reason": "<text>"}` to stdout and exits 0 (the reason is shown to the model). To ALLOW the stop, it exits 0 with no output. `Stop` hook entries (like `SessionStart`) carry no `matcher`.
+
+---
+
+## File Structure
+
+- **Modify** `src/mship/cli/internal.py` — add a module-level `_format_drain_reason(threads)` helper and a hidden `_drain` command inside the existing `register(app, get_container)` (mirrors `_guard-edit`'s stdin-read + fail-open shape).
+- **Modify** `src/mship/core/claude_settings.py` — add `DRAIN_COMMAND` + `install_stop_hook` (third caller of `_install_hook_entry`).
+- **Modify** `src/mship/cli/init.py` — install the Stop hook in `_install_agent_hooks_with_output` alongside the SessionStart + PreToolUse hooks.
+- **Create tests:** `tests/cli/test_drain.py`, `tests/core/test_claude_settings_stop.py`, `tests/cli/test_init_stop_hook.py`.
+
+---
+
+<!-- mship:task id=1 -->
+### Task 1: `mship _drain` hidden command
+
+**Files:**
+- Modify: `src/mship/cli/internal.py` (add `_format_drain_reason` at module level near the top, after the imports; add the `_drain` command inside `register(app, get_container)`, next to `_guard-edit`)
+- Test: `tests/cli/test_drain.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/cli/test_drain.py
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.message_store import MessageStore
+
+runner = CliRunner()
+
+
+def _bootstrap(tmp_path: Path) -> tuple[Path, Path, MessageStore]:
+    """Workspace with a MessageStore; returns (cfg, state_dir, store)."""
+    state_dir = tmp_path / ".mothership"; state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text("workspace: t\nrepos: {}\n")
+    store = MessageStore(state_dir / "messages")
+    return cfg, state_dir, store
+
+
+def _override(cfg, state_dir):
+    container.config.reset(); container.state_manager.reset(); container.log_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+
+
+def _reset():
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override(); container.config.reset()
+    container.state_manager.reset_override(); container.state_manager.reset()
+    container.log_manager.reset()
+
+
+def _event(stop_hook_active: bool = False) -> str:
+    return json.dumps({"hook_event_name": "Stop", "stop_hook_active": stop_hook_active})
+
+
+def test_blocks_when_threads_await(tmp_path: Path):
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    now = datetime.now(timezone.utc)
+    store.create_thread("first idea", "shape this into a spec", now)
+    store.create_thread("second", "and answer this", now)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_drain"], input=_event())
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["decision"] == "block"
+        assert "shape this into a spec" in payload["reason"]
+        assert "and answer this" in payload["reason"]
+        assert "mship reply" in payload["reason"]
+    finally:
+        _reset()
+
+
+def test_allows_when_inbox_empty(tmp_path: Path):
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_drain"], input=_event())
+        assert result.exit_code == 0
+        assert '"decision"' not in result.output
+    finally:
+        _reset()
+
+
+def test_allows_when_thread_already_answered(tmp_path: Path):
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    now = datetime.now(timezone.utc)
+    t = store.create_thread("s", "q", now)
+    store.append(t.id, "agent", "answered", now)  # latest role == agent -> not awaiting
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_drain"], input=_event())
+        assert result.exit_code == 0
+        assert '"decision"' not in result.output
+    finally:
+        _reset()
+
+
+def test_allows_when_stop_hook_active(tmp_path: Path):
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    store.create_thread("s", "still pending", datetime.now(timezone.utc))
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_drain"], input=_event(stop_hook_active=True))
+        assert result.exit_code == 0
+        assert '"decision"' not in result.output  # loop safety: never block twice
+    finally:
+        _reset()
+
+
+def test_malformed_stdin_fails_open(tmp_path: Path):
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    store.create_thread("s", "pending", datetime.now(timezone.utc))
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_drain"], input="not json{{")
+        assert result.exit_code == 0
+        assert '"decision"' not in result.output
+    finally:
+        _reset()
+
+
+def test_outside_workspace_fails_open(tmp_path: Path):
+    # No container override -> get_container(required=False) returns None.
+    result = runner.invoke(app, ["_drain"], input=_event())
+    assert result.exit_code == 0
+    assert '"decision"' not in result.output
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/cli/test_drain.py -q`
+Expected: FAIL — `_drain` is not a registered command (typer "No such command", exit code 2), so the allow-case assertions on exit_code 0 fail and the block case can't parse output.
+
+- [ ] **Step 3: Add the `_format_drain_reason` helper to `src/mship/cli/internal.py`**
+
+Add at module level (after the existing imports / near `_staged_source_paths`):
+
+```python
+def _format_drain_reason(threads) -> str:
+    """Render awaiting threads as a Stop-hook block reason instructing the agent
+    to answer each and clear it with `mship reply`."""
+    n = len(threads)
+    lines = [
+        f"{n} message{'s' if n != 1 else ''} waiting in your inbox. Answer each, "
+        f"then post your answer with `mship reply <thread-id> \"<text>\"` "
+        f"(replying clears the thread):",
+        "",
+    ]
+    for t in threads:
+        pending = t.messages[-1].text if t.messages else ""
+        lines.append(f"- thread {t.id} ({t.subject}): {pending}")
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Add the `_drain` command inside `register(app, get_container)` in `src/mship/cli/internal.py`** (place it next to `_guard-edit`)
+
+```python
+    @app.command(name="_drain", hidden=True)
+    def _drain():
+        """Stop hook: drain this workspace's message inbox at a turn boundary.
+        Reads the Claude Code Stop event JSON from stdin. If threads await an
+        agent reply, blocks the stop and injects them; otherwise allows the stop.
+        Also allows on stop_hook_active (loop safety) and on ANY error (fail
+        open) — a messaging glitch must never trap the agent."""
+        from mship.core.message_store import MessageStore
+
+        try:
+            raw = sys.stdin.read()
+            event = json.loads(raw) if raw.strip() else {}
+            if event.get("stop_hook_active"):
+                raise typer.Exit(code=0)  # already a stop-hook continuation; don't loop
+            container = get_container(required=False)
+            if container is None:
+                raise typer.Exit(code=0)
+            store = MessageStore(Path(container.state_dir()) / "messages")
+            awaiting = [t for t in store.list() if t.awaiting_reply]
+            if not awaiting:
+                raise typer.Exit(code=0)
+            reason = _format_drain_reason(awaiting)
+        except typer.Exit:
+            raise
+        except Exception:
+            raise typer.Exit(code=0)  # fail open
+        print(json.dumps({"decision": "block", "reason": reason}))
+        raise typer.Exit(code=0)
+```
+
+(`json`, `sys`, and `Path` are already imported at the top of `internal.py`.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/cli/test_drain.py -q`
+Expected: PASS (6 passed).
+
+- [ ] **Step 6: Commit + journal**
+
+```bash
+git add src/mship/cli/internal.py tests/cli/test_drain.py
+git commit -m "feat(inbox): mship _drain Stop-hook command (block-when-awaiting, fail-open)"
+mship journal "_drain Stop-hook command + tests passing" --action committed
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=2 -->
+### Task 2: `install_stop_hook`
+
+**Files:**
+- Modify: `src/mship/core/claude_settings.py` (add `DRAIN_COMMAND` constant + `install_stop_hook`)
+- Test: `tests/core/test_claude_settings_stop.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/core/test_claude_settings_stop.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from mship.core.claude_settings import (
+    install_stop_hook, install_session_hook, install_pretooluse_guard_hook,
+    DRAIN_COMMAND,
+)
+
+
+def _settings(ws: Path) -> dict:
+    return json.loads((ws / ".claude" / "settings.json").read_text())
+
+
+def test_installs_stop_hook_into_fresh_settings(tmp_path: Path):
+    assert install_stop_hook(tmp_path) == "installed"
+    stop = _settings(tmp_path)["hooks"]["Stop"]
+    assert stop[0]["hooks"][0]["command"] == DRAIN_COMMAND
+    assert "matcher" not in stop[0]  # Stop hooks carry no matcher
+
+
+def test_install_stop_is_idempotent(tmp_path: Path):
+    assert install_stop_hook(tmp_path) == "installed"
+    assert install_stop_hook(tmp_path) == "up to date"
+    assert len(_settings(tmp_path)["hooks"]["Stop"]) == 1
+
+
+def test_stop_preserves_other_hooks(tmp_path: Path):
+    install_session_hook(tmp_path)
+    install_pretooluse_guard_hook(tmp_path)
+    install_stop_hook(tmp_path)
+    hooks = _settings(tmp_path)["hooks"]
+    assert "SessionStart" in hooks and "PreToolUse" in hooks and "Stop" in hooks
+
+
+def test_stop_tolerates_malformed_settings(tmp_path: Path):
+    cdir = tmp_path / ".claude"; cdir.mkdir()
+    (cdir / "settings.json").write_text("{not json")
+    assert "skipped" in install_stop_hook(tmp_path)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/core/test_claude_settings_stop.py -q`
+Expected: FAIL — `ImportError: cannot import name 'install_stop_hook'`.
+
+- [ ] **Step 3: Add to `src/mship/core/claude_settings.py`**
+
+Add the constant next to the others (after `GUARD_MATCHER`):
+```python
+DRAIN_COMMAND = "mship _drain"
+```
+
+Add the installer after `install_pretooluse_guard_hook`:
+```python
+def install_stop_hook(workspace_root: Path) -> str:
+    """Idempotently add a Stop hook running `mship _drain` (drains the message
+    inbox at each turn boundary). Stop hooks carry no matcher."""
+    return _install_hook_entry(
+        workspace_root, "Stop",
+        {"hooks": [{"type": "command", "command": DRAIN_COMMAND}]},
+        DRAIN_COMMAND,
+    )
+```
+
+- [ ] **Step 4: Run the new tests + existing claude_settings tests**
+
+Run: `uv run pytest tests/core/test_claude_settings_stop.py -q && uv run pytest -q -k claude_settings`
+Expected: PASS (existing SessionStart + guard installer tests still green; the shared `_install_hook_entry` is unchanged).
+
+- [ ] **Step 5: Commit + journal**
+
+```bash
+git add src/mship/core/claude_settings.py tests/core/test_claude_settings_stop.py
+git commit -m "feat(inbox): install_stop_hook for the _drain Stop hook"
+mship journal "install_stop_hook + tests; other hook installers unaffected" --action committed
+```
+<!-- /mship:task -->
+
+<!-- mship:task id=3 -->
+### Task 3: Wire the Stop hook into `mship init --install-hooks`
+
+**Files:**
+- Modify: `src/mship/cli/init.py` (import `install_stop_hook`; install it in `_install_agent_hooks_with_output`)
+- Test: `tests/cli/test_init_stop_hook.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/cli/test_init_stop_hook.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+
+runner = CliRunner()
+
+
+def test_install_hooks_installs_stop_hook(tmp_path: Path):
+    state_dir = tmp_path / ".mothership"; state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text("workspace: t\nrepos: {}\n")
+    container.config.reset(); container.state_manager.reset(); container.log_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    try:
+        result = runner.invoke(app, ["init", "--install-hooks"])
+        data = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+        assert "Stop" in data["hooks"]
+        assert any(
+            h.get("command") == "mship _drain"
+            for e in data["hooks"]["Stop"]
+            for h in e.get("hooks", [])
+        )
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset_override(); container.config.reset()
+        container.state_manager.reset_override(); container.state_manager.reset()
+        container.log_manager.reset()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/cli/test_init_stop_hook.py -q`
+Expected: FAIL — `KeyError: 'Stop'` (only SessionStart + PreToolUse are installed today).
+
+- [ ] **Step 3: Update `src/mship/cli/init.py`**
+
+Change the import line to add `install_stop_hook`:
+```python
+from mship.core.claude_settings import install_session_hook, install_pretooluse_guard_hook, install_stop_hook
+```
+
+Append a third install block to `_install_agent_hooks_with_output` (after the PreToolUse block):
+```python
+    try:
+        output.success(f"Stop hook @ {settings}: {install_stop_hook(ws_root)}")
+    except Exception as e:
+        output.warning(f"Stop hook install skipped: {e}")
+```
+
+- [ ] **Step 4: Run the test + existing init tests**
+
+Run: `uv run pytest tests/cli/test_init_stop_hook.py -q && uv run pytest -q -k init`
+Expected: PASS (existing init/SessionStart/PreToolUse tests still green; the Stop hook now installs too).
+
+- [ ] **Step 5: Commit + journal**
+
+```bash
+git add src/mship/cli/init.py tests/cli/test_init_stop_hook.py
+git commit -m "feat(inbox): install the Stop drain hook in init --install-hooks"
+mship journal "init --install-hooks now installs the Stop drain hook" --action committed
+```
+<!-- /mship:task -->
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] Full suite: `mship test`. Expected: all pass (no regressions to the message/hook/init suites).
+- [ ] Manual smoke from inside this worktree:
+  ```bash
+  # Seed an awaiting thread in THIS workspace, then drain.
+  uv run mship serve --help >/dev/null  # (sanity)
+  printf '{"stop_hook_active": false}' | uv run mship _drain; echo "exit=$?"
+  ```
+  With no awaiting messages, expect empty output + `exit=0`. (A full block smoke would require POSTing a message via `mship serve`; the unit tests cover the block path.)

--- a/src/mship/cli/init.py
+++ b/src/mship/cli/init.py
@@ -6,7 +6,7 @@ import typer
 from mship.cli.output import Output
 from mship.core.config import unique_git_roots
 from mship.core.init import WorkspaceInitializer, DetectedRepo
-from mship.core.claude_settings import install_session_hook, install_pretooluse_guard_hook
+from mship.core.claude_settings import install_session_hook, install_pretooluse_guard_hook, install_stop_hook
 
 
 def _install_agent_hooks_with_output(ws_root: Path, output: Output) -> None:
@@ -19,6 +19,10 @@ def _install_agent_hooks_with_output(ws_root: Path, output: Output) -> None:
         output.success(f"PreToolUse guard hook @ {settings}: {install_pretooluse_guard_hook(ws_root)}")
     except Exception as e:
         output.warning(f"PreToolUse guard hook install skipped: {e}")
+    try:
+        output.success(f"Stop hook @ {settings}: {install_stop_hook(ws_root)}")
+    except Exception as e:
+        output.warning(f"Stop hook install skipped: {e}")
 
 
 def register(app: typer.Typer, get_container):

--- a/src/mship/cli/internal.py
+++ b/src/mship/cli/internal.py
@@ -35,6 +35,22 @@ def _staged_source_paths(toplevel: str, container) -> list[str]:
         return []
 
 
+def _format_drain_reason(threads) -> str:
+    """Render awaiting threads as a Stop-hook block reason instructing the agent
+    to answer each and clear it with `mship reply`."""
+    n = len(threads)
+    lines = [
+        f"{n} message{'s' if n != 1 else ''} waiting in your inbox. Answer each, "
+        f"then post your answer with `mship reply <thread-id> \"<text>\"` "
+        f"(replying clears the thread):",
+        "",
+    ]
+    for t in threads:
+        pending = t.messages[-1].text if t.messages else ""
+        lines.append(f"- thread {t.id} ({t.subject}): {pending}")
+    return "\n".join(lines)
+
+
 def register(app: typer.Typer, get_container):
     @app.command(name="_check-commit", hidden=True)
     def check_commit(toplevel: str = typer.Argument(..., help="git rev-parse --show-toplevel value")):
@@ -303,6 +319,35 @@ def register(app: typer.Typer, get_container):
             raise typer.Exit(code=0)
         sys.stderr.write(decision.reason + "\n")
         raise typer.Exit(code=2)
+
+    @app.command(name="_drain", hidden=True)
+    def _drain():
+        """Stop hook: drain this workspace's message inbox at a turn boundary.
+        Reads the Claude Code Stop event JSON from stdin. If threads await an
+        agent reply, blocks the stop and injects them; otherwise allows the stop.
+        Also allows on stop_hook_active (loop safety) and on ANY error (fail
+        open) — a messaging glitch must never trap the agent."""
+        from mship.core.message_store import MessageStore
+
+        try:
+            raw = sys.stdin.read()
+            event = json.loads(raw) if raw.strip() else {}
+            if event.get("stop_hook_active"):
+                raise typer.Exit(code=0)  # already a stop-hook continuation; don't loop
+            container = get_container(required=False)
+            if container is None:
+                raise typer.Exit(code=0)
+            store = MessageStore(Path(container.state_dir()) / "messages")
+            awaiting = [t for t in store.list() if t.awaiting_reply]
+            if not awaiting:
+                raise typer.Exit(code=0)
+            reason = _format_drain_reason(awaiting)
+        except typer.Exit:
+            raise
+        except Exception:
+            raise typer.Exit(code=0)  # fail open
+        print(json.dumps({"decision": "block", "reason": reason}))
+        raise typer.Exit(code=0)
 
     @app.command(name="_session-context", hidden=True)
     def session_context():

--- a/src/mship/cli/internal.py
+++ b/src/mship/cli/internal.py
@@ -35,7 +35,7 @@ def _staged_source_paths(toplevel: str, container) -> list[str]:
         return []
 
 
-def _format_drain_reason(threads) -> str:
+def _format_drain_reason(threads: list) -> str:
     """Render awaiting threads as a Stop-hook block reason instructing the agent
     to answer each and clear it with `mship reply`."""
     n = len(threads)

--- a/src/mship/core/claude_settings.py
+++ b/src/mship/core/claude_settings.py
@@ -3,8 +3,9 @@
 Supports:
 - SessionStart hook: surfaces the no-active-task notice each session
 - PreToolUse guard hook: blocks edits to a repo's main checkout
+- Stop hook: drains the message inbox at each turn boundary (`mship _drain`)
 
-See spec enforcement-gate (MOS-189).
+See spec enforcement-gate (MOS-189) and stop-hook-inbox-drain (#239).
 """
 from __future__ import annotations
 

--- a/src/mship/core/claude_settings.py
+++ b/src/mship/core/claude_settings.py
@@ -14,6 +14,7 @@ from pathlib import Path
 SESSION_COMMAND = "mship _session-context"
 GUARD_COMMAND = "mship _guard-edit"
 GUARD_MATCHER = "Edit|Write|MultiEdit|NotebookEdit"
+DRAIN_COMMAND = "mship _drain"
 
 
 def _install_hook_entry(workspace_root: Path, event_key: str, entry: dict, command: str) -> str:
@@ -73,4 +74,14 @@ def install_pretooluse_guard_hook(workspace_root: Path) -> str:
         workspace_root, "PreToolUse",
         {"matcher": GUARD_MATCHER, "hooks": [{"type": "command", "command": GUARD_COMMAND}]},
         GUARD_COMMAND,
+    )
+
+
+def install_stop_hook(workspace_root: Path) -> str:
+    """Idempotently add a Stop hook running `mship _drain` (drains the message
+    inbox at each turn boundary). Stop hooks carry no matcher."""
+    return _install_hook_entry(
+        workspace_root, "Stop",
+        {"hooks": [{"type": "command", "command": DRAIN_COMMAND}]},
+        DRAIN_COMMAND,
     )

--- a/tests/cli/test_drain.py
+++ b/tests/cli/test_drain.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.message_store import MessageStore
+
+runner = CliRunner()
+
+
+def _bootstrap(tmp_path: Path) -> tuple[Path, Path, MessageStore]:
+    """Workspace with a MessageStore; returns (cfg, state_dir, store)."""
+    state_dir = tmp_path / ".mothership"; state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text("workspace: t\nrepos: {}\n")
+    store = MessageStore(state_dir / "messages")
+    return cfg, state_dir, store
+
+
+def _override(cfg, state_dir):
+    container.config.reset(); container.state_manager.reset(); container.log_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+
+
+def _reset():
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override(); container.config.reset()
+    container.state_manager.reset_override(); container.state_manager.reset()
+    container.log_manager.reset()
+
+
+def _event(stop_hook_active: bool = False) -> str:
+    return json.dumps({"hook_event_name": "Stop", "stop_hook_active": stop_hook_active})
+
+
+def test_blocks_when_threads_await(tmp_path: Path):
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    now = datetime.now(timezone.utc)
+    store.create_thread("first idea", "shape this into a spec", now)
+    store.create_thread("second", "and answer this", now)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_drain"], input=_event())
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["decision"] == "block"
+        assert "shape this into a spec" in payload["reason"]
+        assert "and answer this" in payload["reason"]
+        assert "mship reply" in payload["reason"]
+    finally:
+        _reset()
+
+
+def test_allows_when_inbox_empty(tmp_path: Path):
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_drain"], input=_event())
+        assert result.exit_code == 0
+        assert '"decision"' not in result.output
+    finally:
+        _reset()
+
+
+def test_allows_when_thread_already_answered(tmp_path: Path):
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    now = datetime.now(timezone.utc)
+    t = store.create_thread("s", "q", now)
+    store.append(t.id, "agent", "answered", now)  # latest role == agent -> not awaiting
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_drain"], input=_event())
+        assert result.exit_code == 0
+        assert '"decision"' not in result.output
+    finally:
+        _reset()
+
+
+def test_allows_when_stop_hook_active(tmp_path: Path):
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    store.create_thread("s", "still pending", datetime.now(timezone.utc))
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_drain"], input=_event(stop_hook_active=True))
+        assert result.exit_code == 0
+        assert '"decision"' not in result.output  # loop safety: never block twice
+    finally:
+        _reset()
+
+
+def test_malformed_stdin_fails_open(tmp_path: Path):
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    store.create_thread("s", "pending", datetime.now(timezone.utc))
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_drain"], input="not json{{")
+        assert result.exit_code == 0
+        assert '"decision"' not in result.output
+    finally:
+        _reset()
+
+
+def test_outside_workspace_fails_open(tmp_path: Path, monkeypatch):
+    # No container override -> get_container(required=False) returns None.
+    # chdir to tmp_path so ConfigLoader.discover() finds no mothership.yaml.
+    monkeypatch.chdir(tmp_path)
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    result = runner.invoke(app, ["_drain"], input=_event())
+    assert result.exit_code == 0
+    assert '"decision"' not in result.output

--- a/tests/cli/test_init_stop_hook.py
+++ b/tests/cli/test_init_stop_hook.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+
+runner = CliRunner()
+
+
+def test_install_hooks_installs_stop_hook(tmp_path: Path):
+    state_dir = tmp_path / ".mothership"; state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text("workspace: t\nrepos: {}\n")
+    container.config.reset(); container.state_manager.reset(); container.log_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    try:
+        result = runner.invoke(app, ["init", "--install-hooks"])
+        data = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+        assert "Stop" in data["hooks"]
+        assert any(
+            h.get("command") == "mship _drain"
+            for e in data["hooks"]["Stop"]
+            for h in e.get("hooks", [])
+        )
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset_override(); container.config.reset()
+        container.state_manager.reset_override(); container.state_manager.reset()
+        container.log_manager.reset()

--- a/tests/core/test_claude_settings_stop.py
+++ b/tests/core/test_claude_settings_stop.py
@@ -1,0 +1,41 @@
+# tests/core/test_claude_settings_stop.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from mship.core.claude_settings import (
+    install_stop_hook, install_session_hook, install_pretooluse_guard_hook,
+    DRAIN_COMMAND,
+)
+
+
+def _settings(ws: Path) -> dict:
+    return json.loads((ws / ".claude" / "settings.json").read_text())
+
+
+def test_installs_stop_hook_into_fresh_settings(tmp_path: Path):
+    assert install_stop_hook(tmp_path) == "installed"
+    stop = _settings(tmp_path)["hooks"]["Stop"]
+    assert stop[0]["hooks"][0]["command"] == DRAIN_COMMAND
+    assert "matcher" not in stop[0]  # Stop hooks carry no matcher
+
+
+def test_install_stop_is_idempotent(tmp_path: Path):
+    assert install_stop_hook(tmp_path) == "installed"
+    assert install_stop_hook(tmp_path) == "up to date"
+    assert len(_settings(tmp_path)["hooks"]["Stop"]) == 1
+
+
+def test_stop_preserves_other_hooks(tmp_path: Path):
+    install_session_hook(tmp_path)
+    install_pretooluse_guard_hook(tmp_path)
+    install_stop_hook(tmp_path)
+    hooks = _settings(tmp_path)["hooks"]
+    assert "SessionStart" in hooks and "PreToolUse" in hooks and "Stop" in hooks
+
+
+def test_stop_tolerates_malformed_settings(tmp_path: Path):
+    cdir = tmp_path / ".claude"; cdir.mkdir()
+    (cdir / "settings.json").write_text("{not json")
+    assert "skipped" in install_stop_hook(tmp_path)


### PR DESCRIPTION
## Summary

Adds a Claude Code **`Stop` hook** that drains this workspace's message inbox at each turn boundary, so a live agent answers pending phone messages with **no manual `mship inbox`**. This is **slice 1 of issue #239** (the notification/auto-dispatch layer on top of the implemented store-and-forward `message-mailbox`).

Scope is deliberately the *active* case — a session that's currently working. Waking an *idle-but-open* session (an agent-backgrounded `mship inbox wait` long-poll + a per-workspace read cursor) is slice 2 and explicitly deferred. Spawning agents / `claude -p` / new sessions is out of #239 entirely.

### What's in it

- **`mship _drain`** (hidden, in `src/mship/cli/internal.py`) — reads the Stop event JSON from stdin and inspects the cwd-resolved workspace's `MessageStore`:
  - threads await **and** not `stop_hook_active` → prints `{"decision":"block","reason":...}` (lists each awaiting thread id + pending text + a `mship reply <id>` instruction) and exits 0, blocking the turn from ending so the agent answers.
  - inbox empty → allow the stop.
  - `stop_hook_active` true → never block (loop safety), even if messages await.
  - **fails open** (allow the stop) on malformed stdin, an unreadable store, or outside a workspace — a messaging glitch can never trap the agent.
  It reuses the exact `MessageStore` + `Thread.awaiting_reply` logic behind `mship inbox`, so drain and inbox can never disagree.
- **`install_stop_hook`** (`src/mship/core/claude_settings.py`) — third caller of the shared `_install_hook_entry`; idempotent, preserves existing hooks, tolerates malformed settings. Wired into `mship init --install-hooks` alongside the SessionStart and PreToolUse hooks.

### Workspace isolation (a design invariant, per the topology of one serve + one agent per workspace)

`_drain` only ever reads the cwd-resolved workspace's `MessageStore` and fails open if it can't resolve one — never a home-dir fallback — so a message can only be drained by its own workspace's agent.

### Acceptance criteria (all met)

- [x] `init --install-hooks` installs a `Stop` hook (`mship _drain`) idempotently, preserving existing hooks, tolerating malformed settings.
- [x] Non-empty inbox + not `stop_hook_active` → block with a reason listing each awaiting thread + reply instruction.
- [x] Empty inbox → allow.
- [x] `stop_hook_active` → never block (loop safety).
- [x] Workspace-scoped; outside a workspace → allow (fail open).
- [x] Fails open on malformed stdin / unreadable store / any error.

## Test plan

- [x] **11 new tests** via TDD across 3 tasks (each reviewed for spec compliance + code quality before the next): `_drain` (6 — block/empty/answered/stop_hook_active/malformed-stdin/outside-workspace), `install_stop_hook` (4 — fresh/idempotent/preserve/malformed), init wiring (1).
- [x] **Full suite green: 1784 passed**, no regressions (existing message/hook/init suites unaffected).
- [x] **Live end-to-end smoke**: against the real workspace mailbox (which had 2 pending messages), `mship _drain` emitted a valid `{"decision":"block",...}` listing both with the reply instruction; malformed stdin returned exit 0 (fail open).

### Follow-on (#239 slice 2)

Idle-session wake: an agent-backgrounded `mship inbox wait [--since <cursor>] [--timeout N]` long-poll (inotify-backed) + a per-workspace read cursor + the arm/re-arm protocol. Captured during brainstorming; its own spec.

Closes #239