### PR TITLE
WorkItem object model + phase state machine (MOS-196)

### DIFF
--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -139,6 +139,7 @@ from mship.cli import serve as _serve_mod
 from mship.cli import sync as _sync_mod
 from mship.cli import view as _view_mod
 from mship.cli import worktree as _worktree_mod
+from mship.cli import workitem as _workitem_mod
 
 def _should_silent_exit(argv: list[str]) -> bool:
     """True if argv is invoking an unknown `_`-prefixed internal command.
@@ -197,3 +198,4 @@ _serve_mod.register(app, get_container)
 _sync_mod.register(app, get_container)
 _view_mod.register(app, get_container)
 _worktree_mod.register(app, get_container)
+_workitem_mod.register(app, get_container)

--- a/src/mship/cli/workitem.py
+++ b/src/mship/cli/workitem.py
@@ -106,8 +106,9 @@ def register(parent: typer.Typer, get_container) -> None:
     @item_app.command("migrate")
     def migrate():
         from mship.core.workitem_migrate import wrap_existing
-        items, specs, state_manager, msgs, _ = _ctx()
-        created = wrap_existing(items, specs, state_manager, msgs, now=datetime.now(timezone.utc))
+        items, specs, state_manager, msgs, workspace = _ctx()
+        created = wrap_existing(items, specs, state_manager, msgs,
+                                now=datetime.now(timezone.utc), workspace=workspace)
         typer.echo(f"created {len(created)} work item(s)")
 
     def _guard(items: WorkItemStore, item_id: str) -> None:

--- a/src/mship/cli/workitem.py
+++ b/src/mship/cli/workitem.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import typer
+
+from mship.core.message_store import MessageStore
+from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+from mship.core.workitem import ExternalLink
+from mship.core.workitem_store import WorkItemStore
+from mship.core.view.workitem_index import build_workitem_index
+
+
+def register(parent: typer.Typer, get_container) -> None:
+    item_app = typer.Typer(help="First-class work items (the phase-aware cockpit spine).")
+    parent.add_typer(item_app, name="item")
+
+    def _ctx():
+        container = get_container()
+        state_dir = Path(container.state_dir())
+        workspace_root = Path(container.config_path()).parent
+        return (
+            WorkItemStore(state_dir / "workitems"),
+            SpecStore(workspace_root / SPECS_DIRNAME),
+            container.state_manager(),
+            MessageStore(state_dir / "messages"),
+            container.config().workspace,
+        )
+
+    @item_app.command("new")
+    def new(title: str, kind: str = typer.Option("feature", "--kind",
+            help="feature | bug | chore | question")):
+        items, _, _, _, workspace = _ctx()
+        wi = items.create(title=title, kind=kind, workspace=workspace,
+                          now=datetime.now(timezone.utc))
+        typer.echo(wi.id)
+
+    @item_app.command("list")
+    def list_items():
+        items, specs, state_manager, msgs, _ = _ctx()
+        summaries = build_workitem_index(
+            items.list(),
+            {s.id: s for s in specs.list()},
+            dict(state_manager.load().tasks),
+            {t.id: t for t in msgs.list()},
+        )
+        rows = [{"id": s.id, "title": s.title, "kind": s.kind, "phase": s.phase,
+                 "needs_approval": s.attention.needs_approval,
+                 "needs_decision": s.attention.needs_decision,
+                 "blocked": s.attention.blocked, "needs_review": s.attention.needs_review}
+                for s in summaries]
+        if sys.stdout.isatty():
+            for r in rows:
+                flags = "".join(k[0].upper() for k in
+                                ("needs_approval", "needs_decision", "blocked", "needs_review")
+                                if r[k])
+                typer.echo(f"{r['id']}  [{r['phase']}]  {r['title']}  {flags}")
+            if not rows:
+                typer.echo("(no work items)")
+        else:
+            typer.echo(json.dumps(rows))
+
+    @item_app.command("show")
+    def show(item_id: str):
+        items, _, _, _, _ = _ctx()
+        wi = items.get(item_id)
+        if wi is None:
+            typer.echo(f"no work item {item_id!r}", err=True)
+            raise typer.Exit(1)
+        typer.echo(wi.model_dump_json(indent=2))
+
+    @item_app.command("link-spec")
+    def link_spec(item_id: str, spec_id: str):
+        items, _, _, _, _ = _ctx()
+        _guard(items, item_id)
+        items.link_spec(item_id, spec_id, now=datetime.now(timezone.utc))
+        typer.echo(f"linked spec {spec_id} -> {item_id}")
+
+    @item_app.command("link-task")
+    def link_task(item_id: str, task_slug: str):
+        items, _, _, _, _ = _ctx()
+        _guard(items, item_id)
+        items.add_task(item_id, task_slug, now=datetime.now(timezone.utc))
+        typer.echo(f"linked task {task_slug} -> {item_id}")
+
+    @item_app.command("link-url")
+    def link_url(item_id: str, url: str,
+                 provider: str = typer.Option("url", "--provider"),
+                 title: str = typer.Option("", "--title")):
+        items, _, _, _, _ = _ctx()
+        _guard(items, item_id)
+        items.add_external_link(item_id, ExternalLink(provider=provider, url=url, title=title),
+                                now=datetime.now(timezone.utc))
+        typer.echo(f"linked {provider} url -> {item_id}")
+
+    @item_app.command("phase")
+    def phase(item_id: str, phase: str):
+        items, _, _, _, _ = _ctx()
+        _guard(items, item_id)
+        items.set_phase_override(item_id, phase, now=datetime.now(timezone.utc))
+        typer.echo(f"set phase_override={phase} on {item_id}")
+
+    @item_app.command("migrate")
+    def migrate():
+        from mship.core.workitem_migrate import wrap_existing
+        items, specs, state_manager, msgs, _ = _ctx()
+        created = wrap_existing(items, specs, state_manager, msgs, now=datetime.now(timezone.utc))
+        typer.echo(f"created {len(created)} work item(s)")
+
+    def _guard(items: WorkItemStore, item_id: str) -> None:
+        if items.get(item_id) is None:
+            typer.echo(f"no work item {item_id!r}", err=True)
+            raise typer.Exit(1)

--- a/src/mship/cli/workitem.py
+++ b/src/mship/cli/workitem.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 import json
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import get_args
 
 import typer
 
+from mship.cli.output import Output
 from mship.core.message_store import MessageStore
 from mship.core.spec_store import SPECS_DIRNAME, SpecStore
-from mship.core.workitem import ExternalLink
+from mship.core.workitem import ExternalLink, Kind, Phase
 from mship.core.workitem_store import WorkItemStore
 from mship.core.view.workitem_index import build_workitem_index
 
@@ -33,6 +34,10 @@ def register(parent: typer.Typer, get_container) -> None:
     @item_app.command("new")
     def new(title: str, kind: str = typer.Option("feature", "--kind",
             help="feature | bug | chore | question")):
+        valid_kinds = get_args(Kind)
+        if kind not in valid_kinds:
+            typer.echo(f"invalid kind: {kind!r} (choose from {', '.join(valid_kinds)})", err=True)
+            raise typer.Exit(1)
         items, _, _, _, workspace = _ctx()
         wi = items.create(title=title, kind=kind, workspace=workspace,
                           now=datetime.now(timezone.utc))
@@ -52,7 +57,10 @@ def register(parent: typer.Typer, get_container) -> None:
                  "needs_decision": s.attention.needs_decision,
                  "blocked": s.attention.blocked, "needs_review": s.attention.needs_review}
                 for s in summaries]
-        if sys.stdout.isatty():
+        output = Output()
+        if output.json_mode:
+            typer.echo(json.dumps(rows))
+        else:
             for r in rows:
                 flags = "".join(k[0].upper() for k in
                                 ("needs_approval", "needs_decision", "blocked", "needs_review")
@@ -60,8 +68,6 @@ def register(parent: typer.Typer, get_container) -> None:
                 typer.echo(f"{r['id']}  [{r['phase']}]  {r['title']}  {flags}")
             if not rows:
                 typer.echo("(no work items)")
-        else:
-            typer.echo(json.dumps(rows))
 
     @item_app.command("show")
     def show(item_id: str):
@@ -98,6 +104,10 @@ def register(parent: typer.Typer, get_container) -> None:
 
     @item_app.command("phase")
     def phase(item_id: str, phase: str):
+        valid_phases = get_args(Phase)
+        if phase not in valid_phases:
+            typer.echo(f"invalid phase: {phase!r} (choose from {', '.join(valid_phases)})", err=True)
+            raise typer.Exit(1)
         items, _, _, _, _ = _ctx()
         _guard(items, item_id)
         items.set_phase_override(item_id, phase, now=datetime.now(timezone.utc))

--- a/src/mship/cli/workitem.py
+++ b/src/mship/cli/workitem.py
@@ -10,7 +10,7 @@ import typer
 from mship.cli.output import Output
 from mship.core.message_store import MessageStore
 from mship.core.spec_store import SPECS_DIRNAME, SpecStore
-from mship.core.workitem import ExternalLink, Kind, Phase
+from mship.core.workitem import ExternalLink, Kind, Phase, Provider
 from mship.core.workitem_store import WorkItemStore
 from mship.core.view.workitem_index import build_workitem_index
 
@@ -96,6 +96,10 @@ def register(parent: typer.Typer, get_container) -> None:
     def link_url(item_id: str, url: str,
                  provider: str = typer.Option("url", "--provider"),
                  title: str = typer.Option("", "--title")):
+        valid_providers = get_args(Provider)
+        if provider not in valid_providers:
+            typer.echo(f"invalid provider: {provider!r} (choose from {', '.join(valid_providers)})", err=True)
+            raise typer.Exit(1)
         items, _, _, _, _ = _ctx()
         _guard(items, item_id)
         items.add_external_link(item_id, ExternalLink(provider=provider, url=url, title=title),

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -404,9 +404,19 @@ def create_app(
 
     @app.get("/items/{item_id}")
     def get_item(item_id: str):
-        for summary in _workitem_index():
-            if summary.id == item_id:
-                return jsonable_encoder(summary)
-        raise HTTPException(status_code=404, detail=f"no work item {item_id!r}")
+        wi = workitems.get(item_id)
+        if wi is None:
+            raise HTTPException(status_code=404, detail=f"no work item {item_id!r}")
+        # Summarize just this item via per-id child lookups (no full list() scans),
+        # mirroring the direct-get short-circuit of GET /threads/{id}, /specs/{id}.
+        spec = store.find_by_id(wi.spec_id) if wi.spec_id else None
+        tasks = state_manager.load().tasks
+        summary = build_workitem_index(
+            [wi],
+            {spec.id: spec} if spec else {},
+            {s: tasks[s] for s in wi.task_slugs if s in tasks},
+            {tid: t for tid in wi.thread_ids if (t := msgs.get(tid))},
+        )[0]
+        return jsonable_encoder(summary)
 
     return app

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -384,4 +384,29 @@ def create_app(
             raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
         return t.model_dump(mode="json")
 
+    # --- work items (phase-aware cockpit spine) ---
+    from mship.core.workitem_store import WorkItemStore
+    from mship.core.view.workitem_index import build_workitem_index
+
+    workitems = WorkItemStore(workspace_root / ".mothership" / "workitems")
+
+    def _workitem_index():
+        return build_workitem_index(
+            workitems.list(),
+            {s.id: s for s in store.list()},
+            dict(state_manager.load().tasks),
+            {t.id: t for t in msgs.list()},
+        )
+
+    @app.get("/items")
+    def list_items():
+        return jsonable_encoder(_workitem_index())
+
+    @app.get("/items/{item_id}")
+    def get_item(item_id: str):
+        for summary in _workitem_index():
+            if summary.id == item_id:
+                return jsonable_encoder(summary)
+        raise HTTPException(status_code=404, detail=f"no work item {item_id!r}")
+
     return app

--- a/src/mship/core/spec.py
+++ b/src/mship/core/spec.py
@@ -37,6 +37,7 @@ class Spec(BaseModel):
     risks: list[str] = []
     task_slug: str | None = None
     body: str = ""
+    work_item_id: str | None = None
 
     @property
     def dispatch_ready(self) -> bool:

--- a/src/mship/core/state.py
+++ b/src/mship/core/state.py
@@ -42,6 +42,7 @@ class Task(BaseModel):
     passive_repos: set[str] = set()
     spec_id: str | None = None
     depends_on: list[DependencyEdge] = []
+    work_item_id: str | None = None
 
 
 class WorkspaceState(BaseModel):

--- a/src/mship/core/view/workitem_index.py
+++ b/src/mship/core/view/workitem_index.py
@@ -1,6 +1,9 @@
 # src/mship/core/view/workitem_index.py
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from mship.core.message import Thread
 from mship.core.spec import Spec
 from mship.core.state import Task
 from mship.core.workitem import Phase, WorkItem
@@ -29,3 +32,25 @@ def compute_phase(item: WorkItem, spec: Spec | None, tasks: list[Task]) -> Phase
     if spec is not None:
         return _SPEC_PHASE.get(spec.status, "shaping")
     return "inbox"
+
+
+@dataclass(frozen=True)
+class Attention:
+    needs_approval: bool
+    needs_decision: bool
+    blocked: bool
+    needs_review: bool
+    blocked_tasks: int
+    total_tasks: int
+
+
+def compute_attention(spec: Spec | None, tasks: list[Task], threads: list[Thread]) -> Attention:
+    blocked_tasks = sum(1 for t in tasks if t.blocked_reason is not None)
+    return Attention(
+        needs_approval=spec is not None and spec.status == "needs_review",
+        needs_decision=any(t.needs_you for t in threads),
+        blocked=blocked_tasks > 0,
+        needs_review=any(bool(t.pr_urls) for t in tasks),
+        blocked_tasks=blocked_tasks,
+        total_tasks=len(tasks),
+    )

--- a/src/mship/core/view/workitem_index.py
+++ b/src/mship/core/view/workitem_index.py
@@ -1,12 +1,13 @@
 # src/mship/core/view/workitem_index.py
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime
 
 from mship.core.message import Thread
 from mship.core.spec import Spec
 from mship.core.state import Task
-from mship.core.workitem import Phase, WorkItem
+from mship.core.workitem import ExternalLink, Kind, Phase, WorkItem
 
 _SPEC_PHASE: dict[str, Phase] = {
     "captured": "inbox",
@@ -54,3 +55,53 @@ def compute_attention(spec: Spec | None, tasks: list[Task], threads: list[Thread
         blocked_tasks=blocked_tasks,
         total_tasks=len(tasks),
     )
+
+
+@dataclass(frozen=True)
+class WorkItemSummary:
+    id: str
+    title: str
+    kind: Kind
+    workspace: str
+    phase: str
+    attention: Attention
+    created_at: datetime
+    updated_at: datetime
+    spec_id: str | None
+    task_slugs: list[str] = field(default_factory=list)
+    thread_ids: list[str] = field(default_factory=list)
+    external_links: list[ExternalLink] = field(default_factory=list)
+
+
+def _summarize(
+    item: WorkItem,
+    specs_by_id: dict[str, Spec],
+    tasks_by_slug: dict[str, Task],
+    threads_by_id: dict[str, Thread],
+) -> WorkItemSummary:
+    spec = specs_by_id.get(item.spec_id) if item.spec_id else None
+    tasks = [tasks_by_slug[s] for s in item.task_slugs if s in tasks_by_slug]
+    threads = [threads_by_id[t] for t in item.thread_ids if t in threads_by_id]
+    return WorkItemSummary(
+        id=item.id, title=item.title, kind=item.kind, workspace=item.workspace,
+        phase=compute_phase(item, spec, tasks),
+        attention=compute_attention(spec, tasks, threads),
+        created_at=item.created_at, updated_at=item.updated_at,
+        spec_id=item.spec_id, task_slugs=list(item.task_slugs),
+        thread_ids=list(item.thread_ids), external_links=list(item.external_links),
+    )
+
+
+def build_workitem_index(
+    workitems: list[WorkItem],
+    specs_by_id: dict[str, Spec],
+    tasks_by_slug: dict[str, Task],
+    threads_by_id: dict[str, Thread],
+) -> list[WorkItemSummary]:
+    """Non-done items first (updated_at desc), then done (also desc). Shared by serve + CLI."""
+    summaries = [_summarize(w, specs_by_id, tasks_by_slug, threads_by_id) for w in workitems]
+    active = sorted([s for s in summaries if s.phase != "done"],
+                    key=lambda s: s.updated_at, reverse=True)
+    done = sorted([s for s in summaries if s.phase == "done"],
+                  key=lambda s: s.updated_at, reverse=True)
+    return active + done

--- a/src/mship/core/view/workitem_index.py
+++ b/src/mship/core/view/workitem_index.py
@@ -1,0 +1,31 @@
+# src/mship/core/view/workitem_index.py
+from __future__ import annotations
+
+from mship.core.spec import Spec
+from mship.core.state import Task
+from mship.core.workitem import Phase, WorkItem
+
+_SPEC_PHASE: dict[str, Phase] = {
+    "captured": "inbox",
+    "drafting": "shaping",
+    "needs_review": "shaping",
+    "needs_clarification": "shaping",
+    "approved": "ready",
+    "dispatched": "in_flight",
+    "implemented": "done",
+    "archived": "done",
+}
+
+
+def compute_phase(item: WorkItem, spec: Spec | None, tasks: list[Task]) -> Phase:
+    if item.phase_override is not None:
+        return item.phase_override
+    if tasks:
+        if any(t.finished_at is None for t in tasks):
+            return "in_flight"
+        if any(t.pr_urls for t in tasks):
+            return "review"
+        return "done"
+    if spec is not None:
+        return _SPEC_PHASE.get(spec.status, "shaping")
+    return "inbox"

--- a/src/mship/core/view/workitem_index.py
+++ b/src/mship/core/view/workitem_index.py
@@ -1,4 +1,3 @@
-# src/mship/core/view/workitem_index.py
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/src/mship/core/workitem.py
+++ b/src/mship/core/workitem.py
@@ -7,12 +7,13 @@ from pydantic import BaseModel
 
 Kind = Literal["feature", "bug", "chore", "question"]
 Phase = Literal["inbox", "shaping", "ready", "in_flight", "review", "done"]
+Provider = Literal["github", "linear", "notion", "jira", "url"]
 
 PHASE_ORDER: tuple[Phase, ...] = ("inbox", "shaping", "ready", "in_flight", "review", "done")
 
 
 class ExternalLink(BaseModel):
-    provider: Literal["github", "linear", "notion", "jira", "url"]
+    provider: Provider
     url: str
     title: str = ""
 

--- a/src/mship/core/workitem.py
+++ b/src/mship/core/workitem.py
@@ -1,0 +1,33 @@
+# src/mship/core/workitem.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+Kind = Literal["feature", "bug", "chore", "question"]
+Phase = Literal["inbox", "shaping", "ready", "in_flight", "review", "done"]
+
+PHASE_ORDER: tuple[Phase, ...] = ("inbox", "shaping", "ready", "in_flight", "review", "done")
+
+
+class ExternalLink(BaseModel):
+    provider: Literal["github", "linear", "notion", "jira", "url"]
+    url: str
+    title: str = ""
+
+
+class WorkItem(BaseModel):
+    id: str
+    title: str
+    workspace: str
+    kind: Kind
+    created_at: datetime
+    updated_at: datetime
+    spec_id: str | None = None
+    task_slugs: list[str] = []
+    thread_ids: list[str] = []
+    external_links: list[ExternalLink] = []
+    # Manual nudge: when set, overrides the phase derived from child state.
+    phase_override: Phase | None = None

--- a/src/mship/core/workitem.py
+++ b/src/mship/core/workitem.py
@@ -1,4 +1,3 @@
-# src/mship/core/workitem.py
 from __future__ import annotations
 
 from datetime import datetime

--- a/src/mship/core/workitem_migrate.py
+++ b/src/mship/core/workitem_migrate.py
@@ -49,8 +49,9 @@ def wrap_existing(items: WorkItemStore, specs: SpecStore, state: StateManager,
         state.mutate(_set)
 
     # 3) Threads -> attach to the item their spec/task already belongs to.
-    item_by_spec = {w.spec_id: w.id for w in items.list() if w.spec_id}
-    item_by_task = {slug: w.id for w in items.list() for slug in w.task_slugs}
+    all_items = items.list()
+    item_by_spec = {w.spec_id: w.id for w in all_items if w.spec_id}
+    item_by_task = {slug: w.id for w in all_items for slug in w.task_slugs}
     for thread in msgs.list():
         target = (item_by_spec.get(thread.spec_id) if thread.spec_id else None) \
             or (item_by_task.get(thread.task_slug) if thread.task_slug else None)

--- a/src/mship/core/workitem_migrate.py
+++ b/src/mship/core/workitem_migrate.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from mship.core.message_store import MessageStore
+from mship.core.spec_store import SpecStore
+from mship.core.state import StateManager
+from mship.core.workitem_store import WorkItemStore
+
+
+def wrap_existing(items: WorkItemStore, specs: SpecStore, state: StateManager,
+                  msgs: MessageStore, now: datetime) -> list[str]:
+    """Idempotently wrap every spec/task lacking a work_item_id in a WorkItem.
+    Returns the ids of newly created items."""
+    created: list[str] = []
+    workspace = "mothership"
+
+    state_now = state.load()
+    task_by_slug = dict(state_now.tasks)
+
+    # 1) Specs -> feature items (carrying their linked task).
+    for spec in specs.list():
+        if spec.work_item_id:
+            continue
+        wi = items.create(title=spec.title, kind="feature", workspace=workspace, now=now)
+        created.append(wi.id)
+        items.link_spec(wi.id, spec.id, now=now)
+        spec.work_item_id = wi.id
+        specs.save(spec)
+        if spec.task_slug and spec.task_slug in task_by_slug:
+            items.add_task(wi.id, spec.task_slug, now=now)
+
+            def _set(s, _slug=spec.task_slug, _wid=wi.id):
+                if _slug in s.tasks:
+                    s.tasks[_slug].work_item_id = _wid
+            state.mutate(_set)
+
+    # 2) Orphan tasks (no spec, no work_item_id) -> chore items.
+    for slug, task in state.load().tasks.items():
+        if task.work_item_id or task.spec_id:
+            continue
+        wi = items.create(title=task.description or slug, kind="chore",
+                          workspace=workspace, now=now)
+        created.append(wi.id)
+        items.add_task(wi.id, slug, now=now)
+
+        def _set(s, _slug=slug, _wid=wi.id):
+            if _slug in s.tasks:
+                s.tasks[_slug].work_item_id = _wid
+        state.mutate(_set)
+
+    # 3) Threads -> attach to the item their spec/task already belongs to.
+    item_by_spec = {w.spec_id: w.id for w in items.list() if w.spec_id}
+    item_by_task = {slug: w.id for w in items.list() for slug in w.task_slugs}
+    for thread in msgs.list():
+        target = (item_by_spec.get(thread.spec_id) if thread.spec_id else None) \
+            or (item_by_task.get(thread.task_slug) if thread.task_slug else None)
+        if target:
+            items.add_thread(target, thread.id, now=now)
+
+    return created

--- a/src/mship/core/workitem_migrate.py
+++ b/src/mship/core/workitem_migrate.py
@@ -9,11 +9,10 @@ from mship.core.workitem_store import WorkItemStore
 
 
 def wrap_existing(items: WorkItemStore, specs: SpecStore, state: StateManager,
-                  msgs: MessageStore, now: datetime) -> list[str]:
+                  msgs: MessageStore, now: datetime, workspace: str) -> list[str]:
     """Idempotently wrap every spec/task lacking a work_item_id in a WorkItem.
     Returns the ids of newly created items."""
     created: list[str] = []
-    workspace = "mothership"
 
     state_now = state.load()
     task_by_slug = dict(state_now.tasks)

--- a/src/mship/core/workitem_store.py
+++ b/src/mship/core/workitem_store.py
@@ -69,15 +69,25 @@ class WorkItemStore:
         self.save(item)
 
     def add_task(self, item_id: str, task_slug: str, now: datetime | None = None) -> None:
-        item = self._mutate(item_id, now)
-        if task_slug not in item.task_slugs:
-            item.task_slugs.append(task_slug)
+        item = self.get(item_id)
+        if item is None:
+            raise KeyError(item_id)
+        if task_slug in item.task_slugs:
+            return
+        item.task_slugs.append(task_slug)
+        if now is not None:
+            item.updated_at = now
         self.save(item)
 
     def add_thread(self, item_id: str, thread_id: str, now: datetime | None = None) -> None:
-        item = self._mutate(item_id, now)
-        if thread_id not in item.thread_ids:
-            item.thread_ids.append(thread_id)
+        item = self.get(item_id)
+        if item is None:
+            raise KeyError(item_id)
+        if thread_id in item.thread_ids:
+            return
+        item.thread_ids.append(thread_id)
+        if now is not None:
+            item.updated_at = now
         self.save(item)
 
     def add_external_link(self, item_id: str, link: ExternalLink, now: datetime | None = None) -> None:

--- a/src/mship/core/workitem_store.py
+++ b/src/mship/core/workitem_store.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import tempfile
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+from mship.core.workitem import ExternalLink, Kind, Phase, WorkItem
+
+
+def _new_id(now: datetime) -> str:
+    return f"wi-{now:%Y%m%d%H%M%S}-{uuid.uuid4().hex[:8]}"
+
+
+class WorkItemStore:
+    """Filesystem registry for work items: one JSON file per item."""
+
+    def __init__(self, workitems_dir: Path) -> None:
+        self._dir = Path(workitems_dir)
+
+    def _path(self, item_id: str) -> Path:
+        if (not item_id or "/" in item_id or "\\" in item_id
+                or item_id in (".", "..") or item_id.startswith(".")):
+            raise ValueError(f"unsafe work item id: {item_id!r}")
+        return self._dir / f"{item_id}.json"
+
+    def save(self, item: WorkItem) -> Path:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        path = self._path(item.id)
+        fd, tmp = tempfile.mkstemp(dir=self._dir, suffix=".json.tmp")
+        try:
+            with open(fd, "w") as f:
+                f.write(item.model_dump_json(indent=2))
+            Path(tmp).replace(path)
+        except Exception:
+            Path(tmp).unlink(missing_ok=True)
+            raise
+        return path
+
+    def get(self, item_id: str) -> WorkItem | None:
+        path = self._path(item_id)
+        if not path.is_file():
+            return None
+        return WorkItem.model_validate_json(path.read_text())
+
+    def list(self) -> list[WorkItem]:
+        if not self._dir.is_dir():
+            return []
+        items = [WorkItem.model_validate_json(p.read_text()) for p in self._dir.glob("*.json")]
+        return sorted(items, key=lambda w: w.updated_at, reverse=True)
+
+    def create(self, title: str, kind: Kind, workspace: str, now: datetime) -> WorkItem:
+        item = WorkItem(id=_new_id(now), title=title, workspace=workspace, kind=kind,
+                        created_at=now, updated_at=now)
+        self.save(item)
+        return item
+
+    def _mutate(self, item_id: str, now: datetime | None) -> WorkItem:
+        item = self.get(item_id)
+        if item is None:
+            raise KeyError(item_id)
+        if now is not None:
+            item.updated_at = now
+        return item
+
+    def link_spec(self, item_id: str, spec_id: str, now: datetime | None = None) -> None:
+        item = self._mutate(item_id, now)
+        item.spec_id = spec_id
+        self.save(item)
+
+    def add_task(self, item_id: str, task_slug: str, now: datetime | None = None) -> None:
+        item = self._mutate(item_id, now)
+        if task_slug not in item.task_slugs:
+            item.task_slugs.append(task_slug)
+        self.save(item)
+
+    def add_thread(self, item_id: str, thread_id: str, now: datetime | None = None) -> None:
+        item = self._mutate(item_id, now)
+        if thread_id not in item.thread_ids:
+            item.thread_ids.append(thread_id)
+        self.save(item)
+
+    def add_external_link(self, item_id: str, link: ExternalLink, now: datetime | None = None) -> None:
+        item = self._mutate(item_id, now)
+        item.external_links.append(link)
+        self.save(item)
+
+    def set_phase_override(self, item_id: str, phase: Phase, now: datetime | None = None) -> None:
+        item = self._mutate(item_id, now)
+        item.phase_override = phase
+        self.save(item)

--- a/tests/cli/test_workitem.py
+++ b/tests/cli/test_workitem.py
@@ -30,3 +30,30 @@ def test_new_then_list_roundtrip(tmp_path):
         container.config_path.reset_override()
         container.state_dir.reset_override()
         container.config.reset()
+
+
+def test_new_with_invalid_kind_errors_cleanly(tmp_path):
+    _isolate(tmp_path)
+    try:
+        res = runner.invoke(app, ["item", "new", "Title", "--kind", "bogus"])
+        assert res.exit_code == 1
+        assert "invalid kind" in res.output
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+
+
+def test_phase_with_invalid_value_errors_cleanly(tmp_path):
+    _isolate(tmp_path)
+    try:
+        res = runner.invoke(app, ["item", "new", "Title", "--kind", "feature"])
+        assert res.exit_code == 0, res.output
+        item_id = res.output.strip()
+        res = runner.invoke(app, ["item", "phase", item_id, "bogus"])
+        assert res.exit_code == 1
+        assert "invalid phase" in res.output
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()

--- a/tests/cli/test_workitem.py
+++ b/tests/cli/test_workitem.py
@@ -57,3 +57,18 @@ def test_phase_with_invalid_value_errors_cleanly(tmp_path):
         container.config_path.reset_override()
         container.state_dir.reset_override()
         container.config.reset()
+
+
+def test_link_url_with_invalid_provider_errors_cleanly(tmp_path):
+    _isolate(tmp_path)
+    try:
+        res = runner.invoke(app, ["item", "new", "Title", "--kind", "feature"])
+        assert res.exit_code == 0, res.output
+        item_id = res.output.strip()
+        res = runner.invoke(app, ["item", "link-url", item_id, "https://x", "--provider", "slack"])
+        assert res.exit_code == 1
+        assert "invalid provider" in res.output
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()

--- a/tests/cli/test_workitem.py
+++ b/tests/cli/test_workitem.py
@@ -1,0 +1,32 @@
+import json
+
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+
+runner = CliRunner()
+
+
+def _isolate(tmp_path):
+    """Point the global container at a throwaway workspace."""
+    (tmp_path / "mothership.yaml").write_text("workspace: testws\nrepos: {}\n")
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(tmp_path / ".mothership")
+    container.config.reset()  # drop any singleton cached by another test
+
+
+def test_new_then_list_roundtrip(tmp_path):
+    _isolate(tmp_path)
+    try:
+        res = runner.invoke(app, ["item", "new", "Make capture conversational", "--kind", "feature"])
+        assert res.exit_code == 0, res.output
+        res = runner.invoke(app, ["--json", "item", "list"])
+        assert res.exit_code == 0, res.output
+        rows = json.loads(res.output)
+        assert len(rows) == 1
+        assert rows[0]["title"] == "Make capture conversational"
+        assert rows[0]["phase"] == "inbox"
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()

--- a/tests/core/test_serve_items.py
+++ b/tests/core/test_serve_items.py
@@ -1,0 +1,44 @@
+# tests/core/test_serve_items.py
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from mship.core.serve import create_app
+from mship.core.spec_store import SpecStore
+from mship.core.state import StateManager
+from mship.core.workitem_store import WorkItemStore
+
+
+def _now():
+    return datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+
+
+def _app(tmp_path):
+    specs_dir = tmp_path / "specs"
+    SpecStore(specs_dir)  # ensure dir resolvable
+    state_manager = StateManager(tmp_path / ".mothership")
+    app = create_app(specs_dir=specs_dir, state_manager=state_manager, log_manager=None,
+                     workspace_root=tmp_path, workspace_name="testws")
+    return TestClient(app)
+
+
+def test_list_items_empty(tmp_path):
+    client = _app(tmp_path)
+    assert client.get("/items").json() == []
+
+
+def test_list_and_get_item_with_derived_phase(tmp_path):
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="Captured idea", kind="question", workspace="testws", now=_now())
+    client = _app(tmp_path)
+
+    listed = client.get("/items").json()
+    assert len(listed) == 1
+    assert listed[0]["id"] == wi.id
+    assert listed[0]["phase"] == "inbox"
+    assert listed[0]["attention"]["blocked"] is False
+
+    got = client.get(f"/items/{wi.id}").json()
+    assert got["id"] == wi.id and got["phase"] == "inbox"
+
+    assert client.get("/items/nope").status_code == 404

--- a/tests/core/test_spec_workitem_field.py
+++ b/tests/core/test_spec_workitem_field.py
@@ -1,0 +1,13 @@
+from datetime import datetime, timezone
+
+from mship.core.spec import Spec
+
+
+def test_spec_work_item_id_defaults_none_and_legacy_loads():
+    # legacy JSON without the field still validates (back-compat)
+    legacy = ('{"id":"s","title":"t","status":"drafting",'
+              '"created_at":"2026-06-30T12:00:00+00:00","updated_at":"2026-06-30T12:00:00+00:00"}')
+    spec = Spec.model_validate_json(legacy)
+    assert spec.work_item_id is None
+    spec.work_item_id = "wi-1"
+    assert Spec.model_validate_json(spec.model_dump_json()).work_item_id == "wi-1"

--- a/tests/core/test_state_workitem_field.py
+++ b/tests/core/test_state_workitem_field.py
@@ -1,0 +1,11 @@
+from datetime import datetime, timezone
+
+from mship.core.state import Task
+
+
+def test_task_work_item_id_defaults_none_and_legacy_loads():
+    legacy = ('{"slug":"s1","description":"d","phase":"dev",'
+              '"created_at":"2026-06-30T12:00:00+00:00","affected_repos":["mothership"],'
+              '"branch":"b"}')
+    task = Task.model_validate_json(legacy)
+    assert task.work_item_id is None

--- a/tests/core/test_workitem.py
+++ b/tests/core/test_workitem.py
@@ -1,0 +1,30 @@
+# tests/core/test_workitem.py
+from datetime import datetime, timezone
+
+from mship.core.workitem import WorkItem, ExternalLink, PHASE_ORDER
+
+
+def _now():
+    return datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+
+
+def test_workitem_defaults_and_roundtrip():
+    wi = WorkItem(id="wi-1", title="Make capture conversational", workspace="mothership",
+                  kind="feature", created_at=_now(), updated_at=_now())
+    assert wi.spec_id is None
+    assert wi.task_slugs == [] and wi.thread_ids == [] and wi.external_links == []
+    assert wi.phase_override is None
+    restored = WorkItem.model_validate_json(wi.model_dump_json())
+    assert restored == wi
+
+
+def test_external_link_and_links_list():
+    link = ExternalLink(provider="github", url="https://github.com/atomikpanda/mothership/issues/249",
+                        title="MOS-196")
+    wi = WorkItem(id="wi-2", title="t", workspace="ws", kind="bug",
+                  created_at=_now(), updated_at=_now(), external_links=[link])
+    assert wi.external_links[0].provider == "github"
+
+
+def test_phase_order_is_the_pipeline():
+    assert PHASE_ORDER == ("inbox", "shaping", "ready", "in_flight", "review", "done")

--- a/tests/core/test_workitem_migrate.py
+++ b/tests/core/test_workitem_migrate.py
@@ -28,12 +28,13 @@ def test_spec_with_task_becomes_one_feature_item(tmp_path):
         slug="alpha", description="d", phase="dev", created_at=_now(),
         affected_repos=["mothership"], branch="b", spec_id="alpha")}))
 
-    wrap_existing(items, specs, state, msgs, now=_now())
+    wrap_existing(items, specs, state, msgs, now=_now(), workspace="testws")
 
     created = items.list()
     assert len(created) == 1
     wi = created[0]
     assert wi.kind == "feature" and wi.spec_id == "alpha" and wi.task_slugs == ["alpha"]
+    assert wi.workspace == "testws"
     assert specs.find_by_id("alpha").work_item_id == wi.id
     assert state.load().tasks["alpha"].work_item_id == wi.id
 
@@ -44,16 +45,51 @@ def test_orphan_task_becomes_chore_item(tmp_path):
         slug="bugfix", description="d", phase="dev", created_at=_now(),
         affected_repos=["mothership"], branch="b")}))
 
-    wrap_existing(items, specs, state, msgs, now=_now())
+    wrap_existing(items, specs, state, msgs, now=_now(), workspace="testws")
 
     wi = items.list()[0]
     assert wi.kind == "chore" and wi.task_slugs == ["bugfix"] and wi.spec_id is None
+    assert wi.workspace == "testws"
 
 
 def test_idempotent(tmp_path):
     specs, state, msgs, items = _setup(tmp_path)
     specs.save(Spec(id="alpha", title="Alpha", status="drafting",
                     created_at=_now(), updated_at=_now()))
-    wrap_existing(items, specs, state, msgs, now=_now())
-    wrap_existing(items, specs, state, msgs, now=_now())
+    wrap_existing(items, specs, state, msgs, now=_now(), workspace="testws")
+    wrap_existing(items, specs, state, msgs, now=_now(), workspace="testws")
     assert len(items.list()) == 1
+
+
+def test_thread_attaches_via_spec(tmp_path):
+    specs, state, msgs, items = _setup(tmp_path)
+    specs.save(Spec(id="alpha", title="Alpha", status="approved",
+                    created_at=_now(), updated_at=_now(), task_slug="alpha"))
+    state.save(WorkspaceState(tasks={"alpha": Task(
+        slug="alpha", description="d", phase="dev", created_at=_now(),
+        affected_repos=["mothership"], branch="b", spec_id="alpha")}))
+    thread = msgs.create_thread(subject="s", text="hi", now=_now())
+    msgs.link_spec(thread.id, "alpha", now=_now())
+
+    wrap_existing(items, specs, state, msgs, now=_now(), workspace="testws")
+
+    wi = items.list()[0]
+    assert thread.id in wi.thread_ids
+
+    # Re-running must not duplicate the thread id.
+    wrap_existing(items, specs, state, msgs, now=_now(), workspace="testws")
+    wi_again = items.list()[0]
+    assert wi_again.thread_ids.count(thread.id) == 1
+
+
+def test_thread_attaches_via_task_slug(tmp_path):
+    specs, state, msgs, items = _setup(tmp_path)
+    state.save(WorkspaceState(tasks={"bugfix": Task(
+        slug="bugfix", description="d", phase="dev", created_at=_now(),
+        affected_repos=["mothership"], branch="b")}))
+    thread = msgs.create_thread(subject="s", text="hi", now=_now(), task_slug="bugfix")
+
+    wrap_existing(items, specs, state, msgs, now=_now(), workspace="testws")
+
+    wi = items.list()[0]
+    assert thread.id in wi.thread_ids

--- a/tests/core/test_workitem_migrate.py
+++ b/tests/core/test_workitem_migrate.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timezone
+
+from mship.core.spec import Spec
+from mship.core.spec_store import SpecStore
+from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.message_store import MessageStore
+from mship.core.workitem_store import WorkItemStore
+from mship.core.workitem_migrate import wrap_existing
+
+
+def _now():
+    return datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+
+
+def _setup(tmp_path):
+    specs = SpecStore(tmp_path / "specs")
+    state = StateManager(tmp_path / ".mothership")
+    msgs = MessageStore(tmp_path / ".mothership" / "messages")
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    return specs, state, msgs, items
+
+
+def test_spec_with_task_becomes_one_feature_item(tmp_path):
+    specs, state, msgs, items = _setup(tmp_path)
+    specs.save(Spec(id="alpha", title="Alpha", status="approved",
+                    created_at=_now(), updated_at=_now(), task_slug="alpha"))
+    state.save(WorkspaceState(tasks={"alpha": Task(
+        slug="alpha", description="d", phase="dev", created_at=_now(),
+        affected_repos=["mothership"], branch="b", spec_id="alpha")}))
+
+    wrap_existing(items, specs, state, msgs, now=_now())
+
+    created = items.list()
+    assert len(created) == 1
+    wi = created[0]
+    assert wi.kind == "feature" and wi.spec_id == "alpha" and wi.task_slugs == ["alpha"]
+    assert specs.find_by_id("alpha").work_item_id == wi.id
+    assert state.load().tasks["alpha"].work_item_id == wi.id
+
+
+def test_orphan_task_becomes_chore_item(tmp_path):
+    specs, state, msgs, items = _setup(tmp_path)
+    state.save(WorkspaceState(tasks={"bugfix": Task(
+        slug="bugfix", description="d", phase="dev", created_at=_now(),
+        affected_repos=["mothership"], branch="b")}))
+
+    wrap_existing(items, specs, state, msgs, now=_now())
+
+    wi = items.list()[0]
+    assert wi.kind == "chore" and wi.task_slugs == ["bugfix"] and wi.spec_id is None
+
+
+def test_idempotent(tmp_path):
+    specs, state, msgs, items = _setup(tmp_path)
+    specs.save(Spec(id="alpha", title="Alpha", status="drafting",
+                    created_at=_now(), updated_at=_now()))
+    wrap_existing(items, specs, state, msgs, now=_now())
+    wrap_existing(items, specs, state, msgs, now=_now())
+    assert len(items.list()) == 1

--- a/tests/core/test_workitem_store.py
+++ b/tests/core/test_workitem_store.py
@@ -51,3 +51,25 @@ def test_link_missing_item_raises(tmp_path):
     store = WorkItemStore(tmp_path / "workitems")
     with pytest.raises(KeyError):
         store.link_spec("nope", "spec-1")
+
+
+def test_redundant_add_task_does_not_bump_updated_at(tmp_path):
+    store = WorkItemStore(tmp_path / "workitems")
+    wi = store.create(title="t", kind="feature", workspace="ws", now=_now())
+    store.add_task(wi.id, "task-a", now=_now())
+    later = datetime(2026, 6, 30, 13, 0, tzinfo=timezone.utc)
+    store.add_task(wi.id, "task-a", now=later)  # already present: no-op
+    got = store.get(wi.id)
+    assert got.task_slugs == ["task-a"]
+    assert got.updated_at == _now()
+
+
+def test_redundant_add_thread_does_not_bump_updated_at(tmp_path):
+    store = WorkItemStore(tmp_path / "workitems")
+    wi = store.create(title="t", kind="feature", workspace="ws", now=_now())
+    store.add_thread(wi.id, "thread-x", now=_now())
+    later = datetime(2026, 6, 30, 13, 0, tzinfo=timezone.utc)
+    store.add_thread(wi.id, "thread-x", now=later)  # already present: no-op
+    got = store.get(wi.id)
+    assert got.thread_ids == ["thread-x"]
+    assert got.updated_at == _now()

--- a/tests/core/test_workitem_store.py
+++ b/tests/core/test_workitem_store.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from mship.core.workitem_store import WorkItemStore
+
+
+def _now():
+    return datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+
+
+def test_create_get_roundtrip(tmp_path):
+    store = WorkItemStore(tmp_path / "workitems")
+    wi = store.create(title="Make capture conversational", kind="feature",
+                      workspace="mothership", now=_now())
+    assert wi.id
+    assert store.get(wi.id) == wi
+
+
+def test_list_sorted_by_updated_desc(tmp_path):
+    store = WorkItemStore(tmp_path / "workitems")
+    a = store.create(title="a", kind="bug", workspace="ws",
+                     now=datetime(2026, 6, 30, 10, 0, tzinfo=timezone.utc))
+    b = store.create(title="b", kind="bug", workspace="ws",
+                     now=datetime(2026, 6, 30, 11, 0, tzinfo=timezone.utc))
+    assert [w.id for w in store.list()] == [b.id, a.id]
+
+
+def test_unsafe_id_rejected(tmp_path):
+    store = WorkItemStore(tmp_path / "workitems")
+    with pytest.raises(ValueError):
+        store.get("../escape")
+
+
+def test_link_helpers(tmp_path):
+    store = WorkItemStore(tmp_path / "workitems")
+    wi = store.create(title="t", kind="feature", workspace="ws", now=_now())
+    store.link_spec(wi.id, "spec-1", now=_now())
+    store.add_task(wi.id, "task-a", now=_now())
+    store.add_task(wi.id, "task-a", now=_now())  # idempotent
+    store.add_thread(wi.id, "thread-x", now=_now())
+    store.set_phase_override(wi.id, "in_flight", now=_now())
+    got = store.get(wi.id)
+    assert got.spec_id == "spec-1"
+    assert got.task_slugs == ["task-a"]
+    assert got.thread_ids == ["thread-x"]
+    assert got.phase_override == "in_flight"
+
+
+def test_link_missing_item_raises(tmp_path):
+    store = WorkItemStore(tmp_path / "workitems")
+    with pytest.raises(KeyError):
+        store.link_spec("nope", "spec-1")

--- a/tests/core/view/test_workitem_index.py
+++ b/tests/core/view/test_workitem_index.py
@@ -4,7 +4,8 @@ from datetime import datetime, timezone
 from mship.core.workitem import WorkItem
 from mship.core.spec import Spec
 from mship.core.state import Task
-from mship.core.view.workitem_index import compute_phase
+from mship.core.message import Message, Thread
+from mship.core.view.workitem_index import Attention, compute_attention, compute_phase
 
 
 def _now():
@@ -60,3 +61,37 @@ def test_tasks_dominate_spec():
 def test_mixed_tasks_one_running_is_in_flight():
     assert compute_phase(_wi(), None,
                          [_task(finished=True, pr=True), _task(finished=False)]) == "in_flight"
+
+
+def _thread(*, needs_you=False):
+    msgs = []
+    if needs_you:
+        msgs = [Message(id="m1", thread_id="t1", role="agent", text="?", created_at=_now(),
+                        kind="needs_you")]
+    return Thread(id="t1", subject="s", created_at=_now(), updated_at=_now(), messages=msgs)
+
+
+def test_attention_clear_when_no_signals():
+    att = compute_attention(_spec("approved"), [_task()], [])
+    assert att == Attention(needs_approval=False, needs_decision=False, blocked=False,
+                            needs_review=False, blocked_tasks=0, total_tasks=1)
+
+
+def test_needs_approval_from_spec_needs_review():
+    att = compute_attention(_spec("needs_review"), [], [])
+    assert att.needs_approval is True
+
+
+def test_blocked_counts_across_parallel_tasks():
+    att = compute_attention(None, [_task(blocked=True), _task(), _task()], [])
+    assert att.blocked is True
+    assert att.blocked_tasks == 1 and att.total_tasks == 3
+
+
+def test_needs_review_when_a_task_has_a_pr():
+    assert compute_attention(None, [_task(pr=True)], []).needs_review is True
+
+
+def test_needs_decision_from_thread_needs_you():
+    assert compute_attention(None, [], [_thread(needs_you=True)]).needs_decision is True
+    assert compute_attention(None, [], [_thread(needs_you=False)]).needs_decision is False

--- a/tests/core/view/test_workitem_index.py
+++ b/tests/core/view/test_workitem_index.py
@@ -1,0 +1,62 @@
+# tests/core/view/test_workitem_index.py
+from datetime import datetime, timezone
+
+from mship.core.workitem import WorkItem
+from mship.core.spec import Spec
+from mship.core.state import Task
+from mship.core.view.workitem_index import compute_phase
+
+
+def _now():
+    return datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+
+
+def _wi(**kw):
+    base = dict(id="wi", title="t", workspace="ws", kind="feature",
+                created_at=_now(), updated_at=_now())
+    base.update(kw)
+    return WorkItem(**base)
+
+
+def _spec(status):
+    return Spec(id="s", title="t", status=status, created_at=_now(), updated_at=_now())
+
+
+def _task(*, finished=False, pr=False, blocked=False):
+    return Task(
+        slug="s1", description="d", phase="dev", created_at=_now(),
+        affected_repos=["mothership"], branch="b",
+        finished_at=_now() if finished else None,
+        pr_urls={"mothership": "http://pr"} if pr else {},
+        blocked_reason="waiting" if blocked else None,
+    )
+
+
+def test_phase_override_wins():
+    assert compute_phase(_wi(phase_override="done"), _spec("drafting"), [_task()]) == "done"
+
+
+def test_no_children_is_inbox():
+    assert compute_phase(_wi(), None, []) == "inbox"
+
+
+def test_spec_status_maps_to_phase():
+    assert compute_phase(_wi(), _spec("captured"), []) == "inbox"
+    assert compute_phase(_wi(), _spec("drafting"), []) == "shaping"
+    assert compute_phase(_wi(), _spec("needs_review"), []) == "shaping"
+    assert compute_phase(_wi(), _spec("approved"), []) == "ready"
+    assert compute_phase(_wi(), _spec("implemented"), []) == "done"
+    assert compute_phase(_wi(), _spec("archived"), []) == "done"
+
+
+def test_tasks_dominate_spec():
+    assert compute_phase(_wi(), _spec("approved"), [_task(finished=False)]) == "in_flight"
+    assert compute_phase(_wi(), _spec("approved"),
+                         [_task(finished=True, pr=True)]) == "review"
+    assert compute_phase(_wi(), _spec("approved"),
+                         [_task(finished=True, pr=False)]) == "done"
+
+
+def test_mixed_tasks_one_running_is_in_flight():
+    assert compute_phase(_wi(), None,
+                         [_task(finished=True, pr=True), _task(finished=False)]) == "in_flight"

--- a/tests/core/view/test_workitem_index.py
+++ b/tests/core/view/test_workitem_index.py
@@ -51,7 +51,9 @@ def test_spec_status_maps_to_phase():
     assert compute_phase(_wi(), _spec("captured"), []) == "inbox"
     assert compute_phase(_wi(), _spec("drafting"), []) == "shaping"
     assert compute_phase(_wi(), _spec("needs_review"), []) == "shaping"
+    assert compute_phase(_wi(), _spec("needs_clarification"), []) == "shaping"
     assert compute_phase(_wi(), _spec("approved"), []) == "ready"
+    assert compute_phase(_wi(), _spec("dispatched"), []) == "in_flight"
     assert compute_phase(_wi(), _spec("implemented"), []) == "done"
     assert compute_phase(_wi(), _spec("archived"), []) == "done"
 

--- a/tests/core/view/test_workitem_index.py
+++ b/tests/core/view/test_workitem_index.py
@@ -5,7 +5,13 @@ from mship.core.workitem import WorkItem
 from mship.core.spec import Spec
 from mship.core.state import Task
 from mship.core.message import Message, Thread
-from mship.core.view.workitem_index import Attention, compute_attention, compute_phase
+from mship.core.view.workitem_index import (
+    Attention,
+    WorkItemSummary,
+    build_workitem_index,
+    compute_attention,
+    compute_phase,
+)
 
 
 def _now():
@@ -95,3 +101,35 @@ def test_needs_review_when_a_task_has_a_pr():
 def test_needs_decision_from_thread_needs_you():
     assert compute_attention(None, [], [_thread(needs_you=True)]).needs_decision is True
     assert compute_attention(None, [], [_thread(needs_you=False)]).needs_decision is False
+
+
+def test_build_index_populates_phase_and_attention():
+    item = _wi(id="wi-1", spec_id="s", task_slugs=["s1"], thread_ids=["t1"])
+    summaries = build_workitem_index(
+        workitems=[item],
+        specs_by_id={"s": _spec("approved")},
+        tasks_by_slug={"s1": _task(blocked=True)},
+        threads_by_id={"t1": _thread(needs_you=True)},
+    )
+    assert len(summaries) == 1
+    s = summaries[0]
+    assert isinstance(s, WorkItemSummary)
+    assert s.id == "wi-1" and s.kind == "feature"
+    assert s.phase == "in_flight"
+    assert s.attention.blocked is True and s.attention.blocked_tasks == 1
+    assert s.attention.needs_decision is True
+
+
+def test_build_index_orders_active_before_done():
+    active = _wi(id="active", updated_at=datetime(2026, 6, 30, 9, 0, tzinfo=timezone.utc))
+    done = _wi(id="done", phase_override="done",
+               updated_at=datetime(2026, 6, 30, 13, 0, tzinfo=timezone.utc))
+    summaries = build_workitem_index([done, active], {}, {}, {})
+    assert [s.id for s in summaries] == ["active", "done"]
+
+
+def test_build_index_tolerates_missing_children():
+    item = _wi(id="wi-x", spec_id="ghost", task_slugs=["missing"], thread_ids=["gone"])
+    s = build_workitem_index([item], {}, {}, {})[0]
+    assert s.phase == "inbox"
+    assert s.attention.total_tasks == 0


### PR DESCRIPTION
## Summary

First-class **WorkItem** in mship core — the foundation (Linear **MOS-196**, Slice 1 of the *Work Items — phase-aware cockpit* program). A WorkItem is the container that owns 0–1 spec, 0–N parallel tasks, and 0–N threads, with a kind-gated lifecycle phase and a derived attention overlay.

- **`WorkItem` model** (`core/workitem.py`) — id/title/workspace/kind + spec/task/thread refs + external links + optional `phase_override`.
- **Derived, tested projections** (`core/view/workitem_index.py`): `compute_phase` (lifecycle derived from child state, override-aware), `compute_attention` (needs-approval / needs-decision / blocked / needs-review overlay + parallel-task counts, mapped onto existing signals — `spec.needs_review`, `thread.needs_you`, `task.blocked_reason`, `task.pr_urls`), and the shared **`build_workitem_index`** consumed by both serve and CLI.
- **`WorkItemStore`** (`core/workitem_store.py`) — JSON file-per-item under `.mothership/workitems/`, atomic writes, unsafe-id guard, idempotent + no-op-safe link helpers (mirrors `MessageStore`).
- **`work_item_id` back-pointer** added to `Spec` and `Task` (additive, back-compatible with existing on-disk data).
- **`wrap_existing` migration** (`core/workitem_migrate.py`) — idempotently wraps existing specs/tasks into WorkItems (spec → feature, orphan task → chore), workspace-parameterized, attaches threads.
- **`mship item` CLI** — `new / list / show / link-spec / link-task / link-url / phase / migrate`.
- **serve** — `GET /items` + `GET /items/{id}` via the shared projection.

Design note: phase is **derived** in the shared projection (with an optional stored `phase_override` for manual nudges), not an event-hook-advanced stored field — the same "derive, don't duplicate" approach the codebase already uses for `awaiting_reply` / `task_index`. Deferred to later slices: auto-inheritance of `work_item_id` on spec/task creation, write endpoints, done-on-merge precision, external-link two-way sync.

## Test plan

- [x] `mship test` green — **1860 passed**, 0 regressions
- [x] Unit coverage: model round-trip; both derivations (all `_SPEC_PHASE` mappings + parallel-task aggregation); store (round-trip, unsafe-id guard, idempotent + no-op-safe link helpers); `build_workitem_index` (ordering, missing-child tolerance); `work_item_id` back-compat; migration (spec→feature, orphan→chore, idempotency, thread-attach); CLI round-trip + invalid-kind/phase errors; serve `/items` (list/get/404 + derived phase & attention)
- [x] Whole-feature review APPROVED (independent reviewer, end-to-end path traced), all findings fixed

Plan: `docs/plans/2026-06-30-workitem-object-model.md`

https://claude.ai/code/session_0186xi8KZg4yxDAMMWXZfgnJ
