### PR TITLE
Full docs pass — add 12 missing commands to docs/cli.md, ~22 missing config fields to docs/configuration.md, fix the 5 stale spawn/.worktrees refs in README + cli.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ uv tool install git+https://github.com/atomikpanda/mothership.git
 
 cd my-project
 mship init --name my-project --detect
-mship spawn "add hello world"
-cd $(mship status | jq -r '.worktrees | to_entries[0].value')
+mship item new "hello world" --kind chore         # every task needs a work item...
+mship spawn "add hello world" --work-item <id>    # ...pass its id (or --hotfix to skip the gate)
+cd $(mship status | jq -r '.resolved_task.worktrees | to_entries[0].value')
 
 echo 'print("hello")' > hello.py
 git add hello.py && git commit -m "feat: hello world"
@@ -43,7 +44,7 @@ The quickstart above is deliberately minimal — one repo, one file — to show 
 
 ```bash
 # Workflow
-mship spawn "description"               # start a task in isolated worktrees
+mship spawn "description" --work-item <id>  # start a task in isolated worktrees (needs a work item; --hotfix to skip)
 mship switch <repo>                     # context switch across repos
 mship phase plan|dev|review|run         # transition through phases
 mship test                              # run tests in dependency order
@@ -56,7 +57,7 @@ mship spec new --title "title"          # design a spec; approve before feature 
 mship spec dispatch <id>                # bind an approved spec to a task + emit a handoff
 
 # Task dependencies (#104)
-mship spawn "downstream" --depends-on a,b  # declare at spawn
+mship spawn "downstream" --work-item <id> --depends-on a,b  # declare at spawn (--work-item required)
 mship depends add/remove/list               # manage task-to-task dependency edges
 mship finish --bypass-deps                 # ship a downstream even if upstream isn't ready
 
@@ -77,7 +78,7 @@ For details, see `mship spawn --help`, [`docs/cli.md`](docs/cli.md), and the `wo
 
 ## What mship gives agents
 
-**Cross-repo coordination as a first-class concept.** A task in mship is a single unit of work that can span many repos. `mship spawn "propagate user schema v2" --repos schemas,svc-users,svc-billing,api,api-client` creates one worktree per repo on a shared feature branch. `mship test` runs them in dependency order. `mship finish` opens five PRs in dependency order with coordination blocks in each body linking the others. Audits catch drift per repo. The agent operates on "the task" — mship tracks which files across which repos belong to it.
+**Cross-repo coordination as a first-class concept.** A task in mship is a single unit of work that can span many repos. `mship spawn "propagate user schema v2" --work-item <id> --repos schemas,svc-users,svc-billing,api,api-client` creates one worktree per repo on a shared feature branch. `mship test` runs them in dependency order. `mship finish` opens five PRs in dependency order with coordination blocks in each body linking the others. Audits catch drift per repo. The agent operates on "the task" — mship tracks which files across which repos belong to it.
 
 **Isolation that makes coordination safe.** Every worktree is on its own feature branch, separate from main. A pre-commit hook refuses commits from outside the active task's worktrees. mship also installs a Claude Code **PreToolUse guard** (`mship _guard-edit`, added by `mship init --install-hooks`) that refuses an Edit/Write to a repo's main checkout while that repo has an active task — closing the gap that the git pre-commit hook can't see, since edit tools bypass git. Override a one-off with `MSHIP_ALLOW_MAIN_EDIT=1`. Parallel tasks on different features get their own worktree sets and don't collide.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,7 +17,7 @@ mship init --install-hooks                          # (re)install pre-commit gua
                                                     # (mship _guard-edit) that blocks edits to a repo's
                                                     # main checkout while it has an active task.
                                                     # Bypass: MSHIP_ALLOW_MAIN_EDIT=1.
-mship spawn "description" --work-item <id> [--repos a,b] [--skip-setup] [--bypass-reconcile]
+mship spawn "description" (--work-item <id> | --hotfix) [--repos a,b] [--skip-setup] [--bypass-reconcile]
                                                     # --work-item <id> required (create via `mship item new`);
                                                     # bypass the gate with --hotfix. Also: --depends-on, --base, --slug.
 mship switch <repo>                                 # cross-repo context switch
@@ -105,7 +105,7 @@ mship audit [--repos r] [--json]
 mship reconcile [--json] [--ignore SLUG] [--clear-ignores] [--refresh]
 mship pr                                            # PR state for every active task with recorded PR URLs
 mship debug hypothesis "..." | rule-out "..." | resolved  # structured debugging journal entries (#30)
-mship view status|logs|diff|spec [--watch]
+mship view status|journal|diff|spec [--watch]
 mship view spec --web                               # serve rendered spec on localhost
 mship graph
 mship worktrees
@@ -201,7 +201,7 @@ audit:
 `mship view` provides read-only TUIs designed for tmux/zellij panes. All views support `--watch` and `--interval N`.
 
 - `mship view status [--task <slug>] [--watch]` — all tasks stacked by default; `--task` narrows to one.
-- `mship view logs [--task <slug>] [--watch]` — tail the task's log.
+- `mship view journal [--task <slug>] [--watch]` — tail the task's journal.
 - `mship view diff [--task <slug>] [--watch]` — per-worktree git diff.
 - `mship view spec [name-or-path] [--task <slug>] [--watch] [--web]` — cross-task spec index picker by default.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,7 +17,9 @@ mship init --install-hooks                          # (re)install pre-commit gua
                                                     # (mship _guard-edit) that blocks edits to a repo's
                                                     # main checkout while it has an active task.
                                                     # Bypass: MSHIP_ALLOW_MAIN_EDIT=1.
-mship spawn "description" [--repos a,b] [--skip-setup] [--bypass-reconcile]
+mship spawn "description" --work-item <id> [--repos a,b] [--skip-setup] [--bypass-reconcile]
+                                                    # --work-item <id> required (create via `mship item new`);
+                                                    # bypass the gate with --hotfix. Also: --depends-on, --base, --slug.
 mship switch <repo>                                 # cross-repo context switch
 mship phase plan|dev|review|run [-f]                # transition with soft-gate warnings
 mship block "reason" | mship unblock
@@ -29,6 +31,26 @@ mship finish [--body-file PATH | --body TEXT] [--base B] [--base-map a=B,b=B] [-
 mship close [--yes] [--abandon] [--force] [--skip-pr-check] [--bypass-reconcile]
 mship commit "message" [--task <slug>]              # commit staged changes across the task's worktrees; pushes if finished
 mship depends add|remove|list                       # manage task-to-task dependency edges (#104)
+```
+
+## Setup & admin
+
+```bash
+mship bootstrap [--repos a,b] [--token TOK]         # clone missing workspace members (fresh clone -> full workspace)
+mship skill install|list [--only claude,codex,gemini] [--force] [-y]  # install/list mship-bundled agent skills
+mship gh preflight                                  # fail-fast check that GitHub auth covers the workspace repos
+mship bind refresh                                  # re-sync bind_files + symlink_dirs from source repos into worktrees
+mship layout init|launch                            # write / launch the mothership zellij layout
+```
+
+`mship relay` manages the reverse-tunnel relay client keys (for `mship serve --relay`, see [`relay-hosting.md`](relay-hosting.md)):
+
+```bash
+mship relay setup                                   # generate the relay SSH key (if absent) + print an enroll command
+mship relay enroll                                  # from a NEW device: request relay access (owner approves/denies)
+mship relay enroll-server                           # run the public enroll endpoint on the relay host
+mship relay requests                                # list pending enroll requests (id · hostname · fingerprint)
+mship relay approve <id> | deny <id>                # approve (add key to allowlist) / deny a pending request
 ```
 
 ## Work items & specs
@@ -68,6 +90,8 @@ mship serve [--relay] [--port N]                    # run the JSON API over the 
 mship inbox wait [--since TS] [--timeout S]         # block until a new human message arrives (JSON)
 mship reply <thread_id> "text"                      # reply to a mailbox thread
 mship ask <thread_id> "question" --option A --option B  # post a decision (>=2 tappable options; --recommend/--multi/--no-free-text)
+mship messages <thread_id>                          # print a mailbox thread's conversation in order
+mship pair                                          # print a pairing deep-link + QR to connect the Ground Control app
 ```
 
 ## Inspection
@@ -79,6 +103,8 @@ mship dispatch --task <slug> -i "<instruction>"     # emit self-contained subage
 mship dispatch --task <slug> --mode standalone -i "<instruction>"  # standalone framing — subagent finishes and opens its own PR
 mship audit [--repos r] [--json]
 mship reconcile [--json] [--ignore SLUG] [--clear-ignores] [--refresh]
+mship pr                                            # PR state for every active task with recorded PR URLs
+mship debug hypothesis "..." | rule-out "..." | resolved  # structured debugging journal entries (#30)
 mship view status|logs|diff|spec [--watch]
 mship view spec --web                               # serve rendered spec on localhost
 mship graph
@@ -100,7 +126,13 @@ mship export [--redacted] [--format dir|zip]        # bundle a task's journal/pl
 mship run [--repos a,b] [--tag t]                   # start services per dependency tier
 mship logs <service>                                # tail logs for a service
 mship run-host add|list|remove                      # manage per-machine run-host connections (role -> {url, token})
+mship build [--all] [--repos a,b] [--tag t] [--remote[=role]]  # `task build` across repos in dependency order
+mship capture [--repo R] [--platform P] [--kind image|layout|all] [--out DIR] [--remote[=role]]
+                                                    # screenshot + layout of the running UI into files;
+                                                    # task-aware but not required (ad-hoc against a repo's main checkout)
 ```
+
+`mship build` and `mship capture` accept `--remote` to execute on a mapped run-host role (an iOS-sim / Android-emu machine): bare `--remote` auto-resolves the repo's `run_host` (or the sole configured `run_hosts` entry), `--remote=<role>` picks one explicitly.
 
 ## `mship finish`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,3 +140,90 @@ repos:
 ## Taskfile contract
 
 Each repo needs a `Taskfile.yml` with standard task names. Mothership calls `task <name>` in each repo. Override names per repo in the `tasks` mapping. Default tasks: `test`, `run`, `lint`, `logs`, `setup`. Missing tasks are skipped gracefully.
+
+## Workspace-level fields
+
+Top-level keys on `mothership.yaml` (alongside `workspace`, `env_runner`, `branch_pattern`, `audit`, and `repos`, all covered above):
+
+| Field | Meaning |
+|-------|---------|
+| `default_scope` | Default repo scope for `mship spawn` when `--repos` is omitted. `"all"` (default) uses every repo; `"none"` requires an explicit `--repos`; a list of repo names uses just those. (#74) |
+| `spawn_confirm_threshold` | If set and a no-`--repos` spawn's effective scope exceeds N repos, require confirmation (TTY) or `--yes` (non-TTY). Unset by default. (#74) |
+| `spec_paths` | Workspace-relative paths searched for specs by `mship phase dev`'s soft gate and `mship view spec`. Default: `["docs/superpowers/specs"]`. (#113) |
+| `require_approved_spec` | When `true`, `mship phase dev` hard-blocks `plan → dev` unless a bound, approved spec exists. Default: `false`. (MOS-151) |
+| `docs_dir` | Workspace-relative directory where the bundled skills write plan docs; plans live at `<docs_dir>/plans/`. Default: `"docs"`. Does not affect canonical specs (always `specs/`). |
+| `default_remote` | Host-agnostic base URL prefix used to resolve a member's clone URL when its `url` is a bare name or omitted (member name appended). Enables `mship bootstrap` from a fresh clone. (MOS-180) |
+| `relay` | Reverse-tunnel relay connection for `mship serve --relay` (see [`relay-hosting.md`](relay-hosting.md)). |
+| `run_hosts` | Logical run-host role names available to the workspace (only the names are committed here). A repo opts into one via its `run_host`; each machine maps the role to a concrete `{url, token}` in the gitignored `.mothership/run-hosts.yaml`. |
+| `redact` | Extra `mship export --redacted` regex patterns, unioned with the built-in set. (MOS-102) |
+| `hooks` | Declarative reactions to task / WorkItem / PR lifecycle transitions. (MOS-220) |
+| `hooks_default_timeout` | Fallback per-hook timeout in seconds when a `hooks:` entry omits `timeout`. Default: `30`. |
+
+```yaml
+workspace: my-platform
+default_scope: none               # force explicit --repos on every spawn
+spawn_confirm_threshold: 3        # confirm a no-flag spawn touching >3 repos
+require_approved_spec: true       # gate plan -> dev on an approved spec
+docs_dir: docs                    # plans land in docs/plans/
+default_remote: https://github.com/atomikpanda   # bootstrap members from bare names
+
+relay:
+  host: relay.example.com
+  ssh_port: 2222                  # optional, default 2222
+  user: tunnel                    # optional; omit for the ssh default
+
+run_hosts: [ios-sim-host, android-emu-host]   # role names; connections live in .mothership/run-hosts.yaml
+
+redact:
+  patterns:
+    - "sk-[A-Za-z0-9]{20,}"                    # bare string -> a "custom" pattern
+    - { name: internal-host, pattern: "corp\\.example\\.internal" }
+
+hooks:
+  - on: pr.merged                 # a lifecycle event (phase.entered.*, workitem.phase.*, task.finished/closed, pr.merged/closed)
+    run: notify-slack             # a go-task target or shell command
+    repo: backend                 # optional: run in this repo's worktree
+    timeout: 60                   # optional: overrides hooks_default_timeout
+    # required: true              # only valid on the pre-mutation events (phase.entered.* / workitem.phase.*)
+```
+
+## Per-repo fields
+
+Additional keys on each entry under `repos:` (alongside `path`, `type`, `depends_on`, `env_runner`, `tasks`, `git_root`, `start_mode`, and `healthcheck`, covered above):
+
+| Field | Meaning |
+|-------|---------|
+| `not_applicable` | Canonical task names that don't apply to this repo (e.g. `[lint]`). Skipped without warning; cannot overlap with `tasks`. (#76) |
+| `tags` | Free-form tags for filtering repos via `--tag` (`mship test`/`run`/`build`). |
+| `symlink_dirs` | Directories symlinked into each task worktree from the source repo (re-synced by `mship bind refresh`). |
+| `bind_files` | Files (relative paths or globs, must stay inside the repo) copied into each task worktree from the source repo (re-synced by `mship bind refresh`). |
+| `base_branch` | Default PR base branch for this repo (overridden by `mship finish --base` / `--base-map`; falls back to the remote default branch). |
+| `expected_branch` | Branch the repo's main checkout is expected to be on; drift audit flags `unexpected_branch` otherwise. |
+| `url` | Explicit clone URL for `mship bootstrap` (overrides `default_remote` + name). Non-GitHub members set a full URL here. |
+| `allow_dirty` | Allow a dirty worktree without failing the drift audit. Default: `false`. |
+| `allow_extra_worktrees` | Allow extra worktrees on the repo without failing the drift audit. Default: `false`. |
+| `capture` | UI-capture config — a `platforms:` list `mship capture` can target (`--platform` required when more than one). |
+| `run_host` | Logical run-host role this repo uses for `--remote` execution (`mship build`/`capture`). Must name an entry in the workspace `run_hosts:` list. |
+
+```yaml
+repos:
+  schemas:
+    path: ../schemas
+    type: library
+    not_applicable: [run]          # this repo has no `run` task
+    tags: [generated]
+    base_branch: main
+    expected_branch: main
+    allow_dirty: false
+    allow_extra_worktrees: false
+    url: https://github.com/other-org/schemas   # overrides default_remote for bootstrap
+    symlink_dirs: [.github]        # symlinked into each worktree from source
+    bind_files: [".env.example", "config/*.toml"]   # copied into each worktree
+
+  ground-control:
+    path: ground-control
+    type: service
+    run_host: android-emu-host     # `mship build/capture --remote` targets this role
+    capture:
+      platforms: [android, ios]    # `mship capture --platform android|ios`
+```


### PR DESCRIPTION
## Summary

Full docs pass — bring the docs in line with the current CLI + config surface.

- **docs/cli.md**: document the 12 previously-undocumented commands (capture, bootstrap, build, pair, pr, skill, bind, debug, gh, layout, relay, messages), each written from real `--help` output.
- **docs/configuration.md**: add reference tables for the ~22 undocumented config fields (WorkspaceConfig: default_scope, spawn_confirm_threshold, spec_paths, require_approved_spec, docs_dir, default_remote, relay, run_hosts, redact, hooks, hooks_default_timeout; RepoConfig: not_applicable, tags, symlink_dirs, bind_files, base_branch, expected_branch, url, allow_dirty, allow_extra_worktrees, capture, run_host).
- **Stale-ref fixes**: README quickstart + cheat sheet now show `mship spawn ... --work-item <id>` (spawn now requires a work item — the old examples errored), the status jq now reads `.resolved_task.worktrees`, and docs/cli.md's spawn line notes `--work-item`/`--hotfix`.
- Verified cloud-agent-auth / relay-hosting / remote-run / tailscale docs — no other stale refs.

## Test plan
- [x] `mship test` — full suite green (docs-only change).
- [x] Grep-verified: all 12 commands present in cli.md, all 22 config fields in configuration.md, no bare `mship spawn "` without `--work-item` in README, `.worktrees` jq fixed.

https://claude.ai/code/session_01WLb3xgnKi4fWy8M4reqhmu
