### PR TITLE
Ground Control chat choice affordances (GC#30 PR2): comment-with-choice + multiselect

### DIFF
--- a/src/mship/cli/message.py
+++ b/src/mship/cli/message.py
@@ -127,6 +127,7 @@ def register(parent: typer.Typer, get_container) -> None:
         option: list[str] = typer.Option(..., "--option", help="A choice (repeat for each; >=2)."),
         recommend: int = typer.Option(None, "--recommend", help="0-based index of the recommended option."),
         no_free_text: bool = typer.Option(False, "--no-free-text", help="Disallow a free-text reply."),
+        multi: bool = typer.Option(False, "--multi", help="Allow selecting more than one option."),
     ) -> None:
         """Post an agent DECISION: a question + tappable options (surfaces as a decision card)."""
         from mship.core.message import DecisionPayload
@@ -141,7 +142,8 @@ def register(parent: typer.Typer, get_container) -> None:
             store.append(thread_id, "agent", question, datetime.now(timezone.utc),
                          kind="decision",
                          decision=DecisionPayload(options=option, recommended=recommend,
-                                                  allow_free_text=not no_free_text))
+                                                  allow_free_text=not no_free_text,
+                                                  multi=multi))
         except KeyError:
             typer.echo(f"no thread {thread_id!r}", err=True)
             raise typer.Exit(1)

--- a/src/mship/core/message.py
+++ b/src/mship/core/message.py
@@ -10,6 +10,9 @@ class DecisionPayload(BaseModel):
     options: list[str]
     recommended: int | None = None
     allow_free_text: bool = True
+    # Default False so existing/older clients and payloads captured before
+    # this field existed are treated as single-select (no breakage).
+    multi: bool = False
 
 
 class Message(BaseModel):

--- a/tests/cli/test_message.py
+++ b/tests/cli/test_message.py
@@ -147,3 +147,25 @@ def test_ask_no_free_text(_configured):
 def test_ask_unknown_thread_errors(_configured):
     r = runner.invoke(app, ["ask", "nope", "q", "--option", "a", "--option", "b"])
     assert r.exit_code != 0
+
+
+def test_ask_multi_sets_multiselect(_configured):
+    s = _seed(_configured)
+    now = datetime(2026, 6, 23, tzinfo=timezone.utc)
+    t = s.create_thread(subject="x", text="q", now=now)
+    r = runner.invoke(app, ["ask", t.id, "Which apply?",
+                            "--option", "a", "--option", "b", "--multi"])
+    assert r.exit_code == 0, r.output
+    got = s.get(t.id)
+    assert got.messages[-1].decision.multi is True
+
+
+def test_ask_defaults_to_single_select(_configured):
+    s = _seed(_configured)
+    now = datetime(2026, 6, 23, tzinfo=timezone.utc)
+    t = s.create_thread(subject="x", text="q", now=now)
+    r = runner.invoke(app, ["ask", t.id, "How to store?",
+                            "--option", "a", "--option", "b"])
+    assert r.exit_code == 0, r.output
+    got = s.get(t.id)
+    assert got.messages[-1].decision.multi is False

--- a/tests/core/test_message_model.py
+++ b/tests/core/test_message_model.py
@@ -118,3 +118,26 @@ def test_decision_kind_with_payload_still_constructs():
     m = _dm("agent", "decision", "pick", decision=d)
     assert m.kind == "decision"
     assert m.decision is d
+
+
+def test_decision_payload_multi_defaults_false():
+    d = DecisionPayload(options=["a", "b"])
+    assert d.multi is False
+
+
+def test_decision_payload_multi_round_trips():
+    d = DecisionPayload(options=["a", "b"], multi=True)
+    m = _dm("agent", "decision", "pick any", decision=d)
+    back = Message.model_validate_json(m.model_dump_json())
+    assert back.decision.multi is True
+
+
+def test_decision_payload_legacy_json_without_multi_defaults_false():
+    # Older clients (or payloads captured before this field existed) omit
+    # "multi" entirely -- must not break, and must be treated as single-select.
+    legacy = (
+        '{"id":"m1","thread_id":"x","role":"agent","text":"pick","kind":"decision",'
+        '"created_at":"2026-06-30T12:01:00+00:00",'
+        '"decision":{"options":["a","b"],"recommended":null,"allow_free_text":true}}'
+    )
+    assert Message.model_validate_json(legacy).decision.multi is False


### PR DESCRIPTION
Ground Control chat choice affordances (GC#30 PR2): comment-with-choice + multiselect
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `ground-control-chat-choice-affordances`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/35 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/280 | this PR |

⚠ Merge in order: ground-control → mothership