### PR TITLE
Ground Control Home surfaces agent messages that need operator action

### DIFF
--- a/src/mship/cli/message.py
+++ b/src/mship/cli/message.py
@@ -75,11 +75,20 @@ def register(parent: typer.Typer, get_container) -> None:
         typer.echo(json.dumps(out))
 
     @parent.command()
-    def reply(thread_id: str, text: str) -> None:
+    def reply(
+        thread_id: str,
+        text: str,
+        needs_you: bool = typer.Option(
+            False, "--needs-you",
+            help="Mark this reply as needing the operator's action "
+                 "(surfaces as a Home action card in Ground Control).",
+        ),
+    ) -> None:
         """Post an agent reply to a thread."""
         store = _store()
         try:
-            store.append(thread_id, "agent", text, datetime.now(timezone.utc))
+            store.append(thread_id, "agent", text, datetime.now(timezone.utc),
+                         kind="needs_you" if needs_you else "note")
         except KeyError:
             typer.echo(f"no thread {thread_id!r}", err=True)
             raise typer.Exit(1)

--- a/src/mship/core/message.py
+++ b/src/mship/core/message.py
@@ -12,6 +12,9 @@ class Message(BaseModel):
     role: Literal["human", "agent"]
     text: str
     created_at: datetime
+    # "needs_you" marks an agent message that needs the operator to act
+    # (surfaces as a Home action card in Ground Control). Default "note".
+    kind: Literal["note", "needs_you"] = "note"
 
 
 class Thread(BaseModel):
@@ -21,6 +24,8 @@ class Thread(BaseModel):
     updated_at: datetime
     task_slug: str | None = None
     spec_id: str | None = None
+    # Operator read cursor: the operator has seen messages up to this time.
+    seen_at: datetime | None = None
     messages: list[Message] = []
 
     @computed_field  # serialized into model_dump()/JSON (a plain @property is not)
@@ -28,3 +33,29 @@ class Thread(BaseModel):
     def awaiting_reply(self) -> bool:
         """A thread needs an agent iff its latest message is from a human."""
         return bool(self.messages) and self.messages[-1].role == "human"
+
+    @computed_field
+    @property
+    def needs_you(self) -> bool:
+        """True iff an agent message marked needs_you is unanswered — i.e. newer
+        than the operator's last human message. Survives a follow-up plain note."""
+        last_human = -1
+        for i, m in enumerate(self.messages):
+            if m.role == "human":
+                last_human = i
+        return any(
+            m.role == "agent" and m.kind == "needs_you"
+            for m in self.messages[last_human + 1:]
+        )
+
+    @computed_field
+    @property
+    def unseen(self) -> bool:
+        """True iff the latest agent message is newer than the operator's seen cursor."""
+        latest_agent = None
+        for m in self.messages:
+            if m.role == "agent":
+                latest_agent = m
+        if latest_agent is None:
+            return False
+        return self.seen_at is None or latest_agent.created_at > self.seen_at

--- a/src/mship/core/message_store.py
+++ b/src/mship/core/message_store.py
@@ -67,12 +67,26 @@ class MessageStore:
             thread.updated_at = now
         self.save(thread)
 
-    def append(self, thread_id: str, role: Literal["human", "agent"], text: str, now: datetime) -> Message:
+    def append(self, thread_id: str, role: Literal["human", "agent"], text: str,
+               now: datetime, kind: Literal["note", "needs_you"] = "note") -> Message:
         thread = self.get(thread_id)
         if thread is None:
             raise KeyError(thread_id)
-        msg = Message(id=_new_id(now), thread_id=thread_id, role=role, text=text, created_at=now)
+        msg = Message(id=_new_id(now), thread_id=thread_id, role=role, text=text,
+                      created_at=now, kind=kind)
         thread.messages.append(msg)
         thread.updated_at = now
         self.save(thread)
         return msg
+
+    def mark_seen(self, thread_id: str, seen_at: datetime) -> Thread:
+        """Advance the operator's read cursor (monotonic — never regresses).
+        Does not bump updated_at: reading is not a content change and must not
+        reorder the thread list."""
+        thread = self.get(thread_id)
+        if thread is None:
+            raise KeyError(thread_id)
+        if thread.seen_at is None or seen_at > thread.seen_at:
+            thread.seen_at = seen_at
+            self.save(thread)
+        return thread

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -323,7 +323,9 @@ def create_app(
 
     @app.post("/threads/{thread_id}/seen")
     def post_seen(thread_id: str, body: SeenBody):
-        if body.seen_at:
+        # `is not None` (not truthiness): an empty string is a malformed timestamp
+        # (-> 422 below), distinct from an omitted seen_at (None -> "now").
+        if body.seen_at is not None:
             try:
                 seen_dt = datetime.fromisoformat(body.seen_at)
             except ValueError:

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -56,6 +56,10 @@ class NewMessageBody(BaseModel):
     text: str
 
 
+class SeenBody(BaseModel):
+    seen_at: str | None = None
+
+
 def _make_auth_dependency(token: str):
     import hmac
     from fastapi import Header, HTTPException
@@ -317,12 +321,31 @@ def create_app(
             raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
         return t.model_dump(mode="json")
 
+    @app.post("/threads/{thread_id}/seen")
+    def post_seen(thread_id: str, body: SeenBody):
+        if body.seen_at:
+            try:
+                seen_dt = datetime.fromisoformat(body.seen_at)
+            except ValueError:
+                raise HTTPException(status_code=422, detail=f"invalid seen_at: {body.seen_at!r}")
+            if seen_dt.tzinfo is None:
+                seen_dt = seen_dt.replace(tzinfo=timezone.utc)
+        else:
+            seen_dt = datetime.now(timezone.utc)
+        try:
+            t = msgs.mark_seen(thread_id, seen_dt)
+        except KeyError:
+            raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
+        return t.model_dump(mode="json")
+
     def _summaries(threads):
         return [
             {
                 "id": t.id, "subject": t.subject,
                 "updated_at": t.updated_at.isoformat(),
                 "awaiting_reply": t.awaiting_reply,
+                "needs_you": t.needs_you,
+                "unseen": t.unseen,
                 "last_message": (t.messages[-1].text[:120] if t.messages else ""),
                 "message_count": len(t.messages),
             }

--- a/tests/cli/test_message.py
+++ b/tests/cli/test_message.py
@@ -72,3 +72,25 @@ def test_messages_renders_thread(_configured):
     s.append(t.id, "agent", "second", now)
     out = json.loads(runner.invoke(app, ["messages", t.id]).output)
     assert [m["text"] for m in out["messages"]] == ["first", "second"]
+
+
+def test_reply_needs_you_marks_kind(_configured):
+    s = _seed(_configured)
+    now = datetime(2026, 6, 23, tzinfo=timezone.utc)
+    t = s.create_thread(subject="x", text="q", now=now)
+    r = runner.invoke(app, ["reply", t.id, "look at this", "--needs-you"])
+    assert r.exit_code == 0, r.output
+    got = s.get(t.id)
+    assert got.messages[-1].kind == "needs_you"
+    assert got.needs_you is True
+
+
+def test_reply_defaults_to_note(_configured):
+    s = _seed(_configured)
+    now = datetime(2026, 6, 23, tzinfo=timezone.utc)
+    t = s.create_thread(subject="x", text="q", now=now)
+    r = runner.invoke(app, ["reply", t.id, "just an fyi"])
+    assert r.exit_code == 0, r.output
+    got = s.get(t.id)
+    assert got.messages[-1].kind == "note"
+    assert got.needs_you is False

--- a/tests/core/test_message_model.py
+++ b/tests/core/test_message_model.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timedelta, timezone
+
+from mship.core.message import Message, Thread
+
+BASE = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+
+
+def _thread(*msgs: Message, seen_at: datetime | None = None) -> Thread:
+    return Thread(
+        id="x", subject="s", created_at=BASE, updated_at=BASE,
+        messages=list(msgs), seen_at=seen_at,
+    )
+
+
+def _m(role: str, minute: int, *, kind: str = "note") -> Message:
+    return Message(
+        id=f"m{minute}", thread_id="x", role=role, text=f"msg {minute}",
+        created_at=BASE + timedelta(minutes=minute), kind=kind,
+    )
+
+
+def test_message_kind_defaults_to_note():
+    assert _m("agent", 1).kind == "note"
+
+
+def test_kind_round_trips_and_legacy_json_defaults_to_note():
+    m = _m("agent", 1, kind="needs_you")
+    assert Message.model_validate_json(m.model_dump_json()).kind == "needs_you"
+    legacy = '{"id":"m1","thread_id":"x","role":"agent","text":"hi","created_at":"2026-06-30T12:01:00+00:00"}'
+    assert Message.model_validate_json(legacy).kind == "note"
+
+
+def test_needs_you_true_for_unanswered_needs_you():
+    t = _thread(_m("human", 0), _m("agent", 1, kind="needs_you"))
+    assert t.needs_you is True
+
+
+def test_needs_you_false_for_plain_note():
+    t = _thread(_m("human", 0), _m("agent", 1))
+    assert t.needs_you is False
+
+
+def test_needs_you_persists_after_a_followup_note():
+    t = _thread(_m("human", 0), _m("agent", 1, kind="needs_you"), _m("agent", 2))
+    assert t.needs_you is True
+
+
+def test_needs_you_clears_after_human_reply():
+    t = _thread(_m("human", 0), _m("agent", 1, kind="needs_you"), _m("human", 2))
+    assert t.needs_you is False
+
+
+def test_unseen_true_when_agent_newer_than_seen_cursor():
+    t = _thread(_m("human", 0), _m("agent", 1), seen_at=None)
+    assert t.unseen is True
+
+
+def test_unseen_false_once_seen_cursor_advances_past_latest_agent():
+    t = _thread(_m("human", 0), _m("agent", 1), seen_at=BASE + timedelta(minutes=2))
+    assert t.unseen is False
+
+
+def test_unseen_false_when_no_agent_messages():
+    t = _thread(_m("human", 0))
+    assert t.unseen is False
+
+
+def test_needs_you_and_unseen_are_serialized():
+    t = _thread(_m("human", 0), _m("agent", 1, kind="needs_you"))
+    dumped = t.model_dump()
+    assert dumped["needs_you"] is True
+    assert dumped["unseen"] is True

--- a/tests/core/test_message_store.py
+++ b/tests/core/test_message_store.py
@@ -91,3 +91,51 @@ def test_link_spec_with_now_advances_updated_at(tmp_path):
     refreshed = s.get(t.id)
     assert refreshed.spec_id == "my-spec"
     assert refreshed.updated_at == linked  # linking bubbles the thread up in list()
+
+
+def test_append_defaults_to_note_kind(tmp_path):
+    now = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    s = _store(tmp_path)
+    t = s.create_thread(subject="x", text="q", now=now)
+    s.append(t.id, "agent", "fyi", now)
+    got = s.get(t.id)
+    assert got.messages[-1].kind == "note"
+    assert got.needs_you is False
+
+
+def test_append_needs_you_kind_flags_thread(tmp_path):
+    now = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    s = _store(tmp_path)
+    t = s.create_thread(subject="x", text="q", now=now)
+    s.append(t.id, "agent", "look at this", now, kind="needs_you")
+    got = s.get(t.id)
+    assert got.messages[-1].kind == "needs_you"
+    assert got.needs_you is True
+
+
+def test_mark_seen_advances_cursor_and_clears_unseen(tmp_path):
+    from datetime import timedelta
+    base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    s = _store(tmp_path)
+    t = s.create_thread(subject="x", text="hi", now=base)
+    s.append(t.id, "agent", "fyi", base + timedelta(minutes=1))
+    assert s.get(t.id).unseen is True
+    s.mark_seen(t.id, base + timedelta(minutes=2))
+    assert s.get(t.id).unseen is False
+    assert s.get(t.id).seen_at == base + timedelta(minutes=2)
+
+
+def test_mark_seen_is_monotonic(tmp_path):
+    from datetime import timedelta
+    base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    s = _store(tmp_path)
+    t = s.create_thread(subject="x", text="hi", now=base)
+    s.mark_seen(t.id, base + timedelta(minutes=5))
+    s.mark_seen(t.id, base + timedelta(minutes=1))  # older — must not regress
+    assert s.get(t.id).seen_at == base + timedelta(minutes=5)
+
+
+def test_mark_seen_unknown_thread_raises(tmp_path):
+    s = _store(tmp_path)
+    with pytest.raises(KeyError):
+        s.mark_seen("nope", datetime(2026, 6, 30, tzinfo=timezone.utc))

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -483,3 +483,15 @@ def test_post_seen_defaults_to_now_when_omitted(tmp_path):
     r = client.post(f"/threads/{t.id}/seen", json={})
     assert r.status_code == 200
     assert next(x for x in client.get("/threads").json() if x["id"] == t.id)["unseen"] is False
+
+
+def test_post_seen_malformed_value_returns_422(tmp_path):
+    from mship.core.message_store import MessageStore
+    from datetime import datetime, timezone
+    store = MessageStore(tmp_path / ".mothership" / "messages")
+    t = store.create_thread("s", "hi", datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc))
+    client = TestClient(_app(tmp_path))
+    # a non-empty but unparseable timestamp -> 422
+    assert client.post(f"/threads/{t.id}/seen", json={"seen_at": "not-a-date"}).status_code == 422
+    # an empty string is malformed too (distinct from an omitted seen_at) -> 422
+    assert client.post(f"/threads/{t.id}/seen", json={"seen_at": ""}).status_code == 422

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -434,3 +434,52 @@ def test_thread_exposes_spec_id(tmp_path):
     tid = client.post("/threads", json={"text": "hi"}).json()["id"]
     MessageStore(tmp_path / ".mothership" / "messages").link_spec(tid, "spec-1")
     assert client.get(f"/threads/{tid}").json()["spec_id"] == "spec-1"
+
+
+def test_thread_summaries_expose_needs_you_and_unseen(tmp_path):
+    from mship.core.message_store import MessageStore
+    from datetime import datetime, timezone, timedelta
+    store = MessageStore(tmp_path / ".mothership" / "messages")
+    base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    t = store.create_thread("s", "hi", base)
+    store.append(t.id, "agent", "need you", base + timedelta(minutes=1), kind="needs_you")
+
+    client = TestClient(_app(tmp_path))
+    summary = next(x for x in client.get("/threads").json() if x["id"] == t.id)
+    assert summary["needs_you"] is True
+    assert summary["unseen"] is True
+    assert summary["awaiting_reply"] is False
+
+
+def test_post_seen_marks_thread_and_clears_unseen(tmp_path):
+    from mship.core.message_store import MessageStore
+    from datetime import datetime, timezone, timedelta
+    store = MessageStore(tmp_path / ".mothership" / "messages")
+    base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    t = store.create_thread("s", "hi", base)
+    store.append(t.id, "agent", "fyi", base + timedelta(minutes=1))
+
+    client = TestClient(_app(tmp_path))
+    assert next(x for x in client.get("/threads").json() if x["id"] == t.id)["unseen"] is True
+    r = client.post(f"/threads/{t.id}/seen", json={"seen_at": (base + timedelta(minutes=2)).isoformat()})
+    assert r.status_code == 200
+    assert next(x for x in client.get("/threads").json() if x["id"] == t.id)["unseen"] is False
+
+
+def test_post_seen_unknown_thread_404(tmp_path):
+    client = TestClient(_app(tmp_path))
+    r = client.post("/threads/nope/seen", json={"seen_at": "2026-06-30T12:00:00+00:00"})
+    assert r.status_code == 404
+
+
+def test_post_seen_defaults_to_now_when_omitted(tmp_path):
+    from mship.core.message_store import MessageStore
+    from datetime import datetime, timezone, timedelta
+    store = MessageStore(tmp_path / ".mothership" / "messages")
+    base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    t = store.create_thread("s", "hi", base)
+    store.append(t.id, "agent", "fyi", base + timedelta(minutes=1))
+    client = TestClient(_app(tmp_path))
+    r = client.post(f"/threads/{t.id}/seen", json={})
+    assert r.status_code == 200
+    assert next(x for x in client.get("/threads").json() if x["id"] == t.id)["unseen"] is False


### PR DESCRIPTION
## Summary

Agent messages that need the operator now surface on Ground Control's **Home** — fixing an inverted-polarity bug where Home's "Needs you" feed surfaced threads the *operator* had already replied to, and an agent's reply *dropped* a thread off Home.

Two tiers, both driven by an agent-set signal:
- **Needs-you → Home action card.** An agent marks a reply with `mship reply --needs-you`; it surfaces as an action card and clears when the operator **replies** (reading isn't acting).
- **Plain note → quiet "new message" line.** Any unread agent note shows a soft line below the action cards and clears when the operator **opens** the thread (a server-side, monotonic seen cursor).

Spec: `ground-control-home-surfaces-agent`. Built mothership-first (the substrate) then ground-control (the surface), each task TDD'd and spec+quality reviewed, plus a final cross-repo contract review.

## What's in it

**mothership (the substrate)**
- `Message.kind: "note" | "needs_you"` (default `note`; legacy on-disk JSON reads back as `note`).
- `Thread.seen_at` operator read cursor + `MessageStore.mark_seen` (monotonic — never regresses; doesn't bump `updated_at`, so reading never reorders the thread list).
- `Thread.needs_you` / `Thread.unseen` as `@computed_field`s (the existing `awaiting_reply` pattern — one shared projection, serialized into both `GET /threads` summaries and `GET /threads/{id}`). `needs_you` = an unanswered `needs_you` newer than the last human message (survives a follow-up plain note); `unseen` = latest agent message newer than `seen_at`.
- `POST /threads/{id}/seen` (monotonic; `seen_at` defaults to now; 422 on malformed, 404 on unknown).
- `mship reply --needs-you` — the only way `needs_you` is set (a human phone message is never "needs you", so serve `POST /messages` was intentionally left as `note`-only).
- `awaiting_reply` (the agent's `inbox`/`inbox wait`/Stop-hook predicate) is unchanged — `needs_you`/`unseen` are purely additive.

**ground-control (the surface)**
- `ThreadSummary` parses `needsYou`/`unseen` (default `false` → degrades cleanly against an un-upgraded server).
- Home action cards now filter `needsYou` (was the inverted `awaitingReply`).
- A quiet "New messages" Home section for `unseen && !needsYou` (clean partition — a `needsYou` thread is an action card, never also a quiet note).
- `markThreadSeen` → `POST /threads/{id}/seen`, fired best-effort when a conversation opens (a failed mark never disturbs the conversation).

## Test plan

- [x] **TDD across 8 tasks** (4 mothership, 4 ground-control), each spec-compliance + code-quality reviewed before the next.
- [x] **mothership:** full `pytest` suite green (1824 passed); new coverage for `kind` round-trip + legacy default, `needs_you`/`unseen` projection (incl. needs_you-then-note and human-reply-clears), monotonic `mark_seen`, the seen endpoint (mark/clear/monotonic/404/422/default-now), and `reply --needs-you`.
- [x] **ground-control:** full JVM unit suite green (`./gradlew testDebugUnitTest --rerun-tasks`); new coverage for DTO parse/defaults, the `needsYou` Home filter, `notesFrom` (`unseen && !needsYou`), `markThreadSeen` request, and mark-seen-on-load.
- [x] **Final cross-repo review:** wire contract exact (`needs_you`/`unseen`/`seen_at` keys match server↔client), the equal-timestamp clear-cycle verified (note `created_at` == the `seen_at` the client sends → strict-`>` `unseen` clears), `awaiting_reply` untouched.
- [ ] **Operator capture** of a `--needs-you` card + a plain-note quiet line on Home, and the line clearing on open — to confirm on a device (no emulator in CI). Requires restarting `mship serve` to expose the new endpoint + summary fields.

## Notes / follow-ups

- **Messages nav tab + unread badge** (the "dot on the Messages tab" half of the design) is a deliberate fast-follow: there's no Messages tab today (the screen exists but isn't wired as one), so it needs a new `Section.MESSAGES` + an app-level unread count — its own slice.
- A new agent message arriving while a thread is open briefly shows `unseen` on Home until the operator revisits (mark-seen fires on open, not on every live poll). Intentional; a later "mark seen on focus/poll" tweak could remove the gap.
- `mship serve` is long-running — it must be restarted to expose `POST /seen` and the new summary fields (same operational note as the `?wait=1` long-poll).
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `ground-control-home-surfaces-agent`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/15 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/247 | this PR |

⚠ Merge in order: ground-control → mothership