### PR TITLE
Console steer: lazily create+link a thread so in-flight items can be steered (server /items/{id}/messages + GC Steer bar)

### DIFF
--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -420,4 +420,34 @@ def create_app(
         )[0]
         return jsonable_encoder(summary)
 
+    @app.post("/items/{item_id}/messages")
+    def post_item_message(item_id: str, body: NewMessageBody):
+        """Steer a work item: append a human message to its conversation thread,
+        lazily creating+linking a thread the first time. In-flight items created
+        from specs/tasks have no thread yet, so posting to POST /threads/{id} has
+        nothing to target — the phone would silently drop the message. Item id is
+        always present, so this is the send path the console uses. Returns the
+        thread, mirroring POST /threads/{thread_id}/messages."""
+        now = datetime.now(timezone.utc)
+        wi = workitems.get(item_id)
+        if wi is None:
+            raise HTTPException(status_code=404, detail=f"no work item {item_id!r}")
+        tid = wi.thread_ids[0] if wi.thread_ids else None
+        if tid is None:
+            subject = wi.title.strip() or (
+                body.text.strip().splitlines()[0][:80] if body.text.strip() else "(no subject)"
+            )
+            task_slug = wi.task_slugs[0] if wi.task_slugs else None
+            thread = msgs.create_thread(subject=subject, text=body.text, now=now, task_slug=task_slug)
+            workitems.add_thread(item_id, thread.id, now=now)
+            return thread.model_dump(mode="json")
+        try:
+            msgs.append(tid, "human", body.text, now)
+        except KeyError:
+            raise HTTPException(status_code=404, detail=f"no thread {tid!r}")
+        t = msgs.get(tid)
+        if t is None:
+            raise HTTPException(status_code=404, detail=f"no thread {tid!r}")
+        return t.model_dump(mode="json")
+
     return app

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import time as _time
 from pathlib import Path
 from typing import Optional
@@ -390,6 +391,11 @@ def create_app(
     from mship.core.view.workitem_index import build_workitem_index
 
     workitems = WorkItemStore(workspace_root / ".mothership" / "workitems")
+    # Serializes the lazy read-decide-create-link in POST /items/{id}/messages. Sync
+    # endpoints run in Starlette's threadpool, so two concurrent first-steers on a
+    # threadless item could otherwise both create a thread (orphaning one message) or
+    # lose the add_thread update. threading.Lock is the right primitive for that pool.
+    _item_msg_lock = threading.Lock()
 
     def _workitem_index():
         return build_workitem_index(
@@ -427,27 +433,30 @@ def create_app(
         from specs/tasks have no thread yet, so posting to POST /threads/{id} has
         nothing to target — the phone would silently drop the message. Item id is
         always present, so this is the send path the console uses. Returns the
-        thread, mirroring POST /threads/{thread_id}/messages."""
+        thread, mirroring POST /threads/{thread_id}/messages. The read-decide-create
+        section is serialized (_item_msg_lock) so concurrent first-steers can't each
+        create a thread and orphan a message."""
         now = datetime.now(timezone.utc)
-        wi = workitems.get(item_id)
-        if wi is None:
-            raise HTTPException(status_code=404, detail=f"no work item {item_id!r}")
-        tid = wi.thread_ids[0] if wi.thread_ids else None
-        if tid is None:
-            subject = wi.title.strip() or (
-                body.text.strip().splitlines()[0][:80] if body.text.strip() else "(no subject)"
-            )
-            task_slug = wi.task_slugs[0] if wi.task_slugs else None
-            thread = msgs.create_thread(subject=subject, text=body.text, now=now, task_slug=task_slug)
-            workitems.add_thread(item_id, thread.id, now=now)
-            return thread.model_dump(mode="json")
-        try:
-            msgs.append(tid, "human", body.text, now)
-        except KeyError:
-            raise HTTPException(status_code=404, detail=f"no thread {tid!r}")
-        t = msgs.get(tid)
-        if t is None:
-            raise HTTPException(status_code=404, detail=f"no thread {tid!r}")
-        return t.model_dump(mode="json")
+        with _item_msg_lock:
+            wi = workitems.get(item_id)
+            if wi is None:
+                raise HTTPException(status_code=404, detail=f"no work item {item_id!r}")
+            tid = wi.thread_ids[0] if wi.thread_ids else None
+            if tid is None:
+                subject = wi.title.strip() or (
+                    body.text.strip().splitlines()[0][:80] if body.text.strip() else "(no subject)"
+                )
+                task_slug = wi.task_slugs[0] if wi.task_slugs else None
+                thread = msgs.create_thread(subject=subject, text=body.text, now=now, task_slug=task_slug)
+                workitems.add_thread(item_id, thread.id, now=now)
+                return thread.model_dump(mode="json")
+            try:
+                msgs.append(tid, "human", body.text, now)
+            except KeyError:
+                raise HTTPException(status_code=404, detail=f"no thread {tid!r}")
+            t = msgs.get(tid)
+            if t is None:
+                raise HTTPException(status_code=404, detail=f"no thread {tid!r}")
+            return t.model_dump(mode="json")
 
     return app

--- a/tests/core/test_serve_items.py
+++ b/tests/core/test_serve_items.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 
 from fastapi.testclient import TestClient
 
+from mship.core.message_store import MessageStore
 from mship.core.serve import create_app
 from mship.core.spec_store import SpecStore
 from mship.core.state import StateManager
@@ -42,3 +43,43 @@ def test_list_and_get_item_with_derived_phase(tmp_path):
     assert got["id"] == wi.id and got["phase"] == "inbox"
 
     assert client.get("/items/nope").status_code == 404
+
+
+def test_post_item_message_creates_and_links_thread_when_none(tmp_path):
+    """An in-flight item created from a spec/task has no thread; steering it must
+    lazily create+link one (not silently no-op) so the message lands somewhere."""
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="Ship the parser", kind="feature", workspace="testws", now=_now())
+    assert wi.thread_ids == []
+    client = _app(tmp_path)
+
+    resp = client.post(f"/items/{wi.id}/messages", json={"text": "focus on the edge cases"})
+    assert resp.status_code == 200
+    thread = resp.json()
+    assert [m["text"] for m in thread["messages"]] == ["focus on the edge cases"]
+    assert thread["subject"] == "Ship the parser"
+
+    # The work item is now linked to the new thread, so the console can find it.
+    relinked = items.get(wi.id)
+    assert relinked.thread_ids == [thread["id"]]
+    assert client.get(f"/items/{wi.id}").json()["thread_ids"] == [thread["id"]]
+
+
+def test_post_item_message_appends_to_existing_thread(tmp_path):
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    msgs = MessageStore(tmp_path / ".mothership" / "messages")
+    wi = items.create(title="Ship the parser", kind="feature", workspace="testws", now=_now())
+    thread = msgs.create_thread(subject="Ship the parser", text="first", now=_now())
+    items.add_thread(wi.id, thread.id, now=_now())
+    client = _app(tmp_path)
+
+    resp = client.post(f"/items/{wi.id}/messages", json={"text": "second"})
+    assert resp.status_code == 200
+    assert [m["text"] for m in resp.json()["messages"]] == ["first", "second"]
+    # No duplicate thread was created.
+    assert items.get(wi.id).thread_ids == [thread.id]
+
+
+def test_post_item_message_404_for_unknown_item(tmp_path):
+    client = _app(tmp_path)
+    assert client.post("/items/nope/messages", json={"text": "hi"}).status_code == 404


### PR DESCRIPTION
## Summary

In-flight work items created from specs/tasks have **no linked thread** — nothing but `mship item migrate` ever attaches one, and only for threads that already carry a `spec_id`/`task_slug`. Ground Control's console "Steer" bar posted to `POST /threads/{id}/messages`, so with no thread it had nothing to target and the message was silently dropped.

This adds an **item-scoped** send: `POST /items/{item_id}/messages`.

- If the item has no thread, it lazily `create_thread` + `add_thread`-links one (subject = item title, seeded with the message, carrying the item's first task slug).
- If it already has a thread, it appends to the first one.
- Returns the thread, mirroring `POST /threads/{thread_id}/messages`. 404s on unknown item.

`item_id` is always present, so this send path can never no-op the way the thread-scoped one did.

## Test plan

- `uv run pytest tests/core/test_serve_items.py` — new cases: creates+links a thread when the item has none; appends to an existing thread without duplicating; 404 on unknown item.
- Full `uv run pytest` suite green on re-run. (One flaky TUI test, `test_scroll_position_preserved_across_refresh`, failed once under the full parallel run but passes in isolation and is unrelated to this diff.)

## Coordination

Merge this **before** the ground-control PR — the client calls this endpoint.

https://claude.ai/code/session_017cp5QTww6xaoXNNsopomeo
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `console-steer`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/23 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/267 | this PR |

⚠ Merge in order: ground-control → mothership