### PR TITLE
Auto-advance on PR merge (no manual close) + safe worktree teardown guard

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -881,7 +881,13 @@ def register(app: typer.Typer, get_container):
                 output.warning(f"lifecycle hook '{hr.hook_name}' for task.closed failed: {hr.error}")
 
         wt_mgr = container.worktree_manager()
-        wt_mgr.abort(task_slug)  # core method retains the name; only CLI verb changed
+        from mship.core.worktree import WorktreeDirtyError
+        try:
+            wt_mgr.abort(task_slug, force=force)  # core method retains the name; only CLI verb changed
+        except WorktreeDirtyError as e:
+            output.error(str(e))
+            output.error("Resolve the changes (commit/push), or re-run `mship close --force` to discard them.")
+            raise typer.Exit(code=1)
 
         if downstream and detach_downstream:
             def _detach(s):

--- a/src/mship/core/pr_watcher.py
+++ b/src/mship/core/pr_watcher.py
@@ -247,12 +247,40 @@ class PrWatcher:
             log.exception("pr_watcher: merge auto-advance failed (task=%s)", slug)
             return
 
-        # Guarded teardown. A dirty/unpushed worktree raises WorktreeDirtyError;
-        # any other failure just logs (fail-open).
+        # Guarded teardown. A dirty/unpushed worktree raises WorktreeDirtyError
+        # -> leave the worktree, post a one-time skip-note (the spec/phase advance
+        # already stands). Any other failure just logs (fail-open).
         try:
             self.worktree_manager.abort(slug, force=False)
-        except Exception:
-            log.exception("pr_watcher: merge teardown failed (task=%s)", slug)
+        except Exception as exc:
+            from mship.core.worktree import WorktreeDirtyError
+            if isinstance(exc, WorktreeDirtyError):
+                try:
+                    self._post_teardown_skipped_note(slug, task, url, exc)
+                except Exception:
+                    log.exception("pr_watcher: teardown-skip note failed (task=%s)", slug)
+            else:
+                log.exception("pr_watcher: merge teardown failed (task=%s)", slug)
+
+    def _post_teardown_skipped_note(
+        self, slug: str, task: Any, url: str, exc: Any,
+    ) -> None:
+        """Post a one-time NOTE (kind='note', not 'event' — informational, no
+        nag) when a merged task's worktree was left intact because it had
+        uncommitted/unpushed changes. Deduped across sweeps by a sentinel line."""
+        now = self.now_fn()
+        tid, _wi = self._resolve_thread(slug, task, url, now)
+        thread = self.msgs.get(tid)
+        sentinel = f"Worktree for {slug} left intact"
+        if thread is not None and any(sentinel in m.text for m in thread.messages):
+            return
+        details = "; ".join(f"{repo}: {reason}" for repo, reason in exc.dirty.items())
+        text = (
+            f"⚠️ {sentinel}: {details}. "
+            f"Resolve (commit/push), then `mship close` "
+            f"(or `mship close --force` to discard)."
+        )
+        self.msgs.append(tid, "agent", text, now, kind="note")
 
     def _check_posted(
         self, slug: str, task: Any, key: tuple[str, str, str, str],

--- a/src/mship/core/pr_watcher.py
+++ b/src/mship/core/pr_watcher.py
@@ -139,12 +139,16 @@ class PrWatcher:
         # WorkItem and tears the worktree down. Gated on presence — like `config`
         # gates lifecycle hooks — so watchers built without it are unchanged.
         self.worktree_manager = worktree_manager
+        # Per-sweep set of task slugs already auto-closed this sweep, so a task
+        # whose N repos all merged advances + tears down ONCE, not once per repo.
+        self._auto_closed_slugs: set[str] = set()
 
     def check_once(self) -> None:
         """One sweep over all tasks' PR urls. Never raises — a failure while
         checking one PR is logged and skipped so it can't abort the sweep for
         every other task."""
         tasks = self.state_manager.load().tasks
+        self._auto_closed_slugs = set()  # reset per-sweep merge-auto-close dedup
         # Snapshot: a merge auto-close can tear a task down (removing it from
         # state) mid-sweep, so iterate a materialized list rather than the live
         # dict view to avoid "dictionary changed size during iteration".
@@ -214,6 +218,10 @@ class PrWatcher:
             return
         if self.worktree_manager is None or self.workspace_root is None:
             return
+        # A task's N repos are checked as N (slug, repo, url) triples in one
+        # sweep; only handle the first one that finds the whole task merged.
+        if slug in self._auto_closed_slugs:
+            return
 
         # Advance phase/spec FIRST, so it stands even if teardown is later
         # skipped for a dirty worktree.
@@ -228,9 +236,11 @@ class PrWatcher:
             open_count = sum(1 for s in states if s == "open")
             # Only advance/tear down when the WHOLE task is cleanly merged
             # (mirrors `mship close`'s routing). A partially-merged multi-PR
-            # task waits for its remaining PRs.
+            # task waits for its remaining PRs — don't mark it done so a later
+            # sweep re-evaluates once its remaining PRs merge.
             if open_count or merged_count == 0 or closed_count > 0:
                 return
+            self._auto_closed_slugs.add(slug)
 
             specs_dir = self.workspace_root / SPECS_DIRNAME
             workitems_dir = self.workspace_root / ".mothership" / "workitems"

--- a/src/mship/core/pr_watcher.py
+++ b/src/mship/core/pr_watcher.py
@@ -120,6 +120,7 @@ class PrWatcher:
         config: Any | None = None,
         workspace_root: Path | None = None,
         shell: Any | None = None,
+        worktree_manager: Any | None = None,
     ) -> None:
         self.msgs = msgs
         self.workitems = workitems
@@ -134,6 +135,10 @@ class PrWatcher:
         self.config = config
         self.workspace_root = workspace_root
         self.shell = shell
+        # When injected (in `serve`), a PR merge auto-advances the bound spec +
+        # WorkItem and tears the worktree down. Gated on presence — like `config`
+        # gates lifecycle hooks — so watchers built without it are unchanged.
+        self.worktree_manager = worktree_manager
 
     def check_once(self) -> None:
         """One sweep over all tasks' PR urls. Never raises — a failure while

--- a/src/mship/core/pr_watcher.py
+++ b/src/mship/core/pr_watcher.py
@@ -145,7 +145,10 @@ class PrWatcher:
         checking one PR is logged and skipped so it can't abort the sweep for
         every other task."""
         tasks = self.state_manager.load().tasks
-        for slug, task in tasks.items():
+        # Snapshot: a merge auto-close can tear a task down (removing it from
+        # state) mid-sweep, so iterate a materialized list rather than the live
+        # dict view to avoid "dictionary changed size during iteration".
+        for slug, task in list(tasks.items()):
             if not task.pr_urls:
                 continue
             for repo, url in task.pr_urls.items():
@@ -191,12 +194,65 @@ class PrWatcher:
         # not at-most-zero). The happy path still posts — and dedups —
         # exactly once.
         self._fire_lifecycle_hook(st, slug, repo)
+        self._auto_close_on_merge(slug, task, repo, url, st)
 
         if self.lock is not None:
             with self.lock:
                 self._post_event(tid, slug, repo, url, st, key)
         else:
             self._post_event(tid, slug, repo, url, st, key)
+
+    def _auto_close_on_merge(
+        self, slug: str, task: Any, repo: str, url: str, st: str,
+    ) -> None:
+        """On a clean full merge, advance the bound spec (dispatched->implemented)
+        and its WorkItem (->done / needs_review cleared), then tear the worktree
+        down — the zero-manual-`mship close` path. Non-interactive and fail-open:
+        every failure is logged and swallowed so the sweep never crashes. Only
+        active when a worktree_manager is injected (i.e. inside `mship serve`)."""
+        if st != "merged":
+            return
+        if self.worktree_manager is None or self.workspace_root is None:
+            return
+
+        # Advance phase/spec FIRST, so it stands even if teardown is later
+        # skipped for a dirty worktree.
+        try:
+            from mship.core.spec_store import SPECS_DIRNAME
+            from mship.core.spec_lifecycle import advance_spec_on_close
+            from mship.core.workitem_lifecycle import advance_workitem_on_close
+
+            states = [self.check_state(u) for u in task.pr_urls.values()]
+            merged_count = sum(1 for s in states if s == "merged")
+            closed_count = sum(1 for s in states if s == "closed")
+            open_count = sum(1 for s in states if s == "open")
+            # Only advance/tear down when the WHOLE task is cleanly merged
+            # (mirrors `mship close`'s routing). A partially-merged multi-PR
+            # task waits for its remaining PRs.
+            if open_count or merged_count == 0 or closed_count > 0:
+                return
+
+            specs_dir = self.workspace_root / SPECS_DIRNAME
+            workitems_dir = self.workspace_root / ".mothership" / "workitems"
+            snapshot = self.state_manager.load()  # still contains the closing task
+            advance_spec_on_close(
+                task=task, specs_dir=specs_dir,
+                merged_count=merged_count, closed_count=closed_count,
+            )
+            advance_workitem_on_close(
+                task=task, workitems_dir=workitems_dir, specs_dir=specs_dir,
+                state=snapshot, merged_count=merged_count, closed_count=closed_count,
+            )
+        except Exception:
+            log.exception("pr_watcher: merge auto-advance failed (task=%s)", slug)
+            return
+
+        # Guarded teardown. A dirty/unpushed worktree raises WorktreeDirtyError;
+        # any other failure just logs (fail-open).
+        try:
+            self.worktree_manager.abort(slug, force=False)
+        except Exception:
+            log.exception("pr_watcher: merge teardown failed (task=%s)", slug)
 
     def _check_posted(
         self, slug: str, task: Any, key: tuple[str, str, str, str],

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -325,6 +325,7 @@ def create_app(
             config=config,
             workspace_root=workspace_root,
             shell=ShellRunner(),
+            worktree_manager=worktree_manager,
         )
         stop = asyncio.Event()
         task = asyncio.create_task(_pr_watch_loop(watcher, stop, interval))

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -1,3 +1,4 @@
+import logging
 import shutil
 import subprocess
 from dataclasses import dataclass, field
@@ -15,12 +16,30 @@ from mship.util.shell import ShellRunner
 from mship.util.slug import slugify
 
 
+logger = logging.getLogger(__name__)
+
+
 class BaseBranchNotFoundError(ValueError):
     """`spawn --base <branch>` was given a branch that doesn't exist in a target repo.
 
     A ValueError subclass so callers that already handle spawn ValueErrors keep
     working; the CLI catches this type specifically to print a clean message.
     """
+
+
+class WorktreeDirtyError(RuntimeError):
+    """Raised by WorktreeManager.abort when a repo's worktree has uncommitted
+    or unpushed changes and force was not requested. Carries the offending
+    repos so callers can render an actionable message and never lose work."""
+
+    def __init__(self, task_slug: str, dirty: dict[str, str]) -> None:
+        self.task_slug = task_slug
+        self.dirty = dirty  # repo_name -> reason ("uncommitted changes" | "unpushed commits")
+        details = "; ".join(f"{repo}: {reason}" for repo, reason in dirty.items())
+        super().__init__(
+            f"Refusing to tear down '{task_slug}': {details}. "
+            f"Resolve them, or pass --force to delete the worktree anyway."
+        )
 
 
 @dataclass
@@ -723,10 +742,39 @@ class WorktreeManager:
 
         return SpawnResult(task=task, setup_warnings=setup_warnings)
 
-    def abort(self, task_slug: str) -> None:
-        state = self._state_manager.load()
-        task = state.tasks[task_slug]
+    def _dirty_worktrees(self, task) -> dict[str, str]:
+        """Return {repo_name: reason} for each affected repo's worktree with
+        uncommitted changes OR unpushed commits. Empty dict = safe to tear down.
+        Skips git_root repos (their worktree is a subdir of the parent's) and
+        already-gone paths (nothing to lose)."""
+        dirty: dict[str, str] = {}
+        for repo_name, wt_path in task.worktrees.items():
+            if self._config.repos[repo_name].git_root is not None:
+                continue
+            p = Path(wt_path)
+            if not p.exists():
+                continue
+            if self._git.has_uncommitted_changes(p):
+                dirty[repo_name] = "uncommitted changes"
+            elif self._git.has_unpushed_commits(p):
+                dirty[repo_name] = "unpushed commits"
+        return dirty
 
+    def abort(self, task_slug: str, force: bool = False) -> None:
+        state = self._state_manager.load()
+        task = state.tasks.get(task_slug)
+        if task is None:
+            return  # idempotent: already torn down
+
+        # Universal safety guard: never delete a worktree with uncommitted or
+        # unpushed changes unless force. Pre-pass over ALL worktrees before
+        # removing any, so a dirty repo refuses the whole task's teardown.
+        if not force:
+            dirty = self._dirty_worktrees(task)
+            if dirty:
+                raise WorktreeDirtyError(task_slug, dirty)
+
+        removal_failed = False
         for repo_name, wt_path in task.worktrees.items():
             repo_config = self._config.repos[repo_name]
 
@@ -741,7 +789,13 @@ class WorktreeManager:
                     worktree_path=Path(wt_path),
                 )
             except Exception:
-                shutil.rmtree(Path(wt_path), ignore_errors=True)
+                # The silent shutil.rmtree(ignore_errors=True) data-loss fallback
+                # was REMOVED: never blow away a directory git refused to remove.
+                # Leave it on disk for `mship prune` to reap.
+                removal_failed = True
+                logger.warning(
+                    "worktree remove failed for %s (%s); left intact", repo_name, wt_path,
+                )
             try:
                 self._git.branch_delete(
                     repo_path=repo_config.path,
@@ -750,24 +804,26 @@ class WorktreeManager:
             except Exception:
                 pass
 
-        # Remove the hub directory for this task. Inferred from the first
-        # worktree's parent.parent, which is `<workspace>/.worktrees/<slug>/`.
-        # Legacy per-repo-layout tasks have a different parent shape — leave
-        # those alone.
-        try:
-            sample_wt = None
-            for name, wt in task.worktrees.items():
-                if self._config.repos[name].git_root is None:
-                    sample_wt = wt
-                    break
-            if sample_wt is not None:
-                hub = Path(sample_wt).parent
-                # Sanity: only remove if it looks like a hub (parent ends in .worktrees)
-                if hub.name == task_slug and hub.parent.name == ".worktrees":
-                    if hub.exists():
-                        shutil.rmtree(hub, ignore_errors=True)
-        except Exception:
-            pass
+        # Remove the hub directory for this task, but ONLY when every worktree
+        # was cleanly removed — otherwise nuking the hub would delete a worktree
+        # git just refused to remove. Inferred from the first worktree's parent,
+        # which is `<workspace>/.worktrees/<slug>/`. Legacy per-repo-layout tasks
+        # have a different parent shape — leave those alone.
+        if not removal_failed:
+            try:
+                sample_wt = None
+                for name, wt in task.worktrees.items():
+                    if self._config.repos[name].git_root is None:
+                        sample_wt = wt
+                        break
+                if sample_wt is not None:
+                    hub = Path(sample_wt).parent
+                    # Sanity: only remove if it looks like a hub (parent ends in .worktrees)
+                    if hub.name == task_slug and hub.parent.name == ".worktrees":
+                        if hub.exists():
+                            shutil.rmtree(hub, ignore_errors=True)
+            except Exception:
+                pass
 
         # Only update state after all cleanup attempts
         def _abort(s):

--- a/src/mship/skills/finishing-a-development-branch/SKILL.md
+++ b/src/mship/skills/finishing-a-development-branch/SKILL.md
@@ -141,6 +141,8 @@ Then: Cleanup worktree (Step 5)
 
 *In a mothership workspace, worktree cleanup is handled by `mship close`. Run it after the local merge (Option 1) or after the PR merges on GitHub (Option 2 — check via `mship pr` for an aggregate view across tasks, `mship reconcile` for drift, or `gh pr view <url>` for a single PR). No manual `git worktree remove` needed.*
 
+*Merge auto-advance (`mship serve`): when `mship serve` is running, a merged PR **auto-advances** the bound spec (`dispatched → implemented`) and its WorkItem (→ `done`, clearing `needs_review`) and tears the worktree down for you — zero manual steps in the common (clean) case, so you usually don't run `mship close` at all after the PR merges. You only need `mship close` when the worktree still has **uncommitted or unpushed** changes: auto-teardown is skipped to protect that work (the spec/WorkItem still advance, and a note is posted on the task's thread) — resolve (commit/push) then `mship close`, or `mship close --force` to discard. `--force` is the only way to delete a dirty/unpushed worktree, and this guard is universal (it also applies to `mship close` and `mship close --abandon`), so uncommitted/unpushed work is **never** deleted without `--force`.*
+
 **For Option 3:** Keep worktree.
 
 ## Quick Reference

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -228,8 +228,10 @@ mship capture [--repo R] [--platform P] [--kind image|layout|all] [--out DIR]
 mship journal "msg" [--action X] [--open Y] [--repo R] [--test-state pass|fail|mixed]
 mship journal --show-open                 # what am I blocked on across this task?
 mship finish [--base B] [--base-map ...] [--push-only] [--handoff] [--force-audit] [--body-file F | --body TEXT] [--force] [--require-tests] [--title T] [--body-map ...]
-mship close [--yes] [--abandon] [--force] [--skip-pr-check]
+mship close [--yes] [--abandon] [--force] [--skip-pr-check]   # --force also required to tear down a dirty/unpushed worktree
 ```
+
+**Merge auto-advance (`mship serve`).** With `mship serve` running, the PR-watcher auto-closes the loop: when a task's PR(s) merge it advances the bound spec `dispatched → implemented` and the WorkItem to `done` (clearing the `needs_review` attention), then tears the worktree down — so **no manual `mship close` is needed** in the common case. `mship close` is now needed only to force-teardown a worktree with **uncommitted or unpushed** changes: every teardown path (merge auto-close, `mship close`, `mship close --abandon`) refuses to delete such a worktree unless you pass `--force`, so work is never lost. When auto-teardown is skipped for a dirty worktree, the spec/WorkItem still advance and a note is posted on the thread — resolve, then `mship close` (or `--force`).
 
 ### Every task needs a WorkItem
 

--- a/src/mship/util/git.py
+++ b/src/mship/util/git.py
@@ -133,6 +133,39 @@ class GitRunner:
         )
         return bool(result.stdout.strip())
 
+    def has_unpushed_commits(self, worktree_path: Path) -> bool:
+        """True if the worktree's current branch has commits not safely on origin.
+
+        Teardown guard (spec auto-advance-on-merge):
+        - No `origin` remote at all -> False (nothing to push to; a no-remote
+          checkout can't have "unpushed" work in the sense this guard protects,
+          and every no-remote fixture must still tear down).
+        - Upstream tracking ref set (post-`finish`, this is origin/<branch>) ->
+          True iff `git rev-list --count @{u}..HEAD` > 0.
+        - `origin` exists but the branch has NO upstream tracking ref (it was
+          never `push -u`'d) -> True: we can't prove its commits are on origin,
+          so refuse (conservative).
+        Any git error -> True (conservative: refuse rather than risk data loss).
+        """
+        if not self.has_remote(worktree_path, "origin"):
+            return False
+        upstream = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+            cwd=worktree_path, capture_output=True, text=True,
+        )
+        if upstream.returncode != 0:
+            return True
+        ahead = subprocess.run(
+            ["git", "rev-list", "--count", "@{u}..HEAD"],
+            cwd=worktree_path, capture_output=True, text=True,
+        )
+        if ahead.returncode != 0:
+            return True
+        try:
+            return int(ahead.stdout.strip() or "0") > 0
+        except ValueError:
+            return True
+
     def run_worktree_prune(self, repo_path: Path) -> None:
         """Clean up stale git worktree tracking."""
         subprocess.run(

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -2170,3 +2170,82 @@ def test_close_non_required_hook_failure_never_blocks_close(configured_git_app):
         assert "t" not in sm.load().tasks
     finally:
         container.shell.reset_override()
+
+
+def test_close_threads_force_true_to_abort(configured_git_app):
+    from datetime import datetime, timezone
+    from unittest.mock import MagicMock
+    from mship.cli import container
+    from mship.core.state import StateManager, Task, WorkspaceState
+    from mship.util.shell import ShellRunner, ShellResult
+    from typer.testing import CliRunner
+    from mship.cli import app as _app
+
+    sm = StateManager(configured_git_app / ".mothership")
+    sm.save(WorkspaceState(tasks={"t": Task(
+        slug="t", description="d", phase="review",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["shared"], branch="feat/t",
+        pr_urls={"shared": "https://github.com/o/r/pull/1"},
+        finished_at=datetime.now(timezone.utc),
+    )}))
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.return_value = ShellResult(returncode=0, stdout="MERGED\n", stderr="")
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="", stderr="")
+
+    class _Rec:
+        def __init__(self): self.calls = []
+        def abort(self, task_slug, force=False): self.calls.append((task_slug, force))
+
+    rec = _Rec()
+    container.shell.override(mock_shell)
+    container.worktree_manager.override(rec)
+    try:
+        result = CliRunner().invoke(_app, ["close", "--yes", "--force", "--task", "t"])
+        assert result.exit_code == 0, result.output
+        assert rec.calls == [("t", True)]              # ac5: force reaches the primitive
+    finally:
+        container.shell.reset_override()
+        container.worktree_manager.reset_override()
+
+
+def test_close_surfaces_worktree_dirty_error_and_keeps_task(configured_git_app):
+    from datetime import datetime, timezone
+    from unittest.mock import MagicMock
+    from mship.cli import container
+    from mship.core.state import StateManager, Task, WorkspaceState
+    from mship.util.shell import ShellRunner, ShellResult
+    from typer.testing import CliRunner
+    from mship.cli import app as _app
+
+    sm = StateManager(configured_git_app / ".mothership")
+    sm.save(WorkspaceState(tasks={"t": Task(
+        slug="t", description="d", phase="review",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["shared"], branch="feat/t",
+        pr_urls={"shared": "https://github.com/o/r/pull/1"},
+        finished_at=datetime.now(timezone.utc),
+    )}))
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.return_value = ShellResult(returncode=0, stdout="MERGED\n", stderr="")
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="", stderr="")
+
+    class _Dirty:
+        def abort(self, task_slug, force=False):
+            from mship.core.worktree import WorktreeDirtyError
+            if not force:
+                raise WorktreeDirtyError(task_slug, {"shared": "uncommitted changes"})
+
+    container.shell.override(mock_shell)
+    container.worktree_manager.override(_Dirty())
+    try:
+        result = CliRunner().invoke(_app, ["close", "--yes", "--task", "t"])
+        assert result.exit_code != 0
+        assert "uncommitted changes" in result.output
+        assert "--force" in result.output
+        assert "t" in sm.load().tasks                   # ac3: task NOT removed
+    finally:
+        container.shell.reset_override()
+        container.worktree_manager.reset_override()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,16 +89,22 @@ repos:
 @pytest.fixture
 def workspace_with_git(workspace: Path) -> Path:
     """Workspace where each repo is a git repo."""
+    _git_env = {**os.environ, "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t.com",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t.com"}
     for name in ["shared", "auth-service", "api-gateway"]:
         repo_dir = workspace / name
         subprocess.run(["git", "init", str(repo_dir)], check=True, capture_output=True)
+        # Commit the working tree (the `workspace` fixture wrote a Taskfile.yml into
+        # each repo) so the checkout is CLEAN — otherwise the untracked file trips
+        # WorktreeManager.abort's dirty-worktree guard in tests that point a task
+        # worktree at the main checkout.
+        subprocess.run(["git", "add", "-A"], cwd=repo_dir, check=True, capture_output=True, env=_git_env)
         subprocess.run(
-            ["git", "commit", "--allow-empty", "-m", "init"],
+            ["git", "commit", "-m", "init"],
             cwd=repo_dir,
             check=True,
             capture_output=True,
-            env={**os.environ, "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t.com",
-                 "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t.com"},
+            env=_git_env,
         )
     return workspace
 

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -773,3 +773,15 @@ def test_announce_dedupes_against_legacy_event_opened_marker():
     announce_prs_on_thread(msgs, workitems, "task-1", task, [{"repo": "r", "url": url}], NOW)
 
     assert not any(c["kind"] == "note" and "PR opened:" in c["text"] for c in msgs.append_calls)
+
+
+def test_pr_watcher_stores_worktree_manager():
+    msgs = FakeMessageStore()
+    workitems = FakeWorkItemStore()
+    state = FakeStateManager({})
+    sentinel = object()
+    watcher = PrWatcher(
+        msgs, workitems, state, lambda u: "open", now_fn,
+        worktree_manager=sentinel,
+    )
+    assert watcher.worktree_manager is sentinel

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -919,3 +919,66 @@ def test_merge_dirty_worktree_advances_then_posts_skip_note(tmp_path):
     watcher.check_once()  # idempotent: does not double-post
     notes = [c for c in msgs.append_calls if c["kind"] == "note"]
     assert len(notes) == 1
+
+
+def test_merge_auto_close_is_idempotent_across_sweeps(tmp_path):
+    """ac7: a repeated merge signal after teardown does not double-advance or error."""
+    from mship.core.spec_store import SpecStore
+    spec, wi, wstore = _seed_dispatched_spec_and_workitem(tmp_path)
+    msgs = FakeMessageStore()
+    url = "https://github.com/org/repo1/pull/1"
+    task = SimpleNamespace(
+        slug="task-m", pr_urls={"repo1": url}, work_item_id=wi.id,
+        spec_id=spec.id, worktrees={"repo1": str(tmp_path / "wt")},
+    )
+    tasks = {"task-m": task}
+    state = FakeStateManager(tasks)
+    fwm = FakeWorktreeManager(tasks)
+    watcher = PrWatcher(msgs, wstore, state, lambda u: "merged", now_fn,
+                        worktree_manager=fwm, workspace_root=tmp_path)
+    watcher.check_once(); watcher.check_once(); watcher.check_once()
+    assert fwm.abort_calls == [("task-m", False)]
+    assert SpecStore(tmp_path / "specs").find_by_id(spec.id).status == "implemented"
+
+
+def test_merge_partial_multipr_does_not_advance_or_tear_down(tmp_path):
+    """ac7-adjacent: a multi-PR task with one PR still open must not advance or tear down."""
+    from mship.core.spec_store import SpecStore
+    spec, wi, wstore = _seed_dispatched_spec_and_workitem(tmp_path)
+    msgs = FakeMessageStore()
+    url_a = "https://github.com/org/repoA/pull/1"
+    url_b = "https://github.com/org/repoB/pull/2"
+    task = SimpleNamespace(
+        slug="task-m", pr_urls={"repoA": url_a, "repoB": url_b},
+        work_item_id=wi.id, spec_id=spec.id,
+        worktrees={"repoA": str(tmp_path / "wtA"), "repoB": str(tmp_path / "wtB")},
+    )
+    tasks = {"task-m": task}
+    state = FakeStateManager(tasks)
+    fwm = FakeWorktreeManager(tasks)
+
+    def check_state(u):
+        return "merged" if u == url_a else "open"
+
+    PrWatcher(msgs, wstore, state, check_state, now_fn,
+              worktree_manager=fwm, workspace_root=tmp_path).check_once()
+    assert fwm.abort_calls == []
+    assert SpecStore(tmp_path / "specs").find_by_id(spec.id).status == "dispatched"
+
+
+def test_merge_teardown_failure_is_fail_open_event_still_posts(tmp_path):
+    """ac2: an unexpected teardown failure never crashes the sweep or drops the event."""
+    spec, wi, wstore = _seed_dispatched_spec_and_workitem(tmp_path)
+    msgs = FakeMessageStore()
+    url = "https://github.com/org/repo1/pull/1"
+    task = SimpleNamespace(
+        slug="task-m", pr_urls={"repo1": url}, work_item_id=wi.id,
+        spec_id=spec.id, worktrees={"repo1": str(tmp_path / "wt")},
+    )
+    tasks = {"task-m": task}
+    state = FakeStateManager(tasks)
+    fwm = FakeWorktreeManager(tasks, boom=True)
+    watcher = PrWatcher(msgs, wstore, state, lambda u: "merged", now_fn,
+                        worktree_manager=fwm, workspace_root=tmp_path)
+    watcher.check_once()  # must not raise
+    assert any(c["kind"] == "event" and "merged" in c["text"] for c in msgs.append_calls)

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -982,3 +982,25 @@ def test_merge_teardown_failure_is_fail_open_event_still_posts(tmp_path):
                         worktree_manager=fwm, workspace_root=tmp_path)
     watcher.check_once()  # must not raise
     assert any(c["kind"] == "event" and "merged" in c["text"] for c in msgs.append_calls)
+
+
+def test_merge_multirepo_all_merged_auto_closes_once(tmp_path):
+    """Greptile P2: a task whose N repos all merged advances + tears down ONCE
+    per sweep, not once per repo (dedup on the task slug)."""
+    from mship.core.spec_store import SpecStore
+    spec, wi, wstore = _seed_dispatched_spec_and_workitem(tmp_path)
+    msgs = FakeMessageStore()
+    url_a = "https://github.com/org/repoA/pull/1"
+    url_b = "https://github.com/org/repoB/pull/2"
+    task = SimpleNamespace(
+        slug="task-m", pr_urls={"repoA": url_a, "repoB": url_b},
+        work_item_id=wi.id, spec_id=spec.id,
+        worktrees={"repoA": str(tmp_path / "wtA"), "repoB": str(tmp_path / "wtB")},
+    )
+    tasks = {"task-m": task}
+    state = FakeStateManager(tasks)
+    fwm = FakeWorktreeManager(tasks)
+    PrWatcher(msgs, wstore, state, lambda u: "merged", now_fn,
+              worktree_manager=fwm, workspace_root=tmp_path).check_once()
+    assert fwm.abort_calls == [("task-m", False)]  # torn down once, not twice
+    assert SpecStore(tmp_path / "specs").find_by_id(spec.id).status == "implemented"

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -785,3 +785,101 @@ def test_pr_watcher_stores_worktree_manager():
         worktree_manager=sentinel,
     )
     assert watcher.worktree_manager is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Merge auto-close (spec auto-advance-on-merge)
+# ---------------------------------------------------------------------------
+
+class FakeWorktreeManager:
+    """Records abort() and mutates the shared task dict so re-sweeps see the
+    teardown, mirroring the real WorktreeManager.abort contract."""
+
+    def __init__(self, tasks: dict, *, dirty: dict | None = None, boom: bool = False) -> None:
+        self._tasks = tasks
+        self._dirty = dirty
+        self._boom = boom
+        self.abort_calls: list[tuple[str, bool]] = []
+
+    def abort(self, task_slug: str, force: bool = False) -> None:
+        self.abort_calls.append((task_slug, force))
+        if task_slug not in self._tasks:
+            return  # idempotent no-op (mirrors real abort)
+        if not force and self._dirty is not None:
+            from mship.core.worktree import WorktreeDirtyError
+            raise WorktreeDirtyError(task_slug, self._dirty)
+        if not force and self._boom:
+            raise RuntimeError("teardown kaboom")
+        self._tasks.pop(task_slug, None)
+
+
+def _seed_dispatched_spec_and_workitem(tmp_path):
+    """Real SpecStore + WorkItemStore on disk: a dispatched spec linked to a
+    feature WorkItem that has one live task. Returns (spec, wi, wstore)."""
+    from mship.core.spec_draft import new_spec
+    from mship.core.spec_store import SpecStore
+    from mship.core.workitem_store import WorkItemStore
+
+    specs_dir = tmp_path / "specs"
+    specs_dir.mkdir(parents=True, exist_ok=True)
+    sstore = SpecStore(specs_dir)
+    spec = new_spec("Auto advance feature", now=NOW, task_slug="task-m")
+    spec.status = "dispatched"
+    sstore.save(spec)
+
+    wstore = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = wstore.create(title="Auto advance feature", kind="feature", workspace="ws", now=NOW)
+    wstore.link_spec(wi.id, spec.id, now=NOW)
+    wstore.add_task(wi.id, "task-m", now=NOW)
+    return spec, wi, wstore
+
+
+def test_merge_auto_advances_spec_and_workitem_then_tears_down(tmp_path):
+    from mship.core.spec_store import SpecStore
+    from mship.core.workitem_store import WorkItemStore
+    from mship.core.view.workitem_index import compute_phase, compute_attention
+
+    spec, wi, wstore = _seed_dispatched_spec_and_workitem(tmp_path)
+
+    msgs = FakeMessageStore()
+    url = "https://github.com/org/repo1/pull/1"
+    task = SimpleNamespace(
+        slug="task-m", pr_urls={"repo1": url}, work_item_id=wi.id,
+        spec_id=spec.id, worktrees={"repo1": str(tmp_path / "wt")},
+    )
+    tasks = {"task-m": task}
+    state = FakeStateManager(tasks)
+    fwm = FakeWorktreeManager(tasks)
+
+    watcher = PrWatcher(
+        msgs, wstore, state, lambda u: "merged", now_fn,
+        worktree_manager=fwm, workspace_root=tmp_path,
+    )
+    watcher.check_once()
+
+    assert SpecStore(tmp_path / "specs").find_by_id(spec.id).status == "implemented"
+    reread_spec = SpecStore(tmp_path / "specs").find_by_id(spec.id)
+    reread_item = WorkItemStore(tmp_path / ".mothership" / "workitems").get(wi.id)
+    assert compute_phase(reread_item, reread_spec, []) == "done"
+    assert compute_attention(reread_spec, [], []).needs_review is False
+    assert fwm.abort_calls == [("task-m", False)]
+    assert "task-m" not in tasks
+    assert any(c["kind"] == "event" and "merged" in c["text"] for c in msgs.append_calls)
+
+
+def test_merge_auto_close_noop_without_worktree_manager(tmp_path):
+    spec, wi, wstore = _seed_dispatched_spec_and_workitem(tmp_path)
+    from mship.core.spec_store import SpecStore
+
+    msgs = FakeMessageStore()
+    url = "https://github.com/org/repo1/pull/1"
+    task = SimpleNamespace(
+        slug="task-m", pr_urls={"repo1": url}, work_item_id=wi.id,
+        spec_id=spec.id, worktrees={"repo1": str(tmp_path / "wt")},
+    )
+    state = FakeStateManager({"task-m": task})
+
+    PrWatcher(msgs, wstore, state, lambda u: "merged", now_fn,
+              workspace_root=tmp_path).check_once()
+
+    assert SpecStore(tmp_path / "specs").find_by_id(spec.id).status == "dispatched"

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -883,3 +883,39 @@ def test_merge_auto_close_noop_without_worktree_manager(tmp_path):
               workspace_root=tmp_path).check_once()
 
     assert SpecStore(tmp_path / "specs").find_by_id(spec.id).status == "dispatched"
+
+
+def test_merge_dirty_worktree_advances_then_posts_skip_note(tmp_path):
+    """ac4: when teardown is refused (dirty), the worktree is left intact, the
+    spec/phase still advances, and a note is posted telling the operator to
+    resolve then `mship close` / --force."""
+    from mship.core.spec_store import SpecStore
+
+    spec, wi, wstore = _seed_dispatched_spec_and_workitem(tmp_path)
+
+    msgs = FakeMessageStore()
+    url = "https://github.com/org/repo1/pull/1"
+    task = SimpleNamespace(
+        slug="task-m", pr_urls={"repo1": url}, work_item_id=wi.id,
+        spec_id=spec.id, worktrees={"repo1": str(tmp_path / "wt")},
+    )
+    tasks = {"task-m": task}
+    state = FakeStateManager(tasks)
+    fwm = FakeWorktreeManager(tasks, dirty={"repo1": "uncommitted changes"})
+
+    watcher = PrWatcher(
+        msgs, wstore, state, lambda u: "merged", now_fn,
+        worktree_manager=fwm, workspace_root=tmp_path,
+    )
+    watcher.check_once()
+
+    assert SpecStore(tmp_path / "specs").find_by_id(spec.id).status == "implemented"
+    assert "task-m" in tasks
+    notes = [c for c in msgs.append_calls if c["kind"] == "note"]
+    assert len(notes) == 1
+    assert "uncommitted changes" in notes[0]["text"]
+    assert "mship close" in notes[0]["text"]
+
+    watcher.check_once()  # idempotent: does not double-post
+    notes = [c for c in msgs.append_calls if c["kind"] == "note"]
+    assert len(notes) == 1

--- a/tests/core/test_serve_pr_watch.py
+++ b/tests/core/test_serve_pr_watch.py
@@ -118,3 +118,33 @@ async def test_pr_watch_loop_survives_check_once_exception():
     await stopper
 
     assert watcher.calls >= 2  # survived an exception and looped again
+
+
+def test_create_app_wires_worktree_manager_into_watcher(tmp_path, monkeypatch):
+    """serve.create_app must forward its worktree_manager into the PrWatcher it
+    builds in the lifespan, so merge auto-close has a teardown primitive."""
+    captured = {}
+
+    class _StubWatcher:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+        def check_once(self):
+            pass
+
+    monkeypatch.setattr("mship.core.serve.PrWatcher", _StubWatcher)
+    monkeypatch.setenv("MSHIP_PR_WATCH_INTERVAL", "0.01")
+
+    sentinel = object()
+    app = create_app(
+        specs_dir=tmp_path / "specs",
+        state_manager=StateManager(tmp_path / ".mothership"),
+        log_manager=None,
+        workspace_root=tmp_path,
+        workspace_name="test-ws",
+        worktree_manager=sentinel,
+    )
+    with TestClient(app):
+        pass
+
+    assert captured.get("worktree_manager") is sentinel

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -1721,3 +1721,72 @@ def test_spawn_dirty_canonical_base_not_fast_forwarded_but_worktree_fresh(tmp_pa
     wt = tmp_path / ".worktrees" / "dirty-base" / "svc"
     assert _sha(wt) == origin_tip                 # worktree still cut from origin (ac1)
     assert _sha(repo, "main") != origin_tip       # dirty canonical base left untouched (ac3)
+
+
+# ---------------------------------------------------------------------------
+# abort teardown guard (spec auto-advance-on-merge)
+# ---------------------------------------------------------------------------
+
+def test_abort_refuses_dirty_worktree_and_leaves_it_intact(worktree_deps):
+    from mship.core.worktree import WorktreeDirtyError
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("dirty task", repos=["shared"], workspace_root=workspace)
+    wt = Path(state_mgr.load().tasks["dirty-task"].worktrees["shared"])
+    (wt / "scratch.txt").write_text("uncommitted work")
+
+    with pytest.raises(WorktreeDirtyError):
+        mgr.abort("dirty-task")
+
+    assert wt.exists()                                   # left intact (ac4)
+    assert "dirty-task" in state_mgr.load().tasks        # state unchanged
+
+
+def test_abort_force_removes_dirty_worktree(worktree_deps):
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("dirty task", repos=["shared"], workspace_root=workspace)
+    wt = Path(state_mgr.load().tasks["dirty-task"].worktrees["shared"])
+    (wt / "scratch.txt").write_text("uncommitted work")
+
+    mgr.abort("dirty-task", force=True)                  # ac5
+
+    assert not wt.exists()
+    assert "dirty-task" not in state_mgr.load().tasks
+
+
+def test_abort_clean_worktree_still_torn_down_without_force(worktree_deps):
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("clean task", repos=["shared"], workspace_root=workspace)
+    wt = Path(state_mgr.load().tasks["clean-task"].worktrees["shared"])
+
+    mgr.abort("clean-task")                              # ac6
+
+    assert not wt.exists()
+    assert "clean-task" not in state_mgr.load().tasks
+
+
+def test_abort_idempotent_when_task_already_gone(worktree_deps):
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.abort("never-existed")                           # ac7: no KeyError, no raise
+
+
+def test_abort_does_not_rmtree_when_git_remove_fails(worktree_deps, monkeypatch):
+    """The silent shutil.rmtree(ignore_errors=True) data-loss fallback is REMOVED:
+    a worktree git refused to remove is LEFT on disk, not force-deleted, and the
+    hub is not nuked either."""
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("keep task", repos=["shared"], workspace_root=workspace)
+    wt = Path(state_mgr.load().tasks["keep-task"].worktrees["shared"])
+
+    def _boom(**kwargs):
+        raise RuntimeError("git worktree remove refused")
+    monkeypatch.setattr(git, "worktree_remove", _boom)
+
+    mgr.abort("keep-task")                               # clean tree -> guard passes
+
+    assert wt.exists()                                   # NOT rmtree'd (fallback gone)
+    assert "keep-task" not in state_mgr.load().tasks     # state still cleared

--- a/tests/util/test_git.py
+++ b/tests/util/test_git.py
@@ -244,3 +244,39 @@ def test_ref_exists_true_for_remote_tracking_ref(tmp_path):
     # origin/main was fetched by the fixture
     assert git.ref_exists(repo, "origin/main") is True
     assert git.ref_exists(repo, "origin/does-not-exist") is False
+
+
+# ---------------------------------------------------------------------------
+# has_unpushed_commits — teardown guard (spec auto-advance-on-merge)
+# ---------------------------------------------------------------------------
+
+def test_has_unpushed_commits_false_when_no_remote(git_repo: Path):
+    # A repo with no `origin` has nothing to push to; teardown must not be blocked.
+    git = GitRunner()
+    assert git.has_unpushed_commits(git_repo) is False
+
+
+def test_has_unpushed_commits_false_when_fully_pushed(tmp_path: Path):
+    # `_repo_with_origin_ahead` leaves `clone` at origin/main (nothing ahead).
+    _repo, _tip = _repo_with_origin_ahead(tmp_path)
+    clone = tmp_path / "svc-clone"
+    git = GitRunner()
+    assert git.has_unpushed_commits(clone) is False
+
+
+def test_has_unpushed_commits_true_when_local_ahead_of_upstream(tmp_path: Path):
+    _repo, _tip = _repo_with_origin_ahead(tmp_path)
+    clone = tmp_path / "svc-clone"
+    (clone / "c.txt").write_text("3")
+    _run(["git", "add", "-A"], clone)
+    _run(["git", "commit", "-m", "c3 (unpushed)"], clone)
+    git = GitRunner()
+    assert git.has_unpushed_commits(clone) is True
+
+
+def test_has_unpushed_commits_true_when_origin_exists_but_no_upstream(tmp_path: Path):
+    _repo, _tip = _repo_with_origin_ahead(tmp_path)
+    clone = tmp_path / "svc-clone"
+    _run(["git", "checkout", "-b", "feat/never-pushed"], clone)  # no upstream tracking
+    git = GitRunner()
+    assert git.has_unpushed_commits(clone) is True


### PR DESCRIPTION
Auto-advance on PR merge (no manual close) + safe worktree teardown guard
---

## Acceptance criteria

- [ ] `ac1` When a task's PR(s) merge, the serve merge-watcher auto-advances the bound spec (dispatched -> implemented) and the WorkItem (-> done, or review-cleared) with no manual 'mship close' - verified by the WorkItem reaching 'done' and its needs_review attention clearing after a simulated merge. — _no evidence_
- [ ] `ac2` The merge-driven auto-close runs non-interactively and fail-open: a failure (gh unavailable, PR-state error, etc.) is logged and never crashes the watcher or the serve process. — _no evidence_
- [ ] `ac3` The dirty/unpushed guard lives in the core teardown primitive (WorktreeManager.abort), so EVERY teardown path enforces it: the new merge auto-close, manual 'mship close', and 'mship close --abandon'. Each affected repo's worktree is checked for uncommitted changes AND unpushed commits; if any repo is dirty or unpushed, the teardown is refused/skipped for the whole task unless --force is passed. — _no evidence_
- [ ] `ac4` When teardown is skipped for dirty/unpushed work (no --force), the worktree is left intact (the silent force shutil.rmtree fallback is removed, so it can never be deleted without --force), and on the merge path the phase/spec still advances and a note is posted telling the operator to resolve then close (or --force). — _no evidence_
- [ ] `ac5` An explicit --force on a teardown command bypasses the dirty/unpushed guard and removes the worktree (the deliberate 'yes, discard it' path). — _no evidence_
- [ ] `ac6` A clean worktree (no uncommitted changes, no unpushed commits) is torn down on merge, so the common case reaches fully-done with zero manual steps. — _no evidence_
- [ ] `ac7` The auto-advance is idempotent: a repeated or duplicate merge signal does not double-advance the spec/WorkItem or raise an error. — _no evidence_
- [ ] `ac8` The skills finishing-a-development-branch and working-with-mothership are updated to reflect merge auto-advance and that 'mship close' is only needed to force teardown of a dirty/unpushed worktree. — _no evidence_