### PR TITLE
Harden WorkItemStore + MessageStore with flock-protected RMW (mirror StateManager._locked); add concurrency regression tests (MOS-233)

### DIFF
--- a/src/mship/core/message_store.py
+++ b/src/mship/core/message_store.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import fcntl
 import tempfile
 import uuid
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import Literal
@@ -12,6 +14,24 @@ from mship.core.message import DecisionPayload, Message, Thread
 def _new_id(now: datetime) -> str:
     """Sortable, collision-free id: a timestamp prefix + short uuid."""
     return f"{now:%Y%m%d%H%M%S}-{uuid.uuid4().hex[:8]}"
+
+
+@contextmanager
+def _locked(lock_path: Path, mode: int):
+    """Advisory flock on `lock_path` (mirrors state.py's `_locked`).
+
+    mode: fcntl.LOCK_SH (shared read) or fcntl.LOCK_EX (exclusive write).
+    Released when the context exits. A per-thread lock file lets writers to
+    DIFFERENT threads proceed in parallel; only same-thread writers serialize.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as lf:
+        fcntl.flock(lf, mode)
+        try:
+            yield
+        finally:
+            fcntl.flock(lf, fcntl.LOCK_UN)
 
 
 class MessageStore:
@@ -25,6 +45,12 @@ class MessageStore:
                 or thread_id in (".", "..") or thread_id.startswith(".")):
             raise ValueError(f"unsafe thread id: {thread_id!r}")
         return self._dir / f"{thread_id}.json"
+
+    def _lock_path(self, thread_id: str) -> Path:
+        """Per-thread lock file (`<id>.json.lock`). Reuses `_path`'s id validation.
+        Not matched by `list()`'s `*.json` glob, so it stays invisible to reads."""
+        p = self._path(thread_id)
+        return p.with_name(p.name + ".lock")
 
     def save(self, thread: Thread) -> Path:
         self._dir.mkdir(parents=True, exist_ok=True)
@@ -59,35 +85,40 @@ class MessageStore:
         return thread
 
     def link_spec(self, thread_id: str, spec_id: str, now: datetime | None = None) -> None:
-        thread = self.get(thread_id)
-        if thread is None:
-            raise KeyError(thread_id)
-        thread.spec_id = spec_id
-        if now is not None:
-            thread.updated_at = now
-        self.save(thread)
+        with _locked(self._lock_path(thread_id), fcntl.LOCK_EX):
+            thread = self.get(thread_id)
+            if thread is None:
+                raise KeyError(thread_id)
+            thread.spec_id = spec_id
+            if now is not None:
+                thread.updated_at = now
+            self.save(thread)
 
     def append(self, thread_id: str, role: Literal["human", "agent"], text: str,
                now: datetime, kind: Literal["note", "needs_you", "decision", "event"] = "note",
                decision: DecisionPayload | None = None) -> Message:
-        thread = self.get(thread_id)
-        if thread is None:
-            raise KeyError(thread_id)
-        msg = Message(id=_new_id(now), thread_id=thread_id, role=role, text=text,
-                      created_at=now, kind=kind, decision=decision)
-        thread.messages.append(msg)
-        thread.updated_at = now
-        self.save(thread)
-        return msg
+        # Exclusive lock spans get+append+save so concurrent appends to the same
+        # thread can't clobber each other's messages (MOS-233).
+        with _locked(self._lock_path(thread_id), fcntl.LOCK_EX):
+            thread = self.get(thread_id)
+            if thread is None:
+                raise KeyError(thread_id)
+            msg = Message(id=_new_id(now), thread_id=thread_id, role=role, text=text,
+                          created_at=now, kind=kind, decision=decision)
+            thread.messages.append(msg)
+            thread.updated_at = now
+            self.save(thread)
+            return msg
 
     def mark_seen(self, thread_id: str, seen_at: datetime) -> Thread:
         """Advance the operator's read cursor (monotonic — never regresses).
         Does not bump updated_at: reading is not a content change and must not
         reorder the thread list."""
-        thread = self.get(thread_id)
-        if thread is None:
-            raise KeyError(thread_id)
-        if thread.seen_at is None or seen_at > thread.seen_at:
-            thread.seen_at = seen_at
-            self.save(thread)
-        return thread
+        with _locked(self._lock_path(thread_id), fcntl.LOCK_EX):
+            thread = self.get(thread_id)
+            if thread is None:
+                raise KeyError(thread_id)
+            if thread.seen_at is None or seen_at > thread.seen_at:
+                thread.seen_at = seen_at
+                self.save(thread)
+            return thread

--- a/src/mship/core/workitem_store.py
+++ b/src/mship/core/workitem_store.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import fcntl
 import tempfile
 import uuid
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
@@ -11,6 +13,24 @@ from mship.core.workitem import ExternalLink, Kind, Phase, WorkItem
 
 def _new_id(now: datetime) -> str:
     return f"wi-{now:%Y%m%d%H%M%S}-{uuid.uuid4().hex[:8]}"
+
+
+@contextmanager
+def _locked(lock_path: Path, mode: int):
+    """Advisory flock on `lock_path` (mirrors state.py's `_locked`).
+
+    mode: fcntl.LOCK_SH (shared read) or fcntl.LOCK_EX (exclusive write).
+    Released when the context exits. A per-item lock file lets writers to
+    DIFFERENT items proceed in parallel; only same-item writers serialize.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as lf:
+        fcntl.flock(lf, mode)
+        try:
+            yield
+        finally:
+            fcntl.flock(lf, fcntl.LOCK_UN)
 
 
 class WorkItemStore:
@@ -24,6 +44,12 @@ class WorkItemStore:
                 or item_id in (".", "..") or item_id.startswith(".")):
             raise ValueError(f"unsafe work item id: {item_id!r}")
         return self._dir / f"{item_id}.json"
+
+    def _lock_path(self, item_id: str) -> Path:
+        """Per-item lock file (`<id>.json.lock`). Reuses `_path`'s id validation.
+        Not matched by `list()`'s `*.json` glob, so it stays invisible to reads."""
+        p = self._path(item_id)
+        return p.with_name(p.name + ".lock")
 
     def save(self, item: WorkItem) -> Path:
         self._dir.mkdir(parents=True, exist_ok=True)
@@ -67,72 +93,84 @@ class WorkItemStore:
         return item
 
     def link_spec(self, item_id: str, spec_id: str, now: datetime | None = None) -> None:
-        item = self._mutate(item_id, now)
-        item.spec_id = spec_id
-        self.save(item)
+        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
+            item = self._mutate(item_id, now)
+            item.spec_id = spec_id
+            self.save(item)
 
     def link_plan(self, item_id: str, plan_path: str, now: datetime | None = None) -> None:
-        item = self._mutate(item_id, now)
-        item.plan_path = plan_path
-        self.save(item)
+        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
+            item = self._mutate(item_id, now)
+            item.plan_path = plan_path
+            self.save(item)
 
     def add_task(self, item_id: str, task_slug: str, now: datetime | None = None,
                 state: StateManager | None = None) -> None:
-        item = self.get(item_id)
-        if item is None:
-            raise KeyError(item_id)
-        if task_slug in item.task_slugs:
-            return
-        item.task_slugs.append(task_slug)
-        if now is not None:
-            item.updated_at = now
-        self.save(item)
+        # Exclusive lock spans get+append+save so concurrent add_task calls to the
+        # same item can't clobber each other's task_slugs (MOS-233).
+        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
+            item = self.get(item_id)
+            if item is None:
+                raise KeyError(item_id)
+            if task_slug in item.task_slugs:
+                return
+            item.task_slugs.append(task_slug)
+            if now is not None:
+                item.updated_at = now
+            self.save(item)
         if state is not None:
             # Reverse link: task.work_item_id, mirroring workitem_migrate.wrap_existing's
-            # pass-2 mutation (workitem_migrate.py:46-49).
+            # pass-2 mutation (workitem_migrate.py:46-49). StateManager.mutate takes its
+            # own state.lock, so keep it outside this item lock to avoid lock coupling.
             def _set(s, _slug=task_slug, _wid=item_id):
                 if _slug in s.tasks:
                     s.tasks[_slug].work_item_id = _wid
             state.mutate(_set)
 
     def add_thread(self, item_id: str, thread_id: str, now: datetime | None = None) -> None:
-        item = self.get(item_id)
-        if item is None:
-            raise KeyError(item_id)
-        if thread_id in item.thread_ids:
-            return
-        item.thread_ids.append(thread_id)
-        if now is not None:
-            item.updated_at = now
-        self.save(item)
+        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
+            item = self.get(item_id)
+            if item is None:
+                raise KeyError(item_id)
+            if thread_id in item.thread_ids:
+                return
+            item.thread_ids.append(thread_id)
+            if now is not None:
+                item.updated_at = now
+            self.save(item)
 
     def add_external_link(self, item_id: str, link: ExternalLink, now: datetime | None = None) -> None:
-        item = self._mutate(item_id, now)
-        item.external_links.append(link)
-        self.save(item)
+        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
+            item = self._mutate(item_id, now)
+            item.external_links.append(link)
+            self.save(item)
 
     def set_phase_override(self, item_id: str, phase: Phase | None, now: datetime | None = None) -> None:
         """Set the manual phase override, or clear it (return to derived phase) when
         `phase` is None. Raises KeyError if the item does not exist."""
-        item = self._mutate(item_id, now)
-        item.phase_override = phase
-        self.save(item)
+        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
+            item = self._mutate(item_id, now)
+            item.phase_override = phase
+            self.save(item)
 
     def set_unattended(self, item_id: str, on: bool, now: datetime | None = None) -> None:
-        item = self._mutate(item_id, now)
-        item.unattended = on
-        self.save(item)
+        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
+            item = self._mutate(item_id, now)
+            item.unattended = on
+            self.save(item)
 
     def archive(self, item_id: str, now: datetime | None = None) -> None:
         """Soft-delete: mark the item archived so it's excluded from list() by
         default. Raises KeyError if the item does not exist."""
-        item = self._mutate(item_id, now)
-        item.archived = True
-        self.save(item)
+        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
+            item = self._mutate(item_id, now)
+            item.archived = True
+            self.save(item)
 
     def unarchive(self, item_id: str, now: datetime | None = None) -> None:
         """Reverse of archive(): clear the archived flag. Raises KeyError if the
         item does not exist."""
-        item = self._mutate(item_id, now)
-        item.archived = False
-        self.save(item)
+        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
+            item = self._mutate(item_id, now)
+            item.archived = False
+            self.save(item)

--- a/tests/core/test_store_concurrency.py
+++ b/tests/core/test_store_concurrency.py
@@ -1,0 +1,139 @@
+"""Concurrency regression tests for the per-file stores (MOS-233).
+
+WorkItemStore and MessageStore each do a get()->modify->save() read-modify-write.
+Without an exclusive lock spanning that window, two concurrent writers to the
+SAME file both load the same JSON, each append their own change, and the second
+save() clobbers the first — a lost update.
+
+These mirror tests/core/test_concurrent_mutations.py: real multiprocessing.Process
+workers, each with its own store instance on a shared tmp dir, asserting the final
+state. Each worker performs several distinct writes to amplify the race window so
+the pre-fix version flakes and the post-fix version is deterministic.
+"""
+from __future__ import annotations
+
+import multiprocessing
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from mship.core.message_store import MessageStore
+from mship.core.workitem_store import WorkItemStore
+
+_BASE = datetime(2026, 7, 12, 12, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# MessageStore.append: N processes appending distinct messages to ONE thread.
+# ---------------------------------------------------------------------------
+
+def _append_worker(messages_dir_str: str, thread_id: str, worker: int, rounds: int) -> None:
+    store = MessageStore(Path(messages_dir_str))
+    for j in range(rounds):
+        store.append(
+            thread_id, "agent", f"w{worker}-m{j}",
+            _BASE + timedelta(seconds=worker * 100 + j),
+        )
+
+
+def test_concurrent_appends_to_same_thread_do_not_lose_messages(tmp_path: Path):
+    messages_dir = tmp_path / ".mothership" / "messages"
+    store = MessageStore(messages_dir)
+    thread = store.create_thread(subject="race", text="start", now=_BASE)
+
+    workers, rounds = 8, 4
+    procs = [
+        multiprocessing.Process(
+            target=_append_worker,
+            args=(str(messages_dir), thread.id, w, rounds),
+        )
+        for w in range(workers)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+        assert p.exitcode == 0, f"worker crashed (exitcode={p.exitcode})"
+
+    got = store.get(thread.id)
+    assert got is not None
+    texts = {m.text for m in got.messages if m.role == "agent"}
+    expected = {f"w{w}-m{j}" for w in range(workers) for j in range(rounds)}
+    missing = expected - texts
+    assert not missing, f"lost {len(missing)} appended messages: {sorted(missing)}"
+    # initial human message + every agent append survived
+    assert len(got.messages) == 1 + workers * rounds
+
+
+# ---------------------------------------------------------------------------
+# WorkItemStore.add_task: N processes adding distinct tasks to ONE work item.
+# ---------------------------------------------------------------------------
+
+def _add_task_worker(workitems_dir_str: str, item_id: str, worker: int, rounds: int) -> None:
+    store = WorkItemStore(Path(workitems_dir_str))
+    for j in range(rounds):
+        store.add_task(item_id, f"task-{worker}-{j}")
+
+
+def test_concurrent_add_task_to_same_item_do_not_lose_updates(tmp_path: Path):
+    workitems_dir = tmp_path / ".mothership" / "workitems"
+    store = WorkItemStore(workitems_dir)
+    item = store.create(title="race", kind="feature", workspace="ws", now=_BASE)
+
+    workers, rounds = 8, 4
+    procs = [
+        multiprocessing.Process(
+            target=_add_task_worker,
+            args=(str(workitems_dir), item.id, w, rounds),
+        )
+        for w in range(workers)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+        assert p.exitcode == 0, f"worker crashed (exitcode={p.exitcode})"
+
+    got = store.get(item.id)
+    assert got is not None
+    slugs = set(got.task_slugs)
+    expected = {f"task-{w}-{j}" for w in range(workers) for j in range(rounds)}
+    missing = expected - slugs
+    assert not missing, f"lost {len(missing)} added task slugs: {sorted(missing)}"
+    assert len(got.task_slugs) == workers * rounds
+
+
+# ---------------------------------------------------------------------------
+# WorkItemStore.add_thread: same shape, exercising a second RMW method.
+# ---------------------------------------------------------------------------
+
+def _add_thread_worker(workitems_dir_str: str, item_id: str, worker: int, rounds: int) -> None:
+    store = WorkItemStore(Path(workitems_dir_str))
+    for j in range(rounds):
+        store.add_thread(item_id, f"thread-{worker}-{j}")
+
+
+def test_concurrent_add_thread_to_same_item_do_not_lose_updates(tmp_path: Path):
+    workitems_dir = tmp_path / ".mothership" / "workitems"
+    store = WorkItemStore(workitems_dir)
+    item = store.create(title="race", kind="feature", workspace="ws", now=_BASE)
+
+    workers, rounds = 8, 4
+    procs = [
+        multiprocessing.Process(
+            target=_add_thread_worker,
+            args=(str(workitems_dir), item.id, w, rounds),
+        )
+        for w in range(workers)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+        assert p.exitcode == 0, f"worker crashed (exitcode={p.exitcode})"
+
+    got = store.get(item.id)
+    assert got is not None
+    expected = {f"thread-{w}-{j}" for w in range(workers) for j in range(rounds)}
+    missing = expected - set(got.thread_ids)
+    assert not missing, f"lost {len(missing)} added thread ids: {sorted(missing)}"
+    assert len(got.thread_ids) == workers * rounds


### PR DESCRIPTION
## Summary

Harden the two per-file stores (WorkItemStore, MessageStore) against concurrent same-file writes with per-file flock-protected read-modify-write, mirroring StateManager._locked (MOS-233). state.yaml itself was already safe (mutate()+flock since April); this closes the real remaining gap. Deadlock-safe (add_task's reverse state.mutate stays outside the item lock). +multiprocessing regression tests (TDD confirmed the race pre-fix); confirmed the state.yaml incident test already exists.

## Test plan
- [x] mship test — full suite green.
- [x] New tests/core/test_store_concurrency.py: 8 parallel processes writing the same thread/item all survive (race reproduced pre-fix, deterministic post-fix).

https://claude.ai/code/session_01WLb3xgnKi4fWy8M4reqhmu
