### PR TITLE
Fix dispatch + context to show the effective base branch via resolve_base (repo_config.base_branch fallback) instead of task.base_branch or main

### DIFF
--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -110,7 +110,7 @@ def register(app: typer.Typer, get_container):
         effective_base = resolve_base(
             resolved_repo, repo_config, cli_base=None, base_map={},
             known_repos=config.repos.keys(), task_base=task_obj.base_override,
-        ) or "main"
+        ) or task_obj.base_branch or "main"
         base_sha_info = _d.collect_base_sha_info(worktree, effective_base)
 
         log_mgr = container.log_manager()

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -13,6 +13,7 @@ import typer
 from mship.cli._resolve import resolve_for_command
 from mship.cli.output import Output
 from mship.core import dispatch as _d
+from mship.core.base_resolver import resolve_base
 from mship.core.skill_install import pkg_skills_source
 
 
@@ -103,7 +104,14 @@ def register(app: typer.Typer, get_container):
             raise typer.Exit(code=1)
 
         worktree = Path(task_obj.worktrees[resolved_repo])
-        base_sha_info = _d.collect_base_sha_info(worktree, task_obj.base_branch or "main")
+
+        config = container.config()
+        repo_config = config.repos.get(resolved_repo)
+        effective_base = resolve_base(
+            resolved_repo, repo_config, cli_base=None, base_map={},
+            known_repos=config.repos.keys(), task_base=task_obj.base_override,
+        ) or "main"
+        base_sha_info = _d.collect_base_sha_info(worktree, effective_base)
 
         log_mgr = container.log_manager()
         journal_entries = log_mgr.read(task_obj.slug, last=10)
@@ -119,6 +127,7 @@ def register(app: typer.Typer, get_container):
             instruction=resolved_instruction,
             journal_entries=journal_entries,
             base_sha_info=base_sha_info,
+            base_branch=effective_base,
             agents_md_path=agents_md_path,
             pkg_skills_source=pkg_skills_source(),
             state=state,

--- a/src/mship/core/context.py
+++ b/src/mship/core/context.py
@@ -218,7 +218,12 @@ def _task_payload(
         else:
             ahead_of_base[repo] = None
 
-    active_repo = task.active_repo or next(iter(task.worktrees), None)
+    # Only the explicitly-active repo drives the scalar base_branch. Falling
+    # back to the first inserted worktree would make a user-facing value depend
+    # on dict order and could report one repo's base while the agent/UI is
+    # focused on another (Greptile, MOS-229) — task.base_branch is the honest
+    # task-level answer when no repo is active.
+    active_repo = task.active_repo
     base_branch = (
         _effective_base_for_repo(task, active_repo, config)
         if active_repo is not None

--- a/src/mship/core/context.py
+++ b/src/mship/core/context.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from mship.core.base_resolver import resolve_base
 from mship.core.config import WorkspaceConfig
 from mship.core.log import LogManager
 from mship.core.reconcile.cache import ReconcileCache
@@ -178,11 +179,31 @@ def _main_checkout_clean(
     return out
 
 
+def _effective_base_for_repo(
+    task: Task, repo: str, config: WorkspaceConfig,
+) -> Optional[str]:
+    """Resolve the effective base branch for `repo` via the canonical resolver.
+
+    Falls back to `task.base_branch` when resolve_base has nothing to go on
+    (no repo config, no `--base` override) — this preserves the pre-MOS-229
+    behavior for repos/workspaces that don't declare `base_branch:` in
+    mothership.yaml, and tolerates a repo missing from config entirely
+    (`config.repos.get` returns None; resolve_base treats that as "no config").
+    """
+    repo_config = config.repos.get(repo)
+    resolved = resolve_base(
+        repo, repo_config, cli_base=None, base_map={},
+        known_repos=config.repos.keys(), task_base=task.base_override,
+    )
+    return resolved if resolved is not None else task.base_branch
+
+
 def _task_payload(
     task: Task,
     log_manager: LogManager,
     git_count: GitCounter,
     cache: Optional[ReconcileCache],
+    config: WorkspaceConfig,
 ) -> dict[str, Any]:
     last_test_state, last_test_iteration = _last_test_summary(task)
 
@@ -191,15 +212,23 @@ def _task_payload(
     for repo, wt_path in task.worktrees.items():
         wt = Path(wt_path)
         ahead_of_origin[repo] = git_count(wt, "@{u}..HEAD")
-        if task.base_branch:
-            ahead_of_base[repo] = git_count(wt, f"{task.base_branch}..HEAD")
+        eff_base = _effective_base_for_repo(task, repo, config)
+        if eff_base:
+            ahead_of_base[repo] = git_count(wt, f"{eff_base}..HEAD")
         else:
             ahead_of_base[repo] = None
+
+    active_repo = task.active_repo or next(iter(task.worktrees), None)
+    base_branch = (
+        _effective_base_for_repo(task, active_repo, config)
+        if active_repo is not None
+        else task.base_branch
+    )
 
     return {
         "slug": task.slug,
         "branch": task.branch,
-        "base_branch": task.base_branch,
+        "base_branch": base_branch,
         "phase": task.phase,
         "finished_at": task.finished_at.isoformat() if task.finished_at else None,
         "worktrees": {repo: str(p) for repo, p in task.worktrees.items()},
@@ -233,7 +262,7 @@ def build_context(
     constructing a real `ReconcileCache(state_dir)`).
     """
     active_tasks = [
-        _task_payload(task, log_manager, git_count, cache)
+        _task_payload(task, log_manager, git_count, cache, config)
         for task in state.tasks.values()
         if task.finished_at is None
     ]

--- a/src/mship/core/dispatch.py
+++ b/src/mship/core/dispatch.py
@@ -297,6 +297,7 @@ def build_dispatch_prompt(
     *,
     journal_entries: list[LogEntry],
     base_sha_info: BaseShaInfo,
+    base_branch: str,
     agents_md_path: Path | None,
     pkg_skills_source: Path,
     state=None,
@@ -308,13 +309,17 @@ def build_dispatch_prompt(
     - "implementer" (default): scope to a single task, report back, do NOT open
       a PR — for per-task execution where an orchestrator owns finishing.
     - "standalone": the subagent finishes the work and opens its own PR.
+
+    `base_branch` is the effective base for `repo`, already resolved by the
+    caller via `mship.core.base_resolver.resolve_base` (MOS-229: this used to
+    fall back to `task.base_branch or "main"` here, bypassing repo config and
+    the `--base` override entirely).
     """
     if mode not in DISPATCH_MODES:
         raise ValueError(
             f"unknown dispatch mode {mode!r}; choose one of {', '.join(DISPATCH_MODES)}"
         )
     worktree = task.worktrees[repo]
-    base_branch = task.base_branch or "main"
     skills_block = _render_skills(canonical_skills(pkg_skills_source))
     journal_block = _render_journal(journal_entries)
     base_block = _render_base_sha_block(base_sha_info, base_branch)

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -255,6 +255,7 @@ def _bootstrap_with_repo_config(
     *,
     repo_base_branch: str | None,
     base_override: str | None = None,
+    task_base_branch: str | None = None,
 ) -> tuple[Path, Path]:
     """Bootstrap a task plus a mothership.yaml that actually declares `repo_name`
     (with an optional `base_branch:`), so dispatch can exercise resolve_base
@@ -281,6 +282,7 @@ def _bootstrap_with_repo_config(
         affected_repos=[repo_name],
         worktrees={repo_name: worktree}, branch="feat/t",
         active_repo=repo_name, base_override=base_override,
+        base_branch=task_base_branch,
     )
     StateManager(state_dir).save(WorkspaceState(tasks={"t": task}))
     return cfg, state_dir
@@ -335,6 +337,26 @@ def test_dispatch_falls_back_to_main_when_repo_config_has_no_base_branch(tmp_pat
         result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing"])
         assert result.exit_code == 0, result.output
         assert "- **base branch:** main" in result.output
+    finally:
+        _reset()
+
+
+def test_dispatch_falls_back_to_stored_task_base_before_main(tmp_path: Path):
+    """No repo_config.base_branch and no override, but the task recorded a
+    non-default base (e.g. the workspace default "staging") -> dispatch honors
+    the stored task.base_branch instead of jumping to "main" (Greptile, MOS-229:
+    keeps dispatch's fallback consistent with the context path)."""
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap_with_repo_config(
+        tmp_path, "only", wt, repo_base_branch=None, task_base_branch="staging",
+    )
+    container.config.reset(); container.state_manager.reset(); container.log_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing"])
+        assert result.exit_code == 0, result.output
+        assert "- **base branch:** staging" in result.output
     finally:
         _reset()
 

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -248,6 +248,114 @@ def test_dispatch_invalid_mode_errors(tmp_path: Path):
         _reset()
 
 
+def _bootstrap_with_repo_config(
+    tmp_path: Path,
+    repo_name: str,
+    worktree: Path,
+    *,
+    repo_base_branch: str | None,
+    base_override: str | None = None,
+) -> tuple[Path, Path]:
+    """Bootstrap a task plus a mothership.yaml that actually declares `repo_name`
+    (with an optional `base_branch:`), so dispatch can exercise resolve_base
+    against real repo config instead of the empty `repos: {}` used elsewhere
+    in this file."""
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    repo_dir = tmp_path / f"{repo_name}-main"
+    repo_dir.mkdir()
+    (repo_dir / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    base_line = f"    base_branch: {repo_base_branch}\n" if repo_base_branch else ""
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\n"
+        "repos:\n"
+        f"  {repo_name}:\n"
+        f"    path: {repo_dir}\n"
+        "    type: library\n"
+        f"{base_line}"
+    )
+    task = Task(
+        slug="t", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=[repo_name],
+        worktrees={repo_name: worktree}, branch="feat/t",
+        active_repo=repo_name, base_override=base_override,
+    )
+    StateManager(state_dir).save(WorkspaceState(tasks={"t": task}))
+    return cfg, state_dir
+
+
+def test_dispatch_uses_repo_config_base_branch(tmp_path: Path):
+    """repo_config.base_branch="dev" (no override) -> the prompt shows "dev",
+    not "main" (MOS-229: dispatch used to ignore repo config entirely)."""
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap_with_repo_config(
+        tmp_path, "only", wt, repo_base_branch="dev",
+    )
+    container.config.reset(); container.state_manager.reset(); container.log_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing"])
+        assert result.exit_code == 0, result.output
+        assert "- **base branch:** dev" in result.output
+        assert "base (dev)" in result.output
+    finally:
+        _reset()
+
+
+def test_dispatch_base_override_wins_over_repo_config(tmp_path: Path):
+    """task.base_override (the --base pin) takes precedence over repo_config.base_branch."""
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap_with_repo_config(
+        tmp_path, "only", wt, repo_base_branch="dev", base_override="stacked",
+    )
+    container.config.reset(); container.state_manager.reset(); container.log_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing"])
+        assert result.exit_code == 0, result.output
+        assert "- **base branch:** stacked" in result.output
+    finally:
+        _reset()
+
+
+def test_dispatch_falls_back_to_main_when_repo_config_has_no_base_branch(tmp_path: Path):
+    """No repo_config.base_branch and no override -> unchanged "main" fallback."""
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap_with_repo_config(
+        tmp_path, "only", wt, repo_base_branch=None,
+    )
+    container.config.reset(); container.state_manager.reset(); container.log_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing"])
+        assert result.exit_code == 0, result.output
+        assert "- **base branch:** main" in result.output
+    finally:
+        _reset()
+
+
+def test_dispatch_repo_missing_from_config_falls_back_to_main(tmp_path: Path):
+    """A repo not declared in mothership.yaml at all (empty `repos: {}`, as in
+    the other tests in this file) must not crash — resolve_base tolerates a
+    missing repo_config and dispatch falls back to "main"."""
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    container.config.reset(); container.state_manager.reset(); container.log_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "x"])
+        assert result.exit_code == 0, result.output
+        assert "- **base branch:** main" in result.output
+    finally:
+        _reset()
+
+
 def test_dispatch_prompt_includes_dependencies_section(tmp_path: Path):
     now = datetime.now(timezone.utc)
     wt_a = tmp_path / "wt-a"; wt_a.mkdir()

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -131,6 +131,71 @@ def test_ahead_of_base_is_null_when_base_branch_unset(tmp_path: Path):
     assert task["ahead_of_origin"] == {"repo": 1}
 
 
+def _config_with_base(tmp_path: Path, base_branch: Optional[str]) -> WorkspaceConfig:
+    """Like `_config` but the repo declares `base_branch` in mothership.yaml."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(exist_ok=True)
+    (repo_dir / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    return WorkspaceConfig(
+        workspace="t",
+        repos={"repo": RepoConfig(path=repo_dir, type="library", base_branch=base_branch)},
+    )
+
+
+def test_task_payload_uses_repo_config_base_branch_not_task_field(tmp_path: Path):
+    """repo_config.base_branch="dev" (no override) drives both the top-level
+    base_branch field and the ahead_of_base count — not task.base_branch,
+    which dispatch/context used to read directly (MOS-229)."""
+    wt = tmp_path / "wt-foo"
+    wt.mkdir()
+    log_mgr = LogManager(tmp_path / "logs")
+    state = WorkspaceState(tasks={"foo": _task(
+        "foo", worktrees={"repo": wt}, active_repo="repo", base_branch="staging",
+    )})
+    cfg = _config_with_base(tmp_path, "dev")
+    git = _fake_git_count({(wt.name, "dev..HEAD"): 4})
+    out = _build(state, cfg, log_mgr, tmp_path, git_count=git)
+    task = out["active_tasks"][0]
+    assert task["base_branch"] == "dev"
+    assert task["ahead_of_base"] == {"repo": 4}
+
+
+def test_task_payload_base_override_wins_over_repo_config(tmp_path: Path):
+    """task.base_override (the --base pin) beats repo_config.base_branch."""
+    wt = tmp_path / "wt-bar"
+    wt.mkdir()
+    log_mgr = LogManager(tmp_path / "logs")
+    state = WorkspaceState(tasks={"bar": _task(
+        "bar", worktrees={"repo": wt}, active_repo="repo",
+        base_branch="main", base_override="stacked",
+    )})
+    cfg = _config_with_base(tmp_path, "dev")
+    git = _fake_git_count({(wt.name, "stacked..HEAD"): 2})
+    out = _build(state, cfg, log_mgr, tmp_path, git_count=git)
+    task = out["active_tasks"][0]
+    assert task["base_branch"] == "stacked"
+    assert task["ahead_of_base"] == {"repo": 2}
+
+
+def test_task_payload_repo_missing_from_config_falls_back_without_error(tmp_path: Path):
+    """A repo referenced by the task but absent from mothership.yaml must not
+    crash — resolve_base tolerates a missing repo_config and context falls
+    back to task.base_branch, same as before this fix."""
+    wt = tmp_path / "wt-baz"
+    wt.mkdir()
+    log_mgr = LogManager(tmp_path / "logs")
+    state = WorkspaceState(tasks={"baz": _task(
+        "baz", worktrees={"missing-repo": wt}, active_repo="missing-repo",
+        base_branch="main",
+    )})
+    cfg = _config(tmp_path)  # only declares "repo", not "missing-repo"
+    git = _fake_git_count({(wt.name, "main..HEAD"): 1})
+    out = _build(state, cfg, log_mgr, tmp_path, git_count=git)
+    task = out["active_tasks"][0]
+    assert task["base_branch"] == "main"
+    assert task["ahead_of_base"] == {"missing-repo": 1}
+
+
 def test_cwd_inside_worktree_populates_match_fields(tmp_path: Path):
     wt = tmp_path / "wt-match"
     (wt / "src").mkdir(parents=True)

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -196,6 +196,25 @@ def test_task_payload_repo_missing_from_config_falls_back_without_error(tmp_path
     assert task["ahead_of_base"] == {"missing-repo": 1}
 
 
+def test_task_payload_scalar_base_uses_task_base_when_no_active_repo(tmp_path: Path):
+    """With no active_repo, the scalar base_branch is the task's own base, NOT
+    the first inserted worktree's repo config (Greptile, MOS-229: avoids a
+    user-facing value depending on dict order). Per-repo ahead_of_base still
+    resolves against each repo's configured base."""
+    wt = tmp_path / "wt-none"
+    wt.mkdir()
+    log_mgr = LogManager(tmp_path / "logs")
+    state = WorkspaceState(tasks={"none": _task(
+        "none", worktrees={"repo": wt}, active_repo=None, base_branch="staging",
+    )})
+    cfg = _config_with_base(tmp_path, "dev")
+    git = _fake_git_count({(wt.name, "dev..HEAD"): 3})
+    out = _build(state, cfg, log_mgr, tmp_path, git_count=git)
+    task = out["active_tasks"][0]
+    assert task["base_branch"] == "staging"          # task base, not repo's "dev"
+    assert task["ahead_of_base"] == {"repo": 3}       # per-repo still uses "dev"
+
+
 def test_cwd_inside_worktree_populates_match_fields(tmp_path: Path):
     wt = tmp_path / "wt-match"
     (wt / "src").mkdir(parents=True)

--- a/tests/core/test_dispatch.py
+++ b/tests/core/test_dispatch.py
@@ -209,7 +209,7 @@ def test_build_prompt_contains_worktree_path_cd_directive(tmp_path: Path):
     task = _task({"repo": worktree})
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="do X",
-        journal_entries=[], base_sha_info=_info_clean(),
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=tmp_path / "AGENTS.md",
         pkg_skills_source=tmp_path / "skills",
     )
@@ -222,7 +222,7 @@ def test_build_prompt_embeds_instruction_verbatim(tmp_path: Path):
     task = _task({"repo": tmp_path / "wt"})
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="implement the --title flag from #45",
-        journal_entries=[], base_sha_info=_info_clean(),
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
     assert "> implement the --title flag from #45" in out
@@ -238,7 +238,7 @@ def test_build_prompt_contains_task_facts(tmp_path: Path):
     )
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="x",
-        journal_entries=[], base_sha_info=_info_clean(),
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
     assert "my-task" in out
@@ -251,7 +251,7 @@ def test_build_prompt_contains_base_sha_block(tmp_path: Path):
     task = _task({"repo": tmp_path / "wt"})
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="x",
-        journal_entries=[], base_sha_info=_info_clean(),
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
     assert "abc1234" in out
@@ -263,7 +263,7 @@ def test_build_prompt_journal_empty_state_when_no_entries(tmp_path: Path):
     task = _task({"repo": tmp_path / "wt"})
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="x",
-        journal_entries=[], base_sha_info=_info_clean(),
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
     assert "No entries yet" in out
@@ -283,7 +283,7 @@ def test_build_prompt_journal_renders_bulleted_list(tmp_path: Path):
     ]
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="x",
-        journal_entries=entries, base_sha_info=_info_clean(),
+        journal_entries=entries, base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
     assert "first commit done" in out
@@ -296,7 +296,7 @@ def test_build_prompt_conventions_common_bullets(tmp_path: Path):
     task = _task({"repo": tmp_path / "wt"})
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="x",
-        journal_entries=[], base_sha_info=_info_clean(),
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
     assert "main checkout" in out
@@ -307,7 +307,7 @@ def test_build_prompt_standalone_conventions_have_finish_bullet(tmp_path: Path):
     task = _task({"repo": tmp_path / "wt"})
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="x", mode="standalone",
-        journal_entries=[], base_sha_info=_info_clean(),
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
     assert "mship finish --body-file" in out
@@ -318,7 +318,7 @@ def test_build_prompt_implementer_conventions_drop_finish_bullet(tmp_path: Path)
     task = _task({"repo": tmp_path / "wt"})
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="x",
-        journal_entries=[], base_sha_info=_info_clean(),
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
     assert "mship finish --body-file" not in out
@@ -329,7 +329,7 @@ def test_build_prompt_lists_canonical_skills_with_paths(tmp_path: Path):
     task = _task({"repo": tmp_path / "wt"})
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="x",
-        journal_entries=[], base_sha_info=_info_clean(),
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
     for name in [
@@ -345,7 +345,7 @@ def test_build_prompt_includes_agents_md_path_when_present(tmp_path: Path):
     agents = tmp_path / "AGENTS.md"
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="x",
-        journal_entries=[], base_sha_info=_info_clean(),
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=agents, pkg_skills_source=tmp_path / "skills",
     )
     assert str(agents) in out
@@ -355,7 +355,7 @@ def test_build_prompt_omits_agents_md_line_when_absent(tmp_path: Path):
     task = _task({"repo": tmp_path / "wt"})
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="x",
-        journal_entries=[], base_sha_info=_info_clean(),
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
     assert "Full doc:" not in out
@@ -365,7 +365,7 @@ def test_build_prompt_standalone_mode_has_finish_contract(tmp_path: Path):
     task = _task({"repo": tmp_path / "wt"})
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="x", mode="standalone",
-        journal_entries=[], base_sha_info=_info_clean(),
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
     assert "How to finish" in out
@@ -379,7 +379,7 @@ def test_build_prompt_default_mode_is_implementer_report_back(tmp_path: Path):
     task = _task({"repo": tmp_path / "wt"})
     out = build_dispatch_prompt(
         task=task, repo="repo", instruction="x",
-        journal_entries=[], base_sha_info=_info_clean(),
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
     lower = out.lower()
@@ -402,10 +402,31 @@ def test_build_prompt_implementer_mode_matches_default(tmp_path: Path):
     task = _task({"repo": tmp_path / "wt"})
     common = dict(
         task=task, repo="repo", instruction="x",
-        journal_entries=[], base_sha_info=_info_clean(),
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
         agents_md_path=None, pkg_skills_source=tmp_path / "skills",
     )
     assert build_dispatch_prompt(**common, mode="implementer") == build_dispatch_prompt(**common)
+
+
+def test_build_prompt_uses_passed_base_branch_not_task_field(tmp_path: Path):
+    """The rendered base branch must come from the `base_branch` param — the
+    caller's resolve_base result — not task.base_branch. Dispatch used to
+    bypass the canonical resolver and always show `task.base_branch or "main"`
+    (MOS-229)."""
+    task = Task(
+        slug="t", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["repo"], worktrees={"repo": tmp_path / "wt"},
+        branch="feat/t", base_branch="staging", active_repo="repo",
+    )
+    out = build_dispatch_prompt(
+        task=task, repo="repo", instruction="x",
+        journal_entries=[], base_sha_info=_info_clean(), base_branch="dev",
+        agents_md_path=None, pkg_skills_source=tmp_path / "skills",
+    )
+    assert "- **base branch:** dev" in out
+    assert "base (dev)" in out
+    assert "staging" not in out
 
 
 def test_build_prompt_unknown_mode_raises(tmp_path: Path):
@@ -413,6 +434,6 @@ def test_build_prompt_unknown_mode_raises(tmp_path: Path):
     with pytest.raises(ValueError, match="mode"):
         build_dispatch_prompt(
             task=task, repo="repo", instruction="x", mode="bogus",
-            journal_entries=[], base_sha_info=_info_clean(),
+            journal_entries=[], base_sha_info=_info_clean(), base_branch="main",
             agents_md_path=None, pkg_skills_source=tmp_path / "skills",
         )


### PR DESCRIPTION
Fix dispatch + context to show the effective base branch via resolve_base (repo_config.base_branch fallback) instead of task.base_branch or main