### PR TITLE
Fix Queue approvals not sticking. (serve) In the /verdict and /prose-verdict endpoints, after persisting a verdict, auto-transition the spec to approved when approval_blockers() is empty (last verdict clears the gate) — so approving the final chunk sticks across sessions; add a test. (GC) cardsFromSpec skips prose sections already approved and the criteria card once all criteria are approved (mirroring how it already skips answered questions) so approved chunks stop reappearing on ViewModel recreation; add a test.

### DIFF
--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -582,6 +582,11 @@ def create_app(
     @app.post("/specs/{spec_id}/approve")
     def post_approve(spec_id: str, body: ApproveBody):
         spec = _load_or_404(spec_id)
+        if spec.status == "approved":
+            # Idempotent: already approved (e.g. auto-approved when the last verdict cleared the
+            # gate). A client that still posts /approve as a belt-and-suspenders step gets a plain
+            # success, not a spurious approved->approved 409.
+            return build_review(spec)
         if not body.bypass_gate:
             blockers = approval_blockers(spec)
             if blockers:

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -512,6 +512,24 @@ def create_app(
         store.save(spec)
         return build_review(spec)
 
+    def _auto_approve_if_ready(spec):
+        """Auto-transition needs_review → approved the moment the last verdict/answer clears the
+        approval gate, so a review 'sticks' without a separate approve call. The client used to
+        detect the final chunk itself and POST /approve, but that intent was lost when its
+        in-memory state was recreated across sessions, leaving fully-reviewed specs stuck in
+        needs_review. No-op unless the spec is approvable AND the transition is legal (mirrors
+        POST /approve's own gate)."""
+        from mship.core.spec import InvalidTransition, validate_transition
+        from mship.core.spec_approve import approval_blockers
+        if spec.status != "needs_review" or approval_blockers(spec):
+            return
+        try:
+            validate_transition(spec.status, "approved")
+        except InvalidTransition:
+            return
+        spec.status = "approved"
+        spec.clarification_reason = None  # an approved spec carries no pending request-changes reason
+
     @app.post("/specs/{spec_id}/verdict")
     def post_verdict(spec_id: str, body: VerdictBody):
         spec = _load_or_404(spec_id)
@@ -519,6 +537,7 @@ def create_app(
             set_criterion_verdict(spec, body.criterion_id, body.verdict, body.comment)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        _auto_approve_if_ready(spec)
         return _save_and_review(spec)
 
     @app.post("/specs/{spec_id}/prose-verdict")
@@ -528,6 +547,7 @@ def create_app(
             set_prose_verdict(spec, body.section_id, body.verdict, body.comment)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        _auto_approve_if_ready(spec)
         return _save_and_review(spec)
 
     @app.post("/specs/{spec_id}/evidence")
@@ -553,6 +573,7 @@ def create_app(
             answer_question(spec, qid, body.answer)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        _auto_approve_if_ready(spec)
         return _save_and_review(spec)
 
     from mship.core.spec import InvalidTransition, validate_transition

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -184,6 +184,48 @@ def test_post_verdict_with_comment(tmp_path):
     assert SpecStore(tmp_path / "specs").find_by_id("dq").acceptance_criteria[0].comment == "fix"
 
 
+def test_answer_clearing_last_blocker_auto_approves(tmp_path):
+    # "dq" already has ac1 approved and no prose blockers; its only remaining blocker is the
+    # unanswered q1. Answering it clears the gate, so the spec auto-approves (and persists) —
+    # a fully-reviewed spec no longer sits stuck in needs_review.
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs/dq/questions/q1/answer", json={"answer": "yes"})
+    assert r.status_code == 200
+    assert r.json()["status"] == "approved"
+    assert SpecStore(tmp_path / "specs").find_by_id("dq").status == "approved"
+
+
+def test_verdict_clearing_last_blocker_auto_approves(tmp_path):
+    now = datetime(2026, 6, 14, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(
+        id="s2", title="s2", status="needs_review", created_at=now, updated_at=now, task_slug="s2",
+        body=render_body("p", "u", "a"),
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="unreviewed")],
+        open_questions=[],
+    ))
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs/s2/verdict", json={"criterion_id": "ac1", "verdict": "approved"})
+    assert r.status_code == 200
+    assert r.json()["status"] == "approved"                                      # sole blocker cleared
+    assert SpecStore(tmp_path / "specs").find_by_id("s2").status == "approved"
+
+
+def test_verdict_not_yet_clearing_blockers_stays_needs_review(tmp_path):
+    now = datetime(2026, 6, 14, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(
+        id="s3", title="s3", status="needs_review", created_at=now, updated_at=now, task_slug="s3",
+        body=render_body("p", "u", "a"),
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="unreviewed"),
+                             AcceptanceCriterion(id="ac2", text="y", verdict="unreviewed")],
+        open_questions=[],
+    ))
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs/s3/verdict", json={"criterion_id": "ac1", "verdict": "approved"})
+    assert r.status_code == 200
+    assert r.json()["status"] == "needs_review"                                  # ac2 still unreviewed
+
+
 def test_post_evidence_persists_and_validates(tmp_path):
     _seed_spec(tmp_path)   # spec "dq" with one AC "ac1"
     client = TestClient(_app(tmp_path))
@@ -230,10 +272,25 @@ def test_post_approve_gate_and_success(tmp_path):
     blocked = client.post("/specs/dq/approve", json={})
     assert blocked.status_code == 409          # q1 unanswered
     assert isinstance(blocked.json()["detail"], str)   # uniform string shape
-    client.post("/specs/dq/questions/q1/answer", json={"answer": "yes"})
-    ok = client.post("/specs/dq/approve", json={})
-    assert ok.status_code == 200 and ok.json()["status"] == "approved"
+    # clearing the last blocker (answering q1) auto-approves — no separate /approve needed
+    ans = client.post("/specs/dq/questions/q1/answer", json={"answer": "yes"})
+    assert ans.status_code == 200 and ans.json()["status"] == "approved"
     assert client.post("/specs/dq/approve", json={}).status_code == 409           # re-approve illegal
+
+
+def test_post_approve_succeeds_when_approvable_but_not_auto_approved(tmp_path):
+    # The explicit /approve still works for an approvable spec that never went through a verdict
+    # endpoint (so auto-approve didn't fire) — e.g. one seeded already-approvable.
+    now = datetime(2026, 6, 14, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(
+        id="ready", title="ready", status="needs_review", created_at=now, updated_at=now, task_slug="ready",
+        body=render_body("p", "u", "a"),
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
+        open_questions=[],
+    ))
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs/ready/approve", json={})
+    assert r.status_code == 200 and r.json()["status"] == "approved"
 
 
 def test_post_approve_bypass(tmp_path):

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -275,7 +275,9 @@ def test_post_approve_gate_and_success(tmp_path):
     # clearing the last blocker (answering q1) auto-approves — no separate /approve needed
     ans = client.post("/specs/dq/questions/q1/answer", json={"answer": "yes"})
     assert ans.status_code == 200 and ans.json()["status"] == "approved"
-    assert client.post("/specs/dq/approve", json={}).status_code == 409           # re-approve illegal
+    # a redundant /approve on the already-approved spec is idempotent (200), not a spurious 409
+    reapprove = client.post("/specs/dq/approve", json={})
+    assert reapprove.status_code == 200 and reapprove.json()["status"] == "approved"
 
 
 def test_post_approve_succeeds_when_approvable_but_not_auto_approved(tmp_path):


### PR DESCRIPTION
## Summary

Fix: **Queue approvals didn't "stick"** — approving a spec's chunks looked like it didn't save, and a fully-reviewed spec stayed in `needs_review`. Two complementary fixes (reported via operator testing 2026-07-14).

**serve (mothership):** the `/verdict`, `/prose-verdict`, and `/answer` endpoints now auto-transition a spec `needs_review → approved` the moment the last verdict/answer clears the approval gate (`approval_blockers()` empty). The client used to detect the "last chunk" and POST `/approve` itself, but that intent was lost when its in-memory state was recreated across sessions, leaving fully-reviewed specs stuck. Now the server owns the transition. Mirrors `POST /approve`'s own gate; a no-op unless the spec is approvable AND the transition is legal. Explicit `/approve` (and `bypass_gate`) still work.

**GC (ground-control):** `cardsFromSpec` now cards off the **saved** verdicts — it skips prose sections already `approved` and the criteria card once every criterion is `approved` (mirroring how it already skips answered questions). Approved chunks no longer reappear when the `QueueViewModel` is recreated (tab switch / app restart), so approvals visibly stick.

Together: approve a chunk → the verdict saves and, on the last one, the spec auto-approves server-side; the approved chunk stops re-carding client-side.

## Root cause

- The Queue rebuilt a card for every prose section + the criteria card **regardless of verdict**, hiding approved ones only in-memory (`resolvedKeys`) — which is lost on ViewModel recreation, so approved cards reappeared ("didn't stick").
- A spec only left `needs_review` when the **client** detected the final chunk and called `/approve`; that detection didn't survive across sessions, so a fully-reviewed spec could sit stuck.

## Test plan

- **mothership:** +3 serve tests (verdict clears last blocker → auto-approve; answer clears last blocker → auto-approve; a non-final verdict stays `needs_review`) + updated the approve-gate test for auto-approve + added an explicit-`/approve`-still-works test. Full suite passes.
- **ground-control:** +2 `cardsFromSpec` tests (approved prose skipped; criteria card skipped once all approved). **308 pass.**

## Deploy

The serve side needs the reinstall + restart to go live (`scripts/redeploy-serve.sh`); GC needs a fresh app build. The two fixes are independent, but both are needed for approvals to fully stick across sessions.

https://claude.ai/code/session_015ZPGS2VyABiXaBDKz9ts8v
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `fix-queue-approvals-not-sticking`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/46 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/347 | this PR |

⚠ Merge in order: ground-control → mothership