### PR TITLE
mship init --detect produces a working monorepo config (issue 366 finding 4)

### DIFF
--- a/src/mship/cli/init.py
+++ b/src/mship/cli/init.py
@@ -247,7 +247,14 @@ def _run_interactive(
         output.error("No repos selected. Aborting.")
         raise typer.Exit(code=1)
 
-    # 4. Repo types
+    # 4. Repo types — classify through plan_detected_repos so the interactive
+    #    wizard emits the SAME relative-path + git_root monorepo config as
+    #    `--detect` (issue #366 finding #4); the user's per-repo type choice
+    #    overrides the classifier's default. Without this, plain `mship init` in
+    #    a TTY on a single-git monorepo produced the broken git_root-less config
+    #    this fix removes for --detect.
+    planned = initializer.plan_detected_repos(cwd, selected)
+    planned_by_name = {p["name"]: p for p in planned}
     repos_data: list[dict] = []
     for det in selected:
         repo_name = det.path.name if det.path != cwd else cwd.name
@@ -256,12 +263,14 @@ def _run_interactive(
             choices=["library", "service"],
             default="service",
         ).execute()
-        repos_data.append({
+        entry = dict(planned_by_name.get(repo_name, {
             "name": repo_name,
-            "path": det.path,
-            "type": repo_type,
+            "path": str(det.path),
+            "git_root": None,
             "depends_on": [],
-        })
+        }))
+        entry["type"] = repo_type
+        repos_data.append(entry)
 
     # 5. Dependencies
     repo_names = [r["name"] for r in repos_data]
@@ -277,7 +286,7 @@ def _run_interactive(
     # 6. Taskfile scaffolding
     created_taskfiles: list[str] = []
     for rd in repos_data:
-        repo_path = Path(rd["path"])
+        repo_path = (cwd / rd["path"]).resolve()
         existing = resolve_go_task_files(repo_path)
         if existing:
             note = f'"{rd["name"]}" already has {existing[0].name}'

--- a/src/mship/cli/init.py
+++ b/src/mship/cli/init.py
@@ -107,16 +107,12 @@ def register(app: typer.Typer, get_container):
         # Auto-detect
         if detect:
             detected = initializer.detect_repos(cwd)
+            planned = initializer.plan_detected_repos(cwd, detected)
             existing_paths = {Path(rd["path"]).resolve() for rd in repos_data}
-            for d in detected:
-                if d.path.resolve() not in existing_paths:
-                    repo_name = d.path.name if d.path != cwd else cwd.name
-                    repos_data.append({
-                        "name": repo_name,
-                        "path": d.path,
-                        "type": "service",
-                        "depends_on": [],
-                    })
+            for entry in planned:
+                abspath = (cwd / entry["path"]).resolve()
+                if abspath not in existing_paths:
+                    repos_data.append(entry)
 
         try:
             config = initializer.generate_config(name, repos_data, env_runner)
@@ -131,7 +127,7 @@ def register(app: typer.Typer, get_container):
         rename_notes: list[tuple[str, Path]] = []
         if scaffold_taskfiles:
             for rd in repos_data:
-                repo_path = Path(rd["path"])
+                repo_path = (cwd / rd["path"]).resolve()
                 result = initializer.write_taskfile(repo_path)
                 if result.wrote:
                     created_taskfiles.append(str(repo_path))

--- a/src/mship/core/init.py
+++ b/src/mship/core/init.py
@@ -139,6 +139,7 @@ tasks:
                 path=Path(repo["path"]),
                 type=repo["type"],
                 depends_on=repo.get("depends_on", []),
+                git_root=repo.get("git_root"),
             )
 
         config = WorkspaceConfig(

--- a/src/mship/core/init.py
+++ b/src/mship/core/init.py
@@ -99,11 +99,12 @@ class WorkspaceInitializer:
                 })
                 continue
             rel = d.path.relative_to(workspace_path)
+            git_root = None if ".git" in d.markers else root_name
             entries.append({
                 "name": d.path.name,
                 "path": str(rel),
                 "type": "service",
-                "git_root": root_name,
+                "git_root": git_root,
                 "depends_on": [],
             })
         return entries

--- a/src/mship/core/init.py
+++ b/src/mship/core/init.py
@@ -80,13 +80,29 @@ class WorkspaceInitializer:
     def plan_detected_repos(
         self, workspace_path: Path, detected: list[DetectedRepo]
     ) -> list[dict]:
-        """Turn detected repos into config-entry dicts with RELATIVE paths.
+        """Classify detected repos into config-entry dicts with RELATIVE paths
+        and, for non-git subdirs of a git-owning root, a `git_root` back-ref.
 
-        The workspace root (path == workspace_path) is emitted standalone with
-        `path: '.'`; every detected subdir becomes a git_root child of the root
-        with a path relative to the root. (Refined for ac3/ac8 in later tasks.)
+        Rules (spec mship-init-detect-monorepo / issue #366 finding #4):
+        - The workspace root (path == workspace_path), if detected, is emitted
+          standalone with `path: '.'` and no git_root.
+        - A subdir owning its own `.git` (a `.git` dir OR a submodule gitlink
+          `.git` file — both make `_find_markers` record ".git") stays standalone
+          with a path relative to the root and no git_root (ac3).
+        - A subdir with NO `.git`, when the root IS a git owner, becomes a
+          `git_root: <root-name>` child with a path relative to the root (ac1).
+          Single-level detection: the parent IS the root, so relative-to-root
+          equals the `(parent.path / child.path)` resolution contract.
+        - If the root is not a git owner, non-git subdirs fall back to standalone
+          emission — never point git_root at a non-git root (ac8).
+        All emitted paths are relative for portability (ac2).
         """
+        root_repo = next(
+            (d for d in detected if d.path == workspace_path), None
+        )
+        root_is_git_owner = root_repo is not None and ".git" in root_repo.markers
         root_name = workspace_path.name
+
         entries: list[dict] = []
         for d in detected:
             if d.path == workspace_path:
@@ -99,7 +115,8 @@ class WorkspaceInitializer:
                 })
                 continue
             rel = d.path.relative_to(workspace_path)
-            git_root = None if ".git" in d.markers else root_name
+            has_own_git = ".git" in d.markers
+            git_root = None if (has_own_git or not root_is_git_owner) else root_name
             entries.append({
                 "name": d.path.name,
                 "path": str(rel),

--- a/src/mship/core/init.py
+++ b/src/mship/core/init.py
@@ -163,6 +163,8 @@ tasks:
                 "path": str(repo.path),
                 "type": repo.type,
             }
+            if repo.git_root is not None:
+                repo_data["git_root"] = repo.git_root
             if repo.depends_on:
                 serialized_deps = []
                 for dep in repo.depends_on:

--- a/src/mship/core/init.py
+++ b/src/mship/core/init.py
@@ -77,6 +77,37 @@ class WorkspaceInitializer:
 
         return repos
 
+    def plan_detected_repos(
+        self, workspace_path: Path, detected: list[DetectedRepo]
+    ) -> list[dict]:
+        """Turn detected repos into config-entry dicts with RELATIVE paths.
+
+        The workspace root (path == workspace_path) is emitted standalone with
+        `path: '.'`; every detected subdir becomes a git_root child of the root
+        with a path relative to the root. (Refined for ac3/ac8 in later tasks.)
+        """
+        root_name = workspace_path.name
+        entries: list[dict] = []
+        for d in detected:
+            if d.path == workspace_path:
+                entries.append({
+                    "name": root_name,
+                    "path": ".",
+                    "type": "service",
+                    "git_root": None,
+                    "depends_on": [],
+                })
+                continue
+            rel = d.path.relative_to(workspace_path)
+            entries.append({
+                "name": d.path.name,
+                "path": str(rel),
+                "type": "service",
+                "git_root": root_name,
+                "depends_on": [],
+            })
+        return entries
+
     def _find_markers(self, path: Path) -> list[str]:
         markers: list[str] = []
         for marker in REPO_MARKERS:

--- a/src/mship/core/init.py
+++ b/src/mship/core/init.py
@@ -95,7 +95,10 @@ class WorkspaceInitializer:
           equals the `(parent.path / child.path)` resolution contract.
         - If the root is not a git owner, non-git subdirs fall back to standalone
           emission — never point git_root at a non-git root (ac8).
-        All emitted paths are relative for portability (ac2).
+        - A repo OUTSIDE the workspace root (e.g. a manually-added path in the
+          interactive wizard) cannot be a git_root child of it and has no path
+          relative to it, so it is emitted standalone with its absolute path.
+        Detected subdir paths are relative for portability (ac2).
         """
         root_repo = next(
             (d for d in detected if d.path == workspace_path), None
@@ -109,6 +112,15 @@ class WorkspaceInitializer:
                 entries.append({
                     "name": root_name,
                     "path": ".",
+                    "type": "service",
+                    "git_root": None,
+                    "depends_on": [],
+                })
+                continue
+            if not d.path.is_relative_to(workspace_path):
+                entries.append({
+                    "name": d.path.name,
+                    "path": str(d.path),
                     "type": "service",
                     "git_root": None,
                     "depends_on": [],

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -265,3 +265,62 @@ def test_install_hooks_refreshed_vs_up_to_date_labels(tmp_path: Path, monkeypatc
         container.state_dir.reset_override()
         container.config.reset()
         container.state_manager.reset()
+
+
+def test_interactive_wizard_emits_git_root_for_single_git_monorepo(tmp_path: Path, monkeypatch):
+    """The interactive wizard (plain `mship init` in a TTY) emits the SAME
+    relative-path + git_root monorepo config as `--detect` on a single-git
+    monorepo — closes the interactive-vs-detect divergence (issue #366 #4)."""
+    import subprocess
+
+    import InquirerPy.inquirer  # noqa: F401  (import so the patch target exists)
+    from mship.cli.init import _run_interactive
+    from mship.cli.output import Output
+    from mship.core.init import WorkspaceInitializer
+
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, capture_output=True)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='root'\n")
+    for sub in ("web", "infra"):
+        (tmp_path / sub).mkdir()
+        (tmp_path / sub / "package.json").write_text("{}")
+
+    class _Prompt:
+        def __init__(self, val):
+            self._val = val
+
+        def execute(self):
+            return self._val
+
+    class _FakeInquirer:
+        # workspace name, then the manual-add loop (blank == stop)
+        def text(self, message="", default="", **kw):
+            return _Prompt("mono") if "Workspace name" in message else _Prompt("")
+
+        # select-repos (take all) vs depends_on (none)
+        def checkbox(self, message="", choices=None, **kw):
+            if "Select repos" in message:
+                return _Prompt([c["value"] for c in (choices or [])])
+            return _Prompt([])
+
+        # per-repo type vs env_runner
+        def select(self, message="", choices=None, default=None, **kw):
+            return _Prompt("service") if "type is" in message else _Prompt(None)
+
+        # taskfile scaffolding prompt
+        def confirm(self, message="", default=True, **kw):
+            return _Prompt(False)
+
+    monkeypatch.setattr("InquirerPy.inquirer", _FakeInquirer())
+
+    _run_interactive(
+        WorkspaceInitializer(), Output(), tmp_path,
+        tmp_path / "mothership.yaml", None, False,
+    )
+
+    data = yaml.safe_load((tmp_path / "mothership.yaml").read_text())
+    root_name = tmp_path.name
+    assert data["repos"][root_name]["path"] == "."
+    assert "git_root" not in data["repos"][root_name]
+    for sub in ("web", "infra"):
+        assert data["repos"][sub]["path"] == sub
+        assert data["repos"][sub]["git_root"] == root_name

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -55,6 +55,33 @@ def test_init_detect(init_workspace: Path, monkeypatch):
     assert "auth-service" in data["repos"]
 
 
+def test_init_detect_emits_git_root_for_single_git_monorepo(tmp_path: Path, monkeypatch):
+    """ac1/ac2: `init --detect` on a single-git monorepo emits the root as
+    `path: .` (no git_root) and each markerless subdir as a git_root child with
+    a relative path."""
+    import subprocess
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, capture_output=True)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='root'\n")
+    for sub in ("web", "infra"):
+        d = tmp_path / sub
+        d.mkdir()
+        (d / "package.json").write_text("{}")
+
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--name", "mono", "--detect"])
+    assert result.exit_code == 0, result.output
+
+    data = yaml.safe_load((tmp_path / "mothership.yaml").read_text())
+    root_name = tmp_path.name
+    assert data["repos"][root_name]["path"] == "."
+    assert "git_root" not in data["repos"][root_name]
+    for sub in ("web", "infra"):
+        assert data["repos"][sub]["path"] == sub
+        assert data["repos"][sub]["git_root"] == root_name
+    for repo in data["repos"].values():          # ac2
+        assert not str(repo["path"]).startswith("/")
+
+
 def test_init_already_exists(init_workspace: Path, monkeypatch):
     monkeypatch.chdir(init_workspace)
     (init_workspace / "mothership.yaml").write_text("workspace: existing")

--- a/tests/core/test_init.py
+++ b/tests/core/test_init.py
@@ -306,3 +306,41 @@ def test_write_config_emits_git_root(tmp_path: Path):
     assert data["repos"]["web"]["path"] == "web"
     assert data["repos"]["root"]["path"] == "."
     assert "git_root" not in data["repos"]["root"]
+
+
+def test_plan_detected_repos_single_git_monorepo(tmp_path: Path):
+    """ac1/ac2: a single-git monorepo emits the root as `path: .` (no git_root)
+    and each markerless subdir as a git_root child with a RELATIVE path; the
+    emitted plan builds a valid WorkspaceConfig (git_root refs, no chaining)."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='root'\n")
+    for sub in ("web", "infra"):
+        d = tmp_path / sub
+        d.mkdir()
+        (d / "package.json").write_text("{}")
+
+    init = WorkspaceInitializer()
+    detected = init.detect_repos(tmp_path)
+    planned = init.plan_detected_repos(tmp_path, detected)
+    by_name = {e["name"]: e for e in planned}
+
+    root_name = tmp_path.name
+    assert by_name[root_name]["path"] == "."
+    assert by_name[root_name]["git_root"] is None
+    for sub in ("web", "infra"):
+        assert by_name[sub]["path"] == sub
+        assert by_name[sub]["git_root"] == root_name
+
+    # ac2: no emitted path is absolute
+    for e in planned:
+        assert not e["path"].startswith("/")
+        assert str(tmp_path) not in e["path"]
+
+    # Regression guard (spec testing #5): generate_config runs the
+    # WorkspaceConfig validators (git_root refs, no chaining, cycles) at
+    # construction — must not raise.
+    config = init.generate_config("mono", planned, env_runner=None)
+    assert config.repos[root_name].git_root is None
+    for sub in ("web", "infra"):
+        assert config.repos[sub].git_root == root_name
+        assert config.repos[config.repos[sub].git_root].git_root is None

--- a/tests/core/test_init.py
+++ b/tests/core/test_init.py
@@ -284,3 +284,25 @@ def test_generate_config_passes_git_root(tmp_path: Path):
     )
     assert config.repos["root"].git_root is None
     assert config.repos["web"].git_root == "root"
+
+
+def test_write_config_emits_git_root(tmp_path: Path):
+    """write_config serializes git_root for subdir children and omits it for
+    standalone repos. See spec mship-init-detect-monorepo ac1."""
+    init = WorkspaceInitializer()
+    config = init.generate_config(
+        workspace_name="mono",
+        repos=[
+            {"name": "root", "path": ".", "type": "service", "depends_on": []},
+            {"name": "web", "path": "web", "type": "service",
+             "git_root": "root", "depends_on": []},
+        ],
+        env_runner=None,
+    )
+    out = tmp_path / "mothership.yaml"
+    init.write_config(out, config)
+    data = yaml.safe_load(out.read_text())
+    assert data["repos"]["web"]["git_root"] == "root"
+    assert data["repos"]["web"]["path"] == "web"
+    assert data["repos"]["root"]["path"] == "."
+    assert "git_root" not in data["repos"]["root"]

--- a/tests/core/test_init.py
+++ b/tests/core/test_init.py
@@ -344,3 +344,36 @@ def test_plan_detected_repos_single_git_monorepo(tmp_path: Path):
     for sub in ("web", "infra"):
         assert config.repos[sub].git_root == root_name
         assert config.repos[config.repos[sub].git_root].git_root is None
+
+
+def test_plan_detected_repos_subdir_with_own_git_is_standalone(tmp_path: Path):
+    """ac3: a subdir with its OWN .git (a directory OR a submodule gitlink FILE)
+    stays standalone (no git_root); a sibling without .git still attaches."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='root'\n")
+
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / ".git").mkdir()                       # independent nested repo
+    (nested / "package.json").write_text("{}")
+
+    submodule = tmp_path / "submodule"
+    submodule.mkdir()
+    (submodule / ".git").write_text(                # submodule gitlink FILE
+        "gitdir: ../.git/modules/submodule\n"
+    )
+    (submodule / "package.json").write_text("{}")
+
+    infra = tmp_path / "infra"
+    infra.mkdir()
+    (infra / "package.json").write_text("{}")
+
+    init = WorkspaceInitializer()
+    detected = init.detect_repos(tmp_path)
+    by_name = {e["name"]: e for e in init.plan_detected_repos(tmp_path, detected)}
+
+    assert by_name["nested"]["git_root"] is None
+    assert by_name["nested"]["path"] == "nested"
+    assert by_name["submodule"]["git_root"] is None
+    assert by_name["submodule"]["path"] == "submodule"
+    assert by_name["infra"]["git_root"] == tmp_path.name

--- a/tests/core/test_init.py
+++ b/tests/core/test_init.py
@@ -267,3 +267,20 @@ def test_detect_stub_dir_with_other_marker_still_promoted(tmp_path: Path):
     svc = next(r for r in init.detect_repos(tmp_path) if r.path.name == "svc")
     assert ".git" in svc.markers
     assert "Taskfile.yml" not in svc.markers
+
+
+def test_generate_config_passes_git_root(tmp_path: Path):
+    """git_root from the repo dict must land on the RepoConfig (init --detect
+    monorepo emission). See spec mship-init-detect-monorepo ac1."""
+    init = WorkspaceInitializer()
+    config = init.generate_config(
+        workspace_name="mono",
+        repos=[
+            {"name": "root", "path": ".", "type": "service", "depends_on": []},
+            {"name": "web", "path": "web", "type": "service",
+             "git_root": "root", "depends_on": []},
+        ],
+        env_runner=None,
+    )
+    assert config.repos["root"].git_root is None
+    assert config.repos["web"].git_root == "root"

--- a/tests/core/test_init.py
+++ b/tests/core/test_init.py
@@ -377,3 +377,24 @@ def test_plan_detected_repos_subdir_with_own_git_is_standalone(tmp_path: Path):
     assert by_name["submodule"]["git_root"] is None
     assert by_name["submodule"]["path"] == "submodule"
     assert by_name["infra"]["git_root"] == tmp_path.name
+
+
+def test_plan_detected_repos_root_not_git_falls_back_to_standalone(tmp_path: Path):
+    """ac8: when the workspace root has no .git, a markerless subdir does NOT get
+    a git_root pointing at the non-git root — it falls back to standalone."""
+    # No .git at root; give it a non-git marker so it is still detected.
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='root'\n")
+    for sub in ("web", "infra"):
+        d = tmp_path / sub
+        d.mkdir()
+        (d / "package.json").write_text("{}")
+
+    init = WorkspaceInitializer()
+    detected = init.detect_repos(tmp_path)
+    by_name = {e["name"]: e for e in init.plan_detected_repos(tmp_path, detected)}
+
+    for sub in ("web", "infra"):
+        assert by_name[sub]["git_root"] is None
+        assert by_name[sub]["path"] == sub
+    assert by_name[tmp_path.name]["path"] == "."
+    assert by_name[tmp_path.name]["git_root"] is None

--- a/tests/core/test_init.py
+++ b/tests/core/test_init.py
@@ -398,3 +398,20 @@ def test_plan_detected_repos_root_not_git_falls_back_to_standalone(tmp_path: Pat
         assert by_name[sub]["path"] == sub
     assert by_name[tmp_path.name]["path"] == "."
     assert by_name[tmp_path.name]["git_root"] is None
+
+
+def test_plan_detected_repos_out_of_tree_repo_is_standalone_absolute(tmp_path: Path):
+    """A repo OUTSIDE the workspace root (the interactive wizard's manual-add
+    case) cannot be a git_root child of it and has no path relative to it, so it
+    is emitted standalone with its absolute path — never raising on relative_to."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='root'\n")
+    outside = tmp_path.parent / "outside-repo"
+    detected = [
+        DetectedRepo(path=tmp_path, markers=[".git", "pyproject.toml"]),
+        DetectedRepo(path=outside, markers=[]),
+    ]
+    by_name = {e["name"]: e for e in WorkspaceInitializer().plan_detected_repos(tmp_path, detected)}
+    assert by_name["outside-repo"]["git_root"] is None
+    assert by_name["outside-repo"]["path"] == str(outside)
+    assert by_name[tmp_path.name]["path"] == "."

--- a/tests/test_init_detect_monorepo.py
+++ b/tests/test_init_detect_monorepo.py
@@ -92,3 +92,34 @@ def test_detected_monorepo_doctor_no_not_a_git_repository(tmp_path: Path, monkey
         git_check = next(c for c in report.checks if c.name == f"{name}/git")
         assert git_check.status == "pass", git_check.message
         assert "not a git repository" not in git_check.message
+
+
+def test_detected_monorepo_audit_no_not_a_git_repo(tmp_path: Path, monkeypatch):
+    """ac5/ac6: audit on the freshly detected monorepo reports NO not_a_git_repo
+    error (subdirs group under the root's git via _git_root_key), so `mship
+    spawn`'s audit gate (audit_gate.run_audit_gate) is not blocked by it."""
+    from mship.core.repo_state import audit_repos
+    from mship.util.shell import ShellRunner
+
+    root = _build_single_git_monorepo(tmp_path)
+    cfg_path = _init_detect(root, monkeypatch)
+    config = ConfigLoader.load(cfg_path, require_paths=True)
+
+    report = audit_repos(config, ShellRunner())
+
+    # ac5: no repo carries a not_a_git_repo error.
+    for repo in report.repos:
+        assert "not_a_git_repo" not in {i.code for i in repo.issues}, (
+            repo.name, [i.code for i in repo.issues]
+        )
+
+    # ac6: the exact error-code list the spawn audit gate keys off
+    # (audit_gate.run_audit_gate builds `<name>:<code>` for severity == error)
+    # contains no not_a_git_repo, so spawn is not blocked by it.
+    error_codes = [
+        f"{r.name}:{i.code}"
+        for r in report.repos
+        for i in r.issues
+        if i.severity == "error"
+    ]
+    assert not any(c.endswith(":not_a_git_repo") for c in error_codes)

--- a/tests/test_init_detect_monorepo.py
+++ b/tests/test_init_detect_monorepo.py
@@ -1,0 +1,71 @@
+"""Integration: `mship init --detect` produces a working single-git monorepo
+config (issue #366 finding #4 / spec mship-init-detect-monorepo)."""
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from mship.cli import app
+from mship.core.config import ConfigLoader
+
+runner = CliRunner()
+
+
+def _git(*args, cwd):
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, env=env)
+
+
+def _build_single_git_monorepo(tmp_path: Path) -> Path:
+    """Real single-git monorepo: root .git; subdirs web/ and infra/ with only
+    package.json (no nested .git)."""
+    root = tmp_path / "mono"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='mono'\n")
+    for sub in ("web", "infra"):
+        d = root / sub
+        d.mkdir()
+        (d / "package.json").write_text("{}")
+    _git("init", "-q", ".", cwd=root)
+    _git("add", ".", cwd=root)
+    _git("commit", "-qm", "init", cwd=root)
+    return root
+
+
+def _init_detect(root: Path, monkeypatch) -> Path:
+    monkeypatch.chdir(root)
+    result = runner.invoke(
+        app, ["init", "--name", "mono", "--detect", "--scaffold-taskfiles"]
+    )
+    assert result.exit_code == 0, result.output
+    return root / "mothership.yaml"
+
+
+def test_detected_monorepo_config_loads_with_require_paths(tmp_path: Path, monkeypatch):
+    """ac7 + ac2: the emitted config loads via ConfigLoader.load(require_paths=True)
+    — each git_root child resolves to (parent.path / child.path) and finds its
+    scaffolded Taskfile.yml — and every emitted path is relative/portable."""
+    root = _build_single_git_monorepo(tmp_path)
+    cfg_path = _init_detect(root, monkeypatch)
+
+    data = yaml.safe_load(cfg_path.read_text())
+    for repo in data["repos"].values():
+        assert not str(repo["path"]).startswith("/")
+        assert str(root) not in str(repo["path"])
+
+    config = ConfigLoader.load(cfg_path, require_paths=True)   # must not raise
+    assert config.repos[root.name].git_root is None
+    for sub in ("web", "infra"):
+        assert config.repos[sub].git_root == root.name
+
+    # ac2 portability: resolution is anchored on the config's directory, not the
+    # process CWD — loading still succeeds from an unrelated cwd.
+    monkeypatch.chdir(tmp_path)
+    reloaded = ConfigLoader.load(cfg_path, require_paths=True)
+    assert set(reloaded.repos) == set(config.repos)

--- a/tests/test_init_detect_monorepo.py
+++ b/tests/test_init_detect_monorepo.py
@@ -69,3 +69,26 @@ def test_detected_monorepo_config_loads_with_require_paths(tmp_path: Path, monke
     monkeypatch.chdir(tmp_path)
     reloaded = ConfigLoader.load(cfg_path, require_paths=True)
     assert set(reloaded.repos) == set(config.repos)
+
+
+def test_detected_monorepo_doctor_no_not_a_git_repository(tmp_path: Path, monkeypatch):
+    """ac4: doctor on a freshly detected single-git monorepo reports NO
+    'not a git repository' for the subdir repos — the git check resolves through
+    git_root to the root (doctor.py:186-191)."""
+    from mship.core.doctor import DoctorChecker
+    from mship.util.shell import ShellRunner, ShellResult
+
+    root = _build_single_git_monorepo(tmp_path)
+    cfg_path = _init_detect(root, monkeypatch)
+    config = ConfigLoader.load(cfg_path, require_paths=True)
+
+    shell = MagicMock(spec=ShellRunner)
+    shell.run.return_value = ShellResult(
+        returncode=0, stdout="test\nrun\nlint\nsetup\n", stderr=""
+    )
+    report = DoctorChecker(config, shell).run()
+
+    for name in (root.name, "web", "infra"):
+        git_check = next(c for c in report.checks if c.name == f"{name}/git")
+        assert git_check.status == "pass", git_check.message
+        assert "not a git repository" not in git_check.message


### PR DESCRIPTION
mship init --detect produces a working monorepo config (issue 366 finding 4)
---

## Acceptance criteria

- [x] `ac1` Given a single-git monorepo where the workspace root has `.git` and subdirs `web/` and `infra/` contain only `package.json` (no nested `.git`), `mship init --detect` emits the root repo with `path: .` and no `git_root`, and emits `web` and `infra` as repos each with `git_root: <root-repo-name>` and a `path` relative to the root (`web`, `infra`) -- NOT as standalone top-level repos. — test:test-runs/1.mothership, commit:074c830
- [x] `ac2` Every emitted repo `path` in the generated `mothership.yaml` is a relative path (`.`, `web`, `infra`); no emitted `path` is absolute (contains no leading `/` and no `/home/<user>/`), so the config is portable across machines and teammates. — test:test-runs/1.mothership, commit:074c830
- [x] `ac3` A detected subdirectory that has its OWN `.git` (an independent nested repo or a git submodule with a `.git` gitlink) is still emitted standalone with a relative `path` and NO `git_root`, preserving today's behavior for genuinely independent repos. — test:test-runs/1.mothership, commit:d8badf7
- [x] `ac4` `mship doctor` run against a freshly `init --detect`-ed single-git monorepo, with zero manual edits, reports NO `not a git repository` failure for the subdir repos (the git check resolves through `git_root` to the root per mothership/src/mship/core/doctor.py:152-157). — test:test-runs/1.mothership, commit:77f6985
- [x] `ac5` `mship audit` run against the same freshly detected workspace, with zero manual edits, reports NO `not_a_git_repo` error (subdir repos group under the root's git via `_git_root_key`, mothership/src/mship/core/repo_state.py:330-347). — test:test-runs/1.mothership, commit:9c7e21a
- [x] `ac6` `mship spawn` against a repo in the freshly detected monorepo is NOT blocked by a `not_a_git_repo` audit error, with zero manual edits to `mothership.yaml` (the finding-#4 gate is removed). — test:test-runs/1.mothership, commit:9c7e21a
- [x] `ac7` The `mothership.yaml` emitted by `init --detect` on the monorepo loads via `ConfigLoader.load(..., require_paths=True)` without raising: each `git_root` child resolves to `(parent.path / child.path)` and finds its scaffolded `Taskfile.yml`. — test:test-runs/1.mothership, commit:863bb71
- [x] `ac8` When the workspace root itself is NOT a git repo (no `.git` at cwd) and a detected subdir also lacks `.git`, detection falls back to today's standalone emission and does not emit a `git_root` referencing the non-git root. — test:test-runs/1.mothership, commit:dff4705