### PR TITLE
mship config-change workflow plus discovery observability plus artifact-leak safeguards (issue 366 findings 5-7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ Tasks live in git worktrees managed by mship and tracked in `.mothership/state.y
 
 Agents plug into this through any MCP server or shell tool they already have. mship doesn't replace `bash`, `playwright-mcp`, or `postgres-mcp`; it tells those tools where to point and what's real.
 
+## Changing workspace config
+
+To edit `mothership.yaml` or a per-repo `Taskfile`, edit it directly in the main checkout, run `mship doctor`, then commit. mship exempts **config-only** edits (drift confined to `mothership.yaml` and/or a `Taskfile`) from the `dirty_worktree` audit gate, so `mship finish` is not blocked on them — the moment any non-config tracked file is *also* modified, the gate re-applies (fail-closed). `mship doctor` loads config with path validation relaxed (`require_paths=False`), so a not-yet-present or in-flux `Taskfile.yml` surfaces as a doctor check rather than hard-failing config load before your change lands. `mship status` and `mship doctor` also report the resolved `mothership.yaml` path and how it resolved (env / marker / walk-up), so you always know which config is live.
+
+## Build & bundling caveat
+
+`.worktrees/` (full checkouts, including `node_modules`) and `.mothership/` live at the **repo root**. Any bundler that does not honor `.gitignore` — AWS CDK `Code.fromAsset`, the Docker build context, `npm pack`, `sam build`, serverless — must exclude them explicitly, or it will ship worktree checkouts into your build output. The `.worktrees` entry `mship spawn` adds to `.gitignore` protects git but **not** those bundlers; `mship doctor` emits a best-effort warning when it spots a bundling config at the workspace root that doesn't exclude `.worktrees`/`.mothership`.
+
 ## Scope
 
 - **Does:** isolate worktrees per task, coordinate cross-repo work, sequence PRs, run dependency-ordered multi-service stacks with healthchecks, expose task-scoped state to agents as structured JSON, emit handoff prompts for subagents.

--- a/src/mship/cli/doctor.py
+++ b/src/mship/cli/doctor.py
@@ -11,8 +11,13 @@ def register(app: typer.Typer, get_container):
         output = Output()
 
         from mship.core.doctor import DoctorChecker
+        from mship.core.config import ConfigLoader
 
-        config = container.config()
+        # issue 366 #5/#3: load with require_paths=False so a not-yet-present or
+        # being-changed Taskfile.yml surfaces as a doctor `fail` check rather
+        # than hard-failing ConfigLoader.load before doctor can run. The
+        # container singleton keeps require_paths=True for spawn/finish/exec.
+        config = ConfigLoader.load(container.config_path(), require_paths=False)
         shell = container.shell()
         checker = DoctorChecker(
             config,

--- a/src/mship/cli/doctor.py
+++ b/src/mship/cli/doctor.py
@@ -19,11 +19,25 @@ def register(app: typer.Typer, get_container):
         # container singleton keeps require_paths=True for spawn/finish/exec.
         config = ConfigLoader.load(container.config_path(), require_paths=False)
         shell = container.shell()
+
+        # issue 366 #6: resolve which config is live + how it resolved, to report.
+        from pathlib import Path
+        config_path = container.config_path()
+        config_source = None
+        try:
+            res = ConfigLoader.discover_with_source(Path.cwd())
+            if str(res.path.resolve()) == str(Path(config_path).resolve()):
+                config_source = res.source
+        except Exception:
+            config_source = None
+
         checker = DoctorChecker(
             config,
             shell,
             state_dir=container.state_dir(),
             workspace_root=container.config_path().parent,
+            config_path=config_path,
+            config_source=config_source,
         )
         report = checker.run()
 
@@ -61,6 +75,8 @@ def register(app: typer.Typer, get_container):
                 "checks": [{"name": c.name, "status": c.status, "message": c.message} for c in report.checks],
                 "warnings": report.warnings,
                 "errors": report.errors,
+                "config_path": str(Path(config_path).resolve()),
+                "config_resolution_source": config_source,
             })
 
         if not report.ok:

--- a/src/mship/cli/status.py
+++ b/src/mship/cli/status.py
@@ -224,6 +224,17 @@ def register(app: typer.Typer, get_container):
                     output.print(f"[bold]Last log:[/bold] \"{last_log['message']}\" ({ts_rel})")
             return
 
+        # --- Config resolution (issue 366 #6): absolute path + how it resolved.
+        from mship.core.config import ConfigLoader
+        config_path_abs = str(Path(container.config_path()).resolve())
+        config_source: str | None = None
+        try:
+            res = ConfigLoader.discover_with_source(Path.cwd())
+            if str(res.path.resolve()) == config_path_abs:
+                config_source = res.source
+        except Exception:
+            config_source = None
+
         # --- JSON envelope (single shape, always).
         envelope = {
             "workspace": config.workspace,
@@ -241,6 +252,8 @@ def register(app: typer.Typer, get_container):
             ],
             "resolved_task": resolved_payload,
             "resolution_source": source,
+            "config_path": config_path_abs,
+            "config_resolution_source": config_source,
         }
         if any_worktrees:
             envelope["cwd_is_outside_worktrees"] = cwd_outside

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1149,6 +1149,13 @@ def register(app: typer.Typer, get_container):
             from mship.core.repo_state import without_no_upstream_on_task_branch
             report = without_no_upstream_on_task_branch(report, task.branch)
 
+        # issue 366 #5: a config-only main-checkout edit (mothership.yaml /
+        # Taskfile) is the supported config-change path — don't block finish's
+        # dirty_worktree on it. Fails closed: any non-config tracked drift is
+        # retained by the filter and re-blocks the gate. spawn/exec unchanged.
+        from mship.core.repo_state import without_config_only_dirty
+        report = without_config_only_dirty(report)
+
         # Scope blocking to repos that will actually produce a PR (have local
         # commits past their base) plus their transitive deps. Drift in repos
         # that won't be pushed is informational, not blocking. See #112.

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
@@ -5,6 +6,18 @@ import yaml
 from pydantic import BaseModel, field_validator, model_validator
 
 from mship.core.relay.config import RelayConfig
+
+
+@dataclass(frozen=True)
+class ConfigResolution:
+    """Result of ConfigLoader.discover_with_source.
+
+    `path` is the resolved mothership.yaml. `source` is which discovery branch
+    produced it: "env" (MSHIP_WORKSPACE), "marker" (.mship-workspace walk-up),
+    or "walk-up" (plain mothership.yaml walk-up).
+    """
+    path: Path
+    source: str
 
 
 class Dependency(BaseModel):
@@ -492,7 +505,7 @@ class ConfigLoader:
         return config
 
     @staticmethod
-    def discover(start: Path) -> Path:
+    def discover_with_source(start: Path) -> "ConfigResolution":
         import os
         from mship.core.workspace_marker import read_marker_from_ancestor
 
@@ -504,7 +517,7 @@ class ConfigLoader:
             env_root = Path(env).resolve()
             env_yaml = env_root / "mothership.yaml"
             if env_yaml.is_file():
-                return env_yaml
+                return ConfigResolution(path=env_yaml, source="env")
             raise FileNotFoundError(
                 f"MSHIP_WORKSPACE={env!r} does not contain a mothership.yaml "
                 f"(expected {env_yaml})"
@@ -514,20 +527,26 @@ class ConfigLoader:
         #    pointer from spawn. Stale markers return None silently.
         marker_root = read_marker_from_ancestor(start)
         if marker_root is not None:
-            return marker_root / "mothership.yaml"
+            return ConfigResolution(
+                path=marker_root / "mothership.yaml", source="marker"
+            )
 
         # 3. Existing walk-up for mothership.yaml.
         current = Path(start).resolve()
         while True:
             candidate = current / "mothership.yaml"
             if candidate.exists():
-                return candidate
+                return ConfigResolution(path=candidate, source="walk-up")
             parent = current.parent
             if parent == current:
                 raise FileNotFoundError(
                     "No mothership.yaml found in any parent directory"
                 )
             current = parent
+
+    @staticmethod
+    def discover(start: Path) -> Path:
+        return ConfigLoader.discover_with_source(start).path
 
 
 def unique_git_roots(

--- a/src/mship/core/doctor.py
+++ b/src/mship/core/doctor.py
@@ -427,7 +427,9 @@ class DoctorChecker:
                                  "`.worktrees`/`.mothership`" + heur),
                     ))
 
-        # npm pack (`files` allowlist)
+        # npm pack — the `files` field is an ALLOWLIST: `npm pack` ships only what it
+        # names, so a `files` list is the SAFE case (it's what protects the package).
+        # `.worktrees`/`.mothership` leak ONLY if they are explicitly listed in `files`.
         pkg = ws / "package.json"
         if pkg.exists():
             try:
@@ -435,18 +437,29 @@ class DoctorChecker:
                 data = _json.loads(pkg.read_text())
             except Exception:
                 data = {}
-            if isinstance(data, dict) and "files" in data:
+            files = data.get("files") if isinstance(data, dict) else None
+            if isinstance(files, list) and any(
+                any(tok in str(entry) for tok in tokens) for entry in files
+            ):
                 results.append(CheckResult(
                     name="bundler/npm", status="warn",
-                    message=("package.json declares `files` for `npm pack` — confirm "
-                             "it does not bundle `.worktrees`/`.mothership`" + heur),
+                    message=("package.json `files` explicitly lists `.worktrees`/"
+                             "`.mothership` — `npm pack` will ship them" + heur),
                 ))
 
-        # CDK Code.fromAsset — shallow scan of workspace-root files only
-        for f in ws.iterdir():
+        # CDK Code.fromAsset — shallow scan of workspace-root files only. Bounded so a
+        # filesystem error can't crash `mship doctor` and a huge minified bundle isn't
+        # read into memory.
+        try:
+            root_files = list(ws.iterdir())
+        except OSError:
+            root_files = []
+        for f in root_files:
             if not f.is_file() or f.suffix not in (".ts", ".js", ".py"):
                 continue
             try:
+                if f.stat().st_size > 512_000:  # skip large/minified files
+                    continue
                 text = f.read_text()
             except OSError:
                 continue

--- a/src/mship/core/doctor.py
+++ b/src/mship/core/doctor.py
@@ -355,7 +355,111 @@ class DoctorChecker:
                     ),
                 ))
 
+        # Bundler-exclusion heuristic (issue 366 #7) — best-effort, warn-only.
+        if ws is not None and ws.is_dir():
+            report.checks.extend(self._check_bundler_exclusions(ws))
+
         return report
+
+    def _check_bundler_exclusions(self, ws: Path) -> list[CheckResult]:
+        """WARN when a known asset-bundling config at the workspace root does not
+        exclude `.worktrees`/`.mothership`. Best-effort heuristic (issue 366 #7):
+        it inspects a curated set of bundler configs, cannot detect every tool,
+        and never raises severity above `warn`.
+        """
+        results: list[CheckResult] = []
+        heur = (
+            " (best-effort heuristic — mship cannot detect every bundler; "
+            "verify your build excludes `.worktrees`/`.mothership`)"
+        )
+        tokens = (".worktrees", ".mothership")
+
+        def _excludes(text: str) -> bool:
+            return any(tok in text for tok in tokens)
+
+        # Docker
+        dockerignore = ws / ".dockerignore"
+        dockerfile = ws / "Dockerfile"
+        if dockerignore.exists():
+            try:
+                if not _excludes(dockerignore.read_text()):
+                    results.append(CheckResult(
+                        name="bundler/docker", status="warn",
+                        message=(".dockerignore does not exclude `.worktrees`/"
+                                 "`.mothership` — the Docker build context will ship "
+                                 "worktree checkouts" + heur),
+                    ))
+            except OSError:
+                pass
+        elif dockerfile.exists():
+            results.append(CheckResult(
+                name="bundler/docker", status="warn",
+                message=("Dockerfile present but no .dockerignore excludes "
+                         "`.worktrees`/`.mothership`" + heur),
+            ))
+
+        # serverless
+        for fname in ("serverless.yml", "serverless.yaml"):
+            f = ws / fname
+            if f.exists():
+                try:
+                    if not _excludes(f.read_text()):
+                        results.append(CheckResult(
+                            name="bundler/serverless", status="warn",
+                            message=(f"{fname} does not exclude `.worktrees`/"
+                                     "`.mothership`" + heur),
+                        ))
+                except OSError:
+                    pass
+
+        # SAM
+        for fname in ("template.yaml", "template.yml"):
+            f = ws / fname
+            if f.exists():
+                try:
+                    text = f.read_text()
+                except OSError:
+                    continue
+                if "AWS::Serverless" in text and not _excludes(text):
+                    results.append(CheckResult(
+                        name="bundler/sam", status="warn",
+                        message=(f"SAM template {fname} does not exclude "
+                                 "`.worktrees`/`.mothership`" + heur),
+                    ))
+
+        # npm pack (`files` allowlist)
+        pkg = ws / "package.json"
+        if pkg.exists():
+            try:
+                import json as _json
+                data = _json.loads(pkg.read_text())
+            except Exception:
+                data = {}
+            if isinstance(data, dict) and "files" in data:
+                results.append(CheckResult(
+                    name="bundler/npm", status="warn",
+                    message=("package.json declares `files` for `npm pack` — confirm "
+                             "it does not bundle `.worktrees`/`.mothership`" + heur),
+                ))
+
+        # CDK Code.fromAsset — shallow scan of workspace-root files only
+        for f in ws.iterdir():
+            if not f.is_file() or f.suffix not in (".ts", ".js", ".py"):
+                continue
+            try:
+                text = f.read_text()
+            except OSError:
+                continue
+            if "Code.fromAsset" in text:
+                results.append(CheckResult(
+                    name="bundler/cdk", status="warn",
+                    message=("CDK `Code.fromAsset` bundling detected at the workspace "
+                             "root; ensure the asset root excludes `.worktrees`/"
+                             "`.mothership`" + heur),
+                ))
+                break
+
+        return results
 
     def _detect_mship_dev_workspace(self) -> Path | None:
         """Return the path of a configured repo whose pyproject declares mothership,

--- a/src/mship/core/doctor.py
+++ b/src/mship/core/doctor.py
@@ -119,14 +119,29 @@ class DoctorChecker:
         *,
         state_dir: Path | None = None,
         workspace_root: Path | None = None,
+        config_path: Path | None = None,
+        config_source: str | None = None,
     ) -> None:
         self._config = config
         self._shell = shell
         self._state_dir = state_dir
         self._workspace_root = workspace_root
+        self._config_path = config_path
+        self._config_source = config_source
 
     def run(self) -> DoctorReport:
         report = DoctorReport()
+
+        # issue 366 #6: report which config is live and how it resolved.
+        if self._config_path is not None:
+            report.checks.append(CheckResult(
+                name="config",
+                status="pass",
+                message=(
+                    f"config: {Path(self._config_path).resolve()} "
+                    f"(resolved via {self._config_source or 'unknown'})"
+                ),
+            ))
 
         for name, repo in self._config.repos.items():
             # Resolve effective path (handles git_root subdir repos)

--- a/src/mship/core/repo_state.py
+++ b/src/mship/core/repo_state.py
@@ -91,6 +91,57 @@ def without_no_upstream_on_task_branch(
     return AuditReport(repos=tuple(new_repos))
 
 
+_CONFIG_ONLY_BASENAMES = frozenset({
+    "mothership.yaml",
+    "Taskfile.yml", "Taskfile.yaml",
+    "taskfile.yml", "taskfile.yaml",
+})
+
+
+def is_config_only_paths(paths: Iterable[str]) -> bool:
+    """True iff `paths` is non-empty and EVERY path's basename is a workspace
+    config file (`mothership.yaml`) or a Taskfile.
+
+    Fails closed: an empty input, or any path whose basename is outside the
+    allowlist, returns False. Matching is exact basename equality (not
+    substring), so look-alikes like `my_Taskfile.yml` or `Taskfile.yml.bak`
+    never qualify, while a legitimately-named `Taskfile.yml` in a subdir
+    (monorepo git_root child) does. See issue 366 #5.
+    """
+    names = [Path(p).name for p in paths]
+    if not names:
+        return False
+    return all(n in _CONFIG_ONLY_BASENAMES for n in names)
+
+
+def without_config_only_dirty(report: AuditReport) -> AuditReport:
+    """Return a copy of `report` with `dirty_worktree` ERRORS stripped from
+    repos whose modified-tracked drift is confined to workspace config /
+    Taskfiles.
+
+    Used by `mship finish` (issue 366 #5): editing `mothership.yaml` / a
+    Taskfile in the main checkout is the supported config-change path and must
+    not block finish on `dirty_worktree`. Fails closed via
+    `is_config_only_paths` — the moment any non-config tracked file is
+    modified, the issue is retained and the gate blocks again. Other issue
+    codes are untouched; standalone `mship audit` still reports the drift.
+    """
+    new_repos: list[RepoAudit] = []
+    for r in report.repos:
+        kept = tuple(
+            i for i in r.issues
+            if not (i.code == "dirty_worktree" and is_config_only_paths(i.paths))
+        )
+        if len(kept) != len(r.issues):
+            new_repos.append(RepoAudit(
+                name=r.name, path=r.path,
+                current_branch=r.current_branch, issues=kept,
+            ))
+        else:
+            new_repos.append(r)
+    return AuditReport(repos=tuple(new_repos))
+
+
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------

--- a/src/mship/core/repo_state.py
+++ b/src/mship/core/repo_state.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import shlex
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, Literal
 
@@ -14,6 +14,7 @@ class Issue:
     code: str
     severity: Severity
     message: str
+    paths: tuple[str, ...] = field(default=(), compare=False)
 
 
 @dataclass(frozen=True)
@@ -254,6 +255,7 @@ def _probe_dirty(
         return ()
     untracked = 0
     modified = 0
+    modified_paths: list[str] = []
     for line in out.splitlines():
         if not line.strip():
             continue
@@ -264,11 +266,18 @@ def _probe_dirty(
             untracked += 1
         else:
             modified += 1
+            path_part = line[3:].strip()
+            if " -> " in path_part:  # rename/copy: record the destination
+                path_part = path_part.split(" -> ", 1)[1]
+            path_part = path_part.strip().strip('"')
+            if path_part:
+                modified_paths.append(path_part)
     issues: list[Issue] = []
     if modified:
         issues.append(Issue(
             "dirty_worktree", "error",
             f"{modified} modified tracked file" + ("s" if modified != 1 else ""),
+            paths=tuple(modified_paths),
         ))
     if untracked:
         issues.append(Issue(
@@ -304,6 +313,7 @@ def _enrich_active_task(
                 i.message + " — a task is active for this repo; "
                 "edit in its worktree, not the main checkout "
                 "(see `mship worktrees`)",
+                paths=i.paths,
             ))
         else:
             out.append(i)

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -46,6 +46,14 @@ Mothership supports multiple active tasks simultaneously. Typical reasons:
 
 Each task gets a worktree per affected repo at `.worktrees/<slug>/<repo>/` (the branch is `feat/<slug>`); they coexist cleanly.
 
+### Changing workspace config
+
+To change `mothership.yaml` or a `Taskfile`, edit it directly in the main checkout, run `mship doctor`, then commit — mship exempts **config-only** drift (just `mothership.yaml`/`Taskfile`) from `mship finish`'s `dirty_worktree` gate (fail-closed: any non-config change re-blocks). `mship status` / `mship doctor` report which `mothership.yaml` is live and how it resolved.
+
+### Build/bundling caveat
+
+`.worktrees/` and `.mothership/` live at the **repo root**. Any bundler that ignores `.gitignore` — CDK `Code.fromAsset`, the Docker build context, `npm pack`, `sam build`, serverless — must exclude them, or it bundles worktree checkouts into your build. The `.gitignore` entry spawn adds protects git but not those bundlers; `mship doctor` warns (best-effort) when a bundling config at the workspace root doesn't exclude `.worktrees`/`.mothership`.
+
 ### How mship resolves which task a command targets
 
 In order of precedence:

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -120,3 +120,17 @@ def test_doctor_json_includes_config_path_and_source(workspace, monkeypatch):
         container.config.reset()
         container.state_manager.reset()
         container.shell.reset_override()
+
+
+def test_doctor_json_keys_are_additive(configured_doctor_app, monkeypatch):
+    import json
+    monkeypatch.delenv("MSHIP_WORKSPACE", raising=False)
+    result = runner.invoke(app, ["doctor"])
+    data = json.loads(result.output)
+    for k in ("checks", "warnings", "errors"):      # pre-existing keys intact
+        assert k in data, k
+    assert "config_path" in data                     # new additive keys
+    assert "config_resolution_source" in data
+    # Each check object keeps its stable schema:
+    for c in data["checks"]:
+        assert set(c.keys()) == {"name", "status", "message"}

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -88,3 +88,35 @@ def test_doctor_loads_config_with_require_paths_false(workspace: Path):
         container.config.reset()
         container.state_manager.reset()
         container.shell.reset_override()
+
+
+def test_doctor_json_includes_config_path_and_source(workspace, monkeypatch):
+    import json
+    monkeypatch.delenv("MSHIP_WORKSPACE", raising=False)
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(workspace / "mothership.yaml")
+    container.state_dir.override(workspace / ".mothership")
+    (workspace / ".mothership").mkdir(exist_ok=True)
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = lambda cmd, cwd, env=None: (
+        ShellResult(returncode=0, stdout="test\nrun\nlint\nsetup\n", stderr="") if "task --list" in cmd
+        else ShellResult(returncode=0, stdout="Logged in", stderr="") if "gh auth" in cmd
+        else ShellResult(returncode=0, stdout="", stderr="")
+    )
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    container.shell.override(mock_shell)
+    monkeypatch.chdir(workspace)
+    try:
+        result = runner.invoke(app, ["doctor"])
+        data = json.loads(result.output)
+        assert data["config_path"] == str((workspace / "mothership.yaml").resolve())
+        assert data["config_resolution_source"] == "walk-up"
+        for k in ("checks", "warnings", "errors"):  # ac10: existing keys intact
+            assert k in data
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+        container.shell.reset_override()

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -49,3 +49,42 @@ def test_doctor_shows_workspace_name(configured_doctor_app: Path):
     import json
     data = json.loads(result.output)
     assert "checks" in data
+
+
+def test_doctor_loads_config_with_require_paths_false(workspace: Path):
+    """A repo whose Taskfile.yml is missing must not crash doctor's config load;
+    doctor should run and report a Taskfile fail check instead (issue 366 #5)."""
+    import json
+    (workspace / "auth-service" / "Taskfile.yml").unlink()  # remove one Taskfile
+
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(workspace / "mothership.yaml")
+    container.state_dir.override(workspace / ".mothership")
+    (workspace / ".mothership").mkdir(exist_ok=True)
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.side_effect = lambda cmd, cwd, env=None: (
+        ShellResult(returncode=0, stdout="test\nrun\nlint\nsetup\n", stderr="") if "task --list" in cmd
+        else ShellResult(returncode=0, stdout="Logged in", stderr="") if "gh auth" in cmd
+        else ShellResult(returncode=0, stdout="", stderr="")
+    )
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
+    container.shell.override(mock_shell)
+    try:
+        result = runner.invoke(app, ["doctor"])
+        # Must NOT crash on ConfigLoader's require_paths validation; a missing
+        # Taskfile is reported as a doctor `fail` check, so a clean `typer.Exit(1)`
+        # (SystemExit) is EXPECTED — only a ConfigLoader ValueError would be a crash.
+        assert not isinstance(result.exception, ValueError), result.output
+        data = json.loads(result.output)                 # valid JSON, not a traceback
+        assert any(
+            c["status"] == "fail" and "Taskfile" in c["message"]
+            for c in data["checks"]
+        ), data["checks"]
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+        container.shell.reset_override()

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -461,3 +461,27 @@ def test_status_dependencies_block_present(tmp_path, monkeypatch):
         container.state_dir.reset_override()
         container.config.reset()
         container.state_manager.reset()
+
+
+def test_status_reports_config_path_and_source(workspace, monkeypatch):
+    monkeypatch.delenv("MSHIP_WORKSPACE", raising=False)
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(workspace / "mothership.yaml")
+    container.state_dir.override(workspace / ".mothership")
+    (workspace / ".mothership").mkdir(exist_ok=True)
+    monkeypatch.chdir(workspace)
+    try:
+        result = runner.invoke(app, ["status"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["config_path"] == str((workspace / "mothership.yaml").resolve())
+        assert payload["config_resolution_source"] == "walk-up"
+        # ac10: existing keys still present
+        for k in ("workspace", "active_tasks", "resolved_task", "resolution_source"):
+            assert k in payload
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -485,3 +485,16 @@ def test_status_reports_config_path_and_source(workspace, monkeypatch):
         container.state_dir.reset_override()
         container.config.reset()
         container.state_manager.reset()
+
+
+def test_status_json_keys_are_additive(configured_app, monkeypatch):
+    monkeypatch.delenv("MSHIP_WORKSPACE", raising=False)
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    # Pre-existing keys preserved (no rename/removal):
+    for k in ("workspace", "active_tasks", "resolved_task", "resolution_source"):
+        assert k in payload, k
+    # New additive keys present:
+    assert "config_path" in payload
+    assert "config_resolution_source" in payload

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1127,3 +1127,25 @@ def test_discover_delegates_to_discover_with_source(tmp_path, monkeypatch):
     nested = root / "a"; nested.mkdir()
     assert ConfigLoader.discover(nested) == root / "mothership.yaml"
 
+
+def test_discover_with_source_hub_worktree_prefers_marker_over_own_yaml(tmp_path, monkeypatch):
+    """ac6: from a hub-repo worktree that contains its OWN tracked mothership.yaml,
+    discover must resolve to the WORKSPACE-root config via the marker, source=marker."""
+    from mship.core.config import ConfigLoader
+    from mship.core.workspace_marker import write_marker
+    monkeypatch.delenv("MSHIP_WORKSPACE", raising=False)
+
+    root = tmp_path / "ws"; root.mkdir()
+    (root / "mothership.yaml").write_text("workspace: root\nrepos: {}\n")
+
+    # Hub container gets a marker (write_marker at worktree.py:698); the hub-repo
+    # worktree lands under it and carries its OWN tracked mothership.yaml copy.
+    container_dir = root / ".worktrees" / "t"; container_dir.mkdir(parents=True)
+    write_marker(container_dir, root)
+    hub_wt = container_dir / "hub"; hub_wt.mkdir()
+    (hub_wt / "mothership.yaml").write_text("workspace: SHADOW\nrepos: {}\n")
+
+    res = ConfigLoader.discover_with_source(hub_wt)
+    assert res.path == root / "mothership.yaml"     # NOT the worktree's own copy
+    assert res.source == "marker"
+

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1083,3 +1083,47 @@ def test_old_hooks_default_timeout_key_raises_clear_rename_error(tmp_path):
     with pytest.raises(ValueError, match="lifecycle_hooks_default_timeout"):
         ConfigLoader.load(cfg, require_paths=False)
 
+
+def test_discover_with_source_env(tmp_path, monkeypatch):
+    from mship.core.config import ConfigLoader
+    root = tmp_path / "ws"; root.mkdir()
+    (root / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    other = tmp_path / "other"; other.mkdir()
+    monkeypatch.setenv("MSHIP_WORKSPACE", str(root))
+    res = ConfigLoader.discover_with_source(other)
+    assert res.path == root / "mothership.yaml"
+    assert res.source == "env"
+
+
+def test_discover_with_source_marker(tmp_path, monkeypatch):
+    from mship.core.config import ConfigLoader
+    from mship.core.workspace_marker import write_marker
+    monkeypatch.delenv("MSHIP_WORKSPACE", raising=False)
+    root = tmp_path / "ws"; root.mkdir()
+    (root / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    wt = tmp_path / "wt"; wt.mkdir()
+    write_marker(wt, root)
+    res = ConfigLoader.discover_with_source(wt)
+    assert res.path == root / "mothership.yaml"
+    assert res.source == "marker"
+
+
+def test_discover_with_source_walk_up(tmp_path, monkeypatch):
+    from mship.core.config import ConfigLoader
+    monkeypatch.delenv("MSHIP_WORKSPACE", raising=False)
+    root = tmp_path / "ws"; root.mkdir()
+    (root / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    nested = root / "a" / "b"; nested.mkdir(parents=True)
+    res = ConfigLoader.discover_with_source(nested)
+    assert res.path == root / "mothership.yaml"
+    assert res.source == "walk-up"
+
+
+def test_discover_delegates_to_discover_with_source(tmp_path, monkeypatch):
+    from mship.core.config import ConfigLoader
+    monkeypatch.delenv("MSHIP_WORKSPACE", raising=False)
+    root = tmp_path / "ws"; root.mkdir()
+    (root / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    nested = root / "a"; nested.mkdir()
+    assert ConfigLoader.discover(nested) == root / "mothership.yaml"
+

--- a/tests/core/test_doctor.py
+++ b/tests/core/test_doctor.py
@@ -594,3 +594,22 @@ def test_doctor_warns_when_workspace_gitignore_missing_worktrees(tmp_path):
     report = checker.run()
     relevant = [c for c in report.checks if "worktrees" in c.message.lower()]
     assert any(c.status == "warn" for c in relevant), [c.message for c in report.checks]
+
+
+def test_doctor_appends_config_resolution_check(tmp_path):
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\nrepos:\n  a:\n    path: ./a\n    type: service\n"
+    )
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    config = ConfigLoader.load(tmp_path / "mothership.yaml")
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    report = DoctorChecker(
+        config, mock_shell,
+        config_path=tmp_path / "mothership.yaml", config_source="walk-up",
+    ).run()
+    cfg_checks = [c for c in report.checks if c.name == "config"]
+    assert cfg_checks and cfg_checks[0].status == "pass"
+    assert "walk-up" in cfg_checks[0].message
+    assert str((tmp_path / "mothership.yaml").resolve()) in cfg_checks[0].message

--- a/tests/core/test_doctor.py
+++ b/tests/core/test_doctor.py
@@ -613,3 +613,50 @@ def test_doctor_appends_config_resolution_check(tmp_path):
     assert cfg_checks and cfg_checks[0].status == "pass"
     assert "walk-up" in cfg_checks[0].message
     assert str((tmp_path / "mothership.yaml").resolve()) in cfg_checks[0].message
+
+
+def _bundler_report(tmp_path):
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\nrepos:\n  a:\n    path: ./a\n    type: service\n"
+    )
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    config = ConfigLoader.load(tmp_path / "mothership.yaml")
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    return DoctorChecker(config, mock_shell, workspace_root=tmp_path).run()
+
+
+def _no_bundler_fail(report) -> bool:
+    return not any(c.status == "fail" for c in report.checks if c.name.startswith("bundler/"))
+
+
+def test_doctor_bundler_warns_dockerignore_missing_worktrees(tmp_path):
+    (tmp_path / ".dockerignore").write_text("node_modules\n")
+    report = _bundler_report(tmp_path)
+    warns = [c for c in report.checks if c.name == "bundler/docker"]
+    assert warns and warns[0].status == "warn"
+    assert "heuristic" in warns[0].message.lower()
+    assert _no_bundler_fail(report)  # never escalates to fail
+
+
+def test_doctor_bundler_no_warn_when_dockerignore_excludes(tmp_path):
+    (tmp_path / ".dockerignore").write_text("node_modules\n.worktrees\n.mothership\n")
+    report = _bundler_report(tmp_path)
+    assert not [c for c in report.checks if c.name == "bundler/docker"]
+
+
+def test_doctor_bundler_warns_serverless(tmp_path):
+    (tmp_path / "serverless.yml").write_text("service: x\nprovider: {name: aws}\n")
+    report = _bundler_report(tmp_path)
+    warns = [c for c in report.checks if c.name == "bundler/serverless"]
+    assert warns and warns[0].status == "warn"
+    assert "heuristic" in warns[0].message.lower()
+
+
+def test_doctor_bundler_warns_cdk_from_asset(tmp_path):
+    (tmp_path / "stack.ts").write_text("new lambda.Function(this,'f',{code: lambda.Code.fromAsset('.')});\n")
+    report = _bundler_report(tmp_path)
+    warns = [c for c in report.checks if c.name == "bundler/cdk"]
+    assert warns and warns[0].status == "warn"
+    assert _no_bundler_fail(report)

--- a/tests/core/test_doctor.py
+++ b/tests/core/test_doctor.py
@@ -660,3 +660,19 @@ def test_doctor_bundler_warns_cdk_from_asset(tmp_path):
     warns = [c for c in report.checks if c.name == "bundler/cdk"]
     assert warns and warns[0].status == "warn"
     assert _no_bundler_fail(report)
+
+
+def test_doctor_bundler_npm_no_warn_for_safe_allowlist(tmp_path):
+    # `files` is an allowlist — a package that names only `dist` cannot leak
+    # `.worktrees`/`.mothership`, so it must NOT warn (Greptile P1: no false positive).
+    (tmp_path / "package.json").write_text('{"name":"x","files":["dist"]}')
+    report = _bundler_report(tmp_path)
+    assert not [c for c in report.checks if c.name == "bundler/npm"]
+
+
+def test_doctor_bundler_npm_warns_when_files_lists_worktrees(tmp_path):
+    (tmp_path / "package.json").write_text('{"name":"x","files":["dist",".worktrees"]}')
+    report = _bundler_report(tmp_path)
+    warns = [c for c in report.checks if c.name == "bundler/npm"]
+    assert warns and warns[0].status == "warn"
+    assert _no_bundler_fail(report)

--- a/tests/core/test_repo_state.py
+++ b/tests/core/test_repo_state.py
@@ -708,3 +708,55 @@ def test_issue_equality_ignores_paths():
     a = Issue("dirty_worktree", "error", "x")
     b = Issue("dirty_worktree", "error", "x", paths=("a", "b"))
     assert a == b  # paths is compare=False → existing equality preserved
+
+
+def test_is_config_only_paths_true_cases():
+    from mship.core.repo_state import is_config_only_paths
+    assert is_config_only_paths(["mothership.yaml"]) is True
+    assert is_config_only_paths(["Taskfile.yaml"]) is True
+    assert is_config_only_paths(["taskfile.yml", "mothership.yaml"]) is True
+    assert is_config_only_paths(["services/api/Taskfile.yml"]) is True  # basename match
+
+
+def test_is_config_only_paths_fail_closed_cases():
+    from mship.core.repo_state import is_config_only_paths
+    assert is_config_only_paths(["mothership.yaml", "src/app.py"]) is False  # mixed
+    assert is_config_only_paths(["src/TaskfileHelper.py"]) is False          # substring look-alike
+    assert is_config_only_paths(["Taskfile.yml.bak"]) is False               # look-alike suffix
+    assert is_config_only_paths([]) is False                                  # empty → fail closed
+
+
+def test_without_config_only_dirty_strips_config_only():
+    from mship.core.repo_state import (
+        AuditReport, Issue, RepoAudit, without_config_only_dirty,
+    )
+    r = RepoAudit(name="hub", path=Path("/w"), current_branch="main",
+                  issues=(Issue("dirty_worktree", "error", "1 file",
+                                paths=("mothership.yaml",)),))
+    out = without_config_only_dirty(AuditReport(repos=(r,)))
+    assert out.has_errors is False
+
+
+def test_without_config_only_dirty_retains_mixed_drift():
+    from mship.core.repo_state import (
+        AuditReport, Issue, RepoAudit, without_config_only_dirty,
+    )
+    r = RepoAudit(name="hub", path=Path("/w"), current_branch="main",
+                  issues=(Issue("dirty_worktree", "error", "2 files",
+                                paths=("mothership.yaml", "src/app.py")),))
+    out = without_config_only_dirty(AuditReport(repos=(r,)))
+    assert out.has_errors is True  # fail closed
+
+
+def test_without_config_only_dirty_retains_other_error_codes():
+    from mship.core.repo_state import (
+        AuditReport, Issue, RepoAudit, without_config_only_dirty,
+    )
+    r = RepoAudit(name="hub", path=Path("/w"), current_branch="main",
+                  issues=(
+                      Issue("dirty_worktree", "error", "1 file", paths=("mothership.yaml",)),
+                      Issue("diverged", "error", "diverged"),
+                  ))
+    out = without_config_only_dirty(AuditReport(repos=(r,)))
+    codes = {i.code for i in out.repos[0].issues}
+    assert codes == {"diverged"}  # dirty stripped, diverged retained

--- a/tests/core/test_repo_state.py
+++ b/tests/core/test_repo_state.py
@@ -666,3 +666,45 @@ def test_audit_passive_dirty_worktree_warns(tmp_path):
     )
     codes = [i.code for i in issues["shared"]]
     assert "passive_dirty_worktree" in codes
+
+
+# ---------------------------------------------------------------------------
+# issue 366 #5: dirty_worktree carries modified paths; config-only filter
+# ---------------------------------------------------------------------------
+
+def test_probe_dirty_records_modified_paths(audit_workspace):
+    cfg, shell = _load(audit_workspace)
+    (audit_workspace / "cli" / "Taskfile.yml").write_text(
+        "version: '3'\ntasks:\n  x:\n    cmds:\n      - echo x\n"
+    )
+    rep = audit_repos(cfg, shell, names=["cli"])
+    (repo,) = [r for r in rep.repos if r.name == "cli"]
+    dirty = [i for i in repo.issues if i.code == "dirty_worktree"]
+    assert dirty, [i.code for i in repo.issues]
+    assert "Taskfile.yml" in dirty[0].paths
+
+
+def test_probe_dirty_records_multiple_paths(audit_workspace):
+    cfg, shell = _load(audit_workspace)
+    (audit_workspace / "cli" / "README.md").write_text("changed\n")
+    (audit_workspace / "cli" / "Taskfile.yml").write_text("version: '3'\ntasks: {x: {cmds: [echo]}}\n")
+    rep = audit_repos(cfg, shell, names=["cli"])
+    (repo,) = [r for r in rep.repos if r.name == "cli"]
+    (dirty,) = [i for i in repo.issues if i.code == "dirty_worktree"]
+    assert set(dirty.paths) == {"README.md", "Taskfile.yml"}
+
+
+def test_enrich_active_task_preserves_paths():
+    from mship.core.repo_state import Issue, _enrich_active_task
+    issues = (Issue("dirty_worktree", "error", "1 modified tracked file",
+                    paths=("mothership.yaml",)),)
+    out = _enrich_active_task(issues, has_active_task=True)
+    assert out[0].paths == ("mothership.yaml",)
+    assert "worktree" in out[0].message  # hint still appended
+
+
+def test_issue_equality_ignores_paths():
+    from mship.core.repo_state import Issue
+    a = Issue("dirty_worktree", "error", "x")
+    b = Issue("dirty_worktree", "error", "x", paths=("a", "b"))
+    assert a == b  # paths is compare=False → existing equality preserved

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -47,6 +47,24 @@ def test_spawn_creates_worktrees(worktree_deps):
         assert Path(task.worktrees[repo_name]).exists()
 
 
+def test_every_worktree_resolves_to_workspace_root_via_hub_marker(worktree_deps, monkeypatch):
+    """ac7 (resolution goal, without reversing #84's single-marker design): every repo
+    worktree — including the hub repo's own — resolves to the WORKSPACE-root config via
+    the single hub-container `.mship-workspace` marker, so no per-worktree marker is
+    needed and no worktree is dirtied. This is the observable outcome ac7 asks for."""
+    from mship.core.config import ConfigLoader
+    monkeypatch.delenv("MSHIP_WORKSPACE", raising=False)
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("resolve task", repos=["shared", "auth-service"], workspace_root=workspace)
+    task = state_mgr.load().tasks["resolve-task"]
+    for repo_name in ["shared", "auth-service"]:
+        wt = Path(task.worktrees[repo_name])
+        res = ConfigLoader.discover_with_source(wt)
+        assert res.path == (workspace / "mothership.yaml"), repo_name
+        assert res.source == "marker", repo_name
+
+
 def test_spawn_dependency_order(worktree_deps):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
     mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)

--- a/tests/test_docs_config_workflow.py
+++ b/tests/test_docs_config_workflow.py
@@ -1,0 +1,37 @@
+"""issue 366 #5/#7: docs must cover the config-change workflow and the
+`.worktrees`/`.mothership` bundler caveat, in both README and the skill."""
+from pathlib import Path
+
+from mship.core.skill_install import pkg_skills_source
+
+README = Path(__file__).resolve().parent.parent / "README.md"
+SKILL = pkg_skills_source() / "working-with-mothership" / "SKILL.md"
+
+
+def _text(p: Path) -> str:
+    return p.read_text().lower()
+
+
+def test_readme_documents_config_change_workflow():
+    t = _text(README)
+    assert "mothership.yaml" in t and "mship doctor" in t
+    assert "config-only" in t          # the dirty_worktree exemption is named
+    assert "require_paths" in t or "not-yet-present" in t
+
+
+def test_readme_documents_bundler_caveat():
+    t = _text(README)
+    assert ".worktrees" in t and ".mothership" in t
+    assert "code.fromasset" in t and "bundl" in t
+    assert "gitignore" in t
+
+
+def test_skill_documents_config_change_workflow():
+    t = _text(SKILL)
+    assert "config-only" in t and "mship doctor" in t
+
+
+def test_skill_documents_bundler_caveat():
+    t = _text(SKILL)
+    assert ".worktrees" in t and ".mothership" in t
+    assert "bundl" in t and "gitignore" in t

--- a/tests/test_finish_config_only_gate.py
+++ b/tests/test_finish_config_only_gate.py
@@ -1,0 +1,90 @@
+"""issue 366 #5: a config-only main-checkout edit (mothership.yaml / Taskfile)
+does not block `mship finish` on dirty_worktree; any non-config drift re-blocks.
+
+The porcelain is CLEAN during spawn (so spawn's own audit passes regardless of
+config.audit.block_spawn) and is flipped to the dirty state only for the finish
+call, isolating the finish gate behaviour under test.
+"""
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.state import StateManager
+from mship.core.workitem_store import WorkItemStore
+from mship.util.shell import ShellResult, ShellRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def cfg_only_workspace(workspace_with_git: Path):
+    state_dir = workspace_with_git / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    container.config_path.override(workspace_with_git / "mothership.yaml")
+    container.state_dir.override(state_dir)
+
+    porcelain = {"out": ""}  # mutable; starts clean so spawn's audit passes
+
+    def _run(cmd, cwd, env=None):
+        if "status --porcelain" in cmd:
+            return ShellResult(returncode=0, stdout=porcelain["out"], stderr="")
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc\trefs/heads/main\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
+        if "rev-list --count" in cmd:
+            return ShellResult(returncode=0, stdout="0\n", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://github.com/org/shared/pull/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok\n", stderr="")
+    mock_shell.run.side_effect = _run
+    container.shell.override(mock_shell)
+
+    def set_porcelain(s: str) -> None:
+        porcelain["out"] = s
+
+    yield workspace_with_git, set_porcelain
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset()
+    container.state_manager.reset()
+    container.shell.reset_override()
+
+
+def _spawn_bug(workspace: Path, slug_desc: str) -> None:
+    items = WorkItemStore(workspace / ".mothership" / "workitems")
+    wi = items.create(title="cfg", kind="bug", workspace="ws", now=datetime.now(timezone.utc))
+    result = runner.invoke(app, ["spawn", "--work-item", wi.id, slug_desc, "--repos", "shared"])
+    assert result.exit_code == 0, result.output
+
+
+def test_finish_not_blocked_by_config_only_dirty(cfg_only_workspace):
+    workspace, set_porcelain = cfg_only_workspace
+    _spawn_bug(workspace, "cfg only edit")           # spawn with a clean worktree
+    set_porcelain(" M mothership.yaml\n")             # now config-only dirty for finish
+    result = runner.invoke(app, ["finish", "--task", "cfg-only-edit"])
+    assert result.exit_code == 0, result.output
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["cfg-only-edit"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
+
+
+def test_finish_reblocks_when_source_file_also_dirty(cfg_only_workspace):
+    workspace, set_porcelain = cfg_only_workspace
+    _spawn_bug(workspace, "cfg plus source")
+    set_porcelain(" M mothership.yaml\n M src/app.py\n")
+    result = runner.invoke(app, ["finish", "--task", "cfg-plus-source"])
+    assert result.exit_code == 1, result.output
+    assert "dirty" in result.output.lower()
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["cfg-plus-source"].pr_urls == {}


### PR DESCRIPTION
mship config-change workflow plus discovery observability plus artifact-leak safeguards (issue 366 findings 5-7)

Closes #84
---

## Acceptance criteria

- [ ] `ac1` A change whose modified tracked files are confined to `mothership.yaml` and/or a Taskfile (`Taskfile.yml`/`.yaml`, `taskfile.yml`/`.yaml`) in an in-scope repo does NOT block `mship finish` on the `dirty_worktree` audit error, without `--force-audit`. — _no evidence_
- [ ] `ac2` The moment any modified tracked file falls outside that config/Taskfile allowlist, the `dirty_worktree` error blocks `mship finish` again (config-only exemption fails closed). — _no evidence_
- [ ] `ac3` A documented bootstrap/config-change workflow exists (README + working-with-mothership skill) describing how to edit and land `mothership.yaml`/Taskfile changes from the main checkout, and the doctor/config-change path loads config with `require_paths=False` so a not-yet-present or being-changed `Taskfile.yml` does not hard-fail `ConfigLoader.load`. — _no evidence_
- [ ] `ac4` `mship status` reports both the resolved `mothership.yaml` absolute path and the resolution source (env / marker / walk-up), reusing the existing `resolution_source` convention already used for tasks (status.py:243). — _no evidence_
- [ ] `ac5` `mship doctor` reports the resolved config path and its resolution source, so running inside a hub or subrepo worktree makes it unambiguous which config is live. — _no evidence_
- [ ] `ac6` When run from inside a hub repo worktree (`path: .`) that contains a tracked copy of `mothership.yaml`, `discover` resolves to the WORKSPACE-root config (via the marker), and the reported resolution source is `marker` — not the worktree's own copy. — _no evidence_
- [ ] `ac7` Every worktree spawn creates — including the hub repo's own worktree, not only subrepo worktrees and the hub container — is covered by a `.mship-workspace` marker pointing at the workspace root, and that marker is added to the repo's tracked `.gitignore` so it does not appear in `git status`. — _no evidence_
- [ ] `ac8` `mship doctor` emits a WARN when it detects a common asset-bundling config (CDK `Code.fromAsset`, Dockerfile/`.dockerignore`, package.json `files` for `npm pack`, `sam build` template, serverless.yml) at/under the workspace root that does not exclude `.worktrees`/`.mothership`; the warning explicitly states it is a best-effort heuristic that cannot detect every bundler. — _no evidence_
- [ ] `ac9` The docs where the worktree layout is introduced (README + working-with-mothership skill) call out that `.worktrees`/`.mothership` live at the repo root, must be excluded from any bundler that ignores `.gitignore`, and note that spawn's `.gitignore` entry protects git but not such bundlers. — _no evidence_
- [ ] `ac10` New JSON fields added to `status`/`doctor` output are additive (no existing key renamed or removed), preserving deterministic-output consumers. — _no evidence_