### PR TITLE
Apply the 6 Greptile fixes to mship export that were lost when #311 merged uncommitted (non-blocking regex timeout, redact state.json leaves, clear stale export dir, three-dot base...branch diff, null redact.patterns coercion, precise plan discovery)

### DIFF
--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -120,6 +120,7 @@ from mship.cli import depends as _depends_mod
 from mship.cli import dispatch as _dispatch_mod
 from mship.cli import doctor as _doctor_mod
 from mship.cli import exec as _exec_mod
+from mship.cli import export as _export_mod
 from mship.cli import gh as _gh_mod
 from mship.cli import init as _init_mod
 from mship.cli import internal as _internal_mod
@@ -181,6 +182,7 @@ _depends_mod.register(app, get_container)
 _dispatch_mod.register(app, get_container)
 _doctor_mod.register(app, get_container)
 _exec_mod.register(app, get_container)
+_export_mod.register(app, get_container)
 _gh_mod.register(app, get_container)
 _init_mod.register(app, get_container)
 _internal_mod.register(app, get_container)

--- a/src/mship/cli/export.py
+++ b/src/mship/cli/export.py
@@ -20,7 +20,10 @@ def register(app: typer.Typer, get_container):
             False, "--redacted",
             help="Strip well-known secret shapes (Stripe/GitHub/AWS/PEM/Bearer/.env-style) "
                  "from the bundle's text artifacts. Opt-in; omitted means a faithful, "
-                 "unredacted copy.",
+                 "unredacted copy. Built-in patterns are vetted and safe. A custom pattern "
+                 "from redact.patterns is your own regex: a pathological one (catastrophic "
+                 "backtracking) can still hang export — Python can't forcibly interrupt a "
+                 "runaway re.sub, so keep custom patterns simple.",
         ),
         fmt: str = typer.Option(
             "dir", "--format",

--- a/src/mship/cli/export.py
+++ b/src/mship/cli/export.py
@@ -1,0 +1,77 @@
+"""`mship export` — assemble a task's journal/plan/spec/state/diffs into a
+portable bundle, with opt-in `--redacted` secret scrubbing. See spec
+`mship-export-redacted-secret-redaction-mos-102` (MOS-102).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from mship.cli._resolve import resolve_for_command
+from mship.cli.output import Output
+
+
+def register(app: typer.Typer, get_container):
+    @app.command(name="export")
+    def export_cmd(
+        redacted: bool = typer.Option(
+            False, "--redacted",
+            help="Strip well-known secret shapes (Stripe/GitHub/AWS/PEM/Bearer/.env-style) "
+                 "from the bundle's text artifacts. Opt-in; omitted means a faithful, "
+                 "unredacted copy.",
+        ),
+        fmt: str = typer.Option(
+            "dir", "--format",
+            help="Bundle format: 'dir' (default, writes <task>-export/) or 'zip' "
+                 "(writes <task>-export.zip).",
+        ),
+        task_opt: Optional[str] = typer.Option(
+            None, "--task",
+            help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env > only active task.",
+        ),
+    ):
+        """Assemble <task>'s journal, plan, spec, state, and per-repo diffs into a bundle."""
+        from mship.core.export import export_task
+        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
+
+        output = Output()
+        if fmt not in ("dir", "zip"):
+            output.error("Invalid --format: use 'dir' or 'zip'.")
+            raise typer.Exit(1)
+
+        container = get_container()
+        state = container.state_manager().load()
+        resolved = resolve_for_command("export", state, task_opt, output)
+        task = resolved.task
+
+        workspace_root = Path(container.config_path()).parent
+        spec_store = SpecStore(workspace_root / SPECS_DIRNAME)
+
+        result = export_task(
+            task=task,
+            config=container.config(),
+            workspace_root=workspace_root,
+            log_manager=container.log_manager(),
+            spec_store=spec_store,
+            redacted=redacted,
+            format=fmt,
+        )
+
+        for warning in result.warnings:
+            output.warning(warning)
+
+        if output.human_mode:
+            suffix = " (redacted)" if redacted else ""
+            output.success(f"Exported {task.slug} → {result.bundle_path}{suffix}")
+        else:
+            output.json({
+                "task": task.slug,
+                "bundle_path": str(result.bundle_path),
+                "format": fmt,
+                "redacted": redacted,
+                "warnings": result.warnings,
+                "resolved_task": resolved.task.slug,
+                "resolution_source": resolved.source,
+            })

--- a/src/mship/cli/export.py
+++ b/src/mship/cli/export.py
@@ -49,15 +49,19 @@ def register(app: typer.Typer, get_container):
         workspace_root = Path(container.config_path()).parent
         spec_store = SpecStore(workspace_root / SPECS_DIRNAME)
 
-        result = export_task(
-            task=task,
-            config=container.config(),
-            workspace_root=workspace_root,
-            log_manager=container.log_manager(),
-            spec_store=spec_store,
-            redacted=redacted,
-            format=fmt,
-        )
+        try:
+            result = export_task(
+                task=task,
+                config=container.config(),
+                workspace_root=workspace_root,
+                log_manager=container.log_manager(),
+                spec_store=spec_store,
+                redacted=redacted,
+                format=fmt,
+            )
+        except ValueError as e:
+            output.error(str(e))
+            raise typer.Exit(1)
 
         for warning in result.warnings:
             output.warning(warning)

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -119,6 +119,33 @@ class AuditPolicy(BaseModel):
     block_finish: bool = True
 
 
+class RedactPatternEntry(BaseModel):
+    """One user-configured `--redacted` pattern (MOS-102).
+
+    A bare YAML string normalizes to `{"pattern": <string>}` (kind "custom");
+    `{name: ..., pattern: ...}` lets an operator label the pattern so its
+    `<REDACTED:kind>` marker is more legible than the generic "custom".
+    """
+    name: str | None = None
+    pattern: str
+
+
+class RedactConfig(BaseModel):
+    """`mothership.yaml#redact.patterns` — extra regexes unioned with the
+    built-in `mship export --redacted` pattern set. See core/export.py."""
+    patterns: list[RedactPatternEntry] = []
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_patterns(cls, data):
+        if isinstance(data, dict) and "patterns" in data and data["patterns"] is not None:
+            normalized = []
+            for entry in data["patterns"]:
+                normalized.append({"pattern": entry} if isinstance(entry, str) else entry)
+            data["patterns"] = normalized
+        return data
+
+
 class WorkspaceConfig(BaseModel):
     workspace: str
     env_runner: str | None = None
@@ -159,6 +186,10 @@ class WorkspaceConfig(BaseModel):
     # mship.core.run_host.RunHostStore / resolve_run_host). A repo opts into
     # one via `RepoConfig.run_host`.
     run_hosts: list[str] = []
+    # Extra `mship export --redacted` patterns unioned with the built-in set
+    # (MOS-102). None (the default — no `redact:` key) leaves export's
+    # redaction pass exactly the built-in patterns.
+    redact: RedactConfig | None = None
     repos: dict[str, RepoConfig]
 
     @field_validator("relay", mode="before")

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -138,11 +138,19 @@ class RedactConfig(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def normalize_patterns(cls, data):
-        if isinstance(data, dict) and "patterns" in data and data["patterns"] is not None:
-            normalized = []
-            for entry in data["patterns"]:
-                normalized.append({"pattern": entry} if isinstance(entry, str) else entry)
-            data["patterns"] = normalized
+        if isinstance(data, dict) and "patterns" in data:
+            if data["patterns"] is None:
+                # `redact:\n  patterns:` (key present, no list) parses as YAML
+                # null, not an omitted key — coerce to the same empty-list
+                # default as omitting `patterns` entirely, rather than
+                # failing pydantic's list validation and erroring the whole
+                # config load.
+                data["patterns"] = []
+            else:
+                normalized = []
+                for entry in data["patterns"]:
+                    normalized.append({"pattern": entry} if isinstance(entry, str) else entry)
+                data["patterns"] = normalized
         return data
 
 

--- a/src/mship/core/export.py
+++ b/src/mship/core/export.py
@@ -12,6 +12,23 @@ Two independent concerns live here:
 - Redaction (`BUILTIN_PATTERNS` / `redact_text` / `load_user_patterns`): a
   deterministic, regex-only pass applied only when `--redacted` is requested.
   Never runs otherwise — plain `mship export` is a faithful copy.
+
+KNOWN LIMITATION — custom `redact.patterns` can still hang export: the
+built-in patterns above are hand-reviewed and applied directly, but a
+user-supplied pattern (from `mothership.yaml#redact.patterns` or
+`~/.config/mship/redact.patterns`) is an arbitrary regex we didn't write. It
+runs under `_apply_pattern_safe`'s daemon-thread `join(timeout=...)` guard,
+but Python's GIL means a thread cannot be preempted mid-`re.sub` — a
+pathological pattern with catastrophic backtracking (e.g. nested
+repetition like `(a+)+b` against a long non-matching string) keeps running
+and holding the GIL even after the timeout "returns" from the caller's
+point of view, so it can still burn a core and, in the worst case, make the
+process appear to hang. There is no way to truly interrupt a CPU-bound
+regex from within the stdlib short of a subprocess/signal-based sandbox,
+which is intentionally out of scope for v1 (see `_apply_pattern_safe`'s
+docstring). Built-in patterns are exempt from this risk since they're
+reviewed for linear-time behavior; only opt-in, operator-authored custom
+patterns are exposed to it.
 """
 from __future__ import annotations
 
@@ -124,6 +141,17 @@ def _apply_pattern_safe(text: str, pattern: RedactionPattern) -> tuple[str, str 
     is left unredacted *for that one pattern* rather than the whole export
     hanging (see spec risks).
 
+    HONEST CAVEAT (not fully solved, by design — see module docstring): this
+    timeout is best-effort, not a hard interrupt. `join(timeout=...)` only
+    bounds how long the *caller* waits; it cannot stop the daemon thread
+    itself from still executing inside `re.sub`, because the GIL means one
+    Python thread can't preempt another mid-C-call. A catastrophic pattern
+    still burns a core indefinitely in the background after we "time out"
+    and move on. We do not chase this further with a subprocess/signal-based
+    hard-kill for v1 — that's real complexity for a risk that only exists
+    for opt-in, operator-authored patterns (built-ins are reviewed and
+    linear-time).
+
     Uses a daemon thread + `join(timeout=...)` rather than a
     `ThreadPoolExecutor` — the executor's `__exit__` does
     `shutdown(wait=True)`, which blocks until the submitted task actually
@@ -219,7 +247,23 @@ _BINARY_MARKERS = ("Binary files ", "GIT binary patch")
 
 
 def _chunk_is_binary(chunk: str) -> bool:
-    return any(marker in chunk for marker in _BINARY_MARKERS) or "\0" in chunk
+    """A chunk is binary only if one of git's own marker LINES is present —
+    not merely if the marker phrase appears anywhere in the chunk's body.
+
+    A text file can legitimately add a line that *mentions* "Binary files "
+    or "GIT binary patch" as ordinary content (e.g. a comment, doc, or log
+    line) sitting right next to a real secret. The old substring-anywhere
+    check treated that whole chunk as binary and skipped it from redaction
+    entirely, leaking the secret into a "redacted" bundle (MOS-102 Greptile
+    fix: "Text Diff Bypasses Redaction"). Git always emits these markers as
+    whole lines starting at column 0, so anchoring on `line.startswith(...)`
+    only matches the real thing.
+    """
+    return "\0" in chunk or any(
+        line.startswith(marker)
+        for line in chunk.splitlines()
+        for marker in _BINARY_MARKERS
+    )
 
 
 def _split_diff_chunks(diff_text: str) -> list[str]:
@@ -244,13 +288,29 @@ def redact_diff_text(diff_text: str, patterns: list[RedactionPattern]) -> tuple[
     return "".join(out), warnings
 
 
-def collect_repo_diff(task: "Task", repo_name: str, config: "WorkspaceConfig") -> str | None:
+def collect_repo_diff(
+    task: "Task", repo_name: str, config: "WorkspaceConfig",
+    *, warnings: list[str] | None = None,
+) -> str | None:
     """Return the `base..branch` diff for one affected repo, or None.
 
     None covers every "nothing to bundle" case (no worktree recorded for
     this repo, base ref unresolvable, git failure, or simply no commits on
     the task branch relative to base) — export omits the file rather than
     erroring (AC8).
+
+    Base resolution mirrors the canonical helper used by dispatch/finish/
+    context (`_effective_base_for_repo` in context.py): `resolve_base(...)`
+    first, then `task.base_branch` as the one documented fallback for
+    workspaces that don't declare `base_branch:` in mothership.yaml. It must
+    NOT go on to guess a hardcoded "main" after that — `resolve_base`
+    returning None means "no configured base", not "the base is main", and a
+    literal "main" fallback can silently diff against an unrelated
+    same-named branch and produce a materially wrong diff instead of erring
+    on the side of omitting it (MOS-102 Greptile fix: "Default Base Becomes
+    Main"). When the base truly can't be resolved, skip this repo's diff
+    and — if `warnings` is given — append a note so the caller can surface
+    it, rather than exporting a diff against a wrong base.
     """
     worktree = task.worktrees.get(repo_name)
     if worktree is None:
@@ -259,7 +319,16 @@ def collect_repo_diff(task: "Task", repo_name: str, config: "WorkspaceConfig") -
     base = resolve_base(
         repo_name, repo_config, cli_base=None, base_map={},
         known_repos=config.repos.keys(), task_base=task.base_override,
-    ) or task.base_branch or "main"
+    )
+    if base is None:
+        base = task.base_branch
+    if base is None:
+        if warnings is not None:
+            warnings.append(
+                f"could not resolve a base branch for repo {repo_name!r}; "
+                "skipped its diff"
+            )
+        return None
     try:
         result = subprocess.run(
             # Three-dot (merge-base) diff, not two-dot: exports only the task
@@ -467,7 +536,7 @@ def build_export_bundle(
 
     # diffs/<repo>.diff (optional per repo)
     for repo_name in task.affected_repos:
-        diff_text = collect_repo_diff(task, repo_name, config)
+        diff_text = collect_repo_diff(task, repo_name, config, warnings=warnings)
         if diff_text is None:
             continue
         if redacted:

--- a/src/mship/core/export.py
+++ b/src/mship/core/export.py
@@ -549,6 +549,21 @@ def build_export_bundle(
     return ExportBundle(bundle_path=dest_dir, warnings=warnings)
 
 
+def _is_prior_export_zip(zip_path: Path, bundle_name: str) -> bool:
+    """True if `zip_path` is a prior mship export bundle — a readable zip
+    containing our `<bundle_name>/.mship-export` marker entry. Gates the zip
+    overwrite the same way the directory path gates its rmtree on the marker,
+    so `mship export --format zip` never clobbers an unrelated same-named file
+    (a corrupt/non-zip file returns False → refuse). See MOS-102 Greptile fix.
+    """
+    marker_arc = f"{bundle_name}/.mship-export"
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            return marker_arc in zf.namelist()
+    except (zipfile.BadZipFile, OSError):
+        return False
+
+
 def export_task(
     *,
     task: "Task",
@@ -580,6 +595,16 @@ def export_task(
     if format != "zip":
         raise ValueError(f"Unknown export format: {format!r} (use 'dir' or 'zip')")
 
+    # Only ever overwrite a zip WE created: refuse an existing same-named file
+    # that isn't a prior mship export (mirrors the directory marker guard, so
+    # an unrelated `<task>-export.zip` isn't silently clobbered). See Greptile.
+    zip_path = output_root / f"{bundle_name}.zip"
+    if zip_path.exists() and not _is_prior_export_zip(zip_path, bundle_name):
+        raise ValueError(
+            f"refusing to overwrite {zip_path}: it exists and is not a prior "
+            f"mship export (no .mship-export marker). Remove it or export elsewhere."
+        )
+
     with tempfile.TemporaryDirectory() as tmp:
         staging = Path(tmp) / bundle_name
         result = build_export_bundle(
@@ -587,7 +612,6 @@ def export_task(
             log_manager=log_manager, spec_store=spec_store,
             dest_dir=staging, redacted=redacted, home_dir=home_dir,
         )
-        zip_path = output_root / f"{bundle_name}.zip"
         with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
             for file_path in sorted(staging.rglob("*")):
                 if file_path.is_file():

--- a/src/mship/core/export.py
+++ b/src/mship/core/export.py
@@ -6,7 +6,7 @@ Two independent concerns live here:
 
 - Bundle assembly (`export_task` / `build_export_bundle`): pull a task's
   journal, bound spec, discovered plan doc, state slice, and per-repo
-  `base..branch` diffs from the sources that already own them (LogManager,
+  `base...branch` merge-base diffs from the sources that already own them (LogManager,
   SpecStore, StateManager-backed Task, git) and lay them out under
   `<task>-export/` (or zip that tree).
 - Redaction (`BUILTIN_PATTERNS` / `redact_text` / `load_user_patterns`): a
@@ -15,11 +15,12 @@ Two independent concerns live here:
 """
 from __future__ import annotations
 
-import concurrent.futures
 import json
 import re
+import shutil
 import subprocess
 import tempfile
+import threading
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -122,18 +123,33 @@ def _apply_pattern_safe(text: str, pattern: RedactionPattern) -> tuple[str, str 
     Bound it with a timeout instead of a blind `re.sub`: on timeout the text
     is left unredacted *for that one pattern* rather than the whole export
     hanging (see spec risks).
+
+    Uses a daemon thread + `join(timeout=...)` rather than a
+    `ThreadPoolExecutor` — the executor's `__exit__` does
+    `shutdown(wait=True)`, which blocks until the submitted task actually
+    finishes even after `future.result(timeout=...)` raised. A genuinely
+    hanging pattern (catastrophic backtracking, infinite loop) would then
+    hang the whole export despite the "timeout". A daemon thread has no such
+    join-on-exit: on timeout we abandon it (it dies with the process) and
+    return immediately.
     """
     if pattern.builtin:
         return _apply_pattern(text, pattern), None
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
-        fut = ex.submit(_apply_pattern, text, pattern)
-        try:
-            return fut.result(timeout=_CUSTOM_PATTERN_TIMEOUT_SECS), None
-        except concurrent.futures.TimeoutError:
-            return text, (
-                f"custom redact pattern timed out (kind={pattern.kind!r}); "
-                "left this artifact unredacted for that pattern"
-            )
+
+    result_box: dict[str, str] = {}
+
+    def _run() -> None:
+        result_box["result"] = _apply_pattern(text, pattern)
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    thread.join(timeout=_CUSTOM_PATTERN_TIMEOUT_SECS)
+    if thread.is_alive():
+        return text, (
+            f"custom redact pattern timed out (kind={pattern.kind!r}); "
+            "left this artifact unredacted for that pattern"
+        )
+    return result_box["result"], None
 
 
 def redact_text(text: str, patterns: list[RedactionPattern]) -> tuple[str, list[str]]:
@@ -246,7 +262,12 @@ def collect_repo_diff(task: "Task", repo_name: str, config: "WorkspaceConfig") -
     ) or task.base_branch or "main"
     try:
         result = subprocess.run(
-            ["git", "diff", f"{base}..{task.branch}"],
+            # Three-dot (merge-base) diff, not two-dot: exports only the task
+            # branch's own patch. A two-dot `base..branch` diff compares tree
+            # snapshots directly, so once `base` has advanced past the fork
+            # point it spuriously includes an "undo" of whatever landed on
+            # `base` afterward. See MOS-102 Greptile fix.
+            ["git", "diff", f"{base}...{task.branch}"],
             cwd=Path(worktree), capture_output=True, check=False,
         )
     except OSError:
@@ -261,15 +282,31 @@ def collect_repo_diff(task: "Task", repo_name: str, config: "WorkspaceConfig") -
 # Bundle assembly
 # ---------------------------------------------------------------------------
 
+def _plan_stem_matches_slug(stem: str, task_slug: str) -> bool:
+    """Precise match, not substring: either the stem IS the slug, or it's the
+    canonical `<YYYY-MM-DD>-<slug>.md` form. A bare `-<slug>` suffix (e.g.
+    'my-add.md' for slug 'add') deliberately does NOT match — that's still a
+    substring-style match in disguise, just anchored to the end instead of
+    anywhere, and would wrongly pick up unrelated docs prefixed with
+    another word (MOS-102 Greptile fix)."""
+    if stem == task_slug:
+        return True
+    escaped_slug = re.escape(task_slug)
+    return re.fullmatch(rf"\d{{4}}-\d{{2}}-\d{{2}}-{escaped_slug}", stem) is not None
+
+
 def discover_plan_path(workspace_root: Path, task_slug: str, docs_dir: str = "docs") -> Path | None:
-    """Best-effort plan-doc discovery: a `docs/plans/*.md` file whose filename
-    contains the task slug. v1 is intentionally exact-match-on-slug (no
-    fuzzy/similarity scoring, no explicit plan_path reference on Task) —
-    picks the most-recently-modified match when more than one file matches."""
+    """Best-effort plan-doc discovery: a `docs/plans/*.md` file whose stem
+    precisely matches the task slug (exact stem, or the canonical
+    `<date>-<slug>.md` form) — not merely containing the slug as a
+    substring, which would false-positive on a short slug like "add"
+    matching "add-labels.md". v1 has no fuzzy/similarity scoring and no
+    explicit plan_path reference on Task — picks the most-recently-modified
+    match when more than one file matches."""
     plans_dir = workspace_root / docs_dir / "plans"
     if not plans_dir.is_dir():
         return None
-    matches = [p for p in sorted(plans_dir.glob("*.md")) if task_slug in p.stem]
+    matches = [p for p in sorted(plans_dir.glob("*.md")) if _plan_stem_matches_slug(p.stem, task_slug)]
     if not matches:
         return None
     return max(matches, key=lambda p: p.stat().st_mtime)
@@ -301,15 +338,43 @@ def _render_journal(task_slug: str, entries: list) -> str:
     return "\n".join(lines)
 
 
-def _task_state_json(task: "Task") -> str:
-    """Serialize a task's state slice the same way StateManager persists it
-    (worktrees as plain strings, passive_repos sorted) so state.json matches
-    what's actually in state.yaml."""
+def _task_state_data(task: "Task") -> dict:
+    """A task's state slice as a plain JSON-serializable dict, the same shape
+    StateManager persists to state.yaml (worktrees as plain strings,
+    passive_repos sorted)."""
     data = task.model_dump(mode="json")
     data["worktrees"] = {k: str(v) for k, v in task.worktrees.items()}
     if "passive_repos" in data:
         data["passive_repos"] = sorted(data["passive_repos"])
-    return json.dumps(data, indent=2, sort_keys=False)
+    return data
+
+
+def _redact_json_leaves(value: object, patterns: list[RedactionPattern]) -> tuple[object, list[str]]:
+    """Recursively redact every string leaf of a JSON-serializable structure
+    (dict/list/str/anything else passed through), preserving its shape.
+
+    Used for state.json under `--redacted` instead of running `redact_text`
+    over the raw serialized JSON string: the built-in patterns' greedy value
+    groups (`env_secret`, `bearer_token`) aren't JSON-aware and would happily
+    swallow a closing quote/brace past the secret, producing invalid JSON.
+    Redacting each string value in isolation instead leaves every non-string
+    leaf and all JSON structure/delimiters untouched, so the result is
+    always valid JSON.
+    """
+    warnings: list[str] = []
+
+    def _walk(v: object) -> object:
+        if isinstance(v, str):
+            redacted, warns = redact_text(v, patterns)
+            warnings.extend(warns)
+            return redacted
+        if isinstance(v, dict):
+            return {k: _walk(sub) for k, sub in v.items()}
+        if isinstance(v, list):
+            return [_walk(sub) for sub in v]
+        return v
+
+    return _walk(value), warnings
 
 
 @dataclass(frozen=True)
@@ -332,10 +397,20 @@ def build_export_bundle(
     """Assemble the bundle directory tree at `dest_dir`. Never errors on a
     missing-but-optional artifact (AC8) — omits it instead.
 
-    Redaction (when `redacted`) covers journal.md, plan.md, spec.md, and
-    diffs/*.diff per the spec's Approach + AC3 (the bundle's TEXT artifacts);
-    state.json is a structured, mship-owned metadata slice, not scanned.
+    Redaction (when `redacted`) covers journal.md, plan.md, spec.md,
+    diffs/*.diff, and state.json. The text artifacts run through
+    `redact_text` directly; state.json is redacted leaf-by-leaf (see
+    `_redact_json_leaves`) so free-text fields like `description` /
+    `blocked_reason` don't leak secrets under `--redacted` while the file
+    stays valid JSON either way.
     """
+    # Clear any stale prior export at this path first — a `--format dir`
+    # export reusing an existing `<task>-export/` dir must not leave behind
+    # files this run no longer writes (e.g. a diff for a repo no longer
+    # ahead of base). The zip path stages into a fresh tempdir, so this is a
+    # no-op there. See MOS-102 Greptile fix.
+    if dest_dir.exists():
+        shutil.rmtree(dest_dir)
     dest_dir.mkdir(parents=True, exist_ok=True)
     warnings: list[str] = []
 
@@ -370,8 +445,13 @@ def build_export_bundle(
             from mship.core.spec_store import serialize_spec
             _write_text("spec.md", serialize_spec(spec))
 
-    # state.json — always faithful, never redacted (see docstring above).
-    (dest_dir / "state.json").write_text(_task_state_json(task))
+    # state.json — leaf-redacted under --redacted (see docstring above),
+    # otherwise a faithful copy.
+    state_data = _task_state_data(task)
+    if redacted:
+        state_data, warns = _redact_json_leaves(state_data, patterns)
+        warnings.extend(warns)
+    (dest_dir / "state.json").write_text(json.dumps(state_data, indent=2, sort_keys=False))
 
     # diffs/<repo>.diff (optional per repo)
     for repo_name in task.affected_repos:

--- a/src/mship/core/export.py
+++ b/src/mship/core/export.py
@@ -409,9 +409,21 @@ def build_export_bundle(
     # files this run no longer writes (e.g. a diff for a repo no longer
     # ahead of base). The zip path stages into a fresh tempdir, so this is a
     # no-op there. See MOS-102 Greptile fix.
+    #
+    # BUT only ever delete a directory WE created: gate the rmtree on our
+    # `.mship-export` marker. If `dest_dir` exists without the marker it's an
+    # unrelated directory the user happened to have at this path — refuse
+    # rather than silently `rmtree` their data (Greptile).
+    marker = dest_dir / ".mship-export"
     if dest_dir.exists():
+        if not marker.exists():
+            raise ValueError(
+                f"refusing to overwrite {dest_dir}: it exists and is not a prior "
+                f"mship export (no .mship-export marker). Remove it or export elsewhere."
+            )
         shutil.rmtree(dest_dir)
     dest_dir.mkdir(parents=True, exist_ok=True)
+    marker.write_text("")  # tag this dir as an mship export bundle (safe to clear next time)
     warnings: list[str] = []
 
     patterns: list[RedactionPattern] = []

--- a/src/mship/core/export.py
+++ b/src/mship/core/export.py
@@ -1,0 +1,435 @@
+"""`mship export` — bundle assembly (journal/plan/spec/state/diffs) plus an
+opt-in `--redacted` regex-based secret-scrubbing pass. See spec
+`mship-export-redacted-secret-redaction-mos-102` (MOS-102).
+
+Two independent concerns live here:
+
+- Bundle assembly (`export_task` / `build_export_bundle`): pull a task's
+  journal, bound spec, discovered plan doc, state slice, and per-repo
+  `base..branch` diffs from the sources that already own them (LogManager,
+  SpecStore, StateManager-backed Task, git) and lay them out under
+  `<task>-export/` (or zip that tree).
+- Redaction (`BUILTIN_PATTERNS` / `redact_text` / `load_user_patterns`): a
+  deterministic, regex-only pass applied only when `--redacted` is requested.
+  Never runs otherwise — plain `mship export` is a faithful copy.
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import re
+import subprocess
+import tempfile
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from mship.core.base_resolver import resolve_base
+
+if TYPE_CHECKING:
+    from mship.core.config import WorkspaceConfig
+    from mship.core.log import LogManager
+    from mship.core.spec_store import SpecStore
+    from mship.core.state import Task
+
+
+# ---------------------------------------------------------------------------
+# Redaction patterns (v1) — deterministic, regex-only. Mirrors the spec's
+# "Redaction patterns (v1)" section verbatim (regex source + whole-vs-value
+# decision). Anything not matching one of these shapes passes through
+# unredacted; this is not a general secrets-scanning tool.
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class RedactionPattern:
+    kind: str
+    regex: "re.Pattern[str]"
+    # "whole": the entire match becomes `<REDACTED:kind>`.
+    # "group": only `regex.span(value_group)` is replaced, so surrounding
+    # context (e.g. the `KEY=` prefix, the `Bearer ` scheme word) survives —
+    # keeps the artifact's shape legible, per the spec's own stated goal.
+    mode: Literal["whole", "group"] = "whole"
+    value_group: int = 1
+    # False for user-supplied patterns (mothership.yaml#redact.patterns /
+    # ~/.config/mship/redact.patterns) — those run under `_apply_pattern_safe`'s
+    # timeout guard since they're arbitrary regexes from a config file, not
+    # code we've reviewed. Built-in patterns are trusted and applied directly.
+    builtin: bool = True
+
+
+BUILTIN_PATTERNS: list[RedactionPattern] = [
+    # Private-key block runs first: non-greedy `[\s\S]*?` is linear-time (no
+    # catastrophic-backtracking risk), and redacting the whole PEM block
+    # before the smaller patterns run means base64 key material can't
+    # coincidentally trip e.g. the AWS or Stripe patterns.
+    RedactionPattern(
+        "private_key",
+        re.compile(r"-----BEGIN [A-Z ]+PRIVATE KEY-----[\s\S]*?-----END [A-Z ]+PRIVATE KEY-----"),
+    ),
+    RedactionPattern("stripe_live_key", re.compile(r"sk_live_[a-zA-Z0-9]+")),
+    RedactionPattern("stripe_test_key", re.compile(r"sk_test_[a-zA-Z0-9]+")),
+    RedactionPattern("github_token", re.compile(r"gh[pousr]_[A-Za-z0-9]{36}")),
+    RedactionPattern("aws_access_key_id", re.compile(r"AKIA[0-9A-Z]{16}")),
+    RedactionPattern(
+        "aws_secret_access_key",
+        # No required proximity to an AKIA... match (spec q4): any
+        # aws_secret_access_key assignment redacts, key id present or not.
+        re.compile(r"(?i)aws_secret_access_key\s*[:=]\s*['\"]?([A-Za-z0-9/+=]{40})['\"]?"),
+        mode="group", value_group=1,
+    ),
+    RedactionPattern(
+        "bearer_token",
+        # Value char class is intersected with "isn't already a marker" so a
+        # later pattern can never re-swallow an earlier one's
+        # `<REDACTED:kind>` output (patterns run in a fixed sequence, each a
+        # single pass — without this guard, a permissive \S+-style value
+        # group would happily re-match the previous marker text, since it
+        # has no whitespace either, clobbering the more specific kind).
+        re.compile(r"Bearer ((?:(?!<REDACTED:)[A-Za-z0-9._\-])+)"),
+        mode="group", value_group=1,
+    ),
+    RedactionPattern(
+        "env_secret",
+        re.compile(r"(?i)(API_KEY|SECRET|PASSWORD|TOKEN|CREDENTIAL)=((?:(?!<REDACTED:)\S)+)"),
+        mode="group", value_group=2,
+    ),
+]
+
+_CUSTOM_PATTERN_TIMEOUT_SECS = 2.0
+
+
+def _redacted_replacement(m: "re.Match[str]", pattern: RedactionPattern) -> str:
+    if pattern.mode == "whole":
+        return f"<REDACTED:{pattern.kind}>"
+    vstart, vend = m.span(pattern.value_group)
+    mstart, mend = m.span(0)
+    prefix = m.string[mstart:vstart]
+    suffix = m.string[vend:mend]
+    return f"{prefix}<REDACTED:{pattern.kind}>{suffix}"
+
+
+def _apply_pattern(text: str, pattern: RedactionPattern) -> str:
+    return pattern.regex.sub(lambda m: _redacted_replacement(m, pattern), text)
+
+
+def _apply_pattern_safe(text: str, pattern: RedactionPattern) -> tuple[str, str | None]:
+    """Apply one pattern; return (result, warning-or-None).
+
+    Built-in patterns are trusted and run directly. User-supplied patterns
+    (from `redact.patterns`) are arbitrary regexes from a config file — a
+    malformed-but-compilable or catastrophic one could hang `mship export`.
+    Bound it with a timeout instead of a blind `re.sub`: on timeout the text
+    is left unredacted *for that one pattern* rather than the whole export
+    hanging (see spec risks).
+    """
+    if pattern.builtin:
+        return _apply_pattern(text, pattern), None
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        fut = ex.submit(_apply_pattern, text, pattern)
+        try:
+            return fut.result(timeout=_CUSTOM_PATTERN_TIMEOUT_SECS), None
+        except concurrent.futures.TimeoutError:
+            return text, (
+                f"custom redact pattern timed out (kind={pattern.kind!r}); "
+                "left this artifact unredacted for that pattern"
+            )
+
+
+def redact_text(text: str, patterns: list[RedactionPattern]) -> tuple[str, list[str]]:
+    """Apply every pattern in order; return (redacted_text, warnings)."""
+    warnings: list[str] = []
+    for pattern in patterns:
+        text, warning = _apply_pattern_safe(text, pattern)
+        if warning:
+            warnings.append(warning)
+    return text, warnings
+
+
+# ---------------------------------------------------------------------------
+# User-configured patterns (optional; unioned with BUILTIN_PATTERNS when
+# --redacted is passed and the source exists).
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class LoadedPatterns:
+    patterns: list[RedactionPattern]
+    warnings: list[str]
+
+
+def load_user_patterns(config: "WorkspaceConfig", *, home_dir: Path | None = None) -> LoadedPatterns:
+    """Load `~/.config/mship/redact.patterns` (one regex per line) and/or
+    `mothership.yaml#redact.patterns`. Missing sources are silently skipped —
+    export works unchanged when neither is present. Invalid regexes are
+    skipped with a warning rather than raising (basic validation; see spec
+    risk on arbitrary user regexes)."""
+    home_dir = home_dir if home_dir is not None else Path.home()
+    patterns: list[RedactionPattern] = []
+    warnings: list[str] = []
+
+    user_file = home_dir / ".config" / "mship" / "redact.patterns"
+    if user_file.is_file():
+        for line in user_file.read_text().splitlines():
+            raw = line.strip()
+            if not raw or raw.startswith("#"):
+                continue
+            try:
+                compiled = re.compile(raw)
+            except re.error as e:
+                warnings.append(f"Skipped invalid pattern in {user_file}: {raw!r} ({e})")
+                continue
+            patterns.append(RedactionPattern("custom", compiled, builtin=False))
+
+    redact_cfg = getattr(config, "redact", None)
+    if redact_cfg is not None:
+        for entry in redact_cfg.patterns:
+            try:
+                compiled = re.compile(entry.pattern)
+            except re.error as e:
+                warnings.append(
+                    f"Skipped invalid mothership.yaml redact pattern {entry.pattern!r}: {e}"
+                )
+                continue
+            patterns.append(RedactionPattern(entry.name or "custom", compiled, builtin=False))
+
+    return LoadedPatterns(patterns=patterns, warnings=warnings)
+
+
+# ---------------------------------------------------------------------------
+# Diff assembly + binary-safe redaction over a per-repo diff blob.
+# ---------------------------------------------------------------------------
+
+_BINARY_MARKERS = ("Binary files ", "GIT binary patch")
+
+
+def _chunk_is_binary(chunk: str) -> bool:
+    return any(marker in chunk for marker in _BINARY_MARKERS) or "\0" in chunk
+
+
+def _split_diff_chunks(diff_text: str) -> list[str]:
+    """Split a `git diff` blob into per-file chunks (each `diff --git ...`)."""
+    from mship.core.view.diff_sources import split_diff_by_file
+
+    chunks = [f.body for f in split_diff_by_file(diff_text)]
+    return chunks if chunks else ([diff_text] if diff_text else [])
+
+
+def redact_diff_text(diff_text: str, patterns: list[RedactionPattern]) -> tuple[str, list[str]]:
+    """Redact a combined per-repo diff, skipping binary chunks untouched (AC6)."""
+    warnings: list[str] = []
+    out: list[str] = []
+    for chunk in _split_diff_chunks(diff_text):
+        if _chunk_is_binary(chunk):
+            out.append(chunk)
+            continue
+        redacted_chunk, warns = redact_text(chunk, patterns)
+        warnings.extend(warns)
+        out.append(redacted_chunk)
+    return "".join(out), warnings
+
+
+def collect_repo_diff(task: "Task", repo_name: str, config: "WorkspaceConfig") -> str | None:
+    """Return the `base..branch` diff for one affected repo, or None.
+
+    None covers every "nothing to bundle" case (no worktree recorded for
+    this repo, base ref unresolvable, git failure, or simply no commits on
+    the task branch relative to base) — export omits the file rather than
+    erroring (AC8).
+    """
+    worktree = task.worktrees.get(repo_name)
+    if worktree is None:
+        return None
+    repo_config = config.repos.get(repo_name)
+    base = resolve_base(
+        repo_name, repo_config, cli_base=None, base_map={},
+        known_repos=config.repos.keys(), task_base=task.base_override,
+    ) or task.base_branch or "main"
+    try:
+        result = subprocess.run(
+            ["git", "diff", f"{base}..{task.branch}"],
+            cwd=Path(worktree), capture_output=True, check=False,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    text = result.stdout.decode("utf-8", errors="replace")
+    return text if text.strip() else None
+
+
+# ---------------------------------------------------------------------------
+# Bundle assembly
+# ---------------------------------------------------------------------------
+
+def discover_plan_path(workspace_root: Path, task_slug: str, docs_dir: str = "docs") -> Path | None:
+    """Best-effort plan-doc discovery: a `docs/plans/*.md` file whose filename
+    contains the task slug. v1 is intentionally exact-match-on-slug (no
+    fuzzy/similarity scoring, no explicit plan_path reference on Task) —
+    picks the most-recently-modified match when more than one file matches."""
+    plans_dir = workspace_root / docs_dir / "plans"
+    if not plans_dir.is_dir():
+        return None
+    matches = [p for p in sorted(plans_dir.glob("*.md")) if task_slug in p.stem]
+    if not matches:
+        return None
+    return max(matches, key=lambda p: p.stat().st_mtime)
+
+
+def _render_journal(task_slug: str, entries: list) -> str:
+    lines = [f"# Task Journal: {task_slug}", ""]
+    if not entries:
+        lines.append("(no journal entries)")
+        return "\n".join(lines) + "\n"
+    for e in entries:
+        lines.append(f"## {e.timestamp.strftime('%Y-%m-%dT%H:%M:%SZ')}")
+        meta = []
+        if e.repo:
+            meta.append(f"repo={e.repo}")
+        if e.iteration is not None:
+            meta.append(f"iteration={e.iteration}")
+        if e.test_state:
+            meta.append(f"test_state={e.test_state}")
+        if e.action:
+            meta.append(f"action={e.action}")
+        if e.open_question:
+            meta.append(f"open_question={e.open_question}")
+        if meta:
+            lines.append(", ".join(meta))
+        lines.append("")
+        lines.append(e.message)
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _task_state_json(task: "Task") -> str:
+    """Serialize a task's state slice the same way StateManager persists it
+    (worktrees as plain strings, passive_repos sorted) so state.json matches
+    what's actually in state.yaml."""
+    data = task.model_dump(mode="json")
+    data["worktrees"] = {k: str(v) for k, v in task.worktrees.items()}
+    if "passive_repos" in data:
+        data["passive_repos"] = sorted(data["passive_repos"])
+    return json.dumps(data, indent=2, sort_keys=False)
+
+
+@dataclass(frozen=True)
+class ExportBundle:
+    bundle_path: Path
+    warnings: list[str] = field(default_factory=list)
+
+
+def build_export_bundle(
+    *,
+    task: "Task",
+    config: "WorkspaceConfig",
+    workspace_root: Path,
+    log_manager: "LogManager",
+    spec_store: "SpecStore",
+    dest_dir: Path,
+    redacted: bool,
+    home_dir: Path | None = None,
+) -> ExportBundle:
+    """Assemble the bundle directory tree at `dest_dir`. Never errors on a
+    missing-but-optional artifact (AC8) — omits it instead.
+
+    Redaction (when `redacted`) covers journal.md, plan.md, spec.md, and
+    diffs/*.diff per the spec's Approach + AC3 (the bundle's TEXT artifacts);
+    state.json is a structured, mship-owned metadata slice, not scanned.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    warnings: list[str] = []
+
+    patterns: list[RedactionPattern] = []
+    if redacted:
+        patterns = list(BUILTIN_PATTERNS)
+        loaded = load_user_patterns(config, home_dir=home_dir)
+        patterns.extend(loaded.patterns)
+        warnings.extend(loaded.warnings)
+
+    def _write_text(rel_path: str, content: str) -> None:
+        path = dest_dir / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if redacted:
+            content, warns = redact_text(content, patterns)
+            warnings.extend(warns)
+        path.write_text(content)
+
+    # journal.md
+    entries = log_manager.read(task.slug)
+    _write_text("journal.md", _render_journal(task.slug, entries))
+
+    # plan.md (optional)
+    plan_path = discover_plan_path(workspace_root, task.slug, docs_dir=config.docs_dir)
+    if plan_path is not None:
+        _write_text("plan.md", plan_path.read_text())
+
+    # spec.md (optional)
+    if task.spec_id:
+        spec = spec_store.find_by_id(task.spec_id)
+        if spec is not None:
+            from mship.core.spec_store import serialize_spec
+            _write_text("spec.md", serialize_spec(spec))
+
+    # state.json — always faithful, never redacted (see docstring above).
+    (dest_dir / "state.json").write_text(_task_state_json(task))
+
+    # diffs/<repo>.diff (optional per repo)
+    for repo_name in task.affected_repos:
+        diff_text = collect_repo_diff(task, repo_name, config)
+        if diff_text is None:
+            continue
+        if redacted:
+            diff_text, warns = redact_diff_text(diff_text, patterns)
+            warnings.extend(warns)
+        diff_path = dest_dir / "diffs" / f"{repo_name}.diff"
+        diff_path.parent.mkdir(parents=True, exist_ok=True)
+        diff_path.write_text(diff_text)
+
+    return ExportBundle(bundle_path=dest_dir, warnings=warnings)
+
+
+def export_task(
+    *,
+    task: "Task",
+    config: "WorkspaceConfig",
+    workspace_root: Path,
+    log_manager: "LogManager",
+    spec_store: "SpecStore",
+    redacted: bool = False,
+    format: Literal["dir", "zip"] = "dir",
+    output_root: Path | None = None,
+    home_dir: Path | None = None,
+) -> ExportBundle:
+    """Top-level `mship export` entry point: assemble the bundle, then either
+    leave it as a directory (`format="dir"`, the default) or zip it
+    (`format="zip"`). Both write into `output_root` (default: cwd) as
+    `<task-slug>-export/` or `<task-slug>-export.zip`.
+    """
+    output_root = output_root if output_root is not None else Path.cwd()
+    bundle_name = f"{task.slug}-export"
+
+    if format == "dir":
+        return build_export_bundle(
+            task=task, config=config, workspace_root=workspace_root,
+            log_manager=log_manager, spec_store=spec_store,
+            dest_dir=output_root / bundle_name, redacted=redacted,
+            home_dir=home_dir,
+        )
+
+    if format != "zip":
+        raise ValueError(f"Unknown export format: {format!r} (use 'dir' or 'zip')")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        staging = Path(tmp) / bundle_name
+        result = build_export_bundle(
+            task=task, config=config, workspace_root=workspace_root,
+            log_manager=log_manager, spec_store=spec_store,
+            dest_dir=staging, redacted=redacted, home_dir=home_dir,
+        )
+        zip_path = output_root / f"{bundle_name}.zip"
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for file_path in sorted(staging.rglob("*")):
+                if file_path.is_file():
+                    arcname = Path(bundle_name) / file_path.relative_to(staging)
+                    zf.write(file_path, arcname)
+        return ExportBundle(bundle_path=zip_path, warnings=result.warnings)

--- a/tests/cli/test_export.py
+++ b/tests/cli/test_export.py
@@ -1,0 +1,165 @@
+"""CLI tests for `mship export` (MOS-102)."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import zipfile
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.state import StateManager
+
+runner = CliRunner()
+
+_GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+def _setup(ws: Path):
+    container.config_path.override(ws / "mothership.yaml")
+    container.state_dir.override(ws / ".mothership")
+
+
+def _teardown():
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset()
+    container.state_manager.reset()
+    container.log_manager.reset()
+
+
+def _commit(repo_dir: Path, filename: str, content: str, message: str):
+    (repo_dir / filename).write_text(content)
+    subprocess.run(["git", "add", "."], cwd=repo_dir, check=True, capture_output=True, env=_GIT_ENV)
+    subprocess.run(["git", "commit", "-m", message], cwd=repo_dir, check=True, capture_output=True, env=_GIT_ENV)
+
+
+def test_export_creates_dir_bundle_with_journal_and_state(workspace_with_git, monkeypatch):
+    _setup(workspace_with_git)
+    try:
+        r = runner.invoke(app, ["spawn", "--hotfix", "add labels", "--repos", "shared", "--force-audit"])
+        assert r.exit_code == 0, r.output
+        runner.invoke(app, ["journal", "made progress", "--task", "add-labels"])
+
+        monkeypatch.chdir(workspace_with_git)
+        result = runner.invoke(app, ["export", "--task", "add-labels"])
+        assert result.exit_code == 0, result.output
+
+        bundle = workspace_with_git / "add-labels-export"
+        assert bundle.is_dir()
+        assert "made progress" in (bundle / "journal.md").read_text()
+        state = json.loads((bundle / "state.json").read_text())
+        assert state["slug"] == "add-labels"
+        assert not (bundle / "spec.md").exists()
+        assert not (bundle / "plan.md").exists()
+    finally:
+        _teardown()
+
+
+def test_export_format_zip(workspace_with_git, monkeypatch):
+    _setup(workspace_with_git)
+    try:
+        runner.invoke(app, ["spawn", "--hotfix", "zip export", "--repos", "shared", "--force-audit"])
+        monkeypatch.chdir(workspace_with_git)
+        result = runner.invoke(app, ["export", "--task", "zip-export", "--format", "zip"])
+        assert result.exit_code == 0, result.output
+
+        zip_path = workspace_with_git / "zip-export-export.zip"
+        assert zip_path.is_file()
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+            assert "zip-export-export/journal.md" in names
+            assert "zip-export-export/state.json" in names
+    finally:
+        _teardown()
+
+
+def test_export_invalid_format_errors(workspace_with_git, monkeypatch):
+    _setup(workspace_with_git)
+    try:
+        runner.invoke(app, ["spawn", "--hotfix", "bad format", "--repos", "shared", "--force-audit"])
+        monkeypatch.chdir(workspace_with_git)
+        result = runner.invoke(app, ["export", "--task", "bad-format", "--format", "yaml"])
+        assert result.exit_code != 0
+        assert "format" in result.output.lower()
+        assert not (workspace_with_git / "bad-format-export").exists()
+    finally:
+        _teardown()
+
+
+def test_export_redacted_scrubs_planted_secret(workspace_with_git, monkeypatch):
+    _setup(workspace_with_git)
+    try:
+        runner.invoke(app, ["spawn", "--hotfix", "redacted export", "--repos", "shared", "--force-audit"])
+        runner.invoke(
+            app,
+            ["journal", "leaked API_KEY=abcdef123456 in a paste",
+             "--task", "redacted-export"],
+        )
+        monkeypatch.chdir(workspace_with_git)
+
+        result = runner.invoke(app, ["export", "--task", "redacted-export", "--redacted"])
+        assert result.exit_code == 0, result.output
+        journal = (workspace_with_git / "redacted-export-export" / "journal.md").read_text()
+        assert "abcdef123456" not in journal
+        assert "<REDACTED:env_secret>" in journal
+    finally:
+        _teardown()
+
+
+def test_export_without_redacted_is_faithful(workspace_with_git, monkeypatch):
+    _setup(workspace_with_git)
+    try:
+        runner.invoke(app, ["spawn", "--hotfix", "faithful export", "--repos", "shared", "--force-audit"])
+        runner.invoke(
+            app,
+            ["journal", "leaked API_KEY=abcdef123456 in a paste",
+             "--task", "faithful-export"],
+        )
+        monkeypatch.chdir(workspace_with_git)
+
+        result = runner.invoke(app, ["export", "--task", "faithful-export"])
+        assert result.exit_code == 0, result.output
+        journal = (workspace_with_git / "faithful-export-export" / "journal.md").read_text()
+        assert "API_KEY=abcdef123456" in journal
+    finally:
+        _teardown()
+
+
+def test_export_includes_diff_for_repo_with_commits_omits_repo_without(workspace_with_git, monkeypatch):
+    _setup(workspace_with_git)
+    try:
+        runner.invoke(
+            app, ["spawn", "--hotfix", "multi repo export", "--repos", "shared,auth-service",
+                  "--force-audit"],
+        )
+        state = StateManager(workspace_with_git / ".mothership").load()
+        task = state.tasks["multi-repo-export"]
+        shared_wt = Path(task.worktrees["shared"])
+        _commit(shared_wt, "secret.env", "API_KEY=abcdef123456\n", "add secret file")
+
+        monkeypatch.chdir(workspace_with_git)
+        result = runner.invoke(app, ["export", "--task", "multi-repo-export"])
+        assert result.exit_code == 0, result.output
+
+        bundle = workspace_with_git / "multi-repo-export-export"
+        assert (bundle / "diffs" / "shared.diff").is_file()
+        assert "API_KEY=abcdef123456" in (bundle / "diffs" / "shared.diff").read_text()
+        assert not (bundle / "diffs" / "auth-service.diff").exists()
+    finally:
+        _teardown()
+
+
+def test_export_no_active_task_errors(workspace_with_git):
+    _setup(workspace_with_git)
+    try:
+        result = runner.invoke(app, ["export"])
+        assert result.exit_code != 0
+    finally:
+        _teardown()

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -805,3 +805,23 @@ def test_repo_without_capture_defaults_none(tmp_path):
     )
     config = ConfigLoader.load(cfg, require_paths=False)
     assert config.repos["app"].capture is None
+
+
+def test_redact_null_patterns_coerces_to_empty_list(tmp_path):
+    """`redact:\\n  patterns:` (no list under the key) parses as YAML null,
+    not an omitted key — must coerce to `[]` rather than fail pydantic list
+    validation and error the whole config load (MOS-102 Greptile fix)."""
+    from mship.core.config import ConfigLoader
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\n"
+        "redact:\n"
+        "  patterns:\n"
+        "repos:\n"
+        "  app:\n"
+        "    path: ./app\n"
+        "    type: service\n"
+    )
+    config = ConfigLoader.load(cfg, require_paths=False)
+    assert config.redact is not None
+    assert config.redact.patterns == []

--- a/tests/core/test_export.py
+++ b/tests/core/test_export.py
@@ -515,6 +515,7 @@ def test_bundle_clears_stale_files_from_a_prior_export(bundle_env, tmp_path):
     Greptile fix)."""
     dest = tmp_path / "out"
     dest.mkdir(parents=True)
+    (dest / ".mship-export").write_text("")  # a genuine prior export carries this marker
     stale = dest / "stale-leftover.txt"
     stale.write_text("from a previous export run")
     stale_diff = dest / "diffs" / "some-old-repo.diff"
@@ -531,6 +532,26 @@ def test_bundle_clears_stale_files_from_a_prior_export(bundle_env, tmp_path):
     assert not stale_diff.exists()
     # This run's own artifacts still land normally.
     assert (dest / "journal.md").is_file()
+
+
+def test_bundle_refuses_to_overwrite_non_export_dir(bundle_env, tmp_path):
+    """The stale-clear must never rmtree a directory mship didn't create: if
+    `dest_dir` exists WITHOUT the `.mship-export` marker (an unrelated dir the
+    user happened to have at this path), refuse rather than delete their data
+    (Greptile)."""
+    dest = tmp_path / "out"
+    dest.mkdir(parents=True)
+    precious = dest / "precious.txt"
+    precious.write_text("do not delete me")
+
+    with pytest.raises(ValueError, match="refusing to overwrite"):
+        build_export_bundle(
+            task=bundle_env["task"], config=bundle_env["config"],
+            workspace_root=bundle_env["workspace_root"],
+            log_manager=bundle_env["log_manager"], spec_store=bundle_env["spec_store"],
+            dest_dir=dest, redacted=False,
+        )
+    assert precious.exists()  # the user's data is untouched
 
 
 def test_unredacted_export_is_faithful(bundle_env, tmp_path):

--- a/tests/core/test_export.py
+++ b/tests/core/test_export.py
@@ -189,6 +189,45 @@ def test_chunk_is_binary_detects_markers():
     assert not export_mod._chunk_is_binary("+some text change\n")
 
 
+def test_chunk_is_binary_only_matches_marker_at_line_start_not_mid_line():
+    """A text file can legitimately add a line that merely *mentions* the
+    phrase 'Binary files ' or 'GIT binary patch' as ordinary content (e.g. a
+    comment about git internals) sitting next to a real secret. The chunk
+    must not be mistaken for git's own binary-diff marker line just because
+    the phrase appears somewhere in the chunk body — only a line that
+    actually STARTS WITH the marker (how git emits it) counts (MOS-102
+    Greptile fix: 'Text Diff Bypasses Redaction')."""
+    chunk = (
+        "diff --git a/notes.py b/notes.py\n"
+        "index 111..222 100644\n"
+        "--- a/notes.py\n"
+        "+++ b/notes.py\n"
+        "@@ -1 +1,2 @@\n"
+        "+# see also: Binary files can appear here too\n"
+        "+API_KEY=abcdef123456\n"
+    )
+    assert not export_mod._chunk_is_binary(chunk)
+
+
+def test_redact_diff_text_redacts_secret_next_to_binary_marker_phrase_as_content():
+    """End-to-end regression for the same bug via redact_diff_text: before
+    the fix, this whole chunk was wrongly classified as binary and copied
+    through unredacted, leaking the secret into a '--redacted' bundle."""
+    diff_text = (
+        "diff --git a/notes.py b/notes.py\n"
+        "index 111..222 100644\n"
+        "--- a/notes.py\n"
+        "+++ b/notes.py\n"
+        "@@ -1 +1,2 @@\n"
+        "+# see also: Binary files can appear here too\n"
+        "+API_KEY=abcdef123456\n"
+    )
+    result, warnings = redact_diff_text(diff_text, BUILTIN_PATTERNS)
+    assert "API_KEY=<REDACTED:env_secret>" in result
+    assert "abcdef123456" not in result
+    assert warnings == []
+
+
 # --------------------------------------------------------------------------
 # User-configured patterns (optional; MOS-102 AC7)
 # --------------------------------------------------------------------------
@@ -440,6 +479,49 @@ def test_collect_repo_diff_none_on_unresolvable_base(workspace_with_git):
     assert collect_repo_diff(task, "shared", config) is None
 
 
+def test_collect_repo_diff_never_falls_back_to_hardcoded_main(workspace_with_git):
+    """If neither the repo config's `base_branch`, a `--base` override, nor
+    `task.base_branch` gives a base, export must skip this repo's diff (and
+    warn) rather than silently assuming "main". A hardcoded "main" fallback
+    can hit an unrelated same-named branch and produce a materially wrong
+    diff instead of erring on the side of omitting it — the documented AC8
+    behavior for an unresolvable base (MOS-102 Greptile fix: "Default Base
+    Becomes Main")."""
+    repo_dir = workspace_with_git / "shared"
+    _sh("git", "checkout", "-b", "develop", cwd=repo_dir)
+    (repo_dir / "develop-baseline.txt").write_text("develop baseline\n")
+    _sh("git", "add", "develop-baseline.txt", cwd=repo_dir)
+    _sh("git", "commit", "-m", "develop baseline", cwd=repo_dir)
+
+    _sh("git", "checkout", "-b", "feat/x", cwd=repo_dir)
+    (repo_dir / "task-change.txt").write_text("task branch work\n")
+    _sh("git", "add", "task-change.txt", cwd=repo_dir)
+    _sh("git", "commit", "-m", "task branch change", cwd=repo_dir)
+
+    config = ConfigLoader.load(workspace_with_git / "mothership.yaml")
+    config.repos["shared"].base_branch = None  # not configured for this repo
+    task = _make_task(worktrees={"shared": repo_dir}, branch="feat/x", base_branch=None)
+
+    warnings: list[str] = []
+    diff = collect_repo_diff(task, "shared", config, warnings=warnings)
+    # Must NOT silently diff against the fixture's literal "main" branch
+    # (the real fork point is "develop") — that would spuriously include
+    # develop-baseline.txt or otherwise misrepresent the task's own patch.
+    assert diff is None
+    assert any("shared" in w and "base" in w for w in warnings)
+
+
+def test_collect_repo_diff_warnings_kwarg_defaults_to_no_collection(workspace_with_git):
+    """Callers that don't care about warnings (existing call sites/tests)
+    keep working unchanged — `warnings` is optional and a no-op when
+    omitted."""
+    repo_dir = workspace_with_git / "shared"
+    config = ConfigLoader.load(workspace_with_git / "mothership.yaml")
+    config.repos["shared"].base_branch = None
+    task = _make_task(worktrees={"shared": repo_dir}, branch="feat/x", base_branch=None)
+    assert collect_repo_diff(task, "shared", config) is None
+
+
 # --------------------------------------------------------------------------
 # build_export_bundle / export_task — full assembly (AC1, AC2, AC5, AC8)
 # --------------------------------------------------------------------------
@@ -662,6 +744,34 @@ def test_bundle_omits_missing_optional_artifacts(workspace_with_git, tmp_path):
     assert not (dest / "diffs" / "auth-service.diff").exists()
     assert not (dest / "diffs" / "shared.diff").exists()  # branch == main: no commits ahead
     assert result.warnings == []
+
+
+def test_bundle_surfaces_warning_when_a_repo_base_is_unresolvable(workspace_with_git, tmp_path):
+    """build_export_bundle propagates collect_repo_diff's unresolvable-base
+    warning into ExportBundle.warnings (surfaced by the CLI as `output.warning`)
+    instead of silently guessing a base (MOS-102 Greptile fix)."""
+    repo_dir = workspace_with_git / "shared"
+    _sh("git", "checkout", "-b", "feat/x", cwd=repo_dir)
+    (repo_dir / "task-change.txt").write_text("task branch work\n")
+    _sh("git", "add", "task-change.txt", cwd=repo_dir)
+    _sh("git", "commit", "-m", "task branch change", cwd=repo_dir)
+
+    state_dir = tmp_path / "state"
+    log_mgr = LogManager(state_dir / "logs")
+    log_mgr.create("no-base")
+    spec_store = SpecStore(workspace_with_git / "specs")
+    config = ConfigLoader.load(workspace_with_git / "mothership.yaml")
+    config.repos["shared"].base_branch = None
+    task = _make_task(
+        slug="no-base", branch="feat/x", worktrees={"shared": repo_dir}, base_branch=None,
+    )
+    dest = tmp_path / "out"
+    result = build_export_bundle(
+        task=task, config=config, workspace_root=workspace_with_git,
+        log_manager=log_mgr, spec_store=spec_store, dest_dir=dest, redacted=False,
+    )
+    assert not (dest / "diffs" / "shared.diff").exists()
+    assert any("shared" in w and "base" in w for w in result.warnings)
 
 
 # --------------------------------------------------------------------------

--- a/tests/core/test_export.py
+++ b/tests/core/test_export.py
@@ -253,6 +253,43 @@ def test_apply_pattern_safe_timeout_leaves_text_unredacted(monkeypatch):
     assert "timed out" in warning
 
 
+def test_apply_pattern_safe_never_returning_regex_does_not_hang(monkeypatch):
+    """A catastrophic custom pattern whose `.sub()` never returns (runaway
+    backtracking / infinite loop) must not hang export — the timeout guard
+    has to abandon the thread rather than join/shutdown(wait=True) on it.
+
+    Run the call on a side thread with a real wall-clock join timeout so a
+    regression (the old ThreadPoolExecutor `__exit__` blocking forever)
+    surfaces as a failed assertion instead of hanging the whole test run.
+    """
+    import threading
+
+    class _HangingRegex:
+        def sub(self, repl, text):
+            threading.Event().wait()  # never returns
+            return text  # unreachable
+
+    monkeypatch.setattr(export_mod, "_CUSTOM_PATTERN_TIMEOUT_SECS", 0.05)
+    pattern = RedactionPattern("custom", _HangingRegex(), builtin=False)
+
+    outcome: dict = {}
+
+    def _call():
+        outcome["value"] = export_mod._apply_pattern_safe("hello world", pattern)
+
+    caller = threading.Thread(target=_call, daemon=True)
+    caller.start()
+    caller.join(timeout=5.0)  # generous margin over the 0.05s internal timeout
+    assert not caller.is_alive(), (
+        "_apply_pattern_safe hung past its own timeout — a catastrophic "
+        "custom pattern must not block export"
+    )
+    result, warning = outcome["value"]
+    assert result == "hello world"
+    assert warning is not None
+    assert "timed out" in warning
+
+
 # --------------------------------------------------------------------------
 # Plan-doc discovery (v1: exact slug-in-filename match)
 # --------------------------------------------------------------------------
@@ -279,10 +316,15 @@ def test_discover_plan_path_no_match_returns_none(tmp_path):
 
 
 def test_discover_plan_path_picks_newest_on_multiple_matches(tmp_path):
+    """Two docs both in the canonical `<date>-<slug>.md` form (re-planned on
+    a different day) — pick the most-recently-modified. Note: a versioned
+    suffix like '-v1'/'-v2' after the slug is deliberately NOT a match under
+    the precise-match rule (MOS-102 Greptile fix) — only exact-stem or
+    exact `<date>-<slug>` qualifies."""
     plans = tmp_path / "docs" / "plans"
     plans.mkdir(parents=True)
-    older = plans / "2026-01-01-add-labels-v1.md"
-    newer = plans / "2026-02-01-add-labels-v2.md"
+    older = plans / "2026-01-01-add-labels.md"
+    newer = plans / "2026-02-01-add-labels.md"
     older.write_text("old")
     newer.write_text("new")
     now = time.time()
@@ -299,6 +341,30 @@ def test_discover_plan_path_honors_custom_docs_dir(tmp_path):
     assert discover_plan_path(tmp_path, "add-labels", docs_dir="docs") is None
     found = discover_plan_path(tmp_path, "add-labels", docs_dir="documentation")
     assert found is not None
+
+
+def test_discover_plan_path_short_slug_precise_match_not_substring(tmp_path):
+    """A short slug like 'add' must not match by substring — 'add-labels.md'
+    contains 'add' but isn't a plan for the 'add' task. Only an exact stem
+    match or the canonical `<date>-<slug>.md` form should match; a bare
+    `-<slug>` suffix (e.g. 'my-add.md') must also be rejected (MOS-102
+    Greptile fix)."""
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "add-labels.md").write_text("wrong: substring match")
+    (plans / "my-add.md").write_text("wrong: suffix match")
+    assert discover_plan_path(tmp_path, "add") is None
+
+    (plans / "add.md").write_text("right: exact stem")
+    found = discover_plan_path(tmp_path, "add")
+    assert found is not None
+    assert found.name == "add.md"
+
+    (plans / "add.md").unlink()
+    (plans / "2026-07-11-add.md").write_text("right: canonical dated form")
+    found = discover_plan_path(tmp_path, "add")
+    assert found is not None
+    assert found.name == "2026-07-11-add.md"
 
 
 # --------------------------------------------------------------------------
@@ -318,6 +384,37 @@ def test_collect_repo_diff_returns_diff_with_commits_ahead(workspace_with_git):
     assert diff is not None
     assert "API_KEY=abcdef123456" in diff
     assert "secret.env" in diff
+
+
+def test_collect_repo_diff_excludes_mainline_only_changes_past_fork_point(workspace_with_git):
+    """Three-dot (merge-base) diff, not two-dot: once `base` has advanced past
+    where the task branch forked, the export diff must contain only the task
+    branch's own commits — not a spurious removal of whatever landed on
+    `base` afterward (which a straight `base..branch` two-dot diff would
+    include, since it compares tree snapshots directly rather than from the
+    merge-base) (MOS-102 Greptile fix)."""
+    repo_dir = workspace_with_git / "shared"
+    _sh("git", "checkout", "-b", "feat/x", cwd=repo_dir)
+    (repo_dir / "task-change.txt").write_text("task branch work\n")
+    # Add only the new file (not `.`) — Taskfile.yml is deliberately left
+    # untracked by the fixture's `--allow-empty` init commit; committing it
+    # here would make `git checkout main` below delete it from the working
+    # tree (main's tree wouldn't have it), breaking ConfigLoader.load.
+    _sh("git", "add", "task-change.txt", cwd=repo_dir)
+    _sh("git", "commit", "-m", "task branch change", cwd=repo_dir)
+
+    # Advance base (main) past the fork point with a mainline-only commit.
+    _sh("git", "checkout", "main", cwd=repo_dir)
+    (repo_dir / "mainline-change.txt").write_text("mainline-only work\n")
+    _sh("git", "add", "mainline-change.txt", cwd=repo_dir)
+    _sh("git", "commit", "-m", "mainline-only change", cwd=repo_dir)
+
+    config = ConfigLoader.load(workspace_with_git / "mothership.yaml")
+    task = _make_task(worktrees={"shared": repo_dir}, branch="feat/x")
+    diff = collect_repo_diff(task, "shared", config)
+    assert diff is not None
+    assert "task-change.txt" in diff
+    assert "mainline-change.txt" not in diff
 
 
 def test_collect_repo_diff_none_when_no_worktree(workspace_with_git):
@@ -379,7 +476,11 @@ def bundle_env(workspace_with_git, tmp_path):
     config = ConfigLoader.load(workspace_with_git / "mothership.yaml")
     task = _make_task(
         worktrees={"shared": repo_dir}, branch="feat/add-labels", spec_id="add-labels",
-        description="task description with API_KEY=taskdescsecret123",
+        description=(
+            "task description with API_KEY=taskdescsecret123 and "
+            "ghp_" + "d" * 36
+        ),
+        blocked_reason="waiting on API_KEY=blockedreasonsecret789",
     )
     return {
         "workspace_root": workspace_with_git,
@@ -406,6 +507,32 @@ def test_bundle_contains_all_expected_artifacts(bundle_env, tmp_path):
     assert (dest / "diffs" / "shared.diff").is_file()
 
 
+def test_bundle_clears_stale_files_from_a_prior_export(bundle_env, tmp_path):
+    """A `--format dir` export reusing an existing `<task>-export/` dir must
+    not leave behind files this run no longer writes (e.g. a diff for a repo
+    that no longer has commits ahead, or an unrelated leftover file) — the
+    dest dir is cleared before this run's files are written (MOS-102
+    Greptile fix)."""
+    dest = tmp_path / "out"
+    dest.mkdir(parents=True)
+    stale = dest / "stale-leftover.txt"
+    stale.write_text("from a previous export run")
+    stale_diff = dest / "diffs" / "some-old-repo.diff"
+    stale_diff.parent.mkdir(parents=True)
+    stale_diff.write_text("stale diff")
+
+    build_export_bundle(
+        task=bundle_env["task"], config=bundle_env["config"],
+        workspace_root=bundle_env["workspace_root"],
+        log_manager=bundle_env["log_manager"], spec_store=bundle_env["spec_store"],
+        dest_dir=dest, redacted=False,
+    )
+    assert not stale.exists()
+    assert not stale_diff.exists()
+    # This run's own artifacts still land normally.
+    assert (dest / "journal.md").is_file()
+
+
 def test_unredacted_export_is_faithful(bundle_env, tmp_path):
     """Without --redacted, every planted secret survives unchanged (AC5)."""
     dest = tmp_path / "out"
@@ -419,7 +546,10 @@ def test_unredacted_export_is_faithful(bundle_env, tmp_path):
     assert "sk_live_SPECSECRET123" in (dest / "spec.md").read_text()
     assert "ghp_" + "c" * 36 in (dest / "plan.md").read_text()
     assert "API_KEY=abcdef123456" in (dest / "diffs" / "shared.diff").read_text()
-    assert "API_KEY=taskdescsecret123" in (dest / "state.json").read_text()
+    state_text = (dest / "state.json").read_text()
+    assert "API_KEY=taskdescsecret123" in state_text
+    assert "ghp_" + "d" * 36 in state_text
+    assert "blockedreasonsecret789" in state_text
 
 
 def test_redacted_export_scrubs_journal_plan_spec_diffs(bundle_env, tmp_path):
@@ -441,10 +571,14 @@ def test_redacted_export_scrubs_journal_plan_spec_diffs(bundle_env, tmp_path):
     assert "abcdef123456" not in diff_text and "<REDACTED:env_secret>" in diff_text
 
 
-def test_redacted_export_does_not_scrub_state_json(bundle_env, tmp_path):
-    """AC3 + Approach scope --redacted to journal/plan/spec/diffs only; state.json
-    is mship's own structured metadata slice, not scanned (see report note on
-    the spec's differing 'every text file above' phrasing in Bundle contents)."""
+def test_redacted_export_scrubs_state_json(bundle_env, tmp_path):
+    """`--redacted` must scrub state.json too — it's written raw otherwise,
+    leaking secrets embedded in free-text fields like `description` /
+    `blocked_reason`. Each string leaf of the serialized state is redacted
+    independently and re-serialized (not `redact_text` over the raw JSON
+    blob — the greedy `env_secret`/`bearer_token` value groups would swallow
+    JSON delimiters, like the closing quote, and produce invalid JSON), so
+    state.json must still be valid JSON afterward (MOS-102 Greptile fix)."""
     dest = tmp_path / "out"
     build_export_bundle(
         task=bundle_env["task"], config=bundle_env["config"],
@@ -453,8 +587,32 @@ def test_redacted_export_does_not_scrub_state_json(bundle_env, tmp_path):
         dest_dir=dest, redacted=True,
     )
     state_text = (dest / "state.json").read_text()
-    assert "API_KEY=taskdescsecret123" in state_text
-    json.loads(state_text)  # still valid JSON
+    parsed = json.loads(state_text)  # still valid JSON
+
+    assert "taskdescsecret123" not in state_text
+    assert "ghp_" + "d" * 36 not in state_text
+    assert "blockedreasonsecret789" not in state_text
+    assert "<REDACTED:env_secret>" in state_text
+    assert "<REDACTED:github_token>" in state_text
+    # Non-secret structure survives untouched.
+    assert parsed["slug"] == "add-labels"
+    assert parsed["branch"] == "feat/add-labels"
+
+
+def test_unredacted_state_json_stays_verbatim(bundle_env, tmp_path):
+    """Without --redacted, state.json is untouched — same faithful-copy
+    guarantee as the other bundle artifacts."""
+    dest = tmp_path / "out"
+    build_export_bundle(
+        task=bundle_env["task"], config=bundle_env["config"],
+        workspace_root=bundle_env["workspace_root"],
+        log_manager=bundle_env["log_manager"], spec_store=bundle_env["spec_store"],
+        dest_dir=dest, redacted=False,
+    )
+    state_text = (dest / "state.json").read_text()
+    assert "taskdescsecret123" in state_text
+    assert "ghp_" + "d" * 36 in state_text
+    assert "blockedreasonsecret789" in state_text
 
 
 def test_bundle_omits_missing_optional_artifacts(workspace_with_git, tmp_path):

--- a/tests/core/test_export.py
+++ b/tests/core/test_export.py
@@ -812,6 +812,51 @@ def test_export_task_format_zip(bundle_env, tmp_path):
         assert b"abcdef123456" not in journal_bytes
 
 
+def test_export_zip_refuses_to_overwrite_unrelated_file(bundle_env, tmp_path):
+    """`--format zip` must not clobber an unrelated file that happens to share
+    the `<task>-export.zip` name: if it exists and isn't a prior mship export
+    (no `.mship-export` marker entry — e.g. a non-zip file), refuse rather than
+    truncate the user's data (Greptile, mirrors the directory guard)."""
+    out_root = tmp_path / "cwd"
+    out_root.mkdir()
+    precious = out_root / "add-labels-export.zip"
+    precious.write_bytes(b"not a zip - the user's important file")
+
+    with pytest.raises(ValueError, match="refusing to overwrite"):
+        export_task(
+            task=bundle_env["task"], config=bundle_env["config"],
+            workspace_root=bundle_env["workspace_root"],
+            log_manager=bundle_env["log_manager"], spec_store=bundle_env["spec_store"],
+            format="zip", output_root=out_root,
+        )
+    assert precious.read_bytes() == b"not a zip - the user's important file"
+
+
+def test_export_zip_overwrites_a_prior_export_zip(bundle_env, tmp_path):
+    """Re-exporting to a `<task>-export.zip` that IS a prior mship export
+    (carries the `<bundle>/.mship-export` marker entry) overwrites cleanly —
+    the marker gate only blocks unrelated files, not our own re-exports."""
+    out_root = tmp_path / "cwd"
+    out_root.mkdir()
+    first = export_task(
+        task=bundle_env["task"], config=bundle_env["config"],
+        workspace_root=bundle_env["workspace_root"],
+        log_manager=bundle_env["log_manager"], spec_store=bundle_env["spec_store"],
+        format="zip", output_root=out_root,
+    )
+    # second export to the same path must succeed (prior export is replaceable)
+    second = export_task(
+        task=bundle_env["task"], config=bundle_env["config"],
+        workspace_root=bundle_env["workspace_root"],
+        log_manager=bundle_env["log_manager"], spec_store=bundle_env["spec_store"],
+        format="zip", output_root=out_root,
+    )
+    assert second.bundle_path == first.bundle_path
+    with zipfile.ZipFile(second.bundle_path) as zf:
+        assert "add-labels-export/.mship-export" in zf.namelist()
+        assert "add-labels-export/journal.md" in zf.namelist()
+
+
 def test_export_task_invalid_format_raises(bundle_env, tmp_path):
     with pytest.raises(ValueError):
         export_task(

--- a/tests/core/test_export.py
+++ b/tests/core/test_export.py
@@ -1,0 +1,533 @@
+"""Tests for mship.core.export — bundle assembly + --redacted patterns (MOS-102)."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import time
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from mship.core import export as export_mod
+from mship.core.config import ConfigLoader
+from mship.core.export import (
+    BUILTIN_PATTERNS,
+    ExportBundle,
+    RedactionPattern,
+    build_export_bundle,
+    collect_repo_diff,
+    discover_plan_path,
+    export_task,
+    load_user_patterns,
+    redact_diff_text,
+    redact_text,
+)
+from mship.core.log import LogManager
+from mship.core.spec_draft import new_spec
+from mship.core.spec_store import SpecStore
+from mship.core.state import Task
+
+
+_GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+def _sh(*args, cwd):
+    subprocess.run(list(args), cwd=cwd, check=True, capture_output=True, env=_GIT_ENV)
+
+
+def _make_task(**overrides) -> Task:
+    defaults = dict(
+        slug="add-labels",
+        description="Add labels",
+        phase="dev",
+        created_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        affected_repos=["shared"],
+        branch="feat/add-labels",
+        worktrees={},
+        base_branch="main",
+    )
+    defaults.update(overrides)
+    return Task(**defaults)
+
+
+# --------------------------------------------------------------------------
+# Built-in redaction patterns — one dedicated case per documented pattern (AC4)
+# --------------------------------------------------------------------------
+
+def test_stripe_live_key_redacted():
+    text, warnings = redact_text("key=sk_live_ABC123xyz789 end", BUILTIN_PATTERNS)
+    assert "sk_live_ABC123xyz789" not in text
+    assert "<REDACTED:stripe_live_key>" in text
+    assert warnings == []
+
+
+def test_stripe_test_key_redacted():
+    text, _ = redact_text("key=sk_test_ABC123xyz789 end", BUILTIN_PATTERNS)
+    assert "sk_test_ABC123xyz789" not in text
+    assert "<REDACTED:stripe_test_key>" in text
+
+
+def test_github_token_redacted():
+    token = "ghp_" + "a" * 36
+    text, _ = redact_text(f"export GH_TOKEN={token}", BUILTIN_PATTERNS)
+    assert token not in text
+    assert "<REDACTED:github_token>" in text
+
+
+@pytest.mark.parametrize("prefix", ["ghp", "gho", "ghu", "ghs"])
+def test_github_token_all_prefixes_redacted(prefix):
+    token = f"{prefix}_" + "b" * 36
+    text, _ = redact_text(token, BUILTIN_PATTERNS)
+    assert token not in text
+    assert "<REDACTED:github_token>" in text
+
+
+def test_aws_access_key_id_redacted():
+    key = "AKIA" + "A" * 16
+    text, _ = redact_text(f"aws_access_key_id = {key}", BUILTIN_PATTERNS)
+    assert key not in text
+    assert "<REDACTED:aws_access_key_id>" in text
+
+
+def test_aws_secret_access_key_redacted_value_only():
+    secret = "abcdEFGH1234abcdEFGH1234abcdEFGH1234abcd"[:40]  # 40 chars
+    assert len(secret) == 40
+    line = f"aws_secret_access_key: {secret}"
+    text, _ = redact_text(line, BUILTIN_PATTERNS)
+    assert secret not in text
+    assert "<REDACTED:aws_secret_access_key>" in text
+    # prefix survives — only the value is replaced (value-only per spec).
+    assert text.startswith("aws_secret_access_key")
+
+
+def test_aws_secret_access_key_redacted_without_nearby_access_key_id():
+    """No proximity requirement to an AKIA... match (spec q4)."""
+    secret = "abcdEFGH1234abcdEFGH1234abcdEFGH1234abcd"[:40]  # 40 chars
+    text, _ = redact_text(f"aws_secret_access_key={secret}", BUILTIN_PATTERNS)
+    assert "<REDACTED:aws_secret_access_key>" in text
+
+
+def test_private_key_block_redacted_whole_block():
+    block = (
+        "before\n"
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIBOgIBAAJBAKj34GkxFhD91aM3wIVA\n"
+        "-----END RSA PRIVATE KEY-----\n"
+        "after"
+    )
+    text, _ = redact_text(block, BUILTIN_PATTERNS)
+    assert "MIIBOgIBAAJBAKj34GkxFhD91aM3wIVA" not in text
+    assert "<REDACTED:private_key>" in text
+    assert "before" in text and "after" in text
+
+
+def test_bearer_token_redacted_keeps_scheme_word():
+    text, _ = redact_text("Authorization: Bearer abc123.def-456_ghi", BUILTIN_PATTERNS)
+    assert "abc123.def-456_ghi" not in text
+    assert "Bearer <REDACTED:bearer_token>" in text
+
+
+@pytest.mark.parametrize("key", ["API_KEY", "SECRET", "PASSWORD", "TOKEN", "CREDENTIAL"])
+def test_env_secret_redacted_keeps_key_name(key):
+    text, _ = redact_text(f"{key}=supersecretvalue123", BUILTIN_PATTERNS)
+    assert "supersecretvalue123" not in text
+    assert f"{key}=<REDACTED:env_secret>" in text
+
+
+def test_env_secret_case_insensitive_key():
+    text, _ = redact_text("api_key=lowercasevalue", BUILTIN_PATTERNS)
+    assert "<REDACTED:env_secret>" in text
+
+
+def test_unredacted_text_untouched_by_redact_text_with_no_patterns():
+    text, warnings = redact_text("nothing secret here", [])
+    assert text == "nothing secret here"
+    assert warnings == []
+
+
+def test_plain_text_with_no_secret_shapes_passes_through():
+    original = "ordinary journal note, no secrets"
+    text, _ = redact_text(original, BUILTIN_PATTERNS)
+    assert text == original
+
+
+# --------------------------------------------------------------------------
+# redact_diff_text — binary chunks skipped (AC6)
+# --------------------------------------------------------------------------
+
+def test_redact_diff_text_skips_binary_chunk_redacts_text_chunk():
+    diff_text = (
+        "diff --git a/config.env b/config.env\n"
+        "index 111..222 100644\n"
+        "--- a/config.env\n"
+        "+++ b/config.env\n"
+        "@@ -1 +1 @@\n"
+        "+API_KEY=abcdef123456\n"
+        "diff --git a/blob.bin b/blob.bin\n"
+        "index 333..444 100644\n"
+        "Binary files a/blob.bin and b/blob.bin differ\n"
+    )
+    result, warnings = redact_diff_text(diff_text, BUILTIN_PATTERNS)
+    assert "API_KEY=<REDACTED:env_secret>" in result
+    assert "abcdef123456" not in result
+    # Binary chunk copied through completely unmodified.
+    assert "Binary files a/blob.bin and b/blob.bin differ" in result
+    assert warnings == []
+
+
+def test_chunk_is_binary_detects_markers():
+    assert export_mod._chunk_is_binary("Binary files a/x and b/y differ\n")
+    assert export_mod._chunk_is_binary("GIT binary patch\nliteral 10\n")
+    assert not export_mod._chunk_is_binary("+some text change\n")
+
+
+# --------------------------------------------------------------------------
+# User-configured patterns (optional; MOS-102 AC7)
+# --------------------------------------------------------------------------
+
+def test_load_user_patterns_absent_sources_returns_empty(tmp_path, workspace):
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    loaded = load_user_patterns(config, home_dir=tmp_path / "no-home-here")
+    assert loaded.patterns == []
+    assert loaded.warnings == []
+
+
+def test_load_user_patterns_from_home_file(tmp_path, workspace):
+    home = tmp_path / "home"
+    cfg_dir = home / ".config" / "mship"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "redact.patterns").write_text(
+        "\n".join(["ACME-[0-9]+", "", "  ", "#comment line", "[unterminated("])
+    )
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    loaded = load_user_patterns(config, home_dir=home)
+    kinds = [p.kind for p in loaded.patterns]
+    assert kinds == ["custom"]
+    assert not any(p.builtin for p in loaded.patterns)
+    assert any("unterminated" in w or "[unterminated(" in w for w in loaded.warnings)
+
+    text, _ = redact_text("case ACME-1234 opened", loaded.patterns)
+    assert "<REDACTED:custom>" in text
+    assert "ACME-1234" not in text
+
+
+def test_load_user_patterns_from_config_named_and_bare(tmp_path, workspace):
+    cfg_path = workspace / "mothership.yaml"
+    cfg_path.write_text(
+        cfg_path.read_text()
+        + "\nredact:\n  patterns:\n    - name: client_id\n      pattern: 'CLIENT-[0-9]+'\n"
+        "    - 'BARE-[a-z]+'\n"
+    )
+    config = ConfigLoader.load(cfg_path)
+    loaded = load_user_patterns(config, home_dir=tmp_path / "no-home")
+    kinds = {p.kind for p in loaded.patterns}
+    assert kinds == {"client_id", "custom"}
+    assert loaded.warnings == []
+
+    text, _ = redact_text("CLIENT-42 and BARE-xyz", loaded.patterns)
+    assert "<REDACTED:client_id>" in text
+    assert "<REDACTED:custom>" in text
+
+
+def test_apply_pattern_safe_timeout_leaves_text_unredacted(monkeypatch):
+    """A pathological/slow custom pattern degrades to 'leave unredacted', not a hang."""
+
+    class _SlowRegex:
+        def sub(self, repl, text):
+            time.sleep(0.2)
+            return text
+
+    monkeypatch.setattr(export_mod, "_CUSTOM_PATTERN_TIMEOUT_SECS", 0.01)
+    pattern = RedactionPattern("custom", _SlowRegex(), builtin=False)
+    result, warning = export_mod._apply_pattern_safe("hello world", pattern)
+    assert result == "hello world"
+    assert warning is not None
+    assert "timed out" in warning
+
+
+# --------------------------------------------------------------------------
+# Plan-doc discovery (v1: exact slug-in-filename match)
+# --------------------------------------------------------------------------
+
+def test_discover_plan_path_returns_none_when_no_docs_dir(tmp_path):
+    assert discover_plan_path(tmp_path, "add-labels") is None
+
+
+def test_discover_plan_path_matches_slug_in_filename(tmp_path):
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "2026-07-01-add-labels.md").write_text("plan body")
+    (plans / "2026-07-01-unrelated.md").write_text("other")
+    found = discover_plan_path(tmp_path, "add-labels")
+    assert found is not None
+    assert found.name == "2026-07-01-add-labels.md"
+
+
+def test_discover_plan_path_no_match_returns_none(tmp_path):
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "2026-07-01-unrelated.md").write_text("other")
+    assert discover_plan_path(tmp_path, "add-labels") is None
+
+
+def test_discover_plan_path_picks_newest_on_multiple_matches(tmp_path):
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    older = plans / "2026-01-01-add-labels-v1.md"
+    newer = plans / "2026-02-01-add-labels-v2.md"
+    older.write_text("old")
+    newer.write_text("new")
+    now = time.time()
+    os.utime(older, (now - 100, now - 100))
+    os.utime(newer, (now, now))
+    found = discover_plan_path(tmp_path, "add-labels")
+    assert found == newer
+
+
+def test_discover_plan_path_honors_custom_docs_dir(tmp_path):
+    plans = tmp_path / "documentation" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "add-labels.md").write_text("plan")
+    assert discover_plan_path(tmp_path, "add-labels", docs_dir="docs") is None
+    found = discover_plan_path(tmp_path, "add-labels", docs_dir="documentation")
+    assert found is not None
+
+
+# --------------------------------------------------------------------------
+# collect_repo_diff — real git repos (workspace_with_git fixture)
+# --------------------------------------------------------------------------
+
+def test_collect_repo_diff_returns_diff_with_commits_ahead(workspace_with_git):
+    repo_dir = workspace_with_git / "shared"
+    _sh("git", "checkout", "-b", "feat/x", cwd=repo_dir)
+    (repo_dir / "secret.env").write_text("API_KEY=abcdef123456\n")
+    _sh("git", "add", ".", cwd=repo_dir)
+    _sh("git", "commit", "-m", "add secret file", cwd=repo_dir)
+
+    config = ConfigLoader.load(workspace_with_git / "mothership.yaml")
+    task = _make_task(worktrees={"shared": repo_dir}, branch="feat/x")
+    diff = collect_repo_diff(task, "shared", config)
+    assert diff is not None
+    assert "API_KEY=abcdef123456" in diff
+    assert "secret.env" in diff
+
+
+def test_collect_repo_diff_none_when_no_worktree(workspace_with_git):
+    config = ConfigLoader.load(workspace_with_git / "mothership.yaml")
+    task = _make_task(worktrees={}, branch="feat/x")
+    assert collect_repo_diff(task, "shared", config) is None
+
+
+def test_collect_repo_diff_none_when_no_commits_ahead(workspace_with_git):
+    repo_dir = workspace_with_git / "shared"
+    config = ConfigLoader.load(workspace_with_git / "mothership.yaml")
+    # branch == base: no diff.
+    task = _make_task(worktrees={"shared": repo_dir}, branch="main")
+    assert collect_repo_diff(task, "shared", config) is None
+
+
+def test_collect_repo_diff_none_on_unresolvable_base(workspace_with_git):
+    repo_dir = workspace_with_git / "shared"
+    config = ConfigLoader.load(workspace_with_git / "mothership.yaml")
+    task = _make_task(
+        worktrees={"shared": repo_dir}, branch="main", base_branch="does-not-exist",
+    )
+    assert collect_repo_diff(task, "shared", config) is None
+
+
+# --------------------------------------------------------------------------
+# build_export_bundle / export_task — full assembly (AC1, AC2, AC5, AC8)
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def bundle_env(workspace_with_git, tmp_path):
+    """A task with a journal entry, a bound spec, a plan doc, and one repo
+    with real commits ahead of base — everything build_export_bundle reads."""
+    state_dir = tmp_path / "state"
+    logs_dir = state_dir / "logs"
+    log_mgr = LogManager(logs_dir)
+    log_mgr.create("add-labels")
+    log_mgr.append("add-labels", "planted secret API_KEY=abcdef123456 in a note")
+
+    specs_dir = workspace_with_git / "specs"
+    spec_store = SpecStore(specs_dir)
+    spec = new_spec("Add labels", now=datetime(2026, 7, 1, tzinfo=timezone.utc),
+                     spec_id="add-labels", task_slug="add-labels")
+    spec.body += "\nsecret in spec: sk_live_SPECSECRET123\n"
+    spec_store.save(spec)
+
+    plans_dir = workspace_with_git / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    (plans_dir / "2026-07-01-add-labels.md").write_text(
+        "# Plan\nsecret in plan: ghp_" + "c" * 36 + "\n"
+    )
+
+    repo_dir = workspace_with_git / "shared"
+    _sh("git", "checkout", "-b", "feat/add-labels", cwd=repo_dir)
+    (repo_dir / "secret.env").write_text("API_KEY=abcdef123456\n")
+    _sh("git", "add", ".", cwd=repo_dir)
+    _sh("git", "commit", "-m", "add secret file", cwd=repo_dir)
+
+    config = ConfigLoader.load(workspace_with_git / "mothership.yaml")
+    task = _make_task(
+        worktrees={"shared": repo_dir}, branch="feat/add-labels", spec_id="add-labels",
+        description="task description with API_KEY=taskdescsecret123",
+    )
+    return {
+        "workspace_root": workspace_with_git,
+        "config": config,
+        "task": task,
+        "log_manager": log_mgr,
+        "spec_store": spec_store,
+    }
+
+
+def test_bundle_contains_all_expected_artifacts(bundle_env, tmp_path):
+    dest = tmp_path / "out"
+    result = build_export_bundle(
+        task=bundle_env["task"], config=bundle_env["config"],
+        workspace_root=bundle_env["workspace_root"],
+        log_manager=bundle_env["log_manager"], spec_store=bundle_env["spec_store"],
+        dest_dir=dest, redacted=False,
+    )
+    assert result.bundle_path == dest
+    assert (dest / "journal.md").is_file()
+    assert (dest / "plan.md").is_file()
+    assert (dest / "spec.md").is_file()
+    assert (dest / "state.json").is_file()
+    assert (dest / "diffs" / "shared.diff").is_file()
+
+
+def test_unredacted_export_is_faithful(bundle_env, tmp_path):
+    """Without --redacted, every planted secret survives unchanged (AC5)."""
+    dest = tmp_path / "out"
+    build_export_bundle(
+        task=bundle_env["task"], config=bundle_env["config"],
+        workspace_root=bundle_env["workspace_root"],
+        log_manager=bundle_env["log_manager"], spec_store=bundle_env["spec_store"],
+        dest_dir=dest, redacted=False,
+    )
+    assert "API_KEY=abcdef123456" in (dest / "journal.md").read_text()
+    assert "sk_live_SPECSECRET123" in (dest / "spec.md").read_text()
+    assert "ghp_" + "c" * 36 in (dest / "plan.md").read_text()
+    assert "API_KEY=abcdef123456" in (dest / "diffs" / "shared.diff").read_text()
+    assert "API_KEY=taskdescsecret123" in (dest / "state.json").read_text()
+
+
+def test_redacted_export_scrubs_journal_plan_spec_diffs(bundle_env, tmp_path):
+    dest = tmp_path / "out"
+    build_export_bundle(
+        task=bundle_env["task"], config=bundle_env["config"],
+        workspace_root=bundle_env["workspace_root"],
+        log_manager=bundle_env["log_manager"], spec_store=bundle_env["spec_store"],
+        dest_dir=dest, redacted=True,
+    )
+    journal = (dest / "journal.md").read_text()
+    spec_text = (dest / "spec.md").read_text()
+    plan_text = (dest / "plan.md").read_text()
+    diff_text = (dest / "diffs" / "shared.diff").read_text()
+
+    assert "abcdef123456" not in journal and "<REDACTED:env_secret>" in journal
+    assert "SPECSECRET123" not in spec_text and "<REDACTED:stripe_live_key>" in spec_text
+    assert "ghp_" + "c" * 36 not in plan_text and "<REDACTED:github_token>" in plan_text
+    assert "abcdef123456" not in diff_text and "<REDACTED:env_secret>" in diff_text
+
+
+def test_redacted_export_does_not_scrub_state_json(bundle_env, tmp_path):
+    """AC3 + Approach scope --redacted to journal/plan/spec/diffs only; state.json
+    is mship's own structured metadata slice, not scanned (see report note on
+    the spec's differing 'every text file above' phrasing in Bundle contents)."""
+    dest = tmp_path / "out"
+    build_export_bundle(
+        task=bundle_env["task"], config=bundle_env["config"],
+        workspace_root=bundle_env["workspace_root"],
+        log_manager=bundle_env["log_manager"], spec_store=bundle_env["spec_store"],
+        dest_dir=dest, redacted=True,
+    )
+    state_text = (dest / "state.json").read_text()
+    assert "API_KEY=taskdescsecret123" in state_text
+    json.loads(state_text)  # still valid JSON
+
+
+def test_bundle_omits_missing_optional_artifacts(workspace_with_git, tmp_path):
+    """No spec_id, no matching plan doc, one repo with no worktree at all —
+    export still succeeds and simply omits those pieces (AC8)."""
+    state_dir = tmp_path / "state"
+    log_mgr = LogManager(state_dir / "logs")
+    log_mgr.create("no-extras")
+    spec_store = SpecStore(workspace_with_git / "specs")
+    config = ConfigLoader.load(workspace_with_git / "mothership.yaml")
+    task = _make_task(
+        slug="no-extras", branch="feat/no-extras",
+        affected_repos=["shared", "auth-service"],
+        worktrees={"shared": workspace_with_git / "shared"},  # no worktree for auth-service
+        spec_id=None,
+    )
+    dest = tmp_path / "out"
+    result = build_export_bundle(
+        task=task, config=config, workspace_root=workspace_with_git,
+        log_manager=log_mgr, spec_store=spec_store, dest_dir=dest, redacted=False,
+    )
+    assert (dest / "journal.md").is_file()
+    assert (dest / "state.json").is_file()
+    assert not (dest / "plan.md").exists()
+    assert not (dest / "spec.md").exists()
+    assert not (dest / "diffs" / "auth-service.diff").exists()
+    assert not (dest / "diffs" / "shared.diff").exists()  # branch == main: no commits ahead
+    assert result.warnings == []
+
+
+# --------------------------------------------------------------------------
+# export_task — --format dir|zip (AC2)
+# --------------------------------------------------------------------------
+
+def test_export_task_format_dir_default(bundle_env, tmp_path):
+    out_root = tmp_path / "cwd"
+    out_root.mkdir()
+    result = export_task(
+        task=bundle_env["task"], config=bundle_env["config"],
+        workspace_root=bundle_env["workspace_root"],
+        log_manager=bundle_env["log_manager"], spec_store=bundle_env["spec_store"],
+        redacted=False, output_root=out_root,
+    )
+    assert result.bundle_path == out_root / "add-labels-export"
+    assert result.bundle_path.is_dir()
+    assert (result.bundle_path / "journal.md").is_file()
+
+
+def test_export_task_format_zip(bundle_env, tmp_path):
+    out_root = tmp_path / "cwd"
+    out_root.mkdir()
+    result = export_task(
+        task=bundle_env["task"], config=bundle_env["config"],
+        workspace_root=bundle_env["workspace_root"],
+        log_manager=bundle_env["log_manager"], spec_store=bundle_env["spec_store"],
+        redacted=True, format="zip", output_root=out_root,
+    )
+    assert result.bundle_path == out_root / "add-labels-export.zip"
+    assert result.bundle_path.is_file()
+    with zipfile.ZipFile(result.bundle_path) as zf:
+        names = set(zf.namelist())
+        assert "add-labels-export/journal.md" in names
+        assert "add-labels-export/state.json" in names
+        assert "add-labels-export/diffs/shared.diff" in names
+        journal_bytes = zf.read("add-labels-export/journal.md")
+        assert b"abcdef123456" not in journal_bytes
+
+
+def test_export_task_invalid_format_raises(bundle_env, tmp_path):
+    with pytest.raises(ValueError):
+        export_task(
+            task=bundle_env["task"], config=bundle_env["config"],
+            workspace_root=bundle_env["workspace_root"],
+            log_manager=bundle_env["log_manager"], spec_store=bundle_env["spec_store"],
+            format="yaml", output_root=tmp_path,
+        )


### PR DESCRIPTION
Apply the 6 Greptile fixes to mship export that were lost when #311 merged uncommitted (non-blocking regex timeout, redact state.json leaves, clear stale export dir, three-dot base...branch diff, null redact.patterns coercion, precise plan discovery)

Closes #311