### PR TITLE
Make implementation plans first-class + gate feature work items on a plan; plan-driven build dispatch — implement docs/plans/2026-07-12-first-class-plans-plan-gate.md

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,7 +33,7 @@ mship depends add|remove|list                       # manage task-to-task depend
 
 ## Work items & specs
 
-A **work item** is the durable unit of intent (`feature`/`bug`/`chore`/`question`) that a task implements; a **spec** is its approved design. Feature work items gate `phase dev`/`finish` on an approved linked spec (bugs and chores don't need one).
+A **work item** is the durable unit of intent (`feature`/`bug`/`chore`/`question`) that a task implements; a **spec** is its approved design and a **plan** is its implementation breakdown. Feature work items gate `phase dev`/`finish` on BOTH an approved linked spec AND a linked/discovered implementation plan (bugs and chores need neither).
 
 ```bash
 mship item new "title" --kind feature|bug|chore|question   # create a work item
@@ -41,6 +41,7 @@ mship item list [--all]                             # list work items (--all inc
 mship item show <id>                                # detail incl. linked spec/tasks
 mship item phase <id> <phase>                       # move the item through its lifecycle
 mship item link-spec|link-task|link-url <id> <ref>  # attach a spec, task, or URL
+mship item link-plan <id> <path>                    # attach an implementation plan doc (feature plan-gate)
 mship item archive|unarchive <id>                   # soft-hide / restore
 
 mship spec new --title "title"                      # create a spec (lands in needs_review)
@@ -55,6 +56,8 @@ mship spec list                                     # list specs
 ```
 
 Specs live at `<workspace>/specs/<date>-<id>.md`. Lifecycle: `new → draft → apply → review → approve → dispatch`.
+
+Plans are first-class too. A **feature** work item can't enter `dev` or `finish` without a valid implementation plan — either linked via `mship item link-plan` or discovered at `<docs_dir>/plans/<date>-<slug>.md` (what the writing-plans skill produces), and containing at least one task block. Bypass with `mship phase dev --bypass-plan-gate` or `mship finish --hotfix`. Build dispatch is plan-driven: once a plan is linked, `mship dispatch --task <slug> --plan-task N` mints the implementer prompt from the plan (no `--plan` needed), and `mship spec dispatch` points the build at the plan's tasks instead of re-deriving from the spec.
 
 ## Messaging & serve
 

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -14,7 +14,27 @@ from mship.cli._resolve import resolve_for_command
 from mship.cli.output import Output
 from mship.core import dispatch as _d
 from mship.core.base_resolver import resolve_base
+from mship.core.plan import resolve_plan_path
 from mship.core.skill_install import pkg_skills_source
+from mship.core.workitem_store import WorkItemStore
+
+
+def _resolve_task_plan(container, task_obj) -> Optional[Path]:
+    """Auto-resolve the implementation plan for a task when `--plan` is omitted.
+
+    Precedence: the task's WorkItem `plan_path` (explicit link) wins, else the
+    `<docs_dir>/plans/<slug>.md` discovery convention. Returns None when nothing
+    resolves.
+    """
+    workspace_root = Path(container.config_path()).parent
+    docs_dir = getattr(container.config(), "docs_dir", "docs")
+    linked = None
+    work_item_id = getattr(task_obj, "work_item_id", None)
+    if work_item_id:
+        wi = WorkItemStore(Path(container.state_dir()) / "workitems").get(work_item_id)
+        if wi is not None:
+            linked = wi.plan_path
+    return resolve_plan_path(task_obj.slug, linked, workspace_root, docs_dir)
 
 
 def register(app: typer.Typer, get_container):
@@ -46,7 +66,10 @@ def register(app: typer.Typer, get_container):
         """Emit a self-contained markdown subagent prompt to stdout.
 
         Exactly one instruction source is required: inline `--instruction "<text>"`,
-        stdin `--instruction -`, or `--plan-task <id>` (with `--plan <path>`).
+        stdin `--instruction -`, or `--plan-task <id>`. With `--plan-task` and no
+        `--plan`, the task's implementation plan is auto-resolved (its WorkItem's
+        linked `plan_path`, else the `<docs_dir>/plans/<slug>.md` convention); an
+        explicit `--plan <path>` overrides that.
         """
         output = Output()
 
@@ -60,7 +83,8 @@ def register(app: typer.Typer, get_container):
         if (instruction is not None) == (plan_task is not None):
             output.error(
                 'provide exactly one instruction source: --instruction "<text>", '
-                "--instruction - (stdin), or --plan-task <id> (with --plan)."
+                "--instruction - (stdin), or --plan-task <id> (with --plan, or "
+                "auto-resolved from the task's plan)."
             )
             raise typer.Exit(code=2)
 
@@ -70,14 +94,29 @@ def register(app: typer.Typer, get_container):
             output.error("--plan requires --plan-task <id>.")
             raise typer.Exit(code=2)
 
+        container = get_container()
+        state = container.state_manager().load()
+        resolved = resolve_for_command("dispatch", state, task, output)
+        task_obj = resolved.task
+
         if plan_task is not None:
-            if plan is None:
-                output.error("--plan-task requires --plan <path>.")
-                raise typer.Exit(code=2)
+            # Explicit --plan wins; else auto-resolve the task's linked/discovered
+            # plan (a resolved plan is the single instruction source).
+            plan_path = plan
+            if plan_path is None:
+                plan_path = _resolve_task_plan(container, task_obj)
+                if plan_path is None:
+                    output.error(
+                        f"no implementation plan found for task {task_obj.slug!r} to "
+                        f"resolve --plan-task {plan_task!r}. Pass --plan <path>, link "
+                        f"one with `mship item link-plan`, or write one at "
+                        f"<docs_dir>/plans/<date>-{task_obj.slug}.md (writing-plans)."
+                    )
+                    raise typer.Exit(code=2)
             try:
-                plan_text = plan.read_text()
+                plan_text = plan_path.read_text()
             except OSError as e:
-                output.error(f"cannot read plan {str(plan)!r}: {e}")
+                output.error(f"cannot read plan {str(plan_path)!r}: {e}")
                 raise typer.Exit(code=2)
             try:
                 resolved_instruction = _d.extract_plan_task(plan_text, plan_task)
@@ -91,11 +130,6 @@ def register(app: typer.Typer, get_container):
                 raise typer.Exit(code=2)
         else:
             resolved_instruction = instruction  # inline (guaranteed non-None here)
-
-        container = get_container()
-        state = container.state_manager().load()
-        resolved = resolve_for_command("dispatch", state, task, output)
-        task_obj = resolved.task
 
         try:
             resolved_repo = _d.resolve_repo(task_obj, repo)

--- a/src/mship/cli/phase.py
+++ b/src/mship/cli/phase.py
@@ -15,6 +15,7 @@ def register(app: typer.Typer, get_container):
         force: bool = typer.Option(False, "--force", "-f", help="Force transition even if task is blocked or finished"),
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),
         bypass_spec_gate: bool = typer.Option(False, "--bypass-spec-gate", help="Skip the plan→dev gate: the universal WorkItem requirement, the feature-kind approved-spec requirement, and (if require_approved_spec: true in mothership.yaml) the legacy task-scoped approved-spec check. Recorded to the bypass log (--hotfix equivalent)."),
+        bypass_plan_gate: bool = typer.Option(False, "--bypass-plan-gate", help="Skip ONLY the plan→dev implementation-plan requirement (feature WorkItems still need their WorkItem + approved spec). Recorded to the bypass log."),
     ):
         """Transition a task to a new phase."""
         container = get_container()
@@ -53,6 +54,7 @@ def register(app: typer.Typer, get_container):
                 force_unblock=force,
                 force_finished=force,
                 bypass_spec_gate=bypass_spec_gate,
+                bypass_plan_gate=bypass_plan_gate,
             )
         except FinishedTaskError as e:
             output.error(str(e))

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -481,6 +481,8 @@ def register(parent: typer.Typer, get_container):
                 workitems=workitems,
                 workspace=container.config().workspace,
                 task_slug=task_slug,
+                workspace_root=workspace_root,
+                docs_dir=container.config().docs_dir,
             )
         except DispatchError as e:
             output.error(str(e))

--- a/src/mship/cli/workitem.py
+++ b/src/mship/cli/workitem.py
@@ -237,6 +237,13 @@ def register(parent: typer.Typer, get_container) -> None:
         items.link_spec(item_id, spec_id, now=datetime.now(timezone.utc))
         typer.echo(f"linked spec {spec_id} -> {item_id}")
 
+    @item_app.command("link-plan")
+    def link_plan(item_id: str, plan_path: str):
+        items, _, _, _, _ = _ctx()
+        _guard(items, item_id)
+        items.link_plan(item_id, plan_path, now=datetime.now(timezone.utc))
+        typer.echo(f"linked plan {plan_path} -> {item_id}")
+
     @item_app.command("link-task")
     def link_task(item_id: str, task_slug: str):
         items, _, state_manager, _, _ = _ctx()

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1018,9 +1018,11 @@ def register(app: typer.Typer, get_container):
         task = t
 
         # --- WorkItem gate: every task must be linked to a WorkItem, and a
-        # feature-kind WorkItem additionally needs an approved spec
-        # (core/workitem_gate.py::check_task_gate). Placed as early as
-        # possible — right after resolving the task — so finish fails fast
+        # feature-kind WorkItem additionally needs an approved spec AND a valid
+        # implementation plan (require_plan=True — finish is one of the two
+        # plan-enforcement sites alongside phase plan→dev; spawn stays
+        # plan-free). (core/workitem_gate.py::check_task_gate). Placed as early
+        # as possible — right after resolving the task — so finish fails fast
         # before any push/PR work. --hotfix downgrades the block to a
         # warning and records a bypass-log entry, mirroring the spawn/
         # phase-dev gates. See spec workitem-mandatory-kind-gated-approval.
@@ -1034,7 +1036,7 @@ def register(app: typer.Typer, get_container):
         from mship.core import workitem_gate
         workspace_root = container.config_path().parent
         try:
-            gate_result = workitem_gate.check_task_gate(task, workspace_root)
+            gate_result = workitem_gate.check_task_gate(task, workspace_root, require_plan=True)
         except Exception as e:
             gate_result = workitem_gate.GateResult(
                 False, f"couldn't evaluate WorkItem gate (corrupt store?): {e}"

--- a/src/mship/core/export.py
+++ b/src/mship/core/export.py
@@ -44,7 +44,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from mship.core.base_resolver import resolve_base
-from mship.core.plan import discover_plan_path
+from mship.core.plan import discover_plan_path, resolve_plan_path  # noqa: F401 (discover_plan_path re-exported)
 
 if TYPE_CHECKING:
     from mship.core.config import WorkspaceConfig
@@ -485,8 +485,15 @@ def build_export_bundle(
     entries = log_manager.read(task.slug)
     _write_text("journal.md", _render_journal(task.slug, entries))
 
-    # plan.md (optional)
-    plan_path = discover_plan_path(workspace_root, task.slug, docs_dir=config.docs_dir)
+    # plan.md (optional) — honor an explicit WorkItem.plan_path link, else the
+    # docs/plans/<date>-<slug>.md convention (same resolver the gate/dispatch use,
+    # so a linked off-convention plan isn't silently omitted from the bundle).
+    _wi_plan = None
+    if getattr(task, "work_item_id", None):
+        from mship.core.workitem_store import WorkItemStore
+        _wi = WorkItemStore(workspace_root / ".mothership" / "workitems").get(task.work_item_id)
+        _wi_plan = _wi.plan_path if _wi else None
+    plan_path = resolve_plan_path(task.slug, _wi_plan, workspace_root, config.docs_dir)
     if plan_path is not None:
         _write_text("plan.md", plan_path.read_text())
 

--- a/src/mship/core/export.py
+++ b/src/mship/core/export.py
@@ -44,6 +44,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from mship.core.base_resolver import resolve_base
+from mship.core.plan import discover_plan_path
 
 if TYPE_CHECKING:
     from mship.core.config import WorkspaceConfig
@@ -350,36 +351,6 @@ def collect_repo_diff(
 # ---------------------------------------------------------------------------
 # Bundle assembly
 # ---------------------------------------------------------------------------
-
-def _plan_stem_matches_slug(stem: str, task_slug: str) -> bool:
-    """Precise match, not substring: either the stem IS the slug, or it's the
-    canonical `<YYYY-MM-DD>-<slug>.md` form. A bare `-<slug>` suffix (e.g.
-    'my-add.md' for slug 'add') deliberately does NOT match — that's still a
-    substring-style match in disguise, just anchored to the end instead of
-    anywhere, and would wrongly pick up unrelated docs prefixed with
-    another word (MOS-102 Greptile fix)."""
-    if stem == task_slug:
-        return True
-    escaped_slug = re.escape(task_slug)
-    return re.fullmatch(rf"\d{{4}}-\d{{2}}-\d{{2}}-{escaped_slug}", stem) is not None
-
-
-def discover_plan_path(workspace_root: Path, task_slug: str, docs_dir: str = "docs") -> Path | None:
-    """Best-effort plan-doc discovery: a `docs/plans/*.md` file whose stem
-    precisely matches the task slug (exact stem, or the canonical
-    `<date>-<slug>.md` form) — not merely containing the slug as a
-    substring, which would false-positive on a short slug like "add"
-    matching "add-labels.md". v1 has no fuzzy/similarity scoring and no
-    explicit plan_path reference on Task — picks the most-recently-modified
-    match when more than one file matches."""
-    plans_dir = workspace_root / docs_dir / "plans"
-    if not plans_dir.is_dir():
-        return None
-    matches = [p for p in sorted(plans_dir.glob("*.md")) if _plan_stem_matches_slug(p.stem, task_slug)]
-    if not matches:
-        return None
-    return max(matches, key=lambda p: p.stat().st_mtime)
-
 
 def _render_journal(task_slug: str, entries: list) -> str:
     lines = [f"# Task Journal: {task_slug}", ""]

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -81,6 +81,7 @@ class PhaseManager:
         # spec checks still run) and records its own bypass-log entry. See spec
         # workitem-mandatory-kind-gated-approval + first-class-implementation-plans.
         if task.phase == "plan" and target == "dev":
+            _plan_bypass_effective = False
             if bypass_spec_gate:
                 if self._workspace_root is not None:
                     from mship.core.workitem_gate import log_hotfix
@@ -105,11 +106,11 @@ class PhaseManager:
                         ) from e
                     if not gate_result.ok:
                         raise SpecGateError(gate_result.reason)
-                    # The transition will proceed. Record a plan-gate bypass ONLY
-                    # when it actually had an effect — i.e. the plan clause WOULD
-                    # have blocked. Avoids audit entries for no-op overrides
-                    # (non-feature item, plan already present) or for transitions
-                    # blocked above anyway (Greptile).
+                    # A plan-gate bypass only counts if the plan clause WOULD have
+                    # blocked (not a no-op override on a non-feature item or when a
+                    # plan is already present). Compute it here, but DON'T log yet —
+                    # a later gate below can still reject the transition, and we must
+                    # not record a bypass for a transition that then fails (Greptile).
                     if bypass_plan_gate:
                         try:
                             with_plan = check_task_gate(
@@ -117,8 +118,7 @@ class PhaseManager:
                             )
                         except Exception:
                             with_plan = None
-                        if with_plan is not None and not with_plan.ok:
-                            log_hotfix(self._workspace_root, "phase-dev-plan", task_slug)
+                        _plan_bypass_effective = with_plan is not None and not with_plan.ok
 
                 # Approved-spec gate: opt-in via require_approved_spec in
                 # mothership.yaml. Older, task-slug-based and kind-agnostic —
@@ -134,6 +134,13 @@ class PhaseManager:
                         f"Create and approve one (`mship spec approve`) or pass "
                         f"--bypass-spec-gate to skip this check."
                     )
+
+            # All dev-transition gates have now passed — safe to record a
+            # plan-gate bypass. Deferred to here so a bypass is never logged for
+            # a transition that a later gate (above) rejected (Greptile).
+            if _plan_bypass_effective and self._workspace_root is not None:
+                from mship.core.workitem_gate import log_hotfix
+                log_hotfix(self._workspace_root, "phase-dev-plan", task_slug)
 
         old_phase = task.phase
         warnings = self._check_gates(task_slug, task.phase, target)

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -51,6 +51,7 @@ class PhaseManager:
         force_unblock: bool = False,
         force_finished: bool = False,
         bypass_spec_gate: bool = False,
+        bypass_plan_gate: bool = False,
     ) -> PhaseTransition:
         # Read-only preflight: compute soft-gate warnings from current state.
         # These read repo state (specs, tests, uncommitted files) and mship
@@ -70,11 +71,15 @@ class PhaseManager:
 
         # WorkItem gate: universal — every task entering dev must be linked to
         # a WorkItem, and a feature-kind WorkItem additionally needs an
-        # approved spec (core/workitem_gate.py::check_task_gate, authoritative
-        # for WorkItem-linked tasks). --bypass-spec-gate is the --hotfix
-        # equivalent for this gate: it skips both checks below and instead
-        # records a bypass-log entry. See spec
-        # workitem-mandatory-kind-gated-approval.
+        # approved spec AND a valid implementation plan (core/workitem_gate.py
+        # ::check_task_gate, authoritative for WorkItem-linked tasks). The plan
+        # clause runs here (require_plan=True) — plan→dev is one of the two
+        # enforcement sites (finish is the other); spawn stays plan-free.
+        # --bypass-spec-gate is the --hotfix equivalent for this gate: it skips
+        # every check below and records a bypass-log entry. --bypass-plan-gate
+        # is narrower — it drops ONLY the plan clause (the WorkItem + approved-
+        # spec checks still run) and records its own bypass-log entry. See spec
+        # workitem-mandatory-kind-gated-approval + first-class-implementation-plans.
         if task.phase == "plan" and target == "dev":
             if bypass_spec_gate:
                 if self._workspace_root is not None:
@@ -82,14 +87,20 @@ class PhaseManager:
                     log_hotfix(self._workspace_root, "phase-dev", task_slug)
             else:
                 if self._workspace_root is not None:
-                    from mship.core.workitem_gate import check_task_gate
+                    from mship.core.workitem_gate import check_task_gate, log_hotfix
+                    if bypass_plan_gate:
+                        log_hotfix(self._workspace_root, "phase-dev-plan", task_slug)
                     # A corrupt/unreadable WorkItem store must not propagate a
                     # raw exception out of transition() — --bypass-spec-gate
                     # already skips this call entirely as the escape hatch;
                     # without --bypass-spec-gate we still want a clean,
                     # actionable SpecGateError instead of a traceback.
                     try:
-                        gate_result = check_task_gate(task, self._workspace_root)
+                        gate_result = check_task_gate(
+                            task,
+                            self._workspace_root,
+                            require_plan=not bypass_plan_gate,
+                        )
                     except Exception as e:
                         raise SpecGateError(
                             f"couldn't evaluate WorkItem gate (corrupt store?): {e}"

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -88,8 +88,6 @@ class PhaseManager:
             else:
                 if self._workspace_root is not None:
                     from mship.core.workitem_gate import check_task_gate, log_hotfix
-                    if bypass_plan_gate:
-                        log_hotfix(self._workspace_root, "phase-dev-plan", task_slug)
                     # A corrupt/unreadable WorkItem store must not propagate a
                     # raw exception out of transition() — --bypass-spec-gate
                     # already skips this call entirely as the escape hatch;
@@ -107,6 +105,20 @@ class PhaseManager:
                         ) from e
                     if not gate_result.ok:
                         raise SpecGateError(gate_result.reason)
+                    # The transition will proceed. Record a plan-gate bypass ONLY
+                    # when it actually had an effect — i.e. the plan clause WOULD
+                    # have blocked. Avoids audit entries for no-op overrides
+                    # (non-feature item, plan already present) or for transitions
+                    # blocked above anyway (Greptile).
+                    if bypass_plan_gate:
+                        try:
+                            with_plan = check_task_gate(
+                                task, self._workspace_root, require_plan=True
+                            )
+                        except Exception:
+                            with_plan = None
+                        if with_plan is not None and not with_plan.ok:
+                            log_hotfix(self._workspace_root, "phase-dev-plan", task_slug)
 
                 # Approved-spec gate: opt-in via require_approved_spec in
                 # mothership.yaml. Older, task-slug-based and kind-agnostic —

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -80,8 +80,8 @@ class PhaseManager:
         # is narrower — it drops ONLY the plan clause (the WorkItem + approved-
         # spec checks still run) and records its own bypass-log entry. See spec
         # workitem-mandatory-kind-gated-approval + first-class-implementation-plans.
+        _plan_bypass_effective = False
         if task.phase == "plan" and target == "dev":
-            _plan_bypass_effective = False
             if bypass_spec_gate:
                 if self._workspace_root is not None:
                     from mship.core.workitem_gate import log_hotfix
@@ -134,13 +134,6 @@ class PhaseManager:
                         f"Create and approve one (`mship spec approve`) or pass "
                         f"--bypass-spec-gate to skip this check."
                     )
-
-            # All dev-transition gates have now passed — safe to record a
-            # plan-gate bypass. Deferred to here so a bypass is never logged for
-            # a transition that a later gate (above) rejected (Greptile).
-            if _plan_bypass_effective and self._workspace_root is not None:
-                from mship.core.workitem_gate import log_hotfix
-                log_hotfix(self._workspace_root, "phase-dev-plan", task_slug)
 
         old_phase = task.phase
         warnings = self._check_gates(task_slug, task.phase, target)
@@ -200,6 +193,14 @@ class PhaseManager:
                 f"Unblocked (forced phase transition to {target})",
             )
         self._log.append(task_slug, f"Phase transition: {old_phase} → {target}")
+
+        # Record a plan-gate bypass ONLY now — after the transition is fully
+        # committed (state mutated + every lifecycle hook passed; a required
+        # phase.entered hook would have raised before here). Guarantees the audit
+        # log never holds a bypass for a transition that was later aborted (Greptile).
+        if _plan_bypass_effective and self._workspace_root is not None:
+            from mship.core.workitem_gate import log_hotfix
+            log_hotfix(self._workspace_root, "phase-dev-plan", task_slug)
 
         return PhaseTransition(new_phase=target, warnings=warnings)
 

--- a/src/mship/core/plan.py
+++ b/src/mship/core/plan.py
@@ -1,0 +1,65 @@
+"""Resolve + validate a task's implementation plan doc (see MOS-235).
+
+Centralizes plan resolution so both `mship export` (bundle assembly) and the
+work-item plan gate share one convention: a `docs/plans/*.md` file whose stem
+precisely matches the task slug, or an explicit `plan_path`. Validity is
+structural — a plan is "real" if it carries at least one `<!-- mship:task -->`
+anchor — not a content/approval check.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_TASK_ANCHOR_RE = re.compile(r"<!--\s*mship:task\s+id=([^\s>]+)\s*-->")
+
+
+def _plan_stem_matches_slug(stem: str, task_slug: str) -> bool:
+    """Precise match, not substring: either the stem IS the slug, or it's the
+    canonical `<YYYY-MM-DD>-<slug>.md` form. A bare `-<slug>` suffix (e.g.
+    'my-add.md' for slug 'add') deliberately does NOT match — that's still a
+    substring-style match in disguise, just anchored to the end instead of
+    anywhere, and would wrongly pick up unrelated docs prefixed with
+    another word (MOS-102 Greptile fix)."""
+    if stem == task_slug:
+        return True
+    escaped_slug = re.escape(task_slug)
+    return re.fullmatch(rf"\d{{4}}-\d{{2}}-\d{{2}}-{escaped_slug}", stem) is not None
+
+
+def discover_plan_path(workspace_root: Path, task_slug: str, docs_dir: str = "docs") -> Path | None:
+    """Best-effort plan-doc discovery: a `docs/plans/*.md` file whose stem
+    precisely matches the task slug (exact stem, or the canonical
+    `<date>-<slug>.md` form) — not merely containing the slug as a
+    substring, which would false-positive on a short slug like "add"
+    matching "add-labels.md". v1 has no fuzzy/similarity scoring and no
+    explicit plan_path reference on Task — picks the most-recently-modified
+    match when more than one file matches."""
+    plans_dir = workspace_root / docs_dir / "plans"
+    if not plans_dir.is_dir():
+        return None
+    matches = [p for p in sorted(plans_dir.glob("*.md")) if _plan_stem_matches_slug(p.stem, task_slug)]
+    if not matches:
+        return None
+    return max(matches, key=lambda p: p.stat().st_mtime)
+
+
+def plan_has_tasks(text: str) -> bool:
+    """A plan is 'real' if it has at least one <!-- mship:task ... --> anchor."""
+    return _TASK_ANCHOR_RE.search(text) is not None
+
+
+def resolve_plan_path(
+    task_slug: str,
+    plan_path: str | None,
+    workspace_root: Path,
+    docs_dir: str = "docs",
+) -> Path | None:
+    """Explicit `plan_path` (workspace-relative or absolute) wins; else the
+    discover_plan_path convention. Returns the Path if the file exists, else None."""
+    if plan_path:
+        p = Path(plan_path)
+        if not p.is_absolute():
+            p = Path(workspace_root) / p
+        return p if p.is_file() else None
+    return discover_plan_path(Path(workspace_root), task_slug, docs_dir)

--- a/src/mship/core/plan.py
+++ b/src/mship/core/plan.py
@@ -55,11 +55,21 @@ def resolve_plan_path(
     workspace_root: Path,
     docs_dir: str = "docs",
 ) -> Path | None:
-    """Explicit `plan_path` (workspace-relative or absolute) wins; else the
-    discover_plan_path convention. Returns the Path if the file exists, else None."""
+    """Explicit `plan_path` (workspace-relative) wins; else the
+    discover_plan_path convention. Returns the Path if the file exists AND lives
+    inside the workspace, else None. The plan path is later read by the gate and
+    dispatch, so a path that escapes the workspace (absolute, or `..` traversal)
+    is rejected — never read files outside the workspace (Greptile security)."""
+    root = Path(workspace_root).resolve()
     if plan_path:
         p = Path(plan_path)
         if not p.is_absolute():
-            p = Path(workspace_root) / p
+            p = root / p
+        try:
+            p = p.resolve()
+        except OSError:
+            return None
+        if not p.is_relative_to(root):
+            return None
         return p if p.is_file() else None
-    return discover_plan_path(Path(workspace_root), task_slug, docs_dir)
+    return discover_plan_path(root, task_slug, docs_dir)

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -624,6 +624,8 @@ def create_app(
                     spec, state_manager=state_manager, store=store,
                     spawn_fn=_serve_spawn, now=datetime.now(timezone.utc),
                     workitems=workitems, workspace=workspace_name,
+                    workspace_root=workspace_root,
+                    docs_dir=(config.docs_dir if config is not None else "docs"),
                 )
                 # Serve-side-only handoff notify (MOS-194): posts an agent `event`
                 # message naming the spec/task/worktree into the WorkItem's thread

--- a/src/mship/core/spec_dispatch.py
+++ b/src/mship/core/spec_dispatch.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Callable
 
 from mship.core.spec import Spec
@@ -37,8 +38,16 @@ class DispatchResult:
     handoff: str        # the subagent handoff prompt
 
 
-def build_dispatch_handoff(spec: Spec, task: Task) -> str:
-    """Render the handoff prompt printed/returned after a successful dispatch."""
+def build_dispatch_handoff(
+    spec: Spec, task: Task, plan_path: Path | str | None = None
+) -> str:
+    """Render the handoff prompt printed/returned after a successful dispatch.
+
+    If `plan_path` is given (a linked/discovered implementation plan exists), the
+    handoff points the build at that plan's anchored task blocks. Otherwise it
+    keeps the spec-based kickoff and reminds the build to write the plan first
+    (writing-plans) during the plan phase.
+    """
     sections = parse_body_sections(spec.body)
     problem = sections.get("Problem", "").strip()
     criteria_lines = "\n".join(
@@ -47,6 +56,32 @@ def build_dispatch_handoff(spec: Spec, task: Task) -> str:
     worktrees_lines = "\n".join(
         f"  - {repo}: {path}" for repo, path in task.worktrees.items()
     ) or "  (no worktrees registered yet)"
+
+    if plan_path is not None:
+        next_step = f"""\
+## Implementation plan (linked)
+
+`{plan_path}`
+
+This work has a plan. Execute its anchored task blocks in order — dispatch each
+one and hand it to a per-task implementer:
+
+```
+mship dispatch --task {task.slug} --plan-task <N>
+```
+
+No `--plan` flag needed: dispatch auto-resolves this plan for the task."""
+    else:
+        next_step = f"""\
+## Next: write the implementation plan
+
+No implementation plan is linked yet. During the plan phase, write one with the
+`writing-plans` skill at `<docs_dir>/plans/<date>-{task.slug}.md` (with anchored
+task blocks), then link it via `mship item link-plan <work-item-id> <path>`.
+Feature work items require a plan before entering dev/finish.
+
+Run `mship dispatch --task {task.slug} --instruction "<your instruction>"` to emit a full subagent prompt."""
+
     return f"""\
 # Spec dispatch: {spec.title}
 
@@ -66,7 +101,7 @@ def build_dispatch_handoff(spec: Spec, task: Task) -> str:
 
 {worktrees_lines}
 
-Run `mship dispatch --task {task.slug} --instruction "<your instruction>"` to emit a full subagent prompt.
+{next_step}
 """
 
 
@@ -97,6 +132,8 @@ def dispatch_spec(
     workitems,
     workspace: str,
     task_slug: str | None = None,
+    workspace_root: Path | None = None,
+    docs_dir: str = "docs",
 ) -> DispatchResult:
     """Bind an approved (or already-dispatched) spec to a task.
 
@@ -194,7 +231,18 @@ def dispatch_spec(
     spec.updated_at = now
     store.save(spec)
 
+    # Point the handoff at the task's implementation plan when one resolves (the
+    # WorkItem's linked `plan_path` wins, else the docs/plans convention) so the
+    # build runs plan-driven; otherwise the handoff reminds it to write one.
+    plan_path = None
+    if workspace_root is not None:
+        from mship.core.plan import resolve_plan_path
+
+        wi_obj = workitems.get(spec.work_item_id) if spec.work_item_id else None
+        linked = wi_obj.plan_path if wi_obj is not None else None
+        plan_path = resolve_plan_path(chosen_slug, linked, Path(workspace_root), docs_dir)
+
     return DispatchResult(
         spec=spec, task=task, spawned=spawned,
-        handoff=build_dispatch_handoff(spec, task),
+        handoff=build_dispatch_handoff(spec, task, plan_path=plan_path),
     )

--- a/src/mship/core/workitem.py
+++ b/src/mship/core/workitem.py
@@ -26,6 +26,7 @@ class WorkItem(BaseModel):
     created_at: datetime
     updated_at: datetime
     spec_id: str | None = None
+    plan_path: str | None = None
     task_slugs: list[str] = []
     thread_ids: list[str] = []
     external_links: list[ExternalLink] = []

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -77,7 +77,14 @@ def _feature_has_plan(wi: WorkItem, task, workspace_root: Path) -> bool:
     p = resolve_plan_path(
         task.slug, getattr(wi, "plan_path", None), workspace_root, _docs_dir(workspace_root)
     )
-    return p is not None and plan_has_tasks(p.read_text())
+    if p is None:
+        return False
+    try:
+        return plan_has_tasks(p.read_text())
+    except OSError:
+        # resolved but unreadable (deleted/permission between resolve and read)
+        # → treat as no valid plan; the gate fails with its actionable message.
+        return False
 
 
 def log_hotfix(workspace_root: Path, where: str, task_slug: str) -> None:

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -81,9 +81,10 @@ def _feature_has_plan(wi: WorkItem, task, workspace_root: Path) -> bool:
         return False
     try:
         return plan_has_tasks(p.read_text())
-    except OSError:
-        # resolved but unreadable (deleted/permission between resolve and read)
-        # → treat as no valid plan; the gate fails with its actionable message.
+    except (OSError, UnicodeDecodeError):
+        # resolved but unreadable — deleted/permission (OSError) or a non-UTF-8
+        # / binary file (UnicodeDecodeError). Treat as no valid plan so the gate
+        # fails with its actionable message, NOT the generic corrupt-store error.
         return False
 
 

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -39,9 +39,11 @@ def check_task_gate(task, workspace_root: Path, require_plan: bool = False) -> G
         return GateResult(False, "feature WorkItem requires an approved spec before dev/finish "
                                  "(approve it in Ground Control, or `--hotfix` to override)")
     if require_plan and wi.kind == "feature" and not _feature_has_plan(wi, task, workspace_root):
-        return GateResult(False, "feature WorkItem requires an implementation plan before dev/finish — "
-                                 "write one (writing-plans, at <docs_dir>/plans/<date>-<slug>.md) or link "
-                                 "it with `mship item link-plan`. Use --bypass-plan-gate / --hotfix to skip.")
+        dd = _docs_dir(workspace_root)
+        return GateResult(False, f"feature WorkItem requires an implementation plan before dev/finish — "
+                                 f"write one (writing-plans) at {dd}/plans/<date>-{task.slug}.md, or link it "
+                                 f"with `mship item link-plan {task.work_item_id} <path>`. "
+                                 f"Use --bypass-plan-gate / --hotfix to skip.")
     return GateResult(True)
 
 
@@ -54,22 +56,27 @@ def _feature_has_approved_spec(wi: WorkItem, task, workspace_root: Path) -> bool
     return any(s.task_slug == task.slug and s.status in APPROVED_STATUSES for s in specs.list())
 
 
-def _feature_has_plan(wi: WorkItem, task, workspace_root: Path) -> bool:
-    """A feature's plan resolves (via the WorkItem's explicit `plan_path` or the
-    `<docs_dir>/plans/<date>-<slug>.md` convention) AND carries a mship:task
-    anchor. `docs_dir` comes from mothership.yaml; fall back to "docs" on any
-    load error (e.g. running outside a materialized workspace)."""
+def _docs_dir(workspace_root: Path) -> str:
+    """`docs_dir` from mothership.yaml; fall back to "docs" on any load error
+    (e.g. running outside a materialized workspace)."""
     from mship.core.config import ConfigLoader
-    from mship.core.plan import plan_has_tasks, resolve_plan_path
-
-    docs_dir = "docs"
     try:
-        docs_dir = ConfigLoader.load(
+        return ConfigLoader.load(
             Path(workspace_root) / "mothership.yaml", require_paths=False
         ).docs_dir
     except Exception:
-        pass
-    p = resolve_plan_path(task.slug, getattr(wi, "plan_path", None), workspace_root, docs_dir)
+        return "docs"
+
+
+def _feature_has_plan(wi: WorkItem, task, workspace_root: Path) -> bool:
+    """A feature's plan resolves (via the WorkItem's explicit `plan_path` or the
+    `<docs_dir>/plans/<date>-<slug>.md` convention) AND carries a mship:task
+    anchor."""
+    from mship.core.plan import plan_has_tasks, resolve_plan_path
+
+    p = resolve_plan_path(
+        task.slug, getattr(wi, "plan_path", None), workspace_root, _docs_dir(workspace_root)
+    )
     return p is not None and plan_has_tasks(p.read_text())
 
 

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -23,9 +23,11 @@ class GateResult:
     reason: str | None = None  # actionable message when not ok
 
 
-def check_task_gate(task, workspace_root: Path) -> GateResult:
+def check_task_gate(task, workspace_root: Path, require_plan: bool = False) -> GateResult:
     """Universal: a task must have a WorkItem. Kind-gated: a feature WorkItem
-    must have an approved spec. bug/chore/question need only the WorkItem."""
+    must have an approved spec. When `require_plan` is set — only at phase
+    plan→dev and finish, never at spawn — a feature WorkItem must ALSO have a
+    valid implementation plan. bug/chore/question need only the WorkItem."""
     if getattr(task, "work_item_id", None) is None:
         return GateResult(False, "no WorkItem — create one with `mship item new --kind <kind>` "
                                  "and spawn with `--work-item <id>` (or pass `--hotfix` to override)")
@@ -36,6 +38,10 @@ def check_task_gate(task, workspace_root: Path) -> GateResult:
     if wi.kind == "feature" and not _feature_has_approved_spec(wi, task, workspace_root):
         return GateResult(False, "feature WorkItem requires an approved spec before dev/finish "
                                  "(approve it in Ground Control, or `--hotfix` to override)")
+    if require_plan and wi.kind == "feature" and not _feature_has_plan(wi, task, workspace_root):
+        return GateResult(False, "feature WorkItem requires an implementation plan before dev/finish — "
+                                 "write one (writing-plans, at <docs_dir>/plans/<date>-<slug>.md) or link "
+                                 "it with `mship item link-plan`. Use --bypass-plan-gate / --hotfix to skip.")
     return GateResult(True)
 
 
@@ -46,6 +52,25 @@ def _feature_has_approved_spec(wi: WorkItem, task, workspace_root: Path) -> bool
         if s is not None and s.status in APPROVED_STATUSES:
             return True
     return any(s.task_slug == task.slug and s.status in APPROVED_STATUSES for s in specs.list())
+
+
+def _feature_has_plan(wi: WorkItem, task, workspace_root: Path) -> bool:
+    """A feature's plan resolves (via the WorkItem's explicit `plan_path` or the
+    `<docs_dir>/plans/<date>-<slug>.md` convention) AND carries a mship:task
+    anchor. `docs_dir` comes from mothership.yaml; fall back to "docs" on any
+    load error (e.g. running outside a materialized workspace)."""
+    from mship.core.config import ConfigLoader
+    from mship.core.plan import plan_has_tasks, resolve_plan_path
+
+    docs_dir = "docs"
+    try:
+        docs_dir = ConfigLoader.load(
+            Path(workspace_root) / "mothership.yaml", require_paths=False
+        ).docs_dir
+    except Exception:
+        pass
+    p = resolve_plan_path(task.slug, getattr(wi, "plan_path", None), workspace_root, docs_dir)
+    return p is not None and plan_has_tasks(p.read_text())
 
 
 def log_hotfix(workspace_root: Path, where: str, task_slug: str) -> None:

--- a/src/mship/core/workitem_store.py
+++ b/src/mship/core/workitem_store.py
@@ -71,6 +71,11 @@ class WorkItemStore:
         item.spec_id = spec_id
         self.save(item)
 
+    def link_plan(self, item_id: str, plan_path: str, now: datetime | None = None) -> None:
+        item = self._mutate(item_id, now)
+        item.plan_path = plan_path
+        self.save(item)
+
     def add_task(self, item_id: str, task_slug: str, now: datetime | None = None,
                 state: StateManager | None = None) -> None:
         item = self.get(item_id)

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -167,14 +167,89 @@ def test_dispatch_rejects_two_instruction_sources(tmp_path: Path):
         _reset()
 
 
-def test_dispatch_plan_task_without_plan_errors(tmp_path: Path):
+def test_dispatch_plan_task_without_resolvable_plan_errors(tmp_path: Path):
+    # --plan-task with no --plan now auto-resolves the task's plan; when there
+    # is no linked/discoverable plan at all, it errors with guidance rather than
+    # the old "--plan-task requires --plan".
     wt = tmp_path / "wt"; wt.mkdir()
     cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
     _override(cfg, state_dir)
     try:
         result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "1"])
         assert result.exit_code != 0
-        assert "--plan-task requires --plan" in result.output
+        assert "no implementation plan" in result.output.lower()
+    finally:
+        _reset()
+
+
+def test_dispatch_task_auto_resolves_convention_plan(tmp_path: Path):
+    # A plan discoverable at docs/plans/<slug>.md is auto-resolved when --plan
+    # is omitted; --plan-task selects the block.
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    plans = tmp_path / "docs" / "plans"; plans.mkdir(parents=True)
+    (plans / "t.md").write_text(
+        "<!-- mship:task id=1 -->\n### Task 1\n\nfirst thing\n<!-- /mship:task -->\n"
+        "<!-- mship:task id=2 -->\n### Task 2\n\nsecond thing\n<!-- /mship:task -->\n"
+    )
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "2"])
+        assert result.exit_code == 0, result.output
+        assert "Task 2" in result.output
+        assert "second thing" in result.output
+        assert "first thing" not in result.output
+    finally:
+        _reset()
+
+
+def test_dispatch_task_auto_resolves_workitem_linked_plan(tmp_path: Path):
+    # A plan linked on the task's WorkItem (WorkItem.plan_path) is auto-resolved
+    # even when it lives outside the docs/plans convention.
+    from mship.core.workitem_store import WorkItemStore
+
+    now = datetime.now(timezone.utc)
+    wt = tmp_path / "wt"; wt.mkdir()
+    state_dir = tmp_path / ".mothership"; state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"; cfg.write_text("workspace: t\nrepos: {}\n")
+    explicit = tmp_path / "custom-plan.md"
+    explicit.write_text("<!-- mship:task id=3 -->\nlinked plan body\n<!-- /mship:task -->\n")
+    items = WorkItemStore(state_dir / "workitems")
+    wi = items.create(title="t", kind="feature", workspace="t", now=now)
+    items.link_plan(wi.id, "custom-plan.md", now=now)
+    task = Task(
+        slug="t", description="d", phase="dev", created_at=now,
+        affected_repos=["only"], worktrees={"only": wt}, branch="feat/t",
+        base_branch="main", work_item_id=wi.id,
+    )
+    StateManager(state_dir).save(WorkspaceState(tasks={"t": task}))
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "3"])
+        assert result.exit_code == 0, result.output
+        assert "linked plan body" in result.output
+    finally:
+        _reset()
+
+
+def test_dispatch_explicit_plan_overrides_linked(tmp_path: Path):
+    # An explicit --plan still wins over the auto-resolved convention plan.
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    plans = tmp_path / "docs" / "plans"; plans.mkdir(parents=True)
+    (plans / "t.md").write_text(
+        "<!-- mship:task id=2 -->\nconvention thing\n<!-- /mship:task -->\n"
+    )
+    explicit = tmp_path / "explicit.md"
+    explicit.write_text("<!-- mship:task id=2 -->\nexplicit thing\n<!-- /mship:task -->\n")
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(
+            app, ["dispatch", "--task", "t", "--plan", str(explicit), "--plan-task", "2"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "explicit thing" in result.output
+        assert "convention thing" not in result.output
     finally:
         _reset()
 

--- a/tests/cli/test_workitem.py
+++ b/tests/cli/test_workitem.py
@@ -462,6 +462,34 @@ def test_item_unattended_cli(tmp_path):
         container.config.reset()
 
 
+def test_link_plan_sets_plan_path(tmp_path):
+    _isolate(tmp_path)
+    try:
+        res = runner.invoke(app, ["item", "new", "Title", "--kind", "feature"])
+        assert res.exit_code == 0, res.output
+        item_id = res.output.strip()
+
+        res = runner.invoke(app, ["item", "link-plan", item_id, "docs/plans/x.md"])
+        assert res.exit_code == 0, res.output
+        assert "docs/plans/x.md" in res.output
+
+        res = runner.invoke(app, ["item", "show", item_id])
+        assert res.exit_code == 0, res.output
+        assert json.loads(res.output)["plan_path"] == "docs/plans/x.md"
+    finally:
+        _reset()
+
+
+def test_link_plan_missing_item_errors(tmp_path):
+    _isolate(tmp_path)
+    try:
+        res = runner.invoke(app, ["item", "link-plan", "nope", "docs/plans/x.md"])
+        assert res.exit_code == 1
+        assert "no work item" in res.output
+    finally:
+        _reset()
+
+
 def test_link_url_with_invalid_provider_errors_cleanly(tmp_path):
     _isolate(tmp_path)
     try:

--- a/tests/core/test_export.py
+++ b/tests/core/test_export.py
@@ -746,6 +746,42 @@ def test_bundle_omits_missing_optional_artifacts(workspace_with_git, tmp_path):
     assert result.warnings == []
 
 
+def test_bundle_honors_explicit_linked_plan_path(workspace_with_git, tmp_path):
+    """export includes a plan linked via WorkItem.plan_path even when it's OFF
+    the docs/plans/<slug>.md convention — same resolver the gate/dispatch use,
+    so a linked off-convention plan isn't silently omitted (Greptile)."""
+    from mship.core.workitem_store import WorkItemStore
+    state_dir = workspace_with_git / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    log_mgr = LogManager(state_dir / "logs")
+    log_mgr.create("linked-plan")
+    spec_store = SpecStore(workspace_with_git / "specs")
+    config = ConfigLoader.load(workspace_with_git / "mothership.yaml")
+
+    # off-convention plan doc inside the workspace (discover_plan_path won't find it)
+    plan_file = workspace_with_git / "custom" / "the-plan.md"
+    plan_file.parent.mkdir(parents=True, exist_ok=True)
+    plan_file.write_text("# Plan\n\n<!-- mship:task id=1 -->\n### Task 1\n<!-- /mship:task -->\n")
+
+    _now = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    items = WorkItemStore(state_dir / "workitems")
+    wi = items.create(title="linked plan", kind="feature", workspace="ws", now=_now)
+    items.link_plan(wi.id, "custom/the-plan.md", now=_now)
+
+    task = _make_task(
+        slug="linked-plan", branch="feat/linked-plan",
+        worktrees={"shared": workspace_with_git / "shared"},
+        spec_id=None, work_item_id=wi.id,
+    )
+    dest = tmp_path / "out"
+    build_export_bundle(
+        task=task, config=config, workspace_root=workspace_with_git,
+        log_manager=log_mgr, spec_store=spec_store, dest_dir=dest, redacted=False,
+    )
+    assert (dest / "plan.md").is_file()
+    assert "Task 1" in (dest / "plan.md").read_text()
+
+
 def test_bundle_surfaces_warning_when_a_repo_base_is_unresolvable(workspace_with_git, tmp_path):
     """build_export_bundle propagates collect_repo_diff's unresolvable-base
     warning into ExportBundle.warnings (surfaced by the CLI as `output.warning`)

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -652,6 +652,31 @@ def test_plan_to_dev_bypass_plan_gate_noop_writes_no_log(tmp_path: Path):
     assert not (tmp_path / ".mothership" / "bypass-log.jsonl").exists()
 
 
+def test_plan_to_dev_bypass_plan_gate_no_log_when_required_hook_aborts(tmp_path: Path):
+    """A --bypass-plan-gate transition later ABORTED by a required
+    phase.entered.dev hook must NOT record a bypass — the audit log never holds a
+    bypass for a transition that didn't commit (Greptile). The bypass is logged
+    only after the state mutation + all lifecycle hooks succeed."""
+    from mship.core.config import HookConfig
+    from mship.core.lifecycle_hooks import HookRequiredError
+
+    wi = _seed_feature_wi_with_approved_spec(tmp_path)  # feature + approved spec, NO plan
+    sm = StateManager(tmp_path / ".mothership")
+    shell = _RecordingShell()
+    shell.fail_substrings.add("notify-dev")
+    pm = _make_phase_manager_with_hooks(
+        sm, tmp_path,
+        hooks=[HookConfig(on="phase.entered.dev", run="task notify-dev", required=True)],
+        shell=shell,
+    )
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+
+    with pytest.raises(HookRequiredError):
+        pm.transition("wi-task", "dev", bypass_plan_gate=True)
+    assert sm.load().tasks["wi-task"].phase == "plan"  # aborted
+    assert not (tmp_path / ".mothership" / "bypass-log.jsonl").exists()  # no bypass logged
+
+
 def test_plan_to_dev_bypass_plan_gate_still_enforces_spec(tmp_path: Path):
     """--bypass-plan-gate skips ONLY the plan clause — a feature with no approved
     spec still blocks (spec + WorkItem checks keep running via require_plan=False)."""

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -634,6 +634,24 @@ def test_plan_to_dev_bypass_plan_gate_allows_and_logs_hotfix(tmp_path: Path):
     assert line["reason"] == "hotfix"
 
 
+def test_plan_to_dev_bypass_plan_gate_noop_writes_no_log(tmp_path: Path):
+    """A --bypass-plan-gate that wasn't needed (a valid plan is already present)
+    records NO bypass-log entry — the bypass only logs when it actually dropped a
+    blocking plan gate, and only after all later gates pass (Greptile)."""
+    wi = _seed_feature_wi_with_approved_spec(tmp_path)
+    sm, pm = _workitem_gate_env(tmp_path)
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True, exist_ok=True)
+    (plans / "wi-task.md").write_text(
+        "# Plan\n\n<!-- mship:task id=1 -->\n### T1\n<!-- /mship:task -->\n"
+    )
+
+    result = pm.transition("wi-task", "dev", bypass_plan_gate=True)
+    assert result.new_phase == "dev"
+    assert not (tmp_path / ".mothership" / "bypass-log.jsonl").exists()
+
+
 def test_plan_to_dev_bypass_plan_gate_still_enforces_spec(tmp_path: Path):
     """--bypass-plan-gate skips ONLY the plan clause — a feature with no approved
     spec still blocks (spec + WorkItem checks keep running via require_plan=False)."""

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -500,6 +500,8 @@ def test_plan_to_dev_feature_work_item_with_approved_spec_allowed(tmp_path: Path
 
     sm, pm = _workitem_gate_env(tmp_path)
     sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+    # plan→dev now also requires an implementation plan (require_plan=True).
+    _write_plan_doc(tmp_path)
     result = pm.transition("wi-task", "dev")
     assert result.new_phase == "dev"
 
@@ -561,6 +563,87 @@ def test_plan_to_dev_bypass_spec_gate_skips_corrupt_workitem_store(tmp_path: Pat
 
     result = pm.transition("wi-task", "dev", bypass_spec_gate=True)
     assert result.new_phase == "dev"
+
+
+# ---------------------------------------------------------------------------
+# Task 4: plan gate at plan→dev (require_plan) + --bypass-plan-gate
+# (first-class-implementation-plans-plan, MOS-235)
+# ---------------------------------------------------------------------------
+
+_PLAN_DOC = "# Plan\n\n<!-- mship:task id=1 -->\n### Task 1\n<!-- /mship:task -->\n"
+
+
+def _seed_feature_wi_with_approved_spec(tmp_path: Path):
+    """Feature WorkItem + an approved, linked spec so ONLY the plan is missing —
+    isolates the plan clause from the spec clause of the gate."""
+    from mship.core.spec import Spec
+    from mship.core.spec_store import SpecStore
+
+    now = datetime(2026, 4, 10, tzinfo=timezone.utc)
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="add thing", kind="feature", workspace="test", now=now)
+    specs = SpecStore(tmp_path / "specs")
+    specs.save(Spec(id="spec-1", title="Spec", status="approved",
+                    created_at=now, updated_at=now))
+    items.link_spec(wi.id, "spec-1", now=now)
+    return wi
+
+
+def _write_plan_doc(tmp_path: Path, slug: str = "wi-task") -> None:
+    d = tmp_path / "docs" / "plans"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"2026-07-12-{slug}.md").write_text(_PLAN_DOC)
+
+
+def test_plan_to_dev_feature_without_plan_blocked(tmp_path: Path):
+    """plan→dev now requires a plan (require_plan=True): feature + approved spec
+    but no plan doc → SpecGateError mentioning the plan."""
+    wi = _seed_feature_wi_with_approved_spec(tmp_path)
+    sm, pm = _workitem_gate_env(tmp_path)
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+    with pytest.raises(SpecGateError, match="plan"):
+        pm.transition("wi-task", "dev")
+
+
+def test_plan_to_dev_feature_with_plan_allowed(tmp_path: Path):
+    wi = _seed_feature_wi_with_approved_spec(tmp_path)
+    _write_plan_doc(tmp_path)
+    sm, pm = _workitem_gate_env(tmp_path)
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+    result = pm.transition("wi-task", "dev")
+    assert result.new_phase == "dev"
+
+
+def test_plan_to_dev_bypass_plan_gate_allows_and_logs_hotfix(tmp_path: Path):
+    """--bypass-plan-gate drops only the plan requirement and records a
+    bypass-log entry under op 'phase-dev-plan'."""
+    import json
+
+    wi = _seed_feature_wi_with_approved_spec(tmp_path)  # no plan on disk
+    sm, pm = _workitem_gate_env(tmp_path)
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+
+    result = pm.transition("wi-task", "dev", bypass_plan_gate=True)
+    assert result.new_phase == "dev"
+
+    log_path = tmp_path / ".mothership" / "bypass-log.jsonl"
+    assert log_path.is_file()
+    line = json.loads(log_path.read_text().splitlines()[-1])
+    assert line["op"] == "phase-dev-plan"
+    assert line["branch"] == "wi-task"
+    assert line["reason"] == "hotfix"
+
+
+def test_plan_to_dev_bypass_plan_gate_still_enforces_spec(tmp_path: Path):
+    """--bypass-plan-gate skips ONLY the plan clause — a feature with no approved
+    spec still blocks (spec + WorkItem checks keep running via require_plan=False)."""
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="add thing", kind="feature", workspace="test",
+                      now=datetime(2026, 4, 10, tzinfo=timezone.utc))
+    sm, pm = _workitem_gate_env(tmp_path)
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+    with pytest.raises(SpecGateError, match="approved spec"):
+        pm.transition("wi-task", "dev", bypass_plan_gate=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -1,0 +1,44 @@
+"""Tests for mship.core.plan — shared plan resolution + validity (MOS-235)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from mship.core.plan import discover_plan_path, plan_has_tasks, resolve_plan_path
+
+_PLAN = "# Plan\n\n<!-- mship:task id=1 -->\n### Task 1\n<!-- /mship:task -->\n"
+
+
+def test_plan_has_tasks_true_when_anchor_present():
+    assert plan_has_tasks(_PLAN) is True
+
+
+def test_plan_has_tasks_false_when_no_anchor():
+    assert plan_has_tasks("# Just prose, no tasks") is False
+
+
+def test_discover_plan_path_matches_dated_slug(tmp_path):
+    d = tmp_path / "docs" / "plans"
+    d.mkdir(parents=True)
+    p = d / "2026-07-12-add-labels.md"
+    p.write_text(_PLAN)
+    assert discover_plan_path(tmp_path, "add-labels", docs_dir="docs") == p
+
+
+def test_resolve_plan_path_prefers_explicit(tmp_path):
+    explicit = tmp_path / "custom" / "myplan.md"
+    explicit.parent.mkdir(parents=True)
+    explicit.write_text(_PLAN)
+    got = resolve_plan_path("add-labels", str(explicit.relative_to(tmp_path)), tmp_path, "docs")
+    assert got == explicit
+
+
+def test_resolve_plan_path_falls_back_to_convention(tmp_path):
+    d = tmp_path / "docs" / "plans"
+    d.mkdir(parents=True)
+    p = d / "add-labels.md"
+    p.write_text(_PLAN)
+    assert resolve_plan_path("add-labels", None, tmp_path, "docs") == p
+
+
+def test_resolve_plan_path_none_when_missing(tmp_path):
+    assert resolve_plan_path("add-labels", None, tmp_path, "docs") is None

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -42,3 +42,16 @@ def test_resolve_plan_path_falls_back_to_convention(tmp_path):
 
 def test_resolve_plan_path_none_when_missing(tmp_path):
     assert resolve_plan_path("add-labels", None, tmp_path, "docs") is None
+
+
+def test_resolve_plan_path_rejects_absolute_escape(tmp_path):
+    """An explicit plan_path outside the workspace is rejected — the gate/dispatch
+    read this path, so never read files outside the workspace (Greptile security)."""
+    outside = tmp_path.parent / "outside-plan.md"
+    outside.write_text(_PLAN)
+    assert resolve_plan_path("add-labels", str(outside), tmp_path, "docs") is None
+
+
+def test_resolve_plan_path_rejects_dotdot_traversal(tmp_path):
+    (tmp_path.parent / "esc-plan.md").write_text(_PLAN)
+    assert resolve_plan_path("add-labels", "../esc-plan.md", tmp_path, "docs") is None

--- a/tests/core/test_spec_dispatch.py
+++ b/tests/core/test_spec_dispatch.py
@@ -60,6 +60,49 @@ def test_build_dispatch_handoff_contains_key_facts():
     assert "mship dispatch --task dq" in out       # next-step command
 
 
+def test_build_dispatch_handoff_points_at_plan_when_linked():
+    out = build_dispatch_handoff(
+        _approved_spec(), _task(), plan_path="docs/plans/2026-07-12-dq.md"
+    )
+    assert "docs/plans/2026-07-12-dq.md" in out            # the plan doc path
+    assert "mship dispatch --task dq --plan-task" in out    # plan-driven next step
+
+
+def test_build_dispatch_handoff_reminds_to_write_plan_when_none():
+    out = build_dispatch_handoff(_approved_spec(), _task())  # no plan
+    assert "writing-plans" in out
+    assert "link-plan" in out
+
+
+def test_dispatch_spec_handoff_points_at_discovered_plan(tmp_path):
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
+    sm.save(WorkspaceState(tasks={"dq": _task()}))
+    spec = _approved_spec()
+    store.save(spec)
+    plans = tmp_path / "docs" / "plans"; plans.mkdir(parents=True)
+    (plans / "dq.md").write_text("<!-- mship:task id=1 -->\nx\n<!-- /mship:task -->\n")
+
+    result = dispatch_spec(
+        spec, state_manager=sm, store=store, spawn_fn=lambda s: None, now=NOW,
+        workitems=items, workspace=WORKSPACE, workspace_root=tmp_path,
+    )
+    assert "dq.md" in result.handoff
+    assert "--plan-task" in result.handoff
+
+
+def test_dispatch_spec_handoff_reminds_write_plan_when_none(tmp_path):
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
+    sm.save(WorkspaceState(tasks={"dq": _task()}))
+    spec = _approved_spec()
+    store.save(spec)
+
+    result = dispatch_spec(
+        spec, state_manager=sm, store=store, spawn_fn=lambda s: None, now=NOW,
+        workitems=items, workspace=WORKSPACE, workspace_root=tmp_path,
+    )
+    assert "writing-plans" in result.handoff
+
+
 def test_dispatch_spec_binds_existing_task_without_spawning(tmp_path):
     sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
     sm.save(WorkspaceState(tasks={"dq": _task()}))

--- a/tests/core/test_workitem.py
+++ b/tests/core/test_workitem.py
@@ -43,6 +43,17 @@ def test_workitem_unattended_defaults_false_and_roundtrips():
     assert WorkItem.model_validate_json(wi2.model_dump_json()).unattended is True
 
 
+def test_workitem_plan_path_defaults_none_and_roundtrips():
+    now = _now()
+    wi = WorkItem(id="wi-1", title="t", workspace="ws", kind="feature",
+                  created_at=now, updated_at=now)
+    assert wi.plan_path is None
+    dumped = wi.model_dump_json()
+    assert WorkItem.model_validate_json(dumped).plan_path is None
+    wi2 = wi.model_copy(update={"plan_path": "docs/plans/x.md"})
+    assert WorkItem.model_validate_json(wi2.model_dump_json()).plan_path == "docs/plans/x.md"
+
+
 def test_workitem_archived_defaults_false_and_roundtrips():
     now = _now()
     wi = WorkItem(id="wi-1", title="t", workspace="ws", kind="feature",

--- a/tests/core/test_workitem_store.py
+++ b/tests/core/test_workitem_store.py
@@ -53,6 +53,21 @@ def test_link_missing_item_raises(tmp_path):
         store.link_spec("nope", "spec-1")
 
 
+def test_link_plan_persists_plan_path(tmp_path):
+    store = WorkItemStore(tmp_path / "workitems")
+    wi = store.create(title="t", kind="feature", workspace="ws", now=_now())
+    store.link_plan(wi.id, "docs/plans/2026-07-12-t.md", now=_now())
+    # reload via a fresh store instance to prove it was persisted
+    fresh = WorkItemStore(tmp_path / "workitems")
+    assert fresh.get(wi.id).plan_path == "docs/plans/2026-07-12-t.md"
+
+
+def test_link_plan_missing_item_raises(tmp_path):
+    store = WorkItemStore(tmp_path / "workitems")
+    with pytest.raises(KeyError):
+        store.link_plan("nope", "docs/plans/x.md")
+
+
 def test_set_unattended_toggles(tmp_path):
     store = WorkItemStore(tmp_path / "workitems")
     wi = store.create(title="t", kind="feature", workspace="ws",

--- a/tests/test_finish_gate.py
+++ b/tests/test_finish_gate.py
@@ -111,6 +111,15 @@ def test_finish_passes_with_bug_work_item_and_no_spec(finish_gate_workspace):
     assert state.tasks["bug-task"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
 
 
+_PLAN_DOC = "# Plan\n\n<!-- mship:task id=1 -->\n### Task 1\n<!-- /mship:task -->\n"
+
+
+def _write_plan(workspace: Path, slug: str) -> None:
+    d = workspace / "docs" / "plans"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"2026-07-12-{slug}.md").write_text(_PLAN_DOC)
+
+
 def test_finish_passes_with_feature_work_item_and_approved_spec(finish_gate_workspace):
     workspace, _ = finish_gate_workspace
     items = WorkItemStore(workspace / ".mothership" / "workitems")
@@ -125,12 +134,63 @@ def test_finish_passes_with_feature_work_item_and_approved_spec(finish_gate_work
         app, ["spawn", "--work-item", wi.id, "feature with spec", "--repos", "shared"],
     )
     assert result.exit_code == 0, result.output
+    # finish now also requires a plan (require_plan=True) — write one.
+    _write_plan(workspace, "feature-with-spec")
 
     result = runner.invoke(app, ["finish", "--task", "feature-with-spec"])
     assert result.exit_code == 0, result.output
 
     state = StateManager(workspace / ".mothership").load()
     assert state.tasks["feature-with-spec"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
+
+
+def test_finish_blocks_feature_work_item_without_plan(finish_gate_workspace):
+    """Feature with an approved spec but no implementation plan → finish refuses."""
+    workspace, _ = finish_gate_workspace
+    items = WorkItemStore(workspace / ".mothership" / "workitems")
+    specs = SpecStore(workspace / "specs")
+    now = datetime.now(timezone.utc)
+    specs.save(Spec(id="spec-1", title="Spec", status="approved",
+                    created_at=now, updated_at=now))
+    wi = items.create(title="add thing", kind="feature", workspace="ws", now=now)
+    items.link_spec(wi.id, "spec-1", now=now)
+
+    result = runner.invoke(
+        app, ["spawn", "--work-item", wi.id, "feature no plan", "--repos", "shared"],
+    )
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(app, ["finish", "--task", "feature-no-plan"])
+    assert result.exit_code == 1, result.output
+    assert "plan" in result.output.lower()
+
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["feature-no-plan"].pr_urls == {}
+
+
+def test_finish_hotfix_bypasses_plan_gate(finish_gate_workspace):
+    """--hotfix downgrades the plan-gate block to a warning and still opens the PR."""
+    workspace, _ = finish_gate_workspace
+    items = WorkItemStore(workspace / ".mothership" / "workitems")
+    specs = SpecStore(workspace / "specs")
+    now = datetime.now(timezone.utc)
+    specs.save(Spec(id="spec-1", title="Spec", status="approved",
+                    created_at=now, updated_at=now))
+    wi = items.create(title="add thing", kind="feature", workspace="ws", now=now)
+    items.link_spec(wi.id, "spec-1", now=now)
+
+    result = runner.invoke(
+        app, ["spawn", "--work-item", wi.id, "feature hotfix plan", "--repos", "shared"],
+    )
+    assert result.exit_code == 0, result.output
+
+    # No plan on disk → --hotfix rescues the finish.
+    result = runner.invoke(app, ["finish", "--hotfix", "--task", "feature-hotfix-plan"])
+    assert result.exit_code == 0, result.output
+    assert "WorkItem gate bypassed" in result.output
+
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["feature-hotfix-plan"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
 
 
 def test_finish_hotfix_warns_and_proceeds_and_logs_bypass(finish_gate_workspace):

--- a/tests/test_spawn_gate.py
+++ b/tests/test_spawn_gate.py
@@ -101,6 +101,21 @@ def test_spawn_with_valid_work_item_sets_forward_and_reverse_link(spawn_gate_wor
     assert "add-labels" in reloaded.task_slugs
 
 
+def test_spawn_feature_work_item_without_spec_or_plan_succeeds(spawn_gate_workspace: Path):
+    """ac3: spawn is never spec/plan-gated — a FEATURE work item spawns fine
+    before its spec is approved or its plan is written (those gate phase dev,
+    not spawn)."""
+    items = _items_store(spawn_gate_workspace)
+    wi = items.create(title="add labels", kind="feature", workspace="ws", now=_now())
+
+    result = runner.invoke(
+        app, ["spawn", "add labels", "--repos", "shared", "--work-item", wi.id],
+    )
+    assert result.exit_code == 0, result.output
+    state = StateManager(spawn_gate_workspace / ".mothership").load()
+    assert state.tasks["add-labels"].work_item_id == wi.id
+
+
 def test_spawn_with_item_alias_flag_accepted(spawn_gate_workspace: Path):
     """--item is the short alias for --work-item."""
     items = _items_store(spawn_gate_workspace)

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -128,6 +128,76 @@ def test_approved_statuses_is_the_expected_set():
     assert APPROVED_STATUSES == {"approved", "dispatched", "implemented"}
 
 
+# ---------------------------------------------------------------------------
+# Plan gate (MOS-235): a feature WorkItem must have a valid implementation
+# plan before dev/finish — opt-in via `require_plan` (default False, so spawn
+# stays plan-free). Validity = plan file resolves AND carries a mship:task
+# anchor. bug/chore/question are never plan-gated.
+# ---------------------------------------------------------------------------
+
+_PLAN_WITH_TASK = "# Plan\n\n<!-- mship:task id=1 -->\n### Task 1\n<!-- /mship:task -->\n"
+
+
+def _approved_feature(tmp_path, slug="t"):
+    """A feature WorkItem with an approved spec so ONLY the plan is missing."""
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    specs = SpecStore(tmp_path / "specs")
+    specs.save(Spec(id="spec-1", title="Spec", status="approved",
+                    created_at=_now(), updated_at=_now()))
+    wi = items.create(title="add thing", kind="feature", workspace="ws", now=_now())
+    items.link_spec(wi.id, "spec-1", now=_now())
+    return items, wi, _task(slug=slug, work_item_id=wi.id)
+
+
+def test_feature_without_plan_blocked_when_require_plan(tmp_path):
+    _items, _wi, task = _approved_feature(tmp_path)
+    res = check_task_gate(task, tmp_path, require_plan=True)
+    assert res.ok is False
+    assert "plan" in res.reason.lower()
+
+
+def test_feature_with_convention_plan_passes(tmp_path):
+    _items, _wi, task = _approved_feature(tmp_path)
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "2026-07-12-t.md").write_text(_PLAN_WITH_TASK)
+    res = check_task_gate(task, tmp_path, require_plan=True)
+    assert res.ok is True
+
+
+def test_feature_with_linked_explicit_plan_passes(tmp_path):
+    items, wi, task = _approved_feature(tmp_path)
+    custom = tmp_path / "custom" / "myplan.md"
+    custom.parent.mkdir(parents=True)
+    custom.write_text(_PLAN_WITH_TASK)
+    items.link_plan(wi.id, "custom/myplan.md", now=_now())
+    res = check_task_gate(task, tmp_path, require_plan=True)
+    assert res.ok is True
+
+
+def test_plan_not_required_by_default(tmp_path):
+    # Same env, NO plan doc, default require_plan=False (spawn path) -> ok.
+    _items, _wi, task = _approved_feature(tmp_path)
+    assert check_task_gate(task, tmp_path).ok is True
+
+
+def test_empty_plan_file_is_invalid(tmp_path):
+    # Plan file exists at the convention path but has no mship:task anchor.
+    _items, _wi, task = _approved_feature(tmp_path)
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "2026-07-12-t.md").write_text("# Prose only, no anchor\n")
+    res = check_task_gate(task, tmp_path, require_plan=True)
+    assert res.ok is False
+
+
+def test_bug_never_plan_gated(tmp_path):
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="fix it", kind="bug", workspace="ws", now=_now())
+    task = _task(work_item_id=wi.id)
+    assert check_task_gate(task, tmp_path, require_plan=True).ok is True
+
+
 def test_workitem_migrate_shares_the_same_approved_statuses_object():
     """workitem_migrate must import (not redefine) workitem_gate's set —
     an identity check, not just an equality check, so a stray local copy

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -191,6 +191,18 @@ def test_empty_plan_file_is_invalid(tmp_path):
     assert res.ok is False
 
 
+def test_non_utf8_plan_file_fails_cleanly(tmp_path):
+    # A non-UTF-8 / binary plan at the convention path must fail the plan gate
+    # cleanly (ok=False), NOT raise UnicodeDecodeError that surfaces as a
+    # misleading "corrupt store" error (Greptile).
+    _items, _wi, task = _approved_feature(tmp_path)
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "2026-07-12-t.md").write_bytes(b"\xff\xfe binary <!-- mship:task id=1 -->")
+    res = check_task_gate(task, tmp_path, require_plan=True)  # must not raise
+    assert res.ok is False
+
+
 def test_bug_never_plan_gated(tmp_path):
     items = WorkItemStore(tmp_path / ".mothership" / "workitems")
     wi = items.create(title="fix it", kind="bug", workspace="ws", now=_now())


### PR DESCRIPTION
## Summary

Make implementation plans first-class in mship and enforce them for feature work items — implementing the approved spec `first-class-implementation-plans-plan-mos-235` (MOS-235). Fittingly, this is the first feature built through the new "features always work from a plan" rule (plan: `docs/plans/2026-07-12-first-class-plans-plan-gate.md`).

Specs were already first-class (`mship spec` + the feature spec-gate); plans were only an ad-hoc `docs/plans/*.md` consumed via `--plan`. This adds the missing half, mirroring the spec gate:

- **Shared resolver** (`core/plan.py`): `discover_plan_path` moved from export.py; new `plan_has_tasks` (validity = ≥1 `mship:task` anchor) and `resolve_plan_path` (explicit `WorkItem.plan_path` wins, else the `<docs_dir>/plans/<date>-<slug>.md` convention).
- **First-class link**: `WorkItem.plan_path` (beside `spec_id`) + `WorkItemStore.link_plan` + `mship item link-plan`.
- **Plan gate**: a feature work item can't enter `phase dev` or `finish` without a valid plan — an opt-in `require_plan` clause in `check_task_gate` (set True only at phase-dev + finish, never spawn; bug/chore/question skip). Bypass with `--bypass-plan-gate` / `--hotfix`, logged.
- **Plan-driven dispatch**: `mship dispatch --task <slug> --plan-task N` auto-resolves the linked/discovered plan and mints from it (no `--plan` needed); `mship spec dispatch`'s handoff points the build at the plan's tasks once one exists, else the spec kickoff + write-the-plan reminder. Spec = intent, plan = build instructions.

This closes the autonomous/GC hole: an agent literally cannot enter dev on a feature without a plan.

## Test plan
- [x] `mship test` — full suite green (no failures/regressions).
- [x] New/updated tests: resolver validity+convention+explicit; gate blocked/allowed/empty-invalid/bug-skips/spawn-not-gated (ac3); phase-dev + finish enforcement + bypass logging; link-plan persistence; plan-driven dispatch auto-resolve + override + handoff.
- [x] Final review: APPROVE_WITH_NITS; fixed concrete-path error message + added the ac3 spawn test.

Spec: `specs/2026-07-12-first-class-implementation-plans-plan-mos-235.md` · Plan: `docs/plans/2026-07-12-first-class-plans-plan-gate.md`

https://claude.ai/code/session_01WLb3xgnKi4fWy8M4reqhmu
