### PR TITLE
WorkItem-mandatory + kind-gated approval enforcement

### DIFF
--- a/src/mship/cli/internal.py
+++ b/src/mship/cli/internal.py
@@ -152,6 +152,30 @@ def register(app: typer.Typer, get_container):
             raise typer.Exit(code=1)
 
         if matched_task is not None:
+            # WorkItem gate: every task must be linked to a WorkItem, and a
+            # feature-kind WorkItem additionally needs an approved spec
+            # (core/workitem_gate.py::check_task_gate). Placed as early as
+            # possible in the matched-task branch, before the reconcile gate,
+            # so a missing WorkItem fails fast. MSHIP_BYPASS_GATE already
+            # short-circuited (exit 0) at the very top of this command,
+            # before state was even loaded, so a bypassed commit never
+            # reaches this check. Fails OPEN on any unexpected error — never
+            # block a commit over a gate bug.
+            try:
+                from mship.core import workitem_gate
+                workspace_root = Path(container.config_path()).parent
+                gate_result = workitem_gate.check_task_gate(matched_task, workspace_root)
+            except Exception:
+                gate_result = None
+            if gate_result is not None and not gate_result.ok:
+                import sys
+                sys.stderr.write(
+                    f"⛔ mship: refusing commit — task '{matched_task.slug}': "
+                    f"{gate_result.reason}\n"
+                    f"   (or `git commit --no-verify` to override).\n"
+                )
+                raise typer.Exit(code=1)
+
             # Reconcile gate (per-task, unchanged behavior)
             try:
                 from mship.core.reconcile.cache import ReconcileCache
@@ -237,8 +261,12 @@ def register(app: typer.Typer, get_container):
     @app.command(name="_check-push", hidden=True)
     def check_push():
         """Reject pushing a branch-pattern branch that is not a registered task
-        branch. Reads git pre-push ref lines from stdin. Fail-open on error."""
+        branch, or a registered task branch whose task fails the WorkItem gate
+        (no WorkItem, or a feature WorkItem without an approved spec —
+        core/workitem_gate.py::check_task_gate). Reads git pre-push ref lines
+        from stdin. Fail-open on error."""
         import sys
+        from mship.core import workitem_gate
         from mship.core.gate import resolve_bypass, record_bypass
 
         try:
@@ -253,9 +281,12 @@ def register(app: typer.Typer, get_container):
             raise typer.Exit(code=0)
 
         prefix = config.branch_pattern.split("{slug}", 1)[0]  # e.g. "feat/"
-        task_branches = {t.branch for t in state.tasks.values()}
+        task_by_branch = {t.branch: t for t in state.tasks.values()}
+        workspace_root = Path(container.config_path()).parent
 
-        offending: list[str] = []
+        offending: list[str] = []           # unregistered branch-pattern branches
+        gate_blocked: list[tuple[str, str]] = []  # (branch, reason) — registered but no WorkItem clearance
+        gate_checked: set[str] = set()
         for line in sys.stdin.read().splitlines():
             parts = line.split()
             if len(parts) < 2:
@@ -266,35 +297,62 @@ def register(app: typer.Typer, get_container):
             if not local_ref.startswith("refs/heads/"):
                 continue
             branch = local_ref[len("refs/heads/"):]
-            if prefix and branch.startswith(prefix) and branch not in task_branches:
+            if prefix and branch.startswith(prefix) and branch not in task_by_branch:
                 if branch not in offending:
                     offending.append(branch)
+                continue
+            task = task_by_branch.get(branch)
+            if task is None or branch in gate_checked:
+                continue
+            gate_checked.add(branch)
+            try:
+                gate_result = workitem_gate.check_task_gate(task, workspace_root)
+            except Exception:
+                gate_result = None  # fail open on gate errors
+            if gate_result is not None and not gate_result.ok:
+                gate_blocked.append((branch, gate_result.reason))
 
-        if not offending:
+        if not offending and not gate_blocked:
             raise typer.Exit(code=0)
 
         bypassed, reason = resolve_bypass()
         if bypassed:
-            ws_root = Path(container.config_path()).parent
             for b in offending:
-                record_bypass(ws_root, op="push", branch=b, reason=reason)
+                record_bypass(workspace_root, op="push", branch=b, reason=reason)
+            for b, _msg in gate_blocked:
+                record_bypass(workspace_root, op="push", branch=b, reason=reason)
             raise typer.Exit(code=0)
 
-        sys.stderr.write(
-            "⛔ mship: refusing push — branch(es) not registered to a task: "
-            + ", ".join(offending) + "\n"
-            + "   Spawn a task (mship spawn) so the branch is tracked, or set "
-            + "MSHIP_BYPASS_GATE=1 (or `git push --no-verify`) to override.\n"
-        )
+        if offending:
+            sys.stderr.write(
+                "⛔ mship: refusing push — branch(es) not registered to a task: "
+                + ", ".join(offending) + "\n"
+                + "   Spawn a task (mship spawn) so the branch is tracked, or set "
+                + "MSHIP_BYPASS_GATE=1 (or `git push --no-verify`) to override.\n"
+            )
+        for branch, msg in gate_blocked:
+            sys.stderr.write(
+                f"⛔ mship: refusing push — branch '{branch}': {msg}\n"
+                f"   Set MSHIP_BYPASS_GATE=1 (or `git push --no-verify`) to override.\n"
+            )
         raise typer.Exit(code=1)
 
     @app.command(name="_guard-edit", hidden=True)
     def _guard_edit():
         """PreToolUse guard: refuse edits to a repo's MAIN checkout while a task
-        is active. Reads the Claude Code hook event JSON from stdin. Denies with
-        exit code 2 (stderr shown to the model); allows with exit 0. Fails OPEN
-        on any error — never block on uncertainty."""
+        is active, and refuse edits inside a task's OWN worktree when that task
+        fails the WorkItem gate (no WorkItem, or a feature WorkItem without an
+        approved spec — core/workitem_gate.py::check_task_gate). Reads the
+        Claude Code hook event JSON from stdin. Denies with exit code 2 (stderr
+        shown to the model); allows with exit 0. Fails OPEN on any error — never
+        block on uncertainty.
+
+        MSHIP_ALLOW_MAIN_EDIT=1 bypasses the main-checkout block entirely
+        (short-circuits below, unchanged). MSHIP_BYPASS_GATE is the hotfix
+        escape for the newer WorkItem gate only — it does not affect the
+        main-checkout block."""
         from mship.core.edit_guard import evaluate_edit
+        from mship.core.gate import resolve_bypass
 
         if os.environ.get("MSHIP_ALLOW_MAIN_EDIT") == "1":
             raise typer.Exit(code=0)
@@ -310,7 +368,13 @@ def register(app: typer.Typer, get_container):
                 raise typer.Exit(code=0)
             state = container.state_manager().load()
             config = container.config()
-            decision = evaluate_edit(target, state, config)
+            workspace_root = Path(container.config_path()).parent
+            bypassed, _reason = resolve_bypass()
+            decision = evaluate_edit(
+                target, state, config,
+                workspace_root=workspace_root,
+                bypass_workitem_gate=bypassed,
+            )
         except typer.Exit:
             raise
         except Exception:

--- a/src/mship/cli/phase.py
+++ b/src/mship/cli/phase.py
@@ -13,7 +13,7 @@ def register(app: typer.Typer, get_container):
         target: str,
         force: bool = typer.Option(False, "--force", "-f", help="Force transition even if task is blocked or finished"),
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),
-        bypass_spec_gate: bool = typer.Option(False, "--bypass-spec-gate", help="Skip the approved-spec requirement for plan→dev (requires require_approved_spec: true in mothership.yaml)."),
+        bypass_spec_gate: bool = typer.Option(False, "--bypass-spec-gate", help="Skip the plan→dev gate: the universal WorkItem requirement, the feature-kind approved-spec requirement, and (if require_approved_spec: true in mothership.yaml) the legacy task-scoped approved-spec check. Recorded to the bypass log (--hotfix equivalent)."),
     ):
         """Transition a task to a new phase."""
         container = get_container()

--- a/src/mship/cli/workitem.py
+++ b/src/mship/cli/workitem.py
@@ -87,9 +87,9 @@ def register(parent: typer.Typer, get_container) -> None:
 
     @item_app.command("link-task")
     def link_task(item_id: str, task_slug: str):
-        items, _, _, _, _ = _ctx()
+        items, _, state_manager, _, _ = _ctx()
         _guard(items, item_id)
-        items.add_task(item_id, task_slug, now=datetime.now(timezone.utc))
+        items.add_task(item_id, task_slug, now=datetime.now(timezone.utc), state=state_manager)
         typer.echo(f"linked task {task_slug} -> {item_id}")
 
     @item_app.command("link-url")

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -262,6 +262,16 @@ def register(app: typer.Typer, get_container):
                  "(stacked PRs: base a task on another task's feat/* branch). "
                  "`mship finish` then targets it as the PR base. See #42.",
         ),
+        work_item: Optional[str] = typer.Option(
+            None, "--work-item", "--item",
+            help="WorkItem id this task implements. Required unless --hotfix is "
+                 "passed. Create one with `mship item new`.",
+        ),
+        hotfix: bool = typer.Option(
+            False, "--hotfix",
+            help="Bypass the WorkItem requirement for this spawn. Recorded to "
+                 "the bypass log.",
+        ),
     ):
         """Create coordinated worktrees across repos for a new task."""
         import re as _re
@@ -283,6 +293,31 @@ def register(app: typer.Typer, get_container):
                 raise typer.Exit(code=1)
 
         _run_gate(get_container, command="spawn", bypass=bypass_reconcile, output=output)
+
+        # --- WorkItem gate: every task must be linked to a WorkItem, unless
+        #     --hotfix explicitly overrides it (logged to the bypass log).
+        #     See spec workitem-mandatory-kind-gated-approval.
+        from mship.core.workitem_gate import log_hotfix
+        from mship.core.workitem_store import WorkItemStore
+        from mship.util.slug import slugify as _slugify
+
+        workspace_root = container.config_path().parent
+        if work_item is None:
+            if hotfix:
+                effective_slug = slug if slug is not None else _slugify(description)
+                log_hotfix(workspace_root, "spawn", effective_slug)
+            else:
+                output.error(
+                    "mship spawn requires a WorkItem: create one with "
+                    "`mship item new` and pass --work-item <id> (or --hotfix)"
+                )
+                raise typer.Exit(code=1)
+        else:
+            items = WorkItemStore(workspace_root / ".mothership" / "workitems")
+            if items.get(work_item) is None:
+                output.error(f"WorkItem {work_item!r} not found")
+                raise typer.Exit(code=1)
+
         wt_mgr = container.worktree_manager()
         config = container.config()
         shell = container.shell()
@@ -447,6 +482,7 @@ def register(app: typer.Typer, get_container):
                 offline=offline,
                 depends_on=dep_edges,
                 base=base,
+                work_item_id=work_item,
             )
         except BaseBranchNotFoundError as e:
             output.error(str(e))

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -910,6 +910,12 @@ def register(app: typer.Typer, get_container):
             None, "--token", help="GitHub token for push + PR creation in "
             "credential-less environments (else GH_TOKEN / GITHUB_TOKEN).",
         ),
+        hotfix: bool = typer.Option(
+            False, "--hotfix",
+            help="Bypass the WorkItem gate for this finish (no WorkItem, or a "
+                 "feature WorkItem without an approved spec). Downgrades the "
+                 "block to a warning and records a bypass-log entry.",
+        ),
     ):
         """Create PRs across repos in dependency order."""
         from pathlib import Path
@@ -991,6 +997,25 @@ def register(app: typer.Typer, get_container):
         resolved_finish = resolve_for_command("finish", state, task, output)
         t = resolved_finish.task
         task = t
+
+        # --- WorkItem gate: every task must be linked to a WorkItem, and a
+        # feature-kind WorkItem additionally needs an approved spec
+        # (core/workitem_gate.py::check_task_gate). Placed as early as
+        # possible — right after resolving the task — so finish fails fast
+        # before any push/PR work. --hotfix downgrades the block to a
+        # warning and records a bypass-log entry, mirroring the spawn/
+        # phase-dev gates. See spec workitem-mandatory-kind-gated-approval.
+        from mship.core import workitem_gate
+        workspace_root = container.config_path().parent
+        gate_result = workitem_gate.check_task_gate(task, workspace_root)
+        if not gate_result.ok:
+            if hotfix:
+                output.warning(f"WorkItem gate bypassed (--hotfix): {gate_result.reason}")
+                workitem_gate.log_hotfix(workspace_root, "finish", task.slug)
+            else:
+                output.error(f"Cannot finish: {gate_result.reason}")
+                raise typer.Exit(code=1)
+
         graph = container.graph()
         config = container.config()
         ordered = graph.topo_sort(task.affected_repos)

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1005,9 +1005,21 @@ def register(app: typer.Typer, get_container):
         # before any push/PR work. --hotfix downgrades the block to a
         # warning and records a bypass-log entry, mirroring the spawn/
         # phase-dev gates. See spec workitem-mandatory-kind-gated-approval.
+        #
+        # check_task_gate reads the WorkItem store (and specs), so a corrupt
+        # store file must not throw an unhandled exception here — that would
+        # skip the --hotfix rescue entirely (the branch below never runs).
+        # Treat any read/parse failure as a failing gate result instead, so
+        # --hotfix can still override it, and the non-hotfix path still exits
+        # cleanly via output.error rather than a traceback.
         from mship.core import workitem_gate
         workspace_root = container.config_path().parent
-        gate_result = workitem_gate.check_task_gate(task, workspace_root)
+        try:
+            gate_result = workitem_gate.check_task_gate(task, workspace_root)
+        except Exception as e:
+            gate_result = workitem_gate.GateResult(
+                False, f"couldn't evaluate WorkItem gate (corrupt store?): {e}"
+            )
         if not gate_result.ok:
             if hotfix:
                 output.warning(f"WorkItem gate bypassed (--hotfix): {gate_result.reason}")

--- a/src/mship/core/edit_guard.py
+++ b/src/mship/core/edit_guard.py
@@ -1,10 +1,17 @@
 """Decide whether an edit may land at a given path while tasks are active.
 
-Pure — no I/O, no env, no git. The CLI adapter in cli/internal.py handles
-stdin/JSON/env/exit-code; this module only answers allow-or-block. Prevents the
-failure mode where an agent edits a repo's MAIN checkout (reachable via a
-symlink or absolute path) instead of the task worktree, silently landing work on
-the base branch. See spec guard-against-editing-a-repos-main.
+No env, no git — the CLI adapter in cli/internal.py handles stdin/JSON/env/
+exit-code; this module only answers allow-or-block. Prevents the failure mode
+where an agent edits a repo's MAIN checkout (reachable via a symlink or
+absolute path) instead of the task worktree, silently landing work on the base
+branch. See spec guard-against-editing-a-repos-main.
+
+Also enforces the WorkItem gate (core/workitem_gate.py::check_task_gate) for
+edits that DO land in the right worktree: every task must carry a WorkItem,
+and a feature-kind WorkItem needs an approved spec. This is opt-in via the
+`workspace_root` parameter (it does do filesystem I/O to load the WorkItem/spec
+stores) — omit it to keep the old, location-only behavior. See spec
+workitem-mandatory-kind-gated-approval.
 """
 from __future__ import annotations
 
@@ -29,11 +36,61 @@ def _within(child: Path, parent: Path) -> bool:
     return child == parent or parent in child.parents
 
 
-def evaluate_edit(target, state, config) -> GuardDecision:
+def _gate_worktree_edit(task, workspace_root, bypass_workitem_gate: bool) -> GuardDecision:
+    """An edit landing inside the task's OWN worktree is the legitimate
+    location, but the task must still carry a WorkItem (feature ⇒ approved
+    spec) — core/workitem_gate.py::check_task_gate. Skipped (allowed) when
+    `workspace_root` is unknown (callers that don't pass it opt out of this
+    check entirely) or when the caller has resolved a MSHIP_BYPASS_GATE
+    hotfix escape. Fails OPEN on any unexpected error — never block an edit
+    over a gate bug."""
+    if workspace_root is None or bypass_workitem_gate:
+        return GuardDecision(allowed=True)
+    try:
+        from mship.core.workitem_gate import check_task_gate
+        result = check_task_gate(task, workspace_root)
+    except Exception:
+        return GuardDecision(allowed=True)  # fail open
+    if result.ok:
+        return GuardDecision(allowed=True)
+    return GuardDecision(
+        allowed=False,
+        reason=(
+            f"Task '{task.slug}' is missing its WorkItem gate clearance: "
+            f"{result.reason}\n(set MSHIP_BYPASS_GATE=1 to override.)"
+        ),
+    )
+
+
+def evaluate_edit(
+    target, state, config,
+    workspace_root=None,
+    bypass_workitem_gate: bool = False,
+) -> GuardDecision:
     """Block an edit whose realpath is inside a repo's main checkout while that
     repo has an active task and the path is not inside that task's worktree.
-    Allows everything else (caller fails open on errors)."""
+    Allows everything else (caller fails open on errors).
+
+    `workspace_root`: when given, an edit that lands inside the owning task's
+    worktree is additionally passed through the WorkItem gate (see module
+    docstring); omit to keep the old, location-only behavior.
+    `bypass_workitem_gate`: the MSHIP_BYPASS_GATE hotfix escape for that gate
+    (resolved by the caller via core/gate.py::resolve_bypass) — does not affect
+    the main-checkout block above, which still requires MSHIP_ALLOW_MAIN_EDIT.
+    """
     rp = _real(Path(target))
+
+    # An edit that lands inside ANY active task's own worktree is the
+    # legitimate location (this is independent of — and checked before — the
+    # main-checkout matching below, since a task's worktree normally lives as
+    # a sibling of the repo's main checkout, not nested inside it, so it would
+    # never match the main-checkout loop at all). Still gated on the task
+    # carrying a WorkItem. See module docstring.
+    for task in state.tasks.values():
+        for wt in task.worktrees.values():
+            if _within(rp, _real(Path(wt))):
+                return _gate_worktree_edit(task, workspace_root, bypass_workitem_gate)
+
     # Among repos whose main checkout contains the target, the MOST-SPECIFIC one
     # (deepest path) owns the file — so a nested repo (e.g. `web` inside
     # `backend`'s tree) is judged by its OWN active-task state, not a parent
@@ -50,7 +107,9 @@ def evaluate_edit(target, state, config) -> GuardDecision:
         return GuardDecision(allowed=True)  # not inside any repo's main checkout
 
     # Collect every active task that owns a worktree for the owning repo. An edit
-    # inside ANY of those worktrees is legitimate, so allow it outright.
+    # inside ANY of those worktrees is legitimate — but the loop above already
+    # returned for that case, so anything reaching here is NOT inside any of
+    # them; these are candidates for the "edit here instead" suggestion below.
     candidates = []  # list[(slug, worktree_realpath)]
     for slug, task in state.tasks.items():
         if owner_name not in task.affected_repos:
@@ -58,10 +117,7 @@ def evaluate_edit(target, state, config) -> GuardDecision:
         wt = task.worktrees.get(owner_name)
         if wt is None:
             continue
-        wt_real = _real(Path(wt))
-        if _within(rp, wt_real):
-            return GuardDecision(allowed=True)
-        candidates.append((slug, wt_real))
+        candidates.append((slug, _real(Path(wt))))
     if not candidates:
         return GuardDecision(allowed=True)  # the owning repo has no active task
 

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -66,20 +66,39 @@ class PhaseManager:
                 f"the next task. Use --force to override."
             )
 
-        # Approved-spec gate: opt-in via require_approved_spec in mothership.yaml.
-        if (
-            task.phase == "plan"
-            and target == "dev"
-            and self._config is not None
-            and self._config.require_approved_spec
-            and not bypass_spec_gate
-            and not self._has_approved_spec(task_slug)
-        ):
-            raise SpecGateError(
-                f"Task '{task_slug}' has no bound approved spec. "
-                f"Create and approve one (`mship spec approve`) or pass "
-                f"--bypass-spec-gate to skip this check."
-            )
+        # WorkItem gate: universal — every task entering dev must be linked to
+        # a WorkItem, and a feature-kind WorkItem additionally needs an
+        # approved spec (core/workitem_gate.py::check_task_gate, authoritative
+        # for WorkItem-linked tasks). --bypass-spec-gate is the --hotfix
+        # equivalent for this gate: it skips both checks below and instead
+        # records a bypass-log entry. See spec
+        # workitem-mandatory-kind-gated-approval.
+        if task.phase == "plan" and target == "dev":
+            if bypass_spec_gate:
+                if self._workspace_root is not None:
+                    from mship.core.workitem_gate import log_hotfix
+                    log_hotfix(self._workspace_root, "phase-dev", task_slug)
+            else:
+                if self._workspace_root is not None:
+                    from mship.core.workitem_gate import check_task_gate
+                    gate_result = check_task_gate(task, self._workspace_root)
+                    if not gate_result.ok:
+                        raise SpecGateError(gate_result.reason)
+
+                # Approved-spec gate: opt-in via require_approved_spec in
+                # mothership.yaml. Older, task-slug-based and kind-agnostic —
+                # kept as a fallback alongside the WorkItem-kind gate above,
+                # which is authoritative for tasks that have a WorkItem.
+                if (
+                    self._config is not None
+                    and self._config.require_approved_spec
+                    and not self._has_approved_spec(task_slug)
+                ):
+                    raise SpecGateError(
+                        f"Task '{task_slug}' has no bound approved spec. "
+                        f"Create and approve one (`mship spec approve`) or pass "
+                        f"--bypass-spec-gate to skip this check."
+                    )
 
         old_phase = task.phase
         warnings = self._check_gates(task_slug, task.phase, target)

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -81,7 +81,17 @@ class PhaseManager:
             else:
                 if self._workspace_root is not None:
                     from mship.core.workitem_gate import check_task_gate
-                    gate_result = check_task_gate(task, self._workspace_root)
+                    # A corrupt/unreadable WorkItem store must not propagate a
+                    # raw exception out of transition() — --bypass-spec-gate
+                    # already skips this call entirely as the escape hatch;
+                    # without --bypass-spec-gate we still want a clean,
+                    # actionable SpecGateError instead of a traceback.
+                    try:
+                        gate_result = check_task_gate(task, self._workspace_root)
+                    except Exception as e:
+                        raise SpecGateError(
+                            f"couldn't evaluate WorkItem gate (corrupt store?): {e}"
+                        ) from e
                     if not gate_result.ok:
                         raise SpecGateError(gate_result.reason)
 
@@ -196,15 +206,15 @@ class PhaseManager:
             return False
         # Import inside method to avoid potential import cycles at module load.
         from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+        from mship.core.workitem_gate import APPROVED_STATUSES
 
         specs_dir = self._workspace_root / SPECS_DIRNAME
         try:
             specs = SpecStore(specs_dir).list()
         except Exception:
             return False
-        approved_statuses = {"approved", "dispatched", "implemented"}
         return any(
-            s.task_slug == task_slug and s.status in approved_statuses
+            s.task_slug == task_slug and s.status in APPROVED_STATUSES
             for s in specs
         )
 

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -1,0 +1,55 @@
+"""Universal + kind-gated enforcement: every task must be linked to a WorkItem,
+and a feature WorkItem must have an approved-or-beyond spec before dev/finish.
+See spec workitem-mandatory-kind-gated-approval."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from mship.core.gate import record_bypass
+from mship.core.spec_store import SpecStore
+from mship.core.workitem import WorkItem
+from mship.core.workitem_store import WorkItemStore
+
+# "approved or beyond" — matches PhaseManager._has_approved_spec (phase.py:174-190)
+_APPROVED = {"approved", "dispatched", "implemented"}
+
+
+@dataclass(frozen=True)
+class GateResult:
+    ok: bool
+    reason: str | None = None  # actionable message when not ok
+
+
+def check_task_gate(task, workspace_root: Path) -> GateResult:
+    """Universal: a task must have a WorkItem. Kind-gated: a feature WorkItem
+    must have an approved spec. bug/chore/question need only the WorkItem."""
+    if getattr(task, "work_item_id", None) is None:
+        return GateResult(False, "no WorkItem — create one with `mship item new --kind <kind>` "
+                                 "and spawn with `--work-item <id>` (or pass `--hotfix` to override)")
+    items = WorkItemStore(Path(workspace_root) / ".mothership" / "workitems")
+    wi = items.get(task.work_item_id)
+    if wi is None:
+        return GateResult(False, f"work_item_id {task.work_item_id!r} not found")
+    if wi.kind == "feature" and not _feature_has_approved_spec(wi, task, workspace_root):
+        return GateResult(False, "feature WorkItem requires an approved spec before dev/finish "
+                                 "(approve it in Ground Control, or `--hotfix` to override)")
+    return GateResult(True)
+
+
+def _feature_has_approved_spec(wi: WorkItem, task, workspace_root: Path) -> bool:
+    specs = SpecStore(Path(workspace_root) / "specs")
+    if wi.spec_id:
+        s = specs.find_by_id(wi.spec_id)
+        if s is not None and s.status in _APPROVED:
+            return True
+    return any(s.task_slug == task.slug and s.status in _APPROVED for s in specs.list())
+
+
+def log_hotfix(workspace_root: Path, where: str, task_slug: str) -> None:
+    """Record a `--hotfix` gate override to `.mothership/bypass-log.jsonl` via the
+    shared bypass log (core/gate.py::record_bypass). `where` identifies the gate
+    site (e.g. "dev", "finish"); `task_slug` identifies the task being bypassed —
+    record_bypass's log schema is (op, branch, reason), so those are threaded in
+    as (where, task_slug, "hotfix") respectively."""
+    record_bypass(Path(workspace_root), op=where, branch=task_slug, reason="hotfix")

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -11,8 +11,10 @@ from mship.core.spec_store import SpecStore
 from mship.core.workitem import WorkItem
 from mship.core.workitem_store import WorkItemStore
 
-# "approved or beyond" — matches PhaseManager._has_approved_spec (phase.py:174-190)
-_APPROVED = {"approved", "dispatched", "implemented"}
+# "approved or beyond" — the single source of truth for this status set.
+# Imported by workitem_migrate.wrap_existing and PhaseManager._has_approved_spec
+# so all three enforcement sites agree on what counts as approved.
+APPROVED_STATUSES = {"approved", "dispatched", "implemented"}
 
 
 @dataclass(frozen=True)
@@ -41,9 +43,9 @@ def _feature_has_approved_spec(wi: WorkItem, task, workspace_root: Path) -> bool
     specs = SpecStore(Path(workspace_root) / "specs")
     if wi.spec_id:
         s = specs.find_by_id(wi.spec_id)
-        if s is not None and s.status in _APPROVED:
+        if s is not None and s.status in APPROVED_STATUSES:
             return True
-    return any(s.task_slug == task.slug and s.status in _APPROVED for s in specs.list())
+    return any(s.task_slug == task.slug and s.status in APPROVED_STATUSES for s in specs.list())
 
 
 def log_hotfix(workspace_root: Path, where: str, task_slug: str) -> None:

--- a/src/mship/core/workitem_migrate.py
+++ b/src/mship/core/workitem_migrate.py
@@ -7,6 +7,9 @@ from mship.core.spec_store import SpecStore
 from mship.core.state import StateManager
 from mship.core.workitem_store import WorkItemStore
 
+# "approved or beyond" — matches workitem_gate._APPROVED / PhaseManager._has_approved_spec.
+_APPROVED = {"approved", "dispatched", "implemented"}
+
 
 def wrap_existing(items: WorkItemStore, specs: SpecStore, state: StateManager,
                   msgs: MessageStore, now: datetime, workspace: str) -> list[str]:
@@ -34,13 +37,30 @@ def wrap_existing(items: WorkItemStore, specs: SpecStore, state: StateManager,
                     s.tasks[_slug].work_item_id = _wid
             state.mutate(_set)
 
-    # 2) Orphan tasks (no spec, no work_item_id) -> chore items.
+    # 2) Orphan tasks (no work_item_id yet) -> feature or chore items. A task
+    # whose spec_id (or a reverse task_slug match) resolves to an
+    # approved-or-beyond spec gets its own feature item linked to that spec;
+    # otherwise it gets a plain chore item, same as a task with no spec at
+    # all. Tasks pass 1 already linked (forward spec.task_slug match) already
+    # carry work_item_id by the time state is reloaded below, so they're
+    # skipped here — no double-creation.
+    all_specs = specs.list()
+    spec_by_id = {s.id: s for s in all_specs}
+    spec_by_task_slug = {s.task_slug: s for s in all_specs if s.task_slug}
     for slug, task in state.load().tasks.items():
-        if task.work_item_id or task.spec_id:
+        if task.work_item_id:
             continue
-        wi = items.create(title=task.description or slug, kind="chore",
-                          workspace=workspace, now=now)
-        created.append(wi.id)
+        spec = (spec_by_id.get(task.spec_id) if task.spec_id else None) \
+            or spec_by_task_slug.get(slug)
+        if spec is not None and spec.status in _APPROVED:
+            wi = items.create(title=task.description or slug, kind="feature",
+                              workspace=workspace, now=now)
+            created.append(wi.id)
+            items.link_spec(wi.id, spec.id, now=now)
+        else:
+            wi = items.create(title=task.description or slug, kind="chore",
+                              workspace=workspace, now=now)
+            created.append(wi.id)
         items.add_task(wi.id, slug, now=now)
 
         def _set(s, _slug=slug, _wid=wi.id):

--- a/src/mship/core/workitem_migrate.py
+++ b/src/mship/core/workitem_migrate.py
@@ -5,10 +5,8 @@ from datetime import datetime
 from mship.core.message_store import MessageStore
 from mship.core.spec_store import SpecStore
 from mship.core.state import StateManager
+from mship.core.workitem_gate import APPROVED_STATUSES
 from mship.core.workitem_store import WorkItemStore
-
-# "approved or beyond" — matches workitem_gate._APPROVED / PhaseManager._has_approved_spec.
-_APPROVED = {"approved", "dispatched", "implemented"}
 
 
 def wrap_existing(items: WorkItemStore, specs: SpecStore, state: StateManager,
@@ -37,13 +35,18 @@ def wrap_existing(items: WorkItemStore, specs: SpecStore, state: StateManager,
                     s.tasks[_slug].work_item_id = _wid
             state.mutate(_set)
 
-    # 2) Orphan tasks (no work_item_id yet) -> feature or chore items. A task
-    # whose spec_id (or a reverse task_slug match) resolves to an
-    # approved-or-beyond spec gets its own feature item linked to that spec;
-    # otherwise it gets a plain chore item, same as a task with no spec at
-    # all. Tasks pass 1 already linked (forward spec.task_slug match) already
-    # carry work_item_id by the time state is reloaded below, so they're
-    # skipped here — no double-creation.
+    # 2) Orphan tasks (no work_item_id yet) -> attach to an existing item, or
+    # else get a feature/chore item of their own. A task's spec_id (or a
+    # reverse task_slug match) may resolve to a spec that pass 1 ALREADY
+    # wrapped in its own feature item — e.g. spec.task_slug was empty or
+    # didn't match this task, so pass 1 wrapped the spec but left the task's
+    # work_item_id null. In that case attach the task to that EXISTING item
+    # rather than creating a second item on the same spec. Otherwise: an
+    # approved-or-beyond spec with no work_item_id yet gets a new feature
+    # item linked to it; no spec (or an unapproved one) gets a plain chore
+    # item, same as a task with no spec at all. Tasks pass 1 already linked
+    # (forward spec.task_slug match) already carry work_item_id by the time
+    # state is reloaded below, so they're skipped here — no double-creation.
     all_specs = specs.list()
     spec_by_id = {s.id: s for s in all_specs}
     spec_by_task_slug = {s.task_slug: s for s in all_specs if s.task_slug}
@@ -52,18 +55,22 @@ def wrap_existing(items: WorkItemStore, specs: SpecStore, state: StateManager,
             continue
         spec = (spec_by_id.get(task.spec_id) if task.spec_id else None) \
             or spec_by_task_slug.get(slug)
-        if spec is not None and spec.status in _APPROVED:
+        if spec is not None and spec.work_item_id:
+            wi_id = spec.work_item_id
+        elif spec is not None and spec.status in APPROVED_STATUSES:
             wi = items.create(title=task.description or slug, kind="feature",
                               workspace=workspace, now=now)
             created.append(wi.id)
             items.link_spec(wi.id, spec.id, now=now)
+            wi_id = wi.id
         else:
             wi = items.create(title=task.description or slug, kind="chore",
                               workspace=workspace, now=now)
             created.append(wi.id)
-        items.add_task(wi.id, slug, now=now)
+            wi_id = wi.id
+        items.add_task(wi_id, slug, now=now)
 
-        def _set(s, _slug=slug, _wid=wi.id):
+        def _set(s, _slug=slug, _wid=wi_id):
             if _slug in s.tasks:
                 s.tasks[_slug].work_item_id = _wid
         state.mutate(_set)

--- a/src/mship/core/workitem_store.py
+++ b/src/mship/core/workitem_store.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 
+from mship.core.state import StateManager
 from mship.core.workitem import ExternalLink, Kind, Phase, WorkItem
 
 
@@ -68,7 +69,8 @@ class WorkItemStore:
         item.spec_id = spec_id
         self.save(item)
 
-    def add_task(self, item_id: str, task_slug: str, now: datetime | None = None) -> None:
+    def add_task(self, item_id: str, task_slug: str, now: datetime | None = None,
+                state: StateManager | None = None) -> None:
         item = self.get(item_id)
         if item is None:
             raise KeyError(item_id)
@@ -78,6 +80,13 @@ class WorkItemStore:
         if now is not None:
             item.updated_at = now
         self.save(item)
+        if state is not None:
+            # Reverse link: task.work_item_id, mirroring workitem_migrate.wrap_existing's
+            # pass-2 mutation (workitem_migrate.py:46-49).
+            def _set(s, _slug=task_slug, _wid=item_id):
+                if _slug in s.tasks:
+                    s.tasks[_slug].work_item_id = _wid
+            state.mutate(_set)
 
     def add_thread(self, item_id: str, thread_id: str, now: datetime | None = None) -> None:
         item = self.get(item_id)

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -411,6 +411,7 @@ class WorktreeManager:
         offline: bool = False,
         depends_on: list[DependencyEdge] | None = None,
         base: str | None = None,
+        work_item_id: str | None = None,
     ) -> SpawnResult:
         slug = slug if slug is not None else slugify(description)
         branch = self._config.branch_pattern.replace("{slug}", slug)
@@ -622,11 +623,12 @@ class WorktreeManager:
         # Single .mship-workspace marker at the hub root.
         write_marker(hub, workspace_root)
 
+        now = datetime.now(timezone.utc)
         task = Task(
             slug=slug,
             description=description,
             phase="plan",
-            created_at=datetime.now(timezone.utc),
+            created_at=now,
             affected_repos=ordered,
             worktrees=worktrees,
             branch=branch,
@@ -634,6 +636,7 @@ class WorktreeManager:
             base_override=base,
             passive_repos=passive,
             depends_on=depends_on or [],
+            work_item_id=work_item_id,
         )
 
         def _apply(s: WorkspaceState) -> None:
@@ -647,6 +650,15 @@ class WorktreeManager:
                 )
             s.tasks[slug] = task
         self._state_manager.mutate(_apply)
+
+        if work_item_id is not None:
+            # Forward link (task_slugs) on the WorkItem. The reverse link
+            # (task.work_item_id) is already set atomically on the Task above;
+            # add_task's state=... mutate is a harmless no-op re-set of the
+            # same value (see WorkItemStore.add_task).
+            from mship.core.workitem_store import WorkItemStore
+            items = WorkItemStore(workspace_root / ".mothership" / "workitems")
+            items.add_task(work_item_id, slug, now=now, state=self._state_manager)
 
         self._log.create(slug)
         log_msg = f"Task spawned. Repos: {', '.join(ordered)}. Branch: {branch}"

--- a/tests/cli/test_bind.py
+++ b/tests/cli/test_bind.py
@@ -41,7 +41,7 @@ def patch_refresh(monkeypatch):
 
 
 def test_bind_refresh_reports_copied(configured_git_app: Path, patch_refresh):
-    runner.invoke(app, ["spawn", "copied test", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "copied test", "--repos", "shared", "--skip-setup"])
     patch_refresh("shared", copied=[".env"])
     result = runner.invoke(app, ["bind", "refresh", "--task", "copied-test"])
     assert result.exit_code == 0, result.output
@@ -51,14 +51,14 @@ def test_bind_refresh_reports_copied(configured_git_app: Path, patch_refresh):
 
 
 def test_bind_refresh_exits_nonzero_on_skipped_without_overwrite(configured_git_app: Path, patch_refresh):
-    runner.invoke(app, ["spawn", "skip test", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "skip test", "--repos", "shared", "--skip-setup"])
     patch_refresh("shared", skipped=[".env"])
     result = runner.invoke(app, ["bind", "refresh", "--task", "skip-test"])
     assert result.exit_code != 0
 
 
 def test_bind_refresh_overwrite_flag_passed_through(configured_git_app: Path, patch_refresh):
-    runner.invoke(app, ["spawn", "ow test", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "ow test", "--repos", "shared", "--skip-setup"])
     patch_refresh("shared", updated=[".env"])
     result = runner.invoke(app, ["bind", "refresh", "--task", "ow-test", "--overwrite"])
     assert result.exit_code == 0, result.output
@@ -67,7 +67,7 @@ def test_bind_refresh_overwrite_flag_passed_through(configured_git_app: Path, pa
 
 
 def test_bind_refresh_unknown_repo_errors(configured_git_app: Path, patch_refresh):
-    runner.invoke(app, ["spawn", "unk", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "unk", "--repos", "shared", "--skip-setup"])
     result = runner.invoke(
         app, ["bind", "refresh", "--task", "unk", "--repos", "not-a-repo"],
     )
@@ -77,7 +77,7 @@ def test_bind_refresh_unknown_repo_errors(configured_git_app: Path, patch_refres
 
 def test_bind_refresh_repos_filter_scopes(configured_git_app: Path, patch_refresh):
     runner.invoke(
-        app, ["spawn", "multi", "--repos", "shared,auth-service", "--skip-setup"],
+        app, ["spawn", "--hotfix", "multi", "--repos", "shared,auth-service", "--skip-setup"],
     )
     result = runner.invoke(
         app, ["bind", "refresh", "--task", "multi", "--repos", "shared"],
@@ -88,7 +88,7 @@ def test_bind_refresh_repos_filter_scopes(configured_git_app: Path, patch_refres
 
 
 def test_bind_refresh_surfaces_warnings(configured_git_app: Path, patch_refresh):
-    runner.invoke(app, ["spawn", "warn", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "warn", "--repos", "shared", "--skip-setup"])
     patch_refresh("shared", warnings=["shared: bind_files source missing: .absent"])
     result = runner.invoke(app, ["bind", "refresh", "--task", "warn"])
     assert result.exit_code == 0, result.output

--- a/tests/cli/test_breadcrumb.py
+++ b/tests/cli/test_breadcrumb.py
@@ -53,7 +53,9 @@ def _parse_json_or_skip(text: str) -> dict:
 
 
 def test_phase_emits_resolution_fields(ws_with_task: Path):
-    result = runner.invoke(app, ["phase", "dev", "--task", "breadcrumb-test"])
+    # Task was spawned with --hotfix (no WorkItem); phase→dev needs its own
+    # bypass now that the WorkItem gate is checked there too.
+    result = runner.invoke(app, ["phase", "dev", "--task", "breadcrumb-test", "--bypass-spec-gate"])
     assert result.exit_code == 0, result.output
     payload = _parse_json_or_skip(result.output)
     assert payload.get("resolved_task") == "breadcrumb-test"

--- a/tests/cli/test_breadcrumb.py
+++ b/tests/cli/test_breadcrumb.py
@@ -25,7 +25,7 @@ def ws_with_task(workspace_with_git: Path):
     mock_shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
     container.shell.override(mock_shell)
-    runner.invoke(app, ["spawn", "breadcrumb test", "--repos", "shared", "--force-audit"])
+    runner.invoke(app, ["spawn", "--hotfix", "breadcrumb test", "--repos", "shared", "--force-audit"])
     yield workspace_with_git
     container.config_path.reset_override()
     container.state_dir.reset_override()
@@ -92,7 +92,7 @@ def test_ambiguity_lists_candidates(ws_with_task: Path):
     """Second task + running from outside both worktrees → ambiguity error with
     `--task <slug>` hints for BOTH tasks."""
     runner.invoke(
-        app, ["spawn", "second task", "--repos", "shared", "--force-audit"],
+        app, ["spawn", "--hotfix", "second task", "--repos", "shared", "--force-audit"],
     )
     import os
     prev = os.getcwd()

--- a/tests/cli/test_check_commit.py
+++ b/tests/cli/test_check_commit.py
@@ -49,17 +49,26 @@ def test_check_commit_no_active_tasks_exits_zero(tmp_path):
 
 
 def test_check_commit_matching_worktree_exits_zero(tmp_path):
+    from mship.core.workitem_store import WorkItemStore
+
     container.config_path.override(tmp_path / "mothership.yaml")
     container.state_dir.override(tmp_path / ".mothership")
     (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
     (tmp_path / ".mothership").mkdir()
     wt = tmp_path / "wt"
     wt.mkdir()
+    # A bug WorkItem is attached so this task clears the WorkItem gate
+    # (core/workitem_gate.py::check_task_gate) without needing an approved
+    # spec — see spec workitem-mandatory-kind-gated-approval, task 5/6.
+    wi = WorkItemStore(tmp_path / ".mothership" / "workitems").create(
+        title="thing", kind="bug", workspace="t", now=datetime.now(timezone.utc),
+    )
     task = Task(
         slug="t", description="d", phase="dev",
         created_at=datetime.now(timezone.utc),
         affected_repos=["cli"], branch="feat/t",
         worktrees={"cli": wt},
+        work_item_id=wi.id,
     )
     _seed(tmp_path / ".mothership", task)
     try:
@@ -384,6 +393,98 @@ def test_check_commit_fails_open_on_corrupt_state(tmp_path):
     try:
         result = runner.invoke(app, ["_check-commit", str(tmp_path)])
         assert result.exit_code == 0, result.output  # fail-open
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+
+
+# -----------------------------------------------------------------------------
+# WorkItem gate (task 5/6): a commit into a registered worktree is refused
+# when the task has no WorkItem (or a feature WorkItem without an approved
+# spec) — core/workitem_gate.py::check_task_gate. MSHIP_BYPASS_GATE is the
+# hotfix escape (already short-circuits at the very top of _check-commit,
+# before state is even loaded).
+# -----------------------------------------------------------------------------
+
+def test_check_commit_refuses_task_without_workitem(tmp_path):
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(tmp_path / ".mothership")
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    (tmp_path / ".mothership").mkdir()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    task = Task(
+        slug="no-workitem", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["cli"], branch="feat/no-workitem",
+        worktrees={"cli": wt},
+    )
+    _seed(tmp_path / ".mothership", task)
+    try:
+        result = runner.invoke(app, ["_check-commit", str(wt)])
+        assert result.exit_code == 1, result.output
+        assert "no WorkItem" in result.output
+        assert "no-workitem" in result.output
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+
+
+def test_check_commit_refuses_feature_workitem_without_approved_spec(tmp_path):
+    from mship.core.workitem_store import WorkItemStore
+
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(tmp_path / ".mothership")
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    (tmp_path / ".mothership").mkdir()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    wi = WorkItemStore(tmp_path / ".mothership" / "workitems").create(
+        title="feature thing", kind="feature", workspace="t",
+        now=datetime.now(timezone.utc),
+    )
+    task = Task(
+        slug="feature-task", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["cli"], branch="feat/feature-task",
+        worktrees={"cli": wt}, work_item_id=wi.id,
+    )
+    _seed(tmp_path / ".mothership", task)
+    try:
+        result = runner.invoke(app, ["_check-commit", str(wt)])
+        assert result.exit_code == 1, result.output
+        assert "approved spec" in result.output
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+
+
+def test_check_commit_bypass_gate_env_allows_task_without_workitem(tmp_path, monkeypatch):
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(tmp_path / ".mothership")
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    (tmp_path / ".mothership").mkdir()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    task = Task(
+        slug="no-workitem", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["cli"], branch="feat/no-workitem",
+        worktrees={"cli": wt},
+    )
+    _seed(tmp_path / ".mothership", task)
+    monkeypatch.setenv("MSHIP_BYPASS_GATE", "1")
+    try:
+        result = runner.invoke(app, ["_check-commit", str(wt)])
+        assert result.exit_code == 0, result.output
+        log = tmp_path / ".mothership" / "bypass-log.jsonl"
+        assert log.exists() and "commit" in log.read_text()
     finally:
         container.config_path.reset_override()
         container.state_dir.reset_override()

--- a/tests/cli/test_commit.py
+++ b/tests/cli/test_commit.py
@@ -26,7 +26,7 @@ def _set_finished(workspace: Path, slug: str, pr_urls: dict[str, str]) -> None:
 
 def test_commit_pre_finish_single_repo(configured_git_app: Path):
     """Stage in one worktree pre-finish → commit + journal, no push."""
-    runner.invoke(app, ["spawn", "pre finish commit", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "pre finish commit", "--repos", "shared"])
     slug = "pre-finish-commit"
 
     commits: list[str] = []
@@ -65,7 +65,7 @@ def test_commit_pre_finish_single_repo(configured_git_app: Path):
 
 def test_commit_pre_finish_multi_repo(configured_git_app: Path):
     """Stage in two worktrees → both commit, no push, two journal entries."""
-    runner.invoke(app, ["spawn", "multi pre", "--repos", "shared,auth-service"])
+    runner.invoke(app, ["spawn", "--hotfix", "multi pre", "--repos", "shared,auth-service"])
     slug = "multi-pre"
 
     commits: list[str] = []
@@ -102,7 +102,7 @@ def test_commit_pre_finish_multi_repo(configured_git_app: Path):
 
 def test_commit_post_finish_single_repo(configured_git_app: Path):
     """Finished task + PR → commit + push + journal."""
-    runner.invoke(app, ["spawn", "post single", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "post single", "--repos", "shared"])
     slug = "post-single"
     _set_finished(configured_git_app, slug, {"shared": "https://github.com/o/r/pull/7"})
 
@@ -136,7 +136,7 @@ def test_commit_post_finish_single_repo(configured_git_app: Path):
 
 def test_commit_post_finish_multi_repo(configured_git_app: Path):
     """Finished multi-repo task → both commit + push."""
-    runner.invoke(app, ["spawn", "post multi", "--repos", "shared,auth-service"])
+    runner.invoke(app, ["spawn", "--hotfix", "post multi", "--repos", "shared,auth-service"])
     slug = "post-multi"
     _set_finished(configured_git_app, slug, {
         "shared": "https://github.com/o/r/pull/1",
@@ -173,7 +173,7 @@ def test_commit_post_finish_multi_repo(configured_git_app: Path):
 
 def test_commit_skips_repos_without_staged_changes(configured_git_app: Path):
     """Partial staging: one repo staged, one not → only first commits."""
-    runner.invoke(app, ["spawn", "partial", "--repos", "shared,auth-service"])
+    runner.invoke(app, ["spawn", "--hotfix", "partial", "--repos", "shared,auth-service"])
     slug = "partial"
 
     commits: list[str] = []
@@ -205,7 +205,7 @@ def test_commit_skips_repos_without_staged_changes(configured_git_app: Path):
 
 def test_commit_errors_when_nothing_staged_anywhere(configured_git_app: Path):
     """No staged changes in any worktree → exit 1 with clear message."""
-    runner.invoke(app, ["spawn", "nothing", "--repos", "shared,auth-service"])
+    runner.invoke(app, ["spawn", "--hotfix", "nothing", "--repos", "shared,auth-service"])
     slug = "nothing"
 
     def mock_run(cmd, cwd, env=None):
@@ -227,7 +227,7 @@ def test_commit_errors_when_nothing_staged_anywhere(configured_git_app: Path):
 
 def test_commit_git_commit_failure_surfaces(configured_git_app: Path):
     """Hook rejection during git commit → exit 1, error message surfaces stderr."""
-    runner.invoke(app, ["spawn", "hook fail", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "hook fail", "--repos", "shared"])
     slug = "hook-fail"
 
     def mock_run(cmd, cwd, env=None):
@@ -254,7 +254,7 @@ def test_commit_git_commit_failure_surfaces(configured_git_app: Path):
 
 def test_commit_push_failure_surfaces_post_finish(configured_git_app: Path):
     """Push fails post-finish → exit 1, but journal DOES record the commit."""
-    runner.invoke(app, ["spawn", "push fail", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "push fail", "--repos", "shared"])
     slug = "push-fail"
     _set_finished(configured_git_app, slug, {"shared": "https://github.com/o/r/pull/1"})
 

--- a/tests/cli/test_debug.py
+++ b/tests/cli/test_debug.py
@@ -10,7 +10,7 @@ runner = CliRunner()
 
 
 def test_debug_hypothesis_writes_journal_entry(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "hypo test", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "hypo test", "--repos", "shared", "--skip-setup"])
     result = runner.invoke(
         app, ["debug", "hypothesis", "test is flaky",
               "--evidence", "test-runs/5", "--task", "hypo-test"],
@@ -24,7 +24,7 @@ def test_debug_hypothesis_writes_journal_entry(configured_git_app: Path):
 
 
 def test_debug_hypothesis_honors_explicit_id(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "id test", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "id test", "--repos", "shared", "--skip-setup"])
     result = runner.invoke(
         app, ["debug", "hypothesis", "H1", "--id", "h1", "--task", "id-test"],
     )
@@ -34,7 +34,7 @@ def test_debug_hypothesis_honors_explicit_id(configured_git_app: Path):
 
 
 def test_debug_rule_out_writes_parent_kv(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "ro test", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "ro test", "--repos", "shared", "--skip-setup"])
     runner.invoke(
         app, ["debug", "hypothesis", "H1", "--id", "h1", "--task", "ro-test"],
     )
@@ -48,7 +48,7 @@ def test_debug_rule_out_writes_parent_kv(configured_git_app: Path):
 
 
 def test_debug_rule_out_with_category(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "cat test", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "cat test", "--repos", "shared", "--skip-setup"])
     runner.invoke(app, ["debug", "hypothesis", "H", "--id", "h", "--task", "cat-test"])
     result = runner.invoke(
         app, ["debug", "rule-out", "R", "--parent", "h",
@@ -60,7 +60,7 @@ def test_debug_rule_out_with_category(configured_git_app: Path):
 
 
 def test_debug_resolved_writes_entry(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "res test", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "res test", "--repos", "shared", "--skip-setup"])
     runner.invoke(app, ["debug", "hypothesis", "H", "--id", "h", "--task", "res-test"])
     result = runner.invoke(
         app, ["debug", "resolved", "fixed by commit abc", "--task", "res-test"],
@@ -73,7 +73,7 @@ def test_debug_resolved_writes_entry(configured_git_app: Path):
 
 def test_debug_resolved_without_hypothesis_warns(configured_git_app: Path):
     """Advisory stderr warning when closing without any prior hypothesis."""
-    runner.invoke(app, ["spawn", "warn test", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "warn test", "--repos", "shared", "--skip-setup"])
     result = runner.invoke(
         app, ["debug", "resolved", "no thread", "--task", "warn-test"],
     )
@@ -89,7 +89,7 @@ def test_debug_resolved_without_hypothesis_warns(configured_git_app: Path):
 def test_debug_auto_id_is_8_char_hex(configured_git_app: Path):
     """Auto-generated id is 8 lowercase-hex chars."""
     import re as _re
-    runner.invoke(app, ["spawn", "auto id", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "auto id", "--repos", "shared", "--skip-setup"])
     runner.invoke(app, ["debug", "hypothesis", "H", "--task", "auto-id"])
     log = (configured_git_app / ".mothership" / "logs" / "auto-id.md").read_text()
     m = _re.search(r"id=([a-f0-9]+)", log)

--- a/tests/cli/test_exec.py
+++ b/tests/cli/test_exec.py
@@ -708,7 +708,7 @@ def test_test_json_output_still_contains_paths(configured_exec_app):
 def test_test_run_journal_entry_includes_parent_during_open_debug_thread(configured_git_app: Path):
     """mship test during open debug thread enriches the `ran tests` journal
     entry with parent=<latest-hypothesis-id>. See #30."""
-    runner.invoke(app, ["spawn", "test parent", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "test parent", "--repos", "shared", "--skip-setup"])
     # Open a debug thread with a known id.
     runner.invoke(
         app, ["debug", "hypothesis", "H1", "--id", "h1", "--task", "test-parent"],
@@ -724,7 +724,7 @@ def test_test_run_journal_entry_includes_parent_during_open_debug_thread(configu
 
 def test_test_run_journal_entry_no_parent_when_no_debug_thread(configured_git_app: Path):
     """Regression: without open debug thread, ran-tests entry has no parent kv."""
-    runner.invoke(app, ["spawn", "plain test", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "plain test", "--repos", "shared", "--skip-setup"])
 
     result = runner.invoke(app, ["test", "--task", "plain-test"])
     assert result.exit_code == 0, result.output

--- a/tests/cli/test_guard_edit.py
+++ b/tests/cli/test_guard_edit.py
@@ -14,17 +14,25 @@ runner = CliRunner()
 
 
 def _bootstrap(tmp_path: Path) -> tuple[Path, Path, Path]:
-    """Workspace with one active task; returns (cfg, state_dir, main_repo)."""
+    """Workspace with one active task (linked to a bug WorkItem, so it clears
+    the WorkItem gate without needing an approved spec); returns
+    (cfg, state_dir, main_repo)."""
+    from mship.core.workitem_store import WorkItemStore
+
     main = tmp_path / "main"; (main / "src").mkdir(parents=True)
     (main / "Taskfile.yml").write_text("version: '3'\n")
     wt = tmp_path / ".worktrees" / "t" / "repo"; (wt / "src").mkdir(parents=True)
     state_dir = tmp_path / ".mothership"; state_dir.mkdir()
     cfg = tmp_path / "mothership.yaml"
     cfg.write_text(f"workspace: t\nrepos:\n  repo:\n    path: {main}\n    type: library\n")
+    wi = WorkItemStore(state_dir / "workitems").create(
+        title="thing", kind="bug", workspace="t", now=datetime.now(timezone.utc),
+    )
     task = Task(
         slug="t", description="d", phase="dev",
         created_at=datetime.now(timezone.utc),
         affected_repos=["repo"], worktrees={"repo": wt}, branch="feat/t",
+        work_item_id=wi.id,
     )
     StateManager(state_dir).save(WorkspaceState(tasks={"t": task}))
     return cfg, state_dir, main
@@ -100,5 +108,67 @@ def test_no_file_path_fails_open(tmp_path: Path):
     try:
         result = runner.invoke(app, ["_guard-edit"], input=json.dumps({"tool_input": {}}))
         assert result.exit_code == 0
+    finally:
+        _reset()
+
+
+# ---------------------------------------------------------------------------
+# WorkItem gate (task 5/6): an edit inside the task's OWN worktree is still
+# blocked if the task fails core/workitem_gate.py::check_task_gate (no
+# WorkItem, or a feature WorkItem without an approved spec). MSHIP_BYPASS_GATE
+# is the hotfix escape — distinct from MSHIP_ALLOW_MAIN_EDIT above.
+# ---------------------------------------------------------------------------
+
+def _bootstrap_no_workitem(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Like _bootstrap, but the task has no WorkItem at all."""
+    main = tmp_path / "main"; (main / "src").mkdir(parents=True)
+    (main / "Taskfile.yml").write_text("version: '3'\n")
+    wt = tmp_path / ".worktrees" / "t" / "repo"; (wt / "src").mkdir(parents=True)
+    state_dir = tmp_path / ".mothership"; state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(f"workspace: t\nrepos:\n  repo:\n    path: {main}\n    type: library\n")
+    task = Task(
+        slug="t", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["repo"], worktrees={"repo": wt}, branch="feat/t",
+    )
+    StateManager(state_dir).save(WorkspaceState(tasks={"t": task}))
+    return cfg, state_dir, main
+
+
+def test_blocks_worktree_edit_when_task_has_no_workitem(tmp_path: Path):
+    cfg, state_dir, _ = _bootstrap_no_workitem(tmp_path)
+    wt_file = tmp_path / ".worktrees" / "t" / "repo" / "src" / "x.py"
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_guard-edit"], input=_event(wt_file))
+        assert result.exit_code == 2
+        assert "WorkItem" in result.stderr
+    finally:
+        _reset()
+
+
+def test_bypass_gate_env_allows_worktree_edit_without_workitem(tmp_path: Path, monkeypatch):
+    cfg, state_dir, _ = _bootstrap_no_workitem(tmp_path)
+    wt_file = tmp_path / ".worktrees" / "t" / "repo" / "src" / "x.py"
+    monkeypatch.setenv("MSHIP_BYPASS_GATE", "1")
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_guard-edit"], input=_event(wt_file))
+        assert result.exit_code == 0
+    finally:
+        _reset()
+
+
+def test_bypass_gate_does_not_lift_main_checkout_block(tmp_path: Path, monkeypatch):
+    """MSHIP_BYPASS_GATE is the WorkItem-gate escape only — it must not also
+    reopen the (separately-gated) main-checkout block."""
+    cfg, state_dir, main = _bootstrap_no_workitem(tmp_path)
+    monkeypatch.setenv("MSHIP_BYPASS_GATE", "1")
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_guard-edit"], input=_event(main / "src" / "x.py"))
+        assert result.exit_code == 2
+        assert "MAIN checkout" in result.stderr
     finally:
         _reset()

--- a/tests/cli/test_internal.py
+++ b/tests/cli/test_internal.py
@@ -142,11 +142,34 @@ def _push(branch, sha="a" * 40):
     return f"refs/heads/{branch} {sha} refs/heads/{branch} {'0'*40}\n"
 
 
+_KNOWN_WORK_ITEM_ID = "wi-test-known"
+
+# A bug WorkItem is attached (via `work_item_id:`) so `known` clears the
+# WorkItem gate (core/workitem_gate.py::check_task_gate) without needing an
+# approved spec — see spec workitem-mandatory-kind-gated-approval, task 5/6.
 _TASK_YAML = (
+    "tasks:\n  known:\n    slug: known\n    description: d\n    phase: dev\n"
+    "    created_at: 2026-01-01T00:00:00+00:00\n    affected_repos: [lib]\n"
+    "    branch: feat/known\n    work_item_id: wi-test-known\n"
+)
+
+# Same task, but with no WorkItem at all — for the WorkItem-gate tests below.
+_TASK_YAML_NO_WORKITEM = (
     "tasks:\n  known:\n    slug: known\n    description: d\n    phase: dev\n"
     "    created_at: 2026-01-01T00:00:00+00:00\n    affected_repos: [lib]\n"
     "    branch: feat/known\n"
 )
+
+
+def _seed_bug_workitem(state_dir, item_id: str = _KNOWN_WORK_ITEM_ID) -> None:
+    from datetime import datetime, timezone
+    from mship.core.workitem import WorkItem
+    from mship.core.workitem_store import WorkItemStore
+    now = datetime.now(timezone.utc)
+    WorkItemStore(state_dir / "workitems").save(
+        WorkItem(id=item_id, title="t", workspace="w", kind="bug",
+                 created_at=now, updated_at=now)
+    )
 
 
 def test_check_push_rejects_unregistered_feat_branch(tmp_path, monkeypatch):
@@ -160,6 +183,7 @@ def test_check_push_rejects_unregistered_feat_branch(tmp_path, monkeypatch):
 
 def test_check_push_allows_registered_task_branch(tmp_path, monkeypatch):
     _setup(tmp_path, monkeypatch, tasks_yaml=_TASK_YAML)
+    _seed_bug_workitem(tmp_path / ".mothership")
     try:
         r = runner.invoke(app, ["_check-push"], input=_push("feat/known"))
         assert r.exit_code == 0
@@ -223,6 +247,36 @@ def test_check_push_dedupes_repeated_branch(tmp_path, monkeypatch):
         assert r.exit_code == 0
         lines = (tmp_path / ".mothership" / "bypass-log.jsonl").read_text().splitlines()
         assert sum(1 for ln in lines if "feat/x" in ln) == 1
+    finally:
+        _reset()
+
+
+# ---------------------------------------------------------------------------
+# WorkItem gate (task 5/6): pushing a REGISTERED task branch is still refused
+# when that task has no WorkItem — core/workitem_gate.py::check_task_gate.
+# MSHIP_BYPASS_GATE is the hotfix escape (same env var used for the
+# unregistered-branch case above, and logged the same way).
+# ---------------------------------------------------------------------------
+
+def test_check_push_refuses_registered_branch_without_workitem(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch, tasks_yaml=_TASK_YAML_NO_WORKITEM)
+    try:
+        r = runner.invoke(app, ["_check-push"], input=_push("feat/known"))
+        assert r.exit_code == 1
+        assert "WorkItem" in r.output or "WorkItem" in (r.stderr or "")
+    finally:
+        _reset()
+
+
+def test_check_push_bypass_allows_registered_branch_without_workitem(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch, tasks_yaml=_TASK_YAML_NO_WORKITEM)
+    monkeypatch.setenv("MSHIP_BYPASS_GATE", "intentional")
+    try:
+        r = runner.invoke(app, ["_check-push"], input=_push("feat/known"))
+        assert r.exit_code == 0
+        log = tmp_path / ".mothership" / "bypass-log.jsonl"
+        assert log.exists() and "intentional" in log.read_text()
+        assert "feat/known" in log.read_text()
     finally:
         _reset()
 

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -95,7 +95,7 @@ def _teardown():
 def test_log_with_action_and_open_flags(workspace_with_git):
     _setup(workspace_with_git)
     try:
-        runner.invoke(app, ["spawn", "flags test", "--repos", "shared", "--force-audit"])
+        runner.invoke(app, ["spawn", "--hotfix", "flags test", "--repos", "shared", "--force-audit"])
         result = runner.invoke(
             app, ["journal", "stuck",
                     "--action", "debugging middleware",
@@ -121,7 +121,7 @@ def test_log_with_action_and_open_flags(workspace_with_git):
 def test_log_infers_repo_from_active_repo(workspace_with_git, monkeypatch):
     _setup(workspace_with_git)
     try:
-        runner.invoke(app, ["spawn", "infer test", "--repos", "shared", "--force-audit"])
+        runner.invoke(app, ["spawn", "--hotfix", "infer test", "--repos", "shared", "--force-audit"])
         runner.invoke(app, ["switch", "shared", "--task", "infer-test"])
         # cd into the worktree so the cwd check passes
         from mship.core.state import StateManager
@@ -140,7 +140,7 @@ def test_log_infers_repo_from_active_repo(workspace_with_git, monkeypatch):
 def test_log_show_open_lists_open_questions(workspace_with_git):
     _setup(workspace_with_git)
     try:
-        runner.invoke(app, ["spawn", "open test", "--repos", "shared", "--force-audit"])
+        runner.invoke(app, ["spawn", "--hotfix", "open test", "--repos", "shared", "--force-audit"])
         runner.invoke(
             app, ["journal", "stuck", "--open", "how to handle nulls", "--repo", "shared",
                   "--task", "open-test"],
@@ -160,7 +160,7 @@ def test_log_show_open_lists_open_questions(workspace_with_git):
 def test_log_show_open_empty_exits_zero(workspace_with_git):
     _setup(workspace_with_git)
     try:
-        runner.invoke(app, ["spawn", "nothing open", "--repos", "shared", "--force-audit"])
+        runner.invoke(app, ["spawn", "--hotfix", "nothing open", "--repos", "shared", "--force-audit"])
         result = runner.invoke(app, ["journal", "--show-open", "--task", "nothing-open"])
         assert result.exit_code == 0
     finally:
@@ -175,7 +175,7 @@ def test_log_refuses_when_cwd_outside_active_worktree(workspace_with_git, tmp_pa
     container.config_path.override(workspace_with_git / "mothership.yaml")
     container.state_dir.override(workspace_with_git / ".mothership")
     try:
-        r.invoke(app, ["spawn", "refuse test", "--repos", "shared", "--force-audit"])
+        r.invoke(app, ["spawn", "--hotfix", "refuse test", "--repos", "shared", "--force-audit"])
         r.invoke(app, ["switch", "shared", "--task", "refuse-test"])
         monkeypatch.chdir(tmp_path)
         result = r.invoke(app, ["journal", "should fail", "--task", "refuse-test"])
@@ -197,7 +197,7 @@ def test_log_force_writes_entry_with_bypass_tag(workspace_with_git, tmp_path, mo
     container.config_path.override(workspace_with_git / "mothership.yaml")
     container.state_dir.override(workspace_with_git / ".mothership")
     try:
-        r.invoke(app, ["spawn", "bypass test", "--repos", "shared", "--force-audit"])
+        r.invoke(app, ["spawn", "--hotfix", "bypass test", "--repos", "shared", "--force-audit"])
         r.invoke(app, ["switch", "shared", "--task", "bypass-test"])
         monkeypatch.chdir(tmp_path)
         result = r.invoke(app, ["journal", "force msg", "--force", "--task", "bypass-test"])
@@ -222,7 +222,7 @@ def test_log_silent_when_cwd_inside_active_worktree(workspace_with_git, monkeypa
     container.config_path.override(workspace_with_git / "mothership.yaml")
     container.state_dir.override(workspace_with_git / ".mothership")
     try:
-        _runner.invoke(app, ["spawn", "cwd test2", "--repos", "shared", "--force-audit"])
+        _runner.invoke(app, ["spawn", "--hotfix", "cwd test2", "--repos", "shared", "--force-audit"])
         _runner.invoke(app, ["switch", "shared", "--task", "cwd-test2"])
 
         # cd into the actual worktree

--- a/tests/cli/test_multi_task.py
+++ b/tests/cli/test_multi_task.py
@@ -53,7 +53,7 @@ def workspace(tmp_path, monkeypatch):
 
 
 def _spawn(runner, desc):
-    result = runner.invoke(app, ["spawn", desc, "--skip-setup", "--force-audit", "--bypass-reconcile"])
+    result = runner.invoke(app, ["spawn", "--hotfix", desc, "--skip-setup", "--force-audit", "--bypass-reconcile"])
     assert result.exit_code == 0, result.output
     return json.loads(result.stdout)
 

--- a/tests/cli/test_multi_task.py
+++ b/tests/cli/test_multi_task.py
@@ -91,7 +91,9 @@ def test_phase_with_task_flag_transitions_correct_task(workspace):
     runner = CliRunner()
     a = _spawn(runner, "first")
     b = _spawn(runner, "second")
-    result = runner.invoke(app, ["phase", "dev", "--task", a["slug"]])
+    # Tasks were spawned with --hotfix (no WorkItem); phase→dev needs its own
+    # bypass now that the WorkItem gate is checked there too.
+    result = runner.invoke(app, ["phase", "dev", "--task", a["slug"], "--bypass-spec-gate"])
     assert result.exit_code == 0, result.output
     state = StateManager(workspace / ".mothership").load()
     assert state.tasks[a["slug"]].phase == "dev"
@@ -103,7 +105,7 @@ def test_env_anchor_scopes_session(workspace, monkeypatch):
     a = _spawn(runner, "first")
     _spawn(runner, "second")
     monkeypatch.setenv("MSHIP_TASK", a["slug"])
-    result = runner.invoke(app, ["phase", "dev"])
+    result = runner.invoke(app, ["phase", "dev", "--bypass-spec-gate"])
     assert result.exit_code == 0, result.output
     state = StateManager(workspace / ".mothership").load()
     assert state.tasks[a["slug"]].phase == "dev"
@@ -115,7 +117,7 @@ def test_cwd_inside_worktree_resolves(workspace, monkeypatch):
     _spawn(runner, "second")
     a_wt = Path(a["worktrees"]["r"])
     monkeypatch.chdir(a_wt)
-    result = runner.invoke(app, ["phase", "dev"])
+    result = runner.invoke(app, ["phase", "dev", "--bypass-spec-gate"])
     assert result.exit_code == 0, result.output
     state = StateManager(workspace / ".mothership").load()
     assert state.tasks[a["slug"]].phase == "dev"

--- a/tests/cli/test_phase.py
+++ b/tests/cli/test_phase.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 
 from mship.cli import app, container
 from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.workitem_store import WorkItemStore
 
 runner = CliRunner()
 
@@ -20,6 +21,15 @@ def configured_app_with_task(workspace: Path):
     container.config_path.override(workspace / "mothership.yaml")
     container.state_dir.override(state_dir)
 
+    # A bug WorkItem is attached so phase→dev's universal WorkItem gate
+    # (core/phase.py::transition → workitem_gate.check_task_gate) doesn't
+    # block these tests. See spec workitem-mandatory-kind-gated-approval.
+    items = WorkItemStore(state_dir / "workitems")
+    wi = items.create(
+        title="Add labels", kind="bug", workspace="test",
+        now=datetime(2026, 4, 10, tzinfo=timezone.utc),
+    )
+
     mgr = StateManager(state_dir)
     task = Task(
         slug="add-labels",
@@ -28,6 +38,7 @@ def configured_app_with_task(workspace: Path):
         created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
         affected_repos=["shared"],
         branch="feat/add-labels",
+        work_item_id=wi.id,
     )
     mgr.save(WorkspaceState(tasks={"add-labels": task}))
     yield

--- a/tests/cli/test_pr.py
+++ b/tests/cli/test_pr.py
@@ -51,8 +51,8 @@ def test_pr_empty_when_no_tasks(configured_git_app: Path):
 
 
 def test_pr_lists_tasks_with_pr_urls(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "first", "--repos", "shared", "--skip-setup"])
-    runner.invoke(app, ["spawn", "second", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "first", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "second", "--repos", "shared", "--skip-setup"])
     _set_pr_urls(configured_git_app, "first", {"shared": "https://github.com/o/r/pull/1"})
     _set_pr_urls(configured_git_app, "second", {"shared": "https://github.com/o/r/pull/2"})
 
@@ -77,7 +77,7 @@ def test_pr_lists_tasks_with_pr_urls(configured_git_app: Path):
 
 
 def test_pr_skips_tasks_without_pr_urls(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "no pr", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "no pr", "--repos", "shared", "--skip-setup"])
     # Don't set pr_urls.
     result = runner.invoke(app, ["pr"])
     assert result.exit_code == 0, result.output
@@ -86,7 +86,7 @@ def test_pr_skips_tasks_without_pr_urls(configured_git_app: Path):
 
 
 def test_pr_gh_failure_shows_unknown(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "fail", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "fail", "--repos", "shared", "--skip-setup"])
     _set_pr_urls(configured_git_app, "fail", {"shared": "https://github.com/o/r/pull/9"})
 
     mock_shell = MagicMock(spec=ShellRunner)
@@ -110,7 +110,7 @@ def test_pr_gh_failure_shows_unknown(configured_git_app: Path):
 
 
 def test_pr_multiple_repos_per_task(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "multi", "--repos", "shared,auth-service", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "multi", "--repos", "shared,auth-service", "--skip-setup"])
     _set_pr_urls(configured_git_app, "multi", {
         "shared": "https://github.com/o/r/pull/1",
         "auth-service": "https://github.com/o/r/pull/2",

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -173,7 +173,9 @@ def test_gate_dev_satisfied_by_blessed_path(tmp_path: Path):
         mgr, MagicMock(spec=LogManager),
         config=config, workspace_root=tmp_path,
     )
-    result = pm.transition("add-labels", "dev")
+    # Task has no WorkItem; bypass the (unrelated) WorkItem gate to isolate
+    # the blessed-spec-path warning behavior under test.
+    result = pm.transition("add-labels", "dev", bypass_spec_gate=True)
     assert not any("spec" in w.lower() for w in result.warnings), result.warnings
 
 
@@ -237,7 +239,9 @@ def test_gate_dev_hint_mentions_spec_new(tmp_path: Path):
         mgr, MagicMock(spec=LogManager),
         config=config, workspace_root=tmp_path,
     )
-    result = pm.transition("add-labels", "dev")
+    # Task has no WorkItem; bypass the (unrelated) WorkItem gate to isolate
+    # the missing-spec warning hint under test.
+    result = pm.transition("add-labels", "dev", bypass_spec_gate=True)
     spec_warn = next((w for w in result.warnings if "spec" in w.lower()), None)
     assert spec_warn is not None, result.warnings
     assert "mship spec new" in spec_warn

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -484,7 +484,7 @@ def test_close_merged_pr_with_unverified_merge_commit_warns_but_proceeds(configu
 
 def test_finish_handoff(configured_git_app: Path):
     runner.invoke(app, ["spawn", "--hotfix", "handoff test", "--repos", "shared,auth-service"])
-    result = runner.invoke(app, ["finish", "--handoff", "--task", "handoff-test"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--handoff", "--task", "handoff-test"])
     assert result.exit_code == 0
     handoff_file = configured_git_app / ".mothership" / "handoffs" / "handoff-test.yaml"
     assert handoff_file.exists()
@@ -519,7 +519,7 @@ def test_finish_creates_prs(configured_git_app: Path):
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
     cli_container.shell.override(mock_shell)
 
-    result = runner.invoke(app, ["finish", "--task", "test-prs"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "test-prs"])
     assert result.exit_code == 0, result.output
 
     # Verify PR URL stored in state
@@ -565,7 +565,7 @@ def test_finish_body_file_passed_to_gh_pr_create(configured_git_app: Path):
     cli_container.shell.override(mock_shell)
     try:
         result = runner.invoke(
-            app, ["finish", "--task", "body-test", "--body-file", str(body_path)]
+            app, ["finish", "--hotfix", "--task", "body-test", "--body-file", str(body_path)]
         )
         assert result.exit_code == 0, result.output
         assert "create_cmd" in captured
@@ -618,7 +618,7 @@ def test_finish_body_map_per_repo_bodies(configured_git_app: Path):
     try:
         result = runner.invoke(
             app, [
-                "finish",
+                "finish", "--hotfix",
                 "--task", "body-map",
                 "--body-map", f"shared={shared_body}",
                 "--body-file", str(fallback_body),
@@ -651,7 +651,7 @@ def test_finish_body_map_unknown_repo_rejected(configured_git_app: Path):
     try:
         result = runner.invoke(
             app, [
-                "finish",
+                "finish", "--hotfix",
                 "--task", "unknown-body",
                 "--body-map", f"ghost={body_path}",
             ],
@@ -678,7 +678,7 @@ def test_finish_body_map_empty_body_rejected(configured_git_app: Path):
     try:
         result = runner.invoke(
             app, [
-                "finish",
+                "finish", "--hotfix",
                 "--task", "empty-body",
                 "--body-map", f"shared={body_path}",
             ],
@@ -747,7 +747,7 @@ def test_finish_title_override_passed_to_gh_pr_create(configured_git_app: Path):
     try:
         result = runner.invoke(
             app, [
-                "finish",
+                "finish", "--hotfix",
                 "--task", "a-long-verbose-description-that-shouldnt",
                 "--title", "feat(spawn): concise PR title",
             ],
@@ -767,7 +767,7 @@ def test_finish_title_rejected_with_force(configured_git_app: Path):
     """--force won't rewrite existing PR titles; conflict rejected like --body."""
     runner.invoke(app, ["spawn", "--hotfix", "force title mutex", "--repos", "shared"])
     result = runner.invoke(
-        app, ["finish", "--task", "force-title-mutex", "--force", "--title", "t"]
+        app, ["finish", "--hotfix", "--task", "force-title-mutex", "--force", "--title", "t"]
     )
     assert result.exit_code != 0
     assert "title" in result.output.lower()
@@ -776,7 +776,7 @@ def test_finish_title_rejected_with_force(configured_git_app: Path):
 def test_finish_title_incompatible_with_push_only(configured_git_app: Path):
     runner.invoke(app, ["spawn", "--hotfix", "po title mutex", "--repos", "shared"])
     result = runner.invoke(
-        app, ["finish", "--task", "po-title-mutex", "--push-only", "--title", "t"]
+        app, ["finish", "--hotfix", "--task", "po-title-mutex", "--push-only", "--title", "t"]
     )
     assert result.exit_code != 0
 
@@ -784,7 +784,7 @@ def test_finish_title_incompatible_with_push_only(configured_git_app: Path):
 def test_finish_body_and_body_file_mutually_exclusive(configured_git_app: Path):
     runner.invoke(app, ["spawn", "--hotfix", "mutex test", "--repos", "shared"])
     result = runner.invoke(
-        app, ["finish", "--task", "mutex-test", "--body", "x", "--body-file", "/tmp/y"]
+        app, ["finish", "--hotfix", "--task", "mutex-test", "--body", "x", "--body-file", "/tmp/y"]
     )
     assert result.exit_code != 0
     assert "mutually exclusive" in result.output
@@ -795,7 +795,7 @@ def test_finish_rejects_empty_body_file(configured_git_app: Path, tmp_path: Path
     empty = tmp_path / "empty.md"
     empty.write_text("   \n\n")
     result = runner.invoke(
-        app, ["finish", "--task", "empty-body-test", "--body-file", str(empty)]
+        app, ["finish", "--hotfix", "--task", "empty-body-test", "--body-file", str(empty)]
     )
     assert result.exit_code != 0
     assert "empty" in result.output.lower()
@@ -805,7 +805,7 @@ def test_finish_body_incompatible_with_push_only(configured_git_app: Path):
     runner.invoke(app, ["spawn", "--hotfix", "po mutex test", "--repos", "shared"])
     result = runner.invoke(
         app,
-        ["finish", "--task", "po-mutex-test", "--push-only", "--body", "x"],
+        ["finish", "--hotfix", "--task", "po-mutex-test", "--push-only", "--body", "x"],
     )
     assert result.exit_code != 0
     assert "no effect" in result.output.lower() or "push-only" in result.output.lower()
@@ -821,7 +821,7 @@ def test_finish_gh_not_available(configured_git_app: Path):
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
     cli_container.shell.override(mock_shell)
 
-    result = runner.invoke(app, ["finish", "--task", "test-no-gh"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "test-no-gh"])
     assert result.exit_code != 0 or "gh" in result.output.lower()
 
     cli_container.shell.reset_override()
@@ -914,7 +914,7 @@ def test_finish_force_repushes_to_existing_pr(configured_git_app: Path):
     try:
         import time
         time.sleep(0.01)  # ensure a new finished_at timestamp differs from `before`
-        result = runner.invoke(app, ["finish", "--force", "--task", "rp"])
+        result = runner.invoke(app, ["finish", "--hotfix", "--force", "--task", "rp"])
         assert result.exit_code == 0, result.output
         assert len(captured["push"]) == 1, f"expected one push, got {captured['push']}"
         assert captured["pr_create"] == [], "should NOT create a new PR under --force"
@@ -937,7 +937,7 @@ def test_finish_without_force_warns_about_unpushed_commits(configured_git_app: P
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
     cli_container.shell.override(mock_shell)
     try:
-        result = runner.invoke(app, ["finish", "--task", "warn"])
+        result = runner.invoke(app, ["finish", "--hotfix", "--task", "warn"])
         assert result.exit_code == 0, result.output
         assert "unpushed commits" in result.output
         assert "--force" in result.output
@@ -950,7 +950,7 @@ def test_finish_without_force_warns_about_unpushed_commits(configured_git_app: P
 def test_finish_force_incompatible_with_body_file(configured_git_app: Path):
     _make_finished_task_with_existing_pr(configured_git_app, slug="bf")
     result = runner.invoke(
-        app, ["finish", "--force", "--task", "bf", "--body", "hi"]
+        app, ["finish", "--hotfix", "--force", "--task", "bf", "--body", "hi"]
     )
     assert result.exit_code != 0
     assert "gh pr edit" in result.output
@@ -958,7 +958,7 @@ def test_finish_force_incompatible_with_body_file(configured_git_app: Path):
 
 def test_finish_force_incompatible_with_handoff(configured_git_app: Path):
     _make_finished_task_with_existing_pr(configured_git_app, slug="ho")
-    result = runner.invoke(app, ["finish", "--force", "--task", "ho", "--handoff"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--force", "--task", "ho", "--handoff"])
     assert result.exit_code != 0
     assert "handoff" in result.output.lower()
 
@@ -1278,7 +1278,7 @@ def test_finish_body_file_dash_reads_stdin(configured_git_app: Path):
     try:
         with patch("sys.stdin.isatty", return_value=False):
             result = runner.invoke(
-                app, ["finish", "--task", "stdin-test", "--body-file", "-"],
+                app, ["finish", "--hotfix", "--task", "stdin-test", "--body-file", "-"],
                 input="Summary\n\nTest plan\n",
             )
         # Finish may fail downstream (audit/gh/etc.) — we only assert the
@@ -1305,7 +1305,7 @@ def test_finish_body_file_dash_tty_errors(configured_git_app: Path):
         mock_read.side_effect = raise_tty_error
         
         result = runner.invoke(
-            app, ["finish", "--task", "tty-test", "--body-file", "-"]
+            app, ["finish", "--hotfix", "--task", "tty-test", "--body-file", "-"]
         )
     assert result.exit_code == 1, result.output
     assert "refusing to read body from an interactive TTY" in result.output
@@ -1326,7 +1326,7 @@ def test_finish_body_dash_tty_also_errors(configured_git_app: Path):
         mock_read.side_effect = raise_tty_error
         
         result = runner.invoke(
-            app, ["finish", "--task", "body-tty-test", "--body", "-"]
+            app, ["finish", "--hotfix", "--task", "body-tty-test", "--body", "-"]
         )
     assert result.exit_code == 1, result.output
     assert "refusing to read body from an interactive TTY" in result.output
@@ -1339,7 +1339,7 @@ def test_finish_body_file_dash_empty_stdin_rejected(configured_git_app: Path):
 
     with patch("sys.stdin.isatty", return_value=False):
         result = runner.invoke(
-            app, ["finish", "--task", "empty-stdin-test", "--body-file", "-"],
+            app, ["finish", "--hotfix", "--task", "empty-stdin-test", "--body-file", "-"],
             input="",
         )
     assert result.exit_code == 1
@@ -1396,7 +1396,7 @@ def test_finish_shared_git_root_creates_one_pr_records_on_all(configured_git_app
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
     cli_container.shell.override(mock_shell)
 
-    result = runner.invoke(app, ["finish", "--task", "group-prs"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "group-prs"])
     assert result.exit_code == 0, result.output
     assert create_pr_call_count == 1, f"Expected 1 gh pr create call, got {create_pr_call_count}"
 
@@ -1443,7 +1443,7 @@ def test_finish_harvests_existing_pr_instead_of_creating(configured_git_app: Pat
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
     cli_container.shell.override(mock_shell)
 
-    result = runner.invoke(app, ["finish", "--task", "reuse-pr"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "reuse-pr"])
     assert result.exit_code == 0, result.output
     assert create_pr_called is False, "gh pr create should not be called when PR already exists"
 
@@ -1500,7 +1500,7 @@ def test_finish_harvests_on_create_pr_duplicate_stderr(configured_git_app: Path)
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
     cli_container.shell.override(mock_shell)
 
-    result = runner.invoke(app, ["finish", "--task", "race-pr"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "race-pr"])
     assert result.exit_code == 0, result.output
     assert list_call_count == 2, "Expected pre-check + fallback list calls"
 
@@ -1561,7 +1561,7 @@ def test_finish_calls_ensure_upstream_after_push(configured_git_app: Path):
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
     cli_container.shell.override(mock_shell)
 
-    result = runner.invoke(app, ["finish", "--task", "upstream-check"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "upstream-check"])
     assert result.exit_code == 0, result.output
     assert set_upstream_called, "ensure_upstream should have run set-upstream-to"
 
@@ -1612,7 +1612,7 @@ def test_finish_captures_diagnostic_when_main_is_dirty_post_op(configured_git_ap
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
     cli_container.shell.override(mock_shell)
 
-    result = runner.invoke(app, ["finish", "--task", "dirty-diag", "--force-audit"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "dirty-diag", "--force-audit"])
     # Finish succeeds (diagnostic is silent).
     assert result.exit_code == 0, result.output
 
@@ -1659,7 +1659,7 @@ def test_finish_does_not_capture_diagnostic_when_main_is_clean(configured_git_ap
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
     cli_container.shell.override(mock_shell)
 
-    result = runner.invoke(app, ["finish", "--task", "clean-diag"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "clean-diag"])
     assert result.exit_code == 0, result.output
 
     diag_dir = configured_git_app / ".mothership" / "diagnostics"
@@ -1912,7 +1912,7 @@ def test_finish_blocked_by_unready_upstream(configured_git_app: Path, monkeypatc
 
     monkeypatch.setattr("mship.cli.worktree._dependency_decisions", _fake_decisions)
 
-    result = runner.invoke(app, ["finish", "--task", "b"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "b"])
     assert result.exit_code != 0
     err = (result.output or "").lower()
     assert "a" in err
@@ -1946,7 +1946,7 @@ def test_finish_bypass_deps(configured_git_app: Path, monkeypatch):
 
     monkeypatch.setattr("mship.cli.worktree._dependency_decisions", _fake_decisions)
 
-    result = runner.invoke(app, ["finish", "--task", "b", "--bypass-deps"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "b", "--bypass-deps"])
     out = (result.output or "").lower()
     # The deps gate must NOT have fired; finish may fail for unrelated reasons
     # (no actual PR infra) but the blocked-upstream message must be absent.

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -33,7 +33,7 @@ def _audit_ok_run(cmd, cwd, env=None):
 
 
 def test_spawn(configured_git_app: Path):
-    result = runner.invoke(app, ["spawn", "add labels to tasks", "--repos", "shared"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "add labels to tasks", "--repos", "shared"])
     assert result.exit_code == 0, result.output
     mgr = StateManager(configured_git_app / ".mothership")
     state = mgr.load()
@@ -43,7 +43,7 @@ def test_spawn(configured_git_app: Path):
 def test_spawn_slug_override(configured_git_app: Path):
     """--slug overrides auto-generated slug. See #59."""
     result = runner.invoke(
-        app, ["spawn", "a very long description for a simple task",
+        app, ["spawn", "--hotfix", "a very long description for a simple task",
               "--repos", "shared", "--slug", "short"],
     )
     assert result.exit_code == 0, result.output
@@ -59,7 +59,7 @@ def test_spawn_slug_rejects_invalid_chars(configured_git_app: Path):
     """Reject uppercase / underscores / spaces / empty. See #59."""
     for bad in ["UPPER", "has_underscore", "with space", "", "-leading", "trailing-"]:
         result = runner.invoke(
-            app, ["spawn", "d", "--repos", "shared", "--slug", bad],
+            app, ["spawn", "--hotfix", "d", "--repos", "shared", "--slug", bad],
         )
         assert result.exit_code != 0, f"expected rejection for slug={bad!r}: {result.output}"
 
@@ -67,11 +67,11 @@ def test_spawn_slug_rejects_invalid_chars(configured_git_app: Path):
 def test_spawn_slug_collision_errors(configured_git_app: Path):
     """Two spawns with the same --slug → second fails with a clear error."""
     first = runner.invoke(
-        app, ["spawn", "first", "--repos", "shared", "--slug", "dupe"],
+        app, ["spawn", "--hotfix", "first", "--repos", "shared", "--slug", "dupe"],
     )
     assert first.exit_code == 0, first.output
     second = runner.invoke(
-        app, ["spawn", "second", "--repos", "shared", "--slug", "dupe"],
+        app, ["spawn", "--hotfix", "second", "--repos", "shared", "--slug", "dupe"],
     )
     assert second.exit_code != 0
     # Collision ValueError bubbles up through the CLI (existing behavior for
@@ -81,7 +81,7 @@ def test_spawn_slug_collision_errors(configured_git_app: Path):
 
 
 def test_spawn_all_repos(configured_git_app: Path):
-    result = runner.invoke(app, ["spawn", "big change"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "big change"])
     assert result.exit_code == 0, result.output
     mgr = StateManager(configured_git_app / ".mothership")
     state = mgr.load()
@@ -114,7 +114,7 @@ def test_spawn_base_stacks_on_branch(configured_git_app: Path):
     base_tip = _commit_base_branch(configured_git_app / "shared", "feat/upstream")
     result = runner.invoke(
         app,
-        ["spawn", "stacked task", "--repos", "shared", "--slug", "stacked",
+        ["spawn", "--hotfix", "stacked task", "--repos", "shared", "--slug", "stacked",
          "--base", "feat/upstream", "--skip-setup"],
     )
     assert result.exit_code == 0, result.output
@@ -131,7 +131,7 @@ def test_spawn_base_unknown_branch_errors_cleanly(configured_git_app: Path):
     """spawn --base <missing> fails with a clean message and creates no task. See #42."""
     result = runner.invoke(
         app,
-        ["spawn", "x", "--repos", "shared", "--slug", "xbase",
+        ["spawn", "--hotfix", "x", "--repos", "shared", "--slug", "xbase",
          "--base", "feat/nope", "--skip-setup"],
     )
     assert result.exit_code != 0
@@ -141,7 +141,7 @@ def test_spawn_base_unknown_branch_errors_cleanly(configured_git_app: Path):
 
 def test_spawn_records_base_branch(configured_git_app: Path):
     """Spawn records base_branch from workspace config if available, else None."""
-    result = runner.invoke(app, ["spawn", "record base", "--repos", "shared"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "record base", "--repos", "shared"])
     assert result.exit_code == 0, result.output
     mgr = StateManager(configured_git_app / ".mothership")
     state = mgr.load()
@@ -156,7 +156,7 @@ def test_spawn_tty_prints_cd_hint(configured_git_app: Path, monkeypatch):
     from mship.cli.output import Output
     monkeypatch.setattr(Output, "is_tty", property(lambda self: True))
 
-    result = runner.invoke(app, ["spawn", "cd hint", "--repos", "shared"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "cd hint", "--repos", "shared"])
     assert result.exit_code == 0, result.output
 
     mgr = StateManager(configured_git_app / ".mothership")
@@ -172,7 +172,7 @@ def test_spawn_tty_prints_cd_hint(configured_git_app: Path, monkeypatch):
 def test_spawn_non_tty_json_omits_cd_hint(configured_git_app: Path):
     """Non-TTY spawn output is JSON only — no cd hint mixed in. See #129."""
     import json as _json
-    result = runner.invoke(app, ["spawn", "json hint", "--repos", "shared"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "json hint", "--repos", "shared"])
     assert result.exit_code == 0, result.output
     # Parses as JSON — proves no hint text was appended.
     payload = _json.loads(result.output)
@@ -197,7 +197,7 @@ def test_spawn_with_depends_on_persists_edges(configured_git_app: Path):
 
     result = runner.invoke(
         app,
-        ["spawn", "downstream task", "--repos", "shared", "--slug", "down",
+        ["spawn", "--hotfix", "downstream task", "--repos", "shared", "--slug", "down",
          "--depends-on", "a", "--skip-setup"],
     )
     assert result.exit_code == 0, result.stderr or result.output
@@ -210,7 +210,7 @@ def test_spawn_with_unknown_depends_on_errors(configured_git_app: Path):
     """spawn --depends-on <unknown> errors before creating the task. See #104."""
     result = runner.invoke(
         app,
-        ["spawn", "x", "--repos", "shared", "--slug", "x",
+        ["spawn", "--hotfix", "x", "--repos", "shared", "--slug", "x",
          "--depends-on", "nope", "--skip-setup"],
     )
     assert result.exit_code != 0
@@ -218,7 +218,7 @@ def test_spawn_with_unknown_depends_on_errors(configured_git_app: Path):
 
 
 def test_worktrees_list(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "test list", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "test list", "--repos", "shared"])
     result = runner.invoke(app, ["worktrees"])
     assert result.exit_code == 0
     assert "test-list" in result.output
@@ -483,7 +483,7 @@ def test_close_merged_pr_with_unverified_merge_commit_warns_but_proceeds(configu
 
 
 def test_finish_handoff(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "handoff test", "--repos", "shared,auth-service"])
+    runner.invoke(app, ["spawn", "--hotfix", "handoff test", "--repos", "shared,auth-service"])
     result = runner.invoke(app, ["finish", "--handoff", "--task", "handoff-test"])
     assert result.exit_code == 0
     handoff_file = configured_git_app / ".mothership" / "handoffs" / "handoff-test.yaml"
@@ -494,7 +494,7 @@ def test_finish_creates_prs(configured_git_app: Path):
     from mship.cli import container as cli_container
 
     # Spawn a task first
-    runner.invoke(app, ["spawn", "test prs", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "test prs", "--repos", "shared"])
 
     # Mock shell for finish operations
     def mock_run(cmd, cwd, env=None):
@@ -536,7 +536,7 @@ def test_finish_body_file_passed_to_gh_pr_create(configured_git_app: Path):
     """--body-file contents must land in the gh pr create invocation."""
     from mship.cli import container as cli_container
 
-    runner.invoke(app, ["spawn", "body test", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "body test", "--repos", "shared"])
 
     body_path = configured_git_app / "body.md"
     body_path.write_text(
@@ -582,7 +582,7 @@ def test_finish_body_map_per_repo_bodies(configured_git_app: Path):
     for repos not in the map. See #114."""
     from mship.cli import container as cli_container
 
-    runner.invoke(app, ["spawn", "body map", "--repos", "shared,auth-service,api-gateway"])
+    runner.invoke(app, ["spawn", "--hotfix", "body map", "--repos", "shared,auth-service,api-gateway"])
 
     shared_body = configured_git_app / "shared.md"
     shared_body.write_text("## Shared\n- lib change\n\n## Test plan\n- [ ] unit\n")
@@ -639,7 +639,7 @@ def test_finish_body_map_unknown_repo_rejected(configured_git_app: Path):
     """--body-map referencing a repo NOT in task.affected_repos errors clearly."""
     from mship.cli import container as cli_container
 
-    runner.invoke(app, ["spawn", "unknown body", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "unknown body", "--repos", "shared"])
 
     body_path = configured_git_app / "ghost.md"
     body_path.write_text("## body\n- noop\n\n## Test plan\n- [ ] x\n")
@@ -666,7 +666,7 @@ def test_finish_body_map_empty_body_rejected(configured_git_app: Path):
     """An empty file in --body-map is rejected (consistent with --body-file rule)."""
     from mship.cli import container as cli_container
 
-    runner.invoke(app, ["spawn", "empty body", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "empty body", "--repos", "shared"])
 
     body_path = configured_git_app / "empty.md"
     body_path.write_text("   \n\n  \n")
@@ -691,7 +691,7 @@ def test_finish_body_map_empty_body_rejected(configured_git_app: Path):
 
 def test_close_accepts_positional_slug(configured_git_app: Path):
     """`mship close <slug>` is an alternative to `--task <slug>`. See #40."""
-    runner.invoke(app, ["spawn", "positional close", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "positional close", "--repos", "shared"])
     result = runner.invoke(app, ["close", "positional-close", "-y", "--abandon"])
     assert result.exit_code == 0, result.output
     mgr = StateManager(configured_git_app / ".mothership")
@@ -700,8 +700,8 @@ def test_close_accepts_positional_slug(configured_git_app: Path):
 
 def test_close_positional_and_task_flag_conflict(configured_git_app: Path):
     """Conflicting positional + --task values fail loudly."""
-    runner.invoke(app, ["spawn", "conflict a", "--repos", "shared"])
-    runner.invoke(app, ["spawn", "conflict b", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "conflict a", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "conflict b", "--repos", "shared"])
     result = runner.invoke(
         app, ["close", "conflict-a", "--task", "conflict-b", "-y", "--abandon"],
     )
@@ -711,7 +711,7 @@ def test_close_positional_and_task_flag_conflict(configured_git_app: Path):
 
 def test_close_positional_equal_to_task_flag_is_ok(configured_git_app: Path):
     """Same value in both is not an error."""
-    runner.invoke(app, ["spawn", "equal case", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "equal case", "--repos", "shared"])
     result = runner.invoke(
         app, ["close", "equal-case", "--task", "equal-case", "-y", "--abandon"],
     )
@@ -722,7 +722,7 @@ def test_finish_title_override_passed_to_gh_pr_create(configured_git_app: Path):
     """--title replaces task.description in the gh pr create invocation. See #45."""
     from mship.cli import container as cli_container
 
-    runner.invoke(app, ["spawn", "a long verbose description that shouldnt be the PR title", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "a long verbose description that shouldnt be the PR title", "--repos", "shared"])
 
     captured: dict[str, str] = {}
 
@@ -765,7 +765,7 @@ def test_finish_title_override_passed_to_gh_pr_create(configured_git_app: Path):
 
 def test_finish_title_rejected_with_force(configured_git_app: Path):
     """--force won't rewrite existing PR titles; conflict rejected like --body."""
-    runner.invoke(app, ["spawn", "force title mutex", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "force title mutex", "--repos", "shared"])
     result = runner.invoke(
         app, ["finish", "--task", "force-title-mutex", "--force", "--title", "t"]
     )
@@ -774,7 +774,7 @@ def test_finish_title_rejected_with_force(configured_git_app: Path):
 
 
 def test_finish_title_incompatible_with_push_only(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "po title mutex", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "po title mutex", "--repos", "shared"])
     result = runner.invoke(
         app, ["finish", "--task", "po-title-mutex", "--push-only", "--title", "t"]
     )
@@ -782,7 +782,7 @@ def test_finish_title_incompatible_with_push_only(configured_git_app: Path):
 
 
 def test_finish_body_and_body_file_mutually_exclusive(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "mutex test", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "mutex test", "--repos", "shared"])
     result = runner.invoke(
         app, ["finish", "--task", "mutex-test", "--body", "x", "--body-file", "/tmp/y"]
     )
@@ -791,7 +791,7 @@ def test_finish_body_and_body_file_mutually_exclusive(configured_git_app: Path):
 
 
 def test_finish_rejects_empty_body_file(configured_git_app: Path, tmp_path: Path):
-    runner.invoke(app, ["spawn", "empty body test", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "empty body test", "--repos", "shared"])
     empty = tmp_path / "empty.md"
     empty.write_text("   \n\n")
     result = runner.invoke(
@@ -802,7 +802,7 @@ def test_finish_rejects_empty_body_file(configured_git_app: Path, tmp_path: Path
 
 
 def test_finish_body_incompatible_with_push_only(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "po mutex test", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "po mutex test", "--repos", "shared"])
     result = runner.invoke(
         app,
         ["finish", "--task", "po-mutex-test", "--push-only", "--body", "x"],
@@ -814,7 +814,7 @@ def test_finish_body_incompatible_with_push_only(configured_git_app: Path):
 def test_finish_gh_not_available(configured_git_app: Path):
     from mship.cli import container as cli_container
 
-    runner.invoke(app, ["spawn", "test no gh", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "test no gh", "--repos", "shared"])
 
     mock_shell = MagicMock(spec=ShellRunner)
     mock_shell.run.return_value = ShellResult(returncode=127, stdout="", stderr="command not found")
@@ -972,7 +972,7 @@ def test_spawn_skip_setup_flag(configured_git_app: Path):
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
     cli_container.shell.override(mock_shell)
 
-    result = runner.invoke(app, ["spawn", "skip flag test", "--repos", "shared", "--skip-setup"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "skip flag test", "--repos", "shared", "--skip-setup"])
     assert result.exit_code == 0, result.output
     # run_task should not have been called for setup
     mock_shell.run_task.assert_not_called()
@@ -991,7 +991,7 @@ def test_spawn_shows_setup_warnings(configured_git_app: Path):
     )
     cli_container.shell.override(mock_shell)
 
-    result = runner.invoke(app, ["spawn", "warning flag test", "--repos", "shared"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "warning flag test", "--repos", "shared"])
     assert result.exit_code == 0, result.output
     # Setup failure should appear in output as a warning
     assert "setup failed" in result.output.lower() or "pnpm install failed" in result.output
@@ -1183,7 +1183,7 @@ def test_spawn_refuses_when_git_root_missing_from_repos(workspace_monorepo_app):
     """spawn --repos pkg_a where pkg_a.git_root=mono must refuse if mono not included."""
     from typer.testing import CliRunner
     from mship.cli import app as _app
-    r = CliRunner().invoke(_app, ["spawn", "validate test", "--repos", "pkg_a", "--force-audit"])
+    r = CliRunner().invoke(_app, ["spawn", "--hotfix", "validate test", "--repos", "pkg_a", "--force-audit"])
     assert r.exit_code != 0
     assert "pkg_a" in r.output
     assert "mono" in r.output
@@ -1193,7 +1193,7 @@ def test_spawn_refuses_when_git_root_missing_from_repos(workspace_monorepo_app):
 def test_spawn_succeeds_when_git_root_present(workspace_monorepo_app):
     from typer.testing import CliRunner
     from mship.cli import app as _app
-    r = CliRunner().invoke(_app, ["spawn", "validate good", "--repos", "mono,pkg_a", "--force-audit"])
+    r = CliRunner().invoke(_app, ["spawn", "--hotfix", "validate good", "--repos", "mono,pkg_a", "--force-audit"])
     assert r.exit_code == 0, r.output
 
 
@@ -1201,7 +1201,7 @@ def test_spawn_plain_repo_unaffected(configured_git_app):
     """spawn with a repo that has no git_root still works without changes."""
     from typer.testing import CliRunner
     from mship.cli import app as _app
-    r = CliRunner().invoke(_app, ["spawn", "plain", "--repos", "shared", "--force-audit"])
+    r = CliRunner().invoke(_app, ["spawn", "--hotfix", "plain", "--repos", "shared", "--force-audit"])
     assert r.exit_code == 0, r.output
 
 
@@ -1248,7 +1248,7 @@ def test_finish_body_file_dash_reads_stdin(configured_git_app: Path):
     from unittest.mock import patch
     from mship.cli import container as cli_container
 
-    runner.invoke(app, ["spawn", "stdin test", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "stdin test", "--repos", "shared"])
 
     def mock_run(cmd, cwd, env=None):
         if "symbolic-ref" in cmd:
@@ -1293,7 +1293,7 @@ def test_finish_body_file_dash_tty_errors(configured_git_app: Path):
     """--body-file - should error if stdin is a TTY."""
     from unittest.mock import patch, MagicMock
 
-    runner.invoke(app, ["spawn", "tty test", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "tty test", "--repos", "shared"])
 
     # Mock the _read_stdin_body_or_exit function to simulate TTY behavior
     with patch('mship.cli.worktree._read_stdin_body_or_exit') as mock_read:
@@ -1314,7 +1314,7 @@ def test_finish_body_dash_tty_also_errors(configured_git_app: Path):
     """--body - should error if stdin is a TTY (symmetry)."""
     from unittest.mock import patch
 
-    runner.invoke(app, ["spawn", "body tty test", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "body tty test", "--repos", "shared"])
 
     # Mock the _read_stdin_body_or_exit function to simulate TTY behavior
     with patch('mship.cli.worktree._read_stdin_body_or_exit') as mock_read:
@@ -1335,7 +1335,7 @@ def test_finish_body_file_dash_empty_stdin_rejected(configured_git_app: Path):
     """--body-file - with empty stdin should error."""
     from unittest.mock import patch
 
-    runner.invoke(app, ["spawn", "empty stdin test", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "empty stdin test", "--repos", "shared"])
 
     with patch("sys.stdin.isatty", return_value=False):
         result = runner.invoke(
@@ -1360,7 +1360,7 @@ def test_finish_shared_git_root_creates_one_pr_records_on_all(configured_git_app
     base_branch: main
 """)
 
-    runner.invoke(app, ["spawn", "group prs", "--repos", "shared,infra", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "group prs", "--repos", "shared,infra", "--skip-setup"])
 
     create_pr_call_count = 0
 
@@ -1415,7 +1415,7 @@ def test_finish_harvests_existing_pr_instead_of_creating(configured_git_app: Pat
     finish harvests it via `gh pr list --head` without calling `gh pr create`."""
     from mship.cli import container as cli_container
 
-    runner.invoke(app, ["spawn", "reuse pr", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "reuse pr", "--repos", "shared", "--skip-setup"])
 
     create_pr_called = False
 
@@ -1460,7 +1460,7 @@ def test_finish_harvests_on_create_pr_duplicate_stderr(configured_git_app: Path)
     'already exists' (race), finish harvests via a second list call."""
     from mship.cli import container as cli_container
 
-    runner.invoke(app, ["spawn", "race pr", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "race pr", "--repos", "shared", "--skip-setup"])
 
     list_call_count = 0
 
@@ -1516,7 +1516,7 @@ def test_finish_calls_ensure_upstream_after_push(configured_git_app: Path):
     """ensure_upstream fires after push; if @{u} fails, set-upstream-to runs."""
     from mship.cli import container as cli_container
 
-    runner.invoke(app, ["spawn", "upstream check", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "upstream check", "--repos", "shared", "--skip-setup"])
 
     set_upstream_called = False
     ensure_upstream_probe_count = 0
@@ -1574,7 +1574,7 @@ def test_finish_captures_diagnostic_when_main_is_dirty_post_op(configured_git_ap
     from mship.util.shell import ShellResult, ShellRunner
     from unittest.mock import MagicMock
 
-    runner.invoke(app, ["spawn", "dirty diag", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "dirty diag", "--repos", "shared", "--skip-setup"])
 
     # Pre-dirty the main repo's shared/ working tree by writing an extra
     # file directly to simulate whatever causes the bug.
@@ -1633,7 +1633,7 @@ def test_finish_does_not_capture_diagnostic_when_main_is_clean(configured_git_ap
     from mship.util.shell import ShellResult, ShellRunner
     from unittest.mock import MagicMock
 
-    runner.invoke(app, ["spawn", "clean diag", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "clean diag", "--repos", "shared", "--skip-setup"])
 
     def mock_run(cmd, cwd, env=None):
         if "gh auth status" in cmd:
@@ -1675,7 +1675,7 @@ def test_close_logs_rate_limit_reason_when_pr_state_unknown(configured_git_app: 
     from mship.util.shell import ShellResult, ShellRunner
     from unittest.mock import MagicMock
 
-    runner.invoke(app, ["spawn", "rate-limit close", "--repos", "shared"])
+    runner.invoke(app, ["spawn", "--hotfix", "rate-limit close", "--repos", "shared"])
     # Set a pr_url manually so close actually calls gh pr view.
     import yaml
     state_path = configured_git_app / ".mothership" / "state.yaml"
@@ -1728,7 +1728,7 @@ def test_spawn_default_scope_none_requires_explicit_repos(configured_git_app: Pa
     from mship.cli import container as cli_container
     cli_container.config.reset()
 
-    result = runner.invoke(app, ["spawn", "no scope"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "no scope"])
     assert result.exit_code != 0
     assert "default_scope" in result.output
     assert "--repos" in result.output
@@ -1744,7 +1744,7 @@ def test_spawn_default_scope_list_selects_repos(configured_git_app: Path):
     from mship.cli import container as cli_container
     cli_container.config.reset()
 
-    result = runner.invoke(app, ["spawn", "scoped default"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "scoped default"])
     assert result.exit_code == 0, result.output
     mgr = StateManager(configured_git_app / ".mothership")
     state = mgr.load()
@@ -1762,7 +1762,7 @@ def test_spawn_threshold_non_tty_requires_yes(configured_git_app: Path):
     cli_container.config.reset()
 
     # CliRunner is non-TTY by default.
-    result = runner.invoke(app, ["spawn", "big fan out"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "big fan out"])
     assert result.exit_code != 0
     assert "spawn_confirm_threshold" in result.output
     assert "--yes" in result.output
@@ -1777,7 +1777,7 @@ def test_spawn_threshold_bypassed_with_yes(configured_git_app: Path):
     from mship.cli import container as cli_container
     cli_container.config.reset()
 
-    result = runner.invoke(app, ["spawn", "confirmed fan out", "--yes"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "confirmed fan out", "--yes"])
     assert result.exit_code == 0, result.output
 
 
@@ -1791,7 +1791,7 @@ def test_spawn_threshold_not_triggered_with_explicit_repos(configured_git_app: P
     from mship.cli import container as cli_container
     cli_container.config.reset()
 
-    result = runner.invoke(app, ["spawn", "explicit scope", "--repos", "shared,auth-service"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "explicit scope", "--repos", "shared,auth-service"])
     assert result.exit_code == 0, result.output
 
 
@@ -1822,7 +1822,7 @@ def test_spawn_cli_passes_offline_flag(workspace_with_git, tmp_path, monkeypatch
                 ),
             )
             result = runner.invoke(
-                app, ["spawn", "x", "--repos", "shared",
+                app, ["spawn", "--hotfix", "x", "--repos", "shared",
                       "--skip-setup", "--force-audit", "--offline"],
             )
             assert result.exit_code == 0, result.output
@@ -1866,7 +1866,7 @@ def test_spawn_cli_writes_offline_journal_entry(workspace_with_git, monkeypatch)
                 ),
             )
             result = runner.invoke(
-                app, ["spawn", "off", "--repos", "shared",
+                app, ["spawn", "--hotfix", "off", "--repos", "shared",
                       "--skip-setup", "--force-audit", "--offline"],
             )
             assert result.exit_code == 0, result.output

--- a/tests/core/test_edit_guard.py
+++ b/tests/core/test_edit_guard.py
@@ -139,3 +139,115 @@ def test_multi_task_allows_edit_inside_one_of_the_worktrees(tmp_path: Path):
                     affected_repos=["repo"], worktrees={"repo": wt}, branch=f"feat/{slug}")
     state = WorkspaceState(tasks={"t1": _t("t1", wt1), "t2": _t("t2", wt2)})
     assert evaluate_edit(wt2 / "src" / "x.py", state, cfg).allowed is True
+
+
+# ---------------------------------------------------------------------------
+# WorkItem gate: an edit inside the task's OWN worktree is the legitimate
+# location, but must still carry a WorkItem (feature ⇒ approved spec) — see
+# core/workitem_gate.py::check_task_gate and spec
+# workitem-mandatory-kind-gated-approval, task 5/6. Only enforced when the
+# caller supplies `workspace_root` (production always does, via
+# `_guard-edit`); omitting it (as every test above does) preserves the old,
+# location-only behavior so those tests are unaffected.
+# ---------------------------------------------------------------------------
+
+def _workitem(workspace_root: Path, *, kind: str = "bug", spec_approved: bool = False):
+    from mship.core.workitem_store import WorkItemStore
+    items = WorkItemStore(workspace_root / ".mothership" / "workitems")
+    wi = items.create(title="thing", kind=kind, workspace="ws",
+                       now=datetime.now(timezone.utc))
+    if spec_approved:
+        from mship.core.spec import Spec
+        from mship.core.spec_store import SpecStore
+        specs = SpecStore(workspace_root / "specs")
+        now = datetime.now(timezone.utc)
+        specs.save(Spec(id="spec-1", title="Spec", status="approved",
+                        created_at=now, updated_at=now))
+        items.link_spec(wi.id, "spec-1", now=now)
+    return wi
+
+
+def test_blocks_worktree_edit_when_task_has_no_workitem(tmp_path: Path):
+    main, wt = _layout(tmp_path)
+    cfg = _Config({"repo": main})
+    state = _state("t", "repo", wt)
+    d = evaluate_edit(wt / "src" / "x.py", state, cfg, workspace_root=tmp_path)
+    assert d.allowed is False
+    assert "WorkItem" in d.reason
+    assert "MSHIP_BYPASS_GATE" in d.reason
+
+
+def test_allows_worktree_edit_when_task_has_bug_workitem(tmp_path: Path):
+    """bug/chore/question WorkItems satisfy the gate without any spec."""
+    main, wt = _layout(tmp_path)
+    cfg = _Config({"repo": main})
+    wi = _workitem(tmp_path, kind="bug")
+    t = Task(slug="t", description="d", phase="dev",
+             created_at=datetime.now(timezone.utc),
+             affected_repos=["repo"], worktrees={"repo": wt}, branch="feat/t",
+             work_item_id=wi.id)
+    state = WorkspaceState(tasks={"t": t})
+    assert evaluate_edit(wt / "src" / "x.py", state, cfg, workspace_root=tmp_path).allowed is True
+
+
+def test_blocks_worktree_edit_when_feature_workitem_has_no_approved_spec(tmp_path: Path):
+    main, wt = _layout(tmp_path)
+    cfg = _Config({"repo": main})
+    wi = _workitem(tmp_path, kind="feature")
+    t = Task(slug="t", description="d", phase="dev",
+             created_at=datetime.now(timezone.utc),
+             affected_repos=["repo"], worktrees={"repo": wt}, branch="feat/t",
+             work_item_id=wi.id)
+    state = WorkspaceState(tasks={"t": t})
+    d = evaluate_edit(wt / "src" / "x.py", state, cfg, workspace_root=tmp_path)
+    assert d.allowed is False
+    assert "approved spec" in d.reason
+
+
+def test_allows_worktree_edit_when_feature_workitem_has_approved_spec(tmp_path: Path):
+    main, wt = _layout(tmp_path)
+    cfg = _Config({"repo": main})
+    wi = _workitem(tmp_path, kind="feature", spec_approved=True)
+    t = Task(slug="t", description="d", phase="dev",
+             created_at=datetime.now(timezone.utc),
+             affected_repos=["repo"], worktrees={"repo": wt}, branch="feat/t",
+             work_item_id=wi.id)
+    state = WorkspaceState(tasks={"t": t})
+    assert evaluate_edit(wt / "src" / "x.py", state, cfg, workspace_root=tmp_path).allowed is True
+
+
+def test_bypass_workitem_gate_allows_edit_without_workitem(tmp_path: Path):
+    main, wt = _layout(tmp_path)
+    cfg = _Config({"repo": main})
+    state = _state("t", "repo", wt)
+    d = evaluate_edit(
+        wt / "src" / "x.py", state, cfg,
+        workspace_root=tmp_path, bypass_workitem_gate=True,
+    )
+    assert d.allowed is True
+
+
+def test_omitting_workspace_root_skips_workitem_gate(tmp_path: Path):
+    """Callers that don't pass workspace_root (e.g. every other test in this
+    file) keep the old, location-only behavior — the WorkItem gate is opt-in
+    via the new parameter, not a silent breaking change."""
+    main, wt = _layout(tmp_path)
+    cfg = _Config({"repo": main})
+    state = _state("t", "repo", wt)
+    assert evaluate_edit(wt / "src" / "x.py", state, cfg).allowed is True
+
+
+def test_fails_open_when_workitem_store_is_corrupt(tmp_path: Path):
+    """A malformed WorkItem gate lookup must never block an edit — fail OPEN."""
+    main, wt = _layout(tmp_path)
+    cfg = _Config({"repo": main})
+    wi_dir = tmp_path / ".mothership" / "workitems"
+    wi_dir.mkdir(parents=True)
+    t = Task(slug="t", description="d", phase="dev",
+             created_at=datetime.now(timezone.utc),
+             affected_repos=["repo"], worktrees={"repo": wt}, branch="feat/t",
+             work_item_id="does-not-exist")
+    (wi_dir / "does-not-exist.json").write_text("not valid json{{{")
+    state = WorkspaceState(tasks={"t": t})
+    d = evaluate_edit(wt / "src" / "x.py", state, cfg, workspace_root=tmp_path)
+    assert d.allowed is True

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -370,6 +370,35 @@ def test_a7_plan_to_dev_default_off_no_spec_still_succeeds(
     assert result.new_phase == "dev"
 
 
+def test_has_approved_spec_uses_shared_workitem_gate_approved_statuses(
+    tmp_path: Path, monkeypatch,
+):
+    """PR review fix: PhaseManager._has_approved_spec must consult the single
+    shared workitem_gate.APPROVED_STATUSES rather than a hardcoded local
+    copy. Proven behaviorally: patching the shared set changes what counts
+    as approved here too."""
+    from mship.core import workitem_gate
+    from mship.core.spec import Spec
+    from mship.core.spec_store import SpecStore
+
+    now = datetime(2026, 4, 10, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(
+        id="s1", title="S", status="drafting",
+        created_at=now, updated_at=now, task_slug="t",
+    ))
+    pm = PhaseManager(
+        StateManager(tmp_path / ".mothership"), MagicMock(spec=LogManager),
+        workspace_root=tmp_path,
+    )
+
+    # "drafting" isn't approved-or-beyond by the real, shared set.
+    assert pm._has_approved_spec("t") is False
+
+    # Patching the SHARED set (not a local copy) must change the outcome.
+    monkeypatch.setattr(workitem_gate, "APPROVED_STATUSES", {"drafting"})
+    assert pm._has_approved_spec("t") is True
+
+
 def test_a7_dispatched_spec_also_satisfies_gate(
     state_with_task: StateManager, tmp_path: Path
 ):
@@ -489,3 +518,46 @@ def test_plan_to_dev_bypass_spec_gate_allows_and_logs_hotfix(tmp_path: Path):
     assert line["reason"] == "hotfix"
     assert line["op"] == "phase-dev"
     assert line["branch"] == "wi-task"
+
+
+# ---------------------------------------------------------------------------
+# PR review fix: corrupt/unreadable WorkItem store must not raise a raw
+# exception out of transition() — --bypass-spec-gate already skips the call
+# entirely as the intended escape hatch; without it we still want a clean
+# SpecGateError instead of a traceback.
+# ---------------------------------------------------------------------------
+
+def test_plan_to_dev_corrupt_workitem_store_raises_clean_spec_gate_error(tmp_path: Path):
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(
+        title="add thing", kind="feature", workspace="test",
+        now=datetime(2026, 4, 10, tzinfo=timezone.utc),
+    )
+    # Corrupt the WorkItem's JSON file on disk after it's been created.
+    wi_path = tmp_path / ".mothership" / "workitems" / f"{wi.id}.json"
+    wi_path.write_text("{not valid json")
+
+    sm, pm = _workitem_gate_env(tmp_path)
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+
+    with pytest.raises(SpecGateError) as excinfo:
+        pm.transition("wi-task", "dev")
+    assert "corrupt store" in str(excinfo.value).lower()
+
+
+def test_plan_to_dev_bypass_spec_gate_skips_corrupt_workitem_store(tmp_path: Path):
+    """--bypass-spec-gate never calls check_task_gate, so a corrupt store
+    doesn't matter — the escape hatch still works."""
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(
+        title="add thing", kind="feature", workspace="test",
+        now=datetime(2026, 4, 10, tzinfo=timezone.utc),
+    )
+    wi_path = tmp_path / ".mothership" / "workitems" / f"{wi.id}.json"
+    wi_path.write_text("{not valid json")
+
+    sm, pm = _workitem_gate_env(tmp_path)
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+
+    result = pm.transition("wi-task", "dev", bypass_spec_gate=True)
+    assert result.new_phase == "dev"

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -7,13 +7,23 @@ import pytest
 from mship.core.log import LogManager
 from mship.core.phase import FinishedTaskError, PhaseManager, PhaseTransition, SpecGateError
 from mship.core.state import StateManager, Task, TestResult, WorkspaceState
+from mship.core.workitem_store import WorkItemStore
 
 
 @pytest.fixture
 def state_with_task(tmp_path: Path) -> StateManager:
+    # A bug WorkItem is attached so the universal WorkItem gate
+    # (core/phase.py::transition → workitem_gate.check_task_gate) doesn't
+    # block these tests — bug-kind WorkItems pass without an approved spec.
+    # See spec workitem-mandatory-kind-gated-approval.
     state_dir = tmp_path / ".mothership"
     state_dir.mkdir()
     mgr = StateManager(state_dir)
+    items = WorkItemStore(state_dir / "workitems")
+    wi = items.create(
+        title="Add labels", kind="bug", workspace="test",
+        now=datetime(2026, 4, 10, tzinfo=timezone.utc),
+    )
     task = Task(
         slug="add-labels",
         description="Add labels",
@@ -25,6 +35,7 @@ def state_with_task(tmp_path: Path) -> StateManager:
             "shared": tmp_path / "shared",
             "auth-service": tmp_path / "auth-service",
         },
+        work_item_id=wi.id,
     )
     state = WorkspaceState(tasks={"add-labels": task})
     mgr.save(state)
@@ -381,3 +392,100 @@ def test_a7_dispatched_spec_also_satisfies_gate(
     pm = _make_phase_manager_with_approved_spec_gate(state_with_task, tmp_path)
     result = pm.transition("add-labels", "dev")
     assert result.new_phase == "dev"
+
+
+# ---------------------------------------------------------------------------
+# Task 3: phase→dev gate — feature ⇒ approved spec
+# (workitem-mandatory-kind-gated-approval)
+# ---------------------------------------------------------------------------
+
+def _workitem_gate_env(tmp_path: Path):
+    """Build a (StateManager, PhaseManager) pair with workspace_root wired in,
+    but no task saved yet — callers save their own task/WorkItem combination."""
+    from mship.core.config import RepoConfig, WorkspaceConfig
+
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    sm = StateManager(state_dir)
+    config = WorkspaceConfig(
+        workspace="test",
+        repos={"shared": RepoConfig(path=Path("./shared"), type="library")},
+    )
+    pm = PhaseManager(sm, MagicMock(spec=LogManager), config=config, workspace_root=tmp_path)
+    return sm, pm
+
+
+def _plan_task(slug: str = "wi-task", work_item_id: str | None = None) -> Task:
+    return Task(
+        slug=slug,
+        description="d",
+        phase="plan",
+        created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        affected_repos=["shared"],
+        branch=f"feat/{slug}",
+        work_item_id=work_item_id,
+    )
+
+
+def test_plan_to_dev_no_work_item_id_raises_spec_gate_error(tmp_path: Path):
+    sm, pm = _workitem_gate_env(tmp_path)
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task()}))
+    with pytest.raises(SpecGateError, match="WorkItem"):
+        pm.transition("wi-task", "dev")
+
+
+def test_plan_to_dev_bug_work_item_allowed(tmp_path: Path):
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(
+        title="fix it", kind="bug", workspace="test",
+        now=datetime(2026, 4, 10, tzinfo=timezone.utc),
+    )
+    sm, pm = _workitem_gate_env(tmp_path)
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+    result = pm.transition("wi-task", "dev")
+    assert result.new_phase == "dev"
+
+
+def test_plan_to_dev_feature_work_item_without_approved_spec_blocked(tmp_path: Path):
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(
+        title="add thing", kind="feature", workspace="test",
+        now=datetime(2026, 4, 10, tzinfo=timezone.utc),
+    )
+    sm, pm = _workitem_gate_env(tmp_path)
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+    with pytest.raises(SpecGateError, match="approved spec"):
+        pm.transition("wi-task", "dev")
+
+
+def test_plan_to_dev_feature_work_item_with_approved_spec_allowed(tmp_path: Path):
+    from mship.core.spec import Spec
+    from mship.core.spec_store import SpecStore
+
+    now = datetime(2026, 4, 10, tzinfo=timezone.utc)
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="add thing", kind="feature", workspace="test", now=now)
+    specs = SpecStore(tmp_path / "specs")
+    specs.save(Spec(id="spec-1", title="Spec", status="approved", created_at=now, updated_at=now))
+    items.link_spec(wi.id, "spec-1", now=now)
+
+    sm, pm = _workitem_gate_env(tmp_path)
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+    result = pm.transition("wi-task", "dev")
+    assert result.new_phase == "dev"
+
+
+def test_plan_to_dev_bypass_spec_gate_allows_and_logs_hotfix(tmp_path: Path):
+    sm, pm = _workitem_gate_env(tmp_path)
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task()}))
+
+    result = pm.transition("wi-task", "dev", bypass_spec_gate=True)
+    assert result.new_phase == "dev"
+
+    log_path = tmp_path / ".mothership" / "bypass-log.jsonl"
+    assert log_path.is_file()
+    import json
+    line = json.loads(log_path.read_text().splitlines()[-1])
+    assert line["reason"] == "hotfix"
+    assert line["op"] == "phase-dev"
+    assert line["branch"] == "wi-task"

--- a/tests/core/test_workitem_migrate.py
+++ b/tests/core/test_workitem_migrate.py
@@ -61,6 +61,56 @@ def test_idempotent(tmp_path):
     assert len(items.list()) == 1
 
 
+def test_orphan_task_with_approved_spec_becomes_feature_item(tmp_path):
+    # spec has no task_slug back-reference, so pass 1 wraps it but does not
+    # attach "orphan" — the task's own spec_id must still resolve it in pass 2.
+    specs, state, msgs, items = _setup(tmp_path)
+    specs.save(Spec(id="alpha", title="Alpha", status="approved",
+                    created_at=_now(), updated_at=_now()))
+    state.save(WorkspaceState(tasks={"orphan": Task(
+        slug="orphan", description="d", phase="dev", created_at=_now(),
+        affected_repos=["mothership"], branch="b", spec_id="alpha")}))
+
+    wrap_existing(items, specs, state, msgs, now=_now(), workspace="testws")
+
+    task_wi = next(w for w in items.list() if "orphan" in w.task_slugs)
+    assert task_wi.kind == "feature"
+    assert task_wi.spec_id == "alpha"
+    assert state.load().tasks["orphan"].work_item_id == task_wi.id
+
+
+def test_orphan_task_with_unapproved_spec_stays_chore_item(tmp_path):
+    specs, state, msgs, items = _setup(tmp_path)
+    specs.save(Spec(id="beta", title="Beta", status="drafting",
+                    created_at=_now(), updated_at=_now()))
+    state.save(WorkspaceState(tasks={"orphan2": Task(
+        slug="orphan2", description="d", phase="dev", created_at=_now(),
+        affected_repos=["mothership"], branch="b", spec_id="beta")}))
+
+    wrap_existing(items, specs, state, msgs, now=_now(), workspace="testws")
+
+    task_wi = next(w for w in items.list() if "orphan2" in w.task_slugs)
+    assert task_wi.kind == "chore"
+    assert task_wi.spec_id is None
+    assert state.load().tasks["orphan2"].work_item_id == task_wi.id
+
+
+def test_pass2_feature_link_is_idempotent(tmp_path):
+    specs, state, msgs, items = _setup(tmp_path)
+    specs.save(Spec(id="alpha", title="Alpha", status="approved",
+                    created_at=_now(), updated_at=_now()))
+    state.save(WorkspaceState(tasks={"orphan": Task(
+        slug="orphan", description="d", phase="dev", created_at=_now(),
+        affected_repos=["mothership"], branch="b", spec_id="alpha")}))
+
+    wrap_existing(items, specs, state, msgs, now=_now(), workspace="testws")
+    count_after_first = len(items.list())
+    wrap_existing(items, specs, state, msgs, now=_now(), workspace="testws")
+    count_after_second = len(items.list())
+
+    assert count_after_first == count_after_second
+
+
 def test_thread_attaches_via_spec(tmp_path):
     specs, state, msgs, items = _setup(tmp_path)
     specs.save(Spec(id="alpha", title="Alpha", status="approved",

--- a/tests/core/test_workitem_migrate.py
+++ b/tests/core/test_workitem_migrate.py
@@ -79,7 +79,15 @@ def test_orphan_task_with_approved_spec_becomes_feature_item(tmp_path):
     assert state.load().tasks["orphan"].work_item_id == task_wi.id
 
 
-def test_orphan_task_with_unapproved_spec_stays_chore_item(tmp_path):
+def test_orphan_task_with_unapproved_spec_attaches_to_wrapped_spec_item(tmp_path):
+    """Pass 1 wraps EVERY spec (regardless of approval) into its own feature
+    item. The task's spec_id resolves to that same spec ("beta", still
+    drafting), so pass 2 must ATTACH the task to the item pass 1 already
+    created rather than spin up a second, disconnected "chore" item (PR
+    review fix for workitem-mandatory-kind-gated-approval). This also closes
+    a gating loophole: a task genuinely linked to a real (if unapproved)
+    spec now correctly inherits the feature WorkItem's approved-spec gate,
+    instead of silently sidestepping it via a chore classification."""
     specs, state, msgs, items = _setup(tmp_path)
     specs.save(Spec(id="beta", title="Beta", status="drafting",
                     created_at=_now(), updated_at=_now()))
@@ -89,9 +97,12 @@ def test_orphan_task_with_unapproved_spec_stays_chore_item(tmp_path):
 
     wrap_existing(items, specs, state, msgs, now=_now(), workspace="testws")
 
-    task_wi = next(w for w in items.list() if "orphan2" in w.task_slugs)
-    assert task_wi.kind == "chore"
-    assert task_wi.spec_id is None
+    all_items = items.list()
+    assert len(all_items) == 1, [w.id for w in all_items]
+    task_wi = all_items[0]
+    assert task_wi.kind == "feature"
+    assert task_wi.spec_id == "beta"
+    assert "orphan2" in task_wi.task_slugs
     assert state.load().tasks["orphan2"].work_item_id == task_wi.id
 
 
@@ -109,6 +120,31 @@ def test_pass2_feature_link_is_idempotent(tmp_path):
     count_after_second = len(items.list())
 
     assert count_after_first == count_after_second
+
+
+def test_pass2_attaches_to_existing_item_no_duplicate(tmp_path):
+    """Pass 1 wraps the approved spec (it has no task_slug, so the task isn't
+    linked to it yet). Pass 2 must resolve that same spec via task.spec_id
+    and ATTACH the task to the item pass 1 already created — not spin up a
+    second WorkItem on the same spec. See spec
+    workitem-mandatory-kind-gated-approval (PR review fix)."""
+    specs, state, msgs, items = _setup(tmp_path)
+    specs.save(Spec(id="alpha", title="Alpha", status="approved",
+                    created_at=_now(), updated_at=_now()))
+    state.save(WorkspaceState(tasks={"orphan": Task(
+        slug="orphan", description="d", phase="dev", created_at=_now(),
+        affected_repos=["mothership"], branch="b", spec_id="alpha")}))
+
+    wrap_existing(items, specs, state, msgs, now=_now(), workspace="testws")
+
+    all_items = items.list()
+    assert len(all_items) == 1, [w.id for w in all_items]
+    wi = all_items[0]
+    assert wi.kind == "feature"
+    assert wi.spec_id == "alpha"
+    assert wi.task_slugs == ["orphan"]
+    assert specs.find_by_id("alpha").work_item_id == wi.id
+    assert state.load().tasks["orphan"].work_item_id == wi.id
 
 
 def test_thread_attaches_via_spec(tmp_path):

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -1099,7 +1099,7 @@ def test_spawn_writes_workspace_marker_in_each_worktree(workspace_with_git: Path
 
     try:
         result = runner.invoke(
-            app, ["spawn", "marker test", "--repos", "shared", "--skip-setup", "--force-audit"]
+            app, ["spawn", "--hotfix", "marker test", "--repos", "shared", "--skip-setup", "--force-audit"]
         )
         assert result.exit_code == 0, result.output
         hub = workspace_with_git / ".worktrees" / "marker-test"

--- a/tests/test_dependency_integration.py
+++ b/tests/test_dependency_integration.py
@@ -64,13 +64,13 @@ def test_dependency_flow(dep_workspace):
     workspace_root = dep_workspace
 
     # 1. Spawn task-a (no deps).
-    r1 = runner.invoke(app, ["spawn", "task a", "--slug", "a", "--skip-setup", "--force-audit"])
+    r1 = runner.invoke(app, ["spawn", "--hotfix", "task a", "--slug", "a", "--skip-setup", "--force-audit"])
     assert r1.exit_code == 0, r1.output
 
     # 2. Spawn task-b depending on a.
     r2 = runner.invoke(
         app,
-        ["spawn", "task b", "--slug", "b", "--depends-on", "a", "--skip-setup", "--force-audit"],
+        ["spawn", "--hotfix", "task b", "--slug", "b", "--depends-on", "a", "--skip-setup", "--force-audit"],
     )
     assert r2.exit_code == 0, r2.output
 

--- a/tests/test_dependency_integration.py
+++ b/tests/test_dependency_integration.py
@@ -83,14 +83,14 @@ def test_dependency_flow(dep_workspace):
     assert deps["blocked_by"] == ["a"]
 
     # 4. finish task-b is blocked by the dependency gate.
-    r4 = runner.invoke(app, ["finish", "--task", "b"])
+    r4 = runner.invoke(app, ["finish", "--hotfix", "--task", "b"])
     err = (r4.output or "").lower()
     assert ("upstream" in err) or ("blocked" in err), (
         f"Expected 'upstream' or 'blocked' in output; got: {r4.output!r}"
     )
 
     # 5. --bypass-deps clears the deps gate (finish may still fail for other reasons).
-    r5 = runner.invoke(app, ["finish", "--task", "b", "--bypass-deps"])
+    r5 = runner.invoke(app, ["finish", "--hotfix", "--task", "b", "--bypass-deps"])
     out5 = (r5.output or "").lower()
     # The specific deps-blocked message must not appear.
     assert "finish blocked: upstream" not in out5, (

--- a/tests/test_finish_gate.py
+++ b/tests/test_finish_gate.py
@@ -155,3 +155,72 @@ def test_finish_hotfix_warns_and_proceeds_and_logs_bypass(finish_gate_workspace)
         entry["op"] == "finish" and entry["branch"] == "hotfix-finish-task" and entry["reason"] == "hotfix"
         for entry in lines
     ), lines
+
+
+# ---------------------------------------------------------------------------
+# PR review fix: corrupt/unreadable WorkItem store must not raise a raw
+# exception out of `finish` — that would skip the --hotfix rescue entirely.
+# ---------------------------------------------------------------------------
+
+def test_finish_blocks_cleanly_on_corrupt_workitem_store(finish_gate_workspace):
+    """Without --hotfix: a corrupt store degrades to a clean, actionable
+    `output.error` + exit 1 — never a traceback."""
+    workspace, _ = finish_gate_workspace
+    items = WorkItemStore(workspace / ".mothership" / "workitems")
+    wi = items.create(title="add thing", kind="bug", workspace="ws",
+                       now=datetime.now(timezone.utc))
+
+    result = runner.invoke(
+        app, ["spawn", "--work-item", wi.id, "corrupt store task", "--repos", "shared"],
+    )
+    assert result.exit_code == 0, result.output
+
+    # Corrupt the WorkItem's JSON file on disk (spawn already validated it
+    # while it was still well-formed).
+    wi_path = workspace / ".mothership" / "workitems" / f"{wi.id}.json"
+    wi_path.write_text("{not valid json")
+
+    result = runner.invoke(app, ["finish", "--task", "corrupt-store-task"])
+    assert result.exit_code == 1, result.output
+    assert "Cannot finish" in result.output
+    assert "Traceback" not in result.output
+
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["corrupt-store-task"].pr_urls == {}
+
+
+def test_finish_hotfix_survives_corrupt_workitem_store(finish_gate_workspace):
+    """With --hotfix: the gate-evaluation exception is caught and downgraded
+    to a failing GateResult, so the pre-existing --hotfix → warn + proceed
+    path still rescues the task."""
+    workspace, _ = finish_gate_workspace
+    items = WorkItemStore(workspace / ".mothership" / "workitems")
+    wi = items.create(title="add thing", kind="bug", workspace="ws",
+                       now=datetime.now(timezone.utc))
+
+    result = runner.invoke(
+        app, ["spawn", "--work-item", wi.id, "corrupt store hotfix task", "--repos", "shared"],
+    )
+    assert result.exit_code == 0, result.output
+
+    wi_path = workspace / ".mothership" / "workitems" / f"{wi.id}.json"
+    wi_path.write_text("{not valid json")
+
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "corrupt-store-hotfix-task"])
+    assert result.exit_code == 0, result.output
+    assert "WorkItem gate bypassed" in result.output
+    assert "corrupt store" in result.output.lower()
+
+    # PR still gets opened — hotfix downgrades the block to a warning.
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["corrupt-store-hotfix-task"].pr_urls.get("shared") == \
+        "https://github.com/org/shared/pull/1"
+
+    bypass_log = workspace / ".mothership" / "bypass-log.jsonl"
+    assert bypass_log.is_file()
+    lines = [json.loads(line) for line in bypass_log.read_text().splitlines()]
+    assert any(
+        entry["op"] == "finish" and entry["branch"] == "corrupt-store-hotfix-task"
+        and entry["reason"] == "hotfix"
+        for entry in lines
+    ), lines

--- a/tests/test_finish_gate.py
+++ b/tests/test_finish_gate.py
@@ -1,0 +1,157 @@
+"""`mship finish` refuses to open a PR when the task has no WorkItem (or a
+feature WorkItem without an approved spec). `--hotfix` downgrades the block to
+a warning and records a bypass-log entry.
+
+See core/workitem_gate.py::check_task_gate (task 1/6) and spec
+workitem-mandatory-kind-gated-approval, task 4/6.
+"""
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.spec import Spec
+from mship.core.spec_store import SpecStore
+from mship.core.state import StateManager
+from mship.core.workitem_store import WorkItemStore
+from mship.util.shell import ShellResult, ShellRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def finish_gate_workspace(workspace_with_git: Path):
+    state_dir = workspace_with_git / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    container.config_path.override(workspace_with_git / "mothership.yaml")
+    container.state_dir.override(state_dir)
+
+    def _default_run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
+        if "rev-list --count" in cmd:
+            return ShellResult(returncode=0, stdout="0\n", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://github.com/org/shared/pull/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok\n", stderr="")
+    mock_shell.run.side_effect = _default_run
+    container.shell.override(mock_shell)
+
+    yield workspace_with_git, mock_shell
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset()
+    container.state_manager.reset()
+    container.shell.reset_override()
+
+
+def test_finish_blocks_when_task_has_no_work_item(finish_gate_workspace):
+    """A task spawned with --hotfix has work_item_id=None; finish must refuse."""
+    workspace, _ = finish_gate_workspace
+    result = runner.invoke(app, ["spawn", "--hotfix", "no workitem task", "--repos", "shared"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(app, ["finish", "--task", "no-workitem-task"])
+    assert result.exit_code == 1, result.output
+    assert "no WorkItem" in result.output
+
+    # No PR should have been opened.
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["no-workitem-task"].pr_urls == {}
+
+
+def test_finish_blocks_feature_work_item_without_approved_spec(finish_gate_workspace):
+    workspace, _ = finish_gate_workspace
+    items = WorkItemStore(workspace / ".mothership" / "workitems")
+    wi = items.create(title="add thing", kind="feature", workspace="ws",
+                       now=datetime.now(timezone.utc))
+
+    result = runner.invoke(
+        app, ["spawn", "--work-item", wi.id, "feature task", "--repos", "shared"],
+    )
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(app, ["finish", "--task", "feature-task"])
+    assert result.exit_code == 1, result.output
+    assert "approved spec" in result.output
+
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["feature-task"].pr_urls == {}
+
+
+def test_finish_passes_with_bug_work_item_and_no_spec(finish_gate_workspace):
+    """bug/chore/question WorkItems satisfy the gate without any spec at all."""
+    workspace, _ = finish_gate_workspace
+    items = WorkItemStore(workspace / ".mothership" / "workitems")
+    wi = items.create(title="fix it", kind="bug", workspace="ws",
+                       now=datetime.now(timezone.utc))
+
+    result = runner.invoke(
+        app, ["spawn", "--work-item", wi.id, "bug task", "--repos", "shared"],
+    )
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(app, ["finish", "--task", "bug-task"])
+    assert result.exit_code == 0, result.output
+
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["bug-task"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
+
+
+def test_finish_passes_with_feature_work_item_and_approved_spec(finish_gate_workspace):
+    workspace, _ = finish_gate_workspace
+    items = WorkItemStore(workspace / ".mothership" / "workitems")
+    specs = SpecStore(workspace / "specs")
+    now = datetime.now(timezone.utc)
+    specs.save(Spec(id="spec-1", title="Spec", status="approved",
+                    created_at=now, updated_at=now))
+    wi = items.create(title="add thing", kind="feature", workspace="ws", now=now)
+    items.link_spec(wi.id, "spec-1", now=now)
+
+    result = runner.invoke(
+        app, ["spawn", "--work-item", wi.id, "feature with spec", "--repos", "shared"],
+    )
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(app, ["finish", "--task", "feature-with-spec"])
+    assert result.exit_code == 0, result.output
+
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["feature-with-spec"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
+
+
+def test_finish_hotfix_warns_and_proceeds_and_logs_bypass(finish_gate_workspace):
+    workspace, _ = finish_gate_workspace
+    result = runner.invoke(app, ["spawn", "--hotfix", "hotfix finish task", "--repos", "shared"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "hotfix-finish-task"])
+    assert result.exit_code == 0, result.output
+    assert "WorkItem gate bypassed" in result.output
+    assert "--hotfix" in result.output
+
+    # PR still gets opened — hotfix downgrades the block to a warning.
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["hotfix-finish-task"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
+
+    # Bypass is recorded to the shared bypass log.
+    bypass_log = workspace / ".mothership" / "bypass-log.jsonl"
+    assert bypass_log.is_file()
+    lines = [json.loads(line) for line in bypass_log.read_text().splitlines()]
+    assert any(
+        entry["op"] == "finish" and entry["branch"] == "hotfix-finish-task" and entry["reason"] == "hotfix"
+        for entry in lines
+    ), lines

--- a/tests/test_finish_integration.py
+++ b/tests/test_finish_integration.py
@@ -40,7 +40,7 @@ def finish_workspace(workspace_with_git: Path):
 def test_finish_single_repo_no_coordination_block(finish_workspace):
     workspace, mock_shell = finish_workspace
 
-    result = runner.invoke(app, ["spawn", "single repo test", "--repos", "shared"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "single repo test", "--repos", "shared"])
     assert result.exit_code == 0, result.output
 
     pr_url = "https://github.com/org/shared/pull/99"
@@ -77,7 +77,7 @@ def test_finish_single_repo_no_coordination_block(finish_workspace):
 def test_finish_multi_repo_adds_coordination(finish_workspace):
     workspace, mock_shell = finish_workspace
 
-    result = runner.invoke(app, ["spawn", "multi repo test", "--repos", "shared,auth-service"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "multi repo test", "--repos", "shared,auth-service"])
     assert result.exit_code == 0, result.output
 
     pr_counter = [0]
@@ -119,7 +119,7 @@ def test_finish_multi_repo_adds_coordination(finish_workspace):
 def test_finish_idempotent_rerun(finish_workspace):
     workspace, mock_shell = finish_workspace
 
-    result = runner.invoke(app, ["spawn", "idempotent test", "--repos", "shared"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "idempotent test", "--repos", "shared"])
     assert result.exit_code == 0, result.output
 
     # First finish
@@ -165,7 +165,7 @@ def test_finish_not_blocked_by_own_worktree(finish_workspace):
 
     # Spawn normally (with --force-audit since the mock shell doesn't actually
     # make audits clean, the point of this test is what finish does).
-    result = runner.invoke(app, ["spawn", "own wt", "--repos", "shared", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "own wt", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0, result.output
 
     # Simulate audit returning extra_worktrees iff the worktree is not known.
@@ -233,7 +233,7 @@ def test_finish_passes_base_from_config(finish_workspace, tmp_path):
     cfg_path.write_text(yaml.safe_dump(cfg))
     container.config.reset()
 
-    result = runner.invoke(app, ["spawn", "base test", "--repos", "shared"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "base test", "--repos", "shared"])
     assert result.exit_code == 0, result.output
 
     call_log: list[str] = []
@@ -277,7 +277,7 @@ def test_finish_uses_spawn_base_override(finish_workspace):
                    check=True, capture_output=True)
 
     result = runner.invoke(
-        app, ["spawn", "stacked", "--repos", "shared", "--slug", "stacked",
+        app, ["spawn", "--hotfix", "stacked", "--repos", "shared", "--slug", "stacked",
               "--base", "feat/upstream", "--skip-setup"],
     )
     assert result.exit_code == 0, result.output
@@ -322,7 +322,7 @@ def test_finish_fails_when_base_missing_on_remote(finish_workspace):
     cfg_path.write_text(yaml.safe_dump(cfg))
     container.config.reset()
 
-    result = runner.invoke(app, ["spawn", "missing base", "--repos", "shared"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "missing base", "--repos", "shared"])
     assert result.exit_code == 0, result.output
 
     pushed: list[str] = []
@@ -355,7 +355,7 @@ def test_finish_blocks_when_affected_repo_is_dirty(finish_workspace):
     """
     workspace, mock_shell = finish_workspace
 
-    result = runner.invoke(app, ["spawn", "finish gate", "--repos", "shared", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "finish gate", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0, result.output
 
     def mock_run(cmd, cwd, env=None):
@@ -387,7 +387,7 @@ def test_finish_unrelated_dirty_repo_does_not_block(finish_workspace):
     """Drift in a repo not in task.affected_repos must not block finish."""
     workspace, mock_shell = finish_workspace
 
-    result = runner.invoke(app, ["spawn", "unrelated test", "--repos", "shared", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "unrelated test", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0
 
     dirty_repos = {"auth-service"}  # NOT in affected_repos
@@ -439,7 +439,7 @@ def test_finish_skips_untouched_repos_in_multi_repo_task(finish_workspace):
     container.config.reset()
 
     result = runner.invoke(
-        app, ["spawn", "partial work", "--repos", "shared,auth-service", "--force-audit"]
+        app, ["spawn", "--hotfix", "partial work", "--repos", "shared,auth-service", "--force-audit"]
     )
     assert result.exit_code == 0, result.output
 
@@ -495,7 +495,7 @@ def test_finish_fails_when_branch_has_no_commits(finish_workspace):
     from mship.cli import container
     container.config.reset()
 
-    result = runner.invoke(app, ["spawn", "empty branch", "--repos", "shared", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "empty branch", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0, result.output
 
     pushed: list[str] = []
@@ -543,7 +543,7 @@ def test_finish_stamps_finished_at(finish_workspace):
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["spawn", "stamp test", "--repos", "shared", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "stamp test", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0, result.output
 
     result = runner.invoke(app, ["finish", "--task", "stamp-test"])
@@ -576,7 +576,7 @@ def test_finish_push_only_skips_gh_pr_create(finish_workspace):
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["spawn", "push only", "--repos", "shared", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "push only", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0, result.output
 
     result = runner.invoke(app, ["finish", "--push-only", "--task", "push-only"])
@@ -596,7 +596,7 @@ def test_finish_push_only_rejects_base_flags(finish_workspace):
     workspace, mock_shell = finish_workspace
     mock_shell.run.side_effect = lambda cmd, cwd, env=None: ShellResult(returncode=0, stdout="", stderr="")
 
-    result = runner.invoke(app, ["spawn", "conflict flags", "--repos", "shared", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "conflict flags", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0
 
     result = runner.invoke(app, ["finish", "--push-only", "--base", "main"])
@@ -611,7 +611,7 @@ def test_finish_suppresses_no_upstream_for_task_branch(finish_workspace):
 
     # Spawn without audit gate interference (the repo has no origin configured
     # in the fixture, so audit would fire no_upstream at spawn time too).
-    result = runner.invoke(app, ["spawn", "noupstream fix", "--repos", "shared", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "noupstream fix", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0, result.output
 
     # Mock shell to simulate a clean worktree on the task branch with no
@@ -661,7 +661,7 @@ def test_finish_still_blocks_other_audit_errors(finish_workspace):
     """
     workspace, mock_shell = finish_workspace
 
-    result = runner.invoke(app, ["spawn", "still blocks", "--repos", "shared", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "still blocks", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0
 
     def mock_run(cmd, cwd, env=None):
@@ -705,7 +705,7 @@ def test_finish_does_not_block_on_drift_in_unrelated_repo(finish_workspace):
     # Spawn affecting shared (will have commits) and api-gateway (untouched).
     # api-gateway depends on shared, but shared has no upstream deps so the
     # scope of "shared has commits" is just {shared} — api-gateway is excluded.
-    result = runner.invoke(app, ["spawn", "scoped finish", "--repos", "shared,auth-service,api-gateway", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "scoped finish", "--repos", "shared,auth-service,api-gateway", "--force-audit"])
     assert result.exit_code == 0
 
     def mock_run(cmd, cwd, env=None):
@@ -757,7 +757,7 @@ def test_finish_auto_links_issue_refs_in_description(finish_workspace):
     """Regression for #8: task description containing `#N` should produce PR body with `Closes #N`."""
     workspace, mock_shell = finish_workspace
 
-    result = runner.invoke(app, ["spawn", "fix #42 something important", "--repos", "shared", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "fix #42 something important", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0, result.output
 
     captured_body: list[str] = []
@@ -807,7 +807,7 @@ def test_finish_pr_body_unchanged_when_no_issue_refs(finish_workspace):
     """Task description without `#N` → PR body is just the description."""
     workspace, mock_shell = finish_workspace
 
-    result = runner.invoke(app, ["spawn", "ordinary task description", "--repos", "shared", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "ordinary task description", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0, result.output
 
     captured_body: list[str] = []
@@ -847,7 +847,7 @@ def test_finish_warns_when_no_test_evidence_default(finish_workspace):
     """Default: missing test evidence is a WARNING (not a block). See #81."""
     workspace, mock_shell = finish_workspace
 
-    result = runner.invoke(app, ["spawn", "no evidence", "--repos", "shared", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "no evidence", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0, result.output
 
     def mock_run(cmd, cwd, env=None):
@@ -877,7 +877,7 @@ def test_finish_blocks_when_require_tests_and_no_evidence(finish_workspace):
     """--require-tests escalates missing evidence to a BLOCK. See #81."""
     workspace, mock_shell = finish_workspace
 
-    result = runner.invoke(app, ["spawn", "require block", "--repos", "shared", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "require block", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0, result.output
 
     pushed: list[str] = []
@@ -913,7 +913,7 @@ def test_finish_evidence_via_journal_suppresses_warning(finish_workspace, tmp_pa
     """Journal `test-state=pass` counts as evidence — no warning. See #81."""
     workspace, mock_shell = finish_workspace
 
-    result = runner.invoke(app, ["spawn", "journal evidence", "--repos", "shared", "--force-audit"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "journal evidence", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0, result.output
 
     # Record journal evidence for the task (global scope — applies to all repos).

--- a/tests/test_finish_integration.py
+++ b/tests/test_finish_integration.py
@@ -62,7 +62,7 @@ def test_finish_single_repo_no_coordination_block(finish_workspace):
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["finish", "--task", "single-repo-test"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "single-repo-test"])
     assert result.exit_code == 0, result.output
 
     mgr = StateManager(workspace / ".mothership")
@@ -104,7 +104,7 @@ def test_finish_multi_repo_adds_coordination(finish_workspace):
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["finish", "--task", "multi-repo-test"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "multi-repo-test"])
     assert result.exit_code == 0, result.output
 
     # Verify 2 PRs created
@@ -137,7 +137,7 @@ def test_finish_idempotent_rerun(finish_workspace):
         return ShellResult(returncode=0, stdout="", stderr="")
     mock_shell.run.side_effect = _first_finish_run
 
-    result = runner.invoke(app, ["finish", "--task", "idempotent-test"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "idempotent-test"])
     assert result.exit_code == 0, result.output
 
     # Second finish — should skip existing PR
@@ -151,7 +151,7 @@ def test_finish_idempotent_rerun(finish_workspace):
 
     mock_shell.run.side_effect = tracking_run
 
-    result = runner.invoke(app, ["finish", "--task", "idempotent-test"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "idempotent-test"])
     assert result.exit_code == 0, result.output
 
     # No gh pr create on second run
@@ -215,7 +215,7 @@ def test_finish_not_blocked_by_own_worktree(finish_workspace):
     from mship.cli import container
     container.state_manager.reset()
 
-    result = runner.invoke(app, ["finish", "--task", slug])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", slug])
     assert result.exit_code == 0, result.output
     assert "extra_worktrees" not in result.output
 
@@ -256,7 +256,7 @@ def test_finish_passes_base_from_config(finish_workspace, tmp_path):
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["finish", "--task", "base-test"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "base-test"])
     assert result.exit_code == 0, result.output
 
     create_calls = [c for c in call_log if "gh pr create" in c]
@@ -303,7 +303,7 @@ def test_finish_uses_spawn_base_override(finish_workspace):
     mock_shell.run.side_effect = mock_run
 
     # No --base at finish: the base must come from the task's spawn-time override.
-    result = runner.invoke(app, ["finish", "--task", "stacked"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "stacked"])
     assert result.exit_code == 0, result.output
 
     create_calls = [c for c in call_log if "gh pr create" in c]
@@ -341,7 +341,7 @@ def test_finish_fails_when_base_missing_on_remote(finish_workspace):
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["finish", "--task", "missing-base"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "missing-base"])
     assert result.exit_code != 0
     assert "nope" in result.output.lower() or "base" in result.output.lower()
     assert pushed == [], "no repo should be pushed when a base is missing"
@@ -378,7 +378,7 @@ def test_finish_blocks_when_affected_repo_is_dirty(finish_workspace):
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["finish", "--task", "finish-gate"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "finish-gate"])
     assert result.exit_code == 1
     assert "dirty_worktree" in result.output
 
@@ -421,7 +421,7 @@ def test_finish_unrelated_dirty_repo_does_not_block(finish_workspace):
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["finish", "--task", "unrelated-test"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "unrelated-test"])
     assert result.exit_code == 0, result.output
 
 
@@ -471,7 +471,7 @@ def test_finish_skips_untouched_repos_in_multi_repo_task(finish_workspace):
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["finish", "--task", "partial-work", "--force-audit"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "partial-work", "--force-audit"])
     assert result.exit_code == 0, result.output
     # auth-service was untouched → no PR created there.
     assert not any("auth-service" in c for c in create_calls), create_calls
@@ -517,7 +517,7 @@ def test_finish_fails_when_branch_has_no_commits(finish_workspace):
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["finish", "--task", "empty-branch"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "empty-branch"])
     assert result.exit_code != 0
     assert "no commits" in result.output.lower() or "No commits to push" in result.output
     assert pushed == [], "no repo should be pushed when a branch is empty"
@@ -546,7 +546,7 @@ def test_finish_stamps_finished_at(finish_workspace):
     result = runner.invoke(app, ["spawn", "--hotfix", "stamp test", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0, result.output
 
-    result = runner.invoke(app, ["finish", "--task", "stamp-test"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "stamp-test"])
     assert result.exit_code == 0, result.output
     assert "mship close" in result.output
 
@@ -579,7 +579,7 @@ def test_finish_push_only_skips_gh_pr_create(finish_workspace):
     result = runner.invoke(app, ["spawn", "--hotfix", "push only", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0, result.output
 
-    result = runner.invoke(app, ["finish", "--push-only", "--task", "push-only"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--push-only", "--task", "push-only"])
     assert result.exit_code == 0, result.output
     assert len(push_calls) == 1
     assert pr_calls == []
@@ -599,7 +599,7 @@ def test_finish_push_only_rejects_base_flags(finish_workspace):
     result = runner.invoke(app, ["spawn", "--hotfix", "conflict flags", "--repos", "shared", "--force-audit"])
     assert result.exit_code == 0
 
-    result = runner.invoke(app, ["finish", "--push-only", "--base", "main"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--push-only", "--base", "main"])
     assert result.exit_code != 0
     assert "push-only" in result.output.lower()
 
@@ -648,7 +648,7 @@ def test_finish_suppresses_no_upstream_for_task_branch(finish_workspace):
     mock_shell.run.side_effect = mock_run
 
     # NO --force-audit — this is the whole point of the fix.
-    result = runner.invoke(app, ["finish", "--task", "noupstream-fix"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "noupstream-fix"])
     assert result.exit_code == 0, result.output
     assert "BYPASSED AUDIT" not in result.output
 
@@ -687,7 +687,7 @@ def test_finish_still_blocks_other_audit_errors(finish_workspace):
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["finish", "--task", "still-blocks"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "still-blocks"])
     assert result.exit_code != 0
     assert "dirty_worktree" in result.output
 
@@ -745,7 +745,7 @@ def test_finish_does_not_block_on_drift_in_unrelated_repo(finish_workspace):
 
     result = runner.invoke(
         app,
-        ["finish", "--task", "scoped-finish", "--body", "## Summary\nx\n## Test plan\n- [x] manual"],
+        ["finish", "--hotfix", "--task", "scoped-finish", "--body", "## Summary\nx\n## Test plan\n- [x] manual"],
     )
     # Tailrd's dirty_worktree is out of scope (no commits) → does not block.
     # Shared has commits and clean state → finish proceeds.
@@ -797,7 +797,7 @@ def test_finish_auto_links_issue_refs_in_description(finish_workspace):
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["finish", "--task", "fix-42-something-important"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "fix-42-something-important"])
     assert result.exit_code == 0, result.output
     assert captured_body, "expected gh pr create to be invoked"
     assert "Closes #42" in captured_body[0]
@@ -836,7 +836,7 @@ def test_finish_pr_body_unchanged_when_no_issue_refs(finish_workspace):
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["finish", "--force-audit", "--task", "ordinary-task-description"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--force-audit", "--task", "ordinary-task-description"])
     assert result.exit_code == 0, result.output
     assert captured_body
     assert "Closes" not in captured_body[0]
@@ -865,7 +865,7 @@ def test_finish_warns_when_no_test_evidence_default(finish_workspace):
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["finish", "--task", "no-evidence", "--force-audit"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "no-evidence", "--force-audit"])
     # Finish still succeeds; the warning is advisory.
     assert result.exit_code == 0, result.output
     # Warning text references the evidence gap.
@@ -901,7 +901,7 @@ def test_finish_blocks_when_require_tests_and_no_evidence(finish_workspace):
     mock_shell.run.side_effect = mock_run
 
     result = runner.invoke(
-        app, ["finish", "--task", "require-block", "--force-audit", "--require-tests"]
+        app, ["finish", "--hotfix", "--task", "require-block", "--force-audit", "--require-tests"]
     )
     assert result.exit_code != 0
     assert pushed == [], "finish must block before pushing when --require-tests"
@@ -936,7 +936,7 @@ def test_finish_evidence_via_journal_suppresses_warning(finish_workspace, tmp_pa
 
     mock_shell.run.side_effect = mock_run
 
-    result = runner.invoke(app, ["finish", "--task", "journal-evidence", "--force-audit"])
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "journal-evidence", "--force-audit"])
     assert result.exit_code == 0, result.output
     # No "not run" / "missing" / "evidence" warning.
     lower = result.output.lower()

--- a/tests/test_hook_integration.py
+++ b/tests/test_hook_integration.py
@@ -96,11 +96,14 @@ def test_commit_inside_worktree_succeeds(workspace_for_hooks):
     wt = Path(state.tasks["inside-ok"].worktrees["cli"])
     assert wt.exists()
 
-    # Commit in the worktree — hook should pass
+    # Commit in the worktree — hook should pass. Spawned with --hotfix, so the
+    # task has no WorkItem; bypass that (unrelated) gate here — this test is
+    # about the worktree-location check, not the WorkItem gate.
     (wt / "new.py").write_text("print('hi')\n")
     env = {**os.environ,
            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
-           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+           "MSHIP_BYPASS_GATE": "1"}
     subprocess.run(["git", "add", "new.py"], cwd=wt, check=True, capture_output=True, env=env)
     result = subprocess.run(
         ["git", "commit", "-m", "from worktree"],
@@ -167,10 +170,13 @@ def test_post_commit_auto_logs_in_worktree(workspace_for_hooks):
     wt = Path(state.tasks["auto-log-test"].worktrees["cli"])
     assert wt.exists()
 
+    # Spawned with --hotfix, so the task has no WorkItem; bypass that
+    # (unrelated) gate here — this test is about the auto-log side effect.
     (wt / "file.txt").write_text("hello\n")
     env = {**os.environ,
            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
-           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+           "MSHIP_BYPASS_GATE": "1"}
     subprocess.run(["git", "add", "."], cwd=wt, check=True, capture_output=True, env=env)
     result = subprocess.run(
         ["git", "commit", "-m", "auto logged"],
@@ -216,10 +222,13 @@ def test_commit_in_task_a_worktree_allowed_with_two_tasks(workspace_for_hooks):
     tmp_path, repo = workspace_for_hooks
     wt_a, _wt_b = _spawn_two_tasks(tmp_path, repo)
 
+    # Spawned with --hotfix, so neither task has a WorkItem; bypass that
+    # (unrelated) gate here — this test is about multi-task worktree isolation.
     (wt_a / "a.py").write_text("a\n")
     env = {**os.environ,
            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
-           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+           "MSHIP_BYPASS_GATE": "1"}
     subprocess.run(["git", "add", "a.py"], cwd=wt_a, check=True, capture_output=True, env=env)
     result = subprocess.run(
         ["git", "commit", "-m", "from task a"],
@@ -235,7 +244,8 @@ def test_commit_in_task_b_worktree_allowed_with_two_tasks(workspace_for_hooks):
     (wt_b / "b.py").write_text("b\n")
     env = {**os.environ,
            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
-           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+           "MSHIP_BYPASS_GATE": "1"}
     subprocess.run(["git", "add", "b.py"], cwd=wt_b, check=True, capture_output=True, env=env)
     result = subprocess.run(
         ["git", "commit", "-m", "from task b"],

--- a/tests/test_hook_integration.py
+++ b/tests/test_hook_integration.py
@@ -66,7 +66,7 @@ def test_commit_outside_task_worktree_refused(workspace_for_hooks):
     """End-to-end: spawn creates a worktree; a commit in the main checkout is refused."""
     tmp_path, repo = workspace_for_hooks
     runner.invoke(app, ["init", "--install-hooks"])
-    r = runner.invoke(app, ["spawn", "add avatars", "--repos", "cli", "--force-audit", "--skip-setup"])
+    r = runner.invoke(app, ["spawn", "--hotfix", "add avatars", "--repos", "cli", "--force-audit", "--skip-setup"])
     assert r.exit_code == 0, r.output
 
     # Make a change in the main checkout (wrong place)
@@ -88,7 +88,7 @@ def test_commit_outside_task_worktree_refused(workspace_for_hooks):
 def test_commit_inside_worktree_succeeds(workspace_for_hooks):
     tmp_path, repo = workspace_for_hooks
     runner.invoke(app, ["init", "--install-hooks"])
-    r = runner.invoke(app, ["spawn", "inside ok", "--repos", "cli", "--force-audit", "--skip-setup"])
+    r = runner.invoke(app, ["spawn", "--hotfix", "inside ok", "--repos", "cli", "--force-audit", "--skip-setup"])
     assert r.exit_code == 0, r.output
 
     from mship.core.state import StateManager
@@ -112,7 +112,7 @@ def test_commit_inside_worktree_succeeds(workspace_for_hooks):
 def test_no_verify_bypasses_hook(workspace_for_hooks):
     tmp_path, repo = workspace_for_hooks
     runner.invoke(app, ["init", "--install-hooks"])
-    runner.invoke(app, ["spawn", "bypass test", "--repos", "cli", "--force-audit", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "bypass test", "--repos", "cli", "--force-audit", "--skip-setup"])
 
     (repo / "new.py").write_text("x\n")
     env = {**os.environ,
@@ -158,7 +158,7 @@ def test_post_commit_auto_logs_in_worktree(workspace_for_hooks):
     tmp_path, repo = workspace_for_hooks
     runner.invoke(app, ["init", "--install-hooks"])
     spawn_result = runner.invoke(
-        app, ["spawn", "auto log test", "--repos", "cli", "--force-audit", "--skip-setup"],
+        app, ["spawn", "--hotfix", "auto log test", "--repos", "cli", "--force-audit", "--skip-setup"],
     )
     assert spawn_result.exit_code == 0, spawn_result.output
 
@@ -194,11 +194,11 @@ def _spawn_two_tasks(tmp_path: Path, repo: Path):
 
     runner.invoke(app, ["init", "--install-hooks"])
     r1 = runner.invoke(
-        app, ["spawn", "task a", "--repos", "cli", "--force-audit", "--skip-setup"],
+        app, ["spawn", "--hotfix", "task a", "--repos", "cli", "--force-audit", "--skip-setup"],
     )
     assert r1.exit_code == 0, r1.output
     r2 = runner.invoke(
-        app, ["spawn", "task b", "--repos", "cli", "--force-audit", "--skip-setup"],
+        app, ["spawn", "--hotfix", "task b", "--repos", "cli", "--force-audit", "--skip-setup"],
     )
     assert r2.exit_code == 0, r2.output
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -62,7 +62,9 @@ def test_full_lifecycle(full_workspace: Path):
     assert "plan" in result.output
 
     # 3. Transition to dev
-    result = runner.invoke(app, ["phase", "dev", "--task", "add-labels"])
+    # Task was spawned with --hotfix (no WorkItem); phase→dev needs its own
+    # bypass now that the WorkItem gate is checked there too.
+    result = runner.invoke(app, ["phase", "dev", "--task", "add-labels", "--bypass-spec-gate"])
     assert result.exit_code == 0
 
     # 4. Check status shows dev

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -51,7 +51,7 @@ def full_workspace(workspace_with_git: Path):
 
 def test_full_lifecycle(full_workspace: Path):
     # 1. Spawn
-    result = runner.invoke(app, ["spawn", "add labels", "--repos", "shared,auth-service"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "add labels", "--repos", "shared,auth-service"])
     assert result.exit_code == 0, result.output
     assert "add-labels" in result.output
 
@@ -119,7 +119,7 @@ def test_spawn_blocks_when_affected_repo_is_dirty(audit_workspace):
     container.log_manager.reset()
     try:
         (audit_workspace / "cli" / "README.md").write_text("modified\n")
-        result = runner.invoke(app, ["spawn", "dirty test", "--repos", "cli"])
+        result = runner.invoke(app, ["spawn", "--hotfix", "dirty test", "--repos", "cli"])
         assert result.exit_code == 1
         assert "dirty_worktree" in result.output
     finally:
@@ -136,7 +136,7 @@ def test_spawn_force_audit_bypasses_and_logs(audit_workspace):
     container.log_manager.reset()
     try:
         (audit_workspace / "cli" / "README.md").write_text("modified\n")
-        result = runner.invoke(app, ["spawn", "force test", "--repos", "cli", "--force-audit"])
+        result = runner.invoke(app, ["spawn", "--hotfix", "force test", "--repos", "cli", "--force-audit"])
         assert result.exit_code == 0, result.output
 
         log_mgr = LogManager(state_dir / "logs")
@@ -180,7 +180,7 @@ def test_full_hub_layout_e2e(tmp_path, monkeypatch):
     try:
         runner = CliRunner()
         # Spawn affected=api, expect shared to be passive
-        result = runner.invoke(app, ["spawn", "feature", "--repos", "api",
+        result = runner.invoke(app, ["spawn", "--hotfix", "feature", "--repos", "api",
                                      "--skip-setup", "--force-audit", "--offline"])
         assert result.exit_code == 0, result.output
 

--- a/tests/test_monorepo_integration.py
+++ b/tests/test_monorepo_integration.py
@@ -97,7 +97,7 @@ repos:
 def test_monorepo_spawn_shares_worktree(monorepo_workspace):
     tmp_path, mock_shell = monorepo_workspace
 
-    result = runner.invoke(app, ["spawn", "add feature"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "add feature"])
     assert result.exit_code == 0, result.output
 
     mgr = StateManager(tmp_path / ".mothership")
@@ -116,7 +116,7 @@ def test_monorepo_spawn_shares_worktree(monorepo_workspace):
 def test_monorepo_close_cleans_up(monorepo_workspace):
     tmp_path, mock_shell = monorepo_workspace
 
-    runner.invoke(app, ["spawn", "cleanup test"])
+    runner.invoke(app, ["spawn", "--hotfix", "cleanup test"])
     mgr = StateManager(tmp_path / ".mothership")
     state = mgr.load()
     root_wt = Path(state.tasks["cleanup-test"].worktrees["tailrd"])
@@ -135,7 +135,7 @@ def test_monorepo_run_uses_background(monorepo_workspace):
     """mship run should launch both services in background."""
     tmp_path, mock_shell = monorepo_workspace
 
-    runner.invoke(app, ["spawn", "run test"])
+    runner.invoke(app, ["spawn", "--hotfix", "run test"])
 
     # Set up Popen mocks that exit immediately
     popen_mocks = []
@@ -159,7 +159,7 @@ def test_monorepo_run_uses_process_group(monorepo_workspace):
     """Background services should be launched in their own process group."""
     tmp_path, mock_shell = monorepo_workspace
 
-    runner.invoke(app, ["spawn", "group test", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "group test", "--skip-setup"])
 
     popen_mocks = []
     def make_popen(*args, **kwargs):
@@ -208,7 +208,7 @@ repos:
 """
     )
 
-    runner.invoke(app, ["spawn", "hc integration", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "hc integration", "--skip-setup"])
 
     popen_mocks = []
     def make_popen(*args, **kwargs):

--- a/tests/test_resilience_integration.py
+++ b/tests/test_resilience_integration.py
@@ -59,7 +59,9 @@ def test_agent_resilience_lifecycle(full_workspace: Path):
     assert result.exit_code == 0
 
     # 3. Phase to dev
-    result = runner.invoke(app, ["phase", "dev", "--task", slug])
+    # Task was spawned with --hotfix (no WorkItem); phase→dev needs its own
+    # bypass now that the WorkItem gate is checked there too.
+    result = runner.invoke(app, ["phase", "dev", "--task", slug, "--bypass-spec-gate"])
     assert result.exit_code == 0
 
     # 4. Block

--- a/tests/test_resilience_integration.py
+++ b/tests/test_resilience_integration.py
@@ -51,7 +51,7 @@ def full_workspace(workspace_with_git: Path):
 def test_agent_resilience_lifecycle(full_workspace: Path):
     slug = "resilience-test"
     # 1. Spawn task
-    result = runner.invoke(app, ["spawn", "resilience test", "--repos", "shared,auth-service"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "resilience test", "--repos", "shared,auth-service"])
     assert result.exit_code == 0, result.output
 
     # 2. Log context

--- a/tests/test_resilience_integration.py
+++ b/tests/test_resilience_integration.py
@@ -88,7 +88,7 @@ def test_agent_resilience_lifecycle(full_workspace: Path):
     assert "BLOCKED" not in result.output
 
     # 9. Generate handoff
-    result = runner.invoke(app, ["finish", "--handoff", "--task", slug])
+    result = runner.invoke(app, ["finish", "--hotfix", "--handoff", "--task", slug])
     assert result.exit_code == 0
     handoff_file = full_workspace / ".mothership" / "handoffs" / "resilience-test.yaml"
     assert handoff_file.exists()

--- a/tests/test_scaling_integration.py
+++ b/tests/test_scaling_integration.py
@@ -92,7 +92,7 @@ repos:
 def test_metarepo_spawn_and_test_all(metarepo_workspace):
     workspace, mock_shell = metarepo_workspace
 
-    result = runner.invoke(app, ["spawn", "add user feed"])
+    result = runner.invoke(app, ["spawn", "--hotfix", "add user feed"])
     assert result.exit_code == 0, result.output
 
     result = runner.invoke(app, ["test", "--task", "add-user-feed"])
@@ -104,7 +104,7 @@ def test_metarepo_spawn_and_test_all(metarepo_workspace):
 def test_metarepo_test_tag_apple(metarepo_workspace):
     workspace, mock_shell = metarepo_workspace
 
-    runner.invoke(app, ["spawn", "apple only test"])
+    runner.invoke(app, ["spawn", "--hotfix", "apple only test"])
     mock_shell.run_task.reset_mock()
 
     result = runner.invoke(app, ["test", "--tag", "apple", "--task", "apple-only-test"])
@@ -126,7 +126,7 @@ def test_metarepo_test_tag_apple(metarepo_workspace):
 def test_metarepo_test_repos_filter(metarepo_workspace):
     workspace, mock_shell = metarepo_workspace
 
-    runner.invoke(app, ["spawn", "repos filter test"])
+    runner.invoke(app, ["spawn", "--hotfix", "repos filter test"])
     mock_shell.run_task.reset_mock()
 
     result = runner.invoke(app, ["test", "--repos", "backend", "--task", "repos-filter-test"])

--- a/tests/test_spawn_gate.py
+++ b/tests/test_spawn_gate.py
@@ -1,0 +1,133 @@
+"""spawn gate: mship spawn requires a WorkItem (--work-item/--item), with a
+--hotfix override. See spec workitem-mandatory-kind-gated-approval, task 2/6."""
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.state import StateManager
+from mship.core.workitem_store import WorkItemStore
+from mship.util.shell import ShellResult, ShellRunner
+
+runner = CliRunner()
+
+
+def _now():
+    return datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+
+
+def _audit_ok_run(cmd, cwd, env=None):
+    """Default shell.run side_effect that satisfies audit_repos probes cleanly."""
+    if "symbolic-ref" in cmd:
+        return ShellResult(returncode=0, stdout="main\n", stderr="")
+    if "fetch" in cmd:
+        return ShellResult(returncode=0, stdout="", stderr="")
+    if "rev-parse --abbrev-ref --symbolic-full-name @{u}" in cmd:
+        return ShellResult(returncode=0, stdout="origin/main\n", stderr="")
+    if "rev-list --count" in cmd:
+        return ShellResult(returncode=0, stdout="0\n", stderr="")
+    if "status --porcelain" in cmd:
+        return ShellResult(returncode=0, stdout="", stderr="")
+    if "worktree list" in cmd:
+        return ShellResult(returncode=0, stdout="worktree /tmp/fake\n", stderr="")
+    return ShellResult(returncode=0, stdout="", stderr="")
+
+
+@pytest.fixture
+def spawn_gate_workspace(workspace_with_git: Path):
+    state_dir = workspace_with_git / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    container.config.reset()
+    container.state_manager.reset()
+    container.log_manager.reset()
+    container.config_path.override(workspace_with_git / "mothership.yaml")
+    container.state_dir.override(state_dir)
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = _audit_ok_run
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok\n", stderr="")
+    container.shell.override(mock_shell)
+
+    yield workspace_with_git
+
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override()
+    container.config.reset()
+    container.state_manager.reset_override()
+    container.state_manager.reset()
+    container.log_manager.reset()
+    container.shell.reset_override()
+
+
+def _items_store(workspace: Path) -> WorkItemStore:
+    return WorkItemStore(workspace / ".mothership" / "workitems")
+
+
+def test_spawn_without_work_item_or_hotfix_fails_and_creates_no_task(spawn_gate_workspace: Path):
+    result = runner.invoke(app, ["spawn", "add labels", "--repos", "shared"])
+    assert result.exit_code != 0
+    state = StateManager(spawn_gate_workspace / ".mothership").load()
+    assert "add-labels" not in state.tasks
+
+
+def test_spawn_with_unknown_work_item_fails_and_creates_no_task(spawn_gate_workspace: Path):
+    result = runner.invoke(
+        app, ["spawn", "add labels", "--repos", "shared", "--work-item", "wi-nope"],
+    )
+    assert result.exit_code != 0
+    state = StateManager(spawn_gate_workspace / ".mothership").load()
+    assert "add-labels" not in state.tasks
+
+
+def test_spawn_with_valid_work_item_sets_forward_and_reverse_link(spawn_gate_workspace: Path):
+    items = _items_store(spawn_gate_workspace)
+    wi = items.create(title="add labels", kind="chore", workspace="ws", now=_now())
+
+    result = runner.invoke(
+        app, ["spawn", "add labels", "--repos", "shared", "--work-item", wi.id],
+    )
+    assert result.exit_code == 0, result.output
+
+    state = StateManager(spawn_gate_workspace / ".mothership").load()
+    task = state.tasks["add-labels"]
+    assert task.work_item_id == wi.id
+
+    reloaded = items.get(wi.id)
+    assert "add-labels" in reloaded.task_slugs
+
+
+def test_spawn_with_item_alias_flag_accepted(spawn_gate_workspace: Path):
+    """--item is the short alias for --work-item."""
+    items = _items_store(spawn_gate_workspace)
+    wi = items.create(title="add labels", kind="chore", workspace="ws", now=_now())
+
+    result = runner.invoke(
+        app, ["spawn", "add labels", "--repos", "shared", "--item", wi.id],
+    )
+    assert result.exit_code == 0, result.output
+    state = StateManager(spawn_gate_workspace / ".mothership").load()
+    assert state.tasks["add-labels"].work_item_id == wi.id
+
+
+def test_spawn_hotfix_without_work_item_creates_task_and_logs_bypass(spawn_gate_workspace: Path):
+    result = runner.invoke(
+        app, ["spawn", "urgent fix", "--repos", "shared", "--hotfix"],
+    )
+    assert result.exit_code == 0, result.output
+
+    state = StateManager(spawn_gate_workspace / ".mothership").load()
+    task = state.tasks["urgent-fix"]
+    assert task.work_item_id is None
+
+    log_path = spawn_gate_workspace / ".mothership" / "bypass-log.jsonl"
+    assert log_path.is_file()
+    entries = [json.loads(line) for line in log_path.read_text().splitlines()]
+    assert any(
+        e.get("reason") == "hotfix" and e.get("op") == "spawn" and e.get("branch") == "urgent-fix"
+        for e in entries
+    )

--- a/tests/test_test_diff_integration.py
+++ b/tests/test_test_diff_integration.py
@@ -27,7 +27,7 @@ def test_workspace(workspace_with_git):
 
 def _spawn(description="first"):
     result = runner.invoke(
-        app, ["spawn", description, "--repos", "shared", "--force-audit"],
+        app, ["spawn", "--hotfix", description, "--repos", "shared", "--force-audit"],
     )
     assert result.exit_code == 0, result.output
 

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -1,0 +1,117 @@
+from datetime import datetime, timezone
+
+from mship.core.spec import Spec
+from mship.core.spec_store import SpecStore
+from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.workitem_gate import GateResult, check_task_gate, log_hotfix
+from mship.core.workitem_store import WorkItemStore
+
+
+def _now():
+    return datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+
+
+def _task(slug="t", work_item_id=None):
+    return Task(slug=slug, description="d", phase="dev", created_at=_now(),
+                affected_repos=["mothership"], branch="feat/t", work_item_id=work_item_id)
+
+
+def test_no_work_item_id_is_not_ok(tmp_path):
+    result = check_task_gate(_task(work_item_id=None), tmp_path)
+    assert isinstance(result, GateResult)
+    assert not result.ok
+    assert "no WorkItem" in result.reason
+
+
+def test_missing_work_item_is_not_ok(tmp_path):
+    result = check_task_gate(_task(work_item_id="wi-nope"), tmp_path)
+    assert not result.ok
+    assert "wi-nope" in result.reason
+
+
+def test_bug_work_item_ok_without_spec(tmp_path):
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="fix it", kind="bug", workspace="ws", now=_now())
+    result = check_task_gate(_task(work_item_id=wi.id), tmp_path)
+    assert result.ok
+    assert result.reason is None
+
+
+def test_feature_work_item_without_approved_spec_is_not_ok(tmp_path):
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="add thing", kind="feature", workspace="ws", now=_now())
+    result = check_task_gate(_task(work_item_id=wi.id), tmp_path)
+    assert not result.ok
+    assert "approved spec" in result.reason
+
+
+def test_feature_work_item_with_approved_spec_via_spec_id_is_ok(tmp_path):
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    specs = SpecStore(tmp_path / "specs")
+    specs.save(Spec(id="spec-1", title="Spec", status="approved",
+                    created_at=_now(), updated_at=_now()))
+    wi = items.create(title="add thing", kind="feature", workspace="ws", now=_now())
+    items.link_spec(wi.id, "spec-1", now=_now())
+    result = check_task_gate(_task(work_item_id=wi.id), tmp_path)
+    assert result.ok
+
+
+def test_feature_work_item_with_unapproved_spec_via_spec_id_is_not_ok(tmp_path):
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    specs = SpecStore(tmp_path / "specs")
+    specs.save(Spec(id="spec-1", title="Spec", status="drafting",
+                    created_at=_now(), updated_at=_now()))
+    wi = items.create(title="add thing", kind="feature", workspace="ws", now=_now())
+    items.link_spec(wi.id, "spec-1", now=_now())
+    result = check_task_gate(_task(work_item_id=wi.id), tmp_path)
+    assert not result.ok
+
+
+def test_feature_work_item_with_approved_spec_via_task_slug_fallback_is_ok(tmp_path):
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    specs = SpecStore(tmp_path / "specs")
+    specs.save(Spec(id="spec-1", title="Spec", status="dispatched",
+                    created_at=_now(), updated_at=_now(), task_slug="t"))
+    wi = items.create(title="add thing", kind="feature", workspace="ws", now=_now())
+    # No spec_id link on the WorkItem itself — fallback must scan specs by task_slug.
+    result = check_task_gate(_task(slug="t", work_item_id=wi.id), tmp_path)
+    assert result.ok
+
+
+def test_add_task_sets_reverse_link_on_task(tmp_path):
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    state = StateManager(tmp_path / ".mothership")
+    state.save(WorkspaceState(tasks={"t": Task(
+        slug="t", description="d", phase="dev", created_at=_now(),
+        affected_repos=["mothership"], branch="feat/t")}))
+    wi = items.create(title="add thing", kind="chore", workspace="ws", now=_now())
+
+    items.add_task(wi.id, "t", now=_now(), state=state)
+
+    assert state.load().tasks["t"].work_item_id == wi.id
+    assert items.get(wi.id).task_slugs == ["t"]
+
+
+def test_add_task_without_state_does_not_write_reverse_link(tmp_path):
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    state = StateManager(tmp_path / ".mothership")
+    state.save(WorkspaceState(tasks={"t": Task(
+        slug="t", description="d", phase="dev", created_at=_now(),
+        affected_repos=["mothership"], branch="feat/t")}))
+    wi = items.create(title="add thing", kind="chore", workspace="ws", now=_now())
+
+    items.add_task(wi.id, "t", now=_now())
+
+    assert state.load().tasks["t"].work_item_id is None
+
+
+def test_log_hotfix_appends_bypass_log(tmp_path):
+    (tmp_path / ".mothership").mkdir()
+    log_hotfix(tmp_path, "dev", "some-task")
+    log_path = tmp_path / ".mothership" / "bypass-log.jsonl"
+    assert log_path.is_file()
+    import json
+    line = json.loads(log_path.read_text().splitlines()[-1])
+    assert line["reason"] == "hotfix"
+    assert line["op"] == "dev"
+    assert line["branch"] == "some-task"

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -115,3 +115,22 @@ def test_log_hotfix_appends_bypass_log(tmp_path):
     assert line["reason"] == "hotfix"
     assert line["op"] == "dev"
     assert line["branch"] == "some-task"
+
+
+# ---------------------------------------------------------------------------
+# PR review fix: consolidate the "approved or beyond" status set. workitem_gate
+# is the single source of truth (APPROVED_STATUSES); workitem_migrate and
+# PhaseManager._has_approved_spec must not keep their own hardcoded copies.
+# ---------------------------------------------------------------------------
+
+def test_approved_statuses_is_the_expected_set():
+    from mship.core.workitem_gate import APPROVED_STATUSES
+    assert APPROVED_STATUSES == {"approved", "dispatched", "implemented"}
+
+
+def test_workitem_migrate_shares_the_same_approved_statuses_object():
+    """workitem_migrate must import (not redefine) workitem_gate's set —
+    an identity check, not just an equality check, so a stray local copy
+    can't silently drift out of sync."""
+    from mship.core import workitem_gate, workitem_migrate
+    assert workitem_migrate.APPROVED_STATUSES is workitem_gate.APPROVED_STATUSES


### PR DESCRIPTION
## Summary

Enforce **"no work without a WorkItem"** as hard mship tooling gates, so agents can't sidestep the process in prose. mship spec `workitem-mandatory-kind-gated-approval` — **approved + dispatched by the operator from Ground Control** (spec-first). Mothership only. 6 commits, 10 production files, +349/−53.

One shared resolver (`core/workitem_gate.py::check_task_gate`) — **WorkItem required universally; `kind=feature` ⇒ an approved spec; bug/chore/question pass with just a WorkItem** — read by four enforcement points:

- **spawn** (`cli/worktree.py`) — refuses without `--work-item <id>` (no auto-create, per operator); writes the reverse link `task.work_item_id` at creation. `--hotfix` overrides (logged).
- **phase→dev** (`core/phase.py`) — a feature WorkItem can't enter `dev` without an approved spec; `--bypass-spec-gate` overrides.
- **finish** (`cli/worktree.py`) — refuses to open a PR without a WorkItem / for a feature without an approved spec; `--hotfix` downgrades to a warning (mirrors the test-evidence gate).
- **hooks** (`cli/internal.py` `_check-commit`/`_check-push`/`_guard-edit` + `core/edit_guard.py`) — commit/push/PreToolUse-edit all require the WorkItem; **fail-open** on any error (never brick git/edits); `MSHIP_BYPASS_GATE` overrides.

Plus the **reverse-link foundation** (`add_task`/`link-task` now set `task.work_item_id` — previously only the migrator did) and a **backfill migration** (`workitem_migrate.wrap_existing`: a feature item for an approved-spec task, else a chore item, per orphan task — idempotent).

**Operator decisions baked in:** explicit WorkItem at spawn (no auto-create) · only feature needs a spec · hard-block + logged `--hotfix` · migrate existing null tasks · PreToolUse default-on.

## Rollout ordering (important)

Run **`mship item migrate`** (the extended backfill) on the live workspace BEFORE these gates bite — every existing task is `work_item_id=null` today and would otherwise be blocked.

## Known follow-ups (from the whole-feature review — APPROVED, all minor)

- **[important] workitems-dir resolution consistency:** the gate/spawn locate the store as `workspace_root/.mothership/workitems` (matching `serve.py`), while `mship item new/list/migrate` use `container.state_dir()/workitems`. They coincide in this workspace (and all 1934 tests pass), but could diverge in a nested-git topology → a spurious "WorkItem not found" on spawn. Fix: a shared `workitems_dir()` helper derived from `state_dir()`. Fast-follow.
- **[nit]** wrap `check_task_gate` in try/except in finish/phase so a corrupt WorkItem-store JSON can't crash them (and `--hotfix`/`--bypass-spec-gate` still works).
- **[nit]** the phase gate fires only on plan→dev (commit/push/finish gate independently, so not exploitable).

## Test plan

- [x] `uv run pytest` → **1934 passed**, 0 failed (incl. legitimate `--hotfix` sweeps across ~200 pre-existing spawn/finish test call-sites).
- [x] `mship test` green at HEAD.
- [x] Whole-feature review **APPROVED** — fail-open confirmed on every hook (corrupt-store tests), no unbypassed sidestep, override logged at commit/push/spawn/phase/finish.

Spec: `specs/2026-07-02-workitem-mandatory-kind-gated-approval.md` · Plan: `docs/plans/2026-07-02-workitem-enforcement.md`

https://claude.ai/code/session_0186xi8KZg4yxDAMMWXZfgnJ
