### PR TITLE
Add a separate serve layout to mship layout: init writes both mothership.kdl and mothership-serve.kdl; launch --serve (or any serve flag) renders + opens the serve layout with mship serve params threaded in. Per plan docs/plans/2026-07-16-mship-layout.md and spec mship-layout.

### DIFF
--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -1,5 +1,7 @@
 import os
+import tempfile
 from pathlib import Path
+from typing import Optional
 
 import typer
 
@@ -59,9 +61,56 @@ layout {
 }
 """
 
+# Composable parts, sliced from _TEMPLATE at stable markers so the normal layout
+# is reconstructed byte-for-byte (_LAYOUT_HEAD + _BASE_TABS + _LAYOUT_TAIL == _TEMPLATE)
+# while the serve layout can reuse the base tabs and append a Serve tab. The final
+# layout-closing "}" is the only brace at column 0, so `\n}\n` locates it uniquely.
+_plan_idx = _TEMPLATE.index('    tab name="Plan"')
+_close_idx = _TEMPLATE.rindex("\n}\n") + 1
+_LAYOUT_HEAD = _TEMPLATE[:_plan_idx]
+_BASE_TABS = _TEMPLATE[_plan_idx:_close_idx]
+_LAYOUT_TAIL = _TEMPLATE[_close_idx:]
+
+
+def serve_cli_args(
+    *, host: Optional[str], port: Optional[int], relay: bool, relay_host: Optional[str]
+) -> list[str]:
+    """Map `mship layout launch` serve options to `mship serve` CLI args, in a stable order."""
+    args: list[str] = []
+    if host is not None:
+        args += ["--host", host]
+    if port is not None:
+        args += ["--port", str(port)]
+    if relay:
+        args += ["--relay"]
+    if relay_host is not None:
+        args += ["--relay-host", relay_host]
+    return args
+
+
+def _serve_tab(serve_args: list[str]) -> str:
+    """The Serve tab KDL block: one pane running `mship serve <serve_args>`."""
+    tokens = " ".join(f'"{a}"' for a in ["serve", *serve_args])
+    return (
+        '\n    tab name="Serve" {\n'
+        '        pane name="Serve" command="mship" close_on_exit=false { args '
+        + tokens
+        + "; }\n"
+        "    }\n"
+    )
+
+
+def render_serve_layout(serve_args: list[str]) -> str:
+    """The serve layout: the normal base tabs plus a Serve tab, as a full KDL document."""
+    return _LAYOUT_HEAD + _BASE_TABS + _serve_tab(serve_args) + _LAYOUT_TAIL
+
 
 def _target_path() -> Path:
     return Path.home() / ".config" / "zellij" / "layouts" / "mothership.kdl"
+
+
+def _serve_target_path() -> Path:
+    return Path.home() / ".config" / "zellij" / "layouts" / "mothership-serve.kdl"
 
 
 def register(app: typer.Typer, get_container):
@@ -69,23 +118,52 @@ def register(app: typer.Typer, get_container):
 
     @layout_app.command()
     def init(
-        force: bool = typer.Option(False, "--force", help="Overwrite existing layout file."),
+        force: bool = typer.Option(False, "--force", help="Overwrite existing layout files."),
     ):
-        """Write the mothership zellij layout to ~/.config/zellij/layouts/mothership.kdl."""
-        target = _target_path()
-        if target.exists() and not force:
+        """Write the mothership zellij layouts (normal + serve) to ~/.config/zellij/layouts/."""
+        normal = _target_path()
+        serve = _serve_target_path()
+        existing = [p for p in (normal, serve) if p.exists()]
+        if existing and not force:
             typer.echo(
-                f"Error: {target} already exists. Use --force to overwrite.",
+                "Error: layout file(s) already exist: "
+                + ", ".join(str(p) for p in existing)
+                + ". Use --force to overwrite.",
                 err=True,
             )
             raise typer.Exit(code=1)
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(_TEMPLATE)
-        typer.echo(f"Written: {target}")
+        normal.parent.mkdir(parents=True, exist_ok=True)
+        normal.write_text(_TEMPLATE)
+        serve.write_text(render_serve_layout([]))
+        typer.echo(f"Written: {normal}")
+        typer.echo(f"Written: {serve}")
 
     @layout_app.command()
-    def launch():
-        """Launch zellij with the mothership layout (replaces current process)."""
-        os.execvp("zellij", ["zellij", "--layout", "mothership"])
+    def launch(
+        serve: bool = typer.Option(False, "--serve", help="Open the serve layout (adds a Serve tab running `mship serve`)."),
+        host: Optional[str] = typer.Option(None, "--host", help="serve --host (implies --serve)."),
+        port: Optional[int] = typer.Option(None, "--port", help="serve --port (implies --serve)."),
+        relay: bool = typer.Option(False, "--relay", help="serve --relay (implies --serve). Collides with a separately-running serve."),
+        relay_host: Optional[str] = typer.Option(None, "--relay-host", help="serve --relay-host (implies --serve)."),
+    ):
+        """Launch zellij with the mothership layout (replaces current process).
+
+        With --serve (or any serve flag) launches the serve layout — the normal
+        tabs plus a Serve tab running `mship serve <flags>`. WARNING: starting a
+        serve here collides with a separately-running `mship serve` (same relay
+        subdomain / bind), so use it only when no standalone serve is up.
+        """
+        serve_selected = (
+            serve or host is not None or port is not None or relay or relay_host is not None
+        )
+        if not serve_selected:
+            os.execvp("zellij", ["zellij", "--layout", "mothership"])
+            return
+        args = serve_cli_args(host=host, port=port, relay=relay, relay_host=relay_host)
+        kdl = render_serve_layout(args)
+        fd, path = tempfile.mkstemp(prefix="mothership-serve-", suffix=".kdl")
+        with os.fdopen(fd, "w") as f:
+            f.write(kdl)
+        os.execvp("zellij", ["zellij", "--layout", path])
 
     app.add_typer(layout_app, rich_help_panel="Setup")

--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -88,9 +87,15 @@ def serve_cli_args(
     return args
 
 
+def _kdl_quote(s: str) -> str:
+    """Quote a string as a KDL string literal, escaping backslash and double-quote
+    so user-supplied values (e.g. --host) can't produce malformed KDL."""
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
 def _serve_tab(serve_args: list[str]) -> str:
     """The Serve tab KDL block: one pane running `mship serve <serve_args>`."""
-    tokens = " ".join(f'"{a}"' for a in ["serve", *serve_args])
+    tokens = " ".join(_kdl_quote(a) for a in ["serve", *serve_args])
     return (
         '\n    tab name="Serve" {\n'
         '        pane name="Serve" command="mship" close_on_exit=false { args '
@@ -111,6 +116,17 @@ def _target_path() -> Path:
 
 def _serve_target_path() -> Path:
     return Path.home() / ".config" / "zellij" / "layouts" / "mothership-serve.kdl"
+
+
+def _serve_launch_path() -> Path:
+    """Deterministic per-user path for the launch-time effective serve layout.
+
+    A fixed path (overwritten each launch, outside the layouts/ picker dir) rather
+    than a unique tempfile: `os.execvp` replaces the process, so no cleanup runs
+    after it — a unique temp would orphan one .kdl per launch. Overwriting one file
+    keeps it bounded.
+    """
+    return Path.home() / ".config" / "zellij" / "mothership-serve-launch.kdl"
 
 
 def register(app: typer.Typer, get_container):
@@ -161,9 +177,9 @@ def register(app: typer.Typer, get_container):
             return
         args = serve_cli_args(host=host, port=port, relay=relay, relay_host=relay_host)
         kdl = render_serve_layout(args)
-        fd, path = tempfile.mkstemp(prefix="mothership-serve-", suffix=".kdl")
-        with os.fdopen(fd, "w") as f:
-            f.write(kdl)
-        os.execvp("zellij", ["zellij", "--layout", path])
+        path = _serve_launch_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(kdl)
+        os.execvp("zellij", ["zellij", "--layout", str(path)])
 
     app.add_typer(layout_app, rich_help_panel="Setup")

--- a/tests/cli/test_layout.py
+++ b/tests/cli/test_layout.py
@@ -68,6 +68,13 @@ def test_render_serve_layout_threads_flags():
     assert 'args "serve" "--relay" "--port" "8080";' in kdl
 
 
+def test_render_serve_layout_escapes_kdl_strings():
+    # A value containing a double-quote must be escaped so the KDL stays valid
+    # (Greptile #364: unescaped user strings could break out of the string).
+    kdl = render_serve_layout(["--host", 'ba"d'])
+    assert '"--host" "ba\\"d";' in kdl
+
+
 # --- Task 3: init writes both layouts -----------------------------------------
 
 def test_layout_init_writes_file(tmp_path: Path, monkeypatch):

--- a/tests/cli/test_layout.py
+++ b/tests/cli/test_layout.py
@@ -4,7 +4,14 @@ import pytest
 from typer.testing import CliRunner
 
 from mship.cli import app
-from mship.cli.layout import _TEMPLATE
+from mship.cli.layout import (
+    _BASE_TABS,
+    _LAYOUT_HEAD,
+    _LAYOUT_TAIL,
+    _TEMPLATE,
+    render_serve_layout,
+    serve_cli_args,
+)
 
 runner = CliRunner()
 
@@ -13,13 +20,71 @@ def _expected_path(tmp_path: Path) -> Path:
     return tmp_path / ".config" / "zellij" / "layouts" / "mothership.kdl"
 
 
+def _serve_path(tmp_path: Path) -> Path:
+    return tmp_path / ".config" / "zellij" / "layouts" / "mothership-serve.kdl"
+
+
+# --- Task 1: template refactor -------------------------------------------------
+
+def test_template_reconstructs_from_parts():
+    assert _TEMPLATE == _LAYOUT_HEAD + _BASE_TABS + _LAYOUT_TAIL
+
+
+def test_base_tabs_has_all_four_tabs():
+    for name in ("Plan", "Dev", "Review", "Run"):
+        assert f'tab name="{name}"' in _BASE_TABS
+    assert 'name="Serve"' not in _BASE_TABS
+
+
+# --- Task 2: pure builders -----------------------------------------------------
+
+def test_serve_cli_args_mapping():
+    assert serve_cli_args(host=None, port=None, relay=False, relay_host=None) == []
+    assert serve_cli_args(host="0.0.0.0", port=8080, relay=False, relay_host=None) == [
+        "--host", "0.0.0.0", "--port", "8080",
+    ]
+    assert serve_cli_args(host=None, port=None, relay=True, relay_host=None) == ["--relay"]
+    assert serve_cli_args(host=None, port=None, relay=False, relay_host="r.example.com") == [
+        "--relay-host", "r.example.com",
+    ]
+    assert serve_cli_args(host="1.2.3.4", port=47100, relay=True, relay_host=None) == [
+        "--host", "1.2.3.4", "--port", "47100", "--relay",
+    ]
+
+
+def test_render_serve_layout_no_args_has_base_tabs_plus_serve():
+    kdl = render_serve_layout([])
+    for name in ("Plan", "Dev", "Review", "Run", "Serve"):
+        assert f'tab name="{name}"' in kdl
+    assert 'command="mship"' in kdl
+    assert 'args "serve";' in kdl
+    # Serve tab comes AFTER Run, and Plan keeps focus.
+    assert kdl.index('tab name="Run"') < kdl.index('tab name="Serve"')
+    assert 'tab name="Plan" focus=true' in kdl
+
+
+def test_render_serve_layout_threads_flags():
+    kdl = render_serve_layout(["--relay", "--port", "8080"])
+    assert 'args "serve" "--relay" "--port" "8080";' in kdl
+
+
+# --- Task 3: init writes both layouts -----------------------------------------
+
 def test_layout_init_writes_file(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     result = runner.invoke(app, ["layout", "init"])
     assert result.exit_code == 0, result.output
-    target = _expected_path(tmp_path)
-    assert target.exists()
-    assert target.read_text() == _TEMPLATE
+    assert _expected_path(tmp_path).read_text() == _TEMPLATE
+
+
+def test_init_writes_both_layouts(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    result = runner.invoke(app, ["layout", "init"])
+    assert result.exit_code == 0, result.output
+    assert _expected_path(tmp_path).read_text() == _TEMPLATE
+    serve = _serve_path(tmp_path).read_text()
+    assert 'tab name="Serve"' in serve
+    assert 'args "serve";' in serve
 
 
 def test_layout_init_refuses_when_exists_without_force(tmp_path: Path, monkeypatch):
@@ -34,6 +99,16 @@ def test_layout_init_refuses_when_exists_without_force(tmp_path: Path, monkeypat
     assert target.read_text() == original_content
 
 
+def test_init_refuses_when_serve_exists_without_force(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    serve = _serve_path(tmp_path)
+    serve.parent.mkdir(parents=True, exist_ok=True)
+    serve.write_text("keep me")
+    result = runner.invoke(app, ["layout", "init"])
+    assert result.exit_code == 1
+    assert serve.read_text() == "keep me"
+
+
 def test_layout_init_overwrites_with_force(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     target = _expected_path(tmp_path)
@@ -43,9 +118,12 @@ def test_layout_init_overwrites_with_force(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["layout", "init", "--force"])
     assert result.exit_code == 0, result.output
     assert target.read_text() == _TEMPLATE
+    assert 'tab name="Serve"' in _serve_path(tmp_path).read_text()
 
 
-def test_layout_launch_execs_zellij(tmp_path: Path, monkeypatch):
+# --- Task 4: launch selects/renders the serve layout ---------------------------
+
+def _capture_launch(monkeypatch, argv):
     captured = {}
 
     def fake_execvp(file, args):
@@ -53,19 +131,52 @@ def test_layout_launch_execs_zellij(tmp_path: Path, monkeypatch):
         captured["args"] = args
 
     monkeypatch.setattr("os.execvp", fake_execvp)
-    result = runner.invoke(app, ["layout", "launch"])
+    result = runner.invoke(app, argv)
     assert result.exit_code == 0, result.output
-    assert captured["file"] == "zellij"
-    assert captured["args"] == ["zellij", "--layout", "mothership"]
+    return captured
 
+
+def test_layout_launch_execs_zellij(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cap = _capture_launch(monkeypatch, ["layout", "launch"])
+    assert cap["file"] == "zellij"
+    assert cap["args"] == ["zellij", "--layout", "mothership"]
+
+
+def test_launch_serve_renders_temp_layout(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cap = _capture_launch(monkeypatch, ["layout", "launch", "--serve"])
+    assert cap["args"][0:2] == ["zellij", "--layout"]
+    layout_path = Path(cap["args"][2])
+    assert layout_path != Path("mothership")
+    body = layout_path.read_text()
+    assert 'tab name="Serve"' in body
+    assert 'args "serve";' in body
+
+
+def test_launch_serve_threads_flags(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cap = _capture_launch(monkeypatch, ["layout", "launch", "--serve", "--relay", "--port", "8080"])
+    body = Path(cap["args"][2]).read_text()
+    # serve_cli_args emits a stable canonical order (host, port, relay, relay_host);
+    # flag order is immaterial to `mship serve`.
+    assert 'args "serve" "--port" "8080" "--relay";' in body
+
+
+def test_launch_serve_flag_implies_serve(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cap = _capture_launch(monkeypatch, ["layout", "launch", "--relay"])
+    body = Path(cap["args"][2]).read_text()
+    assert 'args "serve" "--relay";' in body
+
+
+# --- pre-existing structural assertion ----------------------------------------
 
 def test_review_tab_has_journal_pane():
     """The Review tab must include a Shell pane and a Journal pane wired to
     `mship view journal --watch`."""
-    # Find the Review tab block.
     assert 'tab name="Review"' in _TEMPLATE
     start = _TEMPLATE.index('tab name="Review"')
-    # The Run tab starts with `tab name="Run"`; slice up to it.
     end = _TEMPLATE.index('tab name="Run"', start)
     review_block = _TEMPLATE[start:end]
 


### PR DESCRIPTION
## Summary

Implements #355 (scope 1): a distinct **serve layout** for `mship layout` — the normal workspace tabs plus a Serve tab running `mship serve` — selected on demand and configured with serve's own flags, kept fully separate from the normal layout.

Spec: `mship-layout` (approved). Plan: `docs/plans/2026-07-16-mship-layout.md`.

## What changed (`mship/cli/layout.py`)

- **Composable template.** The single `_TEMPLATE` is now sliced (at stable markers) into `_LAYOUT_HEAD` + `_BASE_TABS` + `_LAYOUT_TAIL`, so the normal layout is reconstructed **byte-for-byte** while the serve layout reuses the base tabs.
- **Pure builders.** `serve_cli_args(host, port, relay, relay_host) -> list[str]` (stable canonical order) and `render_serve_layout(serve_args) -> str` (base tabs + a Serve tab running `mship serve <args>`), both unit-tested without launching zellij.
- **`init` writes both layouts** — `mothership.kdl` (normal, unchanged) and `mothership-serve.kdl` (serve). The exists/`--force` guard now covers either file.
- **`launch` gains `--serve` + serve flags** (`--host/--port/--relay/--relay-host`). Passing `--serve` or any serve flag selects the serve layout: `launch` renders the effective serve layout (flags threaded into the Serve pane) to a temp file and execs `zellij --layout <tempfile>`. Passing none launches `zellij --layout mothership` exactly as before.

## Behavior

- `mship layout launch` → normal layout (no serve; no collision with a standalone serve).
- `mship layout launch --serve` → serve layout; Serve tab runs `mship serve`.
- `mship layout launch --serve --relay --port 8080` → Serve tab runs `mship serve --port 8080 --relay` (flag order is canonical and immaterial to serve).
- Any serve flag implies `--serve`.
- `--help` warns that starting a serve here collides with a separately-running relay serve.

## Test plan

- `mship test --repos mothership` → green.
- `tests/cli/test_layout.py` → 15 passed: template reconstruction + base-tab content, `serve_cli_args` mapping, `render_serve_layout` (no-args + threaded flags + Serve-after-Run + Plan focus), `init` writes/guards both files, and `launch` selection/rendering/threading (execvp captured, temp layout inspected).
- Manual smoke: `layout launch --help` shows the new options + collision warning; `layout init` writes both files with the Serve tab appended.

## Non-goals

Restyling the view panes to match Ground Control (deferred to a follow-up spec); no change to `mship serve`; no serve lifecycle management.

Closes #355
---

## Acceptance criteria

- [ ] `ac1` `mship layout init` writes two layout files: the normal mothership.kdl (tabs Plan/Dev/Review/Run, unchanged from the current default) and a serve layout (mothership-serve.kdl) containing those same tabs plus a Serve tab. — _no evidence_
- [ ] `ac2` `mship layout launch` with no serve args launches the normal layout (same behavior as today — no Serve tab, no serve started). — _no evidence_
- [ ] `ac3` `mship layout launch --serve` launches the serve layout; its Serve tab runs `mship serve` with config/default params. — _no evidence_
- [ ] `ac4` `mship layout launch --serve --relay --port 8080` launches the serve layout whose Serve tab runs `mship serve --relay --port 8080` (flags threaded into the pane command). — _no evidence_
- [ ] `ac5` Passing any serve flag (--host/--port/--relay/--relay-host) without --serve still selects the serve layout (serve flags imply --serve). — _no evidence_
- [ ] `ac6` In the serve layout the Serve tab is appended after the normal tabs and the Plan tab retains focus=true. — _no evidence_
- [ ] `ac7` render_serve_layout(serve_args) is a pure function unit-tested for each flag and combinations (and none), asserting the emitted `mship serve` command without launching zellij. — _no evidence_