### PR TITLE
Fix pr_watcher._resolve_thread so PR merge/close events reuse an existing thread that already contains the PR url (and link it to the WorkItem) instead of creating a new thread; only create a new thread when the url appears in none. Add a pr_watcher test.

### DIFF
--- a/src/mship/core/pr_watcher.py
+++ b/src/mship/core/pr_watcher.py
@@ -9,6 +9,7 @@ event; it does not itself wake or steer anything.
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
@@ -17,6 +18,14 @@ log = logging.getLogger(__name__)
 
 # States that mean "this PR is done, the task's agent should notice."
 _TERMINAL_STATES = ("merged", "closed")
+
+
+def _refs_pr(text: str, needle: str) -> bool:
+    """True if `text` contains `needle` NOT immediately followed by another digit — so a
+    reference to `.../pull/4` doesn't spuriously match `.../pull/42`. Used for both the PR
+    url (thread lookup) and the `PR <state>: <url>` dedup marker; both end in the PR number,
+    so a trailing-digit boundary is exactly the right test."""
+    return re.search(re.escape(needle) + r"(?!\d)", text) is not None
 
 
 class PrWatcher:
@@ -137,7 +146,7 @@ class PrWatcher:
         thread = self.msgs.get(tid)
         marker = f"PR {st}: {url}"
         if thread is not None and any(
-            m.kind == "event" and marker in m.text
+            m.kind == "event" and _refs_pr(m.text, marker)
             for m in thread.messages
         ):
             # Already posted (prior process) — record it so this process's
@@ -220,7 +229,7 @@ class PrWatcher:
 
         url_thread = next(
             (t for t in self.msgs.list()
-             if any(url in m.text for m in t.messages)),
+             if any(_refs_pr(m.text, url) for m in t.messages)),
             None,
         )
         if url_thread is not None:

--- a/src/mship/core/pr_watcher.py
+++ b/src/mship/core/pr_watcher.py
@@ -132,7 +132,7 @@ class PrWatcher:
         Returns (already_posted, thread_id, work_item_or_None)."""
         _, _repo, url, st = key
         now = self.now_fn()
-        tid, wi = self._resolve_thread(slug, task, now)
+        tid, wi = self._resolve_thread(slug, task, url, now)
 
         thread = self.msgs.get(tid)
         marker = f"PR {st}: {url}"
@@ -197,15 +197,36 @@ class PrWatcher:
                 st, slug, repo,
             )
 
-    def _resolve_thread(self, slug: str, task: Any, now: datetime) -> tuple[str, Any]:
-        """Mirror POST /items/{id}/messages' thread resolution: prefer the
-        task's WorkItem's first thread, else an existing thread scoped to
-        this task_slug, else create one (linking it back to the WorkItem when
-        one exists). Returns (thread_id, work_item_or_None)."""
+    def _resolve_thread(self, slug: str, task: Any, url: str, now: datetime) -> tuple[str, Any]:
+        """Resolve the thread a PR merge/close event belongs to, strongly
+        preferring an EXISTING thread over spawning a new one (operator
+        feedback 2026-07-14: PR events were cluttering the app with a fresh
+        thread per task). In order:
+
+          1. the task's WorkItem's first thread (its canonical thread), else
+          2. any existing thread that already references this PR `url` — the
+             operator tracks the PR there (a dispatch/chat message), so the
+             merge/close event belongs with it; link it to the WorkItem so
+             later events for the same item consolidate there too, else
+          3. an existing thread scoped to this task_slug, else
+          4. create one (linking it back to the WorkItem when one exists).
+
+        Only step 4 spawns a new thread, and only when the PR url appears in no
+        thread at all. Returns (thread_id, work_item_or_None)."""
         work_item_id = getattr(task, "work_item_id", None)
         wi = self.workitems.get(work_item_id) if work_item_id else None
         if wi and wi.thread_ids:
             return wi.thread_ids[0], wi
+
+        url_thread = next(
+            (t for t in self.msgs.list()
+             if any(url in m.text for m in t.messages)),
+            None,
+        )
+        if url_thread is not None:
+            if wi is not None:
+                self.workitems.add_thread(wi.id, url_thread.id, now)
+            return url_thread.id, wi
 
         existing = next(
             (t for t in self.msgs.list() if t.task_slug == slug), None

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -271,6 +271,26 @@ def test_workitem_thread_wins_over_pr_url_thread():
     assert events[0]["thread_id"] == canonical.id  # WorkItem's own thread, not the url thread
 
 
+def test_pr_url_match_is_not_a_numeric_prefix():
+    # Resolving .../pull/4 must NOT reuse a thread that only mentions .../pull/42 (a numeric
+    # prefix). With no thread carrying pull/4, a fresh thread is created + linked instead.
+    msgs = FakeMessageStore()
+    workitems = FakeWorkItemStore()
+    workitems.items["wi-7"] = FakeWorkItem(id="wi-7", thread_ids=[])
+    other = msgs.create_thread(subject="chat", text="seed", now=NOW, task_slug=None)
+    msgs.append(other.id, "agent", "see https://github.com/org/repoG/pull/42", NOW, kind="note")
+    task = FakeTask(pr_urls={"repoG": "https://github.com/org/repoG/pull/4"}, work_item_id="wi-7")
+    state = FakeStateManager({"task-7": task})
+
+    watcher = PrWatcher(msgs, workitems, state, lambda u: "merged", now_fn)
+    watcher.check_once()
+
+    events = [c for c in msgs.append_calls if c["kind"] == "event"]
+    assert len(events) == 1
+    assert events[0]["thread_id"] != other.id  # did not post into the pull/42 thread
+    assert workitems.items["wi-7"].thread_ids == [events[0]["thread_id"]]  # fresh thread, linked
+
+
 def test_no_work_item_uses_existing_thread_by_task_slug():
     msgs = FakeMessageStore()
     workitems = FakeWorkItemStore()

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -224,6 +224,53 @@ def test_workitem_with_no_thread_creates_and_links():
     assert new_thread.messages[-1].kind == "event"
 
 
+def test_reuses_existing_thread_that_contains_pr_url():
+    # A CLI-spawned task's WorkItem has no thread, but the PR url was already posted in
+    # some thread (a dispatch/chat message). The merge event must land THERE — not in a
+    # fresh thread (the clutter the operator reported) — and link that thread to the
+    # WorkItem so later events for the item consolidate there too.
+    msgs = FakeMessageStore()
+    workitems = FakeWorkItemStore()
+    workitems.items["wi-5"] = FakeWorkItem(id="wi-5", thread_ids=[])
+    url = "https://github.com/org/repoE/pull/45"
+    chat = msgs.create_thread(subject="chat", text="seed", now=NOW, task_slug=None)
+    msgs.append(chat.id, "agent", f"PR is up: {url}", NOW, kind="note")
+    task = FakeTask(pr_urls={"repoE": url}, work_item_id="wi-5")
+    state = FakeStateManager({"task-5": task})
+
+    watcher = PrWatcher(msgs, workitems, state, lambda u: "merged", now_fn)
+    before = len(msgs.threads)
+    watcher.check_once()
+
+    assert len(msgs.threads) == before  # no new thread spawned
+    events = [c for c in msgs.append_calls if c["kind"] == "event"]
+    assert len(events) == 1
+    assert events[0]["thread_id"] == chat.id  # event posted into the url thread
+    assert "merged" in events[0]["text"]
+    assert workitems.items["wi-5"].thread_ids == [chat.id]  # linked to the WorkItem
+
+
+def test_workitem_thread_wins_over_pr_url_thread():
+    # When the WorkItem already has its own canonical thread, that wins even if another
+    # thread also mentions the url — the item's events stay consolidated on its thread.
+    msgs = FakeMessageStore()
+    workitems = FakeWorkItemStore()
+    canonical = msgs.create_thread(subject="task-6", text="seed", now=NOW, task_slug="task-6")
+    workitems.items["wi-6"] = FakeWorkItem(id="wi-6", thread_ids=[canonical.id])
+    url = "https://github.com/org/repoF/pull/6"
+    other = msgs.create_thread(subject="chat", text="seed", now=NOW, task_slug=None)
+    msgs.append(other.id, "agent", f"see {url}", NOW, kind="note")
+    task = FakeTask(pr_urls={"repoF": url}, work_item_id="wi-6")
+    state = FakeStateManager({"task-6": task})
+
+    watcher = PrWatcher(msgs, workitems, state, lambda u: "merged", now_fn)
+    watcher.check_once()
+
+    events = [c for c in msgs.append_calls if c["kind"] == "event"]
+    assert len(events) == 1
+    assert events[0]["thread_id"] == canonical.id  # WorkItem's own thread, not the url thread
+
+
 def test_no_work_item_uses_existing_thread_by_task_slug():
     msgs = FakeMessageStore()
     workitems = FakeWorkItemStore()


### PR DESCRIPTION
## Summary

Fix: **PR merge/close events no longer spawn a new thread per task** — they reuse the existing thread that already carries the PR url (and link it to the WorkItem), consolidating events instead of cluttering the app with fresh threads. Reported via operator feedback ("pr merge events create a bunch of new threads … it should post the message to the existing WorkItems thread that has that pr url").

### Root cause
`pr_watcher._resolve_thread` posts a merge/close event to the task's WorkItem thread if it has one, else **creates a new thread**. Tasks spawned from the CLI don't get a dispatch thread (only GC-dispatched ones do), so their WorkItem has no thread and every PR event spawned a fresh one.

### Fix
`_resolve_thread` now takes the PR `url` and, before creating a new thread, reuses any existing thread whose messages reference that url — linking it to the WorkItem so later events for the same item consolidate there too. A new thread is created **only** when the url appears in no thread at all (unchanged behavior for that case). Resolution order:

1. the task's WorkItem's canonical thread, else
2. **(new)** any existing thread that already references the PR url, else
3. an existing thread scoped to the task_slug, else
4. create one (linking it to the WorkItem when present).

## Test plan
- `tests/core/test_pr_watcher.py` — **+2 tests**: `test_reuses_existing_thread_that_contains_pr_url` (WorkItem w/o thread + a thread carrying the url → event lands there, no new thread, thread linked) and `test_workitem_thread_wins_over_pr_url_thread` (canonical WorkItem thread still wins). **23 pass.**
- `mship test` (full suite) — no failures/regressions.

https://claude.ai/code/session_015ZPGS2VyABiXaBDKz9ts8v
