### PR TITLE
spec dispatch attaches + links a feature WorkItem to the spawned task (MOS-213)

### DIFF
--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -442,11 +442,13 @@ def register(parent: typer.Typer, get_container):
         from pathlib import Path
         from mship.core.spec_store import SpecStore, SPECS_DIRNAME
         from mship.core.spec_dispatch import DispatchError, dispatch_spec
+        from mship.core.workitem_store import WorkItemStore
 
         output = Output()
         container = get_container()
         workspace_root = Path(container.config_path()).parent
         store = SpecStore(workspace_root / SPECS_DIRNAME)
+        workitems = WorkItemStore(workspace_root / ".mothership" / "workitems")
         spec = store.find_by_id(spec_id)
         if spec is None:
             output.error(f"No spec with id {spec_id!r}.")
@@ -467,6 +469,8 @@ def register(parent: typer.Typer, get_container):
                 store=store,
                 spawn_fn=_spawn,
                 now=datetime.now(timezone.utc),
+                workitems=workitems,
+                workspace=container.config().workspace,
                 task_slug=task_slug,
             )
         except DispatchError as e:

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -283,13 +283,21 @@ def create_app(
 
     @app.post("/specs/{spec_id}/dispatch")
     def post_dispatch(spec_id: str):
-        spec = _load_or_404(spec_id)
+        # Serialized end-to-end (_dispatch_lock): two concurrent dispatches of the
+        # same spec both run in Starlette's sync threadpool, and when
+        # spec.work_item_id is still None, dispatch_spec's create-or-reuse branch
+        # can't tell the second caller apart from the first until store.save(spec)
+        # lands. Re-loading the spec inside the lock (rather than reusing the copy
+        # loaded before it) means the second caller sees the first's work_item_id
+        # already set and reuses it instead of creating a duplicate WorkItem.
         try:
-            result = dispatch_spec(
-                spec, state_manager=state_manager, store=store,
-                spawn_fn=_serve_spawn, now=datetime.now(timezone.utc),
-                workitems=workitems, workspace=workspace_name,
-            )
+            with _dispatch_lock:
+                spec = _load_or_404(spec_id)
+                result = dispatch_spec(
+                    spec, state_manager=state_manager, store=store,
+                    spawn_fn=_serve_spawn, now=datetime.now(timezone.utc),
+                    workitems=workitems, workspace=workspace_name,
+                )
         except DispatchError as e:
             raise HTTPException(status_code=409, detail=str(e))
         return {
@@ -397,6 +405,11 @@ def create_app(
     # threadless item could otherwise both create a thread (orphaning one message) or
     # lose the add_thread update. threading.Lock is the right primitive for that pool.
     _item_msg_lock = threading.Lock()
+    # Serializes POST /specs/{id}/dispatch. Same threadpool hazard as above: two
+    # concurrent dispatches of the same spec (spec.work_item_id still None) could
+    # otherwise both take dispatch_spec's create branch before either store.save(spec)
+    # lands, producing a duplicate/orphaned WorkItem. See post_dispatch for the re-load.
+    _dispatch_lock = threading.Lock()
 
     def _workitem_index():
         return build_workitem_index(

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -288,6 +288,7 @@ def create_app(
             result = dispatch_spec(
                 spec, state_manager=state_manager, store=store,
                 spawn_fn=_serve_spawn, now=datetime.now(timezone.utc),
+                workitems=workitems, workspace=workspace_name,
             )
         except DispatchError as e:
             raise HTTPException(status_code=409, detail=str(e))

--- a/src/mship/core/spec_dispatch.py
+++ b/src/mship/core/spec_dispatch.py
@@ -76,6 +76,8 @@ def dispatch_spec(
     store,
     spawn_fn: Callable[[Spec], Task],
     now: datetime,
+    workitems,
+    workspace: str,
     task_slug: str | None = None,
 ) -> DispatchResult:
     """Bind an approved (or already-dispatched) spec to a task.
@@ -86,6 +88,11 @@ def dispatch_spec(
     - spec already bound (`spec.task_slug` exists in state): reuse it (idempotent).
     - a task named `spec.id` exists: bind to it.
     - otherwise: auto-spawn via `spawn_fn(spec)` (requires `affected_repos`).
+
+    Either way, the chosen task is attached to a feature WorkItem (created if
+    the spec doesn't already have one, reused otherwise) so the WorkItem-required
+    enforcement gate doesn't block the dispatched task — mirrors
+    `workitem_migrate.wrap_existing` pass 1.
     """
     if spec.status not in ("approved", "dispatched"):
         raise DispatchError(
@@ -130,6 +137,17 @@ def dispatch_spec(
 
     # Bind the chosen task to the spec under the state lock.
     chosen_slug = task.slug
+
+    # Attach the chosen task to the spec's feature WorkItem — create-or-reuse,
+    # same as workitem_migrate.wrap_existing pass 1 — so the spawned/bound task
+    # carries a work_item_id and clears the enforcement gate.
+    if spec.work_item_id:
+        workitems.add_task(spec.work_item_id, chosen_slug, now=now, state=state_manager)
+    else:
+        wi = workitems.create(title=spec.title, kind="feature", workspace=workspace, now=now)
+        workitems.link_spec(wi.id, spec.id, now=now)
+        spec.work_item_id = wi.id
+        workitems.add_task(wi.id, chosen_slug, now=now, state=state_manager)
 
     def _bind(s):
         if chosen_slug in s.tasks:

--- a/tests/core/test_spec_dispatch.py
+++ b/tests/core/test_spec_dispatch.py
@@ -8,9 +8,11 @@ from mship.core.spec_body import render_body
 from mship.core.spec_store import SpecStore
 from mship.core.state import StateManager, Task, WorkspaceState
 from mship.core.spec_dispatch import DispatchError, build_dispatch_handoff, dispatch_spec
+from mship.core.workitem_store import WorkItemStore
 
 
 NOW = datetime(2026, 6, 14, tzinfo=timezone.utc)
+WORKSPACE = "testws"
 
 
 def _approved_spec(**over) -> Spec:
@@ -34,6 +36,10 @@ def _sm(tmp_path) -> StateManager:
     return StateManager(d)
 
 
+def _items(tmp_path) -> WorkItemStore:
+    return WorkItemStore(tmp_path / "workitems")
+
+
 def _task(slug="dq", repos=("mothership",)) -> Task:
     return Task(
         slug=slug, description="d", phase="plan", created_at=NOW,
@@ -54,7 +60,7 @@ def test_build_dispatch_handoff_contains_key_facts():
 
 
 def test_dispatch_spec_binds_existing_task_without_spawning(tmp_path):
-    sm, store = _sm(tmp_path), _store(tmp_path)
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
     sm.save(WorkspaceState(tasks={"dq": _task()}))
     spec = _approved_spec()
     store.save(spec)
@@ -62,7 +68,10 @@ def test_dispatch_spec_binds_existing_task_without_spawning(tmp_path):
     def spawn_fn(_s):
         raise AssertionError("must not auto-spawn when the task already exists")
 
-    result = dispatch_spec(spec, state_manager=sm, store=store, spawn_fn=spawn_fn, now=NOW)
+    result = dispatch_spec(
+        spec, state_manager=sm, store=store, spawn_fn=spawn_fn, now=NOW,
+        workitems=items, workspace=WORKSPACE,
+    )
 
     assert result.spawned is False
     assert result.spec.status == "dispatched"
@@ -72,7 +81,7 @@ def test_dispatch_spec_binds_existing_task_without_spawning(tmp_path):
 
 
 def test_dispatch_spec_auto_spawns_when_no_task(tmp_path):
-    sm, store = _sm(tmp_path), _store(tmp_path)
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
     sm.save(WorkspaceState(tasks={}))
     spec = _approved_spec()
     store.save(spec)
@@ -85,7 +94,10 @@ def test_dispatch_spec_auto_spawns_when_no_task(tmp_path):
         sm.mutate(lambda st: st.tasks.__setitem__(s.id, task))
         return task
 
-    result = dispatch_spec(spec, state_manager=sm, store=store, spawn_fn=spawn_fn, now=NOW)
+    result = dispatch_spec(
+        spec, state_manager=sm, store=store, spawn_fn=spawn_fn, now=NOW,
+        workitems=items, workspace=WORKSPACE,
+    )
 
     assert result.spawned is True
     assert calls == [("dq", ("mothership",))]              # spawn_fn got the spec
@@ -95,24 +107,30 @@ def test_dispatch_spec_auto_spawns_when_no_task(tmp_path):
 
 
 def test_dispatch_spec_requires_approved(tmp_path):
-    sm, store = _sm(tmp_path), _store(tmp_path)
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
     spec = _approved_spec(status="needs_review")
     store.save(spec)
     with pytest.raises(DispatchError):
-        dispatch_spec(spec, state_manager=sm, store=store, spawn_fn=lambda s: None, now=NOW)
+        dispatch_spec(
+            spec, state_manager=sm, store=store, spawn_fn=lambda s: None, now=NOW,
+            workitems=items, workspace=WORKSPACE,
+        )
 
 
 def test_dispatch_spec_auto_spawn_requires_affected_repos(tmp_path):
-    sm, store = _sm(tmp_path), _store(tmp_path)
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
     sm.save(WorkspaceState(tasks={}))
     spec = _approved_spec(affected_repos=[])
     store.save(spec)
     with pytest.raises(DispatchError):
-        dispatch_spec(spec, state_manager=sm, store=store, spawn_fn=lambda s: None, now=NOW)
+        dispatch_spec(
+            spec, state_manager=sm, store=store, spawn_fn=lambda s: None, now=NOW,
+            workitems=items, workspace=WORKSPACE,
+        )
 
 
 def test_dispatch_spec_binds_existing_differently_slugged_task(tmp_path):
-    sm, store = _sm(tmp_path), _store(tmp_path)
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
     sm.save(WorkspaceState(tasks={"other": _task(slug="other")}))
     spec = _approved_spec()  # id == "dq", no task named "dq"
     store.save(spec)
@@ -121,7 +139,8 @@ def test_dispatch_spec_binds_existing_differently_slugged_task(tmp_path):
         raise AssertionError("must not auto-spawn when --task binds an existing task")
 
     result = dispatch_spec(
-        spec, state_manager=sm, store=store, spawn_fn=spawn_fn, now=NOW, task_slug="other"
+        spec, state_manager=sm, store=store, spawn_fn=spawn_fn, now=NOW, task_slug="other",
+        workitems=items, workspace=WORKSPACE,
     )
 
     assert result.spawned is False
@@ -132,7 +151,7 @@ def test_dispatch_spec_binds_existing_differently_slugged_task(tmp_path):
 
 
 def test_dispatch_spec_unknown_task_errors(tmp_path):
-    sm, store = _sm(tmp_path), _store(tmp_path)
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
     sm.save(WorkspaceState(tasks={}))
     spec = _approved_spec()
     store.save(spec)
@@ -140,11 +159,12 @@ def test_dispatch_spec_unknown_task_errors(tmp_path):
         dispatch_spec(
             spec, state_manager=sm, store=store,
             spawn_fn=lambda s: None, now=NOW, task_slug="ghost",
+            workitems=items, workspace=WORKSPACE,
         )
 
 
 def test_dispatch_spec_is_idempotent_when_already_bound(tmp_path):
-    sm, store = _sm(tmp_path), _store(tmp_path)
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
     sm.save(WorkspaceState(tasks={"other": _task(slug="other")}))
     spec = _approved_spec()
     store.save(spec)
@@ -153,11 +173,13 @@ def test_dispatch_spec_is_idempotent_when_already_bound(tmp_path):
         spec, state_manager=sm, store=store,
         spawn_fn=lambda s: (_ for _ in ()).throw(AssertionError("no spawn")),
         now=NOW, task_slug="other",
+        workitems=items, workspace=WORKSPACE,
     )
     result = dispatch_spec(
         spec, state_manager=sm, store=store,
         spawn_fn=lambda s: (_ for _ in ()).throw(AssertionError("no spawn")),
         now=NOW,
+        workitems=items, workspace=WORKSPACE,
     )
     assert result.spawned is False
     assert result.task.slug == "other"
@@ -165,7 +187,7 @@ def test_dispatch_spec_is_idempotent_when_already_bound(tmp_path):
 
 
 def test_dispatch_spec_rebind_conflict_errors(tmp_path):
-    sm, store = _sm(tmp_path), _store(tmp_path)
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
     sm.save(WorkspaceState(tasks={
         "other": _task(slug="other"),
         "another": _task(slug="another"),
@@ -175,9 +197,69 @@ def test_dispatch_spec_rebind_conflict_errors(tmp_path):
     dispatch_spec(
         spec, state_manager=sm, store=store,
         spawn_fn=lambda s: None, now=NOW, task_slug="other",
+        workitems=items, workspace=WORKSPACE,
     )
     with pytest.raises(DispatchError, match="already bound"):
         dispatch_spec(
             spec, state_manager=sm, store=store,
             spawn_fn=lambda s: None, now=NOW, task_slug="another",
+            workitems=items, workspace=WORKSPACE,
         )
+
+
+# --- MOS-213: dispatch attaches a feature WorkItem to the spawned/bound task ---
+
+def test_dispatch_spec_auto_spawn_creates_and_links_feature_workitem(tmp_path):
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
+    sm.save(WorkspaceState(tasks={}))
+    spec = _approved_spec()
+    store.save(spec)
+
+    def spawn_fn(s):
+        task = _task(slug=s.id, repos=s.affected_repos)
+        sm.mutate(lambda st: st.tasks.__setitem__(s.id, task))
+        return task
+
+    result = dispatch_spec(
+        spec, state_manager=sm, store=store, spawn_fn=spawn_fn, now=NOW,
+        workitems=items, workspace=WORKSPACE,
+    )
+
+    chosen_slug = result.task.slug
+    assert sm.load().tasks[chosen_slug].work_item_id is not None   # reverse link on the task
+
+    all_items = items.list()
+    assert len(all_items) == 1
+    wi = all_items[0]
+    assert wi.kind == "feature"
+    assert wi.workspace == WORKSPACE
+    assert wi.spec_id == spec.id
+    assert chosen_slug in wi.task_slugs
+
+    assert result.spec.work_item_id == wi.id
+    assert store.find_by_id(spec.id).work_item_id == wi.id         # persisted
+
+
+def test_dispatch_spec_reuses_existing_workitem_when_spec_already_has_one(tmp_path):
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
+    sm.save(WorkspaceState(tasks={"dq": _task()}))
+    existing = items.create(title="Decision Queue", kind="feature", workspace=WORKSPACE, now=NOW)
+    items.link_spec(existing.id, "dq", now=NOW)
+    spec = _approved_spec(work_item_id=existing.id)
+    store.save(spec)
+
+    def spawn_fn(_s):
+        raise AssertionError("must not auto-spawn when the task already exists")
+
+    result = dispatch_spec(
+        spec, state_manager=sm, store=store, spawn_fn=spawn_fn, now=NOW,
+        workitems=items, workspace=WORKSPACE,
+    )
+
+    all_items = items.list()
+    assert len(all_items) == 1                                     # no new item created
+    wi = all_items[0]
+    assert wi.id == existing.id
+    assert "dq" in wi.task_slugs
+    assert result.spec.work_item_id == existing.id
+    assert sm.load().tasks["dq"].work_item_id == existing.id


### PR DESCRIPTION
## Summary

Fix **MOS-213**: `mship spec dispatch` (CLI) and `POST /specs/{id}/dispatch` (serve) spawned/bound a task with `work_item_id = None`, so the WorkItem-required enforcement gate (0.4.0, #271) **blocked** it — a dispatched feature task was born blocked. Hit live dispatching the `chat-experience` spec from Ground Control (MOS-212), where the task had to be hand-linked to a WorkItem.

`dispatch_spec` now **create-or-reuses the spec's feature WorkItem and links the chosen task** (forward `task_slugs` + reverse `task.work_item_id`), mirroring `workitem_migrate.wrap_existing` pass 1 — for both the auto-spawn path and the existing-task/`--task` bind path:

- `spec.work_item_id` already set → link the task to that existing item.
- else → create a `feature` WorkItem, `link_spec` it, set `spec.work_item_id`, link the task.

So the operator's **approve → dispatch (from GC) → build** flow now produces a WorkItem-backed task that clears the `phase dev` / `finish` / commit-push-edit gates without a manual `mship item new` + `link-task` or `--hotfix`. Mothership only.

**Notes:** the WorkItem `workspace` name comes from `container.config().workspace` (not hardcoded); the store path is `workspace_root/.mothership/workitems`, matching serve + the gate reader.

## Test plan

- [x] `uv run pytest` → **1944 passed**, 0 failed — 2 new `test_spec_dispatch` tests (create-new feature WorkItem + reuse-existing), 9 existing calls updated for the new params.
- [x] `mship test` green.
- [ ] After merge + reinstall: dispatch a feature spec from GC → the task should land with a WorkItem (no hand-linking).

https://claude.ai/code/session_0186xi8KZg4yxDAMMWXZfgnJ
