### PR TITLE
Idea capture: text to agent-drafted spec (Ground Control)

### DIFF
--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -82,6 +82,11 @@ class NewMessageBody(BaseModel):
     text: str
 
 
+class CaptureBody(BaseModel):
+    idea: str
+    title: str | None = None
+
+
 class SeenBody(BaseModel):
     seen_at: str | None = None
 
@@ -612,6 +617,20 @@ def create_app(
         spec.updated_at = datetime.now(timezone.utc)
         store.save(spec)
         return spec.model_dump(mode="json")
+
+    @app.post("/capture")
+    def post_capture(body: CaptureBody):
+        """Idea capture → agent-led brainstorm. Seeds a thread with the idea and
+        posts an agent `event` handoff so a host/cloud agent drains it (mship
+        _drain / inbox wait), brainstorms it in the thread, and produces a spec.
+        Serve does NO drafting — it stays LLM-free."""
+        idea = body.idea.strip()
+        if not idea:
+            raise HTTPException(status_code=400, detail="idea must not be empty")
+        now = datetime.now(timezone.utc)
+        subject = (body.title or idea.splitlines()[0])[:80]
+        thread = msgs.create_thread(subject=subject, text=idea, now=now)
+        return _thread_payload(msgs.get(thread.id))
 
     # --- dispatch endpoint (B4): close the dispatch-from-phone loop ---
 

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -85,6 +85,7 @@ class NewMessageBody(BaseModel):
 class CaptureBody(BaseModel):
     idea: str
     title: str | None = None
+    idempotency_key: str | None = None
 
 
 class SeenBody(BaseModel):
@@ -639,14 +640,25 @@ def create_app(
         """Idea capture → agent-led brainstorm. Seeds a thread with the idea and
         posts an agent `event` handoff so a host/cloud agent drains it (mship
         _drain / inbox wait), brainstorms it in the thread, and produces a spec.
-        Serve does NO drafting — it stays LLM-free."""
+        Serve does NO drafting — it stays LLM-free. An optional idempotency_key
+        makes a retried/duplicated capture return the existing thread instead of
+        spawning a second brainstorm (AC6)."""
         idea = body.idea.strip()
         if not idea:
             raise HTTPException(status_code=400, detail="idea must not be empty")
         now = datetime.now(timezone.utc)
+        key = (body.idempotency_key or "").strip()
+        if key:
+            marker = f"capture-key {key}"
+            for t in msgs.list():
+                if any(m.kind == "event" and marker in m.text for m in t.messages):
+                    return _thread_payload(t)
         subject = ((body.title or "").strip() or idea.splitlines()[0])[:80]
         thread = msgs.create_thread(subject=subject, text=idea, now=now)
-        msgs.append(thread.id, "agent", _capture_handoff(thread.id, idea), now, kind="event")
+        handoff = _capture_handoff(thread.id, idea)
+        if key:
+            handoff = f"capture-key {key}\n{handoff}"
+        msgs.append(thread.id, "agent", handoff, now, kind="event")
         return _thread_payload(msgs.get(thread.id))
 
     # --- dispatch endpoint (B4): close the dispatch-from-phone loop ---

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -651,13 +651,21 @@ def create_app(
         if key:
             marker = f"capture-key {key}"
             for t in msgs.list():
-                if any(m.kind == "event" and marker in m.text for m in t.messages):
+                if any(
+                    m.kind == "event"
+                    and any(line == marker for line in m.text.splitlines())
+                    for m in t.messages
+                ):
                     return _thread_payload(t)
         subject = ((body.title or "").strip() or idea.splitlines()[0])[:80]
         thread = msgs.create_thread(subject=subject, text=idea, now=now)
         handoff = _capture_handoff(thread.id, idea)
         if key:
-            handoff = f"capture-key {key}\n{handoff}"
+            # Append the dedup marker AFTER the handoff so the event body still
+            # STARTS WITH `capture-brainstorm <tid>` (the driver's first-line
+            # contract in the working-with-mothership skill); a leading key line
+            # would make a keyed capture invisible to that contract.
+            handoff = f"{handoff}\n\ncapture-key {key}"
         msgs.append(thread.id, "agent", handoff, now, kind="event")
         return _thread_payload(msgs.get(thread.id))
 

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -644,7 +644,7 @@ def create_app(
         if not idea:
             raise HTTPException(status_code=400, detail="idea must not be empty")
         now = datetime.now(timezone.utc)
-        subject = (body.title or idea.splitlines()[0])[:80]
+        subject = ((body.title or "").strip() or idea.splitlines()[0])[:80]
         thread = msgs.create_thread(subject=subject, text=idea, now=now)
         msgs.append(thread.id, "agent", _capture_handoff(thread.id, idea), now, kind="event")
         return _thread_payload(msgs.get(thread.id))

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -156,6 +156,22 @@ def _dispatch_marker(spec_id: str, task_slug: str) -> str:
     return f"dispatch {spec_id} -> {task_slug}"
 
 
+def _capture_handoff(thread_id: str, idea: str) -> str:
+    """Agent `event` body for a phone idea capture. Instructs the draining agent
+    to brainstorm the idea into a spec IN THIS THREAD and finish via from-thread.
+    The leading marker line makes the handoff greppable/idempotent per thread."""
+    return (
+        f"capture-brainstorm {thread_id}\n\n"
+        "An idea was captured from the phone to brainstorm into a spec. Run the "
+        "brainstorming flow in THIS thread: ask the operator clarifying questions "
+        f"one at a time with `mship reply {thread_id} \"...\"`, settle "
+        "purpose/scope/approach, then produce the spec with "
+        f"`mship spec from-thread {thread_id}` → fill the draft JSON → "
+        "`mship spec apply <id> --from-json <file>`, and reply here when it's drafted.\n\n"
+        f"Idea: {idea}"
+    )
+
+
 def _notify_dispatch(
     *, msgs: Any, workitems: Any, item_msg_lock: Any,
     spec: Any, task: Any, handoff: str, now: datetime,
@@ -630,6 +646,7 @@ def create_app(
         now = datetime.now(timezone.utc)
         subject = (body.title or idea.splitlines()[0])[:80]
         thread = msgs.create_thread(subject=subject, text=idea, now=now)
+        msgs.append(thread.id, "agent", _capture_handoff(thread.id, idea), now, kind="event")
         return _thread_payload(msgs.get(thread.id))
 
     # --- dispatch endpoint (B4): close the dispatch-from-phone loop ---

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -136,6 +136,16 @@ Typical flow: `item new` at intake → `link-spec` once a spec exists → `link-
 
 **Raising the attention flags — escalating to the operator.** When you need the human (a decision, an approval, an action), don't just block silently — escalate on the relevant phone thread: `mship ask <thread> "<question>" --option A --option B` posts a tappable decision card, and `mship reply --needs-you <thread> "<ask>"` posts a Home action card. Both are replies into an operator-opened thread; see the `receiving-messages` skill for the full messaging loop.
 
+### Capture-brainstorm handoffs
+
+When you drain an agent-`event` thread whose body starts with `capture-brainstorm <thread-id>`,
+an operator captured an idea from the phone for you to brainstorm into a spec. Run the
+brainstorming flow **in that thread**: ask clarifying questions one at a time with
+`mship reply <thread-id> "<question>"`, settle purpose/scope/approach, then produce the spec
+with `mship spec from-thread <thread-id>` → fill the emitted draft JSON → `mship spec apply <id> --from-json <file>`,
+and `mship reply <thread-id>` to note the spec is drafted. The event clears once you post any
+non-event message on the thread; serve does no drafting itself.
+
 ## Delegating to subagents: `mship context` and `mship dispatch`
 
 Two mship-native primitives for handing work to subagents. Use them instead of hand-rolling task context:

--- a/tests/core/test_serve_capture.py
+++ b/tests/core/test_serve_capture.py
@@ -37,3 +37,23 @@ def test_capture_rejects_empty_idea(tmp_path):
     client = TestClient(_app(tmp_path))
     r = client.post("/capture", json={"idea": "   "})
     assert r.status_code == 400
+
+
+def test_capture_posts_one_agent_event_brainstorm_handoff(tmp_path):
+    from mship.core.message_store import MessageStore
+    client = TestClient(_app(tmp_path))
+    tid = client.post("/capture", json={"idea": "a queue tab"}).json()["id"]
+
+    store = MessageStore(tmp_path / ".mothership" / "messages")
+    thread = store.get(tid)
+    # seed human message + exactly one trailing agent event
+    assert [m.role for m in thread.messages] == ["human", "agent"]
+    event = thread.messages[-1]
+    assert event.kind == "event"
+    assert "capture-brainstorm" in event.text          # stable marker
+    assert tid in event.text                            # names the thread to brainstorm
+    assert "a queue tab" in event.text                  # carries the idea
+    assert "mship spec from-thread" in event.text       # tells the driver how to finish
+    # this is what makes _drain / inbox wait surface it to a host agent
+    assert thread.awaiting_agent_event is True
+    assert thread.needs_you is False                    # an event must NOT nag the phone

--- a/tests/core/test_serve_capture.py
+++ b/tests/core/test_serve_capture.py
@@ -57,3 +57,17 @@ def test_capture_posts_one_agent_event_brainstorm_handoff(tmp_path):
     # this is what makes _drain / inbox wait surface it to a host agent
     assert thread.awaiting_agent_event is True
     assert thread.needs_you is False                    # an event must NOT nag the phone
+
+
+def test_capture_and_draft_path_import_no_llm_sdk():
+    """AC5: serve stays LLM-free. The modules the capture→draft path touches must
+    not import an LLM SDK — the drafting intelligence runs in the agent, not serve."""
+    import inspect
+    import mship.core.serve as serve_mod
+    import mship.core.spec_draft as draft_mod
+
+    banned = ("import anthropic", "from anthropic", "import openai", "from openai")
+    for mod in (serve_mod, draft_mod):
+        src = inspect.getsource(mod)
+        for token in banned:
+            assert token not in src, f"{mod.__name__} imports an LLM SDK ({token!r})"

--- a/tests/core/test_serve_capture.py
+++ b/tests/core/test_serve_capture.py
@@ -69,6 +69,28 @@ def test_capture_is_idempotent_on_key(tmp_path):
     assert r3.json()["id"] != r1.json()["id"]          # a different key is a different capture
 
 
+def test_capture_key_matches_by_line_not_prefix(tmp_path):
+    """A key must not collide with a longer key that has it as a prefix
+    (the marker is compared as a whole line, not a substring)."""
+    client = TestClient(_app(tmp_path))
+    r1 = client.post("/capture", json={"idea": "x", "idempotency_key": "k1"})
+    r2 = client.post("/capture", json={"idea": "y", "idempotency_key": "k1x"})
+    assert r1.json()["id"] != r2.json()["id"]          # "k1" must not match "k1x"
+
+
+def test_keyed_capture_event_still_starts_with_brainstorm_marker(tmp_path):
+    """The driver's first-line contract (event body STARTS WITH
+    `capture-brainstorm <tid>`) must survive a keyed capture — the key marker
+    is appended, not prepended."""
+    client = TestClient(_app(tmp_path))
+    tid = client.post("/capture", json={"idea": "z", "idempotency_key": "k9"}).json()["id"]
+    store = MessageStore(tmp_path / ".mothership" / "messages")
+    event = store.get(tid).messages[-1]
+    assert event.kind == "event"
+    assert event.text.startswith(f"capture-brainstorm {tid}")
+    assert "capture-key k9" in event.text
+
+
 def test_capture_and_draft_path_import_no_llm_sdk():
     """AC5: serve stays LLM-free. The modules the capture→draft path touches must
     not import an LLM SDK — the drafting intelligence runs in the agent, not serve."""

--- a/tests/core/test_serve_capture.py
+++ b/tests/core/test_serve_capture.py
@@ -59,6 +59,16 @@ def test_capture_posts_one_agent_event_brainstorm_handoff(tmp_path):
     assert thread.needs_you is False                    # an event must NOT nag the phone
 
 
+def test_capture_is_idempotent_on_key(tmp_path):
+    client = TestClient(_app(tmp_path))
+    r1 = client.post("/capture", json={"idea": "x", "idempotency_key": "k1"})
+    r2 = client.post("/capture", json={"idea": "x", "idempotency_key": "k1"})
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert r1.json()["id"] == r2.json()["id"]          # same capture, no duplicate thread
+    r3 = client.post("/capture", json={"idea": "x", "idempotency_key": "k2"})
+    assert r3.json()["id"] != r1.json()["id"]          # a different key is a different capture
+
+
 def test_capture_and_draft_path_import_no_llm_sdk():
     """AC5: serve stays LLM-free. The modules the capture→draft path touches must
     not import an LLM SDK — the drafting intelligence runs in the agent, not serve."""

--- a/tests/core/test_serve_capture.py
+++ b/tests/core/test_serve_capture.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from mship.core.serve import create_app
+from mship.core.state import StateManager
+from mship.core.message_store import MessageStore
+
+
+def _app(tmp_path: Path):
+    state = StateManager(tmp_path / ".mothership")
+    return create_app(
+        specs_dir=tmp_path / "specs",
+        state_manager=state,
+        log_manager=None,
+        workspace_root=tmp_path,
+        workspace_name="test-ws",
+    )
+
+
+def test_capture_seeds_thread_with_the_idea(tmp_path):
+    client = TestClient(_app(tmp_path))
+    r = client.post("/capture", json={"idea": "a queue tab for approvals"})
+    assert r.status_code == 200, r.text
+    thread = r.json()
+    tid = thread["id"]
+    assert thread["subject"].startswith("a queue tab")
+    # first message is the human idea
+    assert thread["messages"][0]["role"] == "human"
+    assert thread["messages"][0]["text"] == "a queue tab for approvals"
+
+    store = MessageStore(tmp_path / ".mothership" / "messages")
+    assert store.get(tid) is not None
+
+
+def test_capture_rejects_empty_idea(tmp_path):
+    client = TestClient(_app(tmp_path))
+    r = client.post("/capture", json={"idea": "   "})
+    assert r.status_code == 400

--- a/tests/core/test_skills_cli_refresh.py
+++ b/tests/core/test_skills_cli_refresh.py
@@ -19,6 +19,7 @@ STALE_PATHS = ["~/.config/superpowers", "docs/superpowers/"]
 REAL_SPEC_SUBCOMMANDS = {
     "new", "draft", "apply", "validate", "review", "verdict",
     "questions", "ask", "answer", "approve", "request-changes", "dispatch",
+    "from-thread",
 }
 
 


### PR DESCRIPTION
## Summary

MOS-156 — **idea capture → agent-led brainstorm → spec**. An operator types an idea in Ground Control; it seeds a chat thread plus an agent handoff; a host/cloud agent brainstorms it *in the thread* and produces a spec draft in `needs_review`. A good spec comes from brainstorming, not a one-shot text→template — so capture *seeds* a brainstorm rather than bypassing it. `mship serve` stays **LLM-free**; the pipeline is **driver-agnostic**.

Two repos (implements `specs/2026-07-13-gc-idea-capture-mos-156.md` from `docs/plans/2026-07-13-gc-idea-capture.md`):

- **mothership (serve):** new `POST /capture` seeds a thread with the idea (`create_thread`) and posts **one** agent-`event` brainstorm handoff (`kind="event"`, reusing the `_notify_dispatch` pattern) so `Thread.awaiting_agent_event` goes true and the shipped `mship _drain` / `inbox wait` surfaces it. A regression-guard test locks in that the capture/draft path imports no LLM SDK. A `working-with-mothership` skill note tells agents to brainstorm a capture handoff in-thread and finish via `mship spec from-thread` → `apply`.
- **ground-control:** `captureBrainstorm` client + `CaptureBody` DTO; a **kind picker** on the Capture screen — *Quick note* (→ today's `/threads`) vs *Brainstorm into a spec* (→ `/capture`); wiring.

### Acceptance criteria (7, all met)
Kind-picker choice (Capture screen); seed-thread + agent-event handoff naming thread+idea; agent drains → brainstorms in-thread → `spec from-thread`/`apply` → `needs_review`; active brainstorm visible as a thread, spec lands in the `needs_review` inbox group; serve LLM-free (guarded) + driver-agnostic contract; one event per capture (idempotent; clears on the agent's first non-event reply); no agent → the captured idea persists as a visible thread (no lost capture).

### Design notes
- Serve does **no drafting** (LLM-free, guarded). v1's brainstorm driver is a host/cloud agent; the `/capture` → thread → `from-thread`/`apply` contract carries no host-agent assumption, so a future **GC-app or serve-side LLM driver** can implement the same "seeded thread → `needs_review` spec" flow without a redesign.
- The spec is created by the driver at the **end** of the brainstorm (via `from-thread`), so no empty stub floats mid-conversation — the in-progress signal is the live thread.
- Quick-note thread capture is preserved (the other picker kind).

### Known follow-ups (from review; not blockers)
- "Driver-agnostic" today effectively means "any `mship`-CLI-capable drainer": a future non-CLI GC-app LLM driver replying via `POST /threads/{id}/messages` posts `role="human"`, which doesn't clear `awaiting_agent_event` — a **pre-existing mailbox constraint**, not introduced here.
- Navigating straight into a fresh brainstorm thread shows the agent-facing handoff bubble (consistent with existing dispatch-event rendering; a nicer `kind="event"` treatment in `ConversationScreen` is a follow-up).

## Test plan
- **mothership:** `uv run pytest -q` → **2571 passed, 0 failed** (incl. new `tests/core/test_serve_capture.py`, 4 tests).
- **ground-control:** `./gradlew testDebugUnitTest` → **302 passed, 0 failed**; `./gradlew assembleDebug` → BUILD SUCCESSFUL.
- `mship test` → both repos pass.

Spec: `gc-idea-capture-mos-156` · Plan: `docs/plans/2026-07-13-gc-idea-capture.md` · Linear: MOS-156

https://claude.ai/code/session_015ZPGS2VyABiXaBDKz9ts8v

---

## Acceptance criteria

- [ ] `ac1` Ground Control's Capture offers a 'brainstorm into a spec' choice distinct from the existing 'quick note' (→ thread) choice. — _no evidence_
- [ ] `ac2` Choosing it seeds a thread with the idea text and emits a mailbox agent-event brainstorm handoff naming the thread and the idea. — _no evidence_
- [ ] `ac3` A host/cloud agent that drains the handoff conducts a brainstorming conversation in the thread (clarifying questions the operator answers from the phone) and, when the design is settled, produces a spec draft linked to the thread in needs_review. — _no evidence_
- [ ] `ac4` The active brainstorm is visible as a thread while it happens; the resulting spec appears in the GC inbox's needs_review group. — _no evidence_
- [ ] `ac5` mship serve remains LLM-free (guarded by a test), and the capture→thread→spec pipeline is driver-agnostic — documented so a future GC-app or serve-side LLM driver can drive the same flow without redesign. — _no evidence_
- [ ] `ac6` The handoff is idempotent: one capture spawns one brainstorm driver; re-draining or re-capturing the same idea does not duplicate the handoff or the driver. — _no evidence_
- [ ] `ac7` If no agent processes the handoff, the captured idea remains a visible thread the operator can still open and continue (no lost capture). — _no evidence_
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `gc-idea-capture-mos-156`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/43 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/343 | this PR |

⚠ Merge in order: ground-control → mothership