### PR TITLE
Add mship spec apply --from-file that parses a rendered spec markdown body back into a SpecDraft (inverse of render_body), reusing the same apply path as --from-json

### DIFF
--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -171,10 +171,14 @@ def register(parent: typer.Typer, get_container):
             else:
                 draft = parse_spec_markdown(raw)
         except (json.JSONDecodeError, ValidationError) as e:
-            output.error(f"Invalid draft JSON: {e}")
+            # ValidationError can bubble from SpecDraft(...) on EITHER path, so
+            # label by the actual source flag rather than hard-coding "JSON"
+            # (a --from-file ValidationError must not read as a JSON error).
+            kind = "draft JSON" if from_json is not None else "spec markdown"
+            output.error(f"Invalid {kind} from {source_flag}: {e}")
             raise typer.Exit(1)
         except ValueError as e:
-            output.error(f"Invalid spec markdown: {e}")
+            output.error(f"Invalid spec markdown from {source_flag}: {e}")
             raise typer.Exit(1)
 
         container = get_container()

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -126,32 +126,55 @@ def register(parent: typer.Typer, get_container):
     @spec_app.command("apply")
     def apply(
         spec_id: str = typer.Argument(..., help="Spec id to apply the draft to."),
-        from_json: str = typer.Option(..., "--from-json", help="Path to the draft JSON, or - for stdin."),
+        from_json: Optional[str] = typer.Option(None, "--from-json", help="Path to the draft JSON, or - for stdin."),
+        from_file: Optional[str] = typer.Option(None, "--from-file", help="Path to a rendered spec markdown file, or - for stdin."),
         bypass_status_gate: bool = typer.Option(False, "--bypass-status-gate", help="Apply regardless of current status."),
     ):
-        """Ingest a SpecDraft JSON: render the body, set fields, advance to needs_review."""
+        """Ingest a drafted spec, render the body, set fields, advance to needs_review.
+
+        Provide exactly one source:
+          --from-json <file|->   a structured SpecDraft JSON payload
+          --from-file <file|->   a rendered spec markdown document (## Problem / ## Approach / …)
+        Both feed the SAME apply path; only the deserialization differs. Note the
+        markdown path recovers only the prose + list sections it renders — the
+        JSON path remains authoritative for anything a rendered body omits.
+        """
         import json
         import sys
         from datetime import datetime, timezone
         from pathlib import Path
         from pydantic import ValidationError
         from mship.core.spec import SpecDraft, InvalidTransition, validate_transition
-        from mship.core.spec_draft import apply_draft
+        from mship.core.spec_draft import apply_draft, parse_spec_markdown
         from mship.core.spec_store import SpecStore, SPECS_DIRNAME
 
         output = Output()
-        if from_json == "-":
+
+        if (from_json is None) == (from_file is None):
+            output.error("Provide exactly one of --from-json or --from-file.")
+            raise typer.Exit(1)
+
+        source_flag = "--from-json" if from_json is not None else "--from-file"
+        source_val = from_json if from_json is not None else from_file
+        if source_val == "-":
             raw = sys.stdin.read()
         else:
             try:
-                raw = Path(from_json).read_text()
+                raw = Path(source_val).read_text()
             except OSError as e:
-                output.error(f"Cannot read --from-json {from_json!r}: {e}")
+                output.error(f"Cannot read {source_flag} {source_val!r}: {e}")
                 raise typer.Exit(1)
+
         try:
-            draft = SpecDraft(**json.loads(raw))
+            if from_json is not None:
+                draft = SpecDraft(**json.loads(raw))
+            else:
+                draft = parse_spec_markdown(raw)
         except (json.JSONDecodeError, ValidationError) as e:
             output.error(f"Invalid draft JSON: {e}")
+            raise typer.Exit(1)
+        except ValueError as e:
+            output.error(f"Invalid spec markdown: {e}")
             raise typer.Exit(1)
 
         container = get_container()

--- a/src/mship/core/spec_draft.py
+++ b/src/mship/core/spec_draft.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import datetime
 
 from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec, SpecDraft
@@ -187,16 +188,69 @@ def apply_draft(spec: Spec, draft: SpecDraft) -> Spec:
     return spec
 
 
+_PROSE_SECTIONS = {
+    "problem": "problem",
+    "user story": "user_story",
+    "approach": "approach",
+}
+_LIST_SECTIONS = {
+    "acceptance criteria": "acceptance_criteria",
+    "open questions": "open_questions",
+    "non-goals": "non_goals",
+    "non goals": "non_goals",
+    "risks": "risks",
+    "affected repos": "affected_repos",
+    "affected repositories": "affected_repos",
+}
+_BULLET_RE = re.compile(r"^\s*-\s+(.*)$")
+_CHECKBOX_RE = re.compile(r"^\[[ xX]\]\s+(.*)$")
+_ID_BACKTICK_RE = re.compile(r"^`[A-Za-z]+\d+`\s+(.*)$")
+_ID_BRACKET_RE = re.compile(r"^\[[A-Za-z]+\d+\]\s+(.*)$")
+
+
+def _parse_list_items(heading: str, raw: str) -> list[str]:
+    """Extract bullet-item text from a list section, stripping an optional
+    `[ ]`/`[x]` checkbox and an optional `` `acN` `` / `[acN]` id token. The
+    `\\d+` requirement on ids means real prose like `` `code` does X `` is never
+    mistaken for an id."""
+    items: list[str] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        m = _BULLET_RE.match(line)
+        if m is None:
+            continue  # tolerant here; Task 5 makes malformed lines loud
+        text = m.group(1).strip()
+        cb = _CHECKBOX_RE.match(text)
+        if cb is not None:
+            text = cb.group(1).strip()
+        idm = _ID_BACKTICK_RE.match(text) or _ID_BRACKET_RE.match(text)
+        if idm is not None:
+            text = idm.group(1).strip()
+        if text:
+            items.append(text)
+    return items
+
+
 def parse_spec_markdown(text: str) -> SpecDraft:
     """Parse a rendered spec markdown document back into a SpecDraft.
 
-    Inverse of the `## Problem` / `## User story` / `## Approach` body rendering
-    (see `render_body`). Reuses `parse_body_sections` to split by `## ` headings.
+    Inverse of the body/section rendering used across mship. Reuses
+    `parse_body_sections` to split by `## ` headings, maps known headings to
+    SpecDraft fields, and parses list sections into text-only items (ids are
+    re-derived positionally by `apply_draft`, matching the JSON path).
     """
     sections = parse_body_sections(text)
-    by_key = {heading.strip().lower(): body.strip() for heading, body in sections.items()}
-    return SpecDraft(
-        problem=by_key.get("problem", ""),
-        user_story=by_key.get("user story", ""),
-        approach=by_key.get("approach", ""),
-    )
+    fields: dict[str, object] = {
+        "problem": "", "user_story": "", "approach": "",
+        "non_goals": [], "risks": [], "affected_repos": [],
+        "acceptance_criteria": [], "open_questions": [],
+    }
+    for heading, body in sections.items():
+        key = heading.strip().lower()
+        if key in _PROSE_SECTIONS:
+            fields[_PROSE_SECTIONS[key]] = body.strip()
+        elif key in _LIST_SECTIONS:
+            fields[_LIST_SECTIONS[key]] = _parse_list_items(heading.strip(), body)
+        # else: unknown heading — additional_sections handled in Task 3
+    return SpecDraft(**fields)

--- a/src/mship/core/spec_draft.py
+++ b/src/mship/core/spec_draft.py
@@ -219,7 +219,10 @@ def _parse_list_items(heading: str, raw: str) -> list[str]:
             continue
         m = _BULLET_RE.match(line)
         if m is None:
-            continue  # tolerant here; Task 5 makes malformed lines loud
+            raise ValueError(
+                f"cannot parse spec markdown: '{heading}' section has a "
+                f"non-list line: {line.strip()!r}"
+            )
         text = m.group(1).strip()
         cb = _CHECKBOX_RE.match(text)
         if cb is not None:
@@ -242,6 +245,12 @@ def parse_spec_markdown(text: str) -> SpecDraft:
     how `render_body` appends extras after Approach).
     """
     sections = parse_body_sections(text)
+    present = {heading.strip().lower() for heading in sections}
+    missing = [name for name in ("Problem", "User story", "Approach") if name.lower() not in present]
+    if missing:
+        raise ValueError(
+            "cannot parse spec markdown: missing required section(s): " + ", ".join(missing)
+        )
     fields: dict[str, object] = {
         "problem": "", "user_story": "", "approach": "",
         "non_goals": [], "risks": [], "affected_repos": [],

--- a/src/mship/core/spec_draft.py
+++ b/src/mship/core/spec_draft.py
@@ -202,7 +202,7 @@ _LIST_SECTIONS = {
     "affected repos": "affected_repos",
     "affected repositories": "affected_repos",
 }
-_BULLET_RE = re.compile(r"^\s*-\s+(.*)$")
+_BULLET_RE = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+(.*)$")
 _CHECKBOX_RE = re.compile(r"^\[[ xX]\]\s+(.*)$")
 _ID_BACKTICK_RE = re.compile(r"^`[A-Za-z]+\d+`\s+(.*)$")
 _ID_BRACKET_RE = re.compile(r"^\[[A-Za-z]+\d+\]\s+(.*)$")

--- a/src/mship/core/spec_draft.py
+++ b/src/mship/core/spec_draft.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from datetime import datetime
 
-from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec, SpecDraft
+from mship.core.spec import AcceptanceCriterion, BodySection, OpenQuestion, Spec, SpecDraft
 from mship.core.spec_body import parse_body_sections, render_body
 from mship.util.slug import slugify
 
@@ -237,8 +237,9 @@ def parse_spec_markdown(text: str) -> SpecDraft:
 
     Inverse of the body/section rendering used across mship. Reuses
     `parse_body_sections` to split by `## ` headings, maps known headings to
-    SpecDraft fields, and parses list sections into text-only items (ids are
-    re-derived positionally by `apply_draft`, matching the JSON path).
+    SpecDraft fields, parses list sections into text-only items, and preserves
+    any other `## <Heading>` section as an additional_sections entry (matching
+    how `render_body` appends extras after Approach).
     """
     sections = parse_body_sections(text)
     fields: dict[str, object] = {
@@ -246,11 +247,13 @@ def parse_spec_markdown(text: str) -> SpecDraft:
         "non_goals": [], "risks": [], "affected_repos": [],
         "acceptance_criteria": [], "open_questions": [],
     }
+    additional: list[BodySection] = []
     for heading, body in sections.items():
         key = heading.strip().lower()
         if key in _PROSE_SECTIONS:
             fields[_PROSE_SECTIONS[key]] = body.strip()
         elif key in _LIST_SECTIONS:
             fields[_LIST_SECTIONS[key]] = _parse_list_items(heading.strip(), body)
-        # else: unknown heading — additional_sections handled in Task 3
-    return SpecDraft(**fields)
+        else:
+            additional.append(BodySection(heading=heading.strip(), body=body.strip()))
+    return SpecDraft(additional_sections=additional, **fields)

--- a/src/mship/core/spec_draft.py
+++ b/src/mship/core/spec_draft.py
@@ -185,3 +185,18 @@ def apply_draft(spec: Spec, draft: SpecDraft) -> Spec:
         for i, t in enumerate(draft.open_questions)
     ]
     return spec
+
+
+def parse_spec_markdown(text: str) -> SpecDraft:
+    """Parse a rendered spec markdown document back into a SpecDraft.
+
+    Inverse of the `## Problem` / `## User story` / `## Approach` body rendering
+    (see `render_body`). Reuses `parse_body_sections` to split by `## ` headings.
+    """
+    sections = parse_body_sections(text)
+    by_key = {heading.strip().lower(): body.strip() for heading, body in sections.items()}
+    return SpecDraft(
+        problem=by_key.get("problem", ""),
+        user_story=by_key.get("user story", ""),
+        approach=by_key.get("approach", ""),
+    )

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -932,3 +932,36 @@ def test_spec_apply_from_file_malformed_markdown_errors(configured_app_with_task
     mf.write_text("just some notes, no headings")  # missing required sections
     result = runner.invoke(app, ["spec", "apply", "dq", "--from-file", str(mf)])
     assert result.exit_code != 0
+
+
+# --- spec apply --from-json regression guard (#298 item 1) ---
+
+
+def test_regression_from_json_file_still_applies(configured_app_with_task: Path, tmp_path):
+    runner.invoke(app, ["spec", "new", "--title", "Decision queue", "--id", "dq"])
+    jf = tmp_path / "draft.json"; jf.write_text(_draft_json())
+    result = runner.invoke(app, ["spec", "apply", "dq", "--from-json", str(jf)])
+    assert result.exit_code == 0, result.output
+    spec = _store(configured_app_with_task).find_by_id("dq")
+    assert spec.status == "needs_review"
+    assert [c.id for c in spec.acceptance_criteria] == ["ac1"]
+    assert "## Problem" in spec.body
+
+
+def test_regression_from_json_stdin_still_applies(configured_app_with_task: Path):
+    runner.invoke(app, ["spec", "new", "--title", "Decision queue", "--id", "dq"])
+    result = runner.invoke(app, ["spec", "apply", "dq", "--from-json", "-"], input=_draft_json())
+    assert result.exit_code == 0, result.output
+    assert _store(configured_app_with_task).find_by_id("dq").status == "needs_review"
+
+
+def test_regression_from_json_bad_payload_still_errors(configured_app_with_task: Path, tmp_path):
+    runner.invoke(app, ["spec", "new", "--title", "Decision queue", "--id", "dq"])
+    jf = tmp_path / "bad.json"; jf.write_text("this is not json at all")
+    result = runner.invoke(app, ["spec", "apply", "dq", "--from-json", str(jf)])
+    assert result.exit_code != 0
+    # A valid-JSON but schema-invalid payload still errors via the JSON path
+    # (never routed through the markdown parser).
+    jf2 = tmp_path / "partial.json"; jf2.write_text('{"problem": "only problem"}')
+    result2 = runner.invoke(app, ["spec", "apply", "dq", "--from-json", str(jf2)])
+    assert result2.exit_code != 0

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -869,3 +869,66 @@ def test_spec_apply_stamps_bound_task_activity(configured_app_with_task: Path, t
     assert result.exit_code == 0, result.output
     state = StateManager(configured_app_with_task / ".mothership").load()
     assert state.tasks["add-labels"].last_activity_at is not None
+
+
+# --- spec apply --from-file (#298 item 1) ---
+
+
+def _draft_md() -> str:
+    return (
+        "## Problem\n\nP\n\n"
+        "## User story\n\nU\n\n"
+        "## Approach\n\nA\n\n"
+        "## Acceptance criteria\n\n"
+        "- [ ] `ac1` view questions\n\n"
+        "## Open questions\n\n"
+        "- Android?\n\n"
+        "## Non-goals\n\n"
+        "- chat\n\n"
+        "## Affected repos\n\n"
+        "- mothership\n"
+    )
+
+
+def test_spec_apply_from_file_merges_and_advances_status(configured_app_with_task: Path, tmp_path):
+    runner.invoke(app, ["spec", "new", "--title", "Decision queue", "--id", "dq"])
+    mf = tmp_path / "draft.md"
+    mf.write_text(_draft_md())
+    result = runner.invoke(app, ["spec", "apply", "dq", "--from-file", str(mf)])
+    assert result.exit_code == 0, result.output
+    spec = _store(configured_app_with_task).find_by_id("dq")
+    assert spec.status == "needs_review"
+    assert [c.id for c in spec.acceptance_criteria] == ["ac1"]
+    assert spec.acceptance_criteria[0].text == "view questions"
+    assert spec.non_goals == ["chat"]
+    assert spec.affected_repos == ["mothership"]
+    assert "## Problem" in spec.body
+
+
+def test_spec_apply_requires_exactly_one_source(configured_app_with_task: Path, tmp_path):
+    runner.invoke(app, ["spec", "new", "--title", "Decision queue", "--id", "dq"])
+    # Neither source.
+    neither = runner.invoke(app, ["spec", "apply", "dq"])
+    assert neither.exit_code != 0
+    assert "exactly one" in neither.output.lower()
+    # Both sources.
+    jf = tmp_path / "d.json"; jf.write_text(_draft_json())
+    mf = tmp_path / "d.md"; mf.write_text(_draft_md())
+    both = runner.invoke(app, ["spec", "apply", "dq", "--from-json", str(jf), "--from-file", str(mf)])
+    assert both.exit_code != 0
+    assert "exactly one" in both.output.lower()
+
+
+def test_spec_apply_from_file_missing_file_errors(configured_app_with_task: Path):
+    runner.invoke(app, ["spec", "new", "--title", "Decision queue", "--id", "dq"])
+    result = runner.invoke(app, ["spec", "apply", "dq", "--from-file", "/no/such/file.md"])
+    assert result.exit_code != 0
+    assert "from-file" in result.output or "read" in result.output.lower()
+
+
+def test_spec_apply_from_file_malformed_markdown_errors(configured_app_with_task: Path, tmp_path):
+    runner.invoke(app, ["spec", "new", "--title", "Decision queue", "--id", "dq"])
+    mf = tmp_path / "bad.md"
+    mf.write_text("just some notes, no headings")  # missing required sections
+    result = runner.invoke(app, ["spec", "apply", "dq", "--from-file", str(mf)])
+    assert result.exit_code != 0

--- a/tests/core/test_spec_markdown_parse.py
+++ b/tests/core/test_spec_markdown_parse.py
@@ -1,0 +1,22 @@
+from mship.core.spec import SpecDraft
+from mship.core.spec_draft import parse_spec_markdown
+
+
+def test_parses_required_prose_sections_into_empty_draft():
+    text = (
+        "## Problem\n\nP\n\n"
+        "## User story\n\nU\n\n"
+        "## Approach\n\nA\n"
+    )
+    draft = parse_spec_markdown(text)
+    assert isinstance(draft, SpecDraft)
+    assert draft.problem == "P"
+    assert draft.user_story == "U"
+    assert draft.approach == "A"
+    # Optional fields default empty when their sections are absent.
+    assert draft.acceptance_criteria == []
+    assert draft.open_questions == []
+    assert draft.non_goals == []
+    assert draft.risks == []
+    assert draft.affected_repos == []
+    assert draft.additional_sections == []

--- a/tests/core/test_spec_markdown_parse.py
+++ b/tests/core/test_spec_markdown_parse.py
@@ -46,3 +46,35 @@ def test_parses_list_sections_stripping_checkboxes_and_ids():
     assert draft.non_goals == ["chat"]
     assert draft.risks == ["scope creep"]
     assert draft.affected_repos == ["mothership"]
+
+
+from mship.core.spec import BodySection
+from mship.core.spec_body import render_body
+
+
+def test_round_trips_render_body_prose_only():
+    draft = SpecDraft(
+        problem="the problem",
+        user_story="as a user, I want X, so that Y",
+        approach="the approach; key decisions",
+    )
+    body = render_body(draft.problem, draft.user_story, draft.approach)
+    assert parse_spec_markdown(body) == draft
+
+
+def test_round_trips_render_body_with_additional_sections():
+    draft = SpecDraft(
+        problem="the problem",
+        user_story="as a user, I want X, so that Y",
+        approach="the approach",
+        additional_sections=[
+            BodySection(heading="Architecture", body="the arch"),
+            BodySection(heading="Testing", body="the tests"),
+        ],
+    )
+    body = render_body(
+        draft.problem, draft.user_story, draft.approach,
+        additional_sections=[(s.heading, s.body) for s in draft.additional_sections],
+    )
+    parsed = parse_spec_markdown(body)
+    assert parsed == draft  # full SpecDraft equality (empty lists on both sides)

--- a/tests/core/test_spec_markdown_parse.py
+++ b/tests/core/test_spec_markdown_parse.py
@@ -78,3 +78,25 @@ def test_round_trips_render_body_with_additional_sections():
     )
     parsed = parse_spec_markdown(body)
     assert parsed == draft  # full SpecDraft equality (empty lists on both sides)
+
+
+def test_tolerates_reorder_alt_markers_and_empty_optional_sections():
+    # Sections out of canonical order; `*` and `1.`/`2.` bullet markers;
+    # an empty optional section; a `- [ac1]` (bracket-id) AC form.
+    text = (
+        "## Approach\n\nA\n\n"
+        "## Acceptance criteria\n\n"
+        "* [ac1] first\n"
+        "1. second\n"
+        "2. third\n\n"
+        "## Problem\n\nP\n\n"
+        "## Risks\n\n\n"          # heading present, no items
+        "## Non-goals\n\n"
+        "+ out of scope\n\n"
+        "## User story\n\nU\n"
+    )
+    draft = parse_spec_markdown(text)
+    assert draft.problem == "P" and draft.user_story == "U" and draft.approach == "A"
+    assert draft.acceptance_criteria == ["first", "second", "third"]
+    assert draft.non_goals == ["out of scope"]
+    assert draft.risks == []  # empty optional section → empty list, no error

--- a/tests/core/test_spec_markdown_parse.py
+++ b/tests/core/test_spec_markdown_parse.py
@@ -20,3 +20,29 @@ def test_parses_required_prose_sections_into_empty_draft():
     assert draft.risks == []
     assert draft.affected_repos == []
     assert draft.additional_sections == []
+
+
+def test_parses_list_sections_stripping_checkboxes_and_ids():
+    text = (
+        "## Problem\n\nP\n\n"
+        "## User story\n\nU\n\n"
+        "## Approach\n\nA\n\n"
+        "## Acceptance criteria\n\n"
+        "- [ ] `ac1` view questions\n"
+        "- [x] `ac2` record answer\n\n"
+        "## Open questions\n\n"
+        "- [q1] Android in v0?\n\n"
+        "## Non-goals\n\n"
+        "- chat\n\n"
+        "## Risks\n\n"
+        "- scope creep\n\n"
+        "## Affected repos\n\n"
+        "- mothership\n"
+    )
+    draft = parse_spec_markdown(text)
+    # Text only — ids/checkboxes stripped, matching the JSON path's text-only lists.
+    assert draft.acceptance_criteria == ["view questions", "record answer"]
+    assert draft.open_questions == ["Android in v0?"]
+    assert draft.non_goals == ["chat"]
+    assert draft.risks == ["scope creep"]
+    assert draft.affected_repos == ["mothership"]

--- a/tests/core/test_spec_markdown_parse.py
+++ b/tests/core/test_spec_markdown_parse.py
@@ -100,3 +100,28 @@ def test_tolerates_reorder_alt_markers_and_empty_optional_sections():
     assert draft.acceptance_criteria == ["first", "second", "third"]
     assert draft.non_goals == ["out of scope"]
     assert draft.risks == []  # empty optional section → empty list, no error
+
+
+import pytest
+
+
+def test_missing_required_section_raises_naming_it():
+    text = "## Problem\n\nP\n\n## User story\n\nU\n"  # no Approach
+    with pytest.raises(ValueError) as exc:
+        parse_spec_markdown(text)
+    assert "Approach" in str(exc.value)
+
+
+def test_non_markdown_junk_raises():
+    with pytest.raises(ValueError):
+        parse_spec_markdown("this is not a spec at all")
+
+
+def test_malformed_list_section_raises_naming_section():
+    text = (
+        "## Problem\n\nP\n\n## User story\n\nU\n\n## Approach\n\nA\n\n"
+        "## Acceptance criteria\n\nnot a bullet line\n"
+    )
+    with pytest.raises(ValueError) as exc:
+        parse_spec_markdown(text)
+    assert "Acceptance criteria" in str(exc.value)


### PR DESCRIPTION
Add mship spec apply --from-file that parses a rendered spec markdown body back into a SpecDraft (inverse of render_body), reusing the same apply path as --from-json

Closes #298