### PR TITLE
Add rich_help_panel groups to every mship CLI command/sub-app so --help is grouped (Workflow/Work items & specs/Messaging/Inspection/Runtime/Maintenance/Setup)

### DIFF
--- a/src/mship/cli/audit.py
+++ b/src/mship/cli/audit.py
@@ -6,7 +6,7 @@ from mship.cli.output import Output
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Inspection")
     def audit(
         repos: Optional[str] = typer.Option(None, "--repos", help="Comma-separated repo names"),
         json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),

--- a/src/mship/cli/bind.py
+++ b/src/mship/cli/bind.py
@@ -114,4 +114,4 @@ def register(app: typer.Typer, get_container):
         if any_skipped and not overwrite:
             raise typer.Exit(code=1)
 
-    app.add_typer(bind_app, name="bind")
+    app.add_typer(bind_app, name="bind", rich_help_panel="Maintenance")

--- a/src/mship/cli/block.py
+++ b/src/mship/cli/block.py
@@ -8,7 +8,7 @@ from mship.cli.output import Output
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Workflow")
     def block(
         reason: str,
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),
@@ -48,7 +48,7 @@ def register(app: typer.Typer, get_container):
                 "resolution_source": resolved.source,
             })
 
-    @app.command()
+    @app.command(rich_help_panel="Workflow")
     def unblock(
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),
     ):

--- a/src/mship/cli/bootstrap.py
+++ b/src/mship/cli/bootstrap.py
@@ -6,7 +6,7 @@ from mship.cli.output import Output
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Setup")
     def bootstrap(
         repos: Optional[str] = typer.Option(
             None, "--repos", help="Comma-separated repo names (default: all)."

--- a/src/mship/cli/capture.py
+++ b/src/mship/cli/capture.py
@@ -42,7 +42,7 @@ class _RemoteFlagCommand(TyperCommand):
 
 
 def register(app: typer.Typer, get_container):
-    @app.command(cls=_RemoteFlagCommand)
+    @app.command(cls=_RemoteFlagCommand, rich_help_panel="Runtime")
     def capture(
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug (defaults to cwd-resolved)."),
         repo: Optional[str] = typer.Option(None, "--repo", help="Which repo to capture (required for an ad-hoc capture when the workspace has >1 repo)."),

--- a/src/mship/cli/commit.py
+++ b/src/mship/cli/commit.py
@@ -14,7 +14,7 @@ from mship.cli.output import Output
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Workflow")
     def commit(
         message: str = typer.Argument(..., help="Commit message (same for every repo with staged changes)"),
         task: Optional[str] = typer.Option(

--- a/src/mship/cli/context.py
+++ b/src/mship/cli/context.py
@@ -38,7 +38,7 @@ def _render_audience_block(audience: dict) -> None:
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Inspection")
     def context(
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),
         for_: Optional[str] = typer.Option(

--- a/src/mship/cli/debug.py
+++ b/src/mship/cli/debug.py
@@ -120,4 +120,4 @@ def register(app: typer.Typer, get_container):
             id=entry_id,
         )
 
-    app.add_typer(debug_app, name="debug")
+    app.add_typer(debug_app, name="debug", rich_help_panel="Inspection")

--- a/src/mship/cli/depends.py
+++ b/src/mship/cli/depends.py
@@ -39,7 +39,7 @@ def _render_graph_tty(output, payload):
 
 def register(app: typer.Typer, get_container):
     depends_app = typer.Typer(no_args_is_help=True, help="Manage task-to-task dependencies (#104).")
-    app.add_typer(depends_app, name="depends")
+    app.add_typer(depends_app, name="depends", rich_help_panel="Workflow")
 
     @depends_app.command("add")
     def add(

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -38,7 +38,7 @@ def _resolve_task_plan(container, task_obj) -> Optional[Path]:
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Inspection")
     def dispatch(
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug (defaults to cwd-resolved)."),
         repo: Optional[str] = typer.Option(None, "--repo", help="Which repo's worktree to target (multi-repo tasks)."),

--- a/src/mship/cli/doctor.py
+++ b/src/mship/cli/doctor.py
@@ -4,7 +4,7 @@ from mship.cli.output import Output
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Inspection")
     def doctor():
         """Check workspace health and configuration."""
         container = get_container()

--- a/src/mship/cli/exec.py
+++ b/src/mship/cli/exec.py
@@ -161,7 +161,7 @@ def _run_remote(
 
 
 def register(app: typer.Typer, get_container):
-    @app.command(name="test")
+    @app.command(name="test", rich_help_panel="Workflow")
     def test_cmd(
         run_all: bool = typer.Option(False, "--all", help="Run all repos even on failure"),
         repos: Optional[str] = typer.Option(None, "--repos", help="Comma-separated repo names to filter"),
@@ -383,7 +383,7 @@ def register(app: typer.Typer, get_container):
         if not result.success:
             raise typer.Exit(code=1)
 
-    @app.command(name="run", cls=_RemoteFlagCommand)
+    @app.command(name="run", cls=_RemoteFlagCommand, rich_help_panel="Runtime")
     def run_cmd(
         repos: Optional[str] = typer.Option(None, "--repos", help="Comma-separated repo names to filter"),
         tag: Optional[list[str]] = typer.Option(None, "--tag", help="Filter repos by tag"),
@@ -531,7 +531,7 @@ def register(app: typer.Typer, get_container):
 
         output.print("All background services have exited")
 
-    @app.command(name="build", cls=_RemoteFlagCommand)
+    @app.command(name="build", cls=_RemoteFlagCommand, rich_help_panel="Workflow")
     def build_cmd(
         run_all: bool = typer.Option(False, "--all", help="Build all repos even if one fails"),
         repos: Optional[str] = typer.Option(None, "--repos", help="Comma-separated repo names to filter"),
@@ -634,7 +634,7 @@ def register(app: typer.Typer, get_container):
         if not result.success:
             raise typer.Exit(code=1)
 
-    @app.command()
+    @app.command(rich_help_panel="Runtime")
     def logs(
         service: Optional[str] = typer.Argument(None, help="Service name (omit with --all)"),
         all_services: bool = typer.Option(False, "--all", help="Tail logs for every service"),

--- a/src/mship/cli/export.py
+++ b/src/mship/cli/export.py
@@ -14,7 +14,7 @@ from mship.cli.output import Output
 
 
 def register(app: typer.Typer, get_container):
-    @app.command(name="export")
+    @app.command(name="export", rich_help_panel="Inspection")
     def export_cmd(
         redacted: bool = typer.Option(
             False, "--redacted",

--- a/src/mship/cli/gh.py
+++ b/src/mship/cli/gh.py
@@ -76,4 +76,4 @@ def register(parent: typer.Typer, get_container):
         output.error(result.message)
         raise typer.Exit(code=1)
 
-    parent.add_typer(gh_app)
+    parent.add_typer(gh_app, rich_help_panel="Setup")

--- a/src/mship/cli/init.py
+++ b/src/mship/cli/init.py
@@ -26,7 +26,7 @@ def _install_agent_hooks_with_output(ws_root: Path, output: Output) -> None:
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Setup")
     def init(
         path: Optional[str] = typer.Argument(None, help="Workspace directory (defaults to current directory)"),
         name: Optional[str] = typer.Option(None, "--name", help="Workspace name"),

--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -88,4 +88,4 @@ def register(app: typer.Typer, get_container):
         """Launch zellij with the mothership layout (replaces current process)."""
         os.execvp("zellij", ["zellij", "--layout", "mothership"])
 
-    app.add_typer(layout_app)
+    app.add_typer(layout_app, rich_help_panel="Setup")

--- a/src/mship/cli/log.py
+++ b/src/mship/cli/log.py
@@ -41,7 +41,7 @@ def _resolve_since_cutoff(value: str, entries: list):
 
 
 def register(app: typer.Typer, get_container):
-    @app.command(name="journal")
+    @app.command(name="journal", rich_help_panel="Workflow")
     def log_cmd(
         message: Optional[str] = typer.Argument(None, help="Message to append to task journal"),
         last: Optional[int] = typer.Option(None, "--last", help="Show only last N entries"),

--- a/src/mship/cli/message.py
+++ b/src/mship/cli/message.py
@@ -16,7 +16,7 @@ def register(parent: typer.Typer, get_container) -> None:
         return MessageStore(Path(container.state_dir()) / "messages")
 
     inbox_app = typer.Typer(help="Inspect and wait on the message inbox.")
-    parent.add_typer(inbox_app, name="inbox")
+    parent.add_typer(inbox_app, name="inbox", rich_help_panel="Messaging")
 
     def _print_awaiting() -> None:
         store = _store()
@@ -100,7 +100,7 @@ def register(parent: typer.Typer, get_container) -> None:
         }
         typer.echo(json.dumps(out))
 
-    @parent.command()
+    @parent.command(rich_help_panel="Messaging")
     def reply(
         thread_id: str,
         text: str,
@@ -120,7 +120,7 @@ def register(parent: typer.Typer, get_container) -> None:
             raise typer.Exit(1)
         typer.echo(f"replied to {thread_id}")
 
-    @parent.command()
+    @parent.command(rich_help_panel="Messaging")
     def ask(
         thread_id: str,
         question: str,
@@ -149,7 +149,7 @@ def register(parent: typer.Typer, get_container) -> None:
             raise typer.Exit(1)
         typer.echo(f"asked {thread_id}: {len(option)} options")
 
-    @parent.command()
+    @parent.command(rich_help_panel="Messaging")
     def messages(thread_id: str) -> None:
         """Print a thread's conversation in order."""
         store = _store()

--- a/src/mship/cli/pair.py
+++ b/src/mship/cli/pair.py
@@ -12,7 +12,7 @@ from mship.cli.output import Output
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Messaging")
     def pair():
         """Print a pairing deep-link + QR to connect the Ground Control app to this workspace."""
         from pathlib import Path

--- a/src/mship/cli/phase.py
+++ b/src/mship/cli/phase.py
@@ -9,7 +9,7 @@ from mship.core.phase import PHASE_ORDER, FinishedTaskError, SpecGateError
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Workflow")
     def phase(
         target: str,
         force: bool = typer.Option(False, "--force", "-f", help="Force transition even if task is blocked or finished"),

--- a/src/mship/cli/pr.py
+++ b/src/mship/cli/pr.py
@@ -10,7 +10,7 @@ from mship.cli.output import Output
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Inspection")
     def pr():
         """Show PR state for every active task with recorded PR URLs."""
         container = get_container()

--- a/src/mship/cli/prune.py
+++ b/src/mship/cli/prune.py
@@ -4,7 +4,7 @@ from mship.cli.output import Output
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Maintenance")
     def prune(
         force: bool = typer.Option(False, "--force", help="Actually remove orphaned worktrees"),
     ):

--- a/src/mship/cli/reconcile.py
+++ b/src/mship/cli/reconcile.py
@@ -31,7 +31,7 @@ def _glyph(state: UpstreamState) -> str:
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Inspection")
     def reconcile(
         json_out: bool = typer.Option(False, "--json", help="Emit JSON instead of a table"),
         ignore: Optional[str] = typer.Option(None, "--ignore", help="Persistently ignore drift for this slug"),

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -269,4 +269,4 @@ def register(parent: typer.Typer, get_container):
         out.error("timed out waiting for approval.")
         raise typer.Exit(1)
 
-    parent.add_typer(relay_app)
+    parent.add_typer(relay_app, rich_help_panel="Setup")

--- a/src/mship/cli/run_host.py
+++ b/src/mship/cli/run_host.py
@@ -90,4 +90,4 @@ def register(parent: typer.Typer, get_container):
         RunHostStore(state_dir).remove(role)
         out.success(f"removed run-host {role!r}")
 
-    parent.add_typer(run_host_app)
+    parent.add_typer(run_host_app, rich_help_panel="Runtime")

--- a/src/mship/cli/serve.py
+++ b/src/mship/cli/serve.py
@@ -51,7 +51,7 @@ def _read_gh_app_creds(output: Output) -> tuple[Optional[str], Optional[str]]:
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Messaging")
     def serve(
         host: str = typer.Option(
             "127.0.0.1", "--host",

--- a/src/mship/cli/skill.py
+++ b/src/mship/cli/skill.py
@@ -39,7 +39,7 @@ def _legacy_codex_mothership_warning(output: Output) -> None:
 
 
 def register(app: typer.Typer, get_container):
-    @app.command(name="skill")
+    @app.command(name="skill", rich_help_panel="Setup")
     def skill_cmd(
         action: str = typer.Argument(help="Action: install | list"),
         only: Optional[str] = typer.Option(None, "--only", help="Comma-separated agents (claude,codex,gemini)"),

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -667,4 +667,4 @@ def register(parent: typer.Typer, get_container):
         """Advance an implemented spec to archived."""
         _simple_transition("archived", spec_id)
 
-    parent.add_typer(spec_app)
+    parent.add_typer(spec_app, rich_help_panel="Work items & specs")

--- a/src/mship/cli/status.py
+++ b/src/mship/cli/status.py
@@ -31,7 +31,7 @@ def _collect_worktree_paths(state) -> list[Path]:
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Inspection")
     def status(
         task: Optional[str] = typer.Option(
             None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."
@@ -246,7 +246,7 @@ def register(app: typer.Typer, get_container):
             envelope["cwd_is_outside_worktrees"] = cwd_outside
         output.json(envelope)
 
-    @app.command()
+    @app.command(rich_help_panel="Inspection")
     def graph():
         """Show repo dependency graph."""
         container = get_container()

--- a/src/mship/cli/switch.py
+++ b/src/mship/cli/switch.py
@@ -7,7 +7,7 @@ from mship.cli.output import Output
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Workflow")
     def switch(
         repo: Optional[str] = typer.Argument(None, help="Repo to switch to. Omit to re-render current."),
         task_opt: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),

--- a/src/mship/cli/sync.py
+++ b/src/mship/cli/sync.py
@@ -6,7 +6,7 @@ from mship.cli.output import Output
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Maintenance")
     def sync(
         repos: Optional[str] = typer.Option(None, "--repos", help="Comma-separated repo names"),
         no_passive: bool = typer.Option(

--- a/src/mship/cli/view/__init__.py
+++ b/src/mship/cli/view/__init__.py
@@ -14,4 +14,4 @@ def register(parent: typer.Typer, get_container):
     _diff.register(app, get_container)
     _spec.register(app, get_container)
 
-    parent.add_typer(app, name="view")
+    parent.add_typer(app, name="view", rich_help_panel="Inspection")

--- a/src/mship/cli/workitem.py
+++ b/src/mship/cli/workitem.py
@@ -164,7 +164,7 @@ def _branch_state_for(item, state, log_mgr, config) -> BranchState:
 
 def register(parent: typer.Typer, get_container) -> None:
     item_app = typer.Typer(help="First-class work items (the phase-aware cockpit spine).")
-    parent.add_typer(item_app, name="item")
+    parent.add_typer(item_app, name="item", rich_help_panel="Work items & specs")
 
     def _ctx():
         container = get_container()

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -230,7 +230,7 @@ def _capture_dirty_main_post_op(command: str, task, config, shell, state_dir: Pa
 
 
 def register(app: typer.Typer, get_container):
-    @app.command()
+    @app.command(rich_help_panel="Workflow")
     def spawn(
         description: str,
         repos: Optional[str] = typer.Option(None, help="Comma-separated repo names"),
@@ -517,7 +517,7 @@ def register(app: typer.Typer, get_container):
             data["setup_warnings"] = result.setup_warnings
             output.json(data)
 
-    @app.command()
+    @app.command(rich_help_panel="Inspection")
     def worktrees():
         """List active worktrees grouped by task."""
         container = get_container()
@@ -542,7 +542,7 @@ def register(app: typer.Typer, get_container):
             }
             output.json({"tasks": data})
 
-    @app.command()
+    @app.command(rich_help_panel="Workflow")
     def close(
         task_slug: Optional[str] = typer.Argument(
             None,
@@ -881,7 +881,7 @@ def register(app: typer.Typer, get_container):
         # see the snapshot count via `mship doctor`. See spec 2026-04-21.
         _capture_dirty_main_post_op("close", task, config, container.shell(), container.state_dir())
 
-    @app.command()
+    @app.command(rich_help_panel="Workflow")
     def finish(
         handoff: bool = typer.Option(False, "--handoff", help="Generate CI handoff manifest"),
         base: Optional[str] = typer.Option(None, "--base", help="Global override of PR base branch for all repos"),

--- a/tests/cli/test_help_groups.py
+++ b/tests/cli/test_help_groups.py
@@ -1,0 +1,48 @@
+"""
+`mship --help` groups commands into rich_help_panel sections.
+
+Every visible top-level command / sub-app is tagged with a
+``rich_help_panel="<Group>"`` so the root help renders grouped panels
+instead of one flat Commands list.
+"""
+from typer.testing import CliRunner
+
+from mship.cli import app
+
+runner = CliRunner()
+
+EXPECTED_PANELS = [
+    "Workflow",
+    "Work items & specs",
+    "Messaging",
+    "Inspection",
+    "Runtime",
+    "Maintenance",
+    "Setup",
+]
+
+
+def _help_output() -> str:
+    # Force a wide render so panel titles never wrap/truncate under CliRunner.
+    result = runner.invoke(app, ["--help"], env={"COLUMNS": "120"})
+    assert result.exit_code == 0, result.output
+    return result.output
+
+
+def test_all_seven_panels_present():
+    out = _help_output()
+    for panel in EXPECTED_PANELS:
+        assert panel in out, f"missing panel {panel!r} in --help output"
+
+
+def test_no_flat_commands_panel():
+    """Grouped panels replace the default flat 'Commands' section."""
+    out = _help_output()
+    assert "─ Commands ─" not in out
+
+
+def test_sample_commands_land_in_help():
+    """A representative command from each group shows up in the grouped help."""
+    out = _help_output()
+    for cmd in ["spawn", "finish", "item", "spec", "serve", "status", "run", "sync", "init"]:
+        assert cmd in out, f"command {cmd!r} missing from --help output"


### PR DESCRIPTION
## Summary

Group the `mship --help` output into named sections using Typer's `rich_help_panel`, instead of one flat/registration-ordered command list.

Every visible top-level command and sub-app (45 registrations across 33 files) is tagged into one of 7 panels: **Workflow**, **Work items & specs**, **Messaging**, **Inspection**, **Runtime**, **Maintenance**, **Setup**. Hidden `_`-prefixed internals are unchanged. No behavior change — help rendering only.

## Test plan
- [x] `mship test` — full suite green.
- [x] New `tests/cli/test_help_groups.py` asserts all 7 panel titles render and the flat `─ Commands ─` panel is gone.
- [x] `mship --help` verified to show the 7 grouped panels.

Note: panels render in first-registration order (Inspection currently first); grouping is correct. Can lead with Workflow on request (reorder the `register()` calls).

https://claude.ai/code/session_01WLb3xgnKi4fWy8M4reqhmu
