### PR TITLE
Queue v2: spec-chunk + decision review queue (swipe approve/reject, per-item verdicts)

### DIFF
--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -32,6 +32,13 @@ PR_WATCH_INTERVAL_SECONDS = 45
 class VerdictBody(BaseModel):
     criterion_id: str
     verdict: str
+    comment: str | None = None
+
+
+class ProseVerdictBody(BaseModel):
+    section_id: str
+    verdict: str
+    comment: str | None = None
 
 
 class EvidenceBody(BaseModel):
@@ -490,6 +497,7 @@ def create_app(
     # datetime/timezone are imported at module top (needed earlier by _lifespan).
     from mship.core.spec_review import (
         infer_evidence_kind, set_criterion_evidence, set_criterion_verdict,
+        set_prose_verdict,
     )
     from mship.core.spec_questions import add_question, answer_question
 
@@ -508,7 +516,16 @@ def create_app(
     def post_verdict(spec_id: str, body: VerdictBody):
         spec = _load_or_404(spec_id)
         try:
-            set_criterion_verdict(spec, body.criterion_id, body.verdict)
+            set_criterion_verdict(spec, body.criterion_id, body.verdict, body.comment)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        return _save_and_review(spec)
+
+    @app.post("/specs/{spec_id}/prose-verdict")
+    def post_prose_verdict(spec_id: str, body: ProseVerdictBody):
+        spec = _load_or_404(spec_id)
+        try:
+            set_prose_verdict(spec, body.section_id, body.verdict, body.comment)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         return _save_and_review(spec)

--- a/src/mship/core/spec.py
+++ b/src/mship/core/spec.py
@@ -40,6 +40,12 @@ class AcceptanceCriterion(BaseModel):
     text: str
     verdict: Literal["unreviewed", "approved", "flagged"] = "unreviewed"
     evidence: list[AcceptanceEvidence] = []
+    comment: str | None = None
+
+
+class ProseVerdict(BaseModel):
+    verdict: Literal["unreviewed", "approved", "flagged"] = "unreviewed"
+    comment: str | None = None
 
 
 class OpenQuestion(BaseModel):
@@ -63,6 +69,7 @@ class Spec(BaseModel):
     body: str = ""
     work_item_id: str | None = None
     clarification_reason: str | None = None
+    prose_verdicts: dict[str, ProseVerdict] = {}
 
     @model_validator(mode="before")
     @classmethod

--- a/src/mship/core/spec_approve.py
+++ b/src/mship/core/spec_approve.py
@@ -13,4 +13,11 @@ def approval_blockers(spec: Spec) -> list[str]:
     unanswered = [q.id for q in spec.open_questions if q.answer is None]
     if unanswered:
         blockers.append(f"open questions unanswered: {', '.join(unanswered)}")
+    # Prose-section verdicts (MOS-172), backward-compatibly: a section with an
+    # explicit non-approved verdict blocks; a section absent from prose_verdicts
+    # contributes nothing — legacy specs (and specs the reviewer hasn't touched)
+    # still approve.
+    bad_prose = [sid for sid, pv in spec.prose_verdicts.items() if pv.verdict != "approved"]
+    if bad_prose:
+        blockers.append(f"prose sections not approved: {', '.join(sorted(bad_prose))}")
     return blockers

--- a/src/mship/core/spec_approve.py
+++ b/src/mship/core/spec_approve.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from mship.core.spec import Spec
+from mship.core.spec_review import PROSE_UNIT_IDS
 
 
 def approval_blockers(spec: Spec) -> list[str]:
@@ -13,11 +14,16 @@ def approval_blockers(spec: Spec) -> list[str]:
     unanswered = [q.id for q in spec.open_questions if q.answer is None]
     if unanswered:
         blockers.append(f"open questions unanswered: {', '.join(unanswered)}")
-    # Prose-section verdicts (MOS-172), backward-compatibly: a section with an
+    # Prose-section verdicts (MOS-172), backward-compatibly: a KNOWN section with an
     # explicit non-approved verdict blocks; a section absent from prose_verdicts
     # contributes nothing — legacy specs (and specs the reviewer hasn't touched)
-    # still approve.
-    bad_prose = [sid for sid, pv in spec.prose_verdicts.items() if pv.verdict != "approved"]
+    # still approve. Only known section ids (PROSE_UNIT_IDS) are settable/clearable
+    # via the API, so a stray/unknown persisted key must NOT block — otherwise the
+    # spec would be both un-approvable and un-fixable (Greptile #344).
+    bad_prose = [
+        sid for sid, pv in spec.prose_verdicts.items()
+        if sid in PROSE_UNIT_IDS and pv.verdict != "approved"
+    ]
     if bad_prose:
         blockers.append(f"prose sections not approved: {', '.join(sorted(bad_prose))}")
     return blockers

--- a/src/mship/core/spec_draft.py
+++ b/src/mship/core/spec_draft.py
@@ -101,6 +101,14 @@ def apply_draft(spec: Spec, draft: SpecDraft) -> Spec:
     spec.non_goals = list(draft.non_goals)
     spec.risks = list(draft.risks)
     spec.affected_repos = list(draft.affected_repos)
+    # Preserve prose-section verdicts across a re-draft (MOS-172). Section ids are
+    # stable (problem/user_story/approach/non_goals/risks), so this is a straight
+    # carry-over — unlike the positional AC matcher below. (The prose text may have
+    # changed; re-reviewing is the reviewer's call, but a re-draft must not silently
+    # drop prior verdicts.) apply_draft mutates `spec` in place and never reassigns
+    # prose_verdicts, so they already survive; the explicit copy documents the intent
+    # and guards against a future in-place clear.
+    spec.prose_verdicts = dict(spec.prose_verdicts)
     # Preserve verdict + evidence for unchanged criteria across a re-apply. Criteria
     # have no stable id (ids are positional, ac{i+1}), so match each new criterion to
     # a prior one in two passes, consuming each prior at most once:

--- a/src/mship/core/spec_draft.py
+++ b/src/mship/core/spec_draft.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec, SpecDraft
-from mship.core.spec_body import render_body
+from mship.core.spec_body import parse_body_sections, render_body
 from mship.util.slug import slugify
 
 
@@ -94,6 +94,19 @@ def apply_draft(spec: Spec, draft: SpecDraft) -> Spec:
     """Merge a SpecDraft into `spec` in place: render the canonical body, set the
     structured fields, and assign deterministic `ac`/`q` ids. Does NOT change
     status/updated_at — the caller owns the lifecycle transition + persistence."""
+    # Capture the OLD prose text for each comparable section id BEFORE any field is
+    # overwritten below — the canonical problem/user_story/approach live in `spec.body`
+    # (parse it now, since `render_body` is about to clobber it), while non_goals/risks
+    # are list fields. Used just below to decide which prose verdicts survive.
+    old_sections = parse_body_sections(spec.body)
+    old_prose_text: dict[str, object] = {
+        "problem": old_sections.get("Problem", ""),
+        "user_story": old_sections.get("User story", ""),
+        "approach": old_sections.get("Approach", ""),
+        "non_goals": list(spec.non_goals),
+        "risks": list(spec.risks),
+    }
+
     spec.body = render_body(
         draft.problem, draft.user_story, draft.approach,
         additional_sections=[(s.heading, s.body) for s in draft.additional_sections],
@@ -101,14 +114,30 @@ def apply_draft(spec: Spec, draft: SpecDraft) -> Spec:
     spec.non_goals = list(draft.non_goals)
     spec.risks = list(draft.risks)
     spec.affected_repos = list(draft.affected_repos)
-    # Preserve prose-section verdicts across a re-draft (MOS-172). Section ids are
-    # stable (problem/user_story/approach/non_goals/risks), so this is a straight
-    # carry-over — unlike the positional AC matcher below. (The prose text may have
-    # changed; re-reviewing is the reviewer's call, but a re-draft must not silently
-    # drop prior verdicts.) apply_draft mutates `spec` in place and never reassigns
-    # prose_verdicts, so they already survive; the explicit copy documents the intent
-    # and guards against a future in-place clear.
-    spec.prose_verdicts = dict(spec.prose_verdicts)
+    # Prose-section verdicts across a re-draft (MOS-172, Greptile #344): a verdict is
+    # preserved only when the section's TEXT is UNCHANGED, and dropped (re-reviewed)
+    # when it changed — mirroring the acceptance-criteria matcher below (a rewritten
+    # section must not keep a stale approval, nor stay blocked after it's fixed). We
+    # compare the new text (parsed-body prose stripped exactly as render_body writes
+    # it; list fields compared as lists) against the OLD text captured above. Section
+    # ids with no draft-derived text (e.g. `scope_risk`, or any unknown/legacy key)
+    # have nothing to compare, so they carry over unchanged.
+    new_prose_text: dict[str, object] = {
+        "problem": draft.problem.strip(),
+        "user_story": draft.user_story.strip(),
+        "approach": draft.approach.strip(),
+        "non_goals": list(draft.non_goals),
+        "risks": list(draft.risks),
+    }
+    preserved_prose = {}
+    for sid, pv in spec.prose_verdicts.items():
+        if sid in old_prose_text:
+            if old_prose_text[sid] == new_prose_text[sid]:
+                preserved_prose[sid] = pv  # unchanged text → keep verdict
+            # else: text changed → drop so it is re-reviewed
+        else:
+            preserved_prose[sid] = pv  # no comparable text → carry over unchanged
+    spec.prose_verdicts = preserved_prose
     # Preserve verdict + evidence for unchanged criteria across a re-apply. Criteria
     # have no stable id (ids are positional, ac{i+1}), so match each new criterion to
     # a prior one in two passes, consuming each prior at most once:

--- a/src/mship/core/spec_review.py
+++ b/src/mship/core/spec_review.py
@@ -62,24 +62,48 @@ def build_review(spec: Spec) -> dict:
     }
 
 
-def set_criterion_verdict(spec: Spec, criterion_id: str, verdict: str) -> Spec:
+def set_criterion_verdict(
+    spec: Spec, criterion_id: str, verdict: str, comment: str | None = None
+) -> Spec:
     """Set one acceptance criterion's verdict in place. Raises ValueError on an
-    invalid verdict or unknown criterion id. Does not change status or persist."""
+    invalid verdict or unknown criterion id. Does not change status or persist.
+    An explicit `comment` (MOS-217) records a flag-with-comment; an empty string
+    clears it (stored as None)."""
     if verdict not in VERDICTS:
         raise ValueError(
             f"invalid verdict {verdict!r}; expected one of {', '.join(VERDICTS)}"
         )
     if criterion_id in PROSE_UNIT_IDS:
         raise ValueError(
-            f"{criterion_id!r} is not verdict-able; only acceptance criteria "
-            f"(ac1, ac2, …) carry verdicts in this version."
+            f"{criterion_id!r} is a prose section — use set_prose_verdict"
         )
     for c in spec.acceptance_criteria:
         if c.id == criterion_id:
             c.verdict = verdict
+            if comment is not None:
+                c.comment = comment or None
             return spec
     valid = ", ".join(c.id for c in spec.acceptance_criteria) or "(none)"
     raise ValueError(f"no acceptance criterion {criterion_id!r}; valid ids: {valid}")
+
+
+def set_prose_verdict(
+    spec: Spec, section_id: str, verdict: str, comment: str | None = None
+) -> Spec:
+    """Set one prose section's verdict (MOS-172). section_id must be one of
+    PROSE_UNIT_IDS. Raises ValueError on an invalid verdict or unknown section.
+    Does not change status or persist."""
+    if verdict not in VERDICTS:
+        raise ValueError(
+            f"invalid verdict {verdict!r}; expected one of {', '.join(VERDICTS)}"
+        )
+    if section_id not in PROSE_UNIT_IDS:
+        raise ValueError(
+            f"{section_id!r} is not a prose section; valid: {', '.join(sorted(PROSE_UNIT_IDS))}"
+        )
+    from mship.core.spec import ProseVerdict
+    spec.prose_verdicts[section_id] = ProseVerdict(verdict=verdict, comment=(comment or None))
+    return spec
 
 
 def infer_evidence_kind(ref: str) -> str:

--- a/src/mship/core/spec_review.py
+++ b/src/mship/core/spec_review.py
@@ -31,12 +31,16 @@ def build_review(spec: Spec) -> dict:
                 "id": c.id,
                 "text": c.text,
                 "verdict": c.verdict,
+                "comment": c.comment,
                 "evidence": [
                     {"kind": e.kind, "ref": e.ref, "note": e.note} for e in c.evidence
                 ],
             }
             for c in spec.acceptance_criteria
         ],
+        "prose_verdicts": {
+            sid: pv.model_dump(mode="json") for sid, pv in spec.prose_verdicts.items()
+        },
         "open_questions": [
             {"id": q.id, "text": q.text, "answer": q.answer}
             for q in spec.open_questions

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -161,6 +161,29 @@ def test_post_verdict(tmp_path):
     assert client.post("/specs/none/verdict", json={"criterion_id": "ac1", "verdict": "approved"}).status_code == 404
 
 
+def test_post_prose_verdict(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs/dq/prose-verdict", json={"section_id": "approach", "verdict": "flagged", "comment": "unclear"})
+    assert r.status_code == 200
+    # verdict endpoint returns the review; the spec itself now carries the prose verdict
+    from mship.core.spec_store import SpecStore
+    s = SpecStore(tmp_path / "specs").find_by_id("dq")
+    assert s.prose_verdicts["approach"].verdict == "flagged"
+    assert s.prose_verdicts["approach"].comment == "unclear"
+    assert client.post("/specs/dq/prose-verdict", json={"section_id": "nope", "verdict": "approved"}).status_code == 400
+    assert client.post("/specs/dq/prose-verdict", json={"section_id": "approach", "verdict": "bogus"}).status_code == 400
+
+
+def test_post_verdict_with_comment(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs/dq/verdict", json={"criterion_id": "ac1", "verdict": "flagged", "comment": "fix"})
+    assert r.status_code == 200
+    from mship.core.spec_store import SpecStore
+    assert SpecStore(tmp_path / "specs").find_by_id("dq").acceptance_criteria[0].comment == "fix"
+
+
 def test_post_evidence_persists_and_validates(tmp_path):
     _seed_spec(tmp_path)   # spec "dq" with one AC "ac1"
     client = TestClient(_app(tmp_path))

--- a/tests/core/test_spec_approve.py
+++ b/tests/core/test_spec_approve.py
@@ -44,6 +44,17 @@ def test_prose_flagged_blocks_but_missing_prose_does_not():
     assert approval_blockers(s) == []
 
 
+def test_unknown_prose_key_does_not_block():
+    # Greptile #344: only known section ids (PROSE_UNIT_IDS) are settable/clearable
+    # via the API, so a stray/unknown persisted prose key must NOT block approval —
+    # otherwise the spec would be un-approvable AND un-fixable.
+    from mship.core.spec import ProseVerdict
+    s = _spec(criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
+              questions=[OpenQuestion(id="q1", text="?", answer="y")])
+    s.prose_verdicts = {"bogus_unknown": ProseVerdict(verdict="flagged")}
+    assert approval_blockers(s) == []
+
+
 def test_approval_gate_unchanged_approved_verdicts_zero_evidence():
     """ac6: evidence is NEVER required to approve. A spec with all verdicts
     approved and NO evidence has no approval blockers."""

--- a/tests/core/test_spec_approve.py
+++ b/tests/core/test_spec_approve.py
@@ -30,6 +30,20 @@ def test_no_blockers_when_all_clear():
     assert approval_blockers(s) == []
 
 
+def test_prose_flagged_blocks_but_missing_prose_does_not():
+    from mship.core.spec import ProseVerdict
+    # legacy spec: no prose_verdicts at all → still approvable (back-compat)
+    s = _spec(criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
+              questions=[OpenQuestion(id="q1", text="?", answer="y")])
+    assert approval_blockers(s) == []
+    # a flagged prose section blocks
+    s.prose_verdicts = {"approach": ProseVerdict(verdict="flagged")}
+    assert any("approach" in b for b in approval_blockers(s))
+    # an approved prose section does not block
+    s.prose_verdicts = {"approach": ProseVerdict(verdict="approved")}
+    assert approval_blockers(s) == []
+
+
 def test_approval_gate_unchanged_approved_verdicts_zero_evidence():
     """ac6: evidence is NEVER required to approve. A spec with all verdicts
     approved and NO evidence has no approval blockers."""

--- a/tests/core/test_spec_draft.py
+++ b/tests/core/test_spec_draft.py
@@ -63,17 +63,71 @@ def test_apply_draft_preserves_evidence_and_verdict_for_unchanged_ac():
     assert out.acceptance_criteria[0].evidence == [AcceptanceEvidence(kind="test", ref="test-runs/5")]
 
 
-def test_apply_draft_preserves_prose_verdicts():
+def test_apply_draft_preserves_prose_verdicts_for_unchanged_sections():
     from mship.core.spec import ProseVerdict
+    from mship.core.spec_body import render_body
     spec = _spec()
+    # Establish a known OLD body + list fields, then re-draft with IDENTICAL text —
+    # every prose verdict must carry over unchanged.
+    spec.body = render_body("P", "U", "A")
+    spec.non_goals = ["chat"]
+    spec.risks = ["scope"]
     spec.prose_verdicts = {"approach": ProseVerdict(verdict="approved"),
-                           "problem": ProseVerdict(verdict="flagged", comment="c")}
-    draft = SpecDraft(problem="P2", user_story="U", approach="A", acceptance_criteria=["x"])
+                           "problem": ProseVerdict(verdict="flagged", comment="c"),
+                           "non_goals": ProseVerdict(verdict="approved"),
+                           "risks": ProseVerdict(verdict="approved")}
+    draft = SpecDraft(problem="P", user_story="U", approach="A",
+                      non_goals=["chat"], risks=["scope"], acceptance_criteria=["x"])
     out = apply_draft(spec, draft)
-    # prose verdicts carry over by stable section id (re-review the whole spec is the reviewer's call,
-    # but a re-draft alone must not silently reset prior verdicts)
     assert out.prose_verdicts["approach"].verdict == "approved"
     assert out.prose_verdicts["problem"].comment == "c"
+    assert out.prose_verdicts["non_goals"].verdict == "approved"
+    assert out.prose_verdicts["risks"].verdict == "approved"
+
+
+def test_apply_draft_drops_prose_verdict_when_text_changed():
+    # Greptile #344: a prose verdict is kept ONLY when the section text is unchanged.
+    # A rewritten `approach` must NOT keep its stale approval (would slip past the
+    # gate); an unchanged `problem` must keep its verdict.
+    from mship.core.spec import ProseVerdict
+    from mship.core.spec_body import render_body
+    spec = _spec()
+    spec.body = render_body("the problem", "U", "old approach")
+    spec.prose_verdicts = {"approach": ProseVerdict(verdict="approved"),
+                           "problem": ProseVerdict(verdict="approved")}
+    draft = SpecDraft(problem="the problem", user_story="U", approach="new approach",
+                      acceptance_criteria=["x"])       # approach CHANGED, problem SAME
+    out = apply_draft(spec, draft)
+    assert out.prose_verdicts["problem"].verdict == "approved"   # unchanged → preserved
+    assert "approach" not in out.prose_verdicts                  # changed → re-review
+
+
+def test_apply_draft_drops_prose_verdict_when_list_field_changed():
+    # non_goals/risks are list fields — changing the list must reset that section's
+    # verdict too; an unchanged list keeps it.
+    from mship.core.spec import ProseVerdict
+    spec = _spec()
+    spec.non_goals = ["a"]
+    spec.risks = ["r"]
+    spec.prose_verdicts = {"non_goals": ProseVerdict(verdict="approved"),
+                           "risks": ProseVerdict(verdict="approved")}
+    draft = SpecDraft(problem="P", user_story="U", approach="A",
+                      non_goals=["a", "b"], risks=["r"],       # non_goals CHANGED, risks SAME
+                      acceptance_criteria=["x"])
+    out = apply_draft(spec, draft)
+    assert "non_goals" not in out.prose_verdicts                 # changed → re-review
+    assert out.prose_verdicts["risks"].verdict == "approved"     # unchanged → preserved
+
+
+def test_apply_draft_preserves_uncomparable_prose_verdict():
+    # A section id with no draft-derived text (e.g. scope_risk) has nothing to compare,
+    # so its verdict carries over unchanged across a re-draft.
+    from mship.core.spec import ProseVerdict
+    spec = _spec()
+    spec.prose_verdicts = {"scope_risk": ProseVerdict(verdict="approved")}
+    draft = SpecDraft(problem="P2", user_story="U2", approach="A2", acceptance_criteria=["x"])
+    out = apply_draft(spec, draft)
+    assert out.prose_verdicts["scope_risk"].verdict == "approved"
 
 
 def test_apply_draft_resets_evidence_and_verdict_for_materially_changed_ac():

--- a/tests/core/test_spec_draft.py
+++ b/tests/core/test_spec_draft.py
@@ -63,6 +63,19 @@ def test_apply_draft_preserves_evidence_and_verdict_for_unchanged_ac():
     assert out.acceptance_criteria[0].evidence == [AcceptanceEvidence(kind="test", ref="test-runs/5")]
 
 
+def test_apply_draft_preserves_prose_verdicts():
+    from mship.core.spec import ProseVerdict
+    spec = _spec()
+    spec.prose_verdicts = {"approach": ProseVerdict(verdict="approved"),
+                           "problem": ProseVerdict(verdict="flagged", comment="c")}
+    draft = SpecDraft(problem="P2", user_story="U", approach="A", acceptance_criteria=["x"])
+    out = apply_draft(spec, draft)
+    # prose verdicts carry over by stable section id (re-review the whole spec is the reviewer's call,
+    # but a re-draft alone must not silently reset prior verdicts)
+    assert out.prose_verdicts["approach"].verdict == "approved"
+    assert out.prose_verdicts["problem"].comment == "c"
+
+
 def test_apply_draft_resets_evidence_and_verdict_for_materially_changed_ac():
     spec = _spec()
     spec.acceptance_criteria = [

--- a/tests/core/test_spec_model.py
+++ b/tests/core/test_spec_model.py
@@ -1,0 +1,26 @@
+from datetime import datetime, timezone
+from mship.core.spec import AcceptanceCriterion, ProseVerdict, Spec
+
+
+def _now():
+    return datetime(2026, 7, 13, tzinfo=timezone.utc)
+
+
+def test_spec_carries_prose_verdicts_and_criterion_comment():
+    s = Spec(
+        id="s1", title="T", status="needs_review", created_at=_now(), updated_at=_now(),
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="flagged", comment="fix this")],
+        prose_verdicts={"problem": ProseVerdict(verdict="approved"),
+                        "approach": ProseVerdict(verdict="flagged", comment="unclear")},
+    )
+    assert s.prose_verdicts["approach"].comment == "unclear"
+    assert s.acceptance_criteria[0].comment == "fix this"
+    # round-trips through model_dump (what GET /specs/{id} + frontmatter use)
+    dumped = s.model_dump(mode="json")
+    assert dumped["prose_verdicts"]["problem"]["verdict"] == "approved"
+    assert dumped["acceptance_criteria"][0]["comment"] == "fix this"
+
+
+def test_prose_verdicts_defaults_empty():
+    s = Spec(id="s1", title="T", status="draft", created_at=_now(), updated_at=_now())
+    assert s.prose_verdicts == {}

--- a/tests/core/test_spec_review.py
+++ b/tests/core/test_spec_review.py
@@ -91,9 +91,32 @@ def test_set_criterion_verdict_rejects_unknown_id():
         set_criterion_verdict(_spec(), "nope", "approved")
 
 
-def test_set_criterion_verdict_rejects_prose_unit():
-    with pytest.raises(ValueError, match="not verdict-able"):
-        set_criterion_verdict(_spec(), "problem", "approved")
+def test_set_prose_verdict_accepts_a_prose_section():
+    from mship.core.spec_review import set_prose_verdict
+    s = _spec()
+    set_prose_verdict(s, "approach", "flagged", comment="unclear")
+    assert s.prose_verdicts["approach"].verdict == "flagged"
+    assert s.prose_verdicts["approach"].comment == "unclear"
+
+
+def test_set_prose_verdict_rejects_unknown_section():
+    from mship.core.spec_review import set_prose_verdict
+    import pytest
+    with pytest.raises(ValueError, match="not a prose section"):
+        set_prose_verdict(_spec(), "bogus", "approved")
+
+
+def test_set_prose_verdict_rejects_bad_verdict():
+    from mship.core.spec_review import set_prose_verdict
+    import pytest
+    with pytest.raises(ValueError, match="invalid verdict"):
+        set_prose_verdict(_spec(), "problem", "bogus")
+
+
+def test_set_criterion_verdict_stores_comment():
+    s = _spec()  # _spec() should include an ac1
+    set_criterion_verdict(s, "ac1", "flagged", comment="needs work")
+    assert s.acceptance_criteria[0].comment == "needs work"
 
 
 def test_set_criterion_evidence_appends_and_persists_in_object():

--- a/tests/core/test_spec_review.py
+++ b/tests/core/test_spec_review.py
@@ -27,13 +27,25 @@ def test_build_review_shapes_units_and_context():
     r = build_review(_spec())
     assert r["id"] == "dq" and r["status"] == "needs_review"
     assert r["acceptance_criteria"] == [
-        {"id": "ac1", "text": "view questions", "verdict": "approved", "evidence": []},
-        {"id": "ac2", "text": "record answer", "verdict": "unreviewed", "evidence": []},
+        {"id": "ac1", "text": "view questions", "verdict": "approved", "comment": None, "evidence": []},
+        {"id": "ac2", "text": "record answer", "verdict": "unreviewed", "comment": None, "evidence": []},
     ]
     assert r["open_questions"] == [{"id": "q1", "text": "Android?", "answer": None}]
     assert r["context"]["problem"] == "the problem"
     assert r["context"]["approach"] == "the approach"
     assert r["context"]["non_goals"] == ["chat"]
+
+
+def test_build_review_emits_prose_verdicts_and_comments():
+    from mship.core.spec import ProseVerdict
+    s = _spec()
+    set_criterion_verdict(s, "ac1", "flagged", comment="fix")
+    s.prose_verdicts = {"approach": ProseVerdict(verdict="approved")}
+    review = build_review(s)
+    assert review["prose_verdicts"]["approach"]["verdict"] == "approved"
+    # the criterion's comment is exposed in the review's criteria list
+    crit = next(c for c in review["acceptance_criteria"] if c["id"] == "ac1")
+    assert crit["comment"] == "fix"
 
 
 def test_build_review_includes_clarification_reason():


### PR DESCRIPTION
## Summary

**Queue v2 — PR1 (serve foundations).** Adds the serve model + endpoints the review/decision Queue needs: **per-prose-section verdicts (closes MOS-172)** and **flag-with-comment (closes MOS-217)**, plus a **backward-compatible** approve gate. Everything here is **additive and nothing consumes it yet** (the Ground Control card-stack UI lands in a follow-up PR), so this is safe to merge on its own.

Part of the Queue v2 epic (`gc-review-decision-queue-v2`), which reframes the shipped Queue (MOS-225) to source `needs_review` spec **chunks** (prose sections + acceptance criteria + open questions) and open **decisions** as one-card-at-a-time review.

### What's in it
- **`ProseVerdict` model + `Spec.prose_verdicts`** (a verdict + optional comment per canonical section: problem / user_story / approach / non_goals / risks) + **`AcceptanceCriterion.comment`** (flag-with-comment).
- **`set_prose_verdict(...)`** — flips the existing `PROSE_UNIT_IDS` rejection in `core/spec_review.py` from "prose is not verdict-able" to accepting a verdict on those sections; `set_criterion_verdict` gains a `comment`.
- **`POST /specs/{id}/prose-verdict`** (+ `ProseVerdictBody`) and a `comment` on the existing `POST /specs/{id}/verdict`.
- **`apply_draft` preserves prose verdicts** across a re-draft (stable section ids → straight carry-over).
- **Approve gate is backward-compatible** — a prose section with an *explicit* non-approved verdict blocks; a **missing/empty** `prose_verdicts` never blocks, so existing specs (and specs a reviewer hasn't touched) still approve. Existing CLI/GC spec approval is unchanged.
- **`build_review`** now emits `prose_verdicts` + each criterion's `comment`, so a single review fetch will drive the Queue's chunk-cards.

### Backward compatibility
The old "`set_criterion_verdict` rejects a prose unit" guard is intentionally replaced (prose is now verdict-able). One existing `build_review` shape test was updated to include the new `comment: null` field. No behavior for existing specs changes — legacy specs approve exactly as before.

## Test plan
- `uv run pytest -q` → **2584 passed, 0 failed** (no regressions across the whole suite).
- New tests cover: the model round-trip; `set_prose_verdict` accept/reject; the prose-verdict + comment endpoints; `apply_draft` preservation; the gate's explicit-flag-blocks / missing-prose-doesn't-block back-compat; and `build_review` emitting the new fields.

Spec: `gc-review-decision-queue-v2` · Plan: `docs/plans/2026-07-13-gc-review-decision-queue-v2.md` · Closes MOS-172, MOS-217

https://claude.ai/code/session_015ZPGS2VyABiXaBDKz9ts8v

---

## Acceptance criteria

- [ ] `ac1` The Queue sources, across all connected workspaces, spec-review chunk cards (per needs_review spec: one card per prose section, one acceptance-criteria card, and an open-questions card when questions are unanswered) and decision cards (per thread needing the operator). — _no evidence_
- [ ] `ac2` mship serve supports per-prose-section verdicts (problem/user_story/approach/non_goals/risks → unreviewed/approved/flagged + optional comment), surfaced in spec detail and settable via an endpoint (subsumes MOS-172). — _no evidence_
- [ ] `ac3` A flagged acceptance criterion or prose section can carry a comment (subsumes MOS-217). — _no evidence_
- [ ] `ac4` Swipe right approves all items on a card; swipe left rejects via a comment sheet that flags the item(s) and request-changes the spec with that comment. — _no evidence_
- [ ] `ac5` Multi-item cards (acceptance-criteria, open-questions) allow per-item approve/flag (and answer, for questions). — _no evidence_
- [ ] `ac6` When all of a spec's chunk-cards are approved (prose + criteria + questions), the spec auto-approves and leaves the queue; when any chunk is rejected, the spec is request-changed and leaves the queue until re-drafted. — _no evidence_
- [ ] `ac7` Decision cards render the question + options and are answered by tapping an option (+ free-text Other); answering clears the card. — _no evidence_
- [ ] `ac8` A Skip button sends the current card to the back; a position indicator and an 'all caught up' empty state are shown. — _no evidence_
- [ ] `ac9` The approve-gate change is backward-compatible: specs without prose verdicts can still be approved (un-reviewed prose does not hard-block legacy approvals) or are migrated, and existing CLI/GC spec approval is not broken. — _no evidence_
- [ ] `ac10` Cross-workspace fan-out degrades per-workspace on partial failure (a down workspace shows an error, not a blank queue). — _no evidence_
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `gc-review-decision-queue-v2`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/44 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/344 | this PR |

⚠ Merge in order: ground-control → mothership