### PR TITLE
spawn --base flag: base a new task on another branch for stacked PRs (#42)

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -256,6 +256,12 @@ def register(app: typer.Typer, get_container):
             None, "--depends-on",
             help="Comma-separated upstream task slugs this task depends on. See #104.",
         ),
+        base: Optional[str] = typer.Option(
+            None, "--base",
+            help="Cut the worktree from <branch> instead of the configured base "
+                 "(stacked PRs: base a task on another task's feat/* branch). "
+                 "`mship finish` then targets it as the PR base. See #42.",
+        ),
     ):
         """Create coordinated worktrees across repos for a new task."""
         import re as _re
@@ -433,12 +439,18 @@ def register(app: typer.Typer, get_container):
             now = datetime.now(timezone.utc)
             dep_edges = [DependencyEdge(upstream_slug=s, created_at=now) for s in requested]
 
-        result = wt_mgr.spawn(
-            description, repos=repo_list, skip_setup=skip_setup, slug=slug,
-            workspace_root=container.config_path().parent,
-            offline=offline,
-            depends_on=dep_edges,
-        )
+        from mship.core.worktree import BaseBranchNotFoundError
+        try:
+            result = wt_mgr.spawn(
+                description, repos=repo_list, skip_setup=skip_setup, slug=slug,
+                workspace_root=container.config_path().parent,
+                offline=offline,
+                depends_on=dep_edges,
+                base=base,
+            )
+        except BaseBranchNotFoundError as e:
+            output.error(str(e))
+            raise typer.Exit(code=1)
         task = result.task
 
         if pending_bypass:
@@ -575,6 +587,7 @@ def register(app: typer.Typer, get_container):
                 eff_base = resolve_base(
                     repo_name, config.repos[repo_name],
                     cli_base=None, base_map={}, known_repos=config.repos.keys(),
+                    task_base=task.base_override,
                 )
                 if eff_base is None:
                     eff_base = "main"  # fall back to main when no base_branch configured
@@ -709,6 +722,7 @@ def register(app: typer.Typer, get_container):
                 eff_base = resolve_base(
                     repo_name, config.repos[repo_name],
                     cli_base=None, base_map={}, known_repos=config.repos.keys(),
+                    task_base=task.base_override,
                 )
                 if eff_base is None:
                     eff_base = "main"
@@ -1135,6 +1149,7 @@ def register(app: typer.Typer, get_container):
                     cli_base=base,
                     base_map=parsed_map,
                     known_repos=config.repos.keys(),
+                    task_base=task.base_override,
                 )
                 for repo_name in ordered
             }

--- a/src/mship/core/base_resolver.py
+++ b/src/mship/core/base_resolver.py
@@ -43,10 +43,16 @@ def resolve_base(
     cli_base: str | None,
     base_map: dict[str, str],
     known_repos: Iterable[str],
+    task_base: str | None = None,
 ) -> str | None:
     """Return the effective base branch for a repo or None for gh default.
 
-    Precedence (most-specific wins): base_map entry > cli_base > repo_config.base_branch > None.
+    Precedence (most-specific wins):
+        base_map entry > cli_base > task_base > repo_config.base_branch > None.
+
+    `task_base` is the base pinned at spawn time via `--base` (Task.base_override,
+    #42); it is None for ordinary tasks, so it never overrides a repo's configured
+    base unless the operator explicitly stacked the task on another branch.
     Raises UnknownRepoInBaseMapError if base_map references a repo not in known_repos.
     """
     known = set(known_repos)
@@ -60,4 +66,6 @@ def resolve_base(
         return base_map[repo_name]
     if cli_base is not None:
         return cli_base
+    if task_base is not None:
+        return task_base
     return getattr(repo_config, "base_branch", None)

--- a/src/mship/core/state.py
+++ b/src/mship/core/state.py
@@ -41,9 +41,11 @@ class Task(BaseModel):
     base_branch: str | None = None
     # Non-default base pinned at spawn time via `--base` (stacked PRs, #42).
     # None for ordinary tasks; when set, `finish` targets it as the PR base and
-    # base-relative checks (close/context) compare against it. Kept distinct
-    # from `base_branch` (which is always populated with the workspace default)
-    # so a plain spawn never overrides a repo's configured base.
+    # base-relative checks (close/context) compare against it. Kept distinct from
+    # `base_branch` (which records the effective base — the stacked branch when
+    # `--base` is given, else the workspace default): resolve_base only consults
+    # base_override, so a plain spawn (None here) never overrides a repo's
+    # configured base.
     base_override: str | None = None
     passive_repos: set[str] = set()
     spec_id: str | None = None

--- a/src/mship/core/state.py
+++ b/src/mship/core/state.py
@@ -39,6 +39,12 @@ class Task(BaseModel):
     last_switched_at_sha: dict[str, dict[str, str]] = {}
     test_iteration: int = 0
     base_branch: str | None = None
+    # Non-default base pinned at spawn time via `--base` (stacked PRs, #42).
+    # None for ordinary tasks; when set, `finish` targets it as the PR base and
+    # base-relative checks (close/context) compare against it. Kept distinct
+    # from `base_branch` (which is always populated with the workspace default)
+    # so a plain spawn never overrides a repo's configured base.
+    base_override: str | None = None
     passive_repos: set[str] = set()
     spec_id: str | None = None
     depends_on: list[DependencyEdge] = []

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -15,6 +15,14 @@ from mship.util.shell import ShellRunner
 from mship.util.slug import slugify
 
 
+class BaseBranchNotFoundError(ValueError):
+    """`spawn --base <branch>` was given a branch that doesn't exist in a target repo.
+
+    A ValueError subclass so callers that already handle spawn ValueErrors keep
+    working; the CLI catches this type specifically to print a clean message.
+    """
+
+
 @dataclass
 class SpawnResult:
     task: Task
@@ -402,6 +410,7 @@ class WorktreeManager:
         workspace_root: Path | None = None,
         offline: bool = False,
         depends_on: list[DependencyEdge] | None = None,
+        base: str | None = None,
     ) -> SpawnResult:
         slug = slug if slug is not None else slugify(description)
         branch = self._config.branch_pattern.replace("{slug}", slug)
@@ -448,6 +457,33 @@ class WorktreeManager:
                 "workspace_root required for hub layout spawn; "
                 "callers must pass container.config_path().parent"
             )
+
+        # --- #42 `--base`: validate the requested base exists in every active
+        #     (non-passive) target repo BEFORE creating any worktree, so a
+        #     missing/typo'd branch fails fast with no partial state. Fetch first
+        #     so an origin-only base (the common stacked-PR case) is recognized.
+        if base is not None:
+            missing_base: list[str] = []
+            for repo_name in all_repos:
+                if repo_name in passive:
+                    continue
+                repo_config = self._config.repos[repo_name]
+                if repo_config.git_root is not None:
+                    continue  # subdirectory child shares its parent's checkout + branch
+                repo_path = repo_config.path
+                if not offline and self._git.has_remote(repo_path):
+                    self._git.fetch_remote_ref(repo_path=repo_path, ref=base)
+                if not (
+                    self._git.ref_exists(repo_path, base)
+                    or self._git.ref_exists(repo_path, f"origin/{base}")
+                ):
+                    missing_base.append(repo_name)
+            if missing_base:
+                raise BaseBranchNotFoundError(
+                    f"--base {base!r}: branch not found locally or on origin in "
+                    f"repo(s): {', '.join(missing_base)}. Push the base branch first, "
+                    f"or check the name."
+                )
 
         hub = workspace_root / ".worktrees" / slug
         hub.mkdir(parents=True, exist_ok=True)
@@ -520,16 +556,23 @@ class WorktreeManager:
                 )
             else:
                 start_point = None
-                base = repo_config.base_branch or default_base or "main"
+                # `--base` (stacked PRs, #42) overrides the configured base per repo.
+                cut_base = base or repo_config.base_branch or default_base or "main"
                 if not offline and self._git.has_remote(repo_path):
-                    if self._git.fetch_remote_ref(repo_path=repo_path, ref=base):
-                        start_point = f"origin/{base}"            # cut from fetched tip
-                        self._git.fast_forward_if_clean(repo_path=repo_path, base=base)
+                    if self._git.fetch_remote_ref(repo_path=repo_path, ref=cut_base):
+                        start_point = f"origin/{cut_base}"        # cut from fetched tip
+                        self._git.fast_forward_if_clean(repo_path=repo_path, base=cut_base)
+                    elif base is not None and self._git.ref_exists(repo_path, cut_base):
+                        # explicit --base not on origin but present locally — cut from it
+                        start_point = cut_base
                     else:
                         setup_warnings.append(
-                            f"{repo_name}: could not fetch origin/{base}; "
-                            f"cutting worktree from local {base}"
+                            f"{repo_name}: could not fetch origin/{cut_base}; "
+                            f"cutting worktree from local {cut_base}"
                         )
+                elif base is not None and self._git.ref_exists(repo_path, cut_base):
+                    # offline / no remote, but the explicit --base exists locally
+                    start_point = cut_base
                 self._git.worktree_add(
                     repo_path=repo_path,
                     worktree_path=wt_path,
@@ -569,7 +612,8 @@ class WorktreeManager:
             affected_repos=ordered,
             worktrees=worktrees,
             branch=branch,
-            base_branch=default_base,
+            base_branch=base or default_base,
+            base_override=base,
             passive_repos=passive,
             depends_on=depends_on or [],
         )

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -554,25 +554,43 @@ class WorktreeManager:
                     worktree_path=wt_path,
                     ref=target_ref,
                 )
+            elif base is not None:
+                # --- explicit --base (stacked PRs, #42): deterministic cut from
+                #     the requested branch. Preflight already fetched + validated
+                #     it, so a flapping in-loop fetch is tolerated — we prefer the
+                #     remote-tracking tip that preflight materialised, then a local
+                #     branch, and NEVER fall back to HEAD (which would silently
+                #     defeat the stacked base).
+                start_point = None
+                if not offline and self._git.has_remote(repo_path):
+                    self._git.fetch_remote_ref(repo_path=repo_path, ref=base)  # refresh; may flap
+                if self._git.ref_exists(repo_path, f"origin/{base}"):
+                    start_point = f"origin/{base}"
+                elif self._git.ref_exists(repo_path, base):
+                    start_point = base
+                else:
+                    raise BaseBranchNotFoundError(
+                        f"--base {base!r}: branch for {repo_name} disappeared "
+                        f"between validation and worktree creation."
+                    )
+                self._git.worktree_add(
+                    repo_path=repo_path,
+                    worktree_path=wt_path,
+                    branch=branch,
+                    start_point=start_point,
+                )
             else:
                 start_point = None
-                # `--base` (stacked PRs, #42) overrides the configured base per repo.
-                cut_base = base or repo_config.base_branch or default_base or "main"
+                cut_base = repo_config.base_branch or default_base or "main"
                 if not offline and self._git.has_remote(repo_path):
                     if self._git.fetch_remote_ref(repo_path=repo_path, ref=cut_base):
                         start_point = f"origin/{cut_base}"        # cut from fetched tip
                         self._git.fast_forward_if_clean(repo_path=repo_path, base=cut_base)
-                    elif base is not None and self._git.ref_exists(repo_path, cut_base):
-                        # explicit --base not on origin but present locally — cut from it
-                        start_point = cut_base
                     else:
                         setup_warnings.append(
                             f"{repo_name}: could not fetch origin/{cut_base}; "
                             f"cutting worktree from local {cut_base}"
                         )
-                elif base is not None and self._git.ref_exists(repo_path, cut_base):
-                    # offline / no remote, but the explicit --base exists locally
-                    start_point = cut_base
                 self._git.worktree_add(
                     repo_path=repo_path,
                     worktree_path=wt_path,

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -182,7 +182,7 @@ mship doctor                          # always run after init
 ### Working on a task
 
 ```bash
-mship spawn "description" [--repos a,b] [--skip-setup]
+mship spawn "description" [--repos a,b] [--skip-setup] [--base <branch>] [--depends-on a,b]
 mship switch <repo>                   # before starting work in a different repo
 mship phase plan|dev|review|run [-f]  # `-f` overrides blocked or finished-task guardrail
 mship block "reason" | mship unblock
@@ -223,7 +223,7 @@ If you don't, your edits in the shell affect the main checkout, not the feature 
 
 **Structured debugging entries.** `mship debug hypothesis|rule-out|resolved` records structured debugging entries into the task journal. `mship test` auto-attaches to the open hypothesis if one exists. See the `systematic-debugging` skill for the full workflow.
 
-**`finish`:** PR base resolves as `--base-map` entry > `--base` > `repo.base_branch` in config > gh default. Every base is verified on origin before any push; empty branches and missing bases fail fast with no partial state. `--require-tests` blocks (not just warns) when no passing test evidence exists for the task. `--title` overrides the PR title; `--body-map` sets per-repo bodies when repos need different PR descriptions. `--force`/`-f` re-pushes new commits to an already-finished task's existing PR (useful when iterating post-finish without opening a new task).
+**`finish`:** PR base resolves as `--base-map` entry > `--base` > the task's spawn-time `--base` (see stacked PRs below) > `repo.base_branch` in config > gh default. Every base is verified on origin before any push; empty branches and missing bases fail fast with no partial state. `--require-tests` blocks (not just warns) when no passing test evidence exists for the task. `--title` overrides the PR title; `--body-map` sets per-repo bodies when repos need different PR descriptions. `--force`/`-f` re-pushes new commits to an already-finished task's existing PR (useful when iterating post-finish without opening a new task).
 
 **`finish` PR body — write a real one.** By default the PR body is just the task description plus a `Closes #N` footer for any issue refs found in the description, journal, and commit subjects. That's a placeholder, not a body. For agent-driven finishes, pass `--body-file <path>` (or `--body '<inline>'`, or `--body -` for stdin) with a real Summary and Test plan. Empty bodies are rejected — that's deliberate. If you forgot at finish time, follow up immediately with `gh pr edit <url> --body-file <path>`. A bare task-description PR is treated as incomplete.
 
@@ -240,6 +240,23 @@ mship finish --bypass-deps                              # override the readiness
 mship close --cascade        # also remove downstream from state
 mship close --detach-downstream   # clear inbound edges, leave downstream alive
 ```
+
+### Stacked PRs (`spawn --base`)
+
+To stack a task on top of another open task's branch instead of `main`, pass
+`--base <branch>` at spawn:
+
+```bash
+mship spawn "follow-up fix" --base feat/auth-middleware-refactor --repos api
+```
+
+The worktree is cut from `<branch>` (verified to exist locally or on origin —
+fails fast otherwise, no partial state), and the base is recorded on the task so
+`mship finish` targets it as the PR base automatically (no need to repeat `--base`
+at finish). Base-relative checks (`close` recovery/ancestry, `context` commits-ahead)
+also compare against the stacked base. This differs from `--depends-on`, which
+records an ordering/readiness edge but still cuts from the configured base. Combine
+them when a task both stacks on and depends on the upstream. (#42)
 
 `mship status` exposes the graph under `.resolved_task.dependencies`:
 

--- a/src/mship/util/git.py
+++ b/src/mship/util/git.py
@@ -57,6 +57,19 @@ class GitRunner:
             text=True,
         )
 
+    def ref_exists(self, repo_path: Path, ref: str) -> bool:
+        """True if `ref` resolves to a commit in the repo.
+
+        Works for local branches (`feat/x`), remote-tracking refs
+        (`origin/feat/x`, only after a fetch), tags, and SHAs. Used by
+        `spawn --base` to validate the requested base before cutting worktrees.
+        """
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+            cwd=repo_path, capture_output=True, text=True,
+        )
+        return result.returncode == 0
+
     def fetch_remote_ref(self, repo_path: Path, ref: str, remote: str = "origin") -> bool:
         """Fetch a single ref from `remote`. Returns True on success, False on any failure.
 

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -89,6 +89,56 @@ def test_spawn_all_repos(configured_git_app: Path):
     assert set(task.affected_repos) == {"shared", "auth-service", "api-gateway"}
 
 
+def _commit_base_branch(repo: Path, branch: str) -> str:
+    """Create `branch` in `repo` with an extra commit; restore prior branch. Return tip sha."""
+    env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t.com",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t.com"}
+
+    def g(*a):
+        subprocess.run(["git", *a], cwd=repo, check=True, capture_output=True, text=True, env=env)
+
+    orig = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo,
+                          capture_output=True, text=True, check=True).stdout.strip()
+    g("checkout", "-b", branch)
+    (repo / "upstream.txt").write_text("base task work")
+    g("add", "upstream.txt")  # only our file — the fixture's Taskfile.yml is untracked
+    g("commit", "-m", "base")
+    tip = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,
+                         capture_output=True, text=True, check=True).stdout.strip()
+    g("checkout", orig)
+    return tip
+
+
+def test_spawn_base_stacks_on_branch(configured_git_app: Path):
+    """spawn --base <branch> cuts the worktree from that branch and records it. See #42."""
+    base_tip = _commit_base_branch(configured_git_app / "shared", "feat/upstream")
+    result = runner.invoke(
+        app,
+        ["spawn", "stacked task", "--repos", "shared", "--slug", "stacked",
+         "--base", "feat/upstream", "--skip-setup"],
+    )
+    assert result.exit_code == 0, result.output
+    state = StateManager(configured_git_app / ".mothership").load()
+    task = state.tasks["stacked"]
+    assert task.base_override == "feat/upstream"
+    wt = task.worktrees["shared"]
+    wt_tip = subprocess.run(["git", "rev-parse", "HEAD"], cwd=wt,
+                            capture_output=True, text=True, check=True).stdout.strip()
+    assert wt_tip == base_tip
+
+
+def test_spawn_base_unknown_branch_errors_cleanly(configured_git_app: Path):
+    """spawn --base <missing> fails with a clean message and creates no task. See #42."""
+    result = runner.invoke(
+        app,
+        ["spawn", "x", "--repos", "shared", "--slug", "xbase",
+         "--base", "feat/nope", "--skip-setup"],
+    )
+    assert result.exit_code != 0
+    assert "feat/nope" in result.output
+    assert "xbase" not in StateManager(configured_git_app / ".mothership").load().tasks
+
+
 def test_spawn_records_base_branch(configured_git_app: Path):
     """Spawn records base_branch from workspace config if available, else None."""
     result = runner.invoke(app, ["spawn", "record base", "--repos", "shared"])

--- a/tests/core/test_base_resolver.py
+++ b/tests/core/test_base_resolver.py
@@ -83,3 +83,40 @@ def test_resolve_rejects_unknown_repo_in_map():
     with pytest.raises(UnknownRepoInBaseMapError) as exc:
         resolve_base("cli", KNOWN["cli"], cli_base=None, base_map={"nope": "main"}, known_repos=KNOWN.keys())
     assert "nope" in str(exc.value)
+
+
+# --- resolve_base: task_base (spawn --base override, #42) ---
+
+def test_resolve_task_base_overrides_config():
+    # A base pinned at spawn time beats the repo's configured default.
+    result = resolve_base(
+        "cli", KNOWN["cli"], cli_base=None, base_map={},
+        known_repos=KNOWN.keys(), task_base="feat/upstream",
+    )
+    assert result == "feat/upstream"
+
+
+def test_resolve_cli_base_overrides_task_base():
+    # An explicit finish-time --base beats the spawn-time base.
+    result = resolve_base(
+        "cli", KNOWN["cli"], cli_base="develop", base_map={},
+        known_repos=KNOWN.keys(), task_base="feat/upstream",
+    )
+    assert result == "develop"
+
+
+def test_resolve_base_map_overrides_task_base():
+    result = resolve_base(
+        "cli", KNOWN["cli"], cli_base=None, base_map={"cli": "release/7"},
+        known_repos=KNOWN.keys(), task_base="feat/upstream",
+    )
+    assert result == "release/7"
+
+
+def test_resolve_task_base_none_falls_through_to_config():
+    # The common case: no override → unchanged behavior.
+    result = resolve_base(
+        "cli", KNOWN["cli"], cli_base=None, base_map={},
+        known_repos=KNOWN.keys(), task_base=None,
+    )
+    assert result == "main"

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -179,6 +179,34 @@ def test_spawn_base_missing_branch_raises_before_creating_state(worktree_deps):
     assert not (workspace / ".worktrees" / "bad-base").exists()
 
 
+def test_spawn_base_origin_only_survives_flapping_in_loop_fetch(worktree_deps, tmp_path):
+    """Origin-only stacked base must cut from origin/<base>, never silently HEAD,
+    even if the in-loop fetch fails after preflight materialised it. Regression, #42."""
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    shared = workspace / "shared"
+    head_before = _head(shared)
+
+    # Put feat/upstream ONLY on origin: create locally, push, materialise the
+    # remote-tracking ref, delete the local branch. Then break the remote so any
+    # further fetch fails — simulating a flap after preflight already fetched.
+    origin = tmp_path / "shared-origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    _git_run(shared, "remote", "add", "origin", str(origin))
+    base_tip = _make_base_branch(shared, "feat/upstream")   # local branch at base_tip
+    _git_run(shared, "push", "origin", "feat/upstream")
+    _git_run(shared, "fetch", "origin", "feat/upstream")     # materialise origin/feat/upstream
+    _git_run(shared, "branch", "-D", "feat/upstream")        # now origin-only
+    _git_run(shared, "remote", "set-url", "origin", str(tmp_path / "gone.git"))  # fetch will fail
+
+    assert base_tip != head_before  # the base really is ahead of HEAD
+
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("stacked task", repos=["shared"], workspace_root=workspace, base="feat/upstream")
+    wt = Path(state_mgr.load().tasks["stacked-task"].worktrees["shared"])
+    assert _head(wt) == base_tip        # cut from origin/feat/upstream, NOT HEAD
+    assert _head(wt) != head_before
+
+
 def test_abort_succeeds_even_if_branch_delete_fails(worktree_deps):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -120,6 +120,65 @@ def test_spawn_duplicate_slug_raises(worktree_deps):
         mgr.spawn("duplicate test", repos=["shared"], workspace_root=workspace)
 
 
+# ---------------------------------------------------------------------------
+# spawn --base: cut the new worktree from another branch (stacked PRs, #42)
+# ---------------------------------------------------------------------------
+
+_GENV = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t.com",
+         "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t.com"}
+
+
+def _git_run(repo: Path, *args):
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True, env=_GENV)
+
+
+def _head(repo: Path, ref="HEAD") -> str:
+    return subprocess.run(["git", "rev-parse", ref], cwd=repo,
+                          capture_output=True, text=True, check=True).stdout.strip()
+
+
+def _make_base_branch(repo: Path, branch: str) -> str:
+    """Create `branch` in `repo` with an extra commit; restore original branch. Return tip sha."""
+    orig = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo,
+                          capture_output=True, text=True, check=True).stdout.strip()
+    _git_run(repo, "checkout", "-b", branch)
+    (repo / "base.txt").write_text("from base task")
+    _git_run(repo, "add", "base.txt")  # only our file — the fixture's Taskfile.yml is untracked
+    _git_run(repo, "commit", "-m", "base task commit")
+    tip = _head(repo)
+    _git_run(repo, "checkout", orig)
+    return tip
+
+
+def test_spawn_base_cuts_worktree_from_given_branch(worktree_deps):
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    base_tip = _make_base_branch(workspace / "shared", "feat/upstream")
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("stacked task", repos=["shared"], workspace_root=workspace, base="feat/upstream")
+    task = state_mgr.load().tasks["stacked-task"]
+    wt = Path(task.worktrees["shared"])
+    assert _head(wt) == base_tip                     # cut from the base branch tip
+    assert task.base_branch == "feat/upstream"       # readouts compare against the stacked base
+    assert task.base_override == "feat/upstream"      # finish targets it
+
+
+def test_spawn_without_base_leaves_override_none(worktree_deps):
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("normal task", repos=["shared"], workspace_root=workspace)
+    assert state_mgr.load().tasks["normal-task"].base_override is None
+
+
+def test_spawn_base_missing_branch_raises_before_creating_state(worktree_deps):
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    with pytest.raises(ValueError, match="feat/nope"):
+        mgr.spawn("bad base", repos=["shared"], workspace_root=workspace, base="feat/nope")
+    # fail-fast: no task registered, no worktree hub left behind
+    assert "bad-base" not in state_mgr.load().tasks
+    assert not (workspace / ".worktrees" / "bad-base").exists()
+
+
 def test_abort_succeeds_even_if_branch_delete_fails(worktree_deps):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)

--- a/tests/test_finish_integration.py
+++ b/tests/test_finish_integration.py
@@ -265,6 +265,53 @@ def test_finish_passes_base_from_config(finish_workspace, tmp_path):
     assert "release/7" in create_calls[0]
 
 
+def test_finish_uses_spawn_base_override(finish_workspace):
+    """`spawn --base <branch>` flows into `gh pr create --base` without repeating it. See #42."""
+    import subprocess
+
+    workspace, mock_shell = finish_workspace
+
+    # A base branch must exist for spawn's preflight; create it at HEAD (no
+    # checkout, so the fixture's untracked Taskfile.yml is left in place).
+    subprocess.run(["git", "branch", "feat/upstream"], cwd=workspace / "shared",
+                   check=True, capture_output=True)
+
+    result = runner.invoke(
+        app, ["spawn", "stacked", "--repos", "shared", "--slug", "stacked",
+              "--base", "feat/upstream", "--skip-setup"],
+    )
+    assert result.exit_code == 0, result.output
+    # The chosen base is recorded on the task, not just used for the cut.
+    assert StateManager(workspace / ".mothership").load().tasks["stacked"].base_override == "feat/upstream"
+
+    call_log: list[str] = []
+
+    def mock_run(cmd, cwd, env=None):
+        call_log.append(cmd)
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "git ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc\trefs/heads/feat/upstream\n", stderr="")
+        if "git rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
+        if "git rev-list --count" in cmd:
+            return ShellResult(returncode=0, stdout="0\n", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://github.com/org/shared/pull/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell.run.side_effect = mock_run
+
+    # No --base at finish: the base must come from the task's spawn-time override.
+    result = runner.invoke(app, ["finish", "--task", "stacked"])
+    assert result.exit_code == 0, result.output
+
+    create_calls = [c for c in call_log if "gh pr create" in c]
+    assert len(create_calls) == 1
+    assert "--base" in create_calls[0]
+    assert "feat/upstream" in create_calls[0]
+
+
 def test_finish_fails_when_base_missing_on_remote(finish_workspace):
     import yaml
 

--- a/tests/util/test_git.py
+++ b/tests/util/test_git.py
@@ -221,3 +221,26 @@ def test_fast_forward_if_clean_skips_dirty_tree(tmp_path):
     git = GitRunner()
     assert git.fast_forward_if_clean(repo, "main") is False
     assert _rev(repo, "main") != origin_tip   # untouched
+
+
+# ---------------------------------------------------------------------------
+# ref_exists — used by `spawn --base` to validate the base branch (#42)
+# ---------------------------------------------------------------------------
+
+def test_ref_exists_true_for_existing_branch(git_repo: Path):
+    git = GitRunner()
+    _run(["git", "branch", "feat/base"], git_repo)
+    assert git.ref_exists(git_repo, "feat/base") is True
+
+
+def test_ref_exists_false_for_missing_branch(git_repo: Path):
+    git = GitRunner()
+    assert git.ref_exists(git_repo, "feat/nope") is False
+
+
+def test_ref_exists_true_for_remote_tracking_ref(tmp_path):
+    repo, _ = _repo_with_origin_ahead(tmp_path)
+    git = GitRunner()
+    # origin/main was fetched by the fixture
+    assert git.ref_exists(repo, "origin/main") is True
+    assert git.ref_exists(repo, "origin/does-not-exist") is False


### PR DESCRIPTION
## Summary

Adds `mship spawn --base <branch>` so a new task can be based on another task's
branch instead of the configured base — the missing spawn-side half of stacked-PR
support (the `mship finish --base` companion already existed). Closes #42.

Behavior:
- **Cut from the given branch.** Each active (non-passive) repo's worktree is cut
  from `<branch>` (prefers `origin/<branch>`, falls back to a local branch) instead
  of `repo.base_branch`/workspace default.
- **Recorded on the task.** The chosen base is stored as `Task.base_override`, so
  `mship finish` targets it as the PR base automatically — no need to repeat
  `--base` at finish. Base-relative checks in `close` (recovery + base-ancestry)
  and `context` (commits-ahead) also compare against the stacked base.
- **Fail-fast validation.** The base is verified to exist (locally or on origin) in
  every target repo *before* any worktree is created, so a typo'd/missing branch
  errors cleanly with no partial state.

### Design note

`Task.base_override` is deliberately separate from `Task.base_branch`.
`base_branch` is always populated (workspace default), so making `finish` prefer it
would regress any repo that configures a custom `base_branch`. `base_override` is
`None` for ordinary tasks, so the new precedence level only bites when the operator
explicitly stacked the task:

```
finish --base-map > finish --base > spawn --base (task.base_override) > repo.base_branch > gh default
```

This differs from `--depends-on` (#104), which records an ordering/readiness edge
but still cuts from the configured base; the two compose.

## Test plan

- `GitRunner.ref_exists` — existing/missing local branch, remote-tracking ref.
- `resolve_base` — full precedence with `task_base` (over config, under cli/base-map, None falls through).
- `worktree.spawn(base=...)` — cuts from the branch; records `base_branch` + `base_override`; missing branch raises before any state is written.
- CLI — `spawn --base` stacks and records; unknown branch fails cleanly with no task created.
- Integration — `spawn --base` → `finish` (no `--base`) passes `gh pr create --base <branch>`.
- Full suite: 1888 passed.


https://claude.ai/code/session_01WLb3xgnKi4fWy8M4reqhmu

Closes #42