### PR TITLE
Thread exclusive-membership write guard: WorkItemStore.add_thread only dedups within the same item; add a guard so a thread already in another WorkItem's thread_ids is refused (raise a typed error), enforcing the single-owner invariant the thread->WorkItem resolver assumes. Make the migrate caller defensive.

### DIFF
--- a/src/mship/core/workitem_migrate.py
+++ b/src/mship/core/workitem_migrate.py
@@ -6,7 +6,7 @@ from mship.core.message_store import MessageStore
 from mship.core.spec_store import SpecStore
 from mship.core.state import StateManager
 from mship.core.workitem_gate import APPROVED_STATUSES
-from mship.core.workitem_store import WorkItemStore
+from mship.core.workitem_store import ThreadAlreadyLinkedError, WorkItemStore
 
 
 def wrap_existing(items: WorkItemStore, specs: SpecStore, state: StateManager,
@@ -83,6 +83,12 @@ def wrap_existing(items: WorkItemStore, specs: SpecStore, state: StateManager,
         target = (item_by_spec.get(thread.spec_id) if thread.spec_id else None) \
             or (item_by_task.get(thread.task_slug) if thread.task_slug else None)
         if target:
-            items.add_thread(target, thread.id, now=now)
+            try:
+                items.add_thread(target, thread.id, now=now)
+            except ThreadAlreadyLinkedError:
+                # Legacy data already links this thread to another item; keep the existing owner
+                # rather than crash the (idempotent) migration. The write guard enforces single
+                # ownership from here on.
+                continue
 
     return created

--- a/src/mship/core/workitem_store.py
+++ b/src/mship/core/workitem_store.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from mship.core.state import StateManager
 from mship.core.workitem import ExternalLink, Kind, Phase, WorkItem
 
+__all__ = ["WorkItemStore", "ThreadAlreadyLinkedError"]
+
 
 def _new_id(now: datetime) -> str:
     return f"wi-{now:%Y%m%d%H%M%S}-{uuid.uuid4().hex[:8]}"
@@ -31,6 +33,20 @@ def _locked(lock_path: Path, mode: int):
             yield
         finally:
             fcntl.flock(lf, fcntl.LOCK_UN)
+
+
+class ThreadAlreadyLinkedError(Exception):
+    """Raised when linking a thread to a WorkItem that another WorkItem already owns.
+
+    Threads are single-owner: the thread->WorkItem resolver (view/thread_links) assumes a thread
+    appears in at most one item's `thread_ids`, so the write side refuses dual membership rather than
+    silently creating an ambiguous link.
+    """
+
+    def __init__(self, thread_id: str, owner_id: str) -> None:
+        self.thread_id = thread_id
+        self.owner_id = owner_id
+        super().__init__(f"thread {thread_id!r} is already linked to work item {owner_id!r}")
 
 
 class WorkItemStore:
@@ -127,13 +143,27 @@ class WorkItemStore:
                     s.tasks[_slug].work_item_id = _wid
             state.mutate(_set)
 
+    def _thread_owner(self, thread_id: str, exclude: str) -> str | None:
+        """Id of a WorkItem (other than `exclude`) whose thread_ids contains `thread_id`, else None.
+        Scans archived items too — an archived item still holds its threads in stored data, so it
+        still counts as the thread's owner for the single-owner invariant."""
+        for w in self.list(include_archived=True):
+            if w.id != exclude and thread_id in w.thread_ids:
+                return w.id
+        return None
+
     def add_thread(self, item_id: str, thread_id: str, now: datetime | None = None) -> None:
         with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
             item = self.get(item_id)
             if item is None:
                 raise KeyError(item_id)
             if thread_id in item.thread_ids:
-                return
+                return  # already ours — idempotent no-op
+            # Exclusive membership: a thread belongs to at most one WorkItem (the resolver assumes a
+            # single owner). If another item already holds it, refuse rather than create dual membership.
+            owner = self._thread_owner(thread_id, exclude=item_id)
+            if owner is not None:
+                raise ThreadAlreadyLinkedError(thread_id, owner)
             item.thread_ids.append(thread_id)
             if now is not None:
                 item.updated_at = now

--- a/src/mship/core/workitem_store.py
+++ b/src/mship/core/workitem_store.py
@@ -152,22 +152,34 @@ class WorkItemStore:
                 return w.id
         return None
 
+    def _thread_link_lock_path(self) -> Path:
+        """Store-wide lock serializing all `add_thread` calls. The per-item locks let writers to
+        DIFFERENT items run in parallel, so the cross-item ownership scan + append would otherwise
+        race (two concurrent adds of the same thread to different items could both see "no owner"
+        and both save → dual membership). Held around the scan+append so the exclusivity check is
+        atomic. Starts with '.', so `list()`'s `*.json` glob never reads it."""
+        return self._dir / ".thread-link.lock"
+
     def add_thread(self, item_id: str, thread_id: str, now: datetime | None = None) -> None:
-        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
-            item = self.get(item_id)
-            if item is None:
-                raise KeyError(item_id)
-            if thread_id in item.thread_ids:
-                return  # already ours — idempotent no-op
-            # Exclusive membership: a thread belongs to at most one WorkItem (the resolver assumes a
-            # single owner). If another item already holds it, refuse rather than create dual membership.
-            owner = self._thread_owner(thread_id, exclude=item_id)
-            if owner is not None:
-                raise ThreadAlreadyLinkedError(thread_id, owner)
-            item.thread_ids.append(thread_id)
-            if now is not None:
-                item.updated_at = now
-            self.save(item)
+        # Outer store-wide lock makes the ownership scan + append atomic ACROSS items; inner per-item
+        # lock keeps this item's read-modify-write atomic against other same-item writers. Ordering is
+        # always store-lock → item-lock (other methods take only the item lock), so no deadlock cycle.
+        with _locked(self._thread_link_lock_path(), fcntl.LOCK_EX):
+            with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
+                item = self.get(item_id)
+                if item is None:
+                    raise KeyError(item_id)
+                if thread_id in item.thread_ids:
+                    return  # already ours — idempotent no-op
+                # Exclusive membership: a thread belongs to at most one WorkItem (the resolver assumes
+                # a single owner). If another item holds it, refuse rather than create dual membership.
+                owner = self._thread_owner(thread_id, exclude=item_id)
+                if owner is not None:
+                    raise ThreadAlreadyLinkedError(thread_id, owner)
+                item.thread_ids.append(thread_id)
+                if now is not None:
+                    item.updated_at = now
+                self.save(item)
 
     def add_external_link(self, item_id: str, link: ExternalLink, now: datetime | None = None) -> None:
         with _locked(self._lock_path(item_id), fcntl.LOCK_EX):

--- a/tests/core/test_store_concurrency.py
+++ b/tests/core/test_store_concurrency.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from mship.core.message_store import MessageStore
-from mship.core.workitem_store import WorkItemStore
+from mship.core.workitem_store import ThreadAlreadyLinkedError, WorkItemStore
 
 _BASE = datetime(2026, 7, 12, 12, 0, tzinfo=timezone.utc)
 
@@ -137,3 +137,37 @@ def test_concurrent_add_thread_to_same_item_do_not_lose_updates(tmp_path: Path):
     missing = expected - set(got.thread_ids)
     assert not missing, f"lost {len(missing)} added thread ids: {sorted(missing)}"
     assert len(got.thread_ids) == workers * rounds
+
+
+# Cross-item exclusivity under contention: N processes each try to link the SAME thread to a
+# DIFFERENT item at once. The store-wide thread-link lock must make the ownership check atomic, so
+# exactly one wins and the rest raise ThreadAlreadyLinkedError — never dual membership. (Without the
+# store-wide lock the per-item locks let multiple pass the owner scan and both save.)
+def _claim_shared_thread_worker(workitems_dir_str: str, item_id: str, thread_id: str) -> None:
+    store = WorkItemStore(Path(workitems_dir_str))
+    try:
+        store.add_thread(item_id, thread_id)
+    except ThreadAlreadyLinkedError:
+        pass  # a concurrent worker won the race first; exclusive membership held
+
+
+def test_concurrent_add_same_thread_to_different_items_stays_exclusive(tmp_path: Path):
+    workitems_dir = tmp_path / ".mothership" / "workitems"
+    store = WorkItemStore(workitems_dir)
+    items = [store.create(title=f"i{w}", kind="feature", workspace="ws", now=_BASE) for w in range(8)]
+
+    procs = [
+        multiprocessing.Process(
+            target=_claim_shared_thread_worker,
+            args=(str(workitems_dir), it.id, "shared-thread"),
+        )
+        for it in items
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+        assert p.exitcode == 0, f"worker crashed (exitcode={p.exitcode})"
+
+    owners = [it.id for it in items if "shared-thread" in store.get(it.id).thread_ids]
+    assert len(owners) == 1, f"thread landed in {len(owners)} items, expected exactly 1: {owners}"

--- a/tests/core/test_workitem_store.py
+++ b/tests/core/test_workitem_store.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from mship.core.workitem_store import WorkItemStore
+from mship.core.workitem_store import ThreadAlreadyLinkedError, WorkItemStore
 
 
 def _now():
@@ -109,6 +109,34 @@ def test_archive_sets_flag_and_persists(tmp_path):
     got = fresh.get(wi.id)
     assert got.archived is True
     assert got.updated_at == datetime(2026, 6, 30, 13, 0, tzinfo=timezone.utc)
+
+
+def test_add_thread_refuses_thread_owned_by_another_item(tmp_path):
+    # Exclusive membership: a thread lives in at most one WorkItem's thread_ids. Adding a thread that
+    # another item already owns must raise (not silently create the dual link the resolver can't handle).
+    store = WorkItemStore(tmp_path / "workitems")
+    a = store.create(title="a", kind="feature", workspace="ws", now=_now())
+    b = store.create(title="b", kind="feature", workspace="ws", now=_now())
+    store.add_thread(a.id, "thread-x", now=_now())
+    with pytest.raises(ThreadAlreadyLinkedError) as exc:
+        store.add_thread(b.id, "thread-x", now=_now())
+    assert exc.value.owner_id == a.id
+    assert exc.value.thread_id == "thread-x"
+    # The rejected write left b untouched.
+    assert store.get(b.id).thread_ids == []
+
+
+def test_add_thread_refuses_when_owner_is_archived(tmp_path):
+    # An archived item still holds its threads, so it still counts as the owner — a thread can't be
+    # re-homed to a new item just because its current owner was archived.
+    store = WorkItemStore(tmp_path / "workitems")
+    a = store.create(title="a", kind="feature", workspace="ws", now=_now())
+    b = store.create(title="b", kind="feature", workspace="ws", now=_now())
+    store.add_thread(a.id, "thread-x", now=_now())
+    store.archive(a.id, now=_now())
+    with pytest.raises(ThreadAlreadyLinkedError) as exc:
+        store.add_thread(b.id, "thread-x", now=_now())
+    assert exc.value.owner_id == a.id
 
 
 def test_unarchive_clears_flag(tmp_path):


### PR DESCRIPTION
## Summary

Hardens the thread→WorkItem link at the **write** side. `WorkItemStore.add_thread` previously only deduped within the *same* item, so nothing stopped a thread from being appended to a second WorkItem's `thread_ids` — a state the resolver (`view/thread_links`) can't represent, since it assumes each thread has a single owner.

- New `ThreadAlreadyLinkedError` (carries `thread_id` + `owner_id`).
- `add_thread` now scans for an existing owner (`_thread_owner`, including archived items) and raises rather than create dual membership. Same-item re-adds stay an idempotent no-op.
- The migrate caller (`workitem_migrate`) catches the error and skips, so a legacy re-run over already-dual data can't crash the (idempotent) migration — the guard just enforces single ownership going forward.
- The live serve caller (dispatch handoff) always passes a freshly-created thread, so it never trips the guard.

Closes the thread-grouping audit item (the resolver returns one owner; this makes the data match that invariant by construction).

## Test plan

New `tests/core/test_workitem_store.py` cases:
- `test_add_thread_refuses_thread_owned_by_another_item` — raises `ThreadAlreadyLinkedError` with the right `owner_id`/`thread_id`; the rejected write leaves the target untouched.
- `test_add_thread_refuses_when_owner_is_archived` — an archived owner still blocks (covers the `include_archived=True` scan).
- Same-item idempotency already covered by `test_redundant_add_thread_does_not_bump_updated_at`.

`mship test` — mothership pass (full pytest suite green).

Chore (no spec / plan gate). Serve-side — needs a `redeploy-serve.sh` after merge (I'll handle it).
