### PR TITLE
When mship finish opens a PR, post a 'PR opened: <url>' event into the task's WorkItem thread (creating/linking one if needed) so pr_watcher reuses that thread on merge/close instead of spawning a new one. Extract pr_watcher._resolve_thread's thread-resolution into a shared helper used by both. Add tests.

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1618,6 +1618,23 @@ def register(app: typer.Typer, get_container):
                     f"PR created for {pr_info['repo']}: {pr_info['url']}",
                 )
 
+        # Post the opened PR url(s) into the task's WorkItem/tracking thread so the pr_watcher
+        # reuses that thread on merge/close instead of spawning a new one (PR events had been
+        # cluttering the app with a thread per task). Best-effort: a mailbox hiccup must never
+        # fail an already-created PR.
+        try:
+            from datetime import datetime as _dt_ann, timezone as _tz_ann
+            from mship.core.message_store import MessageStore
+            from mship.core.pr_watcher import announce_prs_on_thread
+            from mship.core.workitem_store import WorkItemStore
+            _md = workspace_root / ".mothership"
+            announce_prs_on_thread(
+                MessageStore(_md / "messages"), WorkItemStore(_md / "workitems"),
+                t.slug, task, pr_list, _dt_ann.now(_tz_ann.utc),
+            )
+        except Exception as e:
+            output.warning(f"could not post the PR url to the task thread: {e}")
+
         # Lifecycle hooks (MOS-220): `task.finished` fires here, after the
         # PRs above are already created/pushed — an irreversible,
         # already-applied side effect. `required: true` is rejected for

--- a/src/mship/core/pr_watcher.py
+++ b/src/mship/core/pr_watcher.py
@@ -28,6 +28,63 @@ def _refs_pr(text: str, needle: str) -> bool:
     return re.search(re.escape(needle) + r"(?!\d)", text) is not None
 
 
+def resolve_task_thread(msgs, workitems, slug, task, url, now):
+    """Resolve the thread a PR event for `task`/`url` belongs to, strongly preferring an EXISTING
+    thread over a fresh one (PR events were cluttering the app with a thread per task). In order:
+
+      1. the task's WorkItem's first thread (its canonical thread), else
+      2. any existing thread that already references this PR `url` — link it to the WorkItem so
+         later events consolidate there too, else
+      3. an existing thread scoped to this task_slug, else
+      4. create one (linked to the WorkItem when present).
+
+    Only step 4 spawns a new thread. Returns (thread_id, work_item_or_None). Shared by the
+    pr_watcher (merge/close events) and `mship finish` ([announce_prs_on_thread], posting the PR
+    url at open time so there's always a thread to reuse)."""
+    work_item_id = getattr(task, "work_item_id", None)
+    wi = workitems.get(work_item_id) if work_item_id else None
+    if wi and wi.thread_ids:
+        return wi.thread_ids[0], wi
+
+    url_thread = next(
+        (t for t in msgs.list() if any(_refs_pr(m.text, url) for m in t.messages)),
+        None,
+    )
+    if url_thread is not None:
+        if wi is not None:
+            workitems.add_thread(wi.id, url_thread.id, now)
+        return url_thread.id, wi
+
+    existing = next((t for t in msgs.list() if t.task_slug == slug), None)
+    if existing is not None:
+        return existing.id, wi
+
+    # create_thread seeds a human message; the event itself is appended separately so it lands as
+    # an agent message, matching every other event/needs_you/decision message.
+    thread = msgs.create_thread(subject=slug, text=f"Tracking {slug}", now=now, task_slug=slug)
+    if wi is not None:
+        workitems.add_thread(wi.id, thread.id, now)
+    return thread.id, wi
+
+
+def announce_prs_on_thread(msgs, workitems, slug, task, pr_list, now):
+    """Post a one-time `PR opened: <url>…` event into the task's WorkItem/tracking thread (resolved
+    via [resolve_task_thread]) when `mship finish` opens PR(s), so the pr_watcher reuses that thread
+    on merge/close instead of spawning a new one. Idempotent for `--force` re-finish: skips when an
+    equivalent opened-event is already present. No-op when there are no urls."""
+    urls = list(dict.fromkeys(p["url"] for p in pr_list if p.get("url")))
+    if not urls:
+        return
+    tid, _wi = resolve_task_thread(msgs, workitems, slug, task, urls[0], now)
+    thread = msgs.get(tid)
+    if thread is not None and any(
+        m.kind == "event" and "PR opened:" in m.text and all(u in m.text for u in urls)
+        for m in thread.messages
+    ):
+        return
+    msgs.append(tid, "agent", "\U0001f500 PR opened: " + ", ".join(urls), now, kind="event")
+
+
 class PrWatcher:
     """Polls each task's `pr_urls` for a merge/close transition and posts a
     single agent `event` message to the task's mailbox thread the first time
@@ -207,49 +264,7 @@ class PrWatcher:
             )
 
     def _resolve_thread(self, slug: str, task: Any, url: str, now: datetime) -> tuple[str, Any]:
-        """Resolve the thread a PR merge/close event belongs to, strongly
-        preferring an EXISTING thread over spawning a new one (operator
-        feedback 2026-07-14: PR events were cluttering the app with a fresh
-        thread per task). In order:
-
-          1. the task's WorkItem's first thread (its canonical thread), else
-          2. any existing thread that already references this PR `url` — the
-             operator tracks the PR there (a dispatch/chat message), so the
-             merge/close event belongs with it; link it to the WorkItem so
-             later events for the same item consolidate there too, else
-          3. an existing thread scoped to this task_slug, else
-          4. create one (linking it back to the WorkItem when one exists).
-
-        Only step 4 spawns a new thread, and only when the PR url appears in no
-        thread at all. Returns (thread_id, work_item_or_None)."""
-        work_item_id = getattr(task, "work_item_id", None)
-        wi = self.workitems.get(work_item_id) if work_item_id else None
-        if wi and wi.thread_ids:
-            return wi.thread_ids[0], wi
-
-        url_thread = next(
-            (t for t in self.msgs.list()
-             if any(_refs_pr(m.text, url) for m in t.messages)),
-            None,
-        )
-        if url_thread is not None:
-            if wi is not None:
-                self.workitems.add_thread(wi.id, url_thread.id, now)
-            return url_thread.id, wi
-
-        existing = next(
-            (t for t in self.msgs.list() if t.task_slug == slug), None
-        )
-        if existing is not None:
-            return existing.id, wi
-
-        # create_thread seeds a human message — the event itself is appended
-        # separately (in _post_event, after the hook has been attempted) so
-        # it lands as an agent message, matching every other
-        # event/needs_you/decision message.
-        thread = self.msgs.create_thread(
-            subject=slug, text=f"PR watcher: tracking {slug}", now=now, task_slug=slug,
-        )
-        if wi is not None:
-            self.workitems.add_thread(wi.id, thread.id, now)
-        return thread.id, wi
+        """Resolve the thread this PR merge/close event belongs to — the shared
+        [resolve_task_thread] (WorkItem thread → url thread → task_slug thread → create),
+        also used by `mship finish` at PR-open time."""
+        return resolve_task_thread(self.msgs, self.workitems, slug, task, url, now)

--- a/src/mship/core/pr_watcher.py
+++ b/src/mship/core/pr_watcher.py
@@ -57,6 +57,8 @@ def resolve_task_thread(msgs, workitems, slug, task, url, now):
 
     existing = next((t for t in msgs.list() if t.task_slug == slug), None)
     if existing is not None:
+        if wi is not None:
+            workitems.add_thread(wi.id, existing.id, now)  # link so later WorkItem events reuse it
         return existing.id, wi
 
     # create_thread seeds a human message; the event itself is appended separately so it lands as

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -676,3 +676,64 @@ def test_pr_hook_refires_after_crash_before_dedup_marker_recorded():
     watcher.check_once()  # re-check after the "crash": must refire, not skip
     assert len(shell.calls) == 2
     assert len(msgs.append_calls) == 1  # now durably recorded, exactly once
+
+
+def test_announce_prs_on_thread_posts_to_workitem_thread():
+    from mship.core.pr_watcher import announce_prs_on_thread
+    msgs = FakeMessageStore()
+    workitems = FakeWorkItemStore()
+    thread = msgs.create_thread(subject="task-1", text="seed", now=NOW, task_slug="task-1")
+    workitems.items["wi-1"] = FakeWorkItem(id="wi-1", thread_ids=[thread.id])
+    pr_list = [{"repo": "r1", "url": "https://github.com/org/r1/pull/1"},
+               {"repo": "r2", "url": "https://github.com/org/r2/pull/2"}]
+    task = FakeTask(pr_urls={}, work_item_id="wi-1")
+
+    announce_prs_on_thread(msgs, workitems, "task-1", task, pr_list, NOW)
+
+    events = [c for c in msgs.append_calls if c["kind"] == "event"]
+    assert len(events) == 1
+    assert events[0]["thread_id"] == thread.id
+    assert "PR opened:" in events[0]["text"]
+    assert "https://github.com/org/r1/pull/1" in events[0]["text"]
+    assert "https://github.com/org/r2/pull/2" in events[0]["text"]
+    # idempotent: a second announce (e.g. --force re-finish) does not double-post
+    announce_prs_on_thread(msgs, workitems, "task-1", task, pr_list, NOW)
+    assert len([c for c in msgs.append_calls if c["kind"] == "event"]) == 1
+
+
+def test_announce_creates_and_links_thread_when_workitem_has_none():
+    from mship.core.pr_watcher import announce_prs_on_thread
+    msgs = FakeMessageStore()
+    workitems = FakeWorkItemStore()
+    workitems.items["wi-9"] = FakeWorkItem(id="wi-9", thread_ids=[])
+    task = FakeTask(pr_urls={}, work_item_id="wi-9")
+
+    announce_prs_on_thread(msgs, workitems, "task-9", task,
+                           [{"repo": "r", "url": "https://github.com/org/r/pull/7"}], NOW)
+
+    events = [c for c in msgs.append_calls if c["kind"] == "event"]
+    assert len(events) == 1
+    new_tid = events[0]["thread_id"]
+    assert workitems.items["wi-9"].thread_ids == [new_tid]  # linked, so later events reuse it
+
+
+def test_finish_announce_then_watcher_merge_share_one_thread():
+    # The end-to-end win: finish announces the PR url (creates+links the thread), and the later
+    # merge event lands in that SAME thread — no second thread spawned per task.
+    from mship.core.pr_watcher import announce_prs_on_thread
+    msgs = FakeMessageStore()
+    workitems = FakeWorkItemStore()
+    workitems.items["wi-5"] = FakeWorkItem(id="wi-5", thread_ids=[])
+    url = "https://github.com/org/r/pull/12"
+    task = FakeTask(pr_urls={"r": url}, work_item_id="wi-5")
+    state = FakeStateManager({"task-5": task})
+
+    announce_prs_on_thread(msgs, workitems, "task-5", task, [{"repo": "r", "url": url}], NOW)
+    threads_after_open = len(msgs.threads)
+
+    PrWatcher(msgs, workitems, state, lambda u: "merged", now_fn).check_once()
+
+    assert len(msgs.threads) == threads_after_open  # merge spawned no new thread
+    events = [c for c in msgs.append_calls if c["kind"] == "event"]
+    assert len({e["thread_id"] for e in events}) == 1  # opened + merged on one thread
+    assert any("opened" in e["text"] for e in events) and any("merged" in e["text"] for e in events)

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -737,3 +737,19 @@ def test_finish_announce_then_watcher_merge_share_one_thread():
     events = [c for c in msgs.append_calls if c["kind"] == "event"]
     assert len({e["thread_id"] for e in events}) == 1  # opened + merged on one thread
     assert any("opened" in e["text"] for e in events) and any("merged" in e["text"] for e in events)
+
+
+def test_resolve_links_task_slug_thread_to_workitem():
+    # A WorkItem with no thread + an existing task_slug thread (no url match): resolve must reuse
+    # AND link it, so later WorkItem events don't fall through and spawn a divergent thread.
+    from mship.core.pr_watcher import resolve_task_thread
+    msgs = FakeMessageStore()
+    workitems = FakeWorkItemStore()
+    workitems.items["wi-8"] = FakeWorkItem(id="wi-8", thread_ids=[])
+    thread = msgs.create_thread(subject="task-8", text="seed", now=NOW, task_slug="task-8")
+    task = FakeTask(pr_urls={}, work_item_id="wi-8")
+
+    tid, _wi = resolve_task_thread(msgs, workitems, "task-8", task, "https://github.com/o/r/pull/8", NOW)
+
+    assert tid == thread.id
+    assert workitems.items["wi-8"].thread_ids == [thread.id]  # linked


### PR DESCRIPTION
## Summary

Fix: PR merge/close events spawned **a new thread per CLI-spawned task** (a WorkItem with no thread + the full PR url in no thread → the pr_watcher fell through to creating one). `mship finish` now posts the opened PR url into the task's WorkItem thread at open time, so the pr_watcher **reuses** that thread on merge/close. Closes the remaining gap after #346 (which reused a thread only if the full url was already in one).

- **Extracted** the pr_watcher's thread resolution into a shared `resolve_task_thread(msgs, workitems, slug, task, url, now)` (WorkItem thread → thread referencing the url → task_slug thread → create+link). `PrWatcher._resolve_thread` now delegates to it.
- **`announce_prs_on_thread(...)`**: `mship finish`, right after opening PR(s), posts a one-time `🔀 PR opened: <url>…` event into that thread. Idempotent for `--force` re-finish; **best-effort** — wrapped so a mailbox hiccup never fails an already-created PR.
- Net: the url is in a thread from open time, so a task's open + merge + close events all consolidate onto its one WorkItem thread — no more thread-per-task clutter.

## Test plan

- `tests/core/test_pr_watcher.py` — **+3 tests**: announce posts to the WorkItem thread + is idempotent; creates+links a thread when the WorkItem has none; **end-to-end** — finish-announce then watcher-merge share ONE thread (no second thread spawned). **27 pass.**
- Full mothership + ground-control suites pass (the `_resolve_thread` refactor + the neutral seed-text change didn't regress anything).

https://claude.ai/code/session_015ZPGS2VyABiXaBDKz9ts8v
