### PR TITLE
fix mship spec show + serve spec-detail crash (AcceptanceCriterion.done) (MOS-214)

### DIFF
--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -583,11 +583,16 @@ def register(parent: typer.Typer, get_container):
             "created_at": spec.created_at.isoformat() if spec.created_at else None,
             "affected_repos": spec.affected_repos,
             "acceptance_criteria": [
-                {"id": ac.id, "text": ac.text, "done": ac.done}
+                {
+                    "id": ac.id,
+                    "text": ac.text,
+                    "verdict": ac.verdict,
+                    "done": ac.verdict == "approved",
+                }
                 for ac in (spec.acceptance_criteria or [])
             ],
             "open_questions": [
-                {"id": oq.id, "question": oq.question, "answer": oq.answer}
+                {"id": oq.id, "text": oq.text, "answer": oq.answer}
                 for oq in (spec.open_questions or [])
             ],
             "non_goals": spec.non_goals,

--- a/tests/cli/test_spec_list_show.py
+++ b/tests/cli/test_spec_list_show.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import typer
 from typer.testing import CliRunner
 
+from mship.core.spec import AcceptanceCriterion, OpenQuestion
 from mship.core.spec_draft import new_spec
 from mship.core.spec_store import SpecStore
 
@@ -145,3 +146,33 @@ class TestSpecShow:
         runner = CliRunner()
         result = runner.invoke(app, ["spec", "show", ids[0]])
         assert result.exit_code == 0
+
+    def test_show_reports_criterion_verdict_and_derived_done(self, tmp_path):
+        """Regression for MOS-214: AcceptanceCriterion carries a `verdict`
+        (unreviewed/approved/flagged), not a `done` boolean. `spec show` used
+        to crash with AttributeError as soon as a spec had real acceptance
+        criteria, because it read `ac.done`. Also covers the sibling
+        `oq.question` typo (OpenQuestion only has `text`), which crashes the
+        same command as soon as a spec has open questions."""
+        store, ids = _make_store(tmp_path, count=1)
+        spec = store.find_by_id(ids[0])
+        spec.acceptance_criteria = [
+            AcceptanceCriterion(id="ac1", text="works", verdict="approved"),
+            AcceptanceCriterion(id="ac2", text="also works", verdict="flagged"),
+        ]
+        spec.open_questions = [OpenQuestion(id="q1", text="Android too?", answer="yes")]
+        store.save(spec)
+        app = _app(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(app, ["spec", "show", ids[0]])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["acceptance_criteria"][0] == {
+            "id": "ac1", "text": "works", "verdict": "approved", "done": True,
+        }
+        assert data["acceptance_criteria"][1] == {
+            "id": "ac2", "text": "also works", "verdict": "flagged", "done": False,
+        }
+        assert data["open_questions"][0] == {
+            "id": "q1", "text": "Android too?", "answer": "yes",
+        }


### PR DESCRIPTION
## Summary

Fix **MOS-214**: `mship spec show <id>` crashed with `AttributeError: 'AcceptanceCriterion' object has no attribute 'done'` on any spec that has acceptance criteria. `AcceptanceCriterion` only has `id` / `text` / `verdict` (`unreviewed` | `approved` | `flagged`) — there is no `done` bool. `show_spec`'s payload builder now exposes the real **`verdict`** and derives **`done = verdict == "approved"`** for back-compat.

Also fixes a **sibling latent crash** in the same function: `oq.question` → `oq.text` (`OpenQuestion` has no `question` attribute), which would crash the same command on any spec with open questions.

**Serve was investigated and is NOT affected:** `GET /specs/{id}` returns `spec.model_dump(mode="json")` directly (already serializes the real `verdict`), and the Ground Control client's `ReviewCriterion` DTO already expects `verdict`, not `done` — so no serve change and no consumer break. Mothership only.

## Test plan

- [x] `uv run pytest` → **1945 passed**, 0 failed — new `test_show_reports_criterion_verdict_and_derived_done` reproduces the `AttributeError` (RED) then passes (GREEN).
- [x] `mship test` green.
- [x] Manual: `mship spec show cloud-auth` (9 real criteria) + 4 other real specs — no crash, payload carries `verdict` + derived `done`.

https://claude.ai/code/session_0186xi8KZg4yxDAMMWXZfgnJ
