### PR TITLE
finish's test-evidence 'stale' warning fires on the recommended orchestrated flow whenever any commit lands after the last mship test (e.g. the orchestrator's final review-fix commit), training people to ignore the signal. Per issue #258 direction 1: distinguish 'tests recorded on an earlier commit of THIS branch' (weak advisory, re-run mship test to refresh) from 'tests never run' (real gap) in format_missing_summary's warning text, so stale reads as the soft, actionable advisory it is.

### DIFF
--- a/src/mship/core/test_evidence.py
+++ b/src/mship/core/test_evidence.py
@@ -156,6 +156,12 @@ def format_missing_summary(
     """Human-readable warning lines for non-passed repos, grouped by status.
 
     Returns an empty list when every repo has passing, non-stale evidence.
+
+    The three concerns carry different weight, so the text distinguishes them (#258):
+    `missing`/`failing` are real gaps, but `stale` only means the recorded run predates a
+    later commit on the SAME branch — the common orchestrated-flow case where the final
+    review-fix commit lands after the last `mship test`. Phrasing it as a soft, actionable
+    advisory (not "stale") keeps the happy path from eroding the evidence signal.
     """
     missing = [r for r, e in evidence.items() if e.status == "missing"]
     stale = [r for r, e in evidence.items() if e.status == "stale"]
@@ -165,7 +171,8 @@ def format_missing_summary(
         lines.append(f"Tests not run in: {', '.join(sorted(missing))}")
     if stale:
         lines.append(
-            f"Tests stale (branch has new commits) in: {', '.join(sorted(stale))}"
+            "Tests passed on an earlier commit of this branch (re-run `mship test` to "
+            f"refresh, or finish as-is if the new commits are trivial) in: {', '.join(sorted(stale))}"
         )
     if failing:
         lines.append(f"Tests failing in: {', '.join(sorted(failing))}")

--- a/tests/core/test_test_evidence.py
+++ b/tests/core/test_test_evidence.py
@@ -190,6 +190,26 @@ def test_evidence_stale_check_gracefully_skipped_when_no_shell(tmp_path: Path):
     assert ev["a"].status == "passed"
 
 
+def test_format_missing_summary_stale_reads_as_soft_advisory():
+    # #258: a stale repo (tests ran on an EARLIER commit of the same branch) must read as a soft,
+    # actionable advisory — clearly distinct from a real "not run" gap — so the common orchestrated
+    # happy path (final review-fix commit after the last `mship test`) stops eroding the signal.
+    from mship.core.test_evidence import RepoEvidence, format_missing_summary
+    ev = {
+        "svc": RepoEvidence(status="stale", source="test_results", at=datetime.now(timezone.utc)),
+        "web": RepoEvidence(status="missing", source="none", at=None),
+    }
+    lines = format_missing_summary(ev)
+    stale_line = next(l for l in lines if "svc" in l)
+    missing_line = next(l for l in lines if "web" in l)
+    # Stale is framed as earlier-commit + actionable, not as a gap.
+    assert "earlier commit" in stale_line.lower()
+    assert "mship test" in stale_line
+    assert "not run" not in stale_line.lower()
+    # The real gap still reads plainly as "not run".
+    assert "not run" in missing_line.lower()
+
+
 def test_format_missing_summary_empty_when_all_pass(tmp_path: Path):
     from mship.core.test_evidence import read_evidence, format_missing_summary
     log = LogManager(tmp_path / "logs")


### PR DESCRIPTION
## Summary

Fixes #258. `finish`/`phase` demote passing test evidence to `stale` whenever any commit lands after the last `mship test` — which is the **normal** subagent-driven flow, where the orchestrator's final review-fix commit follows the last per-task test. The old warning read the same as a real gap:

> Tests stale (branch has new commits) in: mothership

so the happy path trained people/agents to ignore it, eroding the very signal the evidence gate provides.

Per the issue's direction #1, this reframes only the `stale` line's **text** (no behavior change — still warn-only, status logic untouched) to convey that it's a soft, actionable advisory about an *earlier commit of the same branch*, clearly distinct from `not run`:

> Tests passed on an earlier commit of this branch (re-run `mship test` to refresh, or finish as-is if the new commits are trivial) in: mothership

`missing` ("Tests not run in: …") and `failing` lines are unchanged — those remain real concerns.

## Test plan

- New `test_format_missing_summary_stale_reads_as_soft_advisory` — a stale repo's line references "earlier commit" + `mship test` and never says "not run"; a co-present missing repo still reads as "not run".
- `mship test` — mothership full suite pass (existing evidence/staleness tests unchanged and green).

Chore. Follow-up options from the issue not taken here (deliberately, to keep it low-risk): tree-match freshness (option 2) and `mship finish --refresh-tests` (option 3) — happy to do those as a separate PR if you want the auto-rerun.

Closes #258