### PR TITLE
serve resilience (from a read-only bug sweep, both findings verified against the code): (F1) _thread_payload and _workitem_index scan workitems.list()/store.list()/state_manager.load() UNGUARDED, so one corrupt/forward-incompatible workitem or spec file 500s GET /threads/{id}, POST /threads, POST /threads/{id}/messages, POST /threads/{id}/seen, and GET /items — even though the sibling _summaries and get_spec guard the same scans with the documented 'a corrupt WorkItem must never 500 the list' invariant. Wrap them in try/except and degrade (empty list / work_item_id=None). (F2) post_capture does an unlocked scan-then-create for idempotency_key dedup, so a double-tapped/retried capture creates duplicate brainstorm threads; the sibling post_item_message holds _item_msg_lock for the same read-decide-create — wrap post_capture's keyed scan+create in the same lock.

### DIFF
--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -704,8 +704,28 @@ def create_app(
             raise HTTPException(status_code=400, detail="idea must not be empty")
         now = datetime.now(timezone.utc)
         key = (body.idempotency_key or "").strip()
-        if key:
-            marker = f"capture-key {key}"
+
+        def _create_capture_thread():
+            subject = ((body.title or "").strip() or idea.splitlines()[0])[:80]
+            thread = msgs.create_thread(subject=subject, text=idea, now=now)
+            handoff = _capture_handoff(thread.id, idea)
+            if key:
+                # Append the dedup marker AFTER the handoff so the event body still
+                # STARTS WITH `capture-brainstorm <tid>` (the driver's first-line
+                # contract in the working-with-mothership skill); a leading key line
+                # would make a keyed capture invisible to that contract.
+                handoff = f"{handoff}\n\ncapture-key {key}"
+            msgs.append(thread.id, "agent", handoff, now, kind="event")
+            return _thread_payload(msgs.get(thread.id))
+
+        if not key:
+            return _create_capture_thread()
+
+        # Keyed capture: serialize scan-then-create under _item_msg_lock (mirrors post_item_message)
+        # so two concurrent same-key captures can't both miss the marker and each spawn a brainstorm
+        # thread — the retry/double-tap dedup the idempotency_key promises (AC6).
+        marker = f"capture-key {key}"
+        with _item_msg_lock:
             for t in msgs.list():
                 if any(
                     m.kind == "event"
@@ -713,17 +733,7 @@ def create_app(
                     for m in t.messages
                 ):
                     return _thread_payload(t)
-        subject = ((body.title or "").strip() or idea.splitlines()[0])[:80]
-        thread = msgs.create_thread(subject=subject, text=idea, now=now)
-        handoff = _capture_handoff(thread.id, idea)
-        if key:
-            # Append the dedup marker AFTER the handoff so the event body still
-            # STARTS WITH `capture-brainstorm <tid>` (the driver's first-line
-            # contract in the working-with-mothership skill); a leading key line
-            # would make a keyed capture invisible to that contract.
-            handoff = f"{handoff}\n\ncapture-key {key}"
-        msgs.append(thread.id, "agent", handoff, now, kind="event")
-        return _thread_payload(msgs.get(thread.id))
+            return _create_capture_thread()
 
     # --- dispatch endpoint (B4): close the dispatch-from-phone loop ---
 
@@ -900,12 +910,22 @@ def create_app(
     # lands, producing a duplicate/orphaned WorkItem. See post_dispatch for the re-load.
     _dispatch_lock = threading.Lock()
 
+    def _safe(fn, default):
+        """Best-effort store scan: one corrupt/forward-incompatible file (a WorkItemStore
+        ValidationError or a SpecStore SpecParseError) must never 500 the read paths that scan
+        the whole store — degrade to `default` instead. Mirrors the try/except in _summaries /
+        get_spec ('a corrupt WorkItem must never 500 the list')."""
+        try:
+            return fn()
+        except Exception:
+            return default
+
     def _workitem_index(include_archived: bool = False):
         return build_workitem_index(
-            workitems.list(include_archived=include_archived),
-            {s.id: s for s in store.list()},
-            dict(state_manager.load().tasks),
-            {t.id: t for t in msgs.list()},
+            _safe(lambda: workitems.list(include_archived=include_archived), []),
+            _safe(lambda: {s.id: s for s in store.list()}, {}),
+            _safe(lambda: dict(state_manager.load().tasks), {}),
+            _safe(lambda: {t.id: t for t in msgs.list()}, {}),
             include_archived=include_archived,
         )
 
@@ -944,7 +964,9 @@ def create_app(
         # archived-excluding list() would wrongly report work_item_id=null here. The
         # user-facing filter still applies at GET /items (_workitem_index above) and
         # `item list` — only this internal resolution needs the full set.
-        all_items = list(workitems.list(include_archived=True))  # single store scan, reused below
+        # Best-effort scans (one corrupt/forward-incompatible workitem/spec file must not 500 the
+        # thread read paths — mirrors _summaries' guard; the thread itself still resolves).
+        all_items = _safe(lambda: list(workitems.list(include_archived=True)), [])  # reused below
         wi_id = resolve_thread_work_item(t.id, t.spec_id, t.task_slug, all_items)
         data["work_item_id"] = wi_id
         if wi_id is None:
@@ -955,8 +977,8 @@ def create_app(
                 "id": summ.id, "title": summ.title, "kind": summ.kind, "phase": summ.phase,
             }
         item_ids = {w.id for w in all_items}
-        spec_ids = {s.id for s in store.list()}
-        task_slugs = set(state_manager.load().tasks.keys())
+        spec_ids = _safe(lambda: {s.id for s in store.list()}, set())
+        task_slugs = _safe(lambda: set(state_manager.load().tasks.keys()), set())
         for msg in data.get("messages", []):
             if msg.get("role") == "agent" and msg.get("text"):
                 msg["text"] = linkify_entities(msg["text"], item_ids, spec_ids, task_slugs)

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -918,6 +918,9 @@ def create_app(
         try:
             return fn()
         except Exception:
+            # Degrade, but leave a trace: a silently-empty store scan in production (e.g. a corrupt or
+            # forward-incompatible file) should be alertable, not invisible.
+            logger.warning("serve: store scan degraded to default (corrupt/unreadable file?)", exc_info=True)
             return default
 
     def _workitem_index(include_archived: bool = False):

--- a/tests/core/test_serve_items.py
+++ b/tests/core/test_serve_items.py
@@ -357,3 +357,23 @@ def test_get_spec_survives_corrupt_linked_work_item(tmp_path, monkeypatch):
     resp = client.get("/specs/linked")
     assert resp.status_code == 200
     assert resp.json()["work_item_kind"] is None
+
+
+def test_thread_and_items_endpoints_survive_corrupt_workitem_store(tmp_path, monkeypatch):
+    # One corrupt/forward-incompatible workitem file makes WorkItemStore.list raise. The thread read
+    # paths (_thread_payload) and the items surface (_workitem_index) must degrade to
+    # work_item_id=None / [] rather than 500 — mirroring _summaries' documented "must never 500" guard.
+    # Before the guard these scans were unguarded and one bad file 500'd every thread open + /items.
+    client = _app(tmp_path)
+    tid = client.post("/capture", json={"idea": "an idea worth capturing"}).json()["id"]
+
+    def _boom(self, *a, **k):
+        raise ValueError("corrupt/forward-incompatible workitem file")
+
+    monkeypatch.setattr(WorkItemStore, "list", _boom)
+
+    got = client.get(f"/threads/{tid}")
+    assert got.status_code == 200, got.text        # _thread_payload degrades instead of 500
+    assert got.json()["work_item_id"] is None
+
+    assert client.get("/items").status_code == 200  # _workitem_index degrades too


### PR DESCRIPTION
## Summary

Two serve-resilience fixes surfaced by a read-only bug sweep (both verified against the code).

**F1 — corrupt/forward-incompatible store file 500s the thread + items read paths.** `_thread_payload` and `_workitem_index` scanned `workitems.list()` / `store.list()` / `state_manager.load()` / `msgs.list()` **unguarded**, while the sibling `_summaries` and `get_spec` wrap the same scans in `try/except` with the documented invariant *"a corrupt WorkItem must never 500 the list."* So one bad file (a hand-edited spec, or — topically — a workitem written by a newer mship read by an older serve, cf. #342) turned `GET /threads/{id}`, `POST /threads`, `POST /threads/{id}/messages`, `POST /threads/{id}/seen`, and `GET /items` into 500s — the phone could list threads but not open or reply to any. Now those scans go through a `_safe(fn, default)` helper and degrade (`work_item_id=None` / empty) exactly like `_summaries`.

**F2 — `post_capture` idempotency had an unlocked scan-then-create race.** The `idempotency_key` dedup scanned `msgs.list()` for the marker and created a thread with **no lock**, while the structurally-identical first-steer in `post_item_message` holds `_item_msg_lock` *"so concurrent first-steers can't each create a thread and orphan a message."* Two concurrent same-key captures (double-tap / retry) could both miss the marker and each spawn a brainstorm thread. The keyed scan-through-create is now serialized under `_item_msg_lock`, matching `post_item_message`.

## Test plan

- New `test_thread_and_items_endpoints_survive_corrupt_workitem_store` — with `WorkItemStore.list` monkeypatched to raise, `GET /threads/{id}` returns 200 (`work_item_id=None`) and `GET /items` returns 200, instead of 500.
- F2's sequential dedup contract is already covered by the existing capture idempotency tests, which still pass under the lock.
- `mship test` — mothership full suite pass.

Bug (from the sweep). **Serve-side — needs `scripts/redeploy-serve.sh` after merge** (I'll handle it).
