### PR TITLE
Rename the WorkspaceConfig 'hooks' field to 'lifecycle_hooks' (and hooks_default_timeout to lifecycle_hooks_default_timeout) + guard the old key with a clear error

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,8 +156,8 @@ Top-level keys on `mothership.yaml` (alongside `workspace`, `env_runner`, `branc
 | `relay` | Reverse-tunnel relay connection for `mship serve --relay` (see [`relay-hosting.md`](relay-hosting.md)). |
 | `run_hosts` | Logical run-host role names available to the workspace (only the names are committed here). A repo opts into one via its `run_host`; each machine maps the role to a concrete `{url, token}` in the gitignored `.mothership/run-hosts.yaml`. |
 | `redact` | Extra `mship export --redacted` regex patterns, unioned with the built-in set. (MOS-102) |
-| `hooks` | Declarative reactions to task / WorkItem / PR lifecycle transitions. (MOS-220) |
-| `hooks_default_timeout` | Fallback per-hook timeout in seconds when a `hooks:` entry omits `timeout`. Default: `30`. |
+| `lifecycle_hooks` | Declarative reactions to task / WorkItem / PR lifecycle transitions. Named `lifecycle_hooks` (not `hooks`) to disambiguate from the git commit/push hooks. (MOS-220) |
+| `lifecycle_hooks_default_timeout` | Fallback per-hook timeout in seconds when a `lifecycle_hooks:` entry omits `timeout`. Default: `30`. |
 
 ```yaml
 workspace: my-platform
@@ -179,11 +179,11 @@ redact:
     - "sk-[A-Za-z0-9]{20,}"                    # bare string -> a "custom" pattern
     - { name: internal-host, pattern: "corp\\.example\\.internal" }
 
-hooks:
+lifecycle_hooks:
   - on: pr.merged                 # a lifecycle event (phase.entered.*, workitem.phase.*, task.finished/closed, pr.merged/closed)
     run: notify-slack             # a go-task target or shell command
     repo: backend                 # optional: run in this repo's worktree
-    timeout: 60                   # optional: overrides hooks_default_timeout
+    timeout: 60                   # optional: overrides lifecycle_hooks_default_timeout
     # required: true              # only valid on the pre-mutation events (phase.entered.* / workitem.phase.*)
 ```
 

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -76,8 +76,8 @@ _POST_HOC_EVENTS: frozenset[str] = frozenset(
 
 
 class HookConfig(BaseModel):
-    """One `hooks:` entry: run a go-task target or shell command when `on`
-    fires. See mship.core.lifecycle_hooks for the runtime dispatcher — NOT
+    """One `lifecycle_hooks:` entry: run a go-task target or shell command when
+    `on` fires. See mship.core.lifecycle_hooks for the runtime dispatcher — NOT
     mship.core.hooks, which is the unrelated git pre-commit/pre-push installer."""
     on: str
     run: str
@@ -105,7 +105,7 @@ class HookConfig(BaseModel):
     def validate_on(cls, v: str) -> str:
         if v not in LIFECYCLE_EVENTS:
             raise ValueError(
-                f"hooks: unknown event {v!r}. Valid events: "
+                f"lifecycle_hooks: unknown event {v!r}. Valid events: "
                 f"{', '.join(sorted(LIFECYCLE_EVENTS))}"
             )
         return v
@@ -114,7 +114,7 @@ class HookConfig(BaseModel):
     @classmethod
     def validate_run(cls, v: str) -> str:
         if not v.strip():
-            raise ValueError("hooks: `run` must be a non-empty string")
+            raise ValueError("lifecycle_hooks: `run` must be a non-empty string")
         return v
 
     @model_validator(mode="after")
@@ -128,7 +128,7 @@ class HookConfig(BaseModel):
         anything back. See `_POST_HOC_EVENTS` above."""
         if self.required and self.on in _POST_HOC_EVENTS:
             raise ValueError(
-                f"hooks: `required: true` is not meaningful on {self.on!r} — "
+                f"lifecycle_hooks: `required: true` is not meaningful on {self.on!r} — "
                 f"this event fires only after its transition's side effects "
                 f"(PR/branch creation, spec advance, polling-observed "
                 f"merge/close, etc.) already happened, so a hook here cannot "
@@ -303,11 +303,37 @@ class WorkspaceConfig(BaseModel):
     # redaction pass exactly the built-in patterns.
     redact: RedactConfig | None = None
     # Declarative reactions to task/WorkItem/PR state transitions — see spec
-    # mship-lifecycle-hooks (MOS-220) and mship.core.lifecycle_hooks.
-    hooks: list[HookConfig] = []
-    # Fallback per-hook timeout (seconds) when a `hooks:` entry omits `timeout`.
-    hooks_default_timeout: int = 30
+    # mship-lifecycle-hooks (MOS-220) and mship.core.lifecycle_hooks. Named
+    # `lifecycle_hooks` (not `hooks`) to disambiguate from the unrelated git
+    # commit/push hooks installed by mship.core.hooks.
+    lifecycle_hooks: list[HookConfig] = []
+    # Fallback per-hook timeout (seconds) when a `lifecycle_hooks:` entry omits
+    # `timeout`.
+    lifecycle_hooks_default_timeout: int = 30
     repos: dict[str, RepoConfig]
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_renamed_hook_keys(cls, data):
+        """`hooks:`/`hooks_default_timeout:` were renamed to
+        `lifecycle_hooks:`/`lifecycle_hooks_default_timeout:` to disambiguate
+        from the git commit/push hooks. Pydantic's default `extra="ignore"`
+        would SILENTLY drop the old keys — leaving lifecycle hooks quietly
+        never firing — so raise a clear error instead of failing open."""
+        if isinstance(data, dict):
+            renamed = {
+                "hooks": "lifecycle_hooks",
+                "hooks_default_timeout": "lifecycle_hooks_default_timeout",
+            }
+            found = [old for old in renamed if old in data]
+            if found:
+                raise ValueError(
+                    "`hooks:` was renamed to `lifecycle_hooks:` (and "
+                    "`hooks_default_timeout:` → `lifecycle_hooks_default_timeout:`) "
+                    "— update mothership.yaml. Found old key(s): "
+                    f"{', '.join(sorted(found))}."
+                )
+        return data
 
     @field_validator("relay", mode="before")
     @classmethod
@@ -393,10 +419,10 @@ class WorkspaceConfig(BaseModel):
     @model_validator(mode="after")
     def validate_hooks_repo_refs(self) -> "WorkspaceConfig":
         repo_names = set(self.repos.keys())
-        for hook in self.hooks:
+        for hook in self.lifecycle_hooks:
             if hook.repo is not None and hook.repo not in repo_names:
                 raise ValueError(
-                    f"hooks: entry `on: {hook.on}` references unknown repo "
+                    f"lifecycle_hooks: entry `on: {hook.on}` references unknown repo "
                     f"{hook.repo!r}. Valid repos: {sorted(repo_names)}"
                 )
         return self

--- a/src/mship/core/lifecycle_hooks.py
+++ b/src/mship/core/lifecycle_hooks.py
@@ -92,7 +92,7 @@ class HookContext:
 
 
 def _matching_hooks(event: str, config: "WorkspaceConfig") -> list["HookConfig"]:
-    return [h for h in config.hooks if h.on == event]
+    return [h for h in config.lifecycle_hooks if h.on == event]
 
 
 def _resolve_repo_cwd(
@@ -147,7 +147,7 @@ def _run_one(
 ) -> HookResult:
     name = hook.name or hook.run
     repo_name = hook.repo or context.repo
-    timeout = hook.timeout if hook.timeout is not None else config.hooks_default_timeout
+    timeout = hook.timeout if hook.timeout is not None else config.lifecycle_hooks_default_timeout
 
     cwd, env_runner = _resolve_target(
         repo_name, config, workspace_root, state_manager, context.task_slug,

--- a/tests/cli/test_workitem.py
+++ b/tests/cli/test_workitem.py
@@ -348,7 +348,7 @@ def test_item_phase_fires_workitem_phase_hook(tmp_path):
 
     (tmp_path / "mothership.yaml").write_text(
         "workspace: testws\nrepos: {}\n"
-        "hooks:\n"
+        "lifecycle_hooks:\n"
         "  - on: workitem.phase.done\n"
         "    run: notify-done\n"
     )
@@ -397,7 +397,7 @@ def test_item_phase_required_hook_failure_blocks_override(tmp_path):
 
     (tmp_path / "mothership.yaml").write_text(
         "workspace: testws\nrepos: {}\n"
-        "hooks:\n"
+        "lifecycle_hooks:\n"
         "  - on: workitem.phase.done\n"
         "    run: notify-done-fails\n"
         "    required: true\n"

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -2079,7 +2079,7 @@ def test_close_fires_task_closed_hook_on_abandon(configured_git_app):
     cfg_path = configured_git_app / "mothership.yaml"
     cfg_path.write_text(
         cfg_path.read_text()
-        + "hooks:\n"
+        + "lifecycle_hooks:\n"
         + "  - on: task.closed\n"
         + "    run: notify-closed\n"
     )
@@ -2123,7 +2123,7 @@ def test_close_required_hook_on_task_closed_rejected_at_config_load(configured_g
     cfg_path = configured_git_app / "mothership.yaml"
     cfg_path.write_text(
         cfg_path.read_text()
-        + "hooks:\n"
+        + "lifecycle_hooks:\n"
         + "  - on: task.closed\n"
         + "    run: notify-closed-fails\n"
         + "    required: true\n"
@@ -2141,7 +2141,7 @@ def test_close_non_required_hook_failure_never_blocks_close(configured_git_app):
     cfg_path = configured_git_app / "mothership.yaml"
     cfg_path.write_text(
         cfg_path.read_text()
-        + "hooks:\n"
+        + "lifecycle_hooks:\n"
         + "  - on: task.closed\n"
         + "    run: notify-closed-fails\n"
     )

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -828,18 +828,19 @@ def test_redact_null_patterns_coerces_to_empty_list(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# `hooks:` — lifecycle hooks config schema (MOS-220, spec mship-lifecycle-hooks)
+# `lifecycle_hooks:` — lifecycle hooks config schema (MOS-220, spec
+# mship-lifecycle-hooks)
 # ---------------------------------------------------------------------------
 
 
 def test_hooks_default_empty(workspace: Path):
     config = ConfigLoader.load(workspace / "mothership.yaml")
-    assert config.hooks == []
+    assert config.lifecycle_hooks == []
 
 
 def test_hooks_default_timeout_defaults_to_30(workspace: Path):
     config = ConfigLoader.load(workspace / "mothership.yaml")
-    assert config.hooks_default_timeout == 30
+    assert config.lifecycle_hooks_default_timeout == 30
 
 
 def test_hooks_default_timeout_overridable(tmp_path):
@@ -847,14 +848,14 @@ def test_hooks_default_timeout_overridable(tmp_path):
     cfg = tmp_path / "mothership.yaml"
     cfg.write_text(
         "workspace: t\n"
-        "hooks_default_timeout: 90\n"
+        "lifecycle_hooks_default_timeout: 90\n"
         "repos:\n"
         "  app:\n"
         "    path: ./app\n"
         "    type: service\n"
     )
     config = ConfigLoader.load(cfg, require_paths=False)
-    assert config.hooks_default_timeout == 90
+    assert config.lifecycle_hooks_default_timeout == 90
 
 
 def test_hooks_parses_full_entry(tmp_path):
@@ -866,7 +867,7 @@ def test_hooks_parses_full_entry(tmp_path):
         "  app:\n"
         "    path: ./app\n"
         "    type: service\n"
-        "hooks:\n"
+        "lifecycle_hooks:\n"
         "  - on: pr.merged\n"
         "    run: notify-pr-merged\n"
         "    repo: app\n"
@@ -875,8 +876,8 @@ def test_hooks_parses_full_entry(tmp_path):
         "    required: false\n"
     )
     config = ConfigLoader.load(cfg, require_paths=False)
-    assert len(config.hooks) == 1
-    hook = config.hooks[0]
+    assert len(config.lifecycle_hooks) == 1
+    hook = config.lifecycle_hooks[0]
     assert hook.on == "pr.merged"
     assert hook.run == "notify-pr-merged"
     assert hook.repo == "app"
@@ -894,12 +895,12 @@ def test_hooks_entry_defaults(tmp_path):
         "  app:\n"
         "    path: ./app\n"
         "    type: service\n"
-        "hooks:\n"
+        "lifecycle_hooks:\n"
         "  - on: task.finished\n"
         "    run: some-task\n"
     )
     config = ConfigLoader.load(cfg, require_paths=False)
-    hook = config.hooks[0]
+    hook = config.lifecycle_hooks[0]
     assert hook.repo is None
     assert hook.name is None
     assert hook.timeout is None
@@ -921,12 +922,12 @@ def test_hooks_v1_event_catalog_accepted(tmp_path, event):
         "  app:\n"
         "    path: ./app\n"
         "    type: service\n"
-        "hooks:\n"
+        "lifecycle_hooks:\n"
         f"  - on: {event}\n"
         "    run: some-task\n"
     )
     config = ConfigLoader.load(cfg, require_paths=False)
-    assert config.hooks[0].on == event
+    assert config.lifecycle_hooks[0].on == event
 
 
 def test_hooks_unknown_event_rejected(tmp_path):
@@ -938,7 +939,7 @@ def test_hooks_unknown_event_rejected(tmp_path):
         "  app:\n"
         "    path: ./app\n"
         "    type: service\n"
-        "hooks:\n"
+        "lifecycle_hooks:\n"
         "  - on: task.exploded\n"
         "    run: some-task\n"
     )
@@ -955,7 +956,7 @@ def test_hooks_empty_run_rejected(tmp_path):
         "  app:\n"
         "    path: ./app\n"
         "    type: service\n"
-        "hooks:\n"
+        "lifecycle_hooks:\n"
         "  - on: task.finished\n"
         "    run: \"\"\n"
     )
@@ -981,7 +982,7 @@ def test_hooks_required_true_rejected_on_post_hoc_events(tmp_path, event):
         "  app:\n"
         "    path: ./app\n"
         "    type: service\n"
-        "hooks:\n"
+        "lifecycle_hooks:\n"
         f"  - on: {event}\n"
         "    run: some-task\n"
         "    required: true\n"
@@ -1008,13 +1009,13 @@ def test_hooks_required_true_accepted_on_pre_mutation_events(tmp_path, event):
         "  app:\n"
         "    path: ./app\n"
         "    type: service\n"
-        "hooks:\n"
+        "lifecycle_hooks:\n"
         f"  - on: {event}\n"
         "    run: some-task\n"
         "    required: true\n"
     )
     config = ConfigLoader.load(cfg, require_paths=False)
-    assert config.hooks[0].required is True
+    assert config.lifecycle_hooks[0].required is True
 
 
 def test_hooks_unknown_repo_ref_rejected(tmp_path):
@@ -1026,11 +1027,49 @@ def test_hooks_unknown_repo_ref_rejected(tmp_path):
         "  app:\n"
         "    path: ./app\n"
         "    type: service\n"
-        "hooks:\n"
+        "lifecycle_hooks:\n"
         "  - on: task.finished\n"
         "    run: some-task\n"
         "    repo: nonexistent\n"
     )
     with pytest.raises(ValueError, match="nonexistent"):
+        ConfigLoader.load(cfg, require_paths=False)
+
+
+def test_old_hooks_key_raises_clear_rename_error(tmp_path):
+    """The field was renamed `hooks:` -> `lifecycle_hooks:`. Pydantic's default
+    `extra="ignore"` would SILENTLY drop the old key (lifecycle hooks quietly
+    never fire), so a config still using `hooks:` must fail loud with a rename
+    hint pointing at the new key. See the reject_renamed_hook_keys guard."""
+    from mship.core.config import ConfigLoader
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\n"
+        "repos:\n"
+        "  app:\n"
+        "    path: ./app\n"
+        "    type: service\n"
+        "hooks:\n"
+        "  - on: pr.merged\n"
+        "    run: notify\n"
+    )
+    with pytest.raises(ValueError, match="renamed to `lifecycle_hooks:`"):
+        ConfigLoader.load(cfg, require_paths=False)
+
+
+def test_old_hooks_default_timeout_key_raises_clear_rename_error(tmp_path):
+    """`hooks_default_timeout:` -> `lifecycle_hooks_default_timeout:` must also
+    fail loud rather than silently dropping the old key."""
+    from mship.core.config import ConfigLoader
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\n"
+        "hooks_default_timeout: 90\n"
+        "repos:\n"
+        "  app:\n"
+        "    path: ./app\n"
+        "    type: service\n"
+    )
+    with pytest.raises(ValueError, match="lifecycle_hooks_default_timeout"):
         ConfigLoader.load(cfg, require_paths=False)
 

--- a/tests/core/test_lifecycle_hooks.py
+++ b/tests/core/test_lifecycle_hooks.py
@@ -54,8 +54,8 @@ def _config(repos=None, hooks=None, env_runner=None, hooks_default_timeout=30) -
         workspace="test",
         env_runner=env_runner,
         repos=repos or {},
-        hooks=hooks or [],
-        hooks_default_timeout=hooks_default_timeout,
+        lifecycle_hooks=hooks or [],
+        lifecycle_hooks_default_timeout=hooks_default_timeout,
     )
 
 

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -718,7 +718,7 @@ def _make_phase_manager_with_hooks(state_mgr, workspace_root, hooks, shell=None)
     config = WorkspaceConfig(
         workspace="test",
         repos={"shared": RepoConfig(path=Path("./shared"), type="library")},
-        hooks=hooks,
+        lifecycle_hooks=hooks,
     )
     return PhaseManager(
         state_mgr, MagicMock(spec=LogManager),

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -311,7 +311,7 @@ class _RecordingShell:
 
 def _hooks_config(hooks, repos=None):
     from mship.core.config import WorkspaceConfig
-    return WorkspaceConfig(workspace="test", repos=repos or {}, hooks=hooks)
+    return WorkspaceConfig(workspace="test", repos=repos or {}, lifecycle_hooks=hooks)
 
 
 def test_pr_merged_fires_matching_hook():

--- a/tests/core/test_serve_items.py
+++ b/tests/core/test_serve_items.py
@@ -132,7 +132,7 @@ def test_post_item_phase_sets_override(tmp_path):
 
     items = WorkItemStore(tmp_path / ".mothership" / "workitems")
     wi = items.create(title="Stuck item", kind="feature", workspace="testws", now=_now())
-    config = WorkspaceConfig(workspace="testws", repos={}, hooks=[])
+    config = WorkspaceConfig(workspace="testws", repos={}, lifecycle_hooks=[])
     client = _app_with_config(tmp_path, config)
 
     resp = client.post(f"/items/{wi.id}/phase", json={"phase": "done"})
@@ -194,7 +194,7 @@ def test_post_item_phase_fires_workitem_phase_hook(tmp_path):
     marker = tmp_path / "hook-fired.txt"
     config = WorkspaceConfig(
         workspace="testws", repos={},
-        hooks=[HookConfig(on="workitem.phase.done", run=f"touch {marker}")],
+        lifecycle_hooks=[HookConfig(on="workitem.phase.done", run=f"touch {marker}")],
     )
     client = _app_with_config(tmp_path, config)
 
@@ -212,7 +212,7 @@ def test_post_item_phase_required_hook_failure_returns_422_and_blocks_override(t
 
     config = WorkspaceConfig(
         workspace="testws", repos={},
-        hooks=[HookConfig(on="workitem.phase.done", run="false", required=True)],
+        lifecycle_hooks=[HookConfig(on="workitem.phase.done", run="false", required=True)],
     )
     client = _app_with_config(tmp_path, config)
 
@@ -229,7 +229,7 @@ def test_post_item_phase_non_required_hook_failure_still_sets_override(tmp_path)
 
     config = WorkspaceConfig(
         workspace="testws", repos={},
-        hooks=[HookConfig(on="workitem.phase.done", run="false")],
+        lifecycle_hooks=[HookConfig(on="workitem.phase.done", run="false")],
     )
     client = _app_with_config(tmp_path, config)
 
@@ -266,7 +266,7 @@ def test_post_item_phase_hook_fires_iff_config_present(tmp_path):
 
     # Same hook definition, config now wired in -> it must fire, and the
     # override applies normally.
-    config = WorkspaceConfig(workspace="testws", repos={}, hooks=hooks)
+    config = WorkspaceConfig(workspace="testws", repos={}, lifecycle_hooks=hooks)
     client_with_config = _app_with_config(tmp_path, config)
     resp = client_with_config.post(f"/items/{wi_with_config.id}/phase", json={"phase": "done"})
     assert resp.status_code == 200
@@ -293,7 +293,7 @@ def test_post_item_phase_hook_does_not_hold_item_msg_lock(tmp_path):
 
     config = WorkspaceConfig(
         workspace="testws", repos={},
-        hooks=[HookConfig(on="workitem.phase.done", run="sleep 1")],
+        lifecycle_hooks=[HookConfig(on="workitem.phase.done", run="sleep 1")],
     )
     client = _app_with_config(tmp_path, config)
 

--- a/tests/test_finish_integration.py
+++ b/tests/test_finish_integration.py
@@ -973,7 +973,7 @@ def test_finish_fires_task_finished_hook(finish_workspace):
     cfg_path = workspace / "mothership.yaml"
     cfg_path.write_text(
         cfg_path.read_text()
-        + "hooks:\n"
+        + "lifecycle_hooks:\n"
         + "  - on: task.finished\n"
         + "    run: notify-finished\n"
     )
@@ -1028,7 +1028,7 @@ def test_finish_required_hook_on_task_finished_rejected_at_config_load(finish_wo
     cfg_path = workspace / "mothership.yaml"
     cfg_path.write_text(
         cfg_path.read_text()
-        + "hooks:\n"
+        + "lifecycle_hooks:\n"
         + "  - on: task.finished\n"
         + "    run: notify-finished-fails\n"
         + "    required: true\n"
@@ -1046,7 +1046,7 @@ def test_finish_non_required_hook_failure_never_blocks_finished_stamp(finish_wor
     cfg_path = workspace / "mothership.yaml"
     cfg_path.write_text(
         cfg_path.read_text()
-        + "hooks:\n"
+        + "lifecycle_hooks:\n"
         + "  - on: task.finished\n"
         + "    run: notify-finished-fails\n"
     )


### PR DESCRIPTION
## Summary

Rename the `WorkspaceConfig` config key `hooks:` → `lifecycle_hooks:` (and `hooks_default_timeout:` → `lifecycle_hooks_default_timeout:`) to disambiguate the MOS-220 lifecycle reactions from the git commit/push hooks (`core/hooks.py`) — the two "hooks" concepts were a standing comprehension tax (MOS-236 E5).

- `WorkspaceConfig` field + comments renamed; the repo-ref validator + `HookConfig` error strings updated to say `lifecycle_hooks:`.
- All internal readers updated (`core/lifecycle_hooks.py`); `phase.py`/`pr_watcher.py`/`serve.py` go through `run_hooks()` and needed no change.
- **Fail-loud guard**: a `@model_validator(mode="before")` rejects the old `hooks:`/`hooks_default_timeout:` keys with a clear "renamed to lifecycle_hooks:" error — pydantic's default `extra="ignore"` would otherwise silently drop them and quietly stop lifecycle hooks firing.
- docs/configuration.md + all test fixtures/constructors updated.

## Test plan
- [x] `mship test` — full suite green.
- [x] New tests: an old `hooks:` key raises the rename error; `lifecycle_hooks:` loads correctly. Targeted config/phase/lifecycle/serve/pr-watcher hook suites pass.

https://claude.ai/code/session_01WLb3xgnKi4fWy8M4reqhmu
