### PR TITLE
mship pair: --relay-host option plus auto-discover the running serve relay

### DIFF
--- a/src/mship/cli/pair.py
+++ b/src/mship/cli/pair.py
@@ -1,10 +1,15 @@
 """`mship pair` — print a scannable pairing deep-link + QR for the Ground Control app.
 
-Resolves the workspace's relay config, computes the public URL + serve token,
-builds a `groundcontrol://add?...` deep-link, prints it, and renders a terminal
-QR code so the phone app can scan it without typing. See plan Task B7 (ac6).
+Resolves the workspace's relay host with a fixed precedence — an explicit
+`--relay-host` flag > a `relay:` block in mothership.yaml > the runtime record of a
+live `mship serve --relay-host <host>` in this workspace — then builds the SAME
+`groundcontrol://add?…` deep-link the serve prints (via `build_relay_pair_link`) and
+renders a terminal QR. Exits non-zero with an actionable message when nothing
+resolves. See spec mship-pair-relay-host.
 """
 from __future__ import annotations
+
+from typing import Optional
 
 import typer
 
@@ -13,44 +18,55 @@ from mship.cli.output import Output
 
 def register(app: typer.Typer, get_container):
     @app.command(rich_help_panel="Messaging")
-    def pair():
+    def pair(
+        relay_host: Optional[str] = typer.Option(
+            None,
+            "--relay-host",
+            metavar="HOST",
+            show_default=False,
+            help="Relay host for the pairing link. Overrides config.relay.host and "
+                 "any running-serve record (precedence: flag > config > live serve).",
+        ),
+    ):
         """Print a pairing deep-link + QR to connect the Ground Control app to this workspace."""
         from pathlib import Path
 
         import segno
 
-        from mship.core.relay.keys import (
-            ensure_relay_key,
-            ensure_subdomain_secret,
-            relay_public_key,
-        )
-        from mship.core.relay.pairing import build_pair_link
-        from mship.core.relay.token import ensure_serve_token
-        from mship.core.relay.tunnel import device_id, device_subdomain
+        from mship.core.relay.link import build_relay_pair_link
+        from mship.core.relay.runtime import live_runtime_record, resolve_relay
 
         output = Output()
         container = get_container()
         config = container.config()
-        rc = config.relay
-        if rc is None:
+        workspace = config.workspace
+        workspace_root = Path(container.config_path()).parent
+
+        record = live_runtime_record(workspace_root)  # None if absent or pid dead (stale)
+        resolved = resolve_relay(
+            flag_host=relay_host,
+            config_relay=config.relay,
+            record=record,
+        )
+        if resolved is None:
             output.error(
-                "No relay configured. Add a `relay:` block (host) to mothership.yaml "
-                "to enable phone pairing. See docs/relay-hosting.md."
+                "No relay to pair with. Pass `mship pair --relay-host <host>`, add a "
+                "`relay:` block (host) to mothership.yaml, or start "
+                "`mship serve --relay-host <host>` in this workspace first. "
+                "See docs/relay-hosting.md."
             )
             raise typer.Exit(1)
 
-        workspace = config.workspace
-        workspace_root = Path(container.config_path()).parent
-        key_path = ensure_relay_key(home=Path.home())
-        secret = ensure_subdomain_secret(home=Path.home())
-        subdomain = device_subdomain(workspace, device_id(relay_public_key(key_path)), secret)
-        url = f"https://{subdomain}.{rc.host}"
-        token = ensure_serve_token(workspace_root)
-        link = build_pair_link(url=url, token=token, workspace=workspace)
+        result = build_relay_pair_link(
+            workspace=workspace,
+            host=resolved.host,
+            workspace_root=workspace_root,
+            home=Path.home(),
+        )
 
-        output.print(link)
+        output.print(result.link)
         output.print(
             "  (opaque subdomain — no workspace name leaked; if you upgraded mship, "
             "this changed, so re-scan to re-pair. Decode with `mship relay whoami <sub>`.)"
         )
-        typer.echo(segno.make(link).terminal(compact=True))
+        typer.echo(segno.make(result.link).terminal(compact=True))

--- a/src/mship/cli/serve.py
+++ b/src/mship/cli/serve.py
@@ -175,19 +175,10 @@ def _serve_with_relay(
 
     from mship.core.relay.config import RelayConfig
     from mship.core.relay.health import wait_until_reachable
-    from mship.core.relay.keys import (
-        ensure_relay_key,
-        ensure_subdomain_secret,
-        relay_public_key,
-    )
-    from mship.core.relay.pairing import build_pair_link
+    from mship.core.relay.keys import ensure_relay_key
+    from mship.core.relay.link import build_relay_pair_link
     from mship.core.relay.token import ensure_serve_token
-    from mship.core.relay.tunnel import (
-        TunnelSupervisor,
-        build_tunnel_argv,
-        device_id,
-        device_subdomain,
-    )
+    from mship.core.relay.tunnel import TunnelSupervisor, build_tunnel_argv
     from mship.core.serve import create_app
     from mship.core.spec_store import SPECS_DIRNAME
 
@@ -232,13 +223,17 @@ def _serve_with_relay(
     )
 
     key_path = ensure_relay_key(home=Path.home())
-    dev = device_id(relay_public_key(key_path))
-    secret = ensure_subdomain_secret(home=Path.home())
-    subdomain = device_subdomain(workspace, dev, secret)  # opaque; was: subdomain_for(workspace)
+    pair_link = build_relay_pair_link(
+        workspace=workspace,
+        host=rc.host,
+        workspace_root=workspace_root,
+        home=Path.home(),
+    )
+    subdomain = pair_link.subdomain
     argv = build_tunnel_argv(rc, subdomain=subdomain, local_port=port, key_path=key_path)
 
-    public_url = f"https://{subdomain}.{rc.host}"
-    link = build_pair_link(url=public_url, token=token, workspace=workspace)
+    public_url = pair_link.url
+    link = pair_link.link
 
     log_path = workspace_root / ".mothership" / "relay-tunnel.log"
     log_path.unlink(missing_ok=True)                      # fresh per run

--- a/src/mship/cli/serve.py
+++ b/src/mship/cli/serve.py
@@ -243,21 +243,6 @@ def _serve_with_relay(
 
     log_path = workspace_root / ".mothership" / "relay-tunnel.log"
     log_path.unlink(missing_ok=True)                      # fresh per run
-    # Persist the effective relay host so `mship pair` in this workspace can
-    # auto-discover it (spec mship-pair-relay-host). Gitignored, mode 0600, no
-    # secret (the token stays in serve-token). Unlinked in the finally teardown.
-    write_runtime_record(
-        workspace_root,
-        RelayRuntimeRecord(
-            host=rc.host,
-            pid=os.getpid(),
-            subdomain=subdomain,
-            url=public_url,
-            workspace=workspace,
-            ssh_port=rc.ssh_port,
-            user=rc.user,
-        ),
-    )
     sup = TunnelSupervisor(argv=argv, log_path=log_path)
     sup.start()
 
@@ -326,6 +311,23 @@ def _serve_with_relay(
     typer.echo(segno.make(link).terminal(compact=True))
 
     try:
+        # Persist the effective relay host so `mship pair` in this workspace can
+        # auto-discover it (spec mship-pair-relay-host). Gitignored, mode 0600, no
+        # secret (the token stays in serve-token). Written INSIDE the try so the
+        # finally's clear_runtime_record always tears it down — even if an earlier
+        # startup step (e.g. sup.start) had raised, no stale record is left behind.
+        write_runtime_record(
+            workspace_root,
+            RelayRuntimeRecord(
+                host=rc.host,
+                pid=os.getpid(),
+                subdomain=subdomain,
+                url=public_url,
+                workspace=workspace,
+                ssh_port=rc.ssh_port,
+                user=rc.user,
+            ),
+        )
         uvicorn.run(api, host=host, port=port)
     except KeyboardInterrupt:
         pass

--- a/src/mship/cli/serve.py
+++ b/src/mship/cli/serve.py
@@ -168,6 +168,7 @@ def _serve_with_relay(
     uvicorn blocks in the main thread; the tunnel supervisor is ticked from a
     background daemon thread on an interval and torn down on shutdown.
     """
+    import os
     import threading
 
     import segno
@@ -177,6 +178,11 @@ def _serve_with_relay(
     from mship.core.relay.health import wait_until_reachable
     from mship.core.relay.keys import ensure_relay_key
     from mship.core.relay.link import build_relay_pair_link
+    from mship.core.relay.runtime import (
+        RelayRuntimeRecord,
+        clear_runtime_record,
+        write_runtime_record,
+    )
     from mship.core.relay.token import ensure_serve_token
     from mship.core.relay.tunnel import TunnelSupervisor, build_tunnel_argv
     from mship.core.serve import create_app
@@ -237,6 +243,21 @@ def _serve_with_relay(
 
     log_path = workspace_root / ".mothership" / "relay-tunnel.log"
     log_path.unlink(missing_ok=True)                      # fresh per run
+    # Persist the effective relay host so `mship pair` in this workspace can
+    # auto-discover it (spec mship-pair-relay-host). Gitignored, mode 0600, no
+    # secret (the token stays in serve-token). Unlinked in the finally teardown.
+    write_runtime_record(
+        workspace_root,
+        RelayRuntimeRecord(
+            host=rc.host,
+            pid=os.getpid(),
+            subdomain=subdomain,
+            url=public_url,
+            workspace=workspace,
+            ssh_port=rc.ssh_port,
+            user=rc.user,
+        ),
+    )
     sup = TunnelSupervisor(argv=argv, log_path=log_path)
     sup.start()
 
@@ -311,3 +332,4 @@ def _serve_with_relay(
     finally:
         stop_event.set()
         sup.stop()
+        clear_runtime_record(workspace_root)

--- a/src/mship/core/relay/link.py
+++ b/src/mship/core/relay/link.py
@@ -1,0 +1,44 @@
+"""The single derivation of a relay pairing deep-link, shared by `mship serve
+--relay` and `mship pair` so their output is byte-for-byte identical for the same
+workspace + relay host (spec mship-pair-relay-host, ac3/ac4).
+
+Collaborators are called via their MODULES (keys.*, tunnel.*, token.*, pairing.*)
+rather than `from x import name`, so tests that monkeypatch those functions at
+their source modules (e.g. tests/cli/test_serve.py) still intercept them here.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from mship.core.relay import keys, pairing, token, tunnel
+
+
+@dataclass(frozen=True)
+class RelayPairLink:
+    host: str
+    subdomain: str
+    url: str
+    token: str
+    link: str
+
+
+def build_relay_pair_link(
+    *, workspace: str, host: str, workspace_root: Path, home: Path
+) -> RelayPairLink:
+    """Derive the opaque per-device subdomain + serve token and build the
+    `groundcontrol://add?…` deep-link for `workspace` on relay `host`.
+
+    - subdomain: `device_subdomain(workspace, device_id(pubkey), secret)` from
+      `~/.mothership/relay_ed25519(.pub)` + `~/.mothership/relay-subdomain-secret`.
+    - token: `ensure_serve_token(workspace_root)` (env > `.mothership/serve-token` >
+      generated) — the SAME source `mship serve` uses.
+    """
+    key_path = keys.ensure_relay_key(home=home)
+    secret = keys.ensure_subdomain_secret(home=home)
+    dev = tunnel.device_id(keys.relay_public_key(key_path))
+    subdomain = tunnel.device_subdomain(workspace, dev, secret)
+    url = f"https://{subdomain}.{host}"
+    tok = token.ensure_serve_token(workspace_root)
+    link = pairing.build_pair_link(url=url, token=tok, workspace=workspace)
+    return RelayPairLink(host=host, subdomain=subdomain, url=url, token=tok, link=link)

--- a/src/mship/core/relay/runtime.py
+++ b/src/mship/core/relay/runtime.py
@@ -1,0 +1,78 @@
+"""Per-workspace serve runtime record — how `mship pair` auto-discovers the relay
+host of a running `mship serve --relay-host <host>` (spec mship-pair-relay-host).
+
+`mship serve --relay` writes `<workspace>/.mothership/relay-runtime.json` (mode
+0600; `.mothership/` is already gitignored) while it is relaying and unlinks it on
+shutdown. It carries only the relay host (no secret — the token stays in
+`serve-token`) plus liveness/debug fields. `mship pair` reads it, ignores a record
+whose pid is dead, and resolves the relay host with a fixed precedence.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable
+
+from mship.core.relay.config import RelayConfig
+
+RECORD_NAME = "relay-runtime.json"
+
+
+@dataclass(frozen=True)
+class RelayRuntimeRecord:
+    """What a running relay-serve persists so another process (pair) can discover it.
+
+    Only `host` is strictly needed to rebuild the link (pair recomputes subdomain +
+    token deterministically); `pid` gates staleness; the rest is for debugging /
+    `mship relay whoami`.
+    """
+    host: str
+    pid: int
+    subdomain: str | None = None
+    url: str | None = None
+    workspace: str | None = None
+    ssh_port: int = 2222
+    user: str | None = None
+
+
+def _record_path(workspace_root: Path) -> Path:
+    return Path(workspace_root) / ".mothership" / RECORD_NAME
+
+
+def write_runtime_record(workspace_root: Path, record: RelayRuntimeRecord) -> None:
+    """Persist `record` as 0600 JSON at `<workspace_root>/.mothership/relay-runtime.json`."""
+    path = _record_path(workspace_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(asdict(record)))
+    path.chmod(0o600)
+
+
+def read_runtime_record(workspace_root: Path) -> RelayRuntimeRecord | None:
+    """Return the persisted record, or None if absent, unreadable, corrupt, or
+    missing required keys (never raises — a bad record must never break pair)."""
+    path = _record_path(workspace_root)
+    try:
+        data = json.loads(path.read_text())
+    except (FileNotFoundError, ValueError):
+        return None
+    if not isinstance(data, dict) or "host" not in data or "pid" not in data:
+        return None
+    try:
+        return RelayRuntimeRecord(
+            host=data["host"],
+            pid=int(data["pid"]),
+            subdomain=data.get("subdomain"),
+            url=data.get("url"),
+            workspace=data.get("workspace"),
+            ssh_port=int(data.get("ssh_port", 2222)),
+            user=data.get("user"),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def clear_runtime_record(workspace_root: Path) -> None:
+    """Remove the record (idempotent — no error when already gone)."""
+    _record_path(workspace_root).unlink(missing_ok=True)

--- a/src/mship/core/relay/runtime.py
+++ b/src/mship/core/relay/runtime.py
@@ -42,11 +42,20 @@ def _record_path(workspace_root: Path) -> Path:
 
 
 def write_runtime_record(workspace_root: Path, record: RelayRuntimeRecord) -> None:
-    """Persist `record` as 0600 JSON at `<workspace_root>/.mothership/relay-runtime.json`."""
+    """Persist `record` as 0600 JSON at `<workspace_root>/.mothership/relay-runtime.json`.
+
+    Created 0600 from the outset — no world-readable window between create and
+    chmod (the record carries subdomain/workspace/user, so a `write_text` + later
+    `chmod` would leak them to any local process during the TOCTOU gap)."""
     path = _record_path(workspace_root)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(asdict(record)))
-    path.chmod(0o600)
+    payload = json.dumps(asdict(record))
+    # Remove any prior file so O_CREAT's 0o600 mode always applies (O_CREAT does
+    # NOT re-mode an existing file), then create + write in one shot.
+    path.unlink(missing_ok=True)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(payload)
 
 
 def read_runtime_record(workspace_root: Path) -> RelayRuntimeRecord | None:
@@ -55,7 +64,10 @@ def read_runtime_record(workspace_root: Path) -> RelayRuntimeRecord | None:
     path = _record_path(workspace_root)
     try:
         data = json.loads(path.read_text())
-    except (FileNotFoundError, ValueError):
+    except (OSError, ValueError):
+        # OSError covers absent/unreadable/permission-denied; ValueError covers
+        # corrupt JSON. A bad record must NEVER raise (the docstring's contract) —
+        # it just means "no discoverable relay", so pair falls back cleanly.
         return None
     if not isinstance(data, dict) or "host" not in data or "pid" not in data:
         return None

--- a/src/mship/core/relay/runtime.py
+++ b/src/mship/core/relay/runtime.py
@@ -108,3 +108,48 @@ def live_runtime_record(
         return None
     alive = (pid_alive or _pid_alive)(record.pid)
     return record if alive else None
+
+
+@dataclass(frozen=True)
+class ResolvedRelay:
+    host: str
+    ssh_port: int
+    user: str | None
+    source: str  # "flag" | "config" | "record"
+
+
+def resolve_relay(
+    *,
+    flag_host: str | None,
+    config_relay: RelayConfig | None,
+    record: RelayRuntimeRecord | None,
+) -> ResolvedRelay | None:
+    """Resolve the relay host with fixed precedence: flag > config > live record.
+
+    `record` should already be liveness-filtered (see `live_runtime_record`) — this
+    function is pure precedence. Returns None when nothing resolves (caller emits an
+    actionable error). An explicit `flag_host` overrides host but inherits
+    ssh_port/user from `config_relay` when present, mirroring the RelayConfig
+    substitution in `_serve_with_relay` (serve.py:197-201).
+    """
+    if flag_host:
+        if config_relay is not None:
+            return ResolvedRelay(
+                host=flag_host,
+                ssh_port=config_relay.ssh_port,
+                user=config_relay.user,
+                source="flag",
+            )
+        return ResolvedRelay(host=flag_host, ssh_port=2222, user=None, source="flag")
+    if config_relay is not None:
+        return ResolvedRelay(
+            host=config_relay.host,
+            ssh_port=config_relay.ssh_port,
+            user=config_relay.user,
+            source="config",
+        )
+    if record is not None:
+        return ResolvedRelay(
+            host=record.host, ssh_port=record.ssh_port, user=record.user, source="record"
+        )
+    return None

--- a/src/mship/core/relay/runtime.py
+++ b/src/mship/core/relay/runtime.py
@@ -76,3 +76,35 @@ def read_runtime_record(workspace_root: Path) -> RelayRuntimeRecord | None:
 def clear_runtime_record(workspace_root: Path) -> None:
     """Remove the record (idempotent — no error when already gone)."""
     _record_path(workspace_root).unlink(missing_ok=True)
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if a process with `pid` exists (signal 0 probes without killing)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists but owned by another user
+    except (OverflowError, ValueError):
+        return False  # nonsense pid → treat as not alive
+    return True
+
+
+def live_runtime_record(
+    workspace_root: Path,
+    *,
+    pid_alive: Callable[[int], bool] | None = None,
+) -> RelayRuntimeRecord | None:
+    """The runtime record ONLY when present AND its pid is alive; else None.
+
+    A stale record (serve stopped / crashed / pid reused-away) is treated as absent
+    so pair never derives a link from a dead serve. `pid_alive` is injectable for
+    tests; the CLI leaves it None → module-level `_pid_alive` (so a test can also
+    monkeypatch `mship.core.relay.runtime._pid_alive`).
+    """
+    record = read_runtime_record(workspace_root)
+    if record is None:
+        return None
+    alive = (pid_alive or _pid_alive)(record.pid)
+    return record if alive else None

--- a/tests/cli/test_relay_cli.py
+++ b/tests/cli/test_relay_cli.py
@@ -226,6 +226,39 @@ def test_serve_relay_wires_tunnel_and_loopback(relay_configured_workspace, tmp_p
     assert "groundcontrol://add?" in r.output
 
 
+def test_serve_relay_prints_shared_builder_link(relay_configured_workspace, tmp_path, monkeypatch):
+    """ac3 (serve leg): `serve --relay` prints EXACTLY build_relay_pair_link(...).link,
+    so the serve and pair paths are the same builder — byte-for-byte identical."""
+    from mship.core.relay.link import build_relay_pair_link
+
+    fake_home = tmp_path / "home"
+    (fake_home / ".mothership").mkdir(parents=True)
+    key = fake_home / ".mothership" / "relay_ed25519"
+    key.write_text("PRIV\n")
+    (Path(str(key) + ".pub")).write_text("ssh-ed25519 AAAA mship-relay\n")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    workspace_root = relay_configured_workspace  # config parent; seeds serve-token
+    expected = build_relay_pair_link(
+        workspace="Mship Workspace",
+        host="relay.example.com",
+        workspace_root=workspace_root,
+        home=fake_home,
+    )
+
+    fake_sup = MagicMock()
+    with patch("uvicorn.run", lambda *a, **k: None), \
+         patch("mship.core.relay.tunnel.TunnelSupervisor", lambda *a, **k: fake_sup):
+        r = runner.invoke(
+            app,
+            ["serve", "--relay", "--port", "47100", "--relay-tick", "0.01"],
+            catch_exceptions=False,
+        )
+
+    assert r.exit_code == 0, r.output
+    assert expected.link in r.output
+
+
 def test_relay_whoami_matches_known_workspace(tmp_path, monkeypatch):
     """`relay whoami` recovers the workspace by recomputing the opaque slug over
     candidate names on this machine; unrelated subdomains report no match."""

--- a/tests/cli/test_relay_cli.py
+++ b/tests/cli/test_relay_cli.py
@@ -157,6 +157,54 @@ def test_pair_no_relay_error_names_flag_and_serve(workspace_no_relay):
     assert "groundcontrol://add" not in r.output
 
 
+def test_pair_autodiscovers_live_serve_record_byte_for_byte(workspace_no_relay, tmp_path, monkeypatch):
+    """ac2/ac3/ac4: bare `mship pair` with NO relay: block discovers the live serve
+    record's host and prints the SAME link the serve builder produces, same token."""
+    import os
+
+    from mship.core.relay.link import build_relay_pair_link
+    from mship.core.relay.pairing import parse_pair_link
+    from mship.core.relay.runtime import RelayRuntimeRecord, write_runtime_record
+    from mship.core.relay.token import ensure_serve_token
+
+    fake_home = tmp_path / "home"
+    (fake_home / ".mothership").mkdir(parents=True)
+    key = fake_home / ".mothership" / "relay_ed25519"
+    key.write_text("PRIV\n")
+    (Path(str(key) + ".pub")).write_text("ssh-ed25519 AAAA mship-relay\n")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    ws = workspace_no_relay
+    (ws / ".mothership" / "serve-token").write_text("shared-serve-token\n")
+
+    # The serve path: exactly what a running serve builds + prints (Task 5).
+    serve_side = build_relay_pair_link(
+        workspace="test-platform",
+        host="mship-relay.atomikpanda.com",
+        workspace_root=ws,
+        home=fake_home,
+    )
+
+    # Simulate the running serve having persisted its runtime record (pid alive).
+    write_runtime_record(
+        ws, RelayRuntimeRecord(host="mship-relay.atomikpanda.com", pid=os.getpid())
+    )
+
+    # The pair path: no flag, no relay: block → auto-discovery.
+    r = runner.invoke(app, ["pair"])
+    assert r.exit_code == 0, r.output
+
+    # ac3: byte-for-byte identical link.
+    assert serve_side.link in r.output
+    # ac4: token equals ensure_serve_token (the serve's token source).
+    assert serve_side.token == ensure_serve_token(ws) == "shared-serve-token"
+
+    p = parse_pair_link(serve_side.link)
+    assert p["url"] == serve_side.url
+    assert p["token"] == "shared-serve-token"
+    assert p["workspace"] == "test-platform"
+
+
 # --- mship relay setup ---
 
 

--- a/tests/cli/test_relay_cli.py
+++ b/tests/cli/test_relay_cli.py
@@ -104,6 +104,59 @@ def test_pair_errors_without_relay(workspace_no_relay):
     assert "relay" in r.output.lower()
 
 
+def test_pair_with_relay_host_flag_no_block(workspace_no_relay, tmp_path, monkeypatch):
+    """ac1: --relay-host prints a valid link with NO relay: block (no 'No relay
+    configured' exit)."""
+    fake_home = tmp_path / "home"
+    (fake_home / ".mothership").mkdir(parents=True)
+    key = fake_home / ".mothership" / "relay_ed25519"
+    key.write_text("PRIV\n")
+    (Path(str(key) + ".pub")).write_text("ssh-ed25519 AAAA mship-relay\n")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    (workspace_no_relay / ".mothership" / "serve-token").write_text("flag-token\n")
+
+    r = runner.invoke(app, ["pair", "--relay-host", "flag.relay.com"])
+    assert r.exit_code == 0, r.output
+    assert "groundcontrol://add?" in r.output
+    assert "flag.relay.com" in r.output
+    assert "flag-token" in r.output
+
+
+def test_pair_flag_overrides_config_and_record(relay_configured_workspace, tmp_path, monkeypatch):
+    """ac6: --relay-host wins over config.relay.host AND a live runtime record."""
+    import os
+
+    from mship.core.relay.runtime import RelayRuntimeRecord, write_runtime_record
+
+    fake_home = tmp_path / "home"
+    (fake_home / ".mothership").mkdir(parents=True)
+    key = fake_home / ".mothership" / "relay_ed25519"
+    key.write_text("PRIV\n")
+    (Path(str(key) + ".pub")).write_text("ssh-ed25519 AAAA mship-relay\n")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    write_runtime_record(
+        relay_configured_workspace,
+        RelayRuntimeRecord(host="record.relay.com", pid=os.getpid()),
+    )
+
+    r = runner.invoke(app, ["pair", "--relay-host", "flag.relay.com"])
+    assert r.exit_code == 0, r.output
+    assert "flag.relay.com" in r.output
+    assert "relay.example.com" not in r.output   # config host lost
+    assert "record.relay.com" not in r.output    # record host lost
+
+
+def test_pair_no_relay_error_names_flag_and_serve(workspace_no_relay):
+    """ac5: nothing resolves → non-zero + actionable message naming --relay-host +
+    serve; never a partial/empty link."""
+    r = runner.invoke(app, ["pair"])
+    assert r.exit_code != 0
+    assert "--relay-host" in r.output
+    assert "serve" in r.output.lower()
+    assert "groundcontrol://add" not in r.output
+
+
 # --- mship relay setup ---
 
 

--- a/tests/cli/test_relay_cli.py
+++ b/tests/cli/test_relay_cli.py
@@ -223,6 +223,42 @@ def test_pair_ignores_stale_record(workspace_no_relay, monkeypatch):
     assert "--relay-host" in r.output                # actionable fallback message
 
 
+def test_pair_relay_block_unchanged_ignores_record(relay_configured_workspace, tmp_path, monkeypatch):
+    """ac8: with a relay: block and no flag, `mship pair` behaves exactly as today —
+    it uses config.relay.host, prints the same explanatory note, and ignores any live
+    serve record (config > record)."""
+    import os
+
+    from mship.core.relay.link import build_relay_pair_link
+    from mship.core.relay.runtime import RelayRuntimeRecord, write_runtime_record
+
+    fake_home = tmp_path / "home"
+    (fake_home / ".mothership").mkdir(parents=True)
+    key = fake_home / ".mothership" / "relay_ed25519"
+    key.write_text("PRIV\n")
+    (Path(str(key) + ".pub")).write_text("ssh-ed25519 AAAA mship-relay\n")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    # A live record with a DIFFERENT host must NOT override the relay: block.
+    write_runtime_record(
+        relay_configured_workspace,
+        RelayRuntimeRecord(host="other.relay.com", pid=os.getpid()),
+    )
+
+    expected = build_relay_pair_link(
+        workspace="Mship Workspace",
+        host="relay.example.com",  # the configured block host
+        workspace_root=relay_configured_workspace,
+        home=fake_home,
+    )
+
+    r = runner.invoke(app, ["pair"])
+    assert r.exit_code == 0, r.output
+    assert expected.link in r.output            # exactly today's link
+    assert "other.relay.com" not in r.output    # record ignored (config wins)
+    assert "opaque subdomain" in r.output       # the same explanatory note as today
+
+
 # --- mship relay setup ---
 
 

--- a/tests/cli/test_relay_cli.py
+++ b/tests/cli/test_relay_cli.py
@@ -205,6 +205,24 @@ def test_pair_autodiscovers_live_serve_record_byte_for_byte(workspace_no_relay, 
     assert p["workspace"] == "test-platform"
 
 
+def test_pair_ignores_stale_record(workspace_no_relay, monkeypatch):
+    """ac7: a record whose pid is dead is ignored — pair does NOT print a link
+    derived from it and falls through to the clear error (no relay: block, no flag)."""
+    from mship.core.relay.runtime import RelayRuntimeRecord, write_runtime_record
+
+    write_runtime_record(
+        workspace_no_relay, RelayRuntimeRecord(host="dead.relay.com", pid=424242)
+    )
+    # Force the record's pid to read as dead, deterministically.
+    monkeypatch.setattr("mship.core.relay.runtime._pid_alive", lambda pid: False)
+
+    r = runner.invoke(app, ["pair"])
+    assert r.exit_code != 0
+    assert "dead.relay.com" not in r.output          # never a stale link
+    assert "groundcontrol://add" not in r.output
+    assert "--relay-host" in r.output                # actionable fallback message
+
+
 # --- mship relay setup ---
 
 

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -248,3 +248,91 @@ def test_serve_refuses_when_gh_app_key_unreadable(_configured, monkeypatch, tmp_
     assert "not a readable file" in result.output or "Refusing to start" in result.output
     # Serve never started — no silent identity downgrade.
     assert called["create_app"] is False
+
+
+def test_serve_relay_writes_and_clears_runtime_record(tmp_path, monkeypatch):
+    """ac2 producer / ac7 clean-shutdown: `_serve_with_relay` writes
+    .mothership/relay-runtime.json (host + own pid) before serving and unlinks it
+    in the finally teardown."""
+    import os
+
+    from mship.cli.output import Output
+    from mship.cli.serve import _serve_with_relay
+    from mship.core.config import RepoConfig, WorkspaceConfig
+    from mship.core.relay.runtime import read_runtime_record
+    from mship.core.state import StateManager
+
+    monkeypatch.setenv("MSHIP_PR_WATCH_INTERVAL", "0")
+
+    repo_dir = tmp_path / "api"
+    repo_dir.mkdir()
+    (tmp_path / ".mothership").mkdir()
+    config = WorkspaceConfig(
+        workspace="t",
+        repos={"api": RepoConfig(path=repo_dir, type="service", tasks={"run": "start"})},
+    )
+
+    class _FakeContainer:
+        def __init__(self, state_dir):
+            self._sm = StateManager(state_dir)
+
+        def state_manager(self):
+            return self._sm
+
+        def log_manager(self):
+            return None
+
+        def worktree_manager(self):
+            return None
+
+    class _FakeSup:
+        restart_count = 0
+
+        def __init__(self, *a, **k):
+            pass
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def tick(self):
+            pass
+
+        def recent_output(self):
+            return ""
+
+    monkeypatch.setattr("mship.core.relay.token.ensure_serve_token", lambda root: "tok")
+    monkeypatch.setattr("mship.core.relay.keys.ensure_relay_key", lambda home=None: tmp_path / "key")
+    monkeypatch.setattr("mship.core.relay.keys.ensure_subdomain_secret", lambda home=None: b"\x00" * 32)
+    monkeypatch.setattr("mship.core.relay.keys.relay_public_key", lambda key_path: "ssh-ed25519 AAAAfake")
+    monkeypatch.setattr("mship.core.relay.tunnel.device_id", lambda pub: "dev")
+    monkeypatch.setattr("mship.core.relay.tunnel.device_subdomain", lambda ws, dev, secret: "sub")
+    monkeypatch.setattr("mship.core.relay.tunnel.build_tunnel_argv", lambda *a, **k: ["true"])
+    monkeypatch.setattr("mship.core.relay.tunnel.TunnelSupervisor", _FakeSup)
+    monkeypatch.setattr("mship.core.relay.health.wait_until_reachable", lambda *a, **k: (True, ""))
+
+    seen: dict = {}
+
+    def _capture_run(api, **kw):
+        seen["during"] = read_runtime_record(tmp_path)  # record must exist WHILE serving
+
+    monkeypatch.setattr("uvicorn.run", _capture_run)
+
+    _serve_with_relay(
+        container=_FakeContainer(tmp_path / ".mothership"),
+        config=config,
+        workspace_root=tmp_path,
+        output=Output(),
+        relay_host_override="relay.example.test",
+        port=47199,
+        relay_tick=0.01,
+    )
+
+    during = seen["during"]
+    assert during is not None
+    assert during.host == "relay.example.test"
+    assert during.pid == os.getpid()
+    # ac7 clean-shutdown side: record unlinked in the finally teardown.
+    assert read_runtime_record(tmp_path) is None

--- a/tests/core/relay/test_link.py
+++ b/tests/core/relay/test_link.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+from mship.core.relay.keys import ensure_subdomain_secret, relay_public_key
+from mship.core.relay.link import RelayPairLink, build_relay_pair_link
+from mship.core.relay.pairing import build_pair_link, parse_pair_link
+from mship.core.relay.token import ensure_serve_token
+from mship.core.relay.tunnel import device_id, device_subdomain
+
+
+def _fake_home_with_key(tmp_path):
+    home = tmp_path / "home"
+    (home / ".mothership").mkdir(parents=True)
+    key = home / ".mothership" / "relay_ed25519"
+    key.write_text("PRIV\n")
+    (Path(str(key) + ".pub")).write_text("ssh-ed25519 AAAA mship-relay\n")
+    return home
+
+
+def _ws_root_with_token(tmp_path, token="tok-123"):
+    ws_root = tmp_path / "ws"
+    (ws_root / ".mothership").mkdir(parents=True)
+    (ws_root / ".mothership" / "serve-token").write_text(token + "\n")
+    return ws_root
+
+
+def test_build_relay_pair_link_matches_manual_derivation(tmp_path):
+    home = _fake_home_with_key(tmp_path)
+    ws_root = _ws_root_with_token(tmp_path)
+
+    result = build_relay_pair_link(
+        workspace="My WS", host="relay.example.com", workspace_root=ws_root, home=home
+    )
+
+    key_path = home / ".mothership" / "relay_ed25519"
+    secret = ensure_subdomain_secret(home=home)
+    expected_sub = device_subdomain("My WS", device_id(relay_public_key(key_path)), secret)
+
+    assert isinstance(result, RelayPairLink)
+    assert result.host == "relay.example.com"
+    assert result.subdomain == expected_sub
+    assert result.url == f"https://{expected_sub}.relay.example.com"
+    assert result.token == "tok-123"
+    assert result.link == build_pair_link(url=result.url, token="tok-123", workspace="My WS")
+    p = parse_pair_link(result.link)
+    assert p == {"url": result.url, "token": "tok-123", "workspace": "My WS"}
+
+
+def test_token_equals_ensure_serve_token(tmp_path):
+    home = _fake_home_with_key(tmp_path)
+    ws_root = tmp_path / "ws"
+    (ws_root / ".mothership").mkdir(parents=True)  # no seeded token → generated + persisted
+    result = build_relay_pair_link(workspace="w", host="h", workspace_root=ws_root, home=home)
+    # ac4: same token source as serve, and it persists (re-derives identically).
+    assert result.token == ensure_serve_token(ws_root)
+
+
+def test_two_calls_produce_identical_link_and_token(tmp_path):
+    # Simulates the serve path then the pair path with identical inputs (ac3/ac4).
+    home = _fake_home_with_key(tmp_path)
+    ws_root = _ws_root_with_token(tmp_path)
+    serve_side = build_relay_pair_link(
+        workspace="w", host="h.example", workspace_root=ws_root, home=home
+    )
+    pair_side = build_relay_pair_link(
+        workspace="w", host="h.example", workspace_root=ws_root, home=home
+    )
+    assert serve_side.link == pair_side.link
+    assert serve_side.token == pair_side.token
+    assert serve_side.subdomain == pair_side.subdomain

--- a/tests/core/relay/test_runtime.py
+++ b/tests/core/relay/test_runtime.py
@@ -93,3 +93,64 @@ def test_default_pid_alive_true_for_current_process(tmp_path):
 
     write_runtime_record(tmp_path, RelayRuntimeRecord(host="h", pid=os.getpid()))
     assert live_runtime_record(tmp_path) is not None  # real _pid_alive on this pid
+
+
+def test_resolve_flag_only():
+    from mship.core.relay.runtime import ResolvedRelay, resolve_relay
+
+    r = resolve_relay(flag_host="flag.host", config_relay=None, record=None)
+    assert r == ResolvedRelay(host="flag.host", ssh_port=2222, user=None, source="flag")
+
+
+def test_resolve_config_only():
+    from mship.core.relay.config import RelayConfig
+    from mship.core.relay.runtime import ResolvedRelay, resolve_relay
+
+    cfg = RelayConfig(host="cfg.host", ssh_port=2200, user="tunnel")
+    r = resolve_relay(flag_host=None, config_relay=cfg, record=None)
+    assert r == ResolvedRelay(host="cfg.host", ssh_port=2200, user="tunnel", source="config")
+
+
+def test_resolve_record_only():
+    from mship.core.relay.runtime import ResolvedRelay, resolve_relay
+
+    rec = RelayRuntimeRecord(host="rec.host", pid=1, ssh_port=2019, user="u")
+    r = resolve_relay(flag_host=None, config_relay=None, record=rec)
+    assert r == ResolvedRelay(host="rec.host", ssh_port=2019, user="u", source="record")
+
+
+def test_resolve_flag_beats_config_and_record():
+    from mship.core.relay.config import RelayConfig
+    from mship.core.relay.runtime import resolve_relay
+
+    cfg = RelayConfig(host="cfg.host", ssh_port=2200, user="cu")
+    rec = RelayRuntimeRecord(host="rec.host", pid=1)
+    r = resolve_relay(flag_host="flag.host", config_relay=cfg, record=rec)
+    assert r.host == "flag.host" and r.source == "flag"
+    # Flag inherits ssh_port/user from config when present (mirrors _serve_with_relay
+    # RelayConfig substitution at serve.py:197-201).
+    assert r.ssh_port == 2200 and r.user == "cu"
+
+
+def test_resolve_flag_without_config_uses_default_ssh_port():
+    from mship.core.relay.runtime import ResolvedRelay, resolve_relay
+
+    rec = RelayRuntimeRecord(host="rec.host", pid=1)
+    r = resolve_relay(flag_host="flag.host", config_relay=None, record=rec)
+    assert r == ResolvedRelay(host="flag.host", ssh_port=2222, user=None, source="flag")
+
+
+def test_resolve_config_beats_record():
+    from mship.core.relay.config import RelayConfig
+    from mship.core.relay.runtime import resolve_relay
+
+    cfg = RelayConfig(host="cfg.host")
+    rec = RelayRuntimeRecord(host="rec.host", pid=1)
+    r = resolve_relay(flag_host=None, config_relay=cfg, record=rec)
+    assert r.host == "cfg.host" and r.source == "config"
+
+
+def test_resolve_nothing_returns_none():
+    from mship.core.relay.runtime import resolve_relay
+
+    assert resolve_relay(flag_host=None, config_relay=None, record=None) is None

--- a/tests/core/relay/test_runtime.py
+++ b/tests/core/relay/test_runtime.py
@@ -1,0 +1,60 @@
+import json
+
+from mship.core.relay.runtime import (
+    RelayRuntimeRecord,
+    clear_runtime_record,
+    read_runtime_record,
+    write_runtime_record,
+)
+
+
+def test_write_then_read_roundtrips(tmp_path):
+    rec = RelayRuntimeRecord(
+        host="relay.example.com",
+        pid=4321,
+        subdomain="abc-def",
+        url="https://abc-def.relay.example.com",
+        workspace="ws",
+        ssh_port=2222,
+        user="tunnel",
+    )
+    write_runtime_record(tmp_path, rec)
+    assert read_runtime_record(tmp_path) == rec
+
+
+def test_write_is_mode_0600(tmp_path):
+    write_runtime_record(tmp_path, RelayRuntimeRecord(host="h", pid=1))
+    path = tmp_path / ".mothership" / "relay-runtime.json"
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_written_file_is_json_with_host_and_pid(tmp_path):
+    write_runtime_record(tmp_path, RelayRuntimeRecord(host="relay.h", pid=99))
+    raw = json.loads((tmp_path / ".mothership" / "relay-runtime.json").read_text())
+    assert raw["host"] == "relay.h"
+    assert raw["pid"] == 99
+
+
+def test_read_absent_returns_none(tmp_path):
+    assert read_runtime_record(tmp_path) is None
+
+
+def test_read_corrupt_json_returns_none(tmp_path):
+    d = tmp_path / ".mothership"
+    d.mkdir()
+    (d / "relay-runtime.json").write_text("{not json")
+    assert read_runtime_record(tmp_path) is None
+
+
+def test_read_missing_required_keys_returns_none(tmp_path):
+    d = tmp_path / ".mothership"
+    d.mkdir()
+    (d / "relay-runtime.json").write_text(json.dumps({"host": "h"}))  # no pid
+    assert read_runtime_record(tmp_path) is None
+
+
+def test_clear_removes_record_idempotently(tmp_path):
+    write_runtime_record(tmp_path, RelayRuntimeRecord(host="h", pid=1))
+    clear_runtime_record(tmp_path)
+    assert read_runtime_record(tmp_path) is None
+    clear_runtime_record(tmp_path)  # no error when already gone

--- a/tests/core/relay/test_runtime.py
+++ b/tests/core/relay/test_runtime.py
@@ -3,6 +3,7 @@ import json
 from mship.core.relay.runtime import (
     RelayRuntimeRecord,
     clear_runtime_record,
+    live_runtime_record,
     read_runtime_record,
     write_runtime_record,
 )
@@ -58,3 +59,37 @@ def test_clear_removes_record_idempotently(tmp_path):
     clear_runtime_record(tmp_path)
     assert read_runtime_record(tmp_path) is None
     clear_runtime_record(tmp_path)  # no error when already gone
+
+
+def test_live_record_returned_when_pid_alive(tmp_path):
+    write_runtime_record(tmp_path, RelayRuntimeRecord(host="h", pid=1234))
+    got = live_runtime_record(tmp_path, pid_alive=lambda pid: True)
+    assert got is not None and got.host == "h"
+
+
+def test_stale_record_ignored_when_pid_dead(tmp_path):
+    write_runtime_record(tmp_path, RelayRuntimeRecord(host="h", pid=1234))
+    assert live_runtime_record(tmp_path, pid_alive=lambda pid: False) is None
+
+
+def test_live_record_none_when_absent(tmp_path):
+    assert live_runtime_record(tmp_path, pid_alive=lambda pid: True) is None
+
+
+def test_live_record_checks_the_records_pid(tmp_path):
+    write_runtime_record(tmp_path, RelayRuntimeRecord(host="h", pid=777))
+    seen = {}
+
+    def fake_alive(pid):
+        seen["pid"] = pid
+        return True
+
+    live_runtime_record(tmp_path, pid_alive=fake_alive)
+    assert seen["pid"] == 777
+
+
+def test_default_pid_alive_true_for_current_process(tmp_path):
+    import os
+
+    write_runtime_record(tmp_path, RelayRuntimeRecord(host="h", pid=os.getpid()))
+    assert live_runtime_record(tmp_path) is not None  # real _pid_alive on this pid


### PR DESCRIPTION
mship pair: --relay-host option plus auto-discover the running serve relay
---

## Acceptance criteria

- [x] `ac1` `mship pair --relay-host <host>` prints a valid `groundcontrol://add?...` deep-link plus QR with NO `relay:` block in mothership.yaml (it does not hit the current 'No relay configured' exit at pair.py:35-40). — test:test-runs/1.mothership, commit:83423e7
- [x] `ac2` With a serve running under `mship serve --relay-host <host>` and no `relay:` block, bare `mship pair` auto-discovers that relay from the running serve's runtime record and prints the current link plus QR. — test:test-runs/1.mothership, commit:7d26d62
- [x] `ac3` The link `mship pair` prints (URL host, subdomain, and token) is byte-for-byte identical to the link the running serve printed for the same workspace. — test:test-runs/1.mothership, commit:5a58b6d
- [x] `ac4` The printed link's token equals the running serve's token (both from `ensure_serve_token`); re-pairing after a serve restart that did not rotate the token yields the same token. — test:test-runs/1.mothership, commit:3f3f448
- [x] `ac5` When no relay can be resolved (no `--relay-host`, no `relay:` block, no live serve record), `mship pair` exits non-zero with an actionable message that names `--relay-host` and the serve — never a silent, empty, or partial link. — test:test-runs/1.mothership, commit:83423e7
- [x] `ac6` Explicit `--relay-host` overrides both `config.relay.host` and any running-serve record (precedence: flag > config > live record). — test:test-runs/1.mothership, commit:ce1cf3d
- [x] `ac7` A stale runtime record (serve not running / pid dead) is ignored: `mship pair` does not print a link derived from it and falls back to the flag/config or the clear error. — test:test-runs/1.mothership, commit:0d53548
- [x] `ac8` Existing behavior is preserved: with a `relay:` block in mothership.yaml and no flag, `mship pair` behaves exactly as it does today. — test:test-runs/1.mothership, commit:66bbf5a