### PR TITLE
reconcile bug (from the sweep, verified): apply_dependency_stale runs only on the fresh-fetch path (gate.py:166), not in _decisions_from_cache (110-119), which serves both the fresh-cache hit (132) and the FetchError fallback (144). Since reconcile shares one 300s cache across spawn/finish/close/precommit/mship reconcile, the cache is warm almost always, so the #104 dependency-stale override is dropped and a downstream task whose upstream merged after it was created reverts to in_sync — its finish/precommit no longer blocks on the stale base. Fix: apply apply_dependency_stale inside _decisions_from_cache too (it derives from live task state, already available there), so all three paths are consistent.

### DIFF
--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -116,7 +116,14 @@ def _decisions_from_cache(state: WorkspaceState, payload: CachePayload) -> dict[
         d = _decision_from_cache_entry(slug, raw, state)
         if d is not None:
             out[slug] = d
-    return out
+    # Apply the dependency-stale override here too (#104). It's derived from LIVE task state
+    # (depends_on edges + the upstream's cached merge state), not from a fresh fetch, so it must be
+    # recomputed on every path. The fresh-fetch path applies it at the bottom of reconcile_now; both
+    # cache paths (fresh-cache hit + FetchError fallback) route through here. Without this a warm
+    # cache — the common case, since reconcile shares one 300s cache across spawn/finish/close/
+    # precommit — silently drops it and a dependency-stale task reverts to in_sync (finish stops
+    # blocking on the stale base).
+    return apply_dependency_stale(state, out)
 
 
 def reconcile_now(

--- a/tests/core/reconcile/test_gate.py
+++ b/tests/core/reconcile/test_gate.py
@@ -33,6 +33,38 @@ def test_reconcile_now_uses_fresh_cache(tmp_path: Path):
     assert decisions["a"].state == UpstreamState.merged
 
 
+def test_reconcile_now_applies_dependency_stale_from_fresh_cache(tmp_path: Path):
+    # #104 regression: dependency_stale is derived from LIVE task state (depends_on edges + the
+    # upstream's merge state), so it must apply on the cache-hit path too — not only the fresh fetch.
+    # A warm cache (the common case: reconcile shares one 300s cache across spawn/finish/close/
+    # precommit) must NOT silently downgrade a dependency-stale task to in_sync, which would let it
+    # finish against a stale base.
+    from mship.core.state import DependencyEdge
+    t0 = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    t1 = datetime(2026, 5, 10, tzinfo=timezone.utc)
+    cache = ReconcileCache(tmp_path)
+    cache.write(CachePayload(
+        fetched_at=time.time(), ttl_seconds=300,
+        results={
+            "a": {"state": "merged", "pr_url": None, "pr_number": None, "base": None,
+                  "merge_commit": None, "updated_at": t1.isoformat()},
+            "b": {"state": "in_sync"},
+        },
+        ignored=[],
+    ))
+    state = WorkspaceState(tasks={
+        "a": _task("a", created_at=t0, finished_at=t0),
+        "b": _task("b", created_at=t0,
+                   depends_on=[DependencyEdge(upstream_slug="a", created_at=t0)]),
+    })
+    # Fresh cache → fetcher must NOT be called; the override still has to apply.
+    decisions = reconcile_now(
+        state, cache=cache,
+        fetcher=lambda *_: (_ for _ in ()).throw(AssertionError("should not fetch")),
+    )
+    assert decisions["b"].state == UpstreamState.dependency_stale
+
+
 def test_reconcile_now_refetches_when_stale(tmp_path: Path):
     cache = ReconcileCache(tmp_path)
     cache.write(CachePayload(


### PR DESCRIPTION
## Summary

Found by the bug sweep, verified against the code. `apply_dependency_stale` (the #104 gate that blocks finishing a task whose upstream dependency merged *after* it was created — i.e. against a stale base) ran **only** on the fresh-fetch path (`reconcile_now`, bottom). Both cache paths — the fresh-cache hit and the FetchError fallback — route through `_decisions_from_cache`, which never applied it.

Because reconcile shares **one 300s cache** across `spawn` / `finish` / `close` / the pre-commit hook / `mship reconcile`, the cache is warm almost all the time. So in practice the dependency-stale override was dropped on nearly every call: a downstream task reverted to `in_sync` and its `finish` / pre-commit stopped blocking — the gate was effectively disabled except in the brief window right after TTL expiry.

**Fix:** apply `apply_dependency_stale` inside `_decisions_from_cache` too. It derives from live task state (`depends_on` edges + the upstream's cached merge state), which is already available there, so recomputing it on the cache path is correct and makes all three paths consistent.

## Test plan

- New `test_reconcile_now_applies_dependency_stale_from_fresh_cache` — writes a fresh cache (upstream `a` merged after downstream `b` was created, `b` cached as `in_sync`), calls `reconcile_now` with a fetcher that asserts if called (proving the cache path), and asserts `b` resolves to `dependency_stale`. Fails without the fix (returns `in_sync`); passes with it.
- `mship test` — mothership full suite pass; all 49 reconcile tests green.

Bug (from the sweep).

Closes #104