### PR TITLE
Root-cause fix for #342 (WorkItem.plan_path silently cleared). Confirmed via repro: the current store round-trips plan_path fine, but the WorkItem pydantic model uses default extra=ignore, so an OLDER mship binary (e.g. a stale installed 'mship serve' per the deploy gap) whose schema predates plan_path DROPS it on any re-save while keeping spec_id it knows. Fix: set model_config extra=allow on WorkItem so unknown/future fields survive a round-trip through an older binary. Regression test: an unknown field survives load->dump.

### DIFF
--- a/src/mship/core/workitem.py
+++ b/src/mship/core/workitem.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 Kind = Literal["feature", "bug", "chore", "question"]
 Phase = Literal["inbox", "shaping", "ready", "in_flight", "review", "done"]
@@ -19,6 +19,14 @@ class ExternalLink(BaseModel):
 
 
 class WorkItem(BaseModel):
+    # Forward-compatible persistence (#342): keep fields this schema doesn't know about instead of
+    # dropping them on re-serialization. A WorkItem JSON is read-modify-written by many code paths,
+    # including a possibly-OLDER binary (e.g. a stale installed `mship serve`). With the default
+    # extra="ignore", such a binary silently drops any field newer than its schema (that's how
+    # `plan_path` got nulled while the older `spec_id` survived). extra="allow" round-trips unknown
+    # fields so a newer field survives a write by an older binary carrying this fix.
+    model_config = ConfigDict(extra="allow")
+
     id: str
     title: str
     workspace: str

--- a/tests/core/test_workitem.py
+++ b/tests/core/test_workitem.py
@@ -1,4 +1,5 @@
 # tests/core/test_workitem.py
+import json
 from datetime import datetime, timezone
 
 from mship.core.workitem import WorkItem, ExternalLink, PHASE_ORDER
@@ -16,6 +17,24 @@ def test_workitem_defaults_and_roundtrip():
     assert wi.phase_override is None
     restored = WorkItem.model_validate_json(wi.model_dump_json())
     assert restored == wi
+
+
+def test_unknown_future_field_survives_roundtrip():
+    # #342 root cause: a WorkItem JSON is read-modify-written by many code paths, including a
+    # possibly-OLDER binary (e.g. a stale installed `mship serve`) whose schema predates a newer
+    # field. With the default extra="ignore" such a binary silently drops the newer field on re-save
+    # (that's how `plan_path` got nulled while the older `spec_id` survived). extra="allow" must
+    # round-trip fields this schema doesn't know about.
+    raw = {
+        "id": "wi-9", "title": "t", "workspace": "ws", "kind": "feature",
+        "created_at": _now().isoformat(), "updated_at": _now().isoformat(),
+        "spec_id": "spec-1",
+        "a_field_added_by_a_newer_binary": "keep-me",
+    }
+    wi = WorkItem.model_validate(raw)
+    dumped = json.loads(wi.model_dump_json())
+    assert dumped["a_field_added_by_a_newer_binary"] == "keep-me"  # unknown field preserved
+    assert dumped["spec_id"] == "spec-1"                            # known fields intact
 
 
 def test_external_link_and_links_list():

--- a/tests/core/test_workitem.py
+++ b/tests/core/test_workitem.py
@@ -31,7 +31,9 @@ def test_unknown_future_field_survives_roundtrip():
         "spec_id": "spec-1",
         "a_field_added_by_a_newer_binary": "keep-me",
     }
-    wi = WorkItem.model_validate(raw)
+    # Go through model_validate_json → model_dump_json, exactly as WorkItemStore.get/save do when
+    # an older binary reads the on-disk JSON and re-writes it (the real #342 failure path).
+    wi = WorkItem.model_validate_json(json.dumps(raw))
     dumped = json.loads(wi.model_dump_json())
     assert dumped["a_field_added_by_a_newer_binary"] == "keep-me"  # unknown field preserved
     assert dumped["spec_id"] == "spec-1"                            # known fields intact


### PR DESCRIPTION
## Summary

Root-cause fix for #342 (`WorkItem.plan_path` silently cleared between two tasks off one WorkItem, while `spec_id` survived).

**Root cause (repro-confirmed).** Every store writer round-trips the *full current* model, so the current code preserves `plan_path` — I verified with a probe: create → link_spec → link_plan → add_task → add_thread keeps `plan_path`. The clobber comes from a **version skew**: the `WorkItem` pydantic model used the default `extra="ignore"`, so a *binary whose schema predates a field* drops that field on any read-modify-write. A stale installed `mship serve` (separate from the workspace source — see the serve deploy gap) that predates `plan_path` (#317) loads the JSON, ignores the unknown `plan_path`, and re-saves without it — keeping `spec_id`, which it does know. That exactly matches "only `plan_path` lost, `spec_id` survived, reproduced serially."

The probe also showed an unknown/future field does **not** survive the current model round-trip — the mechanism.

**Fix.** `model_config = ConfigDict(extra="allow")` on `WorkItem`, so fields the running schema doesn't recognize are round-tripped instead of dropped. From this fix forward, any field added later survives a re-save by an older binary that carries it — closing the whole class of silent-field-loss, not just `plan_path`.

**Also worth doing (operational, not in this PR):** keep the installed `mship serve` current with the source (`scripts/redeploy-serve.sh`) so schema skew is minimized in the first place.

## Test plan

- New `test_unknown_future_field_survives_roundtrip` — a WorkItem JSON carrying an unknown field survives `model_validate` → `model_dump_json`, with known fields intact. (Fails on `extra="ignore"`, passes with the fix.)
- `mship test` — mothership full suite pass; existing model/store round-trip + equality tests unaffected by `extra="allow"`.

Fixes #342.

Closes #342