### PR TITLE
Widen mship _drain (Stop hook) to surface awaiting_agent_event threads with event-appropriate wording (MOS-232)

### DIFF
--- a/src/mship/cli/internal.py
+++ b/src/mship/cli/internal.py
@@ -36,18 +36,52 @@ def _staged_source_paths(toplevel: str, container) -> list[str]:
 
 
 def _format_drain_reason(threads: list) -> str:
-    """Render awaiting threads as a Stop-hook block reason instructing the agent
-    to answer each and clear it with `mship reply`."""
-    n = len(threads)
-    lines = [
-        f"{n} message{'s' if n != 1 else ''} waiting in your inbox. Answer each, "
-        f"then post your answer with `mship reply <thread-id> \"<text>\"` "
-        f"(replying clears the thread):",
-        "",
-    ]
-    for t in threads:
-        pending = t.messages[-1].text if t.messages else ""
-        lines.append(f"- thread {t.id} ({t.subject}): {pending}")
+    """Render awaiting threads as a Stop-hook block reason, split into two groups
+    with different calls-to-action:
+
+    - HUMAN-REPLY threads (`awaiting_reply` — the latest message is an unanswered
+      human message): answer each and clear it with `mship reply`.
+    - AGENT-EVENT threads (`awaiting_agent_event` and NOT `awaiting_reply` — an
+      unhandled agent `event`, i.e. a dispatched spec handoff or a PR
+      merged/closed, with no pending human reply): these are signals FOR THE
+      AGENT to act on. They are cleared by the agent taking action on the thread
+      (a human reply does not clear them), so they deliberately do NOT instruct
+      `mship reply`.
+
+    A thread that is BOTH (an unanswered human message AND an unhandled event)
+    lands in the human-reply group — replying is the priority action.
+    """
+    replies = [t for t in threads if t.awaiting_reply]
+    events = [t for t in threads if t.awaiting_agent_event and not t.awaiting_reply]
+
+    def _pending(t) -> str:
+        return t.messages[-1].text if t.messages else ""
+
+    lines: list[str] = []
+    if replies:
+        n = len(replies)
+        lines += [
+            f"{n} message{'s' if n != 1 else ''} waiting in your inbox. Answer each, "
+            f"then post your answer with `mship reply <thread-id> \"<text>\"` "
+            f"(replying clears the thread):",
+            "",
+        ]
+        for t in replies:
+            lines.append(f"- thread {t.id} ({t.subject}): {_pending(t)}")
+    if events:
+        if lines:
+            lines.append("")
+        n = len(events)
+        lines += [
+            f"{n} agent signal{'s' if n != 1 else ''} for you to act on "
+            f"(a dispatched spec handoff, or a PR merged/closed). These are FOR "
+            f"THE AGENT, not the operator — take the action each one calls for. "
+            f"The signal clears once you post a follow-up on the thread; a human "
+            f"reply does not clear it:",
+            "",
+        ]
+        for t in events:
+            lines.append(f"- thread {t.id} ({t.subject}): {_pending(t)}")
     return "\n".join(lines)
 
 
@@ -402,7 +436,11 @@ def register(app: typer.Typer, get_container):
             if container is None:
                 raise typer.Exit(code=0)
             store = MessageStore(Path(container.state_dir()) / "messages")
-            awaiting = [t for t in store.list() if t.awaiting_reply]
+            # Widened (MOS-232): surface agent-EVENT threads (dispatch handoffs +
+            # PR-merge notifications) at the turn boundary too, not just
+            # human-reply threads — mirrors `mship inbox wait`'s predicate.
+            awaiting = [t for t in store.list()
+                        if t.awaiting_reply or t.awaiting_agent_event]
             if not awaiting:
                 raise typer.Exit(code=0)
             reason = _format_drain_reason(awaiting)

--- a/tests/cli/test_drain.py
+++ b/tests/cli/test_drain.py
@@ -82,6 +82,89 @@ def test_allows_when_thread_already_answered(tmp_path: Path):
         _reset()
 
 
+def test_blocks_on_agent_event_thread(tmp_path: Path):
+    # MOS-232: an agent-EVENT thread (a dispatch handoff / PR-merge signal) with
+    # no pending human reply must now block the stop too — and with
+    # event-appropriate wording, NOT the "reply to clear" instruction.
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    now = datetime.now(timezone.utc)
+    t = store.create_thread("task-1", "seed", now)
+    store.append(t.id, "agent", "dispatch handoff: pick up spec-42", now, kind="event")
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_drain"], input=_event())
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["decision"] == "block"
+        assert "dispatch handoff: pick up spec-42" in payload["reason"]
+        # event wording, and NOT the reply-to-clear instruction
+        assert "mship reply" not in payload["reason"]
+        assert "act on" in payload["reason"].lower()
+    finally:
+        _reset()
+
+
+def test_blocks_on_trailing_event_after_human_interleave(tmp_path: Path):
+    # Mirror of test_inbox_wait's interleave case: awaiting_agent_event must
+    # survive a human message posted after the event. Here a trailing agent
+    # event (after the human "thanks") keeps awaiting_reply False, so the thread
+    # surfaces under the event group despite the interleaved human message.
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    now = datetime.now(timezone.utc)
+    t = store.create_thread("task-1", "seed", now)
+    store.append(t.id, "agent", "dispatch handoff", now, kind="event")
+    store.append(t.id, "human", "thanks", now)  # the interleave
+    store.append(t.id, "agent", "PR #42 merged", now, kind="event")  # trailing event
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_drain"], input=_event())
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["decision"] == "block"
+        assert t.id in payload["reason"]
+        assert "mship reply" not in payload["reason"]  # event group, not reply
+    finally:
+        _reset()
+
+
+def test_both_reply_and_event_thread_surfaces_under_reply_group(tmp_path: Path):
+    # A thread that is BOTH (an unhandled event AND an unanswered human message)
+    # is prioritized as a reply — it appears under the human-reply group with the
+    # `mship reply` instruction.
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    now = datetime.now(timezone.utc)
+    t = store.create_thread("task-1", "seed", now)
+    store.append(t.id, "agent", "dispatch handoff", now, kind="event")
+    store.append(t.id, "human", "please advise", now)  # unanswered human -> awaiting_reply
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_drain"], input=_event())
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["decision"] == "block"
+        assert "mship reply" in payload["reason"]  # reply is the priority action
+        assert "please advise" in payload["reason"]
+    finally:
+        _reset()
+
+
+def test_allows_when_event_already_handled(tmp_path: Path):
+    # Regression for the widened filter: an event the agent already acted on
+    # (a following non-event agent message) is handled -> no block.
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    now = datetime.now(timezone.utc)
+    t = store.create_thread("task-1", "seed", now)
+    store.append(t.id, "agent", "dispatch handoff", now, kind="event")
+    store.append(t.id, "agent", "acted on it", now)  # non-event -> clears the event
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["_drain"], input=_event())
+        assert result.exit_code == 0
+        assert '"decision"' not in result.output
+    finally:
+        _reset()
+
+
 def test_allows_when_stop_hook_active(tmp_path: Path):
     cfg, state_dir, store = _bootstrap(tmp_path)
     store.create_thread("s", "still pending", datetime.now(timezone.utc))


### PR DESCRIPTION
## Summary

Widen `mship _drain` (the Stop-hook / turn-boundary path) to surface agent-**event** threads, not just human-reply threads — so a live/mid-work host agent learns of dispatched spec handoffs (MOS-194) and PR-merge events (MOS-219) at its next Stop, instead of only when it next idles on `mship inbox wait`. Implements MOS-232.

- **Predicate widened** (`internal.py`): `awaiting_reply` → `awaiting_reply or awaiting_agent_event`, mirroring `mship inbox wait`'s predicate.
- **Event-appropriate wording** (`_format_drain_reason`): output is split into two groups — human-reply threads keep the "answer with `mship reply` (replying clears the thread)" call-to-action; agent-event threads get action-oriented wording that never mentions `mship reply` (an event is cleared by the agent acting/posting a non-event message on the thread; a human reply does not clear it). A thread that is both an unanswered human message and an unhandled event lands in the reply group (reply is the priority action).
- Fail-open contract unchanged (`stop_hook_active` / empty inbox / any exception → allow the stop).

This reverses MOS-219's intentional "events off the drain" choice, per the operator's request.

## Test plan
- [x] `mship test` — full suite green.
- [x] New `test_drain.py` cases: event thread blocks with event wording (no `mship reply`); trailing event after an interleaved human message still surfaces; both-reply-and-event lands in the reply group; already-handled event allows. Regression: human-reply thread still blocks with reply wording; empty/handled inbox allows.

https://claude.ai/code/session_01WLb3xgnKi4fWy8M4reqhmu
