### PR TITLE
On Queue v2 review cards (prose/criteria/questions for a needs_review spec), show the spec title (name), the WorkItem kind (feature/bug/chore), and the affected repos. serve: expose the resolved WorkItem kind on the spec detail (get_spec: resolve spec.work_item_id -> WorkItem.kind as work_item_kind). GC: carry title/kind/affectedRepos on the QueueV2Card + render a compact metadata line on the CardFace.

### DIFF
--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -365,7 +365,12 @@ def create_app(
         spec = store.find_by_id(spec_id)
         if spec is None:
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
-        return spec.model_dump(mode="json")
+        data = spec.model_dump(mode="json")
+        # Resolve the linked WorkItem's kind (feature/bug/chore) so the Queue review cards can show
+        # it alongside the spec title + affected_repos. Null when the spec isn't linked to an item.
+        wi = workitems.get(spec.work_item_id) if spec.work_item_id else None
+        data["work_item_kind"] = wi.kind if wi is not None else None
+        return data
 
     @app.get("/specs/{spec_id}/review")
     def get_review(spec_id: str):

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -367,9 +367,16 @@ def create_app(
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
         data = spec.model_dump(mode="json")
         # Resolve the linked WorkItem's kind (feature/bug/chore) so the Queue review cards can show
-        # it alongside the spec title + affected_repos. Null when the spec isn't linked to an item.
-        wi = workitems.get(spec.work_item_id) if spec.work_item_id else None
-        data["work_item_kind"] = wi.kind if wi is not None else None
+        # it alongside the spec title + affected_repos. Best-effort: the kind is decorative, so a
+        # missing OR corrupt/unreadable WorkItem must never 500 the spec detail — any lookup failure
+        # just falls back to null (the card still renders, minus the kind).
+        data["work_item_kind"] = None
+        if spec.work_item_id:
+            try:
+                wi = workitems.get(spec.work_item_id)
+                data["work_item_kind"] = wi.kind if wi is not None else None
+            except Exception:
+                data["work_item_kind"] = None
         return data
 
     @app.get("/specs/{spec_id}/review")

--- a/tests/core/test_serve_items.py
+++ b/tests/core/test_serve_items.py
@@ -336,3 +336,24 @@ def test_get_spec_includes_resolved_work_item_kind(tmp_path):
     client = _app(tmp_path)
     assert client.get("/specs/linked").json()["work_item_kind"] == "feature"
     assert client.get("/specs/unlinked").json()["work_item_kind"] is None
+
+
+def test_get_spec_survives_corrupt_linked_work_item(tmp_path, monkeypatch):
+    # A corrupt/unreadable linked WorkItem must not 500 the spec detail — the kind is decorative,
+    # so a lookup failure falls back to work_item_kind=None and the spec still loads.
+    from mship.core.spec import Spec
+    from mship.core.spec_store import SpecStore
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="Feat", kind="feature", workspace="testws", now=_now())
+    store = SpecStore(tmp_path / "specs")
+    store.save(Spec(id="linked", title="Linked", status="needs_review",
+                    created_at=_now(), updated_at=_now(), work_item_id=wi.id))
+
+    def _boom(self, item_id):
+        raise ValueError("corrupt workitem file")
+
+    monkeypatch.setattr(WorkItemStore, "get", _boom)
+    client = _app(tmp_path)
+    resp = client.get("/specs/linked")
+    assert resp.status_code == 200
+    assert resp.json()["work_item_kind"] is None

--- a/tests/core/test_serve_items.py
+++ b/tests/core/test_serve_items.py
@@ -320,3 +320,19 @@ def test_post_item_phase_hook_does_not_hold_item_msg_lock(tmp_path):
     assert phase_result["status"] == 200
     assert phase_result["elapsed"] >= 1.0
     assert items.get(slow_item.id).phase_override == "done"
+
+
+def test_get_spec_includes_resolved_work_item_kind(tmp_path):
+    # The Queue review cards show the WorkItem kind; get_spec resolves it from the linked item.
+    from mship.core.spec import Spec
+    from mship.core.spec_store import SpecStore
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="Feat", kind="feature", workspace="testws", now=_now())
+    store = SpecStore(tmp_path / "specs")
+    store.save(Spec(id="linked", title="Linked", status="needs_review",
+                    created_at=_now(), updated_at=_now(), work_item_id=wi.id))
+    store.save(Spec(id="unlinked", title="Unlinked", status="needs_review",
+                    created_at=_now(), updated_at=_now()))
+    client = _app(tmp_path)
+    assert client.get("/specs/linked").json()["work_item_kind"] == "feature"
+    assert client.get("/specs/unlinked").json()["work_item_kind"] is None


### PR DESCRIPTION
## Queue approval cards show WorkItem name, kind, and affected repos

When reviewing a spec from the Queue, the approver could see the workspace and the
chunk being reviewed, but not *what* they were approving — the spec/WorkItem title,
its kind, or which repos the change touches. This adds that context line to every
spec-review card.

### serve
- `get_spec` now resolves the linked WorkItem's `kind` and returns it as
  `work_item_kind` on the spec payload (null when the spec has no linked WorkItem).

### Ground Control
- `SpecRecord` DTO gains `work_item_kind`.
- New `SpecCardMeta(title, workItemKind, affectedRepos)` carried on the Prose,
  Criteria, and Questions review cards (populated from the spec in `cardsFromSpec`).
- `CardFace` renders a metadata block on spec-review cards: the spec title in
  prominent weight, then a muted `kind · repo, repo` line. Blank fields are omitted,
  so a spec with no linked WorkItem just shows its title.

### Tests
- serve: `test_get_spec_includes_resolved_work_item_kind` (linked → kind, unlinked → null).
- GC: `spec_review_cards_carry_title_kind_and_affected_repos_metadata`.
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `on-queue-v2-review-cards`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/50 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/352 | this PR |

⚠ Merge in order: ground-control → mothership