### PR TITLE
Extend advance_workitem_on_close: when a WorkItem is spec-bound, advance its approved/dispatched spec to implemented on the last task's clean merge-close (so compute_phase derives done). Fixes features spawned via mship spawn --work-item landing on 'ready' not 'done'.

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -840,15 +840,20 @@ def register(app: typer.Typer, get_container):
         except Exception:
             pass
 
-        # Auto-mark a spec-less WorkItem `done` when its last live task merges+closes.
-        # Features reach `done` via the spec advance above; bug/chore/question items
-        # have no spec, so without this they fall to `inbox` and their merge
-        # conversation dead-ends on the now-removed task. See workitem_lifecycle.
+        # Advance a WorkItem's completion state when its last live task merges+closes.
+        # Spec-bound items (incl. features spawned via `spawn --work-item`, whose spec
+        # stays `approved` on the WorkItem and so is missed by the task-bound
+        # advance_spec_on_close above) get their spec advanced to `implemented`;
+        # spec-less bug/chore/question items get phase_override=done, so they don't
+        # fall to `inbox` and dead-end their merge conversation. See workitem_lifecycle.
         try:
             from mship.core.workitem_lifecycle import advance_workitem_on_close
+            from mship.core.spec_store import SPECS_DIRNAME
+            _ws_root = Path(container.config_path()).parent
             advance_workitem_on_close(
                 task=task,
-                workitems_dir=Path(container.config_path()).parent / ".mothership" / "workitems",
+                workitems_dir=_ws_root / ".mothership" / "workitems",
+                specs_dir=_ws_root / SPECS_DIRNAME,
                 state=state,
                 merged_count=merged_count,
                 closed_count=closed_count,

--- a/src/mship/core/workitem_lifecycle.py
+++ b/src/mship/core/workitem_lifecycle.py
@@ -77,9 +77,14 @@ def advance_workitem_on_close(
         sstore = SpecStore(specs_dir)
         spec = sstore.find_by_id(item.spec_id)
         if spec is not None and spec.status in ("approved", "dispatched"):
+            now = datetime.now(timezone.utc)
             spec.status = "implemented"
-            spec.updated_at = datetime.now(timezone.utc)
+            spec.updated_at = now
             sstore.save(spec)
+            # Bubble the freshly-done WorkItem to the top of list()'s updated_at-desc
+            # view too (mirrors the spec-less phase_override bump below). The override
+            # stays None — the spec drives `done`; this only refreshes updated_at.
+            store.set_phase_override(wid, None, now=now)
         return
 
     # Spec-less: stamp done directly. The updated_at bump (mirrors

--- a/src/mship/core/workitem_lifecycle.py
+++ b/src/mship/core/workitem_lifecycle.py
@@ -1,8 +1,11 @@
 """WorkItem lifecycle helpers for automated phase transitions.
 
-Sibling of spec_lifecycle.py: where advance_spec_on_close advances a bound
-spec's status on merge-close (which compute_phase then projects to `done`),
-this advances the WorkItem itself for the case a spec can't cover.
+Sibling of spec_lifecycle.py. `advance_spec_on_close` advances a spec bound to a
+task via `task.spec_id` (the `mship spec dispatch` path). This advances a
+WorkItem's completion state on the close of its last task — covering both the
+spec-bound case a task-level spec_id misses (features spawned via
+`mship spawn --work-item`, whose spec lives on the WorkItem) and the spec-less
+case a spec can't cover at all.
 """
 from __future__ import annotations
 
@@ -14,28 +17,32 @@ def advance_workitem_on_close(
     *,
     task,
     workitems_dir: Path,
+    specs_dir: Path,
     state,
     merged_count: int,
     closed_count: int,
 ) -> None:
-    """Mark a spec-less WorkItem `done` when its LAST live task closes after a clean merge.
+    """Advance a WorkItem's completion state when its LAST live task closes after a clean merge.
 
-    A feature WorkItem reaches `done` through its spec: advance_spec_on_close
-    moves the spec `dispatched → implemented`, and compute_phase projects a
-    terminal spec status to `done` before it looks at task state. A spec-less
-    WorkItem (bug/chore/question) has no such signal — once its task is closed
-    it is removed from live state, leaving the item with no spec and no live
-    tasks, so compute_phase falls through to `inbox`. Ground Control's item
-    redirect then routes the item's conversation to its now-removed task
-    ("this task is no longer available"). Stamping phase_override=done keeps the
-    merge conversation grouped under a `done` WorkItem instead.
+    Two cases, both gated on this being the WorkItem's last live task + a clean
+    full merge:
 
-    Safe no-op if:
-    - task.work_item_id is None
-    - not a clean full merge (merged_count == 0 or closed_count > 0)
-    - the WorkItem is missing, already has a phase_override, or has a bound spec
-      (spec'd items are handled by advance_spec_on_close + compute_phase)
-    - another live task still references this WorkItem (this isn't the last one)
+    - **Spec-bound WorkItem:** advance its approved/dispatched spec to
+      `implemented`; compute_phase then projects a terminal spec status to
+      `done`. This covers features spawned via `mship spawn --work-item`, whose
+      spec stays `approved` on the WorkItem — `task.spec_id` is null, so
+      `advance_spec_on_close`'s task-bound path never fires and the item would
+      otherwise sit at `ready` forever.
+    - **Spec-less WorkItem** (bug/chore/question): stamp `phase_override=done`,
+      since compute_phase can't derive `done` without a terminal spec — otherwise
+      the item falls to `inbox` and its merge conversation dead-ends on the
+      now-removed task.
+
+    Safe no-op if: `task.work_item_id` is None; not a clean full merge
+    (`merged_count == 0` or `closed_count > 0`); the WorkItem is missing or
+    already has a `phase_override`; another live task still references the
+    WorkItem; or (spec-bound) the spec is missing or not in an advanceable
+    status (`approved`/`dispatched`).
 
     `state` is the pre-teardown State snapshot: it still contains the closing
     task, so the "last live task" check excludes it explicitly by slug.
@@ -54,8 +61,6 @@ def advance_workitem_on_close(
         return
     if item.phase_override is not None:
         return
-    if item.spec_id is not None:
-        return
 
     this_slug = getattr(task, "slug", None)
     has_other_live_task = any(
@@ -65,7 +70,19 @@ def advance_workitem_on_close(
     if has_other_live_task:
         return
 
-    # Stamp updated_at (mirrors advance_spec_on_close) so the freshly-`done` item
-    # sorts to the top of WorkItemStore.list()'s updated_at-desc view rather than
-    # staying buried at its stale timestamp.
+    if item.spec_id is not None:
+        # Spec-bound: advance the WorkItem's spec so compute_phase derives `done`.
+        from mship.core.spec_store import SpecStore
+
+        sstore = SpecStore(specs_dir)
+        spec = sstore.find_by_id(item.spec_id)
+        if spec is not None and spec.status in ("approved", "dispatched"):
+            spec.status = "implemented"
+            spec.updated_at = datetime.now(timezone.utc)
+            sstore.save(spec)
+        return
+
+    # Spec-less: stamp done directly. The updated_at bump (mirrors
+    # advance_spec_on_close) keeps the freshly-`done` item at the top of
+    # WorkItemStore.list()'s updated_at-desc view rather than buried.
     store.set_phase_override(wid, "done", now=datetime.now(timezone.utc))

--- a/tests/core/test_workitem_lifecycle.py
+++ b/tests/core/test_workitem_lifecycle.py
@@ -152,8 +152,12 @@ def test_advances_approved_spec_on_last_task_merge(tmp_path):
     _call(tmp_path, t, state)
 
     assert SpecStore(tmp_path / "specs").find_by_id(spec_id).status == "implemented"
+    got = store.get(wi.id)
     # Spec-bound items reach done via the spec, not a phase_override.
-    assert store.get(wi.id).phase_override is None
+    assert got.phase_override is None
+    # ...but the WorkItem's updated_at is still bumped so the freshly-done feature
+    # bubbles to the top of list()'s updated_at-desc view (Greptile #365).
+    assert got.updated_at != _now()
 
 
 def test_advances_dispatched_spec(tmp_path):

--- a/tests/core/test_workitem_lifecycle.py
+++ b/tests/core/test_workitem_lifecycle.py
@@ -1,14 +1,18 @@
-"""Tests for advance_workitem_on_close (merge-close phase advancement).
+"""Tests for advance_workitem_on_close (merge-close completion advancement).
 
-Regression coverage for the "merge notification dead-ends on a removed task"
-bug: a spec-less WorkItem whose last task merged+closed used to fall to the
-`inbox` phase (compute_phase can only derive `done` from a terminal spec), so
-Ground Control routed its conversation to the now-removed task ("this task is
-no longer available"). advance_workitem_on_close stamps phase_override=done so
-the conversation stays grouped under a `done` WorkItem instead.
+Two behaviors, both gated on the closing task being the WorkItem's last live task
+after a clean full merge:
+- Spec-LESS WorkItem: stamp phase_override=done (compute_phase can't derive `done`
+  without a terminal spec, so it would fall to `inbox` and its merge conversation
+  would dead-end on the removed task).
+- Spec-BOUND WorkItem: advance its approved/dispatched spec to `implemented`
+  (compute_phase then projects a terminal spec → `done`). Covers features spawned
+  via `mship spawn --work-item`, whose spec stays `approved` on the WorkItem.
 """
 from datetime import datetime, timezone
 
+from mship.core.spec_draft import new_spec
+from mship.core.spec_store import SpecStore
 from mship.core.state import Task, WorkspaceState
 from mship.core.workitem_lifecycle import advance_workitem_on_close
 from mship.core.workitem_store import WorkItemStore
@@ -16,6 +20,10 @@ from mship.core.workitem_store import WorkItemStore
 
 def _now():
     return datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc)
+
+
+def _dirs(tmp_path):
+    return tmp_path / "workitems", tmp_path / "specs"
 
 
 def _task(slug: str, work_item_id: str | None) -> Task:
@@ -39,16 +47,33 @@ def _store_with_item(tmp_path, *, kind="chore", spec_id=None):
     return store, wi
 
 
+def _make_spec(tmp_path, *, status: str) -> str:
+    specs_dir = tmp_path / "specs"
+    specs_dir.mkdir(parents=True, exist_ok=True)
+    sstore = SpecStore(specs_dir)
+    spec = new_spec("Feature", now=_now(), task_slug="task-a")
+    spec.status = status
+    sstore.save(spec)
+    return spec.id
+
+
+def _call(tmp_path, task, state, *, merged_count=1, closed_count=0):
+    workitems_dir, specs_dir = _dirs(tmp_path)
+    advance_workitem_on_close(
+        task=task, workitems_dir=workitems_dir, specs_dir=specs_dir, state=state,
+        merged_count=merged_count, closed_count=closed_count,
+    )
+
+
+# --- spec-less path ------------------------------------------------------------
+
 def test_marks_spec_less_workitem_done_on_last_task_merge(tmp_path):
     store, wi = _store_with_item(tmp_path)
     store.add_task(wi.id, "task-a", now=_now())
     t = _task("task-a", wi.id)
     state = WorkspaceState(tasks={"task-a": t})
 
-    advance_workitem_on_close(
-        task=t, workitems_dir=tmp_path / "workitems", state=state,
-        merged_count=1, closed_count=0,
-    )
+    _call(tmp_path, t, state)
 
     got = store.get(wi.id)
     assert got.phase_override == "done"
@@ -65,26 +90,7 @@ def test_no_op_when_other_live_task_remains(tmp_path):
     sibling = _task("task-b", wi.id)
     state = WorkspaceState(tasks={"task-a": closing, "task-b": sibling})
 
-    advance_workitem_on_close(
-        task=closing, workitems_dir=tmp_path / "workitems", state=state,
-        merged_count=1, closed_count=0,
-    )
-
-    assert store.get(wi.id).phase_override is None
-
-
-def test_no_op_when_spec_bound(tmp_path):
-    # Feature WorkItems reach `done` via advance_spec_on_close + compute_phase's
-    # terminal-spec check; this helper must not clobber that path.
-    store, wi = _store_with_item(tmp_path, kind="feature", spec_id="spec-1")
-    store.add_task(wi.id, "task-a", now=_now())
-    t = _task("task-a", wi.id)
-    state = WorkspaceState(tasks={"task-a": t})
-
-    advance_workitem_on_close(
-        task=t, workitems_dir=tmp_path / "workitems", state=state,
-        merged_count=1, closed_count=0,
-    )
+    _call(tmp_path, closing, state)
 
     assert store.get(wi.id).phase_override is None
 
@@ -96,10 +102,7 @@ def test_no_op_when_phase_override_already_set(tmp_path):
     t = _task("task-a", wi.id)
     state = WorkspaceState(tasks={"task-a": t})
 
-    advance_workitem_on_close(
-        task=t, workitems_dir=tmp_path / "workitems", state=state,
-        merged_count=1, closed_count=0,
-    )
+    _call(tmp_path, t, state)
 
     assert store.get(wi.id).phase_override == "review"
 
@@ -111,14 +114,8 @@ def test_no_op_when_not_fully_merged(tmp_path):
     state = WorkspaceState(tasks={"task-a": t})
 
     # Abandoned / cancelled-on-github / no merges: leave phase derived.
-    advance_workitem_on_close(
-        task=t, workitems_dir=tmp_path / "workitems", state=state,
-        merged_count=0, closed_count=1,
-    )
-    advance_workitem_on_close(
-        task=t, workitems_dir=tmp_path / "workitems", state=state,
-        merged_count=1, closed_count=1,
-    )
+    _call(tmp_path, t, state, merged_count=0, closed_count=1)
+    _call(tmp_path, t, state, merged_count=1, closed_count=1)
 
     assert store.get(wi.id).phase_override is None
 
@@ -128,10 +125,7 @@ def test_no_op_when_no_work_item_id(tmp_path):
     t = _task("task-a", None)
     state = WorkspaceState(tasks={"task-a": t})
 
-    advance_workitem_on_close(
-        task=t, workitems_dir=tmp_path / "workitems", state=state,
-        merged_count=1, closed_count=0,
-    )
+    _call(tmp_path, t, state)
 
     assert store.get(wi.id).phase_override is None
 
@@ -141,7 +135,75 @@ def test_no_op_when_workitem_missing(tmp_path):
     t = _task("task-a", "wi-does-not-exist")
     state = WorkspaceState(tasks={"task-a": t})
 
-    advance_workitem_on_close(
-        task=t, workitems_dir=tmp_path / "workitems", state=state,
-        merged_count=1, closed_count=0,
-    )  # no exception
+    _call(tmp_path, t, state)  # no exception
+
+
+# --- spec-bound path -----------------------------------------------------------
+
+def test_advances_approved_spec_on_last_task_merge(tmp_path):
+    # The reported gap: spawn --work-item leaves the spec `approved` on the WorkItem
+    # (task.spec_id null), so it must be advanced here to reach `done`.
+    spec_id = _make_spec(tmp_path, status="approved")
+    store, wi = _store_with_item(tmp_path, kind="feature", spec_id=spec_id)
+    store.add_task(wi.id, "task-a", now=_now())
+    t = _task("task-a", wi.id)
+    state = WorkspaceState(tasks={"task-a": t})
+
+    _call(tmp_path, t, state)
+
+    assert SpecStore(tmp_path / "specs").find_by_id(spec_id).status == "implemented"
+    # Spec-bound items reach done via the spec, not a phase_override.
+    assert store.get(wi.id).phase_override is None
+
+
+def test_advances_dispatched_spec(tmp_path):
+    spec_id = _make_spec(tmp_path, status="dispatched")
+    store, wi = _store_with_item(tmp_path, kind="feature", spec_id=spec_id)
+    store.add_task(wi.id, "task-a", now=_now())
+    t = _task("task-a", wi.id)
+    state = WorkspaceState(tasks={"task-a": t})
+
+    _call(tmp_path, t, state)
+
+    assert SpecStore(tmp_path / "specs").find_by_id(spec_id).status == "implemented"
+
+
+def test_spec_bound_no_advance_when_other_live_task(tmp_path):
+    spec_id = _make_spec(tmp_path, status="approved")
+    store, wi = _store_with_item(tmp_path, kind="feature", spec_id=spec_id)
+    store.add_task(wi.id, "task-a", now=_now())
+    store.add_task(wi.id, "task-b", now=_now())
+    closing = _task("task-a", wi.id)
+    sibling = _task("task-b", wi.id)
+    state = WorkspaceState(tasks={"task-a": closing, "task-b": sibling})
+
+    _call(tmp_path, closing, state)
+
+    # A sibling task is still implementing the spec — don't advance prematurely.
+    assert SpecStore(tmp_path / "specs").find_by_id(spec_id).status == "approved"
+
+
+def test_no_advance_when_spec_not_approvable(tmp_path):
+    # A spec that isn't approved/dispatched (e.g. still in review) must not be
+    # force-advanced to implemented.
+    spec_id = _make_spec(tmp_path, status="needs_review")
+    store, wi = _store_with_item(tmp_path, kind="feature", spec_id=spec_id)
+    store.add_task(wi.id, "task-a", now=_now())
+    t = _task("task-a", wi.id)
+    state = WorkspaceState(tasks={"task-a": t})
+
+    _call(tmp_path, t, state)
+
+    assert SpecStore(tmp_path / "specs").find_by_id(spec_id).status == "needs_review"
+
+
+def test_spec_bound_missing_spec_no_raise(tmp_path):
+    # WorkItem points at a spec that doesn't exist on disk: no crash, no override.
+    store, wi = _store_with_item(tmp_path, kind="feature", spec_id="spec-does-not-exist")
+    store.add_task(wi.id, "task-a", now=_now())
+    t = _task("task-a", wi.id)
+    state = WorkspaceState(tasks={"task-a": t})
+
+    _call(tmp_path, t, state)  # no exception
+
+    assert store.get(wi.id).phase_override is None


### PR DESCRIPTION
## Summary

Follow-up to #362. Features built via `mship spawn --work-item` land on phase **`ready`** instead of **`done`** after their PR merges + the task closes — so a shipped feature keeps showing as unfinished.

**Root cause.** `mship spawn --work-item` links the spec to the **WorkItem**, leaving `task.spec_id` null. So `advance_spec_on_close` (which resolves the spec via `task.spec_id`) never fires, the spec stays `approved`, and `compute_phase` maps `approved → ready`. Only the `mship spec dispatch` path (which sets `task.spec_id` + `dispatched`) reached `done`.

**Fix.** Extend `advance_workitem_on_close` — which already runs at close with the last-live-task + clean-merge gate and has the WorkItem in hand — to advance a **spec-bound** WorkItem's `approved`/`dispatched` spec to `implemented` (compute_phase then derives `done`). Spec-less items keep the `phase_override=done` path. The last-live-task gate prevents advancing a multi-task feature's spec while a sibling task is still open.

## Changes
- `core/workitem_lifecycle.py` — `advance_workitem_on_close` now takes `specs_dir` and, after the gates, branches: spec-bound → advance the WorkItem's spec to `implemented`; spec-less → `phase_override=done`.
- `cli/worktree.py` — pass `specs_dir` to the call.
- `tests/core/test_workitem_lifecycle.py` — added spec-bound coverage (approved→implemented, dispatched→implemented, no-advance-with-sibling, non-approvable-status no-op, missing-spec no-raise); all spec-less tests retained.

## Test plan
- `mship test --repos mothership` → green.
- `pytest tests/core/test_workitem_lifecycle.py tests/cli/test_worktree.py tests/cli/test_spec_lifecycle_close.py` → 104 passed.

## Note
The `advance_spec_on_close` (task.spec_id / `dispatched`) path is left unchanged for backward compatibility; for a dispatched task it runs first (advancing the spec), and this new branch then no-ops (spec already `implemented`).
