### PR TITLE
Relay: opaque keyed-hash subdomains that don't leak workspace names

### DIFF
--- a/src/mship/cli/pair.py
+++ b/src/mship/cli/pair.py
@@ -49,4 +49,8 @@ def register(app: typer.Typer, get_container):
         link = build_pair_link(url=url, token=token, workspace=workspace)
 
         output.print(link)
+        output.print(
+            "  (opaque subdomain — no workspace name leaked; if you upgraded mship, "
+            "this changed, so re-scan to re-pair. Decode with `mship relay whoami <sub>`.)"
+        )
         typer.echo(segno.make(link).terminal(compact=True))

--- a/src/mship/cli/pair.py
+++ b/src/mship/cli/pair.py
@@ -19,7 +19,11 @@ def register(app: typer.Typer, get_container):
 
         import segno
 
-        from mship.core.relay.keys import ensure_relay_key, relay_public_key
+        from mship.core.relay.keys import (
+            ensure_relay_key,
+            ensure_subdomain_secret,
+            relay_public_key,
+        )
         from mship.core.relay.pairing import build_pair_link
         from mship.core.relay.token import ensure_serve_token
         from mship.core.relay.tunnel import device_id, device_subdomain
@@ -38,7 +42,8 @@ def register(app: typer.Typer, get_container):
         workspace = config.workspace
         workspace_root = Path(container.config_path()).parent
         key_path = ensure_relay_key(home=Path.home())
-        subdomain = device_subdomain(workspace, device_id(relay_public_key(key_path)))
+        secret = ensure_subdomain_secret(home=Path.home())
+        subdomain = device_subdomain(workspace, device_id(relay_public_key(key_path)), secret)
         url = f"https://{subdomain}.{rc.host}"
         token = ensure_serve_token(workspace_root)
         link = build_pair_link(url=url, token=token, workspace=workspace)

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -285,6 +285,7 @@ def register(parent: typer.Typer, get_container):
         recomputes the opaque slug over candidate workspace names on THIS machine
         (using the machine's subdomain secret) and prints the one that matches.
         """
+        import re
         from pathlib import Path
 
         from mship.core.relay.keys import ensure_subdomain_secret
@@ -292,16 +293,25 @@ def register(parent: typer.Typer, get_container):
 
         secret = ensure_subdomain_secret(home=Path.home())
         # Reduce to the slug part: drop any host suffix (".relay.example.com"),
-        # then the trailing "-<devid>" (the opaque slug itself is hyphen-free base32).
-        label = subdomain.strip().split(".", 1)[0]
-        slug = label.rsplit("-", 1)[0] if "-" in label else label
+        # then a trailing "-<6 hex>" device id IF present. The opaque slug itself
+        # is hyphen-free base32, so only strip a suffix matching the real
+        # device-id shape — and also keep the whole label as a candidate, so a
+        # bare slug, a <slug>-<devid>, or a full host all resolve, and malformed
+        # input (multi-hyphen, no valid devid) can't silently mis-strip.
+        label = subdomain.strip().split(".", 1)[0].lower()
+        possible_slugs = {label}
+        m = re.fullmatch(r"(?P<slug>.+)-[0-9a-f]{6}", label)
+        if m:
+            possible_slugs.add(m.group("slug"))
         candidates = list(workspace) if workspace else []
         if not candidates:
             try:
                 candidates = [get_container().config().workspace]
             except Exception:
                 candidates = []
-        match = next((w for w in candidates if opaque_slug(w, secret) == slug), None)
+        match = next(
+            (w for w in candidates if opaque_slug(w, secret) in possible_slugs), None
+        )
         if match:
             typer.echo(match)
         else:

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -269,4 +269,42 @@ def register(parent: typer.Typer, get_container):
         out.error("timed out waiting for approval.")
         raise typer.Exit(1)
 
+    @relay_app.command("whoami")
+    def whoami(
+        subdomain: str = typer.Argument(
+            ..., help="A relay subdomain (or full label <slug>-<devid>, or <sub>.host)."
+        ),
+        workspace: list[str] = typer.Option(
+            None, "--workspace", "-w",
+            help="Candidate workspace name(s) to test. Defaults to the current workspace.",
+        ),
+    ):
+        """Recover which workspace a relay subdomain belongs to.
+
+        Subdomains are opaque (HMAC of the name), so there's no decoding — this
+        recomputes the opaque slug over candidate workspace names on THIS machine
+        (using the machine's subdomain secret) and prints the one that matches.
+        """
+        from pathlib import Path
+
+        from mship.core.relay.keys import ensure_subdomain_secret
+        from mship.core.relay.tunnel import opaque_slug
+
+        secret = ensure_subdomain_secret(home=Path.home())
+        # Reduce to the slug part: drop any host suffix (".relay.example.com"),
+        # then the trailing "-<devid>" (the opaque slug itself is hyphen-free base32).
+        label = subdomain.strip().split(".", 1)[0]
+        slug = label.rsplit("-", 1)[0] if "-" in label else label
+        candidates = list(workspace) if workspace else []
+        if not candidates:
+            try:
+                candidates = [get_container().config().workspace]
+            except Exception:
+                candidates = []
+        match = next((w for w in candidates if opaque_slug(w, secret) == slug), None)
+        if match:
+            typer.echo(match)
+        else:
+            typer.echo(f"no match ({len(candidates)} candidate(s) checked)")
+
     parent.add_typer(relay_app, rich_help_panel="Setup")

--- a/src/mship/cli/serve.py
+++ b/src/mship/cli/serve.py
@@ -175,7 +175,11 @@ def _serve_with_relay(
 
     from mship.core.relay.config import RelayConfig
     from mship.core.relay.health import wait_until_reachable
-    from mship.core.relay.keys import ensure_relay_key, relay_public_key
+    from mship.core.relay.keys import (
+        ensure_relay_key,
+        ensure_subdomain_secret,
+        relay_public_key,
+    )
     from mship.core.relay.pairing import build_pair_link
     from mship.core.relay.token import ensure_serve_token
     from mship.core.relay.tunnel import (
@@ -229,7 +233,8 @@ def _serve_with_relay(
 
     key_path = ensure_relay_key(home=Path.home())
     dev = device_id(relay_public_key(key_path))
-    subdomain = device_subdomain(workspace, dev)          # was: subdomain_for(workspace)
+    secret = ensure_subdomain_secret(home=Path.home())
+    subdomain = device_subdomain(workspace, dev, secret)  # opaque; was: subdomain_for(workspace)
     argv = build_tunnel_argv(rc, subdomain=subdomain, local_port=port, key_path=key_path)
 
     public_url = f"https://{subdomain}.{rc.host}"

--- a/src/mship/cli/serve.py
+++ b/src/mship/cli/serve.py
@@ -302,6 +302,10 @@ def _serve_with_relay(
 
     output.print(f"mship serve → http://{host}:{port}  (auth: bearer token; docs: disabled)")
     output.print(f"relay → {public_url}  (per-device; tunnel via ssh -R to {rc.host})")
+    output.print(
+        "  (opaque subdomain — no workspace name leaked; upgrading changes it, "
+        "so re-pair the phone once. Decode with `mship relay whoami <sub>`.)"
+    )
     output.print(link)
     typer.echo(segno.make(link).terminal(compact=True))
 

--- a/src/mship/core/relay/keys.py
+++ b/src/mship/core/relay/keys.py
@@ -1,11 +1,25 @@
 from __future__ import annotations
 import os
 import subprocess
+import time
 from pathlib import Path
+
+_SUBDOMAIN_SECRET_LEN = 32
 
 
 def _default_runner(argv: list[str]) -> int:
     return subprocess.run(argv, check=True).returncode
+
+
+def _read_secret_if_valid(path: Path) -> bytes | None:
+    """Return the stored secret iff it's present and at least the expected
+    length; None if absent, truncated, or still mid-write (a concurrent creator
+    that O_EXCL-created the file but hasn't written its bytes yet)."""
+    try:
+        data = path.read_bytes()
+    except FileNotFoundError:
+        return None
+    return data if len(data) >= _SUBDOMAIN_SECRET_LEN else None
 
 
 def ensure_subdomain_secret(home: Path) -> bytes:
@@ -16,13 +30,34 @@ def ensure_subdomain_secret(home: Path) -> bytes:
     keys `opaque_slug`, so it must be identical for the two subdomain callers
     (`serve --relay` and `pair`) on the same machine. Losing it re-randomizes
     this machine's subdomains — a one-time re-pair, which is acceptable.
+
+    Concurrency-safe: if two callers race to create it, the loser adopts the
+    winner's secret (so both derive the same subdomain) rather than crashing.
+    A truncated/corrupt persisted file self-heals by regenerating.
     """
     path = home / ".mothership" / "relay-subdomain-secret"
+    existing = _read_secret_if_valid(path)
+    if existing is not None:
+        return existing
     if path.exists():
-        return path.read_bytes()
+        # Present but too short → corrupt/truncated; discard and regenerate.
+        path.unlink(missing_ok=True)
     path.parent.mkdir(parents=True, exist_ok=True)
-    secret = os.urandom(32)
-    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    secret = os.urandom(_SUBDOMAIN_SECRET_LEN)
+    try:
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        # Lost a concurrent-creation race — adopt the winner's secret so both
+        # subdomain callers agree. Briefly retry in case it was O_EXCL-created
+        # but the 32 bytes haven't landed yet.
+        for _ in range(100):
+            adopted = _read_secret_if_valid(path)
+            if adopted is not None:
+                return adopted
+            time.sleep(0.01)
+        raise RuntimeError(
+            f"relay subdomain secret at {path} exists but is unreadable/too short"
+        )
     try:
         os.write(fd, secret)
     finally:

--- a/src/mship/core/relay/keys.py
+++ b/src/mship/core/relay/keys.py
@@ -1,10 +1,33 @@
 from __future__ import annotations
+import os
 import subprocess
 from pathlib import Path
 
 
 def _default_runner(argv: list[str]) -> int:
     return subprocess.run(argv, check=True).returncode
+
+
+def ensure_subdomain_secret(home: Path) -> bytes:
+    """Return the per-machine relay-subdomain HMAC secret, generating it if absent.
+
+    Stored at home/.mothership/relay-subdomain-secret as 32 random bytes with
+    mode 0600 (created O_EXCL so there's no world-readable window). This secret
+    keys `opaque_slug`, so it must be identical for the two subdomain callers
+    (`serve --relay` and `pair`) on the same machine. Losing it re-randomizes
+    this machine's subdomains — a one-time re-pair, which is acceptable.
+    """
+    path = home / ".mothership" / "relay-subdomain-secret"
+    if path.exists():
+        return path.read_bytes()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    secret = os.urandom(32)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(fd, secret)
+    finally:
+        os.close(fd)
+    return secret
 
 
 def ensure_relay_key(home: Path, runner=_default_runner) -> Path:

--- a/src/mship/core/relay/tls_ask.py
+++ b/src/mship/core/relay/tls_ask.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 import re
 
-# A serve per-device subdomain LABEL: <base>-<6 hex>, where base is the
-# DNS-safe workspace slug ([a-z0-9-]). Mirrors device_subdomain() in tunnel.py.
+# A serve per-device subdomain LABEL: <base>-<6 hex>, where base is now an
+# opaque per-workspace slug (base32, [a-z2-7]) — the workspace name is no longer
+# present. Mirrors device_subdomain() in tunnel.py; base32 ⊂ [a-z0-9] so the
+# existing pattern still matches.
 _SERVE_LABEL = re.compile(r"[a-z0-9][a-z0-9-]*-[0-9a-f]{6}")
 
 

--- a/src/mship/core/relay/tunnel.py
+++ b/src/mship/core/relay/tunnel.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+import base64
 import hashlib
+import hmac
 import os
 import re
 import subprocess
@@ -35,15 +37,29 @@ def device_id(relay_public_key: str) -> str:
     return hashlib.sha256(body.encode()).hexdigest()[:6]
 
 
-def device_subdomain(workspace: str, dev_id: str) -> str:
-    """Per-device relay subdomain: `<workspace-slug>-<dev_id>`, DNS-label-safe.
+def opaque_slug(workspace: str, secret: bytes) -> str:
+    """Opaque, DNS-label-safe slug for a workspace.
 
-    `dev_id` is from device_id(). The workspace slug is truncated so the whole
-    label (slug + '-' + id) fits the 63-char DNS limit, with any trailing '-'
-    after truncation stripped.
+    Truncated lowercase base32 of HMAC-SHA256(secret, workspace). Deterministic
+    (so the subdomain is stable), yet reveals nothing about the workspace name
+    without `secret` — the relay host / DNS / network only ever see the hash.
+    Recover the name with `mship relay whoami` (recompute-and-match). Base32
+    yields [a-z2-7] which is a subset of the DNS-label alphabet.
+    """
+    digest = hmac.new(secret, workspace.encode("utf-8"), hashlib.sha256).digest()
+    b32 = base64.b32encode(digest).decode("ascii").lower().rstrip("=")
+    return b32[:12]
+
+
+def device_subdomain(workspace: str, dev_id: str, secret: bytes) -> str:
+    """Per-device relay subdomain: `<opaque-slug>-<dev_id>`, DNS-label-safe.
+
+    `dev_id` is from device_id(); the leading part is now `opaque_slug()` rather
+    than the readable workspace slug, so the workspace name is no longer present
+    in the subdomain. Truncated so the whole label fits the 63-char DNS limit.
     """
     suffix = f"-{dev_id}"
-    base = subdomain_for(workspace)[: 63 - len(suffix)].rstrip("-")
+    base = opaque_slug(workspace, secret)[: 63 - len(suffix)]
     return f"{base}{suffix}"
 
 

--- a/tests/cli/test_relay_cli.py
+++ b/tests/cli/test_relay_cli.py
@@ -231,7 +231,7 @@ def test_relay_whoami_matches_known_workspace(tmp_path, monkeypatch):
     candidate names on this machine; unrelated subdomains report no match."""
     monkeypatch.setenv("HOME", str(tmp_path))
     from mship.core.relay.keys import ensure_subdomain_secret
-    from mship.core.relay.tunnel import device_subdomain
+    from mship.core.relay.tunnel import device_subdomain, opaque_slug
 
     secret = ensure_subdomain_secret(home=tmp_path)
     sub = device_subdomain("ground-control", "abc123", secret)
@@ -245,6 +245,13 @@ def test_relay_whoami_matches_known_workspace(tmp_path, monkeypatch):
     r2 = runner.invoke(app, ["relay", "whoami", "zzzzzzzz-abc123", "--workspace", "ground-control"])
     assert r2.exit_code == 0, r2.output
     assert "no match" in r2.output.lower()
+
+    # A bare slug (no -<devid> suffix) also resolves — the whole label is a candidate.
+    r3 = runner.invoke(
+        app, ["relay", "whoami", opaque_slug("ground-control", secret), "--workspace", "ground-control"]
+    )
+    assert r3.exit_code == 0, r3.output
+    assert "ground-control" in r3.output
 
 
 def test_serve_relay_requires_host(workspace_no_relay, tmp_path, monkeypatch):

--- a/tests/cli/test_relay_cli.py
+++ b/tests/cli/test_relay_cli.py
@@ -75,7 +75,7 @@ def test_pair_outputs_deeplink(relay_configured_workspace):
 def test_pair_url_uses_subdomain_and_relay_host(relay_configured_workspace, tmp_path, monkeypatch):
     """The deep-link url is https://<per-device-subdomain>.<relay-host>, percent-encoded."""
     from mship.core.relay.tunnel import device_id, device_subdomain
-    from mship.core.relay.keys import relay_public_key
+    from mship.core.relay.keys import ensure_subdomain_secret, relay_public_key
 
     # Pre-create the relay key under a fake HOME so no ssh-keygen subprocess runs.
     fake_home = tmp_path / "home"
@@ -86,7 +86,8 @@ def test_pair_url_uses_subdomain_and_relay_host(relay_configured_workspace, tmp_
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
 
     # Compute the expected per-device subdomain from the same stub key material.
-    expected_subdomain = device_subdomain("Mship Workspace", device_id(relay_public_key(key)))
+    secret = ensure_subdomain_secret(home=fake_home)
+    expected_subdomain = device_subdomain("Mship Workspace", device_id(relay_public_key(key)), secret)
     expected_url_fragment = f"{expected_subdomain}.relay.example.com"
 
     r = runner.invoke(app, ["pair"])
@@ -172,7 +173,7 @@ def test_serve_relay_wires_tunnel_and_loopback(relay_configured_workspace, tmp_p
     No real uvicorn or ssh runs: uvicorn.run and TunnelSupervisor are faked.
     """
     from mship.core.relay.tunnel import device_id, device_subdomain
-    from mship.core.relay.keys import relay_public_key
+    from mship.core.relay.keys import ensure_subdomain_secret, relay_public_key
 
     # Pre-create the relay key under a fake HOME so no ssh-keygen subprocess runs.
     fake_home = tmp_path / "home"
@@ -183,7 +184,8 @@ def test_serve_relay_wires_tunnel_and_loopback(relay_configured_workspace, tmp_p
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
 
     # Compute the expected per-device subdomain from the same stub key material.
-    expected_subdomain = device_subdomain("Mship Workspace", device_id(relay_public_key(key)))
+    secret = ensure_subdomain_secret(home=fake_home)
+    expected_subdomain = device_subdomain("Mship Workspace", device_id(relay_public_key(key)), secret)
     expected_public_url = f"https://{expected_subdomain}.relay.example.com"
 
     seen: dict = {}

--- a/tests/cli/test_relay_cli.py
+++ b/tests/cli/test_relay_cli.py
@@ -226,6 +226,27 @@ def test_serve_relay_wires_tunnel_and_loopback(relay_configured_workspace, tmp_p
     assert "groundcontrol://add?" in r.output
 
 
+def test_relay_whoami_matches_known_workspace(tmp_path, monkeypatch):
+    """`relay whoami` recovers the workspace by recomputing the opaque slug over
+    candidate names on this machine; unrelated subdomains report no match."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mship.core.relay.keys import ensure_subdomain_secret
+    from mship.core.relay.tunnel import device_subdomain
+
+    secret = ensure_subdomain_secret(home=tmp_path)
+    sub = device_subdomain("ground-control", "abc123", secret)
+
+    r = runner.invoke(
+        app, ["relay", "whoami", sub, "--workspace", "ground-control", "--workspace", "other"]
+    )
+    assert r.exit_code == 0, r.output
+    assert "ground-control" in r.output
+
+    r2 = runner.invoke(app, ["relay", "whoami", "zzzzzzzz-abc123", "--workspace", "ground-control"])
+    assert r2.exit_code == 0, r2.output
+    assert "no match" in r2.output.lower()
+
+
 def test_serve_relay_requires_host(workspace_no_relay, tmp_path, monkeypatch):
     """`--relay` with no configured relay block and no --relay-host errors cleanly."""
     fake_home = tmp_path / "home"

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -143,9 +143,10 @@ def test_relay_serve_app_serves_exec_with_config_not_503(tmp_path, monkeypatch):
     # ~/.ssh, DNS, or the network — we only care about the app create_app builds.
     monkeypatch.setattr("mship.core.relay.token.ensure_serve_token", lambda root: "test-token")
     monkeypatch.setattr("mship.core.relay.keys.ensure_relay_key", lambda home=None: tmp_path / "key")
+    monkeypatch.setattr("mship.core.relay.keys.ensure_subdomain_secret", lambda home=None: b"\x00" * 32)
     monkeypatch.setattr("mship.core.relay.keys.relay_public_key", lambda key_path: "ssh-ed25519 AAAAfake")
     monkeypatch.setattr("mship.core.relay.tunnel.device_id", lambda pub: "dev")
-    monkeypatch.setattr("mship.core.relay.tunnel.device_subdomain", lambda ws, dev: "sub")
+    monkeypatch.setattr("mship.core.relay.tunnel.device_subdomain", lambda ws, dev, secret: "sub")
     monkeypatch.setattr("mship.core.relay.tunnel.build_tunnel_argv", lambda *a, **k: ["true"])
     monkeypatch.setattr("mship.core.relay.tunnel.TunnelSupervisor", _FakeSup)
     monkeypatch.setattr("mship.core.relay.pairing.build_pair_link", lambda **k: "groundcontrol://add?x=1")

--- a/tests/core/relay/test_keys.py
+++ b/tests/core/relay/test_keys.py
@@ -9,6 +9,18 @@ def test_ensure_subdomain_secret_creates_stable_0600_secret(tmp_path):
     assert oct(path.stat().st_mode & 0o777) == "0o600"
     assert ensure_subdomain_secret(home=tmp_path) == s1   # stable across calls
 
+
+def test_ensure_subdomain_secret_regenerates_truncated_file(tmp_path):
+    # A truncated/corrupt persisted secret self-heals rather than yielding a
+    # short HMAC key (which would produce subdomains no device recognises).
+    path = tmp_path / ".mothership" / "relay-subdomain-secret"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"short")
+    s = ensure_subdomain_secret(home=tmp_path)
+    assert len(s) >= 32
+    assert path.read_bytes() == s
+    assert ensure_subdomain_secret(home=tmp_path) == s   # now stable
+
 def test_generates_key_when_absent(tmp_path):
     calls = []
     def fake_run(argv):                      # stand in for subprocess

--- a/tests/core/relay/test_keys.py
+++ b/tests/core/relay/test_keys.py
@@ -1,5 +1,13 @@
 from pathlib import Path
-from mship.core.relay.keys import ensure_relay_key, relay_public_key
+from mship.core.relay.keys import ensure_relay_key, ensure_subdomain_secret, relay_public_key
+
+
+def test_ensure_subdomain_secret_creates_stable_0600_secret(tmp_path):
+    s1 = ensure_subdomain_secret(home=tmp_path)
+    assert isinstance(s1, bytes) and len(s1) >= 32
+    path = tmp_path / ".mothership" / "relay-subdomain-secret"
+    assert oct(path.stat().st_mode & 0o777) == "0o600"
+    assert ensure_subdomain_secret(home=tmp_path) == s1   # stable across calls
 
 def test_generates_key_when_absent(tmp_path):
     calls = []

--- a/tests/core/relay/test_tls_ask.py
+++ b/tests/core/relay/test_tls_ask.py
@@ -8,6 +8,12 @@ def test_allows_enroll_host():
 def test_rejects_gh_broker_host_after_fold():
     assert tls_ask_allowed(f"gh.{RELAY}", RELAY) is False  # folded into serve; no separate cert
 
+def test_allows_opaque_subdomain():
+    # An opaque (base32-HMAC) device subdomain still passes the cert allowlist.
+    from mship.core.relay.tunnel import device_subdomain
+    sub = device_subdomain("ground-control", "abc123", b"\x00" * 32)
+    assert tls_ask_allowed(f"{sub}.{RELAY}", RELAY) is True
+
 def test_rejects_random_host():
     assert tls_ask_allowed(f"random-host.{RELAY}", RELAY) is False
 

--- a/tests/core/relay/test_tunnel.py
+++ b/tests/core/relay/test_tunnel.py
@@ -1,6 +1,14 @@
 from pathlib import Path
 
-from mship.core.relay.tunnel import TunnelSupervisor, device_id, device_subdomain, subdomain_for
+from mship.core.relay.tunnel import (
+    TunnelSupervisor,
+    device_id,
+    device_subdomain,
+    opaque_slug,
+    subdomain_for,
+)
+
+_SECRET = b"\x00" * 32
 
 _PUBKEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAA mship-relay\n"
 
@@ -20,14 +28,31 @@ def test_device_id_differs_per_key():
     assert device_id(_PUBKEY) != device_id("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDifferentBodyZZZZ x")
 
 
+def test_opaque_slug_is_deterministic_and_dns_safe():
+    s = opaque_slug("My Workspace", _SECRET)
+    assert s == opaque_slug("My Workspace", _SECRET)          # deterministic
+    assert 0 < len(s) <= 12
+    assert all(c in "abcdefghijklmnopqrstuvwxyz234567" for c in s)  # lowercase base32
+
+
+def test_opaque_slug_hides_the_name():
+    # Reveals nothing about the name; different names -> unrelated slugs.
+    assert "workspace" not in opaque_slug("workspace", _SECRET)
+    assert opaque_slug("alpha", _SECRET) != opaque_slug("alphb", _SECRET)
+    # secret matters: same name, different secret -> different slug
+    assert opaque_slug("alpha", _SECRET) != opaque_slug("alpha", b"\x01" * 32)
+
+
 def test_device_subdomain_appends_id_and_is_dns_safe():
-    sd = device_subdomain("mship-workspace", "abc123")
-    assert sd == "mship-workspace-abc123"
+    sd = device_subdomain("mship-workspace", "abc123", _SECRET)
+    assert sd.endswith("-abc123")
     assert len(sd) <= 63 and all(c in "abcdefghijklmnopqrstuvwxyz0123456789-" for c in sd)
+    # The workspace name is no longer present in the subdomain.
+    assert "mship-workspace" not in sd
 
 
 def test_device_subdomain_truncates_to_dns_limit():
-    sd = device_subdomain("w" * 80, "abc123")
+    sd = device_subdomain("w" * 80, "abc123", _SECRET)
     assert len(sd) <= 63
     assert sd.endswith("-abc123")
     assert not sd.startswith("-") and "--" not in sd


### PR DESCRIPTION
Relay: opaque keyed-hash subdomains that don't leak workspace names
---

## Acceptance criteria

- [ ] `ac1` The relay subdomain no longer contains the workspace name: the slug is base32(HMAC-SHA256(machine-secret, workspace-name)) truncated (~12 chars), DNS-label-safe, and the full `<slug>-<device-id>` label is <= 63 chars. — _no evidence_
- [ ] `ac2` The subdomain is stable across serve restarts (deterministic given the machine-secret + workspace name). — _no evidence_
- [ ] `ac3` The machine-secret is generated once and persisted per machine (file mode 0600); a machine with no secret yet generates and stores a fresh one. — _no evidence_
- [ ] `ac4` `mship relay whoami <subdomain>` recovers the workspace name by recomputing the HMAC over the machine's known workspaces and matching; a subdomain with no match reports 'no match' (no crash). — _no evidence_
- [ ] `ac5` Two different workspace names produce unrelated slugs, and the slug reveals nothing about the name — an observer without the machine-secret can't derive the name (unit-tested). — _no evidence_
- [ ] `ac6` Upgrading is documented as a one-time re-pair per device (the subdomain changes); nothing breaks silently. — _no evidence_
- [ ] `ac7` The `core/relay/tls_ask.py` subdomain-slug derivation is updated in lockstep with `tunnel.py` so the two produce the same opaque slug (no drift), and the pairing QR still carries the friendly workspace name for GC display (opacity is on the subdomain/URL only). — _no evidence_