### PR TITLE
inbox-listener lease: mship inbox wait + _drain take an exclusive workspace lease so a 2nd agent can't double-drain the mailbox

### DIFF
--- a/src/mship/cli/message.py
+++ b/src/mship/cli/message.py
@@ -46,7 +46,9 @@ def register(parent: typer.Typer, get_container) -> None:
         timeout: float = typer.Option(50.0, "--timeout", help="Max seconds to block before returning timed_out."),
     ) -> None:
         """Block until a new awaiting (human) message arrives, or timeout. JSON only."""
+        import os
         from mship.core.message_wait import wait_for_change
+        from mship.core.inbox_lease import InboxLease
         store = _store()
         if since:
             try:
@@ -58,10 +60,34 @@ def register(parent: typer.Typer, get_container) -> None:
             since_dt = datetime.now(timezone.utc)
         if since_dt.tzinfo is None:
             since_dt = since_dt.replace(tzinfo=timezone.utc)
-        res = wait_for_change(
-            store.list, since_dt, timeout,
-            predicate=lambda t: t.awaiting_reply,
-        )
+
+        # One-listener lease: if another agent in this workspace already holds it,
+        # stand down instead of double-draining the shared mailbox (every armed
+        # listener would otherwise answer the same message). The caller treats a
+        # `skipped_duplicate_listener` result as "don't re-arm". See core/inbox_lease.
+        pid = os.getpid()
+        lease = InboxLease(Path(get_container().state_dir()) / "inbox-listener.lock")
+        holder = lease.try_acquire(pid, datetime.now(timezone.utc))
+        if holder is not None:
+            typer.echo(json.dumps({
+                "threads": [], "cursor": since_dt.isoformat(), "timed_out": False,
+                "skipped_duplicate_listener": True, "holder_pid": holder.pid,
+            }))
+            return
+
+        def _load_and_heartbeat():
+            # Refresh the lease each poll so a concurrent reclaim can't steal it
+            # mid-wait; the poll loop already ticks ~1s, so no extra thread needed.
+            lease.refresh(pid, datetime.now(timezone.utc))
+            return store.list()
+
+        try:
+            res = wait_for_change(
+                _load_and_heartbeat, since_dt, timeout,
+                predicate=lambda t: t.awaiting_reply,
+            )
+        finally:
+            lease.release(pid)
         out = {
             "threads": [
                 {"id": t.id, "subject": t.subject,

--- a/src/mship/core/inbox_lease.py
+++ b/src/mship/core/inbox_lease.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -75,35 +76,46 @@ class InboxLease:
         return not self._pid_alive(info.pid)
 
     def _write(self, pid: int, now: datetime) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
         tmp = self._path.with_name(self._path.name + ".tmp")
         tmp.write_text(json.dumps({"pid": pid, "heartbeat_at": now.isoformat()}))
         tmp.replace(self._path)
 
-    def try_acquire(self, pid: int, now: datetime) -> LeaseInfo | None:
-        """Take the lease (or take over a dead/stale one). Returns None on
-        success, or the live holder's LeaseInfo if another agent holds it."""
+    @contextmanager
+    def _critical(self):
+        """Advisory-flock the read-decide-write section (mirrors state.lock). ALL
+        mutations — acquire, refresh, release — run under this so a concurrent
+        reclaim can't interleave between a caller's read and its write/unlink."""
         self._path.parent.mkdir(parents=True, exist_ok=True)
         guard = self._path.with_name(self._path.name + ".flock")
         with open(guard, "w") as lf:
             fcntl.flock(lf, fcntl.LOCK_EX)
             try:
-                info = self.read()
-                if not self._reclaimable(info, pid, now):
-                    return info  # live, fresh, different holder → caller stands down
-                self._write(pid, now)
-                return None
+                yield
             finally:
                 fcntl.flock(lf, fcntl.LOCK_UN)
 
-    def refresh(self, pid: int, now: datetime) -> None:
-        """Heartbeat while we still hold it (no-op if another holder took over)."""
-        info = self.read()
-        if info is None or info.pid == pid:
+    def try_acquire(self, pid: int, now: datetime) -> LeaseInfo | None:
+        """Take the lease (or take over a dead/stale one). Returns None on
+        success, or the live holder's LeaseInfo if another agent holds it."""
+        with self._critical():
+            info = self.read()
+            if not self._reclaimable(info, pid, now):
+                return info  # live, fresh, different holder → caller stands down
             self._write(pid, now)
+            return None
+
+    def refresh(self, pid: int, now: datetime) -> None:
+        """Heartbeat while we still hold it (no-op if another holder took over).
+        Under the flock so it can't clobber a takeover that raced our read."""
+        with self._critical():
+            info = self.read()
+            if info is None or info.pid == pid:
+                self._write(pid, now)
 
     def release(self, pid: int) -> None:
-        """Best-effort release on exit; only removes our own lease."""
-        info = self.read()
-        if info is not None and info.pid == pid:
-            self._path.unlink(missing_ok=True)
+        """Best-effort release on exit; only removes our own lease. Under the flock
+        so it can't delete a lease a new holder reclaimed after our read."""
+        with self._critical():
+            info = self.read()
+            if info is not None and info.pid == pid:
+                self._path.unlink(missing_ok=True)

--- a/src/mship/core/inbox_lease.py
+++ b/src/mship/core/inbox_lease.py
@@ -1,0 +1,109 @@
+"""Single-listener lease for the message inbox (enforces one-agent-per-workspace).
+
+The `receiving-messages` skill assumes exactly one agent drains a workspace's
+shared mailbox. When two `claude` sessions in the same workspace both arm
+`mship inbox wait`, every phone message wakes both and gets answered twice
+(duplicate replies / decision cards). This lease makes the invariant enforced,
+not just documented: a second `inbox wait` that finds a live lease stands down
+instead of racing.
+
+The lease is a small JSON file (`<state_dir>/inbox-listener.lock`) holding the
+holder pid + a heartbeat the active waiter refreshes each poll. It is reclaimable
+when the holder process is gone or its heartbeat is older than the TTL, so a
+crashed or exited listener never wedges the mailbox. The acquire critical section
+takes an advisory flock (same primitive as state.lock) so two simultaneous
+acquires can't both win.
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class LeaseInfo:
+    pid: int
+    heartbeat_at: datetime
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if a process with `pid` exists (signal 0 probes without killing)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists but owned by another user
+    return True
+
+
+class InboxLease:
+    """Reclaimable single-holder lease. `try_acquire` returns None on success or
+    the live holder's LeaseInfo when another agent already holds it."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        ttl_seconds: float = 10.0,
+        pid_alive: Callable[[int], bool] = _pid_alive,
+    ) -> None:
+        self._path = path
+        self._ttl = ttl_seconds
+        self._pid_alive = pid_alive
+
+    def read(self) -> LeaseInfo | None:
+        try:
+            raw = json.loads(self._path.read_text())
+            return LeaseInfo(
+                pid=int(raw["pid"]),
+                heartbeat_at=datetime.fromisoformat(raw["heartbeat_at"]),
+            )
+        except (FileNotFoundError, ValueError, KeyError, TypeError):
+            return None  # missing or corrupt → treat as unheld
+
+    def _reclaimable(self, info: LeaseInfo | None, me: int, now: datetime) -> bool:
+        if info is None or info.pid == me:
+            return True
+        if (now - info.heartbeat_at).total_seconds() > self._ttl:
+            return True  # heartbeat went stale → holder is gone or wedged
+        return not self._pid_alive(info.pid)
+
+    def _write(self, pid: int, now: datetime) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._path.with_name(self._path.name + ".tmp")
+        tmp.write_text(json.dumps({"pid": pid, "heartbeat_at": now.isoformat()}))
+        tmp.replace(self._path)
+
+    def try_acquire(self, pid: int, now: datetime) -> LeaseInfo | None:
+        """Take the lease (or take over a dead/stale one). Returns None on
+        success, or the live holder's LeaseInfo if another agent holds it."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        guard = self._path.with_name(self._path.name + ".flock")
+        with open(guard, "w") as lf:
+            fcntl.flock(lf, fcntl.LOCK_EX)
+            try:
+                info = self.read()
+                if not self._reclaimable(info, pid, now):
+                    return info  # live, fresh, different holder → caller stands down
+                self._write(pid, now)
+                return None
+            finally:
+                fcntl.flock(lf, fcntl.LOCK_UN)
+
+    def refresh(self, pid: int, now: datetime) -> None:
+        """Heartbeat while we still hold it (no-op if another holder took over)."""
+        info = self.read()
+        if info is None or info.pid == pid:
+            self._write(pid, now)
+
+    def release(self, pid: int) -> None:
+        """Best-effort release on exit; only removes our own lease."""
+        info = self.read()
+        if info is not None and info.pid == pid:
+            self._path.unlink(missing_ok=True)

--- a/src/mship/skills/receiving-messages/SKILL.md
+++ b/src/mship/skills/receiving-messages/SKILL.md
@@ -25,6 +25,12 @@ mechanisms surface them to a live agent (one serve + one agent per workspace):
    The `--since` cursor means you never re-wake for a message you already handled
    (or for your own reply).
 4. On `timed_out: true`, just re-arm again.
+5. If the result has `"skipped_duplicate_listener": true` (with a `holder_pid`),
+   **another agent in this workspace already holds the inbox lease — do NOT
+   re-arm.** Stand down; that other session is the listener. (One agent per
+   workspace: two armed listeners would each answer every message.) The lease is
+   reclaimable, so if that holder later exits, your next `mship inbox wait` will
+   acquire it cleanly.
 
 Never spawn a new agent / `claude -p` — this is all in your existing session.
 

--- a/tests/cli/test_inbox_wait.py
+++ b/tests/cli/test_inbox_wait.py
@@ -77,6 +77,26 @@ def test_wait_ignores_agent_reply(tmp_path: Path):
         _reset()
 
 
+def test_wait_stands_down_when_another_listener_holds_lease(tmp_path: Path):
+    import os
+    from mship.core.inbox_lease import InboxLease
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    store.create_thread("idea", "shape this", datetime.now(timezone.utc))  # awaiting (human)
+    # Another live listener already holds the lease (parent pid is alive and != ours).
+    InboxLease(state_dir / "inbox-listener.lock").try_acquire(
+        pid=os.getppid(), now=datetime.now(timezone.utc))
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["inbox", "wait", "--since", PAST, "--timeout", "5"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["skipped_duplicate_listener"] is True
+        assert payload["holder_pid"] == os.getppid()
+        assert payload["threads"] == []          # did NOT drain despite an awaiting thread
+    finally:
+        _reset()
+
+
 def test_wait_outside_workspace_errors(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     container.config_path.reset_override(); container.state_dir.reset_override()

--- a/tests/core/test_inbox_lease.py
+++ b/tests/core/test_inbox_lease.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timedelta, timezone
+
+from mship.core.inbox_lease import InboxLease
+
+T0 = datetime(2026, 7, 8, 1, 0, 0, tzinfo=timezone.utc)
+
+
+def _lease(tmp_path, ttl=10.0, alive=True):
+    return InboxLease(
+        tmp_path / "inbox-listener.lock",
+        ttl_seconds=ttl,
+        pid_alive=lambda pid: alive,
+    )
+
+
+def test_acquire_on_empty_succeeds(tmp_path):
+    lease = _lease(tmp_path)
+    assert lease.try_acquire(pid=100, now=T0) is None
+    info = lease.read()
+    assert info is not None and info.pid == 100
+
+
+def test_second_live_holder_is_refused(tmp_path):
+    lease = _lease(tmp_path, alive=True)
+    assert lease.try_acquire(pid=100, now=T0) is None
+    # a different pid, holder still alive + heartbeat fresh → refused
+    holder = lease.try_acquire(pid=200, now=T0 + timedelta(seconds=1))
+    assert holder is not None and holder.pid == 100
+
+
+def test_same_pid_reacquire_is_idempotent(tmp_path):
+    lease = _lease(tmp_path)
+    lease.try_acquire(pid=100, now=T0)
+    assert lease.try_acquire(pid=100, now=T0 + timedelta(seconds=1)) is None
+
+
+def test_reclaims_when_holder_dead(tmp_path):
+    dead = InboxLease(tmp_path / "inbox-listener.lock", ttl_seconds=10.0,
+                      pid_alive=lambda pid: False)
+    dead.try_acquire(pid=100, now=T0)
+    # holder pid not alive → a new pid reclaims even with a fresh heartbeat
+    assert dead.try_acquire(pid=200, now=T0 + timedelta(seconds=1)) is None
+    assert dead.read().pid == 200
+
+
+def test_reclaims_when_heartbeat_stale(tmp_path):
+    lease = _lease(tmp_path, ttl=10.0, alive=True)
+    lease.try_acquire(pid=100, now=T0)
+    # heartbeat older than TTL → reclaimable even though pid is "alive"
+    assert lease.try_acquire(pid=200, now=T0 + timedelta(seconds=11)) is None
+    assert lease.read().pid == 200
+
+
+def test_refresh_advances_heartbeat_only_for_holder(tmp_path):
+    lease = _lease(tmp_path)
+    lease.try_acquire(pid=100, now=T0)
+    lease.refresh(pid=100, now=T0 + timedelta(seconds=5))
+    assert lease.read().heartbeat_at == T0 + timedelta(seconds=5)
+    # a non-holder refresh must not steal the lease
+    lease.refresh(pid=999, now=T0 + timedelta(seconds=6))
+    assert lease.read().pid == 100
+
+
+def test_release_removes_only_own_lease(tmp_path):
+    lease = _lease(tmp_path)
+    lease.try_acquire(pid=100, now=T0)
+    lease.release(pid=999)           # not the holder → no-op
+    assert lease.read() is not None
+    lease.release(pid=100)           # holder → removed
+    assert lease.read() is None
+
+
+def test_corrupt_lease_file_treated_as_unheld(tmp_path):
+    path = tmp_path / "inbox-listener.lock"
+    path.write_text("{not json")
+    lease = _lease(tmp_path)
+    assert lease.read() is None
+    assert lease.try_acquire(pid=100, now=T0) is None


### PR DESCRIPTION
## Summary

Enforce the `receiving-messages` "one agent per workspace" invariant so two
`claude` sessions in the same workspace can't both drain the shared mailbox and
answer every phone message twice (duplicate replies / decision cards — observed
live).

**v1: a wait-arming lease.** `mship inbox wait` now takes a reclaimable
single-holder lease (`<state_dir>/inbox-listener.lock`, holder pid + heartbeat).
If another **live** listener already holds it, `wait` returns
`{"skipped_duplicate_listener": true, "holder_pid": N}` and exits without
draining. The `receiving-messages` skill tells the agent to treat that as "don't
re-arm" — so duplicate listeners **auto-collapse to one**, no manual `kill` needed.

- **Reclaimable**: a lease whose holder pid is gone, or whose heartbeat is older
  than the TTL, is taken over by the next `wait` — a crashed/exited listener never
  wedges the mailbox.
- **Race-safe acquire**: the read-decide-write critical section takes an advisory
  `flock` (same primitive as `state.lock`).
- **No extra thread**: the heartbeat is refreshed on each ~1s poll tick of the
  existing wait loop.

## Scope (honest)

This guards the **primary** vector — two concurrent `mship inbox wait`s. Two
follow-ups from the original design are deliberately deferred because they need a
stable *per-session* identity that a lone process can't derive:

- **`mship _drain` (Stop-hook) lease check** — a `_drain` process can't tell *its
  own* session's wait from another session's by pid alone, so a naive pid lease
  would wrongly silence the sole legitimate agent. Needs a session token.
- **`reply`/`ask` atomic per-message claim** — belt-and-suspenders dedup at
  response time.

The wait-lease needs no session identity because a *blocking wait is itself the
live holder*, so pid-liveness is a sound signal there.

## Test plan
- `test_inbox_lease.py` (8): acquire / refuse-live-other / idempotent-same-pid /
  reclaim-dead-pid / reclaim-stale-heartbeat / heartbeat-only-for-holder /
  release-only-own / corrupt-file-treated-as-unheld.
- `test_inbox_wait.py`: new — `wait` stands down (`skipped_duplicate_listener`,
  does NOT drain an awaiting thread) when a live other holds the lease; existing
  happy-path/timeout/invalid-since tests still green.
- Full suite green.

https://claude.ai/code/session_01WLb3xgnKi4fWy8M4reqhmu


https://claude.ai/code/session_01WLb3xgnKi4fWy8M4reqhmu
