### PR TITLE
Migrate CLI commands that branch output shape on sys.stdout.isatty() to Output().json_mode so --json is honored (start cli/message.py); optional guard test (MOS-206)

### DIFF
--- a/src/mship/cli/message.py
+++ b/src/mship/cli/message.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import json
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 import typer
 
+from mship.cli.output import Output
 from mship.core.message_store import MessageStore
 
 
@@ -26,13 +26,13 @@ def register(parent: typer.Typer, get_container) -> None:
              "updated_at": t.updated_at.isoformat()}
             for t in store.list() if t.awaiting_reply
         ]
-        if sys.stdout.isatty():
+        if Output().json_mode:
+            typer.echo(json.dumps(out))
+        else:
             if not out:
                 typer.echo("(inbox empty)")
             for o in out:
                 typer.echo(f"{o['id']}  {o['subject']}\n  > {o['pending']}")
-        else:
-            typer.echo(json.dumps(out))
 
     @inbox_app.callback(invoke_without_command=True)
     def inbox(ctx: typer.Context) -> None:
@@ -157,8 +157,8 @@ def register(parent: typer.Typer, get_container) -> None:
         if t is None:
             typer.echo(f"no thread {thread_id!r}", err=True)
             raise typer.Exit(1)
-        if sys.stdout.isatty():
+        if Output().json_mode:
+            typer.echo(t.model_dump_json())
+        else:
             for m in t.messages:
                 typer.echo(f"[{m.role}] {m.text}")
-        else:
-            typer.echo(t.model_dump_json())

--- a/tests/cli/test_message.py
+++ b/tests/cli/test_message.py
@@ -207,6 +207,8 @@ def test_ask_defaults_to_single_select(_configured):
     r = runner.invoke(app, ["ask", t.id, "How to store?",
                             "--option", "a", "--option", "b"])
     assert r.exit_code == 0, r.output
+    got = s.get(t.id)
+    assert got.messages[-1].decision.multi is False
 
 
 # ---- MOS-206: --json must be honored on a real TTY (CliRunner's stdout is

--- a/tests/cli/test_message.py
+++ b/tests/cli/test_message.py
@@ -1,4 +1,8 @@
 import json
+import os
+import pty
+import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -9,6 +13,42 @@ from mship.cli import app, container
 from mship.core.message_store import MessageStore
 
 runner = CliRunner()
+
+
+def _run_mship_pty(args: list[str], cwd: Path) -> str:
+    """Run the real CLI in a subprocess over a pty, so stdout is a real TTY.
+
+    CliRunner's stdout is always a pipe (never a TTY), so it can't exercise the
+    MOS-206 bug (a command deciding output shape via `sys.stdout.isatty()`
+    silently ignores `--json` on an interactive terminal). Mirrors
+    tests/cli/test_output_flags.py::_run_mship (kept local/minimal here since
+    that's the only other place a real pty currently matters).
+    """
+    code = (
+        "import sys; from mship.cli import run; "
+        f"sys.argv = ['mship'] + {args!r}; run()"
+    )
+    repo_src = str(Path(__file__).resolve().parents[2] / "src")
+    env = dict(os.environ)
+    env["PYTHONPATH"] = repo_src + os.pathsep + env.get("PYTHONPATH", "")
+    master, slave = pty.openpty()
+    proc = subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdout=slave, stderr=subprocess.DEVNULL, cwd=str(cwd), env=env,
+    )
+    os.close(slave)
+    out = b""
+    while True:
+        try:
+            chunk = os.read(master, 4096)
+        except OSError:
+            break
+        if not chunk:
+            break
+        out += chunk
+    proc.wait(timeout=30)
+    os.close(master)
+    return out.decode().replace("\r", "")
 
 
 @pytest.fixture
@@ -167,5 +207,60 @@ def test_ask_defaults_to_single_select(_configured):
     r = runner.invoke(app, ["ask", t.id, "How to store?",
                             "--option", "a", "--option", "b"])
     assert r.exit_code == 0, r.output
-    got = s.get(t.id)
-    assert got.messages[-1].decision.multi is False
+
+
+# ---- MOS-206: --json must be honored on a real TTY (CliRunner's stdout is
+# always a pipe, so these use a real pty via _run_mship_pty to reproduce the
+# bug: `inbox`/`messages` used to decide JSON-vs-human via raw
+# `sys.stdout.isatty()`, silently ignoring --json on an interactive terminal). ----
+
+def test_inbox_json_flag_honored_over_pty(workspace: Path):
+    s = _seed(workspace)
+    now = datetime(2026, 6, 23, tzinfo=timezone.utc)
+    s.create_thread(subject="needs reply", text="please draft", now=now)
+
+    forced = _run_mship_pty(["--json", "inbox"], workspace)
+    parsed = json.loads(forced)  # must parse as JSON despite stdout being a TTY
+    assert any(o["subject"] == "needs reply" and o["pending"] == "please draft"
+               for o in parsed)
+
+
+def test_inbox_human_output_preserved_over_pty(workspace: Path):
+    s = _seed(workspace)
+    now = datetime(2026, 6, 23, tzinfo=timezone.utc)
+    s.create_thread(subject="needs reply", text="please draft", now=now)
+
+    human = _run_mship_pty(["inbox"], workspace)
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(human)
+    assert "needs reply" in human
+    assert "> please draft" in human
+
+
+def test_inbox_human_output_empty_message_preserved_over_pty(workspace: Path):
+    human = _run_mship_pty(["inbox"], workspace)
+    assert human.strip() == "(inbox empty)"
+
+
+def test_messages_json_flag_honored_over_pty(workspace: Path):
+    s = _seed(workspace)
+    now = datetime(2026, 6, 23, tzinfo=timezone.utc)
+    t = s.create_thread(subject="x", text="first", now=now)
+    s.append(t.id, "agent", "second", now)
+
+    forced = _run_mship_pty(["--json", "messages", t.id], workspace)
+    parsed = json.loads(forced)  # must parse as JSON despite stdout being a TTY
+    assert [m["text"] for m in parsed["messages"]] == ["first", "second"]
+
+
+def test_messages_human_output_preserved_over_pty(workspace: Path):
+    s = _seed(workspace)
+    now = datetime(2026, 6, 23, tzinfo=timezone.utc)
+    t = s.create_thread(subject="x", text="first", now=now)
+    s.append(t.id, "agent", "second", now)
+
+    human = _run_mship_pty(["messages", t.id], workspace)
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(human)
+    assert "[human] first" in human
+    assert "[agent] second" in human

--- a/tests/cli/test_output_flags.py
+++ b/tests/cli/test_output_flags.py
@@ -225,3 +225,47 @@ def test_json_flag_changes_pty_output(workspace):
     forced = _run_mship(["--json", "graph"], workspace, use_pty=True)
     assert human != forced
     json.loads(forced)  # forced output parses as JSON
+
+
+# ---- MOS-206 guard: no command may decide JSON-vs-human output shape via a
+# raw isatty() check — that silently ignores --json/MSHIP_JSON on a real TTY.
+# `Output().json_mode` is the only sanctioned way to make that decision (it
+# already folds in the flag > env > TTY precedence tested above). Any new
+# isatty() use under src/mship/cli/ must either route through json_mode or be
+# added to the allow-list below with a reason it is NOT an output-shape call
+# (e.g. an interactivity or color-only decision made *after* shape is fixed).
+
+_CLI_SRC = Path(__file__).resolve().parents[2] / "src" / "mship" / "cli"
+
+# {relative path under src/mship/cli/: (substrings of allowed isatty lines,)}
+_ALLOWED_ISATTY = {
+    "output.py": (
+        # The canonical is_tty check Output.json_mode's TTY-fallback default is
+        # built on — this *is* the source of truth, not a bypass of it.
+        "self._stream.isatty()",
+    ),
+    "worktree.py": (
+        # Guards `--body -` against blocking on an interactive stdin read; an
+        # input-mode decision, not an output-shape one.
+        "sys.stdin.isatty()",
+    ),
+}
+
+
+def test_no_cli_command_branches_output_shape_on_isatty():
+    offenders = []
+    for path in sorted(_CLI_SRC.rglob("*.py")):
+        rel = path.relative_to(_CLI_SRC).as_posix()
+        allowed = _ALLOWED_ISATTY.get(rel, ())
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            if "isatty" not in line:
+                continue
+            if any(snippet in line for snippet in allowed):
+                continue
+            offenders.append(f"{rel}:{lineno}: {line.strip()}")
+    assert offenders == [], (
+        "found isatty() use(s) in src/mship/cli/ not on the MOS-206 allow-list "
+        "(likely an output-shape branch bypassing Output().json_mode); use "
+        "Output().json_mode instead, or add to _ALLOWED_ISATTY above with a "
+        "reason it's not an output-shape decision:\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
Migrate CLI commands that branch output shape on sys.stdout.isatty() to Output().json_mode so --json is honored (start cli/message.py); optional guard test (MOS-206)