### PR TITLE
Thread↔entity navigation: deep-links + related work item (MOS-218/MOS-223)

### DIFF
--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -345,7 +345,7 @@ def create_app(
         now = datetime.now(timezone.utc)
         text = body.text
         subject = body.subject or (text.strip().splitlines()[0][:80] if text.strip() else "(no subject)")
-        return msgs.create_thread(subject=subject, text=text, now=now).model_dump(mode="json")
+        return _thread_payload(msgs.create_thread(subject=subject, text=text, now=now))
 
     @app.post("/threads/{thread_id}/messages")
     def post_message(thread_id: str, body: NewMessageBody):
@@ -357,7 +357,7 @@ def create_app(
         t = msgs.get(thread_id)
         if t is None:
             raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
-        return t.model_dump(mode="json")
+        return _thread_payload(t)
 
     @app.post("/threads/{thread_id}/seen")
     def post_seen(thread_id: str, body: SeenBody):
@@ -376,7 +376,7 @@ def create_app(
             t = msgs.mark_seen(thread_id, seen_dt)
         except KeyError:
             raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
-        return t.model_dump(mode="json")
+        return _thread_payload(t)
 
     def _summaries(threads):
         return [
@@ -421,11 +421,12 @@ def create_app(
         t = msgs.get(thread_id)
         if t is None:
             raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
-        return t.model_dump(mode="json")
+        return _thread_payload(t)
 
     # --- work items (phase-aware cockpit spine) ---
     from mship.core.workitem_store import WorkItemStore
     from mship.core.view.workitem_index import build_workitem_index
+    from mship.core.view.thread_links import resolve_thread_work_item
 
     workitems = WorkItemStore(workspace_root / ".mothership" / "workitems")
     # Serializes the lazy read-decide-create-link in POST /items/{id}/messages. Sync
@@ -447,25 +448,49 @@ def create_app(
             {t.id: t for t in msgs.list()},
         )
 
+    def _summarize_item(item_id: str):
+        """Summarize a single work item by id via per-id child lookups (no full
+        list() scans), mirroring the direct-get short-circuit of GET /threads/{id},
+        /specs/{id}. Returns None if the item does not exist."""
+        wi = workitems.get(item_id)
+        if wi is None:
+            return None
+        spec = store.find_by_id(wi.spec_id) if wi.spec_id else None
+        tasks = state_manager.load().tasks
+        return build_workitem_index(
+            [wi],
+            {spec.id: spec} if spec else {},
+            {s: tasks[s] for s in wi.task_slugs if s in tasks},
+            {tid: t for tid in wi.thread_ids if (t := msgs.get(tid))},
+        )[0]
+
+    def _thread_payload(t):
+        """Enrich a thread's dumped dict with the WorkItem it's related to (read-time
+        inversion of the WorkItem link graph — see thread_links.resolve_thread_work_item).
+        Shared by every handler that returns a full thread: GET /threads/{id},
+        POST /threads, POST /threads/{id}/messages, POST /threads/{id}/seen. The
+        GET /threads list/summary endpoint is unaffected."""
+        data = t.model_dump(mode="json")
+        wi_id = resolve_thread_work_item(t.id, t.spec_id, t.task_slug, workitems.list())
+        data["work_item_id"] = wi_id
+        if wi_id is None:
+            data["work_item"] = None
+        else:
+            summ = _summarize_item(wi_id)
+            data["work_item"] = None if summ is None else {
+                "id": summ.id, "title": summ.title, "kind": summ.kind, "phase": summ.phase,
+            }
+        return data
+
     @app.get("/items")
     def list_items():
         return jsonable_encoder(_workitem_index())
 
     @app.get("/items/{item_id}")
     def get_item(item_id: str):
-        wi = workitems.get(item_id)
-        if wi is None:
+        summary = _summarize_item(item_id)
+        if summary is None:
             raise HTTPException(status_code=404, detail=f"no work item {item_id!r}")
-        # Summarize just this item via per-id child lookups (no full list() scans),
-        # mirroring the direct-get short-circuit of GET /threads/{id}, /specs/{id}.
-        spec = store.find_by_id(wi.spec_id) if wi.spec_id else None
-        tasks = state_manager.load().tasks
-        summary = build_workitem_index(
-            [wi],
-            {spec.id: spec} if spec else {},
-            {s: tasks[s] for s in wi.task_slugs if s in tasks},
-            {tid: t for tid in wi.thread_ids if (t := msgs.get(tid))},
-        )[0]
         return jsonable_encoder(summary)
 
     @app.post("/items/{item_id}/messages")

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -427,6 +427,7 @@ def create_app(
     from mship.core.workitem_store import WorkItemStore
     from mship.core.view.workitem_index import build_workitem_index
     from mship.core.view.thread_links import resolve_thread_work_item
+    from mship.core.view.entity_links import linkify_entities
 
     workitems = WorkItemStore(workspace_root / ".mothership" / "workitems")
     # Serializes the lazy read-decide-create-link in POST /items/{id}/messages. Sync
@@ -466,10 +467,12 @@ def create_app(
 
     def _thread_payload(t):
         """Enrich a thread's dumped dict with the WorkItem it's related to (read-time
-        inversion of the WorkItem link graph — see thread_links.resolve_thread_work_item).
-        Shared by every handler that returns a full thread: GET /threads/{id},
-        POST /threads, POST /threads/{id}/messages, POST /threads/{id}/seen. The
-        GET /threads list/summary endpoint is unaffected."""
+        inversion of the WorkItem link graph — see thread_links.resolve_thread_work_item)
+        and auto-linkify native entity refs (wi-/spec/task ids) in agent message text
+        (see entity_links.linkify_entities). Human messages are left untouched — the
+        linkifier only rewrites text the agent produced. Shared by every handler that
+        returns a full thread: GET /threads/{id}, POST /threads, POST /threads/{id}/messages,
+        POST /threads/{id}/seen. The GET /threads list/summary endpoint is unaffected."""
         data = t.model_dump(mode="json")
         wi_id = resolve_thread_work_item(t.id, t.spec_id, t.task_slug, workitems.list())
         data["work_item_id"] = wi_id
@@ -480,6 +483,12 @@ def create_app(
             data["work_item"] = None if summ is None else {
                 "id": summ.id, "title": summ.title, "kind": summ.kind, "phase": summ.phase,
             }
+        item_ids = {w.id for w in workitems.list()}
+        spec_ids = {s.id for s in store.list()}
+        task_slugs = set(state_manager.load().tasks.keys())
+        for msg in data.get("messages", []):
+            if msg.get("role") == "agent" and msg.get("text"):
+                msg["text"] = linkify_entities(msg["text"], item_ids, spec_ids, task_slugs)
         return data
 
     @app.get("/items")

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -474,7 +474,8 @@ def create_app(
         returns a full thread: GET /threads/{id}, POST /threads, POST /threads/{id}/messages,
         POST /threads/{id}/seen. The GET /threads list/summary endpoint is unaffected."""
         data = t.model_dump(mode="json")
-        wi_id = resolve_thread_work_item(t.id, t.spec_id, t.task_slug, workitems.list())
+        all_items = list(workitems.list())  # single store scan, reused below
+        wi_id = resolve_thread_work_item(t.id, t.spec_id, t.task_slug, all_items)
         data["work_item_id"] = wi_id
         if wi_id is None:
             data["work_item"] = None
@@ -483,7 +484,7 @@ def create_app(
             data["work_item"] = None if summ is None else {
                 "id": summ.id, "title": summ.title, "kind": summ.kind, "phase": summ.phase,
             }
-        item_ids = {w.id for w in workitems.list()}
+        item_ids = {w.id for w in all_items}
         spec_ids = {s.id for s in store.list()}
         task_slugs = set(state_manager.load().tasks.keys())
         for msg in data.get("messages", []):

--- a/src/mship/core/view/entity_links.py
+++ b/src/mship/core/view/entity_links.py
@@ -8,11 +8,16 @@ from __future__ import annotations
 
 import re
 
-# a run of alnum groups optionally joined by hyphens, matched on word boundaries
-# so "mos-2240" is NOT split into "mos-224" + "0" (greedy quantifier eats the
-# whole run, then a whole-token lookup either hits or misses). Zero hyphens is
-# allowed so bare alnum slugs like "gc31" are still eligible tokens.
-_TOKEN = re.compile(r"(?<![A-Za-z0-9-])[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
+# a run of alnum groups optionally joined by hyphens, matched on identifier
+# boundaries so "mos-2240" is NOT split into "mos-224" + "0" (greedy quantifier
+# eats the whole run, then a whole-token lookup either hits or misses). Zero
+# hyphens is allowed so bare alnum slugs like "gc31" are still eligible tokens.
+# `_` counts as an identifier char on both sides (leading lookbehind + trailing
+# lookahead) so a ref glued into a snake_case name like "some_gc31_thing" is left
+# untouched. Hyphen handling is unchanged.
+_TOKEN = re.compile(r"(?<![A-Za-z0-9_-])[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*(?![A-Za-z0-9_])")
+# KNOWN LIMITATION (do not fix): this is regex-based, not a real markdown parser, so
+# unpaired single backticks and GFM double-backtick (``) code spans aren't perfectly protected.
 _PROTECTED = re.compile(r"```.*?```|`[^`]*`|\[[^\]]*\]\([^)]*\)", re.DOTALL)
 
 

--- a/src/mship/core/view/entity_links.py
+++ b/src/mship/core/view/entity_links.py
@@ -1,0 +1,47 @@
+"""Read-time auto-linkify of native mship entity refs in message text.
+
+Wraps exact tokens that match a live entity id/slug in a groundcontrol:// markdown
+link. Protects existing markdown links, inline code, and fenced code blocks. Native
+mship entities only (wi- ids, spec ids, task slugs) — no external refs.
+"""
+from __future__ import annotations
+
+import re
+
+# a run of alnum groups optionally joined by hyphens, matched on word boundaries
+# so "mos-2240" is NOT split into "mos-224" + "0" (greedy quantifier eats the
+# whole run, then a whole-token lookup either hits or misses). Zero hyphens is
+# allowed so bare alnum slugs like "gc31" are still eligible tokens.
+_TOKEN = re.compile(r"(?<![A-Za-z0-9-])[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
+_PROTECTED = re.compile(r"```.*?```|`[^`]*`|\[[^\]]*\]\([^)]*\)", re.DOTALL)
+
+
+def _kind_for(token, item_ids, spec_ids, task_slugs):
+    if token in item_ids:
+        return "item"
+    if token in spec_ids:
+        return "spec"
+    if token in task_slugs:
+        return "task"
+    return None
+
+
+def _linkify_span(text, item_ids, spec_ids, task_slugs):
+    def repl(m):
+        tok = m.group(0)
+        kind = _kind_for(tok, item_ids, spec_ids, task_slugs)
+        return tok if kind is None else f"[{tok}](groundcontrol://{kind}?id={tok})"
+    return _TOKEN.sub(repl, text)
+
+
+def linkify_entities(text, item_ids, spec_ids, task_slugs):
+    """Rewrite unprotected occurrences of known entity ids/slugs in `text` into
+    groundcontrol:// markdown links, by precedence item > spec > task. Skips
+    fenced code blocks, inline code, and text already inside a markdown link."""
+    out, last = [], 0
+    for m in _PROTECTED.finditer(text):
+        out.append(_linkify_span(text[last:m.start()], item_ids, spec_ids, task_slugs))
+        out.append(m.group(0))
+        last = m.end()
+    out.append(_linkify_span(text[last:], item_ids, spec_ids, task_slugs))
+    return "".join(out)

--- a/src/mship/core/view/thread_links.py
+++ b/src/mship/core/view/thread_links.py
@@ -1,0 +1,30 @@
+"""Read-time resolution of a thread's related WorkItem (inverts the WorkItem link graph)."""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def resolve_thread_work_item(
+    thread_id: str,
+    spec_id: str | None,
+    task_slug: str | None,
+    items: Iterable,
+) -> str | None:
+    """Return the id of the WorkItem related to a thread, or None.
+
+    Precedence: explicit thread_ids link > spec_id > task_slug.
+    `items` is any iterable of objects with .id/.spec_id/.task_slugs/.thread_ids.
+    """
+    items = list(items)
+    by_thread = {tid: w.id for w in items for tid in w.thread_ids}
+    if thread_id in by_thread:
+        return by_thread[thread_id]
+    if spec_id:
+        by_spec = {w.spec_id: w.id for w in items if w.spec_id}
+        if spec_id in by_spec:
+            return by_spec[spec_id]
+    if task_slug:
+        by_task = {slug: w.id for w in items for slug in w.task_slugs}
+        if task_slug in by_task:
+            return by_task[task_slug]
+    return None

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -472,6 +472,26 @@ def test_thread_detail_null_work_item_when_unrelated(tmp_path):
     assert body["work_item"] is None
 
 
+def test_thread_detail_linkifies_spec_ref_in_agent_message_only(tmp_path):
+    from mship.core.message_store import MessageStore
+    from datetime import datetime, timezone, timedelta
+
+    _seed_spec(tmp_path)  # spec id "dq"
+    client = TestClient(_app(tmp_path))
+    tid = client.post("/threads", json={"text": "hi"}).json()["id"]
+
+    store = MessageStore(tmp_path / ".mothership" / "messages")
+    base = datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
+    store.append(tid, "agent", "see spec dq for details", base)
+    store.append(tid, "human", "spec dq mentioned again", base + timedelta(minutes=1))
+
+    messages = client.get(f"/threads/{tid}").json()["messages"]
+    agent_msg = next(m for m in messages if m["role"] == "agent")
+    human_msg = next(m for m in messages if m["text"].startswith("spec dq mentioned"))
+    assert agent_msg["text"] == "see spec [dq](groundcontrol://spec?id=dq) for details"
+    assert human_msg["text"] == "spec dq mentioned again"
+
+
 def test_thread_summaries_expose_needs_you_and_unseen(tmp_path):
     from mship.core.message_store import MessageStore
     from datetime import datetime, timezone, timedelta

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -436,6 +436,42 @@ def test_thread_exposes_spec_id(tmp_path):
     assert client.get(f"/threads/{tid}").json()["spec_id"] == "spec-1"
 
 
+def test_thread_detail_exposes_related_work_item(tmp_path):
+    from mship.core.message_store import MessageStore
+    from mship.core.workitem_store import WorkItemStore
+
+    _seed_spec(tmp_path)  # spec id "dq", status "needs_review" -> phase "shaping"
+    now = datetime(2026, 7, 8, tzinfo=timezone.utc)
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="Decision queue", kind="feature", workspace="test-ws", now=now)
+    items.link_spec(wi.id, "dq", now=now)
+
+    client = TestClient(_app(tmp_path))
+    tid = client.post("/threads", json={"text": "hi"}).json()["id"]
+    MessageStore(tmp_path / ".mothership" / "messages").link_spec(tid, "dq")
+
+    body = client.get(f"/threads/{tid}").json()
+    assert body["work_item_id"] == wi.id
+    assert body["work_item"] == {
+        "id": wi.id, "title": "Decision queue", "kind": "feature", "phase": "shaping",
+    }
+
+
+def test_thread_detail_null_work_item_when_unrelated(tmp_path):
+    from mship.core.workitem_store import WorkItemStore
+
+    now = datetime(2026, 7, 8, tzinfo=timezone.utc)
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    items.create(title="Unrelated", kind="feature", workspace="test-ws", now=now)
+
+    client = TestClient(_app(tmp_path))
+    tid = client.post("/threads", json={"text": "hi"}).json()["id"]
+
+    body = client.get(f"/threads/{tid}").json()
+    assert body["work_item_id"] is None
+    assert body["work_item"] is None
+
+
 def test_thread_summaries_expose_needs_you_and_unseen(tmp_path):
     from mship.core.message_store import MessageStore
     from datetime import datetime, timezone, timedelta

--- a/tests/core/view/test_entity_links.py
+++ b/tests/core/view/test_entity_links.py
@@ -1,0 +1,39 @@
+from mship.core.view.entity_links import linkify_entities
+
+SETS = dict(item_ids={"wi-20260703022747-5b70a0d2"},
+            spec_ids={"gc31", "mos-212-chat"},
+            task_slugs={"gc31", "mos-212-chat", "mos-224"})
+
+def L(text): return linkify_entities(text, **SETS)
+
+def test_links_wi_spec_task():
+    assert L("see wi-20260703022747-5b70a0d2 now") == \
+        "see [wi-20260703022747-5b70a0d2](groundcontrol://item?id=wi-20260703022747-5b70a0d2) now"
+    assert L("the mos-224 task") == "the [mos-224](groundcontrol://task?id=mos-224) task"
+
+def test_precedence_item_gt_spec_gt_task():
+    assert L("check gc31") == "check [gc31](groundcontrol://spec?id=gc31)"  # spec beats task
+
+def test_skips_existing_link_and_code():
+    assert L("[gc31](groundcontrol://spec?id=gc31)") == "[gc31](groundcontrol://spec?id=gc31)"
+    assert L("run `mos-224` here") == "run `mos-224` here"
+    assert L("```\nmos-224\n```") == "```\nmos-224\n```"
+
+def test_unknown_and_substring_untouched():
+    assert L("nope-999 and mos-2240 stay") == "nope-999 and mos-2240 stay"
+
+def test_idempotent():
+    once = L("gc31 and gc31")
+    assert once == "[gc31](groundcontrol://spec?id=gc31) and [gc31](groundcontrol://spec?id=gc31)"
+    assert L(once) == once
+
+def test_trailing_punctuation_not_swallowed():
+    assert L("see gc31, and mos-224.") == \
+        "see [gc31](groundcontrol://spec?id=gc31), and [mos-224](groundcontrol://task?id=mos-224)."
+    assert L("(gc31)") == "([gc31](groundcontrol://spec?id=gc31))"
+
+def test_longer_token_containing_ref_untouched():
+    assert L("gc31-x not gc31") == "gc31-x not [gc31](groundcontrol://spec?id=gc31)"
+
+def test_empty_text():
+    assert L("") == ""

--- a/tests/core/view/test_entity_links.py
+++ b/tests/core/view/test_entity_links.py
@@ -35,5 +35,11 @@ def test_trailing_punctuation_not_swallowed():
 def test_longer_token_containing_ref_untouched():
     assert L("gc31-x not gc31") == "gc31-x not [gc31](groundcontrol://spec?id=gc31)"
 
+def test_snake_case_embedded_ref_untouched():
+    # a ref glued into a snake_case identifier is part of a larger token -> leave it alone
+    assert L("some_gc31_thing") == "some_gc31_thing"
+    # but the standalone ref still linkifies
+    assert L("gc31") == "[gc31](groundcontrol://spec?id=gc31)"
+
 def test_empty_text():
     assert L("") == ""

--- a/tests/core/view/test_thread_links.py
+++ b/tests/core/view/test_thread_links.py
@@ -1,0 +1,24 @@
+from mship.core.view.thread_links import resolve_thread_work_item
+
+
+class _Item:
+    def __init__(self, id, spec_id=None, task_slugs=None, thread_ids=None):
+        self.id = id
+        self.spec_id = spec_id
+        self.task_slugs = task_slugs or []
+        self.thread_ids = thread_ids or []
+
+
+def test_prefers_explicit_thread_link():
+    items = [_Item("wi-a", thread_ids=["t1"]), _Item("wi-b", spec_id="s1")]
+    assert resolve_thread_work_item("t1", "s1", None, items) == "wi-a"
+
+
+def test_falls_back_to_spec_then_task():
+    items = [_Item("wi-b", spec_id="s1"), _Item("wi-c", task_slugs=["k1"])]
+    assert resolve_thread_work_item("t9", "s1", None, items) == "wi-b"
+    assert resolve_thread_work_item("t9", None, "k1", items) == "wi-c"
+
+
+def test_none_when_no_relation():
+    assert resolve_thread_work_item("t9", None, None, [_Item("wi-b", spec_id="s1")]) is None


### PR DESCRIPTION
Thread↔entity navigation: deep-links + related work item (MOS-218/MOS-223)
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `threadentity-navigation`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/41 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/293 | this PR |

⚠ Merge in order: ground-control → mothership