### PR TITLE
serve dispatch posts an agent-event handoff message into the spec's WorkItem thread so a running/idle host agent is notified (MOS-194)

### DIFF
--- a/src/mship/core/message.py
+++ b/src/mship/core/message.py
@@ -87,15 +87,17 @@ class Thread(BaseModel):
     @computed_field
     @property
     def awaiting_agent_event(self) -> bool:
-        """True iff there's an agent message with kind=='event' after the last human
-        message — a PR-merge/close signal the owning agent hasn't handled yet."""
-        last_human = -1
+        """True iff there's an unhandled agent `event` message — one posted after
+        the agent's own last non-event message. A *human* message does NOT clear it
+        (the event is for the agent, not the operator); the owning agent clears it
+        by acting on the thread (posting any non-event message after the event)."""
+        last_agent_action = -1  # index of the agent's last NON-event message
         for i, m in enumerate(self.messages):
-            if m.role == "human":
-                last_human = i
+            if m.role == "agent" and m.kind != "event":
+                last_agent_action = i
         return any(
             m.role == "agent" and m.kind == "event"
-            for m in self.messages[last_human + 1:]
+            for m in self.messages[last_agent_action + 1:]
         )
 
     @computed_field

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -9,7 +9,7 @@ import time as _time
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel
 
@@ -133,6 +133,82 @@ async def _pr_watch_loop(watcher: PrWatcher, stop: asyncio.Event, interval: floa
             await asyncio.wait_for(stop.wait(), timeout=interval)
         except asyncio.TimeoutError:
             pass
+
+
+def _dispatch_marker(spec_id: str, task_slug: str) -> str:
+    """Stable substring embedded in the posted event's text, scanned by
+    `_notify_dispatch` for idempotency (see there) — one marker per
+    (spec, task) pair rather than per-dispatch-call, so a re-dispatch of the
+    same spec/task is recognized as already-notified."""
+    return f"dispatch {spec_id} -> {task_slug}"
+
+
+def _notify_dispatch(
+    *, msgs: Any, workitems: Any, item_msg_lock: Any,
+    spec: Any, task: Any, handoff: str, now: datetime,
+) -> bool:
+    """Post a one-time agent `event` message announcing a serve-side dispatch's
+    handoff (spec id, task slug, worktree paths — the same text
+    `build_dispatch_handoff` renders) into the spec's WorkItem thread. This is
+    what makes `Thread.awaiting_agent_event` true, so an idle host agent armed
+    on `mship inbox wait` (whose predicate already includes
+    `awaiting_agent_event`) picks the handoff up automatically — no separate
+    flag or wake mechanism needed.
+
+    Called ONLY from `post_dispatch` (`POST /specs/{id}/dispatch`) — never from
+    `dispatch_spec` itself — so this is serve-only: `mship spec dispatch` (the
+    CLI, which calls `dispatch_spec` directly with no message store in hand)
+    never posts an event.
+
+    Idempotency mirrors `PrWatcher` (`pr_watcher.py`): before appending, the
+    resolved thread's existing messages are scanned for a prior `kind=="event"`
+    message containing `_dispatch_marker(spec.id, task.slug)`; if found, this is
+    a re-dispatch and nothing is posted. The marker is embedded as the event
+    message's leading line so the scan is reliable across both a re-dispatch in
+    the same process and a restart (the scan reads persisted messages, not
+    in-memory state).
+
+    Thread resolution mirrors `post_item_message` / `PrWatcher._resolve_thread`:
+    reuse the WorkItem's first thread if it has one; otherwise create one
+    (linking it back to the WorkItem) and seed it with a short human placeholder
+    — `create_thread` always seeds a human message, and the event must land as
+    a *separate*, trailing agent message for `awaiting_agent_event` to compute
+    True.
+
+    Returns whether a new event message was posted (False when idempotency
+    skipped it). The caller wraps this in a broad try/except regardless — a
+    mailbox glitch here must never turn a successful dispatch into a 500."""
+    if spec.work_item_id is None:
+        # Shouldn't happen — dispatch_spec always attaches a WorkItem — but
+        # there's nowhere to hang a thread without one, so just skip.
+        return False
+
+    marker = _dispatch_marker(spec.id, task.slug)
+    text = f"{marker}\n\n{handoff}"
+
+    with item_msg_lock:
+        wi = workitems.get(spec.work_item_id)
+        if wi is None:
+            return False
+
+        if wi.thread_ids:
+            tid = wi.thread_ids[0]
+        else:
+            seed = f"Dispatch handoff for {task.slug}"
+            thread = msgs.create_thread(
+                subject=spec.title or task.slug, text=seed, now=now, task_slug=task.slug,
+            )
+            workitems.add_thread(wi.id, thread.id, now=now)
+            tid = thread.id
+
+        thread = msgs.get(tid)
+        if thread is not None and any(
+            m.kind == "event" and marker in m.text for m in thread.messages
+        ):
+            return False  # already notified (this dispatch or a prior process) — skip
+
+        msgs.append(tid, "agent", text, now, kind="event")
+        return True
 
 
 def create_app(
@@ -457,6 +533,22 @@ def create_app(
                     spawn_fn=_serve_spawn, now=datetime.now(timezone.utc),
                     workitems=workitems, workspace=workspace_name,
                 )
+                # Serve-side-only handoff notify (MOS-194): posts an agent `event`
+                # message naming the spec/task/worktree into the WorkItem's thread
+                # so an idle host agent armed on `mship inbox wait` picks it up.
+                # Never lets a mailbox glitch turn a successful dispatch into a
+                # 500 — mirrors PrWatcher's never-raise philosophy.
+                try:
+                    _notify_dispatch(
+                        msgs=msgs, workitems=workitems, item_msg_lock=_item_msg_lock,
+                        spec=result.spec, task=result.task, handoff=result.handoff,
+                        now=datetime.now(timezone.utc),
+                    )
+                except Exception:
+                    logger.exception(
+                        "dispatch handoff notify failed (spec=%s task=%s) — "
+                        "dispatch itself succeeded", result.spec.id, result.task.slug,
+                    )
         except DispatchError as e:
             raise HTTPException(status_code=409, detail=str(e))
         return {

--- a/tests/cli/test_inbox_wait.py
+++ b/tests/cli/test_inbox_wait.py
@@ -77,6 +77,55 @@ def test_wait_ignores_agent_reply(tmp_path: Path):
         _reset()
 
 
+def test_wait_matches_event_thread_even_after_interleaved_human_message(tmp_path: Path):
+    # MOS-194 (Greptile finding on PR #307): a dispatch/PR event is a signal FOR
+    # THE AGENT. A human posting on the thread afterwards (e.g. a quick "thanks"
+    # from the phone) must not make `mship inbox wait` stop matching it -- the
+    # predicate is `awaiting_reply or awaiting_agent_event`, and it's
+    # `awaiting_agent_event` that must survive the interleave.
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    t = store.create_thread("task-1", "seed", datetime.now(timezone.utc))
+    store.append(t.id, "agent", "dispatch handoff", datetime.now(timezone.utc), kind="event")
+    store.append(t.id, "human", "thanks", datetime.now(timezone.utc))  # the interleave
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["inbox", "wait", "--since", PAST, "--timeout", "5"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["timed_out"] is False
+        assert [th["id"] for th in payload["threads"]] == [t.id]
+    finally:
+        _reset()
+
+
+def test_wait_does_not_reloop_on_a_still_pending_event_once_cursor_advances(tmp_path: Path):
+    # Loop-safety: once a wait has surfaced the event thread and its cursor has
+    # advanced past it, a fresh wait `--since` that cursor must NOT immediately
+    # re-hit on the very same still-unhandled event -- `changed_since` gates on
+    # `updated_at > since`, independent of `awaiting_agent_event` itself, so a
+    # more-persistent flag can't cause a wake-loop.
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    t = store.create_thread("task-1", "seed", datetime.now(timezone.utc))
+    store.append(t.id, "agent", "dispatch handoff", datetime.now(timezone.utc), kind="event")
+    _override(cfg, state_dir)
+    try:
+        first = runner.invoke(app, ["inbox", "wait", "--since", PAST, "--timeout", "5"])
+        assert first.exit_code == 0, first.output
+        first_payload = json.loads(first.output)
+        assert first_payload["timed_out"] is False
+        assert [th["id"] for th in first_payload["threads"]] == [t.id]
+
+        second = runner.invoke(app, [
+            "inbox", "wait", "--since", first_payload["cursor"], "--timeout", "0.1",
+        ])
+        assert second.exit_code == 0, second.output
+        second_payload = json.loads(second.output)
+        assert second_payload["timed_out"] is True
+        assert second_payload["threads"] == []  # no re-wake on the still-True flag
+    finally:
+        _reset()
+
+
 def test_wait_stands_down_when_another_listener_holds_lease(tmp_path: Path):
     import os
     from mship.core.inbox_lease import InboxLease

--- a/tests/core/test_message_model.py
+++ b/tests/core/test_message_model.py
@@ -143,10 +143,34 @@ def test_awaiting_agent_event_true_for_trailing_event():
     assert t.needs_decision is False
 
 
-def test_awaiting_agent_event_reset_by_later_human():
-    t = _thread(_m("agent", 0, kind="event"), _m("human", 1))
+def test_awaiting_agent_event_false_with_no_event():
+    t = _thread(_m("human", 0), _m("agent", 1))
     assert t.awaiting_agent_event is False
-    assert t.awaiting_reply is True
+
+
+def test_awaiting_agent_event_survives_a_later_human_message():
+    # The Greptile finding on PR #307 (MOS-194): an `event` is a signal FOR THE
+    # AGENT, not the operator, so a human posting on the thread after it must
+    # NOT clear it -- otherwise an idle host agent armed on `mship inbox wait`
+    # can miss a dispatch/PR-merge handoff whenever a human happens to reply
+    # first. This is the inverse of `test_awaiting_agent_event_reset_by_later_human`
+    # (old, now-wrong behavior) it replaces.
+    t = _thread(_m("agent", 0, kind="event"), _m("human", 1))
+    assert t.awaiting_agent_event is True
+    assert t.awaiting_reply is True  # the human message still needs an agent reply
+
+
+def test_awaiting_agent_event_cleared_by_agent_non_event_message():
+    # The owning agent clears its own event by acting on the thread -- posting
+    # any non-event message after it (even with a human message interleaved).
+    t = _thread(_m("agent", 0, kind="event"), _m("human", 1), _m("agent", 2))
+    assert t.awaiting_agent_event is False
+
+
+def test_awaiting_agent_event_persists_through_agent_followup_event_only():
+    # Sanity: a second event with no intervening agent action stays pending.
+    t = _thread(_m("agent", 0, kind="event"), _m("human", 1), _m("agent", 2, kind="event"))
+    assert t.awaiting_agent_event is True
 
 
 def test_decision_payload_legacy_json_without_multi_defaults_false():

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -2,12 +2,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from fastapi.testclient import TestClient
 
+from mship.core.message_store import MessageStore
 from mship.core.serve import create_app
 from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec
 from mship.core.spec_body import render_body
 from mship.core.spec_store import SpecStore
 from mship.core.state import StateManager, Task, WorkspaceState
 from mship.core.log import LogManager
+from mship.core.workitem_store import WorkItemStore
 
 
 def _app(tmp_path: Path):
@@ -384,6 +386,78 @@ def test_post_dispatch_auto_spawn_unavailable_409(tmp_path):
         workspace_root=tmp_path, workspace_name="t",
     )
     assert TestClient(app).post("/specs/cap/dispatch").status_code == 409
+
+
+# --- MOS-194: serve dispatch posts an agent-event handoff into the WorkItem thread ---
+
+
+def _dispatch_app(tmp_path, spec_id="cap", repos=("shared",)):
+    sm = _empty_state(tmp_path)
+    _seed_approved_spec(tmp_path, spec_id=spec_id, repos=list(repos))
+    app = create_app(
+        specs_dir=tmp_path / "specs", state_manager=sm, log_manager=None,
+        workspace_root=tmp_path, workspace_name="t",
+        worktree_manager=_FakeWorktreeManager(sm),
+    )
+    return app, sm
+
+
+def test_post_dispatch_posts_agent_event_handoff(tmp_path):
+    app, sm = _dispatch_app(tmp_path)
+    r = TestClient(app).post("/specs/cap/dispatch")
+    assert r.status_code == 200, r.text
+    wi_id = r.json()["spec"]["work_item_id"]
+    assert wi_id
+
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    msgs = MessageStore(tmp_path / ".mothership" / "messages")
+    wi = items.get(wi_id)
+    assert wi is not None and wi.thread_ids, "dispatch should create+link a thread for the handoff event"
+    thread = msgs.get(wi.thread_ids[0])
+    assert thread is not None
+
+    # A seed (human) message plus exactly one agent event carrying the handoff.
+    assert [m.role for m in thread.messages] == ["human", "agent"]
+    event = thread.messages[-1]
+    assert event.kind == "event"
+    assert "dispatch cap -> cap" in event.text     # stable marker (spec id -> task slug)
+    assert "cap" in event.text                     # spec id / task slug
+    assert "/wt/cap/shared" in event.text          # worktree path, from the rendered handoff
+
+    assert thread.awaiting_agent_event is True
+    assert thread.needs_you is False
+
+
+def test_post_dispatch_idempotent_no_double_event(tmp_path):
+    app, sm = _dispatch_app(tmp_path)
+    client = TestClient(app)
+    first = client.post("/specs/cap/dispatch")
+    assert first.status_code == 200, first.text
+    wi_id = first.json()["spec"]["work_item_id"]
+
+    second = client.post("/specs/cap/dispatch")   # re-dispatch: idempotent bind, no new task
+    assert second.status_code == 200, second.text
+    assert second.json()["spawned"] is False
+
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    msgs = MessageStore(tmp_path / ".mothership" / "messages")
+    wi = items.get(wi_id)
+    thread = msgs.get(wi.thread_ids[0])
+    events = [m for m in thread.messages if m.kind == "event"]
+    assert len(events) == 1                        # no double-post on re-dispatch
+
+
+def test_post_dispatch_never_500s_if_notify_raises(tmp_path, monkeypatch):
+    sm, log = _seed_task(tmp_path)                 # task "dq", affected_repos=["mothership"]
+    _seed_approved_spec(tmp_path)                  # approved spec "dq"
+    monkeypatch.setattr(
+        "mship.core.serve._notify_dispatch",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("mailbox glitch")),
+    )
+    client = TestClient(_app_with(tmp_path, sm, log))
+    r = client.post("/specs/dq/dispatch")
+    assert r.status_code == 200, r.text            # dispatch itself is unaffected
+    assert r.json()["spec"]["status"] == "dispatched"
 
 
 # --- message mailbox endpoints ---

--- a/tests/core/test_spec_dispatch.py
+++ b/tests/core/test_spec_dispatch.py
@@ -361,3 +361,30 @@ def test_dispatch_spec_ignores_closed_workitem_candidates_and_auto_spawns(tmp_pa
     assert calls == ["dq"]
     assert result.task.slug == "dq"
     assert sorted(items.get(wi.id).task_slugs) == ["closed-task", "dq"]
+
+
+# --- MOS-194: the agent-event handoff notify is serve-only, not part of dispatch_spec ---
+
+def test_dispatch_spec_does_not_touch_message_store(tmp_path):
+    """`mship spec dispatch` (the CLI) calls `dispatch_spec` directly, with no
+    message store in hand at all — the agent-event handoff notify (MOS-194)
+    lives only in serve's `post_dispatch` (`mship.core.serve._notify_dispatch`),
+    never here, so a bare `dispatch_spec` call must not create any thread."""
+    from mship.core.message_store import MessageStore
+
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
+    sm.save(WorkspaceState(tasks={}))
+    spec = _approved_spec()
+    store.save(spec)
+
+    def spawn_fn(s):
+        task = _task(slug=s.id, repos=s.affected_repos)
+        sm.mutate(lambda st: st.tasks.__setitem__(s.id, task))
+        return task
+
+    dispatch_spec(
+        spec, state_manager=sm, store=store, spawn_fn=spawn_fn, now=NOW,
+        workitems=items, workspace=WORKSPACE,
+    )
+
+    assert MessageStore(tmp_path / "messages").list() == []


### PR DESCRIPTION
serve dispatch posts an agent-event handoff message into the spec's WorkItem thread so a running/idle host agent is notified (MOS-194)