### PR TITLE
UX polish from #298 items 2+3: (2) AmbiguousTaskError renders terse — make _format_ambiguity lead with the candidate slugs inline (mship journal and all commands route through it) so the fix is visible at a glance, not just as indented --task hints. (3) Add a doc-ordering note in mothership/docs that for spec-driven work 'mship spec dispatch' is the entry point and spawns its own task, so spawn's --work-item requirement doesn't read as 'spawn is the entry point' (prevents the spawn/dispatch duplication of #296). Item 1 (spec apply --from-file) deferred — needs an inverse markdown-body parser.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,6 +35,8 @@ mship commit "message" [--task <slug>]              # commit staged changes acro
 mship depends add|remove|list                       # manage task-to-task dependency edges (#104)
 ```
 
+> **Entry point — spawn vs. spec dispatch:** `mship spawn` starts an ad-hoc task directly, but for **spec-driven** work you don't call it first. `mship spec dispatch <id>` (see **Work items & specs** below) is the entry point: it binds an approved spec and **spawns its own task**. Running `spawn` and then `spec dispatch` against the same spec double-creates tasks (#296). Rule of thumb: have an approved spec → `spec dispatch`; ad-hoc chore/bug → `spawn`.
+
 ## Setup & admin
 
 ```bash

--- a/src/mship/cli/_resolve.py
+++ b/src/mship/cli/_resolve.py
@@ -42,18 +42,20 @@ class ResolvedTask(NamedTuple):
 
 
 def _format_ambiguity(e: AmbiguousTaskError) -> list[str]:
-    """Turn an AmbiguousTaskError into human-readable lines."""
-    lines: list[str] = []
+    """Turn an AmbiguousTaskError into human-readable lines.
+
+    Leads with the candidate slugs inline (#298) so the fix is visible at a glance instead of
+    being tucked only into indented `--task` hints, then keeps the copy-paste hints below.
+    """
+    slugs = ", ".join(e.active)
+    lines: list[str] = [f"{len(e.active)} active tasks: {slugs}."]
     if e.candidates:
         lines.append("Pick one with --task:")
         for slug, path in e.candidates:
             suffix = f"  ({path})" if path else ""
             lines.append(f"  --task {slug}{suffix}")
     else:
-        lines.append(
-            f"Multiple active tasks ({', '.join(e.active)}). "
-            "Specify --task, set MSHIP_TASK, or cd into a worktree."
-        )
+        lines.append("Specify --task, set MSHIP_TASK, or cd into a worktree.")
     return lines
 
 

--- a/tests/cli/test_resolve_helper.py
+++ b/tests/cli/test_resolve_helper.py
@@ -55,3 +55,6 @@ def test_ambiguous_exits_nonzero_lists_active(monkeypatch, tmp_path, capsys):
     err = capsys.readouterr().err
     assert "A" in err and "B" in err
     assert "--task" in err or "MSHIP_TASK" in err
+    # #298: the candidate slugs are echoed inline on a single line, not only tucked into the
+    # indented --task hints, so recovery is visible at a glance.
+    assert any("active tasks:" in line and "A" in line and "B" in line for line in err.splitlines())


### PR DESCRIPTION
## Summary

Addresses two of the three items in #298 (the low-priority dogfooding-polish bundle).

**Item 2 — terser `AmbiguousTaskError` recovery.** `mship journal` (and every command; they all route through `_resolve._format_ambiguity`) listed the candidate slugs only inside indented `--task <slug>` hints. Now the message **leads with the slugs inline** so recovery is visible at a glance:

```
ambiguous task:
2 active tasks: A, B.
Pick one with --task:
  --task A  (/path/A)
  --task B  (/path/B)
```

**Item 3 — doc-ordering / entry-point clarity.** `docs/cli.md` led with `mship spawn (--work-item …)`, reading as if `spawn` is *the* entry point. Added an explicit note that for spec-driven work `mship spec dispatch <id>` is the entry point and **spawns its own task** — running `spawn` then `spec dispatch` double-creates tasks (#296). Rule of thumb spelled out: approved spec → `spec dispatch`; ad-hoc chore/bug → `spawn`.

**Item 1 — `spec apply --from-file <markdown>` — deliberately deferred.** Unlike `--from-json` (a `SpecDraft` structured payload), a markdown shortcut needs an *inverse* parser that reads a rendered spec body (`## Problem` / `## Approach` / …) back into `SpecDraft` fields — more than the "small" this bundle targets, and the JSON path already works. Happy to do it as its own PR if you want it; #298 can stay open for that item.

## Test plan

- `test_ambiguous_exits_nonzero_lists_active` strengthened: asserts a single line contains both candidate slugs (`active tasks: … A … B`), not just their presence somewhere.
- `mship test` — mothership full suite pass; existing resolver tests green.

Chore.

Closes #296, #298