### PR TITLE
Typed decision protocol (MOS-198)

### DIFF
--- a/src/mship/cli/message.py
+++ b/src/mship/cli/message.py
@@ -95,6 +95,33 @@ def register(parent: typer.Typer, get_container) -> None:
         typer.echo(f"replied to {thread_id}")
 
     @parent.command()
+    def ask(
+        thread_id: str,
+        question: str,
+        option: list[str] = typer.Option(..., "--option", help="A choice (repeat for each; >=2)."),
+        recommend: int = typer.Option(None, "--recommend", help="0-based index of the recommended option."),
+        no_free_text: bool = typer.Option(False, "--no-free-text", help="Disallow a free-text reply."),
+    ) -> None:
+        """Post an agent DECISION: a question + tappable options (surfaces as a decision card)."""
+        from mship.core.message import DecisionPayload
+        if len(option) < 2:
+            typer.echo("a decision needs at least two --option values", err=True)
+            raise typer.Exit(2)
+        if recommend is not None and not (0 <= recommend < len(option)):
+            typer.echo(f"--recommend {recommend} out of range for {len(option)} options", err=True)
+            raise typer.Exit(2)
+        store = _store()
+        try:
+            store.append(thread_id, "agent", question, datetime.now(timezone.utc),
+                         kind="decision",
+                         decision=DecisionPayload(options=option, recommended=recommend,
+                                                  allow_free_text=not no_free_text))
+        except KeyError:
+            typer.echo(f"no thread {thread_id!r}", err=True)
+            raise typer.Exit(1)
+        typer.echo(f"asked {thread_id}: {len(option)} options")
+
+    @parent.command()
     def messages(thread_id: str) -> None:
         """Print a thread's conversation in order."""
         store = _store()

--- a/src/mship/core/message.py
+++ b/src/mship/core/message.py
@@ -6,6 +6,12 @@ from typing import Literal
 from pydantic import BaseModel, computed_field
 
 
+class DecisionPayload(BaseModel):
+    options: list[str]
+    recommended: int | None = None
+    allow_free_text: bool = True
+
+
 class Message(BaseModel):
     id: str
     thread_id: str
@@ -13,8 +19,11 @@ class Message(BaseModel):
     text: str
     created_at: datetime
     # "needs_you" marks an agent message that needs the operator to act
-    # (surfaces as a Home action card in Ground Control). Default "note".
-    kind: Literal["note", "needs_you"] = "note"
+    # (surfaces as a Home action card in Ground Control).
+    # "decision" marks an agent message presenting a typed decision (see
+    # DecisionPayload / Thread.needs_decision). Default "note".
+    kind: Literal["note", "needs_you", "decision"] = "note"
+    decision: DecisionPayload | None = None
 
 
 class Thread(BaseModel):
@@ -45,6 +54,20 @@ class Thread(BaseModel):
                 last_human = i
         return any(
             m.role == "agent" and m.kind == "needs_you"
+            for m in self.messages[last_human + 1:]
+        )
+
+    @computed_field
+    @property
+    def needs_decision(self) -> bool:
+        """True iff an unanswered agent message with kind=decision exists after the
+        operator's last human message (mirrors needs_you)."""
+        last_human = -1
+        for i, m in enumerate(self.messages):
+            if m.role == "human":
+                last_human = i
+        return any(
+            m.role == "agent" and m.kind == "decision"
             for m in self.messages[last_human + 1:]
         )
 

--- a/src/mship/core/message.py
+++ b/src/mship/core/message.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, computed_field, model_validator
 
 
 class DecisionPayload(BaseModel):
@@ -24,6 +24,12 @@ class Message(BaseModel):
     # DecisionPayload / Thread.needs_decision). Default "note".
     kind: Literal["note", "needs_you", "decision"] = "note"
     decision: DecisionPayload | None = None
+
+    @model_validator(mode="after")
+    def decision_kind_requires_payload(self) -> "Message":
+        if self.kind == "decision" and self.decision is None:
+            raise ValueError("kind='decision' requires a decision payload")
+        return self
 
 
 class Thread(BaseModel):

--- a/src/mship/core/message_store.py
+++ b/src/mship/core/message_store.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
-from mship.core.message import Message, Thread
+from mship.core.message import DecisionPayload, Message, Thread
 
 
 def _new_id(now: datetime) -> str:
@@ -68,12 +68,13 @@ class MessageStore:
         self.save(thread)
 
     def append(self, thread_id: str, role: Literal["human", "agent"], text: str,
-               now: datetime, kind: Literal["note", "needs_you"] = "note") -> Message:
+               now: datetime, kind: Literal["note", "needs_you", "decision"] = "note",
+               decision: DecisionPayload | None = None) -> Message:
         thread = self.get(thread_id)
         if thread is None:
             raise KeyError(thread_id)
         msg = Message(id=_new_id(now), thread_id=thread_id, role=role, text=text,
-                      created_at=now, kind=kind)
+                      created_at=now, kind=kind, decision=decision)
         thread.messages.append(msg)
         thread.updated_at = now
         self.save(thread)

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -347,6 +347,7 @@ def create_app(
                 "updated_at": t.updated_at.isoformat(),
                 "awaiting_reply": t.awaiting_reply,
                 "needs_you": t.needs_you,
+                "needs_decision": t.needs_decision,
                 "unseen": t.unseen,
                 "last_message": (t.messages[-1].text[:120] if t.messages else ""),
                 "message_count": len(t.messages),

--- a/src/mship/core/view/workitem_index.py
+++ b/src/mship/core/view/workitem_index.py
@@ -48,7 +48,7 @@ def compute_attention(spec: Spec | None, tasks: list[Task], threads: list[Thread
     blocked_tasks = sum(1 for t in tasks if t.blocked_reason is not None)
     return Attention(
         needs_approval=spec is not None and spec.status == "needs_review",
-        needs_decision=any(t.needs_you for t in threads),
+        needs_decision=any(t.needs_you or t.needs_decision for t in threads),
         blocked=blocked_tasks > 0,
         needs_review=any(bool(t.pr_urls) for t in tasks),
         blocked_tasks=blocked_tasks,

--- a/tests/cli/test_message.py
+++ b/tests/cli/test_message.py
@@ -94,3 +94,56 @@ def test_reply_defaults_to_note(_configured):
     got = s.get(t.id)
     assert got.messages[-1].kind == "note"
     assert got.needs_you is False
+
+
+def test_ask_emits_decision(_configured):
+    s = _seed(_configured)
+    now = datetime(2026, 6, 23, tzinfo=timezone.utc)
+    t = s.create_thread(subject="x", text="q", now=now)
+    r = runner.invoke(app, ["ask", t.id, "How to store?",
+                            "--option", "File-per-thread", "--option", "SQLite",
+                            "--recommend", "0"])
+    assert r.exit_code == 0, r.output
+    got = s.get(t.id)
+    last = got.messages[-1]
+    assert last.role == "agent"
+    assert last.kind == "decision"
+    assert last.decision.options == ["File-per-thread", "SQLite"]
+    assert last.decision.recommended == 0
+    assert last.decision.allow_free_text is True
+    assert got.needs_decision is True
+
+
+def test_ask_requires_at_least_two_options(_configured):
+    s = _seed(_configured)
+    now = datetime(2026, 6, 23, tzinfo=timezone.utc)
+    t = s.create_thread(subject="x", text="q", now=now)
+    r = runner.invoke(app, ["ask", t.id, "How to store?", "--option", "only-one"])
+    assert r.exit_code != 0
+    assert s.get(t.id).messages[-1].kind != "decision"
+
+
+def test_ask_recommend_out_of_range_errors(_configured):
+    s = _seed(_configured)
+    now = datetime(2026, 6, 23, tzinfo=timezone.utc)
+    t = s.create_thread(subject="x", text="q", now=now)
+    r = runner.invoke(app, ["ask", t.id, "How to store?",
+                            "--option", "a", "--option", "b", "--recommend", "5"])
+    assert r.exit_code != 0
+    assert s.get(t.id).messages[-1].kind != "decision"
+
+
+def test_ask_no_free_text(_configured):
+    s = _seed(_configured)
+    now = datetime(2026, 6, 23, tzinfo=timezone.utc)
+    t = s.create_thread(subject="x", text="q", now=now)
+    r = runner.invoke(app, ["ask", t.id, "How to store?",
+                            "--option", "a", "--option", "b", "--no-free-text"])
+    assert r.exit_code == 0, r.output
+    got = s.get(t.id)
+    assert got.messages[-1].decision.allow_free_text is False
+
+
+def test_ask_unknown_thread_errors(_configured):
+    r = runner.invoke(app, ["ask", "nope", "q", "--option", "a", "--option", "b"])
+    assert r.exit_code != 0

--- a/tests/core/test_message_model.py
+++ b/tests/core/test_message_model.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
+from pydantic import ValidationError
+
 from mship.core.message import DecisionPayload, Message, Thread
 
 BASE = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
@@ -103,3 +106,15 @@ def test_needs_decision_false_after_human_reply():
                 messages=[_dm("agent", "decision", "pick", DecisionPayload(options=["a", "b"])),
                           _dm("human", "note", "a")])
     assert th.needs_decision is False
+
+
+def test_decision_kind_requires_decision_payload():
+    with pytest.raises(ValidationError):
+        _dm("agent", "decision", "pick", decision=None)
+
+
+def test_decision_kind_with_payload_still_constructs():
+    d = DecisionPayload(options=["a", "b"])
+    m = _dm("agent", "decision", "pick", decision=d)
+    assert m.kind == "decision"
+    assert m.decision is d

--- a/tests/core/test_message_model.py
+++ b/tests/core/test_message_model.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta, timezone
 
-from mship.core.message import Message, Thread
+from mship.core.message import DecisionPayload, Message, Thread
 
 BASE = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
 
@@ -70,3 +70,36 @@ def test_needs_you_and_unseen_are_serialized():
     dumped = t.model_dump()
     assert dumped["needs_you"] is True
     assert dumped["unseen"] is True
+
+
+# NOTE: `_dm` (not `_m`) is used below — the plan's snippet defines a helper
+# named `_m` with a different signature (role, kind, text, decision, t) that
+# would collide with and shadow the `_m(role, minute, *, kind)` helper used by
+# the tests above. Renamed to avoid breaking the existing suite.
+def _dm(role, kind="note", text="x", decision=None, t="2026-07-01T00:00:00+00:00"):
+    return Message(id=text, thread_id="th", role=role, text=text,
+                   created_at=datetime.fromisoformat(t), kind=kind, decision=decision)
+
+
+def test_decision_payload_roundtrips():
+    d = DecisionPayload(options=["File-per-thread", "SQLite"], recommended=0)
+    m = _dm("agent", "decision", "How to store?", decision=d)
+    back = Message.model_validate_json(m.model_dump_json())
+    assert back.kind == "decision"
+    assert back.decision.options == ["File-per-thread", "SQLite"]
+    assert back.decision.recommended == 0 and back.decision.allow_free_text is True
+
+
+def test_needs_decision_true_when_unanswered():
+    th = Thread(id="t", subject="s", created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+                messages=[_dm("agent", "decision", "pick", DecisionPayload(options=["a", "b"]))])
+    assert th.needs_decision is True
+
+
+def test_needs_decision_false_after_human_reply():
+    th = Thread(id="t", subject="s", created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+                messages=[_dm("agent", "decision", "pick", DecisionPayload(options=["a", "b"])),
+                          _dm("human", "note", "a")])
+    assert th.needs_decision is False

--- a/tests/core/test_message_store.py
+++ b/tests/core/test_message_store.py
@@ -139,3 +139,16 @@ def test_mark_seen_unknown_thread_raises(tmp_path):
     s = _store(tmp_path)
     with pytest.raises(KeyError):
         s.mark_seen("nope", datetime(2026, 6, 30, tzinfo=timezone.utc))
+
+
+def test_append_decision_roundtrips(tmp_path):
+    from mship.core.message import DecisionPayload
+    s = _store(tmp_path)
+    now = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    th = s.create_thread("s", "hi", now)
+    s.append(th.id, "agent", "How to store?", now, kind="decision",
+              decision=DecisionPayload(options=["a", "b"], recommended=1))
+    got = s.get(th.id)
+    assert got.messages[-1].kind == "decision"
+    assert got.messages[-1].decision.options == ["a", "b"]
+    assert got.needs_decision is True

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -451,6 +451,23 @@ def test_thread_summaries_expose_needs_you_and_unseen(tmp_path):
     assert summary["awaiting_reply"] is False
 
 
+def test_thread_summaries_expose_needs_decision(tmp_path):
+    from mship.core.message_store import MessageStore
+    from mship.core.message import DecisionPayload
+    from datetime import datetime, timezone, timedelta
+    store = MessageStore(tmp_path / ".mothership" / "messages")
+    base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    t = store.create_thread("s", "hi", base)
+    store.append(
+        t.id, "agent", "pick one", base + timedelta(minutes=1),
+        kind="decision", decision=DecisionPayload(options=["a", "b"]),
+    )
+
+    client = TestClient(_app(tmp_path))
+    summary = next(x for x in client.get("/threads").json() if x["id"] == t.id)
+    assert summary["needs_decision"] is True
+
+
 def test_post_seen_marks_thread_and_clears_unseen(tmp_path):
     from mship.core.message_store import MessageStore
     from datetime import datetime, timezone, timedelta

--- a/tests/core/view/test_workitem_index.py
+++ b/tests/core/view/test_workitem_index.py
@@ -105,6 +105,17 @@ def test_needs_decision_from_thread_needs_you():
     assert compute_attention(None, [], [_thread(needs_you=False)]).needs_decision is False
 
 
+def test_attention_needs_decision_from_a_real_decision():
+    from mship.core.message import DecisionPayload, Message, Thread
+    from datetime import datetime, timezone
+    now = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    th = Thread(id="t1", subject="s", created_at=now, updated_at=now,
+                messages=[Message(id="m", thread_id="t1", role="agent", text="?", created_at=now,
+                                  kind="decision", decision=DecisionPayload(options=["a", "b"]))])
+    att = compute_attention(None, [], [th])
+    assert att.needs_decision is True
+
+
 def test_build_index_populates_phase_and_attention():
     item = _wi(id="wi-1", spec_id="s", task_slugs=["s1"], thread_ids=["t1"])
     summaries = build_workitem_index(


### PR DESCRIPTION
## Summary

The typed **decision protocol** (Linear **MOS-198**, the "band-aid payoff" of the *Work Items — phase-aware cockpit* program): an agent emits a question + tappable options; the operator answers with one tap — replacing chat-at-a-fork. Spans mship (substrate) + ground-control (UI).

**mothership:**
- `Message.kind` gains `"decision"` + a nested `DecisionPayload` (`options` / `recommended` / `allow_free_text`).
- `Thread.needs_decision` computed field — an unanswered `kind=decision` message since the last human reply (mirrors `needs_you`).
- `MessageStore.append` carries the payload; **`mship ask <thread> "<question>" --option A --option B [--recommend N] [--no-free-text]`** emits it (agent-side).
- serve thread summaries expose `needs_decision`.
- The WorkItem `Attention.needs_decision` rollup repointed from `any(needs_you)` → `any(needs_you or needs_decision)` — the farm "decide" badge (MOS-197) now reflects real decisions, no regression.

**ground-control:**
- `Message.decision` (nested DTO) + `ThreadSummary.needsDecision`.
- The conversation renders a **decision card**: question + one button per option (recommended accented); tapping posts a **normal human reply carrying the option's text — reusing the existing send path, no new endpoint**. An answered card disables its buttons ("Answered"); `allow_free_text=false` gates the compose bar to the active unanswered decision.
- Unanswered decisions surface on Home (deduped against `needs_you`) and fire/clear notifications.

**Agent-agnostic:** the answer is a plain human reply carrying the option's text — `mship inbox` reads it as-is, no SDK. The in-flight console that *hosts* this card is the paired follow-up (MOS-202).

## Test plan

- [x] `mship test` green — **both repos** (mothership 1872 passed; ground-control unit suite). New coverage: decision model + `needs_decision` derivation, `append` payload round-trip, `mship ask` + its validation branches, serve `needs_decision`, the attention repoint (old `needs_you` test preserved), GC decision DTOs, Home dedup (`needsDecision && !needsYou`), notification fire/clear.
- [x] `./gradlew -p android :app:assembleDebug` — BUILD SUCCESSFUL.
- [x] Whole-feature review APPROVED (independent reviewer, full `mship ask` → card → option-tap → reply round-trip traced across both repos); 2 review nits fixed (answered-card resolution, free-text gate on the active decision).
- [ ] Visual (operator): `mship ask` a decision on a live workspace, confirm the card renders and an option tap posts the reply. Deferred — no emulator in CI; needs a serve exposing the message.

Plan: `docs/plans/2026-07-01-decision-protocol.md`

https://claude.ai/code/session_0186xi8KZg4yxDAMMWXZfgnJ
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `decision-protocol`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/18 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/261 | this PR |

⚠ Merge in order: ground-control → mothership