### PR TITLE
mship spawn auto-fetches and fast-forwards the stale base before cutting the branch (warn on divergence, --offline opt-out); mship context surfaces a per-repo base_behind_origin flag (MOS-203)

### DIFF
--- a/src/mship/core/context.py
+++ b/src/mship/core/context.py
@@ -209,14 +209,17 @@ def _task_payload(
 
     ahead_of_origin: dict[str, Optional[int]] = {}
     ahead_of_base: dict[str, Optional[int]] = {}
+    base_behind_origin: dict[str, Optional[int]] = {}
     for repo, wt_path in task.worktrees.items():
         wt = Path(wt_path)
         ahead_of_origin[repo] = git_count(wt, "@{u}..HEAD")
         eff_base = _effective_base_for_repo(task, repo, config)
         if eff_base:
             ahead_of_base[repo] = git_count(wt, f"{eff_base}..HEAD")
+            base_behind_origin[repo] = git_count(wt, f"{eff_base}..origin/{eff_base}")
         else:
             ahead_of_base[repo] = None
+            base_behind_origin[repo] = None
 
     # Only the explicitly-active repo drives the scalar base_branch. Falling
     # back to the first inserted worktree would make a user-facing value depend
@@ -240,6 +243,7 @@ def _task_payload(
         "active_repo": task.active_repo,
         "ahead_of_origin": ahead_of_origin,
         "ahead_of_base": ahead_of_base,
+        "base_behind_origin": base_behind_origin,
         "pr_urls": dict(task.pr_urls),
         "last_test_state": last_test_state,
         "last_test_iteration": last_test_iteration,

--- a/src/mship/core/spec_dispatch.py
+++ b/src/mship/core/spec_dispatch.py
@@ -22,6 +22,7 @@ from typing import Callable
 from mship.core.spec import Spec
 from mship.core.spec_body import parse_body_sections
 from mship.core.state import Task
+from mship.core.worktree import BaseBranchNotFoundError
 
 
 class DispatchError(Exception):
@@ -76,7 +77,14 @@ def _auto_spawn(spec: Spec, spawn_fn: Callable[[Spec], Task]) -> tuple[Task, boo
             f"spec {spec.id!r} has no affected_repos; cannot auto-spawn a task. "
             f"Add repos to the spec or spawn a task named {spec.id!r} first."
         )
-    return spawn_fn(spec), True
+    try:
+        return spawn_fn(spec), True
+    except BaseBranchNotFoundError as e:
+        # Surface a missing base as a clean DispatchError so the CLI
+        # (`mship spec dispatch`) and serve (`POST /specs/{id}/dispatch`) —
+        # which already catch DispatchError — report it cleanly instead of
+        # letting the ValueError escape as a traceback / 500.
+        raise DispatchError(str(e)) from e
 
 
 def dispatch_spec(

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -595,9 +595,13 @@ class WorktreeManager:
                         )
                 # When we didn't cut from origin's tip (offline / no remote / fetch
                 # failed), cut from the local base branch explicitly rather than the
-                # checkout's HEAD.
+                # checkout's HEAD. If there's no local base branch either (only a
+                # stale remote-tracking ref from an earlier fetch), fall back to
+                # that rather than silently defaulting to HEAD.
                 if start_point is None and self._git.ref_exists(repo_path, cut_base):
                     start_point = cut_base
+                elif start_point is None and self._git.ref_exists(repo_path, f"origin/{cut_base}"):
+                    start_point = f"origin/{cut_base}"
                 self._git.worktree_add(
                     repo_path=repo_path,
                     worktree_path=wt_path,

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -485,6 +485,41 @@ class WorktreeManager:
                     f"repo(s): {', '.join(missing_base)}. Push the base branch first, "
                     f"or check the name."
                 )
+        else:
+            # --- MOS-203 (Greptile, "HEAD fallback remains"): validate the
+            #     default cut_base the SAME way, BEFORE creating any worktree.
+            #     Mirrors the --base preflight above: fetch first (so an
+            #     origin-only base is recognized), then require a local branch
+            #     or an origin/<base> remote-tracking ref. If cut_base resolves
+            #     to NEITHER anywhere, the in-loop code below would otherwise
+            #     leave start_point as None and `git worktree add` would
+            #     silently cut from the checkout's current HEAD instead —
+            #     inheriting whatever unrelated commits happen to be checked
+            #     out there. Fail loudly instead.
+            missing_default_base: list[str] = []
+            for repo_name in all_repos:
+                if repo_name in passive:
+                    continue
+                repo_config = self._config.repos[repo_name]
+                if repo_config.git_root is not None:
+                    continue  # subdirectory child shares its parent's checkout + branch
+                repo_path = repo_config.path
+                cut_base = repo_config.base_branch or default_base or "main"
+                if not offline and self._git.has_remote(repo_path):
+                    self._git.fetch_remote_ref(repo_path=repo_path, ref=cut_base)
+                if not (
+                    self._git.ref_exists(repo_path, cut_base)
+                    or self._git.ref_exists(repo_path, f"origin/{cut_base}")
+                ):
+                    missing_default_base.append(
+                        f"{repo_name}: base branch '{cut_base}' not found locally or on origin"
+                    )
+            if missing_default_base:
+                raise BaseBranchNotFoundError(
+                    "; ".join(missing_default_base)
+                    + " — set `base_branch` in mothership.yaml or create the "
+                    "branch, then re-spawn"
+                )
 
         hub = workspace_root / ".worktrees" / slug
         hub.mkdir(parents=True, exist_ok=True)
@@ -602,6 +637,16 @@ class WorktreeManager:
                     start_point = cut_base
                 elif start_point is None and self._git.ref_exists(repo_path, f"origin/{cut_base}"):
                     start_point = f"origin/{cut_base}"
+                if start_point is None:
+                    # MOS-203: the preflight above should already have caught
+                    # this — this is a TOCTOU safety net only (e.g. the base
+                    # branch was deleted between preflight and here). Never
+                    # silently fall back to worktree_add's HEAD default.
+                    raise BaseBranchNotFoundError(
+                        f"{repo_name}: base branch '{cut_base}' not found locally or on "
+                        "origin — set `base_branch` in mothership.yaml or create the "
+                        "branch, then re-spawn"
+                    )
                 self._git.worktree_add(
                     repo_path=repo_path,
                     worktree_path=wt_path,

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -589,8 +589,9 @@ class WorktreeManager:
                         self._git.fast_forward_if_clean(repo_path=repo_path, base=cut_base)
                     else:
                         setup_warnings.append(
-                            f"{repo_name}: could not fetch origin/{cut_base}; "
-                            f"cutting worktree from local {cut_base}"
+                            f"{repo_name}: could not fetch origin/{cut_base} — worktree cut "
+                            f"from possibly-stale local {cut_base}; run `mship sync` and "
+                            f"re-check, or re-spawn with a fresh base"
                         )
                 self._git.worktree_add(
                     repo_path=repo_path,

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -593,6 +593,11 @@ class WorktreeManager:
                             f"from possibly-stale local {cut_base}; run `mship sync` and "
                             f"re-check, or re-spawn with a fresh base"
                         )
+                # When we didn't cut from origin's tip (offline / no remote / fetch
+                # failed), cut from the local base branch explicitly rather than the
+                # checkout's HEAD.
+                if start_point is None and self._git.ref_exists(repo_path, cut_base):
+                    start_point = cut_base
                 self._git.worktree_add(
                     repo_path=repo_path,
                     worktree_path=wt_path,

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -101,6 +101,7 @@ def test_task_payload_shape(tmp_path: Path):
     git = _fake_git_count({
         (wt.name, "@{u}..HEAD"): 2,
         (wt.name, "main..HEAD"): 4,
+        (wt.name, "main..origin/main"): 1,
     })
     out = _build(state, _config(tmp_path), log_mgr, tmp_path, git_count=git)
     task = out["active_tasks"][0]
@@ -111,6 +112,7 @@ def test_task_payload_shape(tmp_path: Path):
     assert task["active_repo"] == "repo"
     assert task["ahead_of_origin"] == {"repo": 2}
     assert task["ahead_of_base"] == {"repo": 4}
+    assert task["base_behind_origin"] == {"repo": 1}
     assert task["pr_urls"] == {"repo": "https://example/pr/1"}
     assert task["last_test_state"] == "pass"
     assert task["last_test_iteration"] == 3
@@ -213,6 +215,44 @@ def test_task_payload_scalar_base_uses_task_base_when_no_active_repo(tmp_path: P
     task = out["active_tasks"][0]
     assert task["base_branch"] == "staging"          # task base, not repo's "dev"
     assert task["ahead_of_base"] == {"repo": 3}       # per-repo still uses "dev"
+
+
+def test_base_behind_origin_reports_commits_behind(tmp_path: Path):
+    """MOS-203: an agent should be able to gate on how far the repo's base is
+    behind origin/<base> (read-only — reflects the last fetch, no fetch here)
+    instead of eyeballing last_workspace_fetch_at."""
+    wt = tmp_path / "wt-foo"
+    wt.mkdir()
+    log_mgr = LogManager(tmp_path / "logs")
+    state = WorkspaceState(tasks={"foo": _task("foo", worktrees={"repo": wt})})
+    git = _fake_git_count({(wt.name, "main..origin/main"): 5})
+    out = _build(state, _config(tmp_path), log_mgr, tmp_path, git_count=git)
+    task = out["active_tasks"][0]
+    assert task["base_behind_origin"] == {"repo": 5}
+
+
+def test_base_behind_origin_zero_when_base_current(tmp_path: Path):
+    wt = tmp_path / "wt-foo"
+    wt.mkdir()
+    log_mgr = LogManager(tmp_path / "logs")
+    state = WorkspaceState(tasks={"foo": _task("foo", worktrees={"repo": wt})})
+    git = _fake_git_count({(wt.name, "main..origin/main"): 0})
+    out = _build(state, _config(tmp_path), log_mgr, tmp_path, git_count=git)
+    task = out["active_tasks"][0]
+    assert task["base_behind_origin"] == {"repo": 0}
+
+
+def test_base_behind_origin_null_when_base_branch_unset(tmp_path: Path):
+    wt = tmp_path / "wt-x"
+    wt.mkdir()
+    log_mgr = LogManager(tmp_path / "logs")
+    state = WorkspaceState(tasks={"x": _task(
+        "x", worktrees={"repo": wt}, base_branch=None,
+    )})
+    git = _fake_git_count({(wt.name, "@{u}..HEAD"): 1})
+    out = _build(state, _config(tmp_path), log_mgr, tmp_path, git_count=git)
+    task = out["active_tasks"][0]
+    assert task["base_behind_origin"] == {"repo": None}
 
 
 def test_cwd_inside_worktree_populates_match_fields(tmp_path: Path):

--- a/tests/core/test_spec_dispatch.py
+++ b/tests/core/test_spec_dispatch.py
@@ -9,6 +9,7 @@ from mship.core.spec_store import SpecStore
 from mship.core.state import StateManager, Task, WorkspaceState
 from mship.core.spec_dispatch import DispatchError, build_dispatch_handoff, dispatch_spec
 from mship.core.workitem_store import WorkItemStore
+from mship.core.worktree import BaseBranchNotFoundError
 
 
 NOW = datetime(2026, 6, 14, tzinfo=timezone.utc)
@@ -125,6 +126,26 @@ def test_dispatch_spec_auto_spawn_requires_affected_repos(tmp_path):
     with pytest.raises(DispatchError):
         dispatch_spec(
             spec, state_manager=sm, store=store, spawn_fn=lambda s: None, now=NOW,
+            workitems=items, workspace=WORKSPACE,
+        )
+
+
+def test_dispatch_spec_auto_spawn_surfaces_base_not_found_as_dispatch_error(tmp_path):
+    """A missing base during auto-spawn surfaces as DispatchError (which the CLI
+    and serve already handle) rather than an unhandled BaseBranchNotFoundError."""
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
+    sm.save(WorkspaceState(tasks={}))
+    spec = _approved_spec()
+    store.save(spec)
+
+    def spawn_fn(_s):
+        raise BaseBranchNotFoundError(
+            "shared: base branch 'main' not found locally or on origin"
+        )
+
+    with pytest.raises(DispatchError, match="not found"):
+        dispatch_spec(
+            spec, state_manager=sm, store=store, spawn_fn=spawn_fn, now=NOW,
             workitems=items, workspace=WORKSPACE,
         )
 

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -207,6 +207,27 @@ def test_spawn_base_origin_only_survives_flapping_in_loop_fetch(worktree_deps, t
     assert _head(wt) != head_before
 
 
+def test_spawn_default_base_warns_loudly_when_fetch_fails(worktree_deps, tmp_path):
+    """MOS-203: when the normal (non --base) spawn path can't fetch origin/<base>,
+    the worktree is cut from a possibly-stale local base. The warning must say so
+    explicitly and name `mship sync` as the remedy — not a quiet 'cutting from
+    local <base>' aside."""
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    shared = workspace / "shared"
+
+    origin = tmp_path / "shared-origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    _git_run(shared, "remote", "add", "origin", str(origin))
+    _git_run(shared, "push", "origin", "HEAD:main")          # materialize origin/main
+    _git_run(shared, "remote", "set-url", "origin", str(tmp_path / "gone.git"))  # fetch will fail
+
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    result = mgr.spawn("fetch fail test", repos=["shared"], workspace_root=workspace)
+
+    matches = [w for w in result.setup_warnings if "shared" in w and "mship sync" in w]
+    assert len(matches) == 1, result.setup_warnings
+
+
 def test_abort_succeeds_even_if_branch_delete_fails(worktree_deps):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -269,6 +269,54 @@ def test_spawn_default_base_cuts_from_local_base_not_checkout_head_when_fetch_fa
     assert _head(wt) != unrelated_tip
 
 
+def test_spawn_default_base_cuts_from_origin_when_no_local_base_and_fetch_fails(
+    worktree_deps, tmp_path
+):
+    """MOS-203 (Greptile, worktree.py ~600): when the default (non --base) cut
+    can't fetch origin/<base> AND there is no local <base> branch at all (only
+    a stale remote-tracking origin/<base> from an earlier fetch), it must cut
+    the new worktree from origin/<base> — NOT silently fall through to the
+    checkout's HEAD. Regression for "no local base ref means ref_exists(base)
+    is False and start_point stays None"."""
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    shared = workspace / "shared"
+
+    # Normalize the fixture's default branch to literally "main" regardless of
+    # the host's git init.defaultBranch, so `cut_base` ("main") is unambiguous.
+    _git_run(shared, "branch", "-m", "main")
+    main_tip = _head(shared)
+
+    # Materialize origin/main (push + explicit fetch), so it exists as a
+    # remote-tracking ref, then break the remote so the in-spawn fetch fails.
+    origin = tmp_path / "shared-origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    _git_run(shared, "remote", "add", "origin", str(origin))
+    _git_run(shared, "push", "origin", "main")
+    _git_run(shared, "fetch", "origin", "main")
+
+    # Move HEAD off main onto an unrelated commit (also required to delete the
+    # local main branch below), so a HEAD-based cut would silently pick up the
+    # wrong tip.
+    _git_run(shared, "checkout", "-b", "unrelated-work")
+    (shared / "unrelated.txt").write_text("unrelated work in progress")
+    _git_run(shared, "add", "unrelated.txt")
+    _git_run(shared, "commit", "-m", "unrelated work commit")
+    unrelated_tip = _head(shared)
+    assert unrelated_tip != main_tip  # sanity: HEAD really is ahead of, and distinct from, main
+
+    # Delete the local main branch entirely — main now exists ONLY as
+    # origin/main — then break the remote so any further fetch fails.
+    _git_run(shared, "branch", "-D", "main")
+    _git_run(shared, "remote", "set-url", "origin", str(tmp_path / "gone.git"))
+
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("no local base test", repos=["shared"], workspace_root=workspace)
+    wt = Path(state_mgr.load().tasks["no-local-base-test"].worktrees["shared"])
+
+    assert _head(wt) == main_tip        # cut from origin/main, not the checkout's HEAD
+    assert _head(wt) != unrelated_tip
+
+
 def test_abort_succeeds_even_if_branch_delete_fails(worktree_deps):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -228,6 +228,47 @@ def test_spawn_default_base_warns_loudly_when_fetch_fails(worktree_deps, tmp_pat
     assert len(matches) == 1, result.setup_warnings
 
 
+def test_spawn_default_base_cuts_from_local_base_not_checkout_head_when_fetch_fails(
+    worktree_deps, tmp_path
+):
+    """MOS-203 (Greptile, worktree.py ~594): when the default (non --base) cut can't
+    fetch origin/<base>, it must cut the new worktree from the local <base> branch
+    tip — NOT from whatever branch the canonical checkout's HEAD happens to be on.
+    Regression for "fetch failure uses current HEAD"."""
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    shared = workspace / "shared"
+
+    # Normalize the fixture's default branch to literally "main" regardless of the
+    # host's git init.defaultBranch, so `cut_base` ("main") is unambiguous.
+    _git_run(shared, "branch", "-m", "main")
+    main_tip = _head(shared)
+
+    # Materialize origin/main so the fetch path is exercised (has_remote is True),
+    # then break the remote so `fetch_remote_ref` fails — the exact scenario named
+    # in the warning ("could not fetch origin/main").
+    origin = tmp_path / "shared-origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    _git_run(shared, "remote", "add", "origin", str(origin))
+    _git_run(shared, "push", "origin", "main")
+    _git_run(shared, "remote", "set-url", "origin", str(tmp_path / "gone.git"))
+
+    # Move the canonical checkout's HEAD to an unrelated branch with a DIFFERENT
+    # commit than main, so a HEAD-based cut would silently pick up the wrong tip.
+    _git_run(shared, "checkout", "-b", "unrelated-work")
+    (shared / "unrelated.txt").write_text("unrelated work in progress")
+    _git_run(shared, "add", "unrelated.txt")
+    _git_run(shared, "commit", "-m", "unrelated work commit")
+    unrelated_tip = _head(shared)
+    assert unrelated_tip != main_tip  # sanity: HEAD really is ahead of, and distinct from, main
+
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("default base test", repos=["shared"], workspace_root=workspace)
+    wt = Path(state_mgr.load().tasks["default-base-test"].worktrees["shared"])
+
+    assert _head(wt) == main_tip        # cut from local main, not the checkout's HEAD
+    assert _head(wt) != unrelated_tip
+
+
 def test_abort_succeeds_even_if_branch_delete_fails(worktree_deps):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -317,6 +317,45 @@ def test_spawn_default_base_cuts_from_origin_when_no_local_base_and_fetch_fails(
     assert _head(wt) != unrelated_tip
 
 
+def test_spawn_default_base_raises_when_base_exists_nowhere(worktree_deps):
+    """MOS-203 (Greptile, 'HEAD fallback remains'): when the default (non
+    --base) cut_base resolves to NEITHER a local branch NOR an origin/<base>
+    remote-tracking ref (no remote at all here, so no fetch to fall back on),
+    spawn must raise a clear, actionable error naming the repo and the
+    missing base — NOT silently cut the new worktree from the checkout's
+    current HEAD (which can carry unrelated commits). No worktree/hub
+    directory should be left behind."""
+    from mship.core.worktree import BaseBranchNotFoundError
+
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    shared = workspace / "shared"
+
+    # Normalize the fixture's default branch to literally "main" (base_branch
+    # in mothership.yaml), then delete it entirely so cut_base ("main") exists
+    # nowhere: no local branch, and no remote at all (so no origin/main
+    # either). Move HEAD to an unrelated branch first — required to delete
+    # main, and it also proves a HEAD-based cut would silently succeed here.
+    _git_run(shared, "branch", "-m", "main")
+    _git_run(shared, "checkout", "-b", "unrelated-work")
+    (shared / "unrelated.txt").write_text("unrelated work in progress")
+    _git_run(shared, "add", "unrelated.txt")
+    _git_run(shared, "commit", "-m", "unrelated work commit")
+    _git_run(shared, "branch", "-D", "main")  # main now exists nowhere
+
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    with pytest.raises(BaseBranchNotFoundError) as exc_info:
+        mgr.spawn("no base anywhere", repos=["shared"], workspace_root=workspace)
+
+    msg = str(exc_info.value)
+    assert "shared" in msg
+    assert "main" in msg
+    assert "not found" in msg.lower()
+
+    # Preflight: fail-fast before any worktree/hub is created.
+    assert "no-base-anywhere" not in state_mgr.load().tasks
+    assert not (workspace / ".worktrees" / "no-base-anywhere").exists()
+
+
 def test_abort_succeeds_even_if_branch_delete_fails(worktree_deps):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)

--- a/tests/test_finish_integration.py
+++ b/tests/test_finish_integration.py
@@ -222,6 +222,7 @@ def test_finish_not_blocked_by_own_worktree(finish_workspace):
 
 def test_finish_passes_base_from_config(finish_workspace, tmp_path):
     """Config base_branch flows into gh pr create --base."""
+    import subprocess
     import yaml
 
     workspace, mock_shell = finish_workspace
@@ -232,6 +233,14 @@ def test_finish_passes_base_from_config(finish_workspace, tmp_path):
     cfg["repos"]["shared"]["base_branch"] = "release/7"
     cfg_path.write_text(yaml.safe_dump(cfg))
     container.config.reset()
+
+    # MOS-203: spawn's default-cut preflight now requires the base branch to
+    # exist somewhere (local or origin) before it will cut a worktree. This
+    # test only cares about `release/7` flowing through to `gh pr create
+    # --base` at finish time (which is entirely mocked below), so create the
+    # branch locally at HEAD to satisfy the preflight.
+    subprocess.run(["git", "branch", "release/7"], cwd=workspace / "shared",
+                   check=True, capture_output=True)
 
     result = runner.invoke(app, ["spawn", "--hotfix", "base test", "--repos", "shared"])
     assert result.exit_code == 0, result.output
@@ -313,6 +322,7 @@ def test_finish_uses_spawn_base_override(finish_workspace):
 
 
 def test_finish_fails_when_base_missing_on_remote(finish_workspace):
+    import subprocess
     import yaml
 
     workspace, mock_shell = finish_workspace
@@ -321,6 +331,14 @@ def test_finish_fails_when_base_missing_on_remote(finish_workspace):
     cfg["repos"]["shared"]["base_branch"] = "nope"
     cfg_path.write_text(yaml.safe_dump(cfg))
     container.config.reset()
+
+    # MOS-203: spawn's default-cut preflight now requires the base branch to
+    # exist somewhere (local or origin) before it will cut a worktree. This
+    # test is about `finish` discovering the base is missing on the *real*
+    # remote (mocked below via an empty `git ls-remote`), so create `nope`
+    # locally at HEAD to get spawn past its own preflight.
+    subprocess.run(["git", "branch", "nope"], cwd=workspace / "shared",
+                   check=True, capture_output=True)
 
     result = runner.invoke(app, ["spawn", "--hotfix", "missing base", "--repos", "shared"])
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
mship spawn auto-fetches and fast-forwards the stale base before cutting the branch (warn on divergence, --offline opt-out); mship context surfaces a per-repo base_behind_origin flag (MOS-203)