### PR TITLE
document new agent-facing CLI commands in skills (ask, item, build, messages, reply --needs-you)

### DIFF
--- a/src/mship/skills/receiving-messages/SKILL.md
+++ b/src/mship/skills/receiving-messages/SKILL.md
@@ -19,10 +19,38 @@ mechanisms surface them to a live agent (one serve + one agent per workspace):
    It blocks until a new *human* message arrives (or it times out), then returns
    JSON `{threads, cursor, timed_out}` and your harness re-invokes you.
 2. On wake with `threads`, answer each and clear it:
-   `mship reply <thread-id> "<your answer>"`.
+   `mship reply <thread-id> "<your answer>"`. If the pending line isn't enough
+   context, read the whole conversation first with `mship messages <thread-id>`.
 3. **Re-arm** with the returned cursor: `mship inbox wait --since <cursor> --timeout 50`.
    The `--since` cursor means you never re-wake for a message you already handled
    (or for your own reply).
 4. On `timed_out: true`, just re-arm again.
 
 Never spawn a new agent / `claude -p` — this is all in your existing session.
+
+## Answering: plain reply, needs-you, and decisions
+
+Every agent→operator message is a reply into an **existing** thread (the phone
+opens threads; you can't cold-start one). Pick the form by what you need back:
+
+- **Plain answer** (no action needed from the operator):
+  `mship reply <thread-id> "<answer>"`.
+- **Needs the operator to act** (do a thing, then it's done): add `--needs-you` —
+  `mship reply --needs-you <thread-id> "<what you need them to do>"`. This surfaces
+  as a **Home action card** in Ground Control instead of a plain chat reply. Use it
+  sparingly, for genuine hand-backs (e.g. "approve the deploy", "the base branch
+  needs pushing").
+- **Need a decision between options:** `mship ask` posts a tappable **decision card**:
+
+  ```bash
+  mship ask <thread-id> "Which auth approach?" \
+      --option "Session cookies" --option "JWT" \
+      --recommend 0            # 0-based index of your recommendation (optional)
+      # --no-free-text         # disallow a typed reply — force one of the options
+  ```
+
+  Needs ≥2 `--option`s. Prefer `ask` over a prose "A or B?" reply when the answer
+  is a choice — the operator taps once and you get a clean, unambiguous response.
+
+Read any thread's full history at any time with `mship messages <thread-id>`
+(`--json`-friendly when piped).

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -110,6 +110,27 @@ Review a spec without the CLI via `mship view spec [--web]`, or over HTTP via `m
 
 **The approval gate.** With `require_approved_spec: true` in `mothership.yaml`, `mship phase dev` is **hard-blocked** until a bound, approved spec exists — escape with `mship phase dev --bypass-spec-gate`. **This is opt-in: the default is OFF**, so by default `phase dev` only warns when no spec is found. Spec-first is the recommended methodology regardless of the gate.
 
+## Work items: the cross-artifact spine (`mship item`)
+
+A **work item** is the durable unit of intent that outlives any single spec, task, or thread. Where a `spec` is the design and a `task` is one worktree of execution, a work item groups everything about one piece of work — its spec, its task(s), the phone thread(s) discussing it, and external links (GitHub/Linear/Notion/Jira/url) — so it can drive a phase-aware cockpit (the Ground Control home). Use it when a piece of work spans more than one of those artifacts, or when you want a stable id to hang external tracker links off.
+
+A work item's **phase is derived** from the state of its linked children — `inbox → shaping → ready → in_flight → review → done` — with an optional manual override. `mship item list` surfaces attention flags per item: **A** needs-approval, **D** needs-decision, **B** blocked, **R** needs-review.
+
+```bash
+mship item new "<title>" [--kind feature|bug|chore|question]   # prints the new id (wi-<ts>-<hex>)
+mship item list                    # one line per item: `<id>  [phase]  <title>  <flags>`  (--json for agents)
+mship item show <id>               # full JSON: linked spec/tasks/threads/links + derived phase
+mship item link-spec <id> <spec-id>        # bind the design artifact
+mship item link-task <id> <task-slug>      # bind an execution worktree (repeatable)
+mship item link-url  <id> <url> [--provider github|linear|notion|jira|url] [--title T]
+mship item phase <id> <phase>      # manual override ("nudge") when the derived phase is wrong
+mship item migrate                 # backfill items from existing specs/tasks (one-time)
+```
+
+Typical flow: `item new` at intake → `link-spec` once a spec exists → `link-task` when you `spawn` → the phase advances as those children move, so the cockpit reshapes without manual bookkeeping. Reach for `item phase` only to correct a wrong derivation, not as the normal way to move work forward.
+
+**Raising the attention flags — escalating to the operator.** When you need the human (a decision, an approval, an action), don't just block silently — escalate on the relevant phone thread: `mship ask <thread> "<question>" --option A --option B` posts a tappable decision card, and `mship reply --needs-you <thread> "<ask>"` posts a Home action card. Both are replies into an operator-opened thread; see the `receiving-messages` skill for the full messaging loop.
+
 ## Delegating to subagents: `mship context` and `mship dispatch`
 
 Two mship-native primitives for handing work to subagents. Use them instead of hand-rolling task context:
@@ -187,6 +208,7 @@ mship switch <repo>                   # before starting work in a different repo
 mship phase plan|dev|review|run [-f]  # `-f` overrides blocked or finished-task guardrail
 mship block "reason" | mship unblock
 mship test [--all] [--repos|--tag] [--no-diff]
+mship build [--all] [--repos|--tag]   # runs `task build` across repos in dep order
 mship capture [--repo R] [--platform P] [--kind image|layout|all] [--out DIR]
 mship journal "msg" [--action X] [--open Y] [--repo R] [--test-state pass|fail|mixed]
 mship journal --show-open                 # what am I blocked on across this task?
@@ -218,6 +240,8 @@ If you don't, your edits in the shell affect the main checkout, not the feature 
 `mship journal` and `mship test` will warn when run from outside the active worktree.
 
 **`test` writes a numbered iteration file** under `.mothership/test-runs/<task>/`. The next run shows tags per repo (`new failure`, `fix`, `regression`, `still passing`, `still failing`). Auto-appends a structured log entry with `iteration`, `test_state`, `action="ran tests"`. Iterate until clean before transitioning to `review`.
+
+**`build` is the compile/artifact analog of `test`.** It runs each affected repo's `task build` in dependency order; `--all` continues past a failing repo (default stops at the first), and `--repos`/`--tag` scope it. Run it before `finish` when a repo has a build step CI will run, so you catch breakage locally rather than in review.
 
 **Always log structured.** `--action` makes session resume actually work. `--open` flags blockers you'll come back to. `--show-open` lists them. The `repo` field is auto-inferred from `mship switch`'s active repo.
 

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -119,7 +119,8 @@ A work item's **phase is derived** from the state of its linked children — `in
 ```bash
 mship item new "<title>" [--kind feature|bug|chore|question]   # prints the new id (wi-<ts>-<hex>)
 mship item list                    # one line per item: `<id>  [phase]  <title>  <flags>`  (--json for agents)
-mship item show <id>               # full JSON: linked spec/tasks/threads/links + derived phase
+mship item show <id>               # full JSON: linked spec/tasks/threads/links + phase_override
+                                   #   (use `mship item list --json` for the live derived phase)
 mship item link-spec <id> <spec-id>        # bind the design artifact
 mship item link-task <id> <task-slug>      # bind an execution worktree (repeatable)
 mship item link-url  <id> <url> [--provider github|linear|notion|jira|url] [--title T]


### PR DESCRIPTION
## Summary

Audited the full `mship` CLI surface against the bundled skills and documented the
agent-facing commands that were missing, so agents actually discover and use them.
Docs-only — no behavior change.

The gaps (0 skill mentions, agent-workflow-relevant): `ask`, `item`, `build`,
`messages`, and `reply --needs-you`. Setup/infra commands (`bootstrap`, `pair`,
`layout`, `relay`) were intentionally left out of the daily-workflow skills.

### `working-with-mothership`
- **`build`** — added to the task-workflow synopsis + a note framing it as the
  compile/artifact analog of `test` (dep-ordered `task build`; `--all`/`--repos`/`--tag`).
- **`mship item`** — new "Work items: the cross-artifact spine" section. Covers the
  derived phase (`inbox → shaping → ready → in_flight → review → done`), the
  attention flags (A/D/B/R), all subcommands (`new`/`list`/`show`/`link-spec`/
  `link-task`/`link-url`/`phase`/`migrate`), and the typical intake→link→derive flow.
- **Escalation pointer** — a note tying the work-item attention flags to `mship ask`
  (decision card) and `mship reply --needs-you` (Home action card), cross-linking
  `receiving-messages`.

### `receiving-messages`
- New "Answering: plain reply, needs-you, and decisions" section: `reply`,
  `reply --needs-you`, and `mship ask` (tappable decision card, `--option`/
  `--recommend`/`--no-free-text`), plus `mship messages <thread>` to read a thread's
  full history. Documents the real constraint that all three reply into an
  operator-opened thread (agents can't cold-start one).

## How I verified accuracy
- Enumerated every command/subcommand and each command's `--help`, and read the
  `item`/message CLI + `WorkItem` model source — so phases, kinds, providers, id
  format, and the thread-scoped reply constraint are documented from the code, not
  guessed.
- `test_skill_cli_consistency.py` (the guard that every `mship <cmd>`/`<group> <sub>`
  in a skill is a real command) passes with the new content, so no doc references a
  nonexistent command.

## Test plan
- Skill tests (consistency, install, refresh, namespace): 49 passed.
- Full suite: green.


https://claude.ai/code/session_01WLb3xgnKi4fWy8M4reqhmu
