### PR TITLE
Implement the read indicator per approved spec read-indicator-agent-read-cursor-in: add Thread.agent_seen_at (agent read cursor, symmetric to seen_at, never moves backward); stamp it when mship _drain / inbox wait surface human messages to the agent; serve exposes it on the thread; GC shows a Read indicator (Sent→Read→Replied).

### DIFF
--- a/src/mship/cli/internal.py
+++ b/src/mship/cli/internal.py
@@ -441,6 +441,13 @@ def register(app: typer.Typer, get_container):
             # human-reply threads — mirrors `mship inbox wait`'s predicate.
             awaiting = [t for t in store.list()
                         if t.awaiting_reply or t.awaiting_agent_event]
+            # The agent is now seeing these human messages at the turn boundary — stamp the agent
+            # read cursor so Ground Control shows them as Read (#345). Best-effort; stamps only the
+            # awaiting_reply ones. Done before the empty-check so it runs whenever there's a human
+            # message to consume (a no-op on an empty list anyway).
+            from datetime import datetime as _dt, timezone as _tz
+            from mship.core.message_wait import stamp_agent_seen
+            stamp_agent_seen(store, awaiting, _dt.now(_tz.utc))
             if not awaiting:
                 raise typer.Exit(code=0)
             reason = _format_drain_reason(awaiting)

--- a/src/mship/cli/message.py
+++ b/src/mship/cli/message.py
@@ -88,6 +88,10 @@ def register(parent: typer.Typer, get_container) -> None:
             )
         finally:
             lease.release(pid)
+        # The agent is now seeing these human messages — stamp the agent read cursor (#345). Only
+        # awaiting_reply threads; best-effort so a stamp can't fail the wait.
+        from mship.core.message_wait import stamp_agent_seen
+        stamp_agent_seen(store, res.threads, datetime.now(timezone.utc))
         out = {
             "threads": [
                 {"id": t.id, "subject": t.subject,

--- a/src/mship/core/message.py
+++ b/src/mship/core/message.py
@@ -48,6 +48,10 @@ class Thread(BaseModel):
     spec_id: str | None = None
     # Operator read cursor: the operator has seen messages up to this time.
     seen_at: datetime | None = None
+    # Agent read cursor: the agent has consumed (seen) human messages up to this time.
+    # Symmetric to `seen_at`; drives Ground Control's "Read" indicator (#345). A human message
+    # reads as Read iff `agent_seen_at is not None and agent_seen_at >= message.created_at`.
+    agent_seen_at: datetime | None = None
     messages: list[Message] = []
 
     @computed_field  # serialized into model_dump()/JSON (a plain @property is not)

--- a/src/mship/core/message_store.py
+++ b/src/mship/core/message_store.py
@@ -122,3 +122,16 @@ class MessageStore:
                 thread.seen_at = seen_at
                 self.save(thread)
             return thread
+
+    def mark_agent_seen(self, thread_id: str, seen_at: datetime) -> Thread:
+        """Advance the AGENT read cursor (monotonic — never regresses), stamped when the agent
+        consumes a human message (`mship inbox wait` / `_drain` surface it). Mirrors `mark_seen`;
+        does not bump updated_at (consuming is not a content change and must not reorder threads)."""
+        with _locked(self._lock_path(thread_id), fcntl.LOCK_EX):
+            thread = self.get(thread_id)
+            if thread is None:
+                raise KeyError(thread_id)
+            if thread.agent_seen_at is None or seen_at > thread.agent_seen_at:
+                thread.agent_seen_at = seen_at
+                self.save(thread)
+            return thread

--- a/src/mship/core/message_wait.py
+++ b/src/mship/core/message_wait.py
@@ -23,6 +23,20 @@ def changed_since(threads, since: datetime):
     return changed, cursor
 
 
+def stamp_agent_seen(store, threads, now: datetime) -> None:
+    """Advance the AGENT read cursor to `now` on every surfaced thread whose latest message is human
+    (`awaiting_reply`) — the agent is now SEEING it, which is the "Read" signal (#345). Shared by
+    `mship inbox wait` and `_drain`, the two places that surface human messages to the agent. Only
+    awaiting_reply threads (not `awaiting_agent_event`-only ones). Best-effort per thread — a stamp
+    failure (e.g. a thread deleted mid-flight) must never propagate to the caller."""
+    for t in threads:
+        if getattr(t, "awaiting_reply", False):
+            try:
+                store.mark_agent_seen(t.id, now)
+            except Exception:
+                pass
+
+
 @dataclass(frozen=True)
 class WaitResult:
     threads: list

--- a/src/mship/core/message_wait.py
+++ b/src/mship/core/message_wait.py
@@ -24,15 +24,24 @@ def changed_since(threads, since: datetime):
 
 
 def stamp_agent_seen(store, threads, now: datetime) -> None:
-    """Advance the AGENT read cursor to `now` on every surfaced thread whose latest message is human
+    """Advance the AGENT read cursor on every surfaced thread whose latest message is human
     (`awaiting_reply`) — the agent is now SEEING it, which is the "Read" signal (#345). Shared by
-    `mship inbox wait` and `_drain`, the two places that surface human messages to the agent. Only
-    awaiting_reply threads (not `awaiting_agent_event`-only ones). Best-effort per thread — a stamp
-    failure (e.g. a thread deleted mid-flight) must never propagate to the caller."""
+    `mship inbox wait` and `_drain`, the two places that surface human messages to the agent.
+
+    Stamps to the created_at of the latest message in THIS snapshot — the message the agent actually
+    saw — NOT a wall-clock `now`. A human message appended after the snapshot but before this stamp
+    would otherwise be marked Read even though this wait/drain never surfaced it (its created_at could
+    fall before `now`). `now` is only a fallback for the shouldn't-happen empty-messages case.
+
+    Only awaiting_reply threads (not `awaiting_agent_event`-only ones); `mark_agent_seen` is monotonic
+    so a later consume advances it. Best-effort per thread — a stamp failure (e.g. a thread deleted
+    mid-flight) must never propagate to the caller."""
     for t in threads:
         if getattr(t, "awaiting_reply", False):
+            msgs = getattr(t, "messages", None)
+            up_to = msgs[-1].created_at if msgs else now
             try:
-                store.mark_agent_seen(t.id, now)
+                store.mark_agent_seen(t.id, up_to)
             except Exception:
                 pass
 

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -821,6 +821,7 @@ def create_app(
                 "needs_you": t.needs_you,
                 "needs_decision": t.needs_decision,
                 "unseen": t.unseen,
+                "agent_seen_at": t.agent_seen_at.isoformat() if t.agent_seen_at else None,
                 "last_message": (t.messages[-1].text[:120] if t.messages else ""),
                 "message_count": len(t.messages),
             }

--- a/tests/core/test_message_store.py
+++ b/tests/core/test_message_store.py
@@ -141,6 +141,32 @@ def test_mark_seen_unknown_thread_raises(tmp_path):
         s.mark_seen("nope", datetime(2026, 6, 30, tzinfo=timezone.utc))
 
 
+def test_mark_agent_seen_advances_cursor(tmp_path):
+    from datetime import timedelta
+    base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    s = _store(tmp_path)
+    t = s.create_thread(subject="x", text="hi", now=base)
+    assert s.get(t.id).agent_seen_at is None   # default: agent hasn't consumed anything yet
+    s.mark_agent_seen(t.id, base + timedelta(minutes=2))
+    assert s.get(t.id).agent_seen_at == base + timedelta(minutes=2)
+
+
+def test_mark_agent_seen_is_monotonic(tmp_path):
+    from datetime import timedelta
+    base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    s = _store(tmp_path)
+    t = s.create_thread(subject="x", text="hi", now=base)
+    s.mark_agent_seen(t.id, base + timedelta(minutes=5))
+    s.mark_agent_seen(t.id, base + timedelta(minutes=1))  # older — must not regress
+    assert s.get(t.id).agent_seen_at == base + timedelta(minutes=5)
+
+
+def test_mark_agent_seen_unknown_thread_raises(tmp_path):
+    s = _store(tmp_path)
+    with pytest.raises(KeyError):
+        s.mark_agent_seen("nope", datetime(2026, 6, 30, tzinfo=timezone.utc))
+
+
 def test_append_decision_roundtrips(tmp_path):
     from mship.core.message import DecisionPayload
     s = _store(tmp_path)

--- a/tests/core/test_message_wait.py
+++ b/tests/core/test_message_wait.py
@@ -88,10 +88,29 @@ def test_stamp_agent_seen_marks_only_awaiting_reply_threads():
 
     now = T0 + timedelta(minutes=1)
     s = FakeStore()
-    human = _thread("h", T0, role="human")   # latest is human → awaiting_reply
+    human = _thread("h", T0, role="human")   # latest is human → awaiting_reply, message at T0
     agent = _thread("a", T0, role="agent")   # latest is agent → not awaiting_reply
     stamp_agent_seen(s, [human, agent], now)
-    assert s.marked == [("h", now)]          # only the human-latest thread is stamped
+    assert s.marked == [("h", T0)]           # only the human thread, stamped to its message time
+
+
+def test_stamp_agent_seen_uses_snapshot_message_time_not_now():
+    # Stamp the latest message the agent actually SAW (the snapshot), not a wall clock — so a human
+    # message that arrives after the snapshot (with a later created_at) is not marked Read early.
+    from mship.core.message_wait import stamp_agent_seen
+
+    class FakeStore:
+        def __init__(self):
+            self.marked = []
+
+        def mark_agent_seen(self, tid, up_to):
+            self.marked.append((tid, up_to))
+
+    s = FakeStore()
+    human = _thread("h", T0, role="human")       # message at T0
+    much_later = T0 + timedelta(hours=1)
+    stamp_agent_seen(s, [human], much_later)
+    assert s.marked == [("h", T0)]               # T0 (message time), NOT much_later
 
 
 def test_stamp_agent_seen_swallows_store_errors():

--- a/tests/core/test_message_wait.py
+++ b/tests/core/test_message_wait.py
@@ -74,3 +74,31 @@ def test_wait_predicate_filters_hits_but_cursor_still_advances():
     assert res.timed_out is True            # agent message is not a hit
     assert res.threads == []
     assert res.cursor == T0 + timedelta(seconds=1)   # cursor advanced past it
+
+
+def test_stamp_agent_seen_marks_only_awaiting_reply_threads():
+    from mship.core.message_wait import stamp_agent_seen
+
+    class FakeStore:
+        def __init__(self):
+            self.marked = []
+
+        def mark_agent_seen(self, tid, now):
+            self.marked.append((tid, now))
+
+    now = T0 + timedelta(minutes=1)
+    s = FakeStore()
+    human = _thread("h", T0, role="human")   # latest is human → awaiting_reply
+    agent = _thread("a", T0, role="agent")   # latest is agent → not awaiting_reply
+    stamp_agent_seen(s, [human, agent], now)
+    assert s.marked == [("h", now)]          # only the human-latest thread is stamped
+
+
+def test_stamp_agent_seen_swallows_store_errors():
+    from mship.core.message_wait import stamp_agent_seen
+
+    class BoomStore:
+        def mark_agent_seen(self, tid, now):
+            raise KeyError(tid)   # e.g. thread deleted mid-flight
+
+    stamp_agent_seen(BoomStore(), [_thread("h", T0, role="human")], T0)  # must not raise

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -68,3 +68,16 @@ def test_wait_invalid_since_returns_422(tmp_path: Path):
     client, _ = _client(tmp_path)
     r = client.get("/threads", params={"wait": 1, "since": "notadate", "timeout": 0.1})
     assert r.status_code == 422
+
+
+def test_agent_seen_at_exposed_on_list_and_detail(tmp_path: Path):
+    # #345: the agent read cursor must be visible to Ground Control on both the thread list
+    # (custom summary) and the thread detail (model dump), null when unset.
+    client, store = _client(tmp_path)
+    now = datetime.now(timezone.utc)
+    t = store.create_thread("s", "hi", now)
+    assert client.get("/threads").json()[0]["agent_seen_at"] is None
+    assert client.get(f"/threads/{t.id}").json()["agent_seen_at"] is None
+    store.mark_agent_seen(t.id, now)
+    assert client.get("/threads").json()[0]["agent_seen_at"] is not None
+    assert client.get(f"/threads/{t.id}").json()["agent_seen_at"] is not None


### PR DESCRIPTION
## Summary

Read indicator (#345) — implements the approved spec `read-indicator-agent-read-cursor-in`. When an agent **consumes** a human's inbox message, mark it Read and surface it in Ground Control, so a message reads **Sent → Read → Replied** (not just awaiting-reply ↔ replied).

**serve (mothership):**
- `Thread.agent_seen_at` — a symmetric AGENT read cursor (mirrors the operator's `seen_at`/`unseen`).
- `MessageStore.mark_agent_seen` — monotonic (never regresses), exactly like `mark_seen`.
- `stamp_agent_seen(store, threads, now)` — a shared helper that advances the cursor on every surfaced `awaiting_reply` (human-latest) thread; wired into **`mship inbox wait`** and **`_drain`** (the two places the agent consumes human messages), best-effort so a stamp can't fail the wait/drain.
- Serve exposes `agent_seen_at` on the thread list (`_summaries`) + detail (the `Thread` model dump).

**GC (ground-control):**
- `agentSeenAt` on the `Thread` / `ThreadSummary` DTOs.
- `messageReadState(message, thread)` — a pure helper: **REPLIED** if an agent message follows, else **READ** if the cursor is at/after the message, else **SENT**. Timestamps are parsed to instants (not string-compared — a whole-second cursor vs a microsecond message time would fool a lexicographic compare). Rendered as a small `Sent / Read / Replied` label under the operator's **latest** outbound message (standard messaging convention).

## Test plan

- **mothership:** +8 tests — `mark_agent_seen` (advance / monotonic / unknown-thread), `stamp_agent_seen` (only awaiting_reply / swallows errors), serve list+detail exposure. Full suite **2607 pass**.
- **ground-control:** +5 `messageReadState` tests incl. the parsed-not-string-compared case. `compileDebugKotlin` + `testDebugUnitTest` + `assembleDebug` green.
- All 6 acceptance criteria carry evidence.

## Deploy

serve side needs the reinstall + restart (`scripts/redeploy-serve.sh`); GC needs a fresh build.

Closes #345.

https://claude.ai/code/session_015ZPGS2VyABiXaBDKz9ts8v

Closes #345
---

## Acceptance criteria

- [x] `ac1` Thread gains an agent read cursor agent_seen_at (datetime | None), symmetric to the operator's seen_at; a helper advances it to the latest consumed human-message time and never moves it backward. — commit:e221f3f
- [x] `ac2` mship _drain and mship inbox wait stamp agent_seen_at when they surface pending human messages to the agent, under the existing per-thread lock (idempotent; no double-write on overlapping waits). — commit:e221f3f
- [x] `ac3` Serve exposes agent_seen_at on the thread in the endpoints Ground Control reads (thread list + thread detail). — commit:e221f3f
- [x] `ac4` The mship client / Ground Control deserializes agent_seen_at and shows a 'Read' indicator on a human message once agent_seen_at is at or past that message's created_at. — commit:27812dc
- [x] `ac5` The indicator composes with the existing state so a human message reads Sent → Read → Replied; it does not regress the operator-side seen_at / unseen behavior. — commit:27812dc
- [x] `ac6` Backward-compatible: a thread persisted without agent_seen_at deserializes with it null and shows no false 'Read'; a human message posted after the last consume reads un-Read until the next consume. — commit:27812dc
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `implement-the-read-indicator-per`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/48 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/351 | this PR |

⚠ Merge in order: ground-control → mothership