### PR TITLE
Group Ground Control threads by WorkItem (see approved spec group-ground-control-threads-by-workitem): serve stamps work_item_id on thread summaries; GC groups messages surface by WorkItem

### DIFF
--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -17,6 +17,7 @@ from mship.core.gh_app import GhAppError, mint_installation_token, resolve_insta
 from mship.core.pr import PRManager
 from mship.core.pr_watcher import PrWatcher
 from mship.core.spec import SpecDraft
+from mship.core.view.thread_links import index_thread_work_items
 from mship.core.workitem import Phase
 from mship.util.shell import ShellRunner
 
@@ -833,7 +834,6 @@ def create_app(
         # resolution). Best-effort — a corrupt WorkItem must never 500 the list, so the store
         # scan is guarded and index_thread_work_items degrades to None, matching get_spec's
         # work_item_kind stamping.
-        from mship.core.view.thread_links import index_thread_work_items
         try:
             all_items = list(workitems.list(include_archived=True))
         except Exception:

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -825,17 +825,34 @@ def create_app(
         return _thread_payload(t)
 
     def _summaries(threads):
+        threads = list(threads)
+        # Stamp each summary with the single WorkItem that owns the thread (direct thread_ids
+        # membership, else indirect via spec_id/task_slug) so Ground Control can group the
+        # messages surface by work item. Invariant: a thread resolves to AT MOST ONE item.
+        # include_archived=True: link ownership survives archival (mirrors _thread_payload's
+        # resolution). Best-effort — a corrupt WorkItem must never 500 the list, so the store
+        # scan is guarded and index_thread_work_items degrades to None, matching get_spec's
+        # work_item_kind stamping.
+        from mship.core.view.thread_links import index_thread_work_items
+        try:
+            all_items = list(workitems.list(include_archived=True))
+        except Exception:
+            all_items = []
+        wi_by_thread = index_thread_work_items(threads, all_items)
         return [
             {
                 "id": t.id, "subject": t.subject,
                 "updated_at": t.updated_at.isoformat(),
                 "awaiting_reply": t.awaiting_reply,
+                # unhandled agent `event` (e.g. a PR merge) — feeds GC's group attention rollup.
+                "awaiting_agent_event": t.awaiting_agent_event,
                 "needs_you": t.needs_you,
                 "needs_decision": t.needs_decision,
                 "unseen": t.unseen,
                 "agent_seen_at": t.agent_seen_at.isoformat() if t.agent_seen_at else None,
                 "last_message": (t.messages[-1].text[:120] if t.messages else ""),
                 "message_count": len(t.messages),
+                "work_item_id": wi_by_thread.get(t.id),
             }
             for t in threads
         ]

--- a/src/mship/core/view/thread_links.py
+++ b/src/mship/core/view/thread_links.py
@@ -4,6 +4,29 @@ from __future__ import annotations
 from typing import Iterable
 
 
+def _build_link_index(items: Iterable):
+    """Build the three reverse lookups (thread_id / spec_id / task_slug -> work_item_id)
+    once, so a whole thread list can be resolved without re-scanning `items` per thread."""
+    items = list(items)
+    by_thread = {tid: w.id for w in items for tid in w.thread_ids}
+    by_spec = {w.spec_id: w.id for w in items if w.spec_id}
+    by_task = {slug: w.id for w in items for slug in w.task_slugs}
+    return by_thread, by_spec, by_task
+
+
+def _resolve_from_index(thread_id: str, spec_id: str | None, task_slug: str | None, index) -> str | None:
+    """Resolve one thread against a prebuilt index. Precedence: explicit thread_ids link >
+    spec_id > task_slug. Direct membership is exclusive, so this yields AT MOST ONE item."""
+    by_thread, by_spec, by_task = index
+    if thread_id in by_thread:
+        return by_thread[thread_id]
+    if spec_id and spec_id in by_spec:
+        return by_spec[spec_id]
+    if task_slug and task_slug in by_task:
+        return by_task[task_slug]
+    return None
+
+
 def resolve_thread_work_item(
     thread_id: str,
     spec_id: str | None,
@@ -14,17 +37,30 @@ def resolve_thread_work_item(
 
     Precedence: explicit thread_ids link > spec_id > task_slug.
     `items` is any iterable of objects with .id/.spec_id/.task_slugs/.thread_ids.
+    A thread resolves to AT MOST ONE WorkItem (direct membership is exclusive; the
+    indirect fallback resolves to exactly one item deterministically).
     """
-    items = list(items)
-    by_thread = {tid: w.id for w in items for tid in w.thread_ids}
-    if thread_id in by_thread:
-        return by_thread[thread_id]
-    if spec_id:
-        by_spec = {w.spec_id: w.id for w in items if w.spec_id}
-        if spec_id in by_spec:
-            return by_spec[spec_id]
-    if task_slug:
-        by_task = {slug: w.id for w in items for slug in w.task_slugs}
-        if task_slug in by_task:
-            return by_task[task_slug]
-    return None
+    return _resolve_from_index(thread_id, spec_id, task_slug, _build_link_index(items))
+
+
+def index_thread_work_items(threads: Iterable, items: Iterable) -> dict[str, str | None]:
+    """Best-effort batch of [resolve_thread_work_item] for a whole thread list: returns
+    {thread.id: work_item_id or None}, building the reverse link index ONCE (not once per
+    thread) for the GET /threads summary endpoint.
+
+    Guarded so a single corrupt/unreadable WorkItem can never 500 the list — any failure
+    falls back to None (the thread still lists, just without its work_item_id), mirroring
+    get_spec's best-effort work_item_kind stamping. A thread never resolves to two items:
+    direct thread_ids membership wins over the indirect spec_id/task_slug fallback.
+    """
+    try:
+        index = _build_link_index(items)
+    except Exception:
+        index = ({}, {}, {})
+    out: dict[str, str | None] = {}
+    for t in threads:
+        try:
+            out[t.id] = _resolve_from_index(t.id, t.spec_id, t.task_slug, index)
+        except Exception:
+            out[t.id] = None
+    return out

--- a/src/mship/core/view/thread_links.py
+++ b/src/mship/core/view/thread_links.py
@@ -7,10 +7,21 @@ from typing import Iterable
 def _build_link_index(items: Iterable):
     """Build the three reverse lookups (thread_id / spec_id / task_slug -> work_item_id)
     once, so a whole thread list can be resolved without re-scanning `items` per thread."""
-    items = list(items)
-    by_thread = {tid: w.id for w in items for tid in w.thread_ids}
-    by_spec = {w.spec_id: w.id for w in items if w.spec_id}
-    by_task = {slug: w.id for w in items for slug in w.task_slugs}
+    # Per-item guard: a single corrupt/unreadable WorkItem degrades ONLY its own threads (they fall
+    # back to None), not every thread — a coarse whole-index try/except would blank healthy items too.
+    by_thread: dict = {}
+    by_spec: dict = {}
+    by_task: dict = {}
+    for w in items:
+        try:
+            for tid in w.thread_ids:
+                by_thread[tid] = w.id
+            if w.spec_id:
+                by_spec[w.spec_id] = w.id
+            for slug in w.task_slugs:
+                by_task[slug] = w.id
+        except Exception:
+            continue
     return by_thread, by_spec, by_task
 
 

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from mship.core.serve import create_app
 from mship.core.message_store import MessageStore
 from mship.core.state import StateManager
+from mship.core.workitem_store import WorkItemStore
 
 
 def _client(tmp_path: Path, auth_token=None) -> tuple[TestClient, MessageStore]:
@@ -68,6 +69,73 @@ def test_wait_invalid_since_returns_422(tmp_path: Path):
     client, _ = _client(tmp_path)
     r = client.get("/threads", params={"wait": 1, "since": "notadate", "timeout": 0.1})
     assert r.status_code == 422
+
+
+def _workitems(tmp_path: Path) -> WorkItemStore:
+    return WorkItemStore(tmp_path / ".mothership" / "workitems")
+
+
+def test_summary_stamps_direct_work_item_id(tmp_path: Path):
+    # A thread in an item's thread_ids resolves to that item on the list payload.
+    client, store = _client(tmp_path)
+    now = datetime.now(timezone.utc)
+    t = store.create_thread("s", "hi", now)
+    items = _workitems(tmp_path)
+    wi = items.create("Feature X", "feature", "test-ws", now)
+    items.add_thread(wi.id, t.id, now)
+    assert client.get("/threads").json()[0]["work_item_id"] == wi.id
+
+
+def test_summary_stamps_indirect_via_task_slug(tmp_path: Path):
+    # A thread linked only by task_slug (no direct thread_ids membership) still resolves.
+    client, store = _client(tmp_path)
+    now = datetime.now(timezone.utc)
+    store.create_thread("s", "hi", now, task_slug="my-task")
+    items = _workitems(tmp_path)
+    wi = items.create("Feature X", "feature", "test-ws", now)
+    items.add_task(wi.id, "my-task", now)
+    assert client.get("/threads").json()[0]["work_item_id"] == wi.id
+
+
+def test_summary_stamps_indirect_via_spec_id(tmp_path: Path):
+    client, store = _client(tmp_path)
+    now = datetime.now(timezone.utc)
+    t = store.create_thread("s", "hi", now)
+    store.link_spec(t.id, "spec-42", now)
+    items = _workitems(tmp_path)
+    wi = items.create("Feature X", "feature", "test-ws", now)
+    items.link_spec(wi.id, "spec-42", now)
+    assert client.get("/threads").json()[0]["work_item_id"] == wi.id
+
+
+def test_summary_work_item_id_null_when_unowned(tmp_path: Path):
+    client, store = _client(tmp_path)
+    store.create_thread("s", "hi", datetime.now(timezone.utc))
+    assert client.get("/threads").json()[0]["work_item_id"] is None
+
+
+def test_summary_resolves_to_single_item_when_also_indirectly_linkable(tmp_path: Path):
+    # Direct thread_ids membership is exclusive and outranks the indirect fallback, so the
+    # stamped work_item_id is never ambiguous (the merge-watcher routes to the same item).
+    client, store = _client(tmp_path)
+    now = datetime.now(timezone.utc)
+    t = store.create_thread("s", "hi", now, task_slug="my-task")
+    items = _workitems(tmp_path)
+    owner = items.create("Owner", "feature", "test-ws", now)
+    items.add_thread(owner.id, t.id, now)
+    other = items.create("Other", "chore", "test-ws", now)
+    items.add_task(other.id, "my-task", now)
+    assert client.get("/threads").json()[0]["work_item_id"] == owner.id
+
+
+def test_summary_exposes_awaiting_agent_event(tmp_path: Path):
+    # The group attention rollup needs the unhandled-agent-event signal on the list payload.
+    client, store = _client(tmp_path)
+    now = datetime.now(timezone.utc)
+    t = store.create_thread("s", "hi", now)
+    assert client.get("/threads").json()[0]["awaiting_agent_event"] is False
+    store.append(t.id, "agent", "PR merged", now, kind="event")
+    assert client.get("/threads").json()[0]["awaiting_agent_event"] is True
 
 
 def test_agent_seen_at_exposed_on_list_and_detail(tmp_path: Path):

--- a/tests/core/view/test_thread_links.py
+++ b/tests/core/view/test_thread_links.py
@@ -68,3 +68,20 @@ def test_index_guards_corrupt_item_to_none():
 
     # A corrupt WorkItem must never blow up the whole list — resolution degrades to None.
     assert index_thread_work_items([_Thread("t1")], [_Bad()]) == {"t1": None}
+
+
+def test_corrupt_item_degrades_only_its_own_threads():
+    """One corrupt item alongside healthy ones degrades only its own threads — healthy items still
+    resolve (the per-item guard is surgical, not a whole-index blank)."""
+    class _Bad:
+        id = "wi-bad"
+        spec_id = None
+        task_slugs = []
+
+        @property
+        def thread_ids(self):
+            raise RuntimeError("corrupt work item")
+
+    good = _Item("wi-good", thread_ids=["t-good"])
+    out = index_thread_work_items([_Thread("t-good"), _Thread("t-orphan")], [good, _Bad()])
+    assert out == {"t-good": "wi-good", "t-orphan": None}

--- a/tests/core/view/test_thread_links.py
+++ b/tests/core/view/test_thread_links.py
@@ -1,4 +1,4 @@
-from mship.core.view.thread_links import resolve_thread_work_item
+from mship.core.view.thread_links import index_thread_work_items, resolve_thread_work_item
 
 
 class _Item:
@@ -7,6 +7,13 @@ class _Item:
         self.spec_id = spec_id
         self.task_slugs = task_slugs or []
         self.thread_ids = thread_ids or []
+
+
+class _Thread:
+    def __init__(self, id, spec_id=None, task_slug=None):
+        self.id = id
+        self.spec_id = spec_id
+        self.task_slug = task_slug
 
 
 def test_prefers_explicit_thread_link():
@@ -22,3 +29,42 @@ def test_falls_back_to_spec_then_task():
 
 def test_none_when_no_relation():
     assert resolve_thread_work_item("t9", None, None, [_Item("wi-b", spec_id="s1")]) is None
+
+
+def test_index_batches_direct_and_indirect_resolution():
+    items = [
+        _Item("wi-a", thread_ids=["t1"]),
+        _Item("wi-b", spec_id="s1"),
+        _Item("wi-c", task_slugs=["k1"]),
+    ]
+    threads = [
+        _Thread("t1", spec_id="s1"),   # direct membership wins over its spec_id
+        _Thread("t2", spec_id="s1"),   # indirect via spec_id
+        _Thread("t3", task_slug="k1"),  # indirect via task_slug
+        _Thread("t4"),                  # unowned -> None
+    ]
+    assert index_thread_work_items(threads, items) == {
+        "t1": "wi-a", "t2": "wi-b", "t3": "wi-c", "t4": None,
+    }
+
+
+def test_index_never_yields_two_items_for_one_thread():
+    # Direct membership is exclusive and outranks the indirect fallback, so a thread that
+    # is ALSO indirectly linkable still resolves to exactly one (its direct) item.
+    items = [_Item("wi-a", thread_ids=["t1"]), _Item("wi-b", spec_id="s1", task_slugs=["k1"])]
+    out = index_thread_work_items([_Thread("t1", spec_id="s1", task_slug="k1")], items)
+    assert out == {"t1": "wi-a"}
+
+
+def test_index_guards_corrupt_item_to_none():
+    class _Bad:
+        id = "wi-bad"
+        spec_id = None
+        task_slugs = []
+
+        @property
+        def thread_ids(self):
+            raise RuntimeError("corrupt work item")
+
+    # A corrupt WorkItem must never blow up the whole list — resolution degrades to None.
+    assert index_thread_work_items([_Thread("t1")], [_Bad()]) == {"t1": None}


### PR DESCRIPTION
## Group Ground Control threads by WorkItem

The messages surface was a flat thread list; now it's grouped by WorkItem so all the conversation
for one piece of work sits together, with an "Other" bucket for unowned threads.

**Spec:** `group-ground-control-threads-by-workitem` (approved). serve + GC — needs a serve deploy
after merge.

### serve
- New `core/view/thread_links.py`: resolves a single `work_item_id` per thread — precedence
  **thread_ids link > spec_id > task_slug** — so a thread belongs to AT MOST ONE WorkItem (the
  invariant you flagged). `index_thread_work_items` builds the reverse index once per list call and
  is guarded so a corrupt WorkItem can't 500 the thread list (falls back to null), mirroring
  `get_spec`.
- `core/serve.py` `_summaries` stamps `work_item_id` + `awaiting_agent_event` on each thread summary.

### Ground Control
- DTO: `workItemId` + `awaitingAgentEvent` on `ThreadSummary`.
- New `ui/messages/ThreadGrouping.kt`: pure `groupThreadsByWorkItem(threads, items)` → one group per
  WorkItem (header = title + kind), threads newest-first within a group, null → a single "Other"
  group, groups ordered by newest thread, attention rolled up (awaiting-reply OR unhandled agent
  event). `MessagesScreen` renders the grouped sections; tapping a thread still opens the existing
  conversation unchanged.

### Note (intentional deviation)
AC4's attention rollup needs the "unhandled agent event" signal, which wasn't on the thread summary,
so I added `awaiting_agent_event` to the serve summary + the DTO (additive, backwards-compatible via
`ignoreUnknownKeys`) and folded it into the rollup. Exclusive membership is enforced at the resolver
(single-valued); a link-site move-guard on `WorkItemStore.add_thread` remains a separate audit item
(the only live linker already links unlinked threads only).

### Tests
- serve: `test_thread_links.py` (batch resolve, exclusivity, corruption fallback);
  `test_serve_threads_wait.py` (direct / task_slug / spec_id / null / single-item / agent-event on the payload).
- GC: `ThreadGroupingTest` (grouping, ordering, Other bucket, attention rollup); `ThreadDtosTest`.

---

## Acceptance criteria

- [ ] `ac1` Each thread summary in the payload GC consumes carries a resolved work_item_id: the id of the WorkItem that owns it (direct thread_ids membership, else indirect via task_slug/spec_id), or null when no item owns it. — _no evidence_
- [ ] `ac2` A thread belongs to at most one WorkItem: direct thread_ids membership is exclusive (no thread is in two items' thread_ids — enforced at the link site), and the indirect fallback resolves to exactly one item, so the stamped work_item_id is never ambiguous; a thread the merge-watcher routed to an item resolves to that same item. — _no evidence_
- [ ] `ac3` The Ground Control messages surface renders one group per WorkItem, labeled with the item's title + kind, its threads nested and ordered most-recent-first; threads with a null work_item_id render together in a single 'Other' group. — _no evidence_
- [ ] `ac4` A WorkItem group surfaces an attention indicator when any of its threads is awaiting the operator (awaiting_reply) or carries an unhandled agent event, so an item needing attention is visible without expanding it. — _no evidence_
- [ ] `ac5` Tapping a thread opens the existing conversation view unchanged; the read indicator, reply, and decision behaviors are unaffected. — _no evidence_
- [ ] `ac6` Groups order by their most-recently-updated thread so an item with fresh activity floats to the top; the 'Other' group sorts among the item groups by the same rule. — _no evidence_
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `group-ground-control-threads-by-workitem`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/54 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/354 | this PR |

⚠ Merge in order: ground-control → mothership