### PR TITLE
In announce_prs_on_thread (core/pr_watcher.py), post the 'PR opened' message with kind=note instead of kind=event, so mship finish doesn't trip Thread.awaiting_agent_event and nag the agent on every finish — it's informational and still carries the url for pr_watcher reuse. Update/add a test asserting the announced message is kind=note.

### DIFF
--- a/src/mship/core/pr_watcher.py
+++ b/src/mship/core/pr_watcher.py
@@ -70,21 +70,23 @@ def resolve_task_thread(msgs, workitems, slug, task, url, now):
 
 
 def announce_prs_on_thread(msgs, workitems, slug, task, pr_list, now):
-    """Post a one-time `PR opened: <url>…` event into the task's WorkItem/tracking thread (resolved
+    """Post a one-time `PR opened: <url>…` NOTE into the task's WorkItem/tracking thread (resolved
     via [resolve_task_thread]) when `mship finish` opens PR(s), so the pr_watcher reuses that thread
-    on merge/close instead of spawning a new one. Idempotent for `--force` re-finish: skips when an
-    equivalent opened-event is already present. No-op when there are no urls."""
+    on merge/close instead of spawning a new one. Posted as kind='note' (informational) — NOT
+    kind='event' — so it does not trip `Thread.awaiting_agent_event` and nag the agent on every
+    finish; the url still carries for reuse. Idempotent for `--force` re-finish: skips when an
+    equivalent opened-note is already present. No-op when there are no urls."""
     urls = list(dict.fromkeys(p["url"] for p in pr_list if p.get("url")))
     if not urls:
         return
     tid, _wi = resolve_task_thread(msgs, workitems, slug, task, urls[0], now)
     thread = msgs.get(tid)
     if thread is not None and any(
-        m.kind == "event" and "PR opened:" in m.text and all(u in m.text for u in urls)
+        m.kind == "note" and "PR opened:" in m.text and all(u in m.text for u in urls)
         for m in thread.messages
     ):
         return
-    msgs.append(tid, "agent", "\U0001f500 PR opened: " + ", ".join(urls), now, kind="event")
+    msgs.append(tid, "agent", "\U0001f500 PR opened: " + ", ".join(urls), now, kind="note")
 
 
 class PrWatcher:

--- a/src/mship/core/pr_watcher.py
+++ b/src/mship/core/pr_watcher.py
@@ -82,7 +82,9 @@ def announce_prs_on_thread(msgs, workitems, slug, task, pr_list, now):
     tid, _wi = resolve_task_thread(msgs, workitems, slug, task, urls[0], now)
     thread = msgs.get(tid)
     if thread is not None and any(
-        m.kind == "note" and "PR opened:" in m.text and all(u in m.text for u in urls)
+        # match both kinds so a --force re-finish also dedupes against an OLD kind='event'
+        # opened-marker left by a pre-note finish (event→note transition).
+        m.kind in ("note", "event") and "PR opened:" in m.text and all(u in m.text for u in urls)
         for m in thread.messages
     ):
         return

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -756,3 +756,20 @@ def test_resolve_links_task_slug_thread_to_workitem():
 
     assert tid == thread.id
     assert workitems.items["wi-8"].thread_ids == [thread.id]  # linked
+
+
+def test_announce_dedupes_against_legacy_event_opened_marker():
+    # Transition safety: a thread already carrying the OLD kind='event' "PR opened" marker (from a
+    # pre-note finish) must not get a duplicate note on a --force re-finish.
+    from mship.core.pr_watcher import announce_prs_on_thread
+    msgs = FakeMessageStore()
+    workitems = FakeWorkItemStore()
+    thread = msgs.create_thread(subject="task-1", text="seed", now=NOW, task_slug="task-1")
+    workitems.items["wi-1"] = FakeWorkItem(id="wi-1", thread_ids=[thread.id])
+    url = "https://github.com/org/r/pull/3"
+    msgs.append(thread.id, "agent", f"\U0001f500 PR opened: {url}", NOW, kind="event")  # legacy marker
+    task = FakeTask(pr_urls={}, work_item_id="wi-1")
+
+    announce_prs_on_thread(msgs, workitems, "task-1", task, [{"repo": "r", "url": url}], NOW)
+
+    assert not any(c["kind"] == "note" and "PR opened:" in c["text"] for c in msgs.append_calls)

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -690,15 +690,17 @@ def test_announce_prs_on_thread_posts_to_workitem_thread():
 
     announce_prs_on_thread(msgs, workitems, "task-1", task, pr_list, NOW)
 
-    events = [c for c in msgs.append_calls if c["kind"] == "event"]
-    assert len(events) == 1
-    assert events[0]["thread_id"] == thread.id
-    assert "PR opened:" in events[0]["text"]
-    assert "https://github.com/org/r1/pull/1" in events[0]["text"]
-    assert "https://github.com/org/r2/pull/2" in events[0]["text"]
+    notes = [c for c in msgs.append_calls if c["kind"] == "note"]
+    assert len(notes) == 1
+    assert notes[0]["thread_id"] == thread.id
+    assert "PR opened:" in notes[0]["text"]
+    assert "https://github.com/org/r1/pull/1" in notes[0]["text"]
+    assert "https://github.com/org/r2/pull/2" in notes[0]["text"]
+    # informational note, NOT an event — must not trip awaiting_agent_event / nag the agent
+    assert not any(c["kind"] == "event" for c in msgs.append_calls)
     # idempotent: a second announce (e.g. --force re-finish) does not double-post
     announce_prs_on_thread(msgs, workitems, "task-1", task, pr_list, NOW)
-    assert len([c for c in msgs.append_calls if c["kind"] == "event"]) == 1
+    assert len([c for c in msgs.append_calls if c["kind"] == "note"]) == 1
 
 
 def test_announce_creates_and_links_thread_when_workitem_has_none():
@@ -711,9 +713,9 @@ def test_announce_creates_and_links_thread_when_workitem_has_none():
     announce_prs_on_thread(msgs, workitems, "task-9", task,
                            [{"repo": "r", "url": "https://github.com/org/r/pull/7"}], NOW)
 
-    events = [c for c in msgs.append_calls if c["kind"] == "event"]
-    assert len(events) == 1
-    new_tid = events[0]["thread_id"]
+    notes = [c for c in msgs.append_calls if c["kind"] == "note"]
+    assert len(notes) == 1
+    new_tid = notes[0]["thread_id"]
     assert workitems.items["wi-9"].thread_ids == [new_tid]  # linked, so later events reuse it
 
 
@@ -734,9 +736,10 @@ def test_finish_announce_then_watcher_merge_share_one_thread():
     PrWatcher(msgs, workitems, state, lambda u: "merged", now_fn).check_once()
 
     assert len(msgs.threads) == threads_after_open  # merge spawned no new thread
-    events = [c for c in msgs.append_calls if c["kind"] == "event"]
-    assert len({e["thread_id"] for e in events}) == 1  # opened + merged on one thread
-    assert any("opened" in e["text"] for e in events) and any("merged" in e["text"] for e in events)
+    # opened (informational note) + merged (agent event) both landed on ONE thread
+    assert len({c["thread_id"] for c in msgs.append_calls}) == 1
+    assert any(c["kind"] == "note" and "opened" in c["text"] for c in msgs.append_calls)
+    assert any(c["kind"] == "event" and "merged" in c["text"] for c in msgs.append_calls)
 
 
 def test_resolve_links_task_slug_thread_to_workitem():


### PR DESCRIPTION
## Summary

Follow-up to #348. `announce_prs_on_thread` (the `mship finish` "🔀 PR opened: <url>" post into the WorkItem thread) used `kind="event"`, which trips `Thread.awaiting_agent_event` — so **every finish nagged the agent** as if there were a signal to act on, when it's purely informational. Post it as **`kind="note"`** instead: it still lands in the thread and carries the url for `pr_watcher` thread-reuse, but no longer nags. The idempotency dedup check matches on `kind="note"` accordingly.

## Test plan

- `tests/core/test_pr_watcher.py` — updated the 3 announce tests to assert `kind="note"` (and that no `event` is posted by the announce); the end-to-end test now checks opened(note) + merged(event) share one thread. **28 pass.** Full suite green.
