### PR TITLE
AC evidence loop PR-b: enforcement (resolve_bound_spec + phase/finish AC-evidence warnings + --require-evidence + PR-body Acceptance criteria section) (plan tasks 7-9)

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -919,6 +919,12 @@ def register(app: typer.Typer, get_container):
                  "(task.test_results or journal test_state=pass). Default: WARN only. "
                  "See #81.",
         ),
+        require_evidence: bool = typer.Option(
+            False, "--require-evidence",
+            help="Block finish when any acceptance criterion on the bound spec lacks "
+                 "evidence. Default: WARN only. Mirrors --require-tests. "
+                 "See ac-evidence-loop.",
+        ),
         title: Optional[str] = typer.Option(
             None, "--title",
             help="Override the PR title (default: task.description). "
@@ -1351,6 +1357,30 @@ def register(app: typer.Typer, get_container):
                 "`mship test` / "
                 "`mship journal \"tests verified externally\" --test-state pass`."
             )
+
+        # --- Acceptance-criteria evidence gate (ac-evidence-loop) ---
+        # Mirror the test-evidence gate: WARN by default when any AC on the bound
+        # spec lacks evidence; BLOCK only with --require-evidence. Resolve the spec
+        # via the task's WorkItem link; no bound spec ⇒ no-op. `bound_spec` is
+        # reused by the PR-body assembly below (build_acceptance_block).
+        from mship.core.workitem_gate import resolve_bound_spec
+        bound_spec = resolve_bound_spec(task, workspace_root)
+        if bound_spec is not None:
+            unverified_acs = [c.id for c in bound_spec.acceptance_criteria if not c.evidence]
+            if unverified_acs:
+                if require_evidence:
+                    output.error("Acceptance criteria without evidence — blocking finish (--require-evidence):")
+                    output.error(f"  {bound_spec.id}: {', '.join(unverified_acs)}")
+                    output.error(
+                        "Attach evidence via `mship spec evidence <spec> <ac> <ref>`, then retry."
+                    )
+                    raise typer.Exit(code=1)
+                output.warning("Acceptance-criteria evidence warnings:")
+                output.warning(f"  {bound_spec.id}: {', '.join(unverified_acs)} lack evidence")
+                output.warning(
+                    "Pass `--require-evidence` to treat as blocking, or attach evidence via "
+                    "`mship spec evidence <spec> <ac> <ref>`."
+                )
 
         pr_list: list[dict] = []
         repushed_repos: list[str] = []  # repos where --force re-pushed commits

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1382,6 +1382,11 @@ def register(app: typer.Typer, get_container):
                     "`mship spec evidence <spec> <ac> <ref>`."
                 )
 
+        # Render the acceptance-criteria PR-body section once (reuses bound_spec
+        # from the gate above). Empty string when there's no bound spec or no ACs.
+        from mship.core.pr import build_acceptance_block
+        acceptance_block = build_acceptance_block(bound_spec) if bound_spec is not None else ""
+
         pr_list: list[dict] = []
         repushed_repos: list[str] = []  # repos where --force re-pushed commits
 
@@ -1534,6 +1539,8 @@ def register(app: typer.Typer, get_container):
                 else:
                     pr_body_base = task.description
                 pr_body = append_closes_footer(pr_body_base, extract_issue_refs(texts))
+                if acceptance_block:
+                    pr_body = pr_body + acceptance_block
 
                 try:
                     pr_url = pr_mgr.create_pr(

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1367,16 +1367,17 @@ def register(app: typer.Typer, get_container):
         try:
             bound_spec = resolve_bound_spec(task, workspace_root)
         except Exception as e:
-            # A corrupt/unreadable spec store must not SILENTLY skip a required check.
-            # Under --require-evidence, fail safe (block); otherwise warn and proceed.
+            # The bound spec should exist but couldn't be resolved (ambiguous slug,
+            # missing linked spec, or a corrupt store). Never SILENTLY skip a required
+            # check: under --require-evidence fail safe (block); otherwise warn+proceed.
             if require_evidence:
                 output.error(
-                    "Could not read the bound spec to verify acceptance-criteria "
+                    "Could not resolve the bound spec to verify acceptance-criteria "
                     f"evidence — blocking finish (--require-evidence): {e}"
                 )
-                output.error("Fix the spec store or drop --require-evidence, then retry.")
+                output.error("Resolve the spec binding or drop --require-evidence, then retry.")
                 raise typer.Exit(code=1)
-            output.warning(f"Could not check acceptance-criteria evidence (spec store unreadable): {e}")
+            output.warning(f"Could not check acceptance-criteria evidence (spec binding unresolved): {e}")
             bound_spec = None
         if bound_spec is not None:
             unverified_acs = [c.id for c in bound_spec.acceptance_criteria if not c.evidence]

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1364,7 +1364,20 @@ def register(app: typer.Typer, get_container):
         # via the task's WorkItem link; no bound spec ⇒ no-op. `bound_spec` is
         # reused by the PR-body assembly below (build_acceptance_block).
         from mship.core.workitem_gate import resolve_bound_spec
-        bound_spec = resolve_bound_spec(task, workspace_root)
+        try:
+            bound_spec = resolve_bound_spec(task, workspace_root)
+        except Exception as e:
+            # A corrupt/unreadable spec store must not SILENTLY skip a required check.
+            # Under --require-evidence, fail safe (block); otherwise warn and proceed.
+            if require_evidence:
+                output.error(
+                    "Could not read the bound spec to verify acceptance-criteria "
+                    f"evidence — blocking finish (--require-evidence): {e}"
+                )
+                output.error("Fix the spec store or drop --require-evidence, then retry.")
+                raise typer.Exit(code=1)
+            output.warning(f"Could not check acceptance-criteria evidence (spec store unreadable): {e}")
+            bound_spec = None
         if bound_spec is not None:
             unverified_acs = [c.id for c in bound_spec.acceptance_criteria if not c.evidence]
             if unverified_acs:

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -127,7 +127,7 @@ class PhaseManager:
                 if (
                     self._config is not None
                     and self._config.require_approved_spec
-                    and not self._has_approved_spec(task_slug)
+                    and not self._has_approved_spec(task)
                 ):
                     raise SpecGateError(
                         f"Task '{task_slug}' has no bound approved spec. "
@@ -255,23 +255,25 @@ class PhaseManager:
             return [warn]
         return []
 
-    def _has_approved_spec(self, task_slug: str) -> bool:
-        """Return True if a spec bound to task_slug has an approved-or-beyond status."""
+    def _has_approved_spec(self, task) -> bool:
+        """Return True iff the task's bound spec is approved-or-beyond, resolved via
+        the shared `resolve_bound_spec` (single source of truth with the WorkItem
+        gate and the AC-evidence path). The explicit WorkItem `spec_id` link is
+        terminal, so a correctly-linked feature is never rejected here just because
+        its spec's `task_slug` differs from the task slug. An unresolvable binding
+        (deleted link / ambiguous slug) counts as 'no approved spec'."""
         if self._workspace_root is None:
             return False
         # Import inside method to avoid potential import cycles at module load.
-        from mship.core.spec_store import SPECS_DIRNAME, SpecStore
-        from mship.core.workitem_gate import APPROVED_STATUSES
+        from mship.core.workitem_gate import APPROVED_STATUSES, resolve_bound_spec
 
-        specs_dir = self._workspace_root / SPECS_DIRNAME
         try:
-            specs = SpecStore(specs_dir).list()
+            spec = resolve_bound_spec(task, self._workspace_root)
         except Exception:
+            # Unresolvable binding (deleted link / ambiguous slug) or unreadable
+            # store → treat as no approved spec (the gate blocks).
             return False
-        return any(
-            s.task_slug == task_slug and s.status in APPROVED_STATUSES
-            for s in specs
-        )
+        return spec is not None and spec.status in APPROVED_STATUSES
 
     def _gate_review(self, task) -> list[str]:
         # Unified reader honors both task.test_results and journal

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -298,7 +298,12 @@ class PhaseManager:
             return []
         from mship.core.workitem_gate import resolve_bound_spec
 
-        spec = resolve_bound_spec(task, self._workspace_root)
+        try:
+            spec = resolve_bound_spec(task, self._workspace_root)
+        except Exception:
+            # A corrupt/unreadable spec store must never block or crash the review
+            # transition — this is a soft advisory gate. Skip the AC warning.
+            return []
         if spec is None:
             return []
         missing = [c.id for c in spec.acceptance_criteria if not c.evidence]

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -281,10 +281,33 @@ class PhaseManager:
 
         evidence = read_evidence(task, self._log)
         lines = format_missing_summary(evidence)
-        if not lines:
+        if lines:
+            hint = " — consider running tests before review"
+            warnings = [lines[0] + hint] + lines[1:]
+        else:
+            warnings = []
+        # AC-evidence warnings (ac8): soft, never blocks; no bound spec ⇒ no-op.
+        warnings.extend(self._unverified_ac_warnings(task))
+        return warnings
+
+    def _unverified_ac_warnings(self, task) -> list[str]:
+        """WARNING lines listing bound-spec acceptance criteria with no evidence.
+        Loads the task's bound spec via the shared resolver (self._workspace_root
+        + SpecStore, same pattern as _has_approved_spec). Never blocks."""
+        if self._workspace_root is None:
             return []
-        hint = " — consider running tests before review"
-        return [lines[0] + hint] + lines[1:]
+        from mship.core.workitem_gate import resolve_bound_spec
+
+        spec = resolve_bound_spec(task, self._workspace_root)
+        if spec is None:
+            return []
+        missing = [c.id for c in spec.acceptance_criteria if not c.evidence]
+        if not missing:
+            return []
+        return [
+            f"Acceptance criteria without evidence: {', '.join(missing)} "
+            f"— attach with `mship spec evidence {spec.id} <ac> <ref>`"
+        ]
 
     def _gate_run(self, task) -> list[str]:
         return []

--- a/src/mship/core/pr.py
+++ b/src/mship/core/pr.py
@@ -423,3 +423,28 @@ class PRManager:
         lines.append(f"⚠ Merge in order: {deps_note}")
 
         return "\n".join(lines)
+
+
+def build_acceptance_block(spec) -> str:
+    """Render an 'Acceptance criteria' PR-body section listing each AC as verified
+    (with its evidence refs) or unverified. Pure analogue of
+    PRManager.build_coordination_block: returns '' when there is nothing to render
+    (no criteria), else a leading-separator markdown block ready to append to a
+    PR body."""
+    acs = getattr(spec, "acceptance_criteria", None) or []
+    if not acs:
+        return ""
+    lines = [
+        "",
+        "---",
+        "",
+        "## Acceptance criteria",
+        "",
+    ]
+    for c in acs:
+        if c.evidence:
+            refs = ", ".join(f"{e.kind}:{e.ref}" for e in c.evidence)
+            lines.append(f"- [x] `{c.id}` {c.text} — {refs}")
+        else:
+            lines.append(f"- [ ] `{c.id}` {c.text} — _no evidence_")
+    return "\n".join(lines)

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -79,9 +79,15 @@ def resolve_bound_spec(task, workspace_root: Path):
             bound = specs.find_by_id(wi.spec_id)
             if bound is not None:
                 return bound
-    for s in specs.list():
-        if s.task_slug == task.slug and s.status in APPROVED_STATUSES:
-            return s
+    candidates = [
+        s for s in specs.list()
+        if s.task_slug == task.slug and s.status in APPROVED_STATUSES
+    ]
+    if candidates:
+        # If several approved specs share the slug, bind the MOST RECENTLY UPDATED
+        # one (not list() order, which is by filename date-prefix) so a superseding
+        # spec wins over an older checklist.
+        return max(candidates, key=lambda s: s.updated_at)
     return None
 
 

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -57,24 +57,31 @@ def _feature_has_approved_spec(wi: WorkItem, task, workspace_root: Path) -> bool
 
 
 def resolve_bound_spec(task, workspace_root: Path):
-    """Return the Spec bound to `task` (its WorkItem's spec_id, else a spec whose
-    task_slug matches), or None. Reuses the SpecStore/WorkItemStore resolution the
-    WorkItem gate + PhaseManager._has_approved_spec already use. Never raises — a
-    missing/corrupt store yields None, so the AC-evidence gate is simply a no-op."""
-    try:
-        specs = SpecStore(Path(workspace_root) / "specs")
-        wi_id = getattr(task, "work_item_id", None)
-        if wi_id is not None:
-            wi = WorkItemStore(Path(workspace_root) / ".mothership" / "workitems").get(wi_id)
-            if wi is not None and wi.spec_id:
-                bound = specs.find_by_id(wi.spec_id)
-                if bound is not None:
-                    return bound
-        for s in specs.list():
-            if s.task_slug == task.slug:
-                return s
-    except Exception:
-        return None
+    """Return the Spec bound to `task`, or None when nothing is bound.
+
+    Resolution: the task's WorkItem `spec_id` first (an EXPLICIT link — returned
+    regardless of status, it is authoritative), else a fallback to a spec whose
+    `task_slug` matches AND is approved. The fallback is a HEURISTIC guess, so it is
+    restricted to `APPROVED_STATUSES` — never binding to a draft, archived, or
+    superseded spec (which would let `finish --require-evidence` block on, or a PR
+    body render, an irrelevant checklist).
+
+    Returns None cleanly when the stores are simply empty/absent (missing dir →
+    empty list, unknown id → None). It does NOT swallow genuine read/parse errors
+    (e.g. a corrupt spec file): those propagate so callers can fail safe. Soft gates
+    (phase review) catch and skip; `finish --require-evidence` catches and BLOCKs
+    rather than silently skipping the required check."""
+    specs = SpecStore(Path(workspace_root) / "specs")
+    wi_id = getattr(task, "work_item_id", None)
+    if wi_id is not None:
+        wi = WorkItemStore(Path(workspace_root) / ".mothership" / "workitems").get(wi_id)
+        if wi is not None and wi.spec_id:
+            bound = specs.find_by_id(wi.spec_id)
+            if bound is not None:
+                return bound
+    for s in specs.list():
+        if s.task_slug == task.slug and s.status in APPROVED_STATUSES:
+            return s
     return None
 
 

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -56,38 +56,61 @@ def _feature_has_approved_spec(wi: WorkItem, task, workspace_root: Path) -> bool
     return any(s.task_slug == task.slug and s.status in APPROVED_STATUSES for s in specs.list())
 
 
+class BoundSpecUnresolved(Exception):
+    """A spec SHOULD bind to the task but couldn't be resolved unambiguously
+    (explicit link points at a missing spec, or several approved specs tie on the
+    slug). Distinct from 'no spec bound at all' (which `resolve_bound_spec` signals
+    with None). Callers fail safe: `finish --require-evidence` BLOCKs; soft gates
+    (phase review, default finish) warn/skip."""
+
+
 def resolve_bound_spec(task, workspace_root: Path):
-    """Return the Spec bound to `task`, or None when nothing is unambiguously bound.
+    """Return the Spec bound to `task`, or None when the task genuinely has NO spec.
+
+    The three outcomes are distinct on purpose:
+    - a Spec: the bound spec, resolved unambiguously;
+    - None: the task legitimately has no spec to check (no explicit link AND no
+      approved slug match — e.g. a bug/chore WorkItem) → the AC gate is a real no-op;
+    - raises `BoundSpecUnresolved`: a spec SHOULD exist but can't be pinned down, so
+      callers must NOT silently skip — `finish --require-evidence` blocks, soft gates
+      warn/skip. This prevents an ambiguous/broken binding from quietly opening a PR
+      with the required evidence check skipped.
 
     Resolution never GUESSES:
-    - If the task's WorkItem has an explicit `spec_id`, that link is AUTHORITATIVE and
-      TERMINAL: return the linked spec (regardless of status), or None if it's gone
-      (deleted/renamed). It does NOT fall through to a slug guess — an explicit intent
-      exists, so binding some other spec would be wrong.
-    - Otherwise, fall back to a spec whose `task_slug` matches AND is approved, but
-      bind ONLY when exactly one such spec exists. If several match, the mapping is
-      ambiguous (which is "the" spec is undecidable from the data) and any pick risks
-      enforcing/rendering the wrong checklist, so refuse to guess and return None.
+    - An explicit WorkItem `spec_id` is AUTHORITATIVE and TERMINAL: return that spec
+      (any status), or RAISE if it's gone (deleted/renamed) — never fall through to a
+      slug guess when an explicit intent exists.
+    - Otherwise fall back to an approved spec whose `task_slug` matches, but only when
+      EXACTLY ONE does. Zero → None (unbound); several → RAISE (ambiguous). Full
+      disambiguation needs stable spec identity — tracked in MOS-247.
 
-    Full disambiguation of the fallback needs stable spec identity — tracked in
-    MOS-247.
-
-    Returns None cleanly when the stores are simply empty/absent (missing dir →
-    empty list, unknown id → None). It does NOT swallow genuine read/parse errors
-    (e.g. a corrupt spec file): those propagate so callers can fail safe. Soft gates
-    (phase review) catch and skip; `finish --require-evidence` catches and BLOCKs
-    rather than silently skipping the required check."""
+    Genuine read/parse errors (a corrupt spec file) are NOT swallowed — they
+    propagate, and callers treat them the same as `BoundSpecUnresolved`."""
     specs = SpecStore(Path(workspace_root) / "specs")
     wi_id = getattr(task, "work_item_id", None)
     if wi_id is not None:
         wi = WorkItemStore(Path(workspace_root) / ".mothership" / "workitems").get(wi_id)
         if wi is not None and wi.spec_id:
-            return specs.find_by_id(wi.spec_id)
+            bound = specs.find_by_id(wi.spec_id)
+            if bound is None:
+                raise BoundSpecUnresolved(
+                    f"WorkItem {wi_id} links spec {wi.spec_id!r}, but that spec was not "
+                    f"found (deleted or renamed). Re-link with `mship item link-spec`."
+                )
+            return bound
     candidates = [
         s for s in specs.list()
         if s.task_slug == task.slug and s.status in APPROVED_STATUSES
     ]
-    return candidates[0] if len(candidates) == 1 else None
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1:
+        raise BoundSpecUnresolved(
+            f"{len(candidates)} approved specs share task_slug {task.slug!r} "
+            f"({', '.join(sorted(s.id for s in candidates))}); cannot unambiguously "
+            f"bind one. Link the intended spec explicitly with `mship item link-spec`."
+        )
+    return None
 
 
 def _docs_dir(workspace_root: Path) -> str:

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -86,8 +86,11 @@ def resolve_bound_spec(task, workspace_root: Path):
     if candidates:
         # If several approved specs share the slug, bind the MOST RECENTLY UPDATED
         # one (not list() order, which is by filename date-prefix) so a superseding
-        # spec wins over an older checklist.
-        return max(candidates, key=lambda s: s.updated_at)
+        # spec wins over an older checklist. `id` is a deterministic secondary key so
+        # an exact updated_at tie never resolves by filesystem order. (The fallback
+        # is a heuristic used only when there's no explicit WorkItem spec_id link;
+        # full disambiguation needs stable spec identity — tracked in MOS-247.)
+        return max(candidates, key=lambda s: (s.updated_at, s.id))
     return None
 
 

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -57,14 +57,20 @@ def _feature_has_approved_spec(wi: WorkItem, task, workspace_root: Path) -> bool
 
 
 def resolve_bound_spec(task, workspace_root: Path):
-    """Return the Spec bound to `task`, or None when nothing is bound.
+    """Return the Spec bound to `task`, or None when nothing is unambiguously bound.
 
-    Resolution: the task's WorkItem `spec_id` first (an EXPLICIT link — returned
-    regardless of status, it is authoritative), else a fallback to a spec whose
-    `task_slug` matches AND is approved. The fallback is a HEURISTIC guess, so it is
-    restricted to `APPROVED_STATUSES` — never binding to a draft, archived, or
-    superseded spec (which would let `finish --require-evidence` block on, or a PR
-    body render, an irrelevant checklist).
+    Resolution never GUESSES:
+    - If the task's WorkItem has an explicit `spec_id`, that link is AUTHORITATIVE and
+      TERMINAL: return the linked spec (regardless of status), or None if it's gone
+      (deleted/renamed). It does NOT fall through to a slug guess — an explicit intent
+      exists, so binding some other spec would be wrong.
+    - Otherwise, fall back to a spec whose `task_slug` matches AND is approved, but
+      bind ONLY when exactly one such spec exists. If several match, the mapping is
+      ambiguous (which is "the" spec is undecidable from the data) and any pick risks
+      enforcing/rendering the wrong checklist, so refuse to guess and return None.
+
+    Full disambiguation of the fallback needs stable spec identity — tracked in
+    MOS-247.
 
     Returns None cleanly when the stores are simply empty/absent (missing dir →
     empty list, unknown id → None). It does NOT swallow genuine read/parse errors
@@ -76,22 +82,12 @@ def resolve_bound_spec(task, workspace_root: Path):
     if wi_id is not None:
         wi = WorkItemStore(Path(workspace_root) / ".mothership" / "workitems").get(wi_id)
         if wi is not None and wi.spec_id:
-            bound = specs.find_by_id(wi.spec_id)
-            if bound is not None:
-                return bound
+            return specs.find_by_id(wi.spec_id)
     candidates = [
         s for s in specs.list()
         if s.task_slug == task.slug and s.status in APPROVED_STATUSES
     ]
-    if candidates:
-        # If several approved specs share the slug, bind the MOST RECENTLY UPDATED
-        # one (not list() order, which is by filename date-prefix) so a superseding
-        # spec wins over an older checklist. `id` is a deterministic secondary key so
-        # an exact updated_at tie never resolves by filesystem order. (The fallback
-        # is a heuristic used only when there's no explicit WorkItem spec_id link;
-        # full disambiguation needs stable spec identity — tracked in MOS-247.)
-        return max(candidates, key=lambda s: (s.updated_at, s.id))
-    return None
+    return candidates[0] if len(candidates) == 1 else None
 
 
 def _docs_dir(workspace_root: Path) -> str:

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -48,12 +48,16 @@ def check_task_gate(task, workspace_root: Path, require_plan: bool = False) -> G
 
 
 def _feature_has_approved_spec(wi: WorkItem, task, workspace_root: Path) -> bool:
-    specs = SpecStore(Path(workspace_root) / "specs")
-    if wi.spec_id:
-        s = specs.find_by_id(wi.spec_id)
-        if s is not None and s.status in APPROVED_STATUSES:
-            return True
-    return any(s.task_slug == task.slug and s.status in APPROVED_STATUSES for s in specs.list())
+    """Feature gate: satisfied iff the task resolves to an APPROVED spec, using the
+    SAME resolution rules as `resolve_bound_spec` (single source of truth) — the
+    explicit `spec_id` link is terminal, and an unresolvable binding (a deleted
+    linked spec, or several approved specs tying on the slug) is NOT satisfied rather
+    than silently falling back to a possibly-unrelated slug match."""
+    try:
+        spec = resolve_bound_spec(task, workspace_root)
+    except BoundSpecUnresolved:
+        return False
+    return spec is not None and spec.status in APPROVED_STATUSES
 
 
 class BoundSpecUnresolved(Exception):
@@ -80,13 +84,17 @@ def resolve_bound_spec(task, workspace_root: Path):
     - An explicit WorkItem `spec_id` is AUTHORITATIVE and TERMINAL: return that spec
       (any status), or RAISE if it's gone (deleted/renamed) — never fall through to a
       slug guess when an explicit intent exists.
-    - Otherwise fall back to an approved spec whose `task_slug` matches, but only when
-      EXACTLY ONE does. Zero → None (unbound); several → RAISE (ambiguous). Full
-      disambiguation needs stable spec identity — tracked in MOS-247.
+    - Otherwise the `task_slug` fallback runs ONLY for spec-ELIGIBLE tasks (a feature
+      WorkItem). A bug/chore/question/hotfix task — or a task with no WorkItem — has
+      no spec, so a coincidental slug collision with an unrelated feature spec must
+      NOT bind it: those return None. For an eligible task, bind an approved
+      slug-matching spec only when EXACTLY ONE exists: zero → None (unbound); several
+      → RAISE (ambiguous). Full disambiguation needs stable spec identity — MOS-247.
 
     Genuine read/parse errors (a corrupt spec file) are NOT swallowed — they
     propagate, and callers treat them the same as `BoundSpecUnresolved`."""
     specs = SpecStore(Path(workspace_root) / "specs")
+    wi = None
     wi_id = getattr(task, "work_item_id", None)
     if wi_id is not None:
         wi = WorkItemStore(Path(workspace_root) / ".mothership" / "workitems").get(wi_id)
@@ -98,6 +106,10 @@ def resolve_bound_spec(task, workspace_root: Path):
                     f"found (deleted or renamed). Re-link with `mship item link-spec`."
                 )
             return bound
+    # Slug fallback is gated on spec-eligibility: only a feature WorkItem can bind a
+    # spec by slug. Non-feature / unlinked tasks have no spec → never slug-collide.
+    if wi is None or wi.kind != "feature":
+        return None
     candidates = [
         s for s in specs.list()
         if s.task_slug == task.slug and s.status in APPROVED_STATUSES

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -56,6 +56,28 @@ def _feature_has_approved_spec(wi: WorkItem, task, workspace_root: Path) -> bool
     return any(s.task_slug == task.slug and s.status in APPROVED_STATUSES for s in specs.list())
 
 
+def resolve_bound_spec(task, workspace_root: Path):
+    """Return the Spec bound to `task` (its WorkItem's spec_id, else a spec whose
+    task_slug matches), or None. Reuses the SpecStore/WorkItemStore resolution the
+    WorkItem gate + PhaseManager._has_approved_spec already use. Never raises — a
+    missing/corrupt store yields None, so the AC-evidence gate is simply a no-op."""
+    try:
+        specs = SpecStore(Path(workspace_root) / "specs")
+        wi_id = getattr(task, "work_item_id", None)
+        if wi_id is not None:
+            wi = WorkItemStore(Path(workspace_root) / ".mothership" / "workitems").get(wi_id)
+            if wi is not None and wi.spec_id:
+                bound = specs.find_by_id(wi.spec_id)
+                if bound is not None:
+                    return bound
+        for s in specs.list():
+            if s.task_slug == task.slug:
+                return s
+    except Exception:
+        return None
+    return None
+
+
 def _docs_dir(workspace_root: Path) -> str:
     """`docs_dir` from mothership.yaml; fall back to "docs" on any load error
     (e.g. running outside a materialized workspace)."""

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -343,8 +343,22 @@ def test_a7_plan_to_dev_blocked_when_require_approved_spec_and_no_spec(
 def test_a7_plan_to_dev_allowed_when_approved_spec_exists(
     state_with_task: StateManager, tmp_path: Path
 ):
-    """require_approved_spec=True + bound approved spec → transition succeeds."""
-    _seed_approved_spec(tmp_path, "add-labels")
+    """require_approved_spec=True + an approved spec linked via the WorkItem spec_id
+    → transition succeeds. The gate resolves via resolve_bound_spec, and this
+    regresses the reported bug: the linked spec's task_slug does NOT match the task
+    slug, so a slug-only gate would have wrongly rejected the correctly-linked task."""
+    from datetime import datetime, timezone
+    from mship.core.spec import Spec
+    from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+    from mship.core.workitem_store import WorkItemStore
+    now = datetime(2026, 4, 10, tzinfo=timezone.utc)
+    SpecStore(tmp_path / SPECS_DIRNAME).save(Spec(
+        id="linked-spec", title="S", status="approved",
+        created_at=now, updated_at=now, task_slug="a-different-slug",   # NOT "add-labels"
+    ))
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi_id = state_with_task.load().tasks["add-labels"].work_item_id
+    items.link_spec(wi_id, "linked-spec", now=now)
     pm = _make_phase_manager_with_approved_spec_gate(state_with_task, tmp_path)
     result = pm.transition("add-labels", "dev")
     assert result.new_phase == "dev"
@@ -380,23 +394,29 @@ def test_has_approved_spec_uses_shared_workitem_gate_approved_statuses(
     from mship.core import workitem_gate
     from mship.core.spec import Spec
     from mship.core.spec_store import SpecStore
+    from mship.core.state import Task
+    from mship.core.workitem_store import WorkItemStore
 
     now = datetime(2026, 4, 10, tzinfo=timezone.utc)
     SpecStore(tmp_path / "specs").save(Spec(
-        id="s1", title="S", status="draft",
-        created_at=now, updated_at=now, task_slug="t",
+        id="s1", title="S", status="draft", created_at=now, updated_at=now,
     ))
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="F", kind="feature", workspace="test", now=now)
+    items.link_spec(wi.id, "s1", now=now)   # explicit link → resolves the spec (any status)
+    task = Task(slug="t", description="d", phase="dev", created_at=now,
+                affected_repos=["shared"], branch="feat/t", work_item_id=wi.id)
     pm = PhaseManager(
         StateManager(tmp_path / ".mothership"), MagicMock(spec=LogManager),
         workspace_root=tmp_path,
     )
 
     # "draft" isn't approved-or-beyond by the real, shared set.
-    assert pm._has_approved_spec("t") is False
+    assert pm._has_approved_spec(task) is False
 
     # Patching the SHARED set (not a local copy) must change the outcome.
     monkeypatch.setattr(workitem_gate, "APPROVED_STATUSES", {"draft"})
-    assert pm._has_approved_spec("t") is True
+    assert pm._has_approved_spec(task) is True
 
 
 def test_a7_dispatched_spec_also_satisfies_gate(
@@ -407,6 +427,7 @@ def test_a7_dispatched_spec_also_satisfies_gate(
     from mship.core.spec import Spec
     from mship.core.spec_store import SPECS_DIRNAME, SpecStore
 
+    from mship.core.workitem_store import WorkItemStore
     now = datetime.now(timezone.utc)
     spec = Spec(
         id="add-labels-dispatched",
@@ -417,6 +438,9 @@ def test_a7_dispatched_spec_also_satisfies_gate(
         task_slug="add-labels",
     )
     SpecStore(tmp_path / SPECS_DIRNAME).save(spec)
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi_id = state_with_task.load().tasks["add-labels"].work_item_id
+    items.link_spec(wi_id, "add-labels-dispatched", now=now)
 
     pm = _make_phase_manager_with_approved_spec_gate(state_with_task, tmp_path)
     result = pm.transition("add-labels", "dev")

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -787,3 +787,34 @@ def test_transition_with_no_hooks_configured_is_unaffected(state_with_task, tmp_
     pm = _make_phase_manager_with_hooks(state_with_task, tmp_path, hooks=[])
     result = pm.transition("add-labels", "dev")
     assert result.new_phase == "dev"
+
+
+# ---------------------------------------------------------------------------
+# ac8 (PR-b): entering review WARNs listing bound-spec acceptance criteria that
+# have no evidence — a soft signal that never blocks the transition.
+# ---------------------------------------------------------------------------
+
+def test_transition_to_review_warns_on_acs_without_evidence(state_with_task, tmp_path):
+    """ac8: entering review WARNs listing bound-spec ACs with no evidence, and
+    never blocks the transition."""
+    from mship.core.spec import AcceptanceCriterion, Spec
+    from mship.core.spec_store import SpecStore
+    now = datetime(2026, 4, 10, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(
+        id="add-labels-spec", title="S", status="approved",
+        created_at=now, updated_at=now, task_slug="add-labels",
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
+    ))
+    pm = _make_phase_manager(state_with_task, tmp_path)
+    pm.transition("add-labels", "dev")
+    result = pm.transition("add-labels", "review")
+    assert result.new_phase == "review"                                   # never blocks
+    assert any("evidence" in w.lower() and "ac1" in w for w in result.warnings)
+
+
+def test_transition_to_review_no_ac_warning_without_bound_spec(state_with_task, tmp_path):
+    pm = _make_phase_manager(state_with_task, tmp_path)
+    pm.transition("add-labels", "dev")
+    result = pm.transition("add-labels", "review")
+    assert not any("evidence" in w.lower() and "acceptance" in w.lower()
+                   for w in result.warnings)

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -799,12 +799,18 @@ def test_transition_to_review_warns_on_acs_without_evidence(state_with_task, tmp
     never blocks the transition."""
     from mship.core.spec import AcceptanceCriterion, Spec
     from mship.core.spec_store import SpecStore
+    from mship.core.workitem_store import WorkItemStore
     now = datetime(2026, 4, 10, tzinfo=timezone.utc)
     SpecStore(tmp_path / "specs").save(Spec(
         id="add-labels-spec", title="S", status="approved",
-        created_at=now, updated_at=now, task_slug="add-labels",
+        created_at=now, updated_at=now,
         acceptance_criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
     ))
+    # Bind via the explicit spec_id link (authoritative for any WorkItem kind); the
+    # slug fallback is feature-gated, and this fixture's WorkItem is a bug.
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi_id = state_with_task.load().tasks["add-labels"].work_item_id
+    items.link_spec(wi_id, "add-labels-spec", now=now)
     pm = _make_phase_manager(state_with_task, tmp_path)
     pm.transition("add-labels", "dev")
     result = pm.transition("add-labels", "review")

--- a/tests/core/test_pr.py
+++ b/tests/core/test_pr.py
@@ -130,6 +130,33 @@ def test_build_coordination_block_single_repo():
     assert block == ""
 
 
+def _spec_with_acs(acs):
+    from datetime import datetime, timezone
+    from mship.core.spec import Spec
+    now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    return Spec(id="dq", title="DQ", status="approved", created_at=now, updated_at=now,
+                acceptance_criteria=acs)
+
+
+def test_build_acceptance_block_renders_verified_and_unverified():
+    from mship.core.pr import build_acceptance_block
+    from mship.core.spec import AcceptanceCriterion, AcceptanceEvidence
+    spec = _spec_with_acs([
+        AcceptanceCriterion(id="ac1", text="does X", verdict="approved",
+                            evidence=[AcceptanceEvidence(kind="test", ref="test-runs/5")]),
+        AcceptanceCriterion(id="ac2", text="does Y"),   # no evidence
+    ])
+    block = build_acceptance_block(spec)
+    assert "## Acceptance criteria" in block
+    assert "ac1" in block and "test:test-runs/5" in block   # verified with its ref
+    assert "ac2" in block and "no evidence" in block.lower()  # unverified
+
+
+def test_build_acceptance_block_empty_when_no_criteria():
+    from mship.core.pr import build_acceptance_block
+    assert build_acceptance_block(_spec_with_acs([])) == ""
+
+
 def test_create_pr_with_base(mock_shell: MagicMock):
     mock_shell.run.return_value = ShellResult(
         returncode=0,

--- a/tests/test_finish_gate.py
+++ b/tests/test_finish_gate.py
@@ -370,7 +370,7 @@ def test_finish_require_evidence_blocks_when_spec_resolution_errors(finish_gate_
 
     result = runner.invoke(app, ["finish", "--task", "ev-err-block", "--require-evidence"])
     assert result.exit_code == 1, result.output
-    assert "could not read the bound spec" in result.output.lower()
+    assert "could not resolve the bound spec" in result.output.lower()
     state = StateManager(workspace / ".mothership").load()
     assert state.tasks["ev-err-block"].pr_urls == {}          # blocked before any PR
 

--- a/tests/test_finish_gate.py
+++ b/tests/test_finish_gate.py
@@ -284,3 +284,68 @@ def test_finish_hotfix_survives_corrupt_workitem_store(finish_gate_workspace):
         and entry["reason"] == "hotfix"
         for entry in lines
     ), lines
+
+
+# ---------------------------------------------------------------------------
+# Acceptance-criteria evidence gate (ac-evidence-loop): WARN by default when
+# any AC on the task's bound spec lacks evidence; BLOCK only under
+# --require-evidence. No bound spec ⇒ no-op.
+# ---------------------------------------------------------------------------
+
+def _seed_feature_with_ac(workspace: Path, *, ac_evidence=None):
+    """Feature WI + approved spec whose ac1 has (or lacks) evidence, linked so
+    resolve_bound_spec finds it via wi.spec_id."""
+    from mship.core.spec import AcceptanceCriterion, Spec
+    items = WorkItemStore(workspace / ".mothership" / "workitems")
+    specs = SpecStore(workspace / "specs")
+    now = datetime.now(timezone.utc)
+    specs.save(Spec(id="ev-spec", title="S", status="approved", created_at=now, updated_at=now,
+                    acceptance_criteria=[AcceptanceCriterion(
+                        id="ac1", text="x", verdict="approved", evidence=ac_evidence or [])]))
+    wi = items.create(title="add thing", kind="feature", workspace="ws", now=now)
+    items.link_spec(wi.id, "ev-spec", now=now)
+    return wi
+
+
+def test_finish_warns_by_default_on_acs_without_evidence(finish_gate_workspace):
+    workspace, _ = finish_gate_workspace
+    wi = _seed_feature_with_ac(workspace)   # ac1 has NO evidence
+    runner.invoke(app, ["spawn", "--work-item", wi.id, "ev warn", "--repos", "shared"])
+    _write_plan(workspace, "ev-warn")       # plan-gate satisfied
+    result = runner.invoke(app, ["finish", "--task", "ev-warn"])
+    assert result.exit_code == 0, result.output          # WARN only → still finishes
+    # Assert on output UNIQUE to the AC-evidence gate (the pre-existing test-evidence
+    # gate also prints "evidence", so a bare "evidence" check would pass even if the
+    # AC gate never fired). The bound spec id + the --require-evidence hint are only
+    # emitted by the AC gate.
+    out = result.output.lower()
+    assert "ev-spec" in out and "ac1" in out             # names the bound spec + the unverified AC
+    assert "--require-evidence" in result.output         # the AC gate's escalation hint
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["ev-warn"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
+
+
+def test_finish_blocks_under_require_evidence(finish_gate_workspace):
+    workspace, _ = finish_gate_workspace
+    wi = _seed_feature_with_ac(workspace)   # ac1 has NO evidence
+    runner.invoke(app, ["spawn", "--work-item", wi.id, "ev block", "--repos", "shared"])
+    _write_plan(workspace, "ev-block")
+    result = runner.invoke(app, ["finish", "--task", "ev-block", "--require-evidence"])
+    assert result.exit_code == 1, result.output
+    # Blocked specifically by the AC-evidence gate (names the bound spec + AC), not by
+    # some unrelated failure — exit 1 alone could come from anywhere.
+    assert "ev-spec" in result.output.lower() and "ac1" in result.output.lower()
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["ev-block"].pr_urls == {}          # blocked before any PR
+
+
+def test_finish_require_evidence_noop_without_bound_spec(finish_gate_workspace):
+    """No bound spec (a bug WI) ⇒ --require-evidence is a no-op, not a block."""
+    workspace, _ = finish_gate_workspace
+    items = WorkItemStore(workspace / ".mothership" / "workitems")
+    wi = items.create(title="fix it", kind="bug", workspace="ws", now=datetime.now(timezone.utc))
+    runner.invoke(app, ["spawn", "--work-item", wi.id, "ev noop", "--repos", "shared"])
+    result = runner.invoke(app, ["finish", "--task", "ev-noop", "--require-evidence"])
+    assert result.exit_code == 0, result.output
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["ev-noop"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"

--- a/tests/test_finish_gate.py
+++ b/tests/test_finish_gate.py
@@ -351,6 +351,52 @@ def test_finish_require_evidence_noop_without_bound_spec(finish_gate_workspace):
     assert state.tasks["ev-noop"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
 
 
+def test_finish_require_evidence_blocks_when_spec_resolution_errors(finish_gate_workspace, monkeypatch):
+    """Greptile #341 fail-safe: if resolving the bound spec RAISES (corrupt/unreadable
+    store), --require-evidence must BLOCK — never silently skip the required check —
+    even though the real ev-spec HAS evidence and would otherwise pass. (Monkeypatch
+    resolve_bound_spec so only the AC-gate path errors, not the WorkItem spec-gate.)"""
+    from mship.core.spec import AcceptanceEvidence
+    workspace, _ = finish_gate_workspace
+    wi = _seed_feature_with_ac(
+        workspace, ac_evidence=[AcceptanceEvidence(kind="test", ref="test-runs/1")],
+    )
+    runner.invoke(app, ["spawn", "--work-item", wi.id, "ev err block", "--repos", "shared"])
+    _write_plan(workspace, "ev-err-block")
+
+    def _boom(*a, **k):
+        raise RuntimeError("spec store unreadable")
+    monkeypatch.setattr("mship.core.workitem_gate.resolve_bound_spec", _boom)
+
+    result = runner.invoke(app, ["finish", "--task", "ev-err-block", "--require-evidence"])
+    assert result.exit_code == 1, result.output
+    assert "could not read the bound spec" in result.output.lower()
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["ev-err-block"].pr_urls == {}          # blocked before any PR
+
+
+def test_finish_default_warns_and_proceeds_when_spec_resolution_errors(finish_gate_workspace, monkeypatch):
+    """Without --require-evidence, a spec-resolution error is a WARNING, not a crash
+    or a block — finish still opens the PR (the AC check is advisory by default)."""
+    from mship.core.spec import AcceptanceEvidence
+    workspace, _ = finish_gate_workspace
+    wi = _seed_feature_with_ac(
+        workspace, ac_evidence=[AcceptanceEvidence(kind="test", ref="test-runs/1")],
+    )
+    runner.invoke(app, ["spawn", "--work-item", wi.id, "ev err warn", "--repos", "shared"])
+    _write_plan(workspace, "ev-err-warn")
+
+    def _boom(*a, **k):
+        raise RuntimeError("spec store unreadable")
+    monkeypatch.setattr("mship.core.workitem_gate.resolve_bound_spec", _boom)
+
+    result = runner.invoke(app, ["finish", "--task", "ev-err-warn"])
+    assert result.exit_code == 0, result.output
+    assert "could not check acceptance-criteria evidence" in result.output.lower()
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["ev-err-warn"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
+
+
 def test_finish_appends_acceptance_block_to_pr_body(finish_gate_workspace):
     from mship.core.spec import AcceptanceEvidence
     workspace, mock_shell = finish_gate_workspace

--- a/tests/test_finish_gate.py
+++ b/tests/test_finish_gate.py
@@ -351,50 +351,26 @@ def test_finish_require_evidence_noop_without_bound_spec(finish_gate_workspace):
     assert state.tasks["ev-noop"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
 
 
-def test_finish_require_evidence_blocks_when_spec_resolution_errors(finish_gate_workspace, monkeypatch):
-    """Greptile #341 fail-safe: if resolving the bound spec RAISES (corrupt/unreadable
-    store), --require-evidence must BLOCK — never silently skip the required check —
-    even though the real ev-spec HAS evidence and would otherwise pass. (Monkeypatch
-    resolve_bound_spec so only the AC-gate path errors, not the WorkItem spec-gate.)"""
-    from mship.core.spec import AcceptanceEvidence
+def test_finish_blocks_feature_with_unresolvable_linked_spec(finish_gate_workspace):
+    """Greptile #341: a feature whose linked spec was deleted can't be resolved, so
+    finish blocks at the (now unified) WorkItem gate — it no longer sneaks through via
+    a slug collision, and the resolution failure isn't silently skipped."""
     workspace, _ = finish_gate_workspace
-    wi = _seed_feature_with_ac(
-        workspace, ac_evidence=[AcceptanceEvidence(kind="test", ref="test-runs/1")],
-    )
-    runner.invoke(app, ["spawn", "--work-item", wi.id, "ev err block", "--repos", "shared"])
-    _write_plan(workspace, "ev-err-block")
-
-    def _boom(*a, **k):
-        raise RuntimeError("spec store unreadable")
-    monkeypatch.setattr("mship.core.workitem_gate.resolve_bound_spec", _boom)
-
-    result = runner.invoke(app, ["finish", "--task", "ev-err-block", "--require-evidence"])
+    items = WorkItemStore(workspace / ".mothership" / "workitems")
+    specs = SpecStore(workspace / "specs")
+    now = datetime.now(timezone.utc)
+    # An unrelated approved spec shares the slug (the old fallthrough would have used
+    # it); the terminal explicit-link rule means it must NOT be consulted.
+    specs.save(Spec(id="unrelated", title="U", status="approved",
+                    created_at=now, updated_at=now, task_slug="ev-gone"))
+    wi = items.create(title="add thing", kind="feature", workspace="ws", now=now)
+    items.link_spec(wi.id, "deleted-spec", now=now)   # linked spec absent
+    runner.invoke(app, ["spawn", "--work-item", wi.id, "ev gone", "--repos", "shared"])
+    _write_plan(workspace, "ev-gone")
+    result = runner.invoke(app, ["finish", "--task", "ev-gone"])
     assert result.exit_code == 1, result.output
-    assert "could not resolve the bound spec" in result.output.lower()
     state = StateManager(workspace / ".mothership").load()
-    assert state.tasks["ev-err-block"].pr_urls == {}          # blocked before any PR
-
-
-def test_finish_default_warns_and_proceeds_when_spec_resolution_errors(finish_gate_workspace, monkeypatch):
-    """Without --require-evidence, a spec-resolution error is a WARNING, not a crash
-    or a block — finish still opens the PR (the AC check is advisory by default)."""
-    from mship.core.spec import AcceptanceEvidence
-    workspace, _ = finish_gate_workspace
-    wi = _seed_feature_with_ac(
-        workspace, ac_evidence=[AcceptanceEvidence(kind="test", ref="test-runs/1")],
-    )
-    runner.invoke(app, ["spawn", "--work-item", wi.id, "ev err warn", "--repos", "shared"])
-    _write_plan(workspace, "ev-err-warn")
-
-    def _boom(*a, **k):
-        raise RuntimeError("spec store unreadable")
-    monkeypatch.setattr("mship.core.workitem_gate.resolve_bound_spec", _boom)
-
-    result = runner.invoke(app, ["finish", "--task", "ev-err-warn"])
-    assert result.exit_code == 0, result.output
-    assert "could not check acceptance-criteria evidence" in result.output.lower()
-    state = StateManager(workspace / ".mothership").load()
-    assert state.tasks["ev-err-warn"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
+    assert state.tasks["ev-gone"].pr_urls == {}       # blocked before any PR
 
 
 def test_finish_appends_acceptance_block_to_pr_body(finish_gate_workspace):

--- a/tests/test_finish_gate.py
+++ b/tests/test_finish_gate.py
@@ -349,3 +349,20 @@ def test_finish_require_evidence_noop_without_bound_spec(finish_gate_workspace):
     assert result.exit_code == 0, result.output
     state = StateManager(workspace / ".mothership").load()
     assert state.tasks["ev-noop"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
+
+
+def test_finish_appends_acceptance_block_to_pr_body(finish_gate_workspace):
+    from mship.core.spec import AcceptanceEvidence
+    workspace, mock_shell = finish_gate_workspace
+    wi = _seed_feature_with_ac(
+        workspace, ac_evidence=[AcceptanceEvidence(kind="test", ref="test-runs/1")],
+    )
+    runner.invoke(app, ["spawn", "--work-item", wi.id, "ev body", "--repos", "shared"])
+    _write_plan(workspace, "ev-body")
+    result = runner.invoke(app, ["finish", "--task", "ev-body"])
+    assert result.exit_code == 0, result.output
+    create_cmds = [c.args[0] for c in mock_shell.run.call_args_list if "gh pr create" in c.args[0]]
+    assert create_cmds, "expected a gh pr create call"
+    assert "Acceptance criteria" in create_cmds[0]      # block injected into the PR body
+    assert "test:test-runs/1" in create_cmds[0]         # the evidence ref renders end-to-end
+    assert "ac1" in create_cmds[0]                        # the criterion id is listed

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -237,12 +237,21 @@ def test_resolve_bound_spec_via_workitem_spec_id(tmp_path):
     assert resolve_bound_spec(task, tmp_path).id == "s1"
 
 
+def _feature_task(tmp_path, now, slug="t"):
+    """A task linked to a feature WorkItem with NO spec_id (so the slug fallback,
+    which is gated on feature-eligibility, applies)."""
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="F", kind="feature", workspace="ws", now=now)
+    return Task(slug=slug, description="d", phase="dev", created_at=now,
+                affected_repos=["shared"], branch=f"feat/{slug}", work_item_id=wi.id)
+
+
 def test_resolve_bound_spec_via_task_slug_fallback(tmp_path):
+    # A feature task with no explicit spec_id binds an approved spec by task_slug.
     now = datetime(2026, 7, 12, tzinfo=timezone.utc)
     SpecStore(tmp_path / "specs").save(Spec(id="s2", title="S", status="approved",
                                             created_at=now, updated_at=now, task_slug="t"))
-    task = Task(slug="t", description="d", phase="dev", created_at=now,
-                affected_repos=["shared"], branch="feat/t")
+    task = _feature_task(tmp_path, now)
     assert resolve_bound_spec(task, tmp_path).id == "s2"
 
 
@@ -253,24 +262,39 @@ def test_resolve_bound_spec_none_when_unbound(tmp_path):
     assert resolve_bound_spec(task, tmp_path) is None
 
 
+def test_resolve_bound_spec_bug_task_ignores_slug_collision(tmp_path):
+    # Greptile #341 "Slug Collision Binds Unrelated Specs": a bug/chore/hotfix task
+    # whose slug coincidentally matches an approved FEATURE spec must NOT bind it —
+    # the slug fallback is gated on feature-eligibility. Both a bug WorkItem and a
+    # task with no WorkItem must resolve to None here.
+    now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(id="feat-spec", title="S", status="approved",
+                                            created_at=now, updated_at=now, task_slug="t"))
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    bug = items.create(title="B", kind="bug", workspace="ws", now=now)
+    bug_task = Task(slug="t", description="d", phase="dev", created_at=now,
+                    affected_repos=["shared"], branch="feat/t", work_item_id=bug.id)
+    assert resolve_bound_spec(bug_task, tmp_path) is None
+    hotfix_task = Task(slug="t", description="d", phase="dev", created_at=now,
+                       affected_repos=["shared"], branch="feat/t")   # no WorkItem
+    assert resolve_bound_spec(hotfix_task, tmp_path) is None
+
+
 def test_resolve_bound_spec_fallback_skips_non_approved_spec(tmp_path):
-    # Greptile #341: the task_slug FALLBACK must not bind to a draft/archived/
-    # superseded spec — only an approved one. A drafting spec matching the slug is
-    # ignored (returns None), so finish/--require-evidence can't block on a stale
+    # The feature slug fallback binds only an APPROVED spec — a drafting spec matching
+    # the slug is ignored (None), so finish/--require-evidence can't block on a stale
     # checklist and the PR body can't render the wrong one.
     now = datetime(2026, 7, 12, tzinfo=timezone.utc)
     SpecStore(tmp_path / "specs").save(Spec(id="draft-s", title="S", status="drafting",
                                             created_at=now, updated_at=now, task_slug="t"))
-    task = Task(slug="t", description="d", phase="dev", created_at=now,
-                affected_repos=["shared"], branch="feat/t")
+    task = _feature_task(tmp_path, now)
     assert resolve_bound_spec(task, tmp_path) is None
 
 
 def test_resolve_bound_spec_raises_when_multiple_approved_matches(tmp_path):
-    # Greptile #341: several APPROVED specs sharing a slug is ambiguous — the resolver
-    # RAISES (not None) so finish --require-evidence fails safe rather than opening a
-    # PR with the required check silently skipped. (None is reserved for genuinely
-    # unbound tasks.)
+    # Several APPROVED specs sharing a slug is ambiguous — the resolver RAISES (not
+    # None) so finish --require-evidence fails safe rather than opening a PR with the
+    # required check silently skipped. (None is reserved for genuinely unbound tasks.)
     import pytest
     from mship.core.workitem_gate import BoundSpecUnresolved
     store = SpecStore(tmp_path / "specs")
@@ -280,8 +304,7 @@ def test_resolve_bound_spec_raises_when_multiple_approved_matches(tmp_path):
                     created_at=older, updated_at=older, task_slug="t"))
     store.save(Spec(id="two-s", title="two", status="approved",
                     created_at=older, updated_at=newer, task_slug="t"))
-    task = Task(slug="t", description="d", phase="dev", created_at=newer,
-                affected_repos=["shared"], branch="feat/t")
+    task = _feature_task(tmp_path, newer)
     with pytest.raises(BoundSpecUnresolved):
         resolve_bound_spec(task, tmp_path)
 
@@ -327,8 +350,27 @@ def test_resolve_bound_spec_propagates_corrupt_store_error(tmp_path):
     # It propagates so callers can fail safe.
     (tmp_path / "specs").mkdir(parents=True)
     (tmp_path / "specs" / "2026-07-12-broken.md").write_text("not valid frontmatter, no ---\n")
-    task = Task(slug="t", description="d", phase="dev", created_at=_now(),
-                affected_repos=["shared"], branch="feat/t")
+    # A feature task with no spec_id reaches the slug fallback → SpecStore.list()
+    # parses the corrupt file and raises; the resolver must let it propagate.
+    task = _feature_task(tmp_path, _now())
     import pytest
     with pytest.raises(Exception):
         resolve_bound_spec(task, tmp_path)
+
+
+def test_feature_gate_blocks_when_linked_spec_deleted_despite_slug_match(tmp_path):
+    # Greptile #341 "Spec Gates Diverge": the feature spec-gate shares
+    # resolve_bound_spec's terminal-explicit-link rule, so a feature whose linked
+    # spec was deleted does NOT pass the gate just because another approved spec
+    # happens to share the task slug (which the old slug fallthrough allowed).
+    now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="F", kind="feature", workspace="ws", now=now)
+    items.link_spec(wi.id, "gone-spec", now=now)          # linked spec absent
+    SpecStore(tmp_path / "specs").save(Spec(id="other-s", title="other", status="approved",
+                                            created_at=now, updated_at=now, task_slug="t"))
+    task = Task(slug="t", description="d", phase="dev", created_at=now,
+                affected_repos=["shared"], branch="feat/t", work_item_id=wi.id)
+    result = check_task_gate(task, tmp_path)
+    assert result.ok is False
+    assert "approved spec" in (result.reason or "")

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -266,35 +266,37 @@ def test_resolve_bound_spec_fallback_skips_non_approved_spec(tmp_path):
     assert resolve_bound_spec(task, tmp_path) is None
 
 
-def test_resolve_bound_spec_fallback_picks_most_recently_updated_approved(tmp_path):
-    # Greptile #341: with multiple APPROVED specs sharing a slug, bind the most
-    # recently updated one (a superseding spec wins over an older checklist), not
-    # list()'s filename order.
+def test_resolve_bound_spec_fallback_none_when_multiple_approved_matches(tmp_path):
+    # Greptile #341: when several APPROVED specs share a slug the mapping is
+    # ambiguous — the resolver refuses to guess (returns None) rather than pick a
+    # possibly-wrong checklist. No pick means no "wrong spec" is ever bound.
     store = SpecStore(tmp_path / "specs")
     older = datetime(2026, 7, 10, tzinfo=timezone.utc)
     newer = datetime(2026, 7, 12, tzinfo=timezone.utc)
-    store.save(Spec(id="old-s", title="old", status="approved",
+    store.save(Spec(id="one-s", title="one", status="approved",
                     created_at=older, updated_at=older, task_slug="t"))
-    store.save(Spec(id="new-s", title="new", status="approved",
+    store.save(Spec(id="two-s", title="two", status="approved",
                     created_at=older, updated_at=newer, task_slug="t"))
     task = Task(slug="t", description="d", phase="dev", created_at=newer,
                 affected_repos=["shared"], branch="feat/t")
-    assert resolve_bound_spec(task, tmp_path).id == "new-s"
+    assert resolve_bound_spec(task, tmp_path) is None
 
 
-def test_resolve_bound_spec_fallback_tiebreak_is_deterministic_on_equal_updated_at(tmp_path):
-    # Greptile #341: an exact updated_at tie must resolve deterministically (by id),
-    # never by filesystem/list() order.
-    store = SpecStore(tmp_path / "specs")
+def test_resolve_bound_spec_explicit_missing_spec_does_not_fall_back(tmp_path):
+    # Greptile #341 "Explicit Link Falls Back": if the WorkItem's spec_id points at a
+    # spec that no longer exists (deleted/renamed), the resolver returns None — it
+    # must NOT silently fall back to a task_slug guess, even when an approved
+    # slug-matching spec exists. The explicit link is authoritative and terminal.
     now = datetime(2026, 7, 12, tzinfo=timezone.utc)
-    store.save(Spec(id="aaa-s", title="a", status="approved",
-                    created_at=now, updated_at=now, task_slug="t"))
-    store.save(Spec(id="zzz-s", title="z", status="approved",
-                    created_at=now, updated_at=now, task_slug="t"))
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="F", kind="feature", workspace="ws", now=now)
+    items.link_spec(wi.id, "gone-spec", now=now)          # spec_id set...
+    # ...but only an unrelated approved spec sharing the slug is actually on disk.
+    SpecStore(tmp_path / "specs").save(Spec(id="other-s", title="other", status="approved",
+                                            created_at=now, updated_at=now, task_slug="t"))
     task = Task(slug="t", description="d", phase="dev", created_at=now,
-                affected_repos=["shared"], branch="feat/t")
-    # max((updated_at, id)) → the lexicographically-greater id, deterministically.
-    assert resolve_bound_spec(task, tmp_path).id == "zzz-s"
+                affected_repos=["shared"], branch="feat/t", work_item_id=wi.id)
+    assert resolve_bound_spec(task, tmp_path) is None
 
 
 def test_resolve_bound_spec_explicit_spec_id_bypasses_status_filter(tmp_path):

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -266,10 +266,13 @@ def test_resolve_bound_spec_fallback_skips_non_approved_spec(tmp_path):
     assert resolve_bound_spec(task, tmp_path) is None
 
 
-def test_resolve_bound_spec_fallback_none_when_multiple_approved_matches(tmp_path):
-    # Greptile #341: when several APPROVED specs share a slug the mapping is
-    # ambiguous — the resolver refuses to guess (returns None) rather than pick a
-    # possibly-wrong checklist. No pick means no "wrong spec" is ever bound.
+def test_resolve_bound_spec_raises_when_multiple_approved_matches(tmp_path):
+    # Greptile #341: several APPROVED specs sharing a slug is ambiguous — the resolver
+    # RAISES (not None) so finish --require-evidence fails safe rather than opening a
+    # PR with the required check silently skipped. (None is reserved for genuinely
+    # unbound tasks.)
+    import pytest
+    from mship.core.workitem_gate import BoundSpecUnresolved
     store = SpecStore(tmp_path / "specs")
     older = datetime(2026, 7, 10, tzinfo=timezone.utc)
     newer = datetime(2026, 7, 12, tzinfo=timezone.utc)
@@ -279,24 +282,28 @@ def test_resolve_bound_spec_fallback_none_when_multiple_approved_matches(tmp_pat
                     created_at=older, updated_at=newer, task_slug="t"))
     task = Task(slug="t", description="d", phase="dev", created_at=newer,
                 affected_repos=["shared"], branch="feat/t")
-    assert resolve_bound_spec(task, tmp_path) is None
+    with pytest.raises(BoundSpecUnresolved):
+        resolve_bound_spec(task, tmp_path)
 
 
-def test_resolve_bound_spec_explicit_missing_spec_does_not_fall_back(tmp_path):
-    # Greptile #341 "Explicit Link Falls Back": if the WorkItem's spec_id points at a
-    # spec that no longer exists (deleted/renamed), the resolver returns None — it
-    # must NOT silently fall back to a task_slug guess, even when an approved
-    # slug-matching spec exists. The explicit link is authoritative and terminal.
+def test_resolve_bound_spec_raises_when_explicit_link_missing(tmp_path):
+    # Greptile #341 "Explicit Link Falls Back": a WorkItem spec_id pointing at a
+    # deleted/renamed spec must RAISE (a spec was intended but is gone) — NOT fall
+    # back to a slug guess, and NOT silently return None (which would let
+    # --require-evidence skip the check). An unrelated approved slug-match exists to
+    # prove there's no fallthrough.
+    import pytest
+    from mship.core.workitem_gate import BoundSpecUnresolved
     now = datetime(2026, 7, 12, tzinfo=timezone.utc)
     items = WorkItemStore(tmp_path / ".mothership" / "workitems")
     wi = items.create(title="F", kind="feature", workspace="ws", now=now)
-    items.link_spec(wi.id, "gone-spec", now=now)          # spec_id set...
-    # ...but only an unrelated approved spec sharing the slug is actually on disk.
+    items.link_spec(wi.id, "gone-spec", now=now)          # spec_id set, spec absent
     SpecStore(tmp_path / "specs").save(Spec(id="other-s", title="other", status="approved",
                                             created_at=now, updated_at=now, task_slug="t"))
     task = Task(slug="t", description="d", phase="dev", created_at=now,
                 affected_repos=["shared"], branch="feat/t", work_item_id=wi.id)
-    assert resolve_bound_spec(task, tmp_path) is None
+    with pytest.raises(BoundSpecUnresolved):
+        resolve_bound_spec(task, tmp_path)
 
 
 def test_resolve_bound_spec_explicit_spec_id_bypasses_status_filter(tmp_path):

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -251,3 +251,44 @@ def test_resolve_bound_spec_none_when_unbound(tmp_path):
     task = Task(slug="t", description="d", phase="dev", created_at=now,
                 affected_repos=["shared"], branch="feat/t")
     assert resolve_bound_spec(task, tmp_path) is None
+
+
+def test_resolve_bound_spec_fallback_skips_non_approved_spec(tmp_path):
+    # Greptile #341: the task_slug FALLBACK must not bind to a draft/archived/
+    # superseded spec — only an approved one. A drafting spec matching the slug is
+    # ignored (returns None), so finish/--require-evidence can't block on a stale
+    # checklist and the PR body can't render the wrong one.
+    now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(id="draft-s", title="S", status="drafting",
+                                            created_at=now, updated_at=now, task_slug="t"))
+    task = Task(slug="t", description="d", phase="dev", created_at=now,
+                affected_repos=["shared"], branch="feat/t")
+    assert resolve_bound_spec(task, tmp_path) is None
+
+
+def test_resolve_bound_spec_explicit_spec_id_bypasses_status_filter(tmp_path):
+    # The EXPLICIT WorkItem.spec_id link is authoritative and status-agnostic — a
+    # linked spec resolves even while still in review (evidence warnings should
+    # surface pre-approval for the linked spec).
+    now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="F", kind="feature", workspace="ws", now=now)
+    SpecStore(tmp_path / "specs").save(Spec(id="nr", title="S", status="needs_review",
+                                            created_at=now, updated_at=now))
+    items.link_spec(wi.id, "nr", now=now)
+    task = Task(slug="t", description="d", phase="dev", created_at=now,
+                affected_repos=["shared"], branch="feat/t", work_item_id=wi.id)
+    assert resolve_bound_spec(task, tmp_path).id == "nr"
+
+
+def test_resolve_bound_spec_propagates_corrupt_store_error(tmp_path):
+    # Greptile #341: a corrupt/unreadable spec store must NOT be silently turned into
+    # None (which would make finish --require-evidence skip the required check).
+    # It propagates so callers can fail safe.
+    (tmp_path / "specs").mkdir(parents=True)
+    (tmp_path / "specs" / "2026-07-12-broken.md").write_text("not valid frontmatter, no ---\n")
+    task = Task(slug="t", description="d", phase="dev", created_at=_now(),
+                affected_repos=["shared"], branch="feat/t")
+    import pytest
+    with pytest.raises(Exception):
+        resolve_bound_spec(task, tmp_path)

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -282,6 +282,21 @@ def test_resolve_bound_spec_fallback_picks_most_recently_updated_approved(tmp_pa
     assert resolve_bound_spec(task, tmp_path).id == "new-s"
 
 
+def test_resolve_bound_spec_fallback_tiebreak_is_deterministic_on_equal_updated_at(tmp_path):
+    # Greptile #341: an exact updated_at tie must resolve deterministically (by id),
+    # never by filesystem/list() order.
+    store = SpecStore(tmp_path / "specs")
+    now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    store.save(Spec(id="aaa-s", title="a", status="approved",
+                    created_at=now, updated_at=now, task_slug="t"))
+    store.save(Spec(id="zzz-s", title="z", status="approved",
+                    created_at=now, updated_at=now, task_slug="t"))
+    task = Task(slug="t", description="d", phase="dev", created_at=now,
+                affected_repos=["shared"], branch="feat/t")
+    # max((updated_at, id)) → the lexicographically-greater id, deterministically.
+    assert resolve_bound_spec(task, tmp_path).id == "zzz-s"
+
+
 def test_resolve_bound_spec_explicit_spec_id_bypasses_status_filter(tmp_path):
     # The EXPLICIT WorkItem.spec_id link is authoritative and status-agnostic — a
     # linked spec resolves even while still in review (evidence warnings should

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from mship.core.spec import Spec
 from mship.core.spec_store import SpecStore
 from mship.core.state import StateManager, Task, WorkspaceState
-from mship.core.workitem_gate import GateResult, check_task_gate, log_hotfix
+from mship.core.workitem_gate import GateResult, check_task_gate, log_hotfix, resolve_bound_spec
 from mship.core.workitem_store import WorkItemStore
 
 
@@ -216,3 +216,38 @@ def test_workitem_migrate_shares_the_same_approved_statuses_object():
     can't silently drift out of sync."""
     from mship.core import workitem_gate, workitem_migrate
     assert workitem_migrate.APPROVED_STATUSES is workitem_gate.APPROVED_STATUSES
+
+
+# ---------------------------------------------------------------------------
+# ac8 (PR-b): shared resolve_bound_spec(task, workspace_root) -> Spec | None.
+# Resolves the spec bound to a task via the WorkItem's spec_id first, then a
+# task_slug fallback — the same resolution the WorkItem gate +
+# PhaseManager._has_approved_spec use. Never raises (missing/corrupt store -> None).
+# ---------------------------------------------------------------------------
+
+def test_resolve_bound_spec_via_workitem_spec_id(tmp_path):
+    now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="F", kind="feature", workspace="ws", now=now)
+    SpecStore(tmp_path / "specs").save(Spec(id="s1", title="S", status="approved",
+                                            created_at=now, updated_at=now))
+    items.link_spec(wi.id, "s1", now=now)
+    task = Task(slug="t", description="d", phase="dev", created_at=now,
+                affected_repos=["shared"], branch="feat/t", work_item_id=wi.id)
+    assert resolve_bound_spec(task, tmp_path).id == "s1"
+
+
+def test_resolve_bound_spec_via_task_slug_fallback(tmp_path):
+    now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(id="s2", title="S", status="approved",
+                                            created_at=now, updated_at=now, task_slug="t"))
+    task = Task(slug="t", description="d", phase="dev", created_at=now,
+                affected_repos=["shared"], branch="feat/t")
+    assert resolve_bound_spec(task, tmp_path).id == "s2"
+
+
+def test_resolve_bound_spec_none_when_unbound(tmp_path):
+    now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    task = Task(slug="t", description="d", phase="dev", created_at=now,
+                affected_repos=["shared"], branch="feat/t")
+    assert resolve_bound_spec(task, tmp_path) is None

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -266,6 +266,22 @@ def test_resolve_bound_spec_fallback_skips_non_approved_spec(tmp_path):
     assert resolve_bound_spec(task, tmp_path) is None
 
 
+def test_resolve_bound_spec_fallback_picks_most_recently_updated_approved(tmp_path):
+    # Greptile #341: with multiple APPROVED specs sharing a slug, bind the most
+    # recently updated one (a superseding spec wins over an older checklist), not
+    # list()'s filename order.
+    store = SpecStore(tmp_path / "specs")
+    older = datetime(2026, 7, 10, tzinfo=timezone.utc)
+    newer = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    store.save(Spec(id="old-s", title="old", status="approved",
+                    created_at=older, updated_at=older, task_slug="t"))
+    store.save(Spec(id="new-s", title="new", status="approved",
+                    created_at=older, updated_at=newer, task_slug="t"))
+    task = Task(slug="t", description="d", phase="dev", created_at=newer,
+                affected_repos=["shared"], branch="feat/t")
+    assert resolve_bound_spec(task, tmp_path).id == "new-s"
+
+
 def test_resolve_bound_spec_explicit_spec_id_bypasses_status_filter(tmp_path):
     # The EXPLICIT WorkItem.spec_id link is authoritative and status-agnostic — a
     # linked spec resolves even while still in review (evidence warnings should


### PR DESCRIPTION
AC evidence loop PR-b: enforcement (resolve_bound_spec + phase/finish AC-evidence warnings + --require-evidence + PR-body Acceptance criteria section) (plan tasks 7-9)