### PR TITLE
GC: spec phase-progress + live agent heartbeat indicator

### DIFF
--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -122,6 +122,7 @@ from mship.cli import doctor as _doctor_mod
 from mship.cli import exec as _exec_mod
 from mship.cli import export as _export_mod
 from mship.cli import gh as _gh_mod
+from mship.cli import heartbeat as _heartbeat_mod
 from mship.cli import init as _init_mod
 from mship.cli import internal as _internal_mod
 from mship.cli import layout as _layout_mod
@@ -184,6 +185,7 @@ _doctor_mod.register(app, get_container)
 _exec_mod.register(app, get_container)
 _export_mod.register(app, get_container)
 _gh_mod.register(app, get_container)
+_heartbeat_mod.register(app, get_container)
 _init_mod.register(app, get_container)
 _internal_mod.register(app, get_container)
 _layout_mod.register(app, get_container)

--- a/src/mship/cli/commit.py
+++ b/src/mship/cli/commit.py
@@ -96,6 +96,9 @@ def register(app: typer.Typer, get_container):
             )
             raise typer.Exit(code=1)
 
+        # Agent-agnostic activity heartbeat: a successful commit is task work.
+        state_mgr.record_activity(t.slug)
+
         if output.human_mode:
             for r in results:
                 short = r["commit_sha"][:8] if r["commit_sha"] else "(no sha)"

--- a/src/mship/cli/exec.py
+++ b/src/mship/cli/exec.py
@@ -277,6 +277,8 @@ def register(app: typer.Typer, get_container):
         # Persist iteration on task (read-modify-write under the lock).
         def _record(s):
             s.tasks[t.slug].test_iteration = new_iter
+            # Agent-agnostic activity heartbeat: running tests is task work.
+            s.tasks[t.slug].last_activity_at = datetime.now(timezone.utc)
         state_mgr.mutate(_record)
 
         prune(state_dir, t.slug, keep=20)

--- a/src/mship/cli/heartbeat.py
+++ b/src/mship/cli/heartbeat.py
@@ -24,11 +24,15 @@ def register(app: typer.Typer, get_container):
         t = resolved.task
 
         state_mgr.record_activity(t.slug)
-        stamped = state_mgr.load().tasks[t.slug].last_activity_at
 
         if output.human_mode:
             output.success(f"Heartbeat: {t.slug}")
         else:
+            # Re-read for the stamp only in JSON mode, and guard against the task
+            # being removed in the narrow window after record_activity (e.g. a
+            # concurrent `mship kill`) — `.get()` avoids a KeyError crash.
+            task = state_mgr.load().tasks.get(t.slug)
+            stamped = task.last_activity_at if task else None
             output.json({
                 "task": t.slug,
                 "last_activity_at": stamped.isoformat() if stamped else None,

--- a/src/mship/cli/heartbeat.py
+++ b/src/mship/cli/heartbeat.py
@@ -1,0 +1,37 @@
+from typing import Optional
+
+import typer
+
+from mship.cli._resolve import resolve_for_command
+from mship.cli.output import Output
+
+
+def register(app: typer.Typer, get_container):
+    @app.command(rich_help_panel="Workflow")
+    def heartbeat(
+        task: Optional[str] = typer.Option(
+            None, "--task",
+            help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var.",
+        ),
+    ):
+        """Stamp a task's activity heartbeat (last_activity_at). No other side effects."""
+        container = get_container()
+        output = Output()
+        state_mgr = container.state_manager()
+        state = state_mgr.load()
+
+        resolved = resolve_for_command("heartbeat", state, task, output)
+        t = resolved.task
+
+        state_mgr.record_activity(t.slug)
+        stamped = state_mgr.load().tasks[t.slug].last_activity_at
+
+        if output.human_mode:
+            output.success(f"Heartbeat: {t.slug}")
+        else:
+            output.json({
+                "task": t.slug,
+                "last_activity_at": stamped.isoformat() if stamped else None,
+                "resolved_task": resolved.task.slug,
+                "resolution_source": resolved.source,
+            })

--- a/src/mship/cli/log.py
+++ b/src/mship/cli/log.py
@@ -166,6 +166,8 @@ def register(app: typer.Typer, get_container):
                 action=action,
                 open_question=open_question,
             )
+            # Agent-agnostic activity heartbeat: journaling is real task work.
+            state_mgr.record_activity(t.slug)
             if output.human_mode:
                 output.success("Logged")
             else:

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -178,6 +178,11 @@ def register(parent: typer.Typer, get_container):
         spec.updated_at = datetime.now(timezone.utc)
         path = store.save(spec)
 
+        # Agent-agnostic activity heartbeat: applying a drafted spec is task work.
+        # No-ops when the spec's bound task_slug isn't (yet) a live task.
+        if spec.task_slug:
+            container.state_manager().record_activity(spec.task_slug)
+
         if output.human_mode:
             output.success(f"Applied draft → {spec.status}: {path}")
         else:

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -181,7 +181,10 @@ class PhaseManager:
                 t.blocked_reason = None
                 t.blocked_at = None
             t.phase = target
-            t.phase_entered_at = datetime.now(timezone.utc)
+            now = datetime.now(timezone.utc)
+            t.phase_entered_at = now
+            # Agent-agnostic activity heartbeat: a phase transition is task work.
+            t.last_activity_at = now
 
         self._state_manager.mutate(_apply)
 

--- a/src/mship/core/state.py
+++ b/src/mship/core/state.py
@@ -1,5 +1,5 @@
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
@@ -35,6 +35,7 @@ class Task(BaseModel):
     pr_urls: dict[str, str] = {}
     finished_at: datetime | None = None
     phase_entered_at: datetime | None = None
+    last_activity_at: datetime | None = None
     active_repo: str | None = None
     last_switched_at_sha: dict[str, dict[str, str]] = {}
     test_iteration: int = 0
@@ -129,3 +130,20 @@ class StateManager:
             fn(state)
             self._save_nolock(state)
             return state
+
+    def record_activity(self, slug: str, now: "datetime | None" = None) -> None:
+        """Stamp `last_activity_at` on a task — the agent-agnostic activity heartbeat.
+
+        Cheap: one field write under the same exclusive lock as any other
+        mutation. A no-op when `slug` is unknown, so callers that may pass a
+        slug that isn't (yet) a task (e.g. `mship spec apply` before dispatch)
+        stay safe.
+        """
+        stamp = now or datetime.now(timezone.utc)
+
+        def _apply(state: WorkspaceState) -> None:
+            task = state.tasks.get(slug)
+            if task is not None:
+                task.last_activity_at = stamp
+
+        self.mutate(_apply)

--- a/src/mship/core/view/task_index.py
+++ b/src/mship/core/view/task_index.py
@@ -25,6 +25,8 @@ class TaskSummary:
     pr_urls: dict[str, str] = field(default_factory=dict)
     test_results: dict[str, str] = field(default_factory=dict)
     depends_on: list[str] = field(default_factory=list)
+    last_activity_at: datetime | None = None
+    phase_entered_at: datetime | None = None
 
 
 def _summarize(task: Task) -> TaskSummary:
@@ -52,6 +54,8 @@ def _summarize(task: Task) -> TaskSummary:
         pr_urls=dict(task.pr_urls),
         test_results={repo: tr.status for repo, tr in task.test_results.items()},
         depends_on=[e.upstream_slug for e in task.depends_on],
+        last_activity_at=task.last_activity_at,
+        phase_entered_at=task.phase_entered_at,
     )
 
 

--- a/src/mship/core/view/workitem_index.py
+++ b/src/mship/core/view/workitem_index.py
@@ -98,6 +98,17 @@ class WorkItemSummary:
     thread_ids: list[str] = field(default_factory=list)
     external_links: list[ExternalLink] = field(default_factory=list)
     unattended: bool = False
+    active_phase: str | None = None
+    active_last_activity_at: datetime | None = None
+
+
+def _active_task(tasks: list[Task]) -> Task | None:
+    """The task an operator is watching: the first still-running (unfinished) task,
+    or None when every linked task is finished."""
+    for t in tasks:
+        if t.finished_at is None:
+            return t
+    return None
 
 
 def _summarize(
@@ -108,6 +119,7 @@ def _summarize(
 ) -> WorkItemSummary:
     spec = specs_by_id.get(item.spec_id) if item.spec_id else None
     tasks = [tasks_by_slug[s] for s in item.task_slugs if s in tasks_by_slug]
+    active = _active_task(tasks)
     threads = [threads_by_id[t] for t in item.thread_ids if t in threads_by_id]
     return WorkItemSummary(
         id=item.id, title=item.title, kind=item.kind, workspace=item.workspace,
@@ -117,6 +129,8 @@ def _summarize(
         spec_id=item.spec_id, task_slugs=list(item.task_slugs),
         thread_ids=list(item.thread_ids), external_links=list(item.external_links),
         unattended=item.unattended,
+        active_phase=active.phase if active else None,
+        active_last_activity_at=active.last_activity_at if active else None,
     )
 
 

--- a/src/mship/core/view/workitem_index.py
+++ b/src/mship/core/view/workitem_index.py
@@ -103,12 +103,17 @@ class WorkItemSummary:
 
 
 def _active_task(tasks: list[Task]) -> Task | None:
-    """The task an operator is watching: the first still-running (unfinished) task,
-    or None when every linked task is finished."""
-    for t in tasks:
-        if t.finished_at is None:
-            return t
-    return None
+    """The task an operator is watching. Among still-running (unfinished) tasks, prefer the one
+    with the most recent activity — so a work item linked to several in-flight tasks reflects
+    where work is actually happening — falling back to the first unfinished task when none have
+    recorded activity yet. None when every linked task is finished."""
+    unfinished = [t for t in tasks if t.finished_at is None]
+    if not unfinished:
+        return None
+    active = [t for t in unfinished if t.last_activity_at is not None]
+    if active:
+        return max(active, key=lambda t: t.last_activity_at)
+    return unfinished[0]
 
 
 def _summarize(

--- a/tests/cli/test_commit.py
+++ b/tests/cli/test_commit.py
@@ -311,3 +311,27 @@ def test_commit_push_failure_surfaces_post_finish(configured_git_app: Path):
         assert "fix: will-fail-push" in log
     finally:
         container.shell.reset_override()
+
+
+def test_commit_stamps_last_activity(configured_git_app: Path):
+    """A successful commit stamps the task's activity heartbeat."""
+    runner.invoke(app, ["spawn", "--hotfix", "activity commit", "--repos", "shared"])
+    slug = "activity-commit"
+
+    def mock_run(cmd, cwd, env=None):
+        if "git diff --cached --quiet" in cmd:
+            return ShellResult(returncode=1, stdout="", stderr="")  # staged
+        if "git rev-parse HEAD" in cmd:
+            return ShellResult(returncode=0, stdout="7f3a1b2abcdef\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = mock_run
+    container.shell.override(mock_shell)
+    try:
+        result = runner.invoke(app, ["commit", "fix: thing", "--task", slug])
+        assert result.exit_code == 0, result.output
+        state = StateManager(configured_git_app / ".mothership").load()
+        assert state.tasks[slug].last_activity_at is not None
+    finally:
+        container.shell.reset_override()

--- a/tests/cli/test_exec.py
+++ b/tests/cli/test_exec.py
@@ -1088,3 +1088,11 @@ def test_mship_build_works_without_active_task(workspace: Path):
         container.state_dir.reset_override()
         container.config.reset()
         container.state_manager.reset()
+
+
+def test_test_command_stamps_last_activity(configured_exec_app):
+    workspace, mock_shell = configured_exec_app
+    result = runner.invoke(app, ["test", "--task", "test-task"])
+    assert result.exit_code == 0, result.output
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["test-task"].last_activity_at is not None

--- a/tests/cli/test_heartbeat.py
+++ b/tests/cli/test_heartbeat.py
@@ -1,0 +1,61 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.state import StateManager, Task, WorkspaceState
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def configured_app_with_task(workspace: Path):
+    state_dir = workspace / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    container.config_path.override(workspace / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    mgr = StateManager(state_dir)
+    task = Task(
+        slug="add-labels", description="Add labels", phase="dev",
+        created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        affected_repos=["shared"], branch="feat/add-labels",
+    )
+    mgr.save(WorkspaceState(tasks={"add-labels": task}))
+    yield workspace
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset()
+    container.state_manager.reset()
+
+
+def test_heartbeat_stamps_last_activity(configured_app_with_task: Path):
+    result = runner.invoke(app, ["heartbeat", "--task", "add-labels"])
+    assert result.exit_code == 0, result.output
+    state = StateManager(configured_app_with_task / ".mothership").load()
+    assert state.tasks["add-labels"].last_activity_at is not None
+
+
+def test_heartbeat_has_no_other_side_effects(configured_app_with_task: Path):
+    before = StateManager(configured_app_with_task / ".mothership").load().tasks["add-labels"]
+    runner.invoke(app, ["heartbeat", "--task", "add-labels"])
+    after = StateManager(configured_app_with_task / ".mothership").load().tasks["add-labels"]
+    # Only last_activity_at may differ.
+    b = before.model_dump(exclude={"last_activity_at"})
+    a = after.model_dump(exclude={"last_activity_at"})
+    assert a == b
+
+
+def test_heartbeat_json_output(configured_app_with_task: Path):
+    result = runner.invoke(app, ["--json", "heartbeat", "--task", "add-labels"])
+    assert result.exit_code == 0, result.output
+    import json
+    payload = json.loads(result.output)
+    assert payload["task"] == "add-labels"
+    assert payload["last_activity_at"] is not None
+
+
+def test_heartbeat_unknown_task_errors(configured_app_with_task: Path):
+    result = runner.invoke(app, ["heartbeat", "--task", "ghost"])
+    assert result.exit_code != 0

--- a/tests/cli/test_heartbeat.py
+++ b/tests/cli/test_heartbeat.py
@@ -5,6 +5,7 @@ import pytest
 from typer.testing import CliRunner
 
 from mship.cli import app, container
+from mship.cli.output import reset_output_settings
 from mship.core.state import StateManager, Task, WorkspaceState
 
 runner = CliRunner()
@@ -28,6 +29,10 @@ def configured_app_with_task(workspace: Path):
     container.state_dir.reset_override()
     container.config.reset()
     container.state_manager.reset()
+    # The `--json` global flag is process-global (set once by the top-level
+    # callback, never auto-reset to False); clear it so the TTY-shape assertions
+    # in other suites (e.g. test_output.py) aren't polluted by our --json test.
+    reset_output_settings()
 
 
 def test_heartbeat_stamps_last_activity(configured_app_with_task: Path):

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -409,3 +409,22 @@ def test_journal_json_with_message_errors(configured_app_with_task: Path):
     result = runner.invoke(app, ["journal", "hello", "--task", "add-labels", "--json"])
     assert result.exit_code != 0
     assert "read-only" in result.output.lower()
+
+
+def test_journal_write_stamps_last_activity(configured_app_with_task: Path):
+    result = runner.invoke(app, ["journal", "did a thing", "--task", "add-labels"])
+    assert result.exit_code == 0, result.output
+    state = StateManager(configured_app_with_task / ".mothership").load()
+    assert state.tasks["add-labels"].last_activity_at is not None
+
+
+def test_journal_read_does_not_stamp(configured_app_with_task: Path):
+    runner.invoke(app, ["journal", "seed", "--task", "add-labels"])
+    # reset the stamp, then do a read-only invocation
+    mgr = StateManager(configured_app_with_task / ".mothership")
+    st = mgr.load()
+    st.tasks["add-labels"].last_activity_at = None
+    mgr.save(st)
+    result = runner.invoke(app, ["journal", "--task", "add-labels"])  # read path
+    assert result.exit_code == 0, result.output
+    assert mgr.load().tasks["add-labels"].last_activity_at is None

--- a/tests/cli/test_phase.py
+++ b/tests/cli/test_phase.py
@@ -163,3 +163,10 @@ def test_phase_refuses_when_active_repo_is_passive(tmp_path, monkeypatch):
         container.state_dir.reset_override()
         container.config.reset()
         container.state_manager.reset()
+
+
+def test_phase_transition_stamps_last_activity(configured_app_with_task, workspace: Path):
+    result = runner.invoke(app, ["phase", "dev", "--task", "add-labels"])
+    assert result.exit_code == 0, result.output
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["add-labels"].last_activity_at is not None

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -858,3 +858,14 @@ def test_spec_from_thread_is_idempotent_and_does_not_orphan(_configured):
     store = SpecStore(ws / SPECS_DIRNAME)
     assert len(store.list()) == 1  # no orphaned spec
     assert "reusing spec" in second.output
+
+
+def test_spec_apply_stamps_bound_task_activity(configured_app_with_task: Path, tmp_path):
+    # `spec new --task add-labels` binds spec.task_slug = "add-labels" (id "add-labels").
+    runner.invoke(app, ["spec", "new", "--task", "add-labels"])
+    jf = tmp_path / "draft.json"
+    jf.write_text(_draft_json())
+    result = runner.invoke(app, ["spec", "apply", "add-labels", "--from-json", str(jf)])
+    assert result.exit_code == 0, result.output
+    state = StateManager(configured_app_with_task / ".mothership").load()
+    assert state.tasks["add-labels"].last_activity_at is not None

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -912,3 +912,19 @@ def test_post_archive_already_archived_409(tmp_path):
     _seed_status_spec(tmp_path, "archived")
     client = TestClient(_app(tmp_path))
     assert client.post("/specs/ar/archive").status_code == 409
+
+
+def test_get_task_serializes_activity_fields(tmp_path):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    sm = StateManager(state_dir)
+    now = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+    sm.save(WorkspaceState(tasks={"dq": Task(
+        slug="dq", description="d", phase="dev",
+        created_at=datetime(2026, 6, 14, tzinfo=timezone.utc),
+        affected_repos=["mothership"], branch="feat/dq",
+        last_activity_at=now, phase_entered_at=now,
+    )}))
+    body = TestClient(_app(tmp_path)).get("/tasks/dq").json()
+    assert body["last_activity_at"].startswith("2026-07-13T12:00:00")
+    assert body["phase_entered_at"].startswith("2026-07-13T12:00:00")

--- a/tests/core/test_serve_items.py
+++ b/tests/core/test_serve_items.py
@@ -377,3 +377,22 @@ def test_thread_and_items_endpoints_survive_corrupt_workitem_store(tmp_path, mon
     assert got.json()["work_item_id"] is None
 
     assert client.get("/items").status_code == 200  # _workitem_index degrades too
+
+
+def test_get_item_surfaces_active_task_activity(tmp_path):
+    from mship.core.state import Task, WorkspaceState
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    sm = StateManager(state_dir)
+    now = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+    sm.save(WorkspaceState(tasks={"s1": Task(
+        slug="s1", description="d", phase="dev", created_at=_now(),
+        affected_repos=["mothership"], branch="b", last_activity_at=now,
+    )}))
+    items = WorkItemStore(state_dir / "workitems")
+    wi = items.create(title="Feat", kind="feature", workspace="testws", now=_now())
+    items.add_task(wi.id, "s1", now=_now())
+
+    got = _app(tmp_path).get(f"/items/{wi.id}").json()
+    assert got["active_phase"] == "dev"
+    assert got["active_last_activity_at"].startswith("2026-07-13T12:00:00")

--- a/tests/core/test_state.py
+++ b/tests/core/test_state.py
@@ -397,3 +397,59 @@ def test_legacy_state_without_spec_id_loads(tmp_path):
         }}
     }))
     assert StateManager(tmp_path).load().tasks["t"].spec_id is None
+
+
+def test_last_activity_at_defaults_none(state_dir: Path):
+    mgr = StateManager(state_dir)
+    task = Task(
+        slug="a", description="d", phase="dev",
+        created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        affected_repos=["shared"], branch="feat/a",
+    )
+    mgr.save(WorkspaceState(tasks={"a": task}))
+    assert mgr.load().tasks["a"].last_activity_at is None
+
+
+def test_last_activity_at_roundtrips(state_dir: Path):
+    mgr = StateManager(state_dir)
+    stamp = datetime(2026, 7, 13, 9, 30, tzinfo=timezone.utc)
+    task = Task(
+        slug="a", description="d", phase="dev",
+        created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        affected_repos=["shared"], branch="feat/a",
+        last_activity_at=stamp,
+    )
+    mgr.save(WorkspaceState(tasks={"a": task}))
+    assert mgr.load().tasks["a"].last_activity_at == stamp
+
+
+def test_record_activity_stamps_last_activity_at(state_dir: Path):
+    mgr = StateManager(state_dir)
+    task = Task(
+        slug="a", description="d", phase="dev",
+        created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        affected_repos=["shared"], branch="feat/a",
+    )
+    mgr.save(WorkspaceState(tasks={"a": task}))
+    fixed = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+    mgr.record_activity("a", now=fixed)
+    assert mgr.load().tasks["a"].last_activity_at == fixed
+
+
+def test_record_activity_defaults_to_now(state_dir: Path):
+    mgr = StateManager(state_dir)
+    task = Task(
+        slug="a", description="d", phase="dev",
+        created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        affected_repos=["shared"], branch="feat/a",
+    )
+    mgr.save(WorkspaceState(tasks={"a": task}))
+    mgr.record_activity("a")
+    assert mgr.load().tasks["a"].last_activity_at is not None
+
+
+def test_record_activity_unknown_slug_is_noop(state_dir: Path):
+    mgr = StateManager(state_dir)
+    mgr.save(WorkspaceState(tasks={}))
+    mgr.record_activity("ghost")  # must not raise
+    assert mgr.load().tasks == {}

--- a/tests/core/view/test_task_index.py
+++ b/tests/core/view/test_task_index.py
@@ -160,3 +160,19 @@ def test_build_task_index_includes_enriched_fields(tmp_path: Path):
     assert s.pr_urls == {"mothership": "https://github.com/x/mothership/pull/1"}
     assert s.test_results == {"mothership": "pass"}
     assert s.depends_on == ["up"]
+
+
+def test_summary_carries_activity_and_phase_entered(tmp_path: Path):
+    now = datetime.now(timezone.utc)
+    t = _task("a", last_activity_at=now, phase_entered_at=now)
+    state = WorkspaceState(tasks={"a": t})
+    [summary] = build_task_index(state, tmp_path)
+    assert summary.last_activity_at == now
+    assert summary.phase_entered_at == now
+
+
+def test_summary_activity_defaults_none(tmp_path: Path):
+    t = _task("a")
+    [summary] = build_task_index(WorkspaceState(tasks={"a": t}), tmp_path)
+    assert summary.last_activity_at is None
+    assert summary.phase_entered_at is None

--- a/tests/core/view/test_workitem_index.py
+++ b/tests/core/view/test_workitem_index.py
@@ -267,3 +267,17 @@ def test_summary_active_fields_none_without_active_task():
     summaries = build_workitem_index([item], {}, {"s1": finished}, {})
     assert summaries[0].active_phase is None
     assert summaries[0].active_last_activity_at is None
+
+
+def test_active_task_prefers_most_recently_active():
+    older = _now()
+    newer = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    t1 = Task(slug="s1", description="d", phase="dev", created_at=_now(),
+              affected_repos=["m"], branch="b", finished_at=None, last_activity_at=older)
+    t2 = Task(slug="s2", description="d", phase="review", created_at=_now(),
+              affected_repos=["m"], branch="b", finished_at=None, last_activity_at=newer)
+    item = _wi(task_slugs=["s1", "s2"])
+    summaries = build_workitem_index([item], {}, {"s1": t1, "s2": t2}, {})
+    # s2 is more recently active → its phase + activity surface (not first-in-list s1).
+    assert summaries[0].active_phase == "review"
+    assert summaries[0].active_last_activity_at == newer

--- a/tests/core/view/test_workitem_index.py
+++ b/tests/core/view/test_workitem_index.py
@@ -243,3 +243,27 @@ def test_build_index_include_archived_true_includes_archived():
     hidden = _wi(id="hidden", archived=True)
     summaries = build_workitem_index([hidden], {}, {}, {}, include_archived=True)
     assert [s.id for s in summaries] == ["hidden"]
+
+
+def _task_active(last_activity):
+    return Task(
+        slug="s1", description="d", phase="review", created_at=_now(),
+        affected_repos=["mothership"], branch="b",
+        finished_at=None, last_activity_at=last_activity,
+    )
+
+
+def test_summary_surfaces_active_task_activity_and_phase():
+    now = _now()
+    item = _wi(task_slugs=["s1"])
+    summaries = build_workitem_index([item], {}, {"s1": _task_active(now)}, {})
+    assert summaries[0].active_phase == "review"
+    assert summaries[0].active_last_activity_at == now
+
+
+def test_summary_active_fields_none_without_active_task():
+    item = _wi(task_slugs=["s1"])
+    finished = _task(finished=True)  # finished_at set
+    summaries = build_workitem_index([item], {}, {"s1": finished}, {})
+    assert summaries[0].active_phase is None
+    assert summaries[0].active_last_activity_at is None


### PR DESCRIPTION
GC: spec phase-progress + live agent heartbeat indicator
---

## Acceptance criteria

- [ ] `ac1` mship stamps last_activity_at on a task whenever the agent runs a task-scoped mship command (at minimum journal, commit, test, phase, spec apply), with no dependency on which agent or LLM is driving. — _no evidence_
- [ ] `ac2` mship heartbeat --task <slug> updates the task's last_activity_at and has no other side effects, so a cooperating agent can pulse it on a timer. — _no evidence_
- [ ] `ac3` GET /tasks/{slug} and GET /tasks include last_activity_at and phase_entered_at; GET /items/{id} surfaces the active task's last_activity_at and phase so GC renders liveness without an extra round-trip. — _no evidence_
- [ ] `ac4` Ground Control renders a shared phase stepper (Dispatched -> Planning -> Building -> Review -> Done) driven by task.phase, with the current stage visually active/animated. — _no evidence_
- [ ] `ac5` Ground Control shows a live chip derived from last_activity_at: 'working' when recent (~90s window), 'quiet <N>m' after the stall threshold (~5 min), and 'done' on merge; the thresholds are named constants. — _no evidence_
- [ ] `ac6` The spec-detail screen shows the compact stepper+chip after Dispatch, polling only while the spec is dispatched or in-flight and stopping at a terminal state. — _no evidence_
- [ ] `ac7` The Console/WorkItem cockpit shows the full stepper + live chip alongside the existing journal feed, reusing its existing polling with no new poll loop. — _no evidence_
- [ ] `ac8` When last_activity_at is absent (older tasks or no activity yet), the UI degrades gracefully - the stepper still shows the phase and the chip shows a neutral/unknown state rather than a false 'working'. — _no evidence_
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `gc-phase-progress-heartbeat`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/59 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/372 | this PR |

⚠ Merge in order: ground-control → mothership