### PR TITLE
Auto-link acceptance-criterion evidence at finish (#377)

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1451,7 +1451,7 @@ def register(app: typer.Typer, get_container):
             from mship.core.evidence_autolink import (
                 commits_since_base,
                 compute_evidence_links,
-                test_run_refs_for_task,
+                passing_test_run_refs,
             )
             from mship.core.spec_review import set_criterion_evidence
             from mship.core.spec_store import SPECS_DIRNAME, SpecStore
@@ -1467,7 +1467,7 @@ def register(app: typer.Typer, get_container):
                     commits_since_base(shell, _al_path, _al_base, task.branch)
                 )
             _al_links = compute_evidence_links(
-                bound_spec, _al_commits, test_run_refs_for_task(task),
+                bound_spec, _al_commits, passing_test_run_refs(task),
             )
             if _al_links:
                 for _al_link in _al_links:

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1438,6 +1438,45 @@ def register(app: typer.Typer, get_container):
                     "`mship spec evidence <spec> <ac> <ref>`."
                 )
 
+        # --- Auto-link acceptance-criterion evidence (spec 377) ---
+        # For a spec-bound task, attach the passing test-run(s) to EVERY acceptance
+        # criterion and each implementing commit to the AC(s) its message names --
+        # BEFORE build_acceptance_block renders below. Placed AFTER the evidence
+        # gate on purpose: it must not silently satisfy `--require-evidence` via an
+        # auto-attached test-run (that gate is out of scope for 377). Idempotent +
+        # additive; no bound spec => skipped entirely.
+        if bound_spec is not None:
+            from datetime import datetime as _dt_al, timezone as _tz_al
+
+            from mship.core.evidence_autolink import (
+                commits_since_base,
+                compute_evidence_links,
+                test_run_refs_for_task,
+            )
+            from mship.core.spec_review import set_criterion_evidence
+            from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+
+            _al_commits: list[tuple[str, str]] = []
+            for _al_repo, _al_base in effective_bases.items():
+                _al_path = config.repos[_al_repo].path
+                if _al_repo in task.worktrees:
+                    _al_wt = Path(task.worktrees[_al_repo])
+                    if _al_wt.exists():
+                        _al_path = _al_wt
+                _al_commits.extend(
+                    commits_since_base(shell, _al_path, _al_base, task.branch)
+                )
+            _al_links = compute_evidence_links(
+                bound_spec, _al_commits, test_run_refs_for_task(task),
+            )
+            if _al_links:
+                for _al_link in _al_links:
+                    set_criterion_evidence(
+                        bound_spec, _al_link.criterion_id, _al_link.kind, _al_link.ref,
+                    )
+                bound_spec.updated_at = _dt_al.now(_tz_al.utc)
+                SpecStore(workspace_root / SPECS_DIRNAME).save(bound_spec)
+
         # Render the acceptance-criteria PR-body section once (reuses bound_spec
         # from the gate above). Empty string when there's no bound spec or no ACs.
         from mship.core.pr import build_acceptance_block

--- a/src/mship/core/evidence_autolink.py
+++ b/src/mship/core/evidence_autolink.py
@@ -15,12 +15,19 @@ persists with `SpecStore`.
 from __future__ import annotations
 
 import re
+import shlex
 from dataclasses import dataclass
 
 # `\b` word boundaries make `ac7` match the standalone token `ac7` but never the
 # longer id `ac70` (`\d+` is greedy up to a boundary) nor an `ac7` buried inside
 # another word (e.g. `mac7book`). Case-insensitive so `AC7` in a subject matches.
 _AC_TOKEN_RE = re.compile(r"\bac\d+\b", re.IGNORECASE)
+
+# Record/field separators for the `git log` format below. These control chars
+# never appear in shas or human commit prose, so they delimit multi-line commit
+# bodies unambiguously.
+_FIELD_SEP = "\x1f"   # US -- between sha and message within one commit record
+_COMMIT_SEP = "\x1e"  # RS -- between commit records
 
 
 @dataclass(frozen=True)
@@ -91,3 +98,28 @@ def test_run_refs_for_task(task) -> list[str]:
         if getattr(result, "status", None) == "pass":
             refs.append(f"test-runs/{iteration}.{repo}")
     return refs
+
+
+def commits_since_base(shell, repo_path, base, branch) -> list[tuple[str, str]]:
+    """Return `(sha, message)` for each commit on `branch` since `origin/<base>`
+    (git log default order). Mirrors the `origin/<base>..<branch>` range that
+    `mship finish` already uses for its subject scan. Returns `[]` on any git
+    failure (fail-open: a missing branch simply yields no commit evidence)."""
+    eff_base = base or "HEAD"
+    rng = f"origin/{eff_base}..{branch}"
+    result = shell.run(
+        f"git log --format=%H{_FIELD_SEP}%B{_COMMIT_SEP} {shlex.quote(rng)}",
+        cwd=repo_path,
+    )
+    if result.returncode != 0:
+        return []
+    commits: list[tuple[str, str]] = []
+    for record in result.stdout.split(_COMMIT_SEP):
+        record = record.strip()
+        if not record:
+            continue
+        sha, _, message = record.partition(_FIELD_SEP)
+        sha = sha.strip()
+        if sha:
+            commits.append((sha, message.strip()))
+    return commits

--- a/src/mship/core/evidence_autolink.py
+++ b/src/mship/core/evidence_autolink.py
@@ -84,7 +84,7 @@ def compute_evidence_links(spec, commits, test_run_refs) -> list[EvidenceLink]:
     return links
 
 
-def test_run_refs_for_task(task) -> list[str]:
+def passing_test_run_refs(task) -> list[str]:
     """Return `test-runs/<iteration>.<repo>` refs for every repo whose most recent
     recorded test result passed (spec 377 ac10). `task.test_iteration` is the run
     number; `task.test_results[repo].status == "pass"` selects the repos. Empty

--- a/src/mship/core/evidence_autolink.py
+++ b/src/mship/core/evidence_autolink.py
@@ -75,3 +75,19 @@ def compute_evidence_links(spec, commits, test_run_refs) -> list[EvidenceLink]:
             if criterion_id is not None:
                 _add(criterion_id, "commit", sha)
     return links
+
+
+def test_run_refs_for_task(task) -> list[str]:
+    """Return `test-runs/<iteration>.<repo>` refs for every repo whose most recent
+    recorded test result passed (spec 377 ac10). `task.test_iteration` is the run
+    number; `task.test_results[repo].status == "pass"` selects the repos. Empty
+    when the task has never recorded a test iteration."""
+    iteration = getattr(task, "test_iteration", 0) or 0
+    if iteration <= 0:
+        return []
+    refs: list[str] = []
+    for repo in sorted(task.test_results):
+        result = task.test_results[repo]
+        if getattr(result, "status", None) == "pass":
+            refs.append(f"test-runs/{iteration}.{repo}")
+    return refs

--- a/src/mship/core/evidence_autolink.py
+++ b/src/mship/core/evidence_autolink.py
@@ -43,10 +43,19 @@ def extract_ac_ids(message: str) -> set[str]:
 def compute_evidence_links(spec, commits, test_run_refs) -> list[EvidenceLink]:
     """Plan the evidence links to add for `spec` (pure -- no mutation).
 
-    Every ref in `test_run_refs` becomes a `test` link on EVERY acceptance
-    criterion. (Commit handling and de-duplication are added in later tasks.)"""
+    - every ref in `test_run_refs` -> a `test` link on EVERY acceptance criterion;
+    - every `(sha, message)` in `commits` -> a `commit` link on each acceptance
+      criterion whose id is named (word-boundary) in the message.
+
+    (De-duplication is added in the next task.)"""
+    id_by_lower = {c.id.lower(): c.id for c in spec.acceptance_criteria}
     links: list[EvidenceLink] = []
     for ref in test_run_refs:
         for c in spec.acceptance_criteria:
             links.append(EvidenceLink(criterion_id=c.id, kind="test", ref=ref))
+    for sha, message in commits:
+        for token in extract_ac_ids(message):
+            criterion_id = id_by_lower.get(token)
+            if criterion_id is not None:
+                links.append(EvidenceLink(criterion_id=criterion_id, kind="commit", ref=sha))
     return links

--- a/src/mship/core/evidence_autolink.py
+++ b/src/mship/core/evidence_autolink.py
@@ -38,3 +38,15 @@ def extract_ac_ids(message: str) -> set[str]:
     inside a larger word (`mac7book`) and the longer id `ac70` when only `ac7`
     is written are excluded by the word-boundary anchors."""
     return {m.group(0).lower() for m in _AC_TOKEN_RE.finditer(message or "")}
+
+
+def compute_evidence_links(spec, commits, test_run_refs) -> list[EvidenceLink]:
+    """Plan the evidence links to add for `spec` (pure -- no mutation).
+
+    Every ref in `test_run_refs` becomes a `test` link on EVERY acceptance
+    criterion. (Commit handling and de-duplication are added in later tasks.)"""
+    links: list[EvidenceLink] = []
+    for ref in test_run_refs:
+        for c in spec.acceptance_criteria:
+            links.append(EvidenceLink(criterion_id=c.id, kind="test", ref=ref))
+    return links

--- a/src/mship/core/evidence_autolink.py
+++ b/src/mship/core/evidence_autolink.py
@@ -1,0 +1,40 @@
+"""Auto-link acceptance-criterion evidence at `mship finish` (spec 377).
+
+For a spec-bound task, `mship finish` attaches:
+  1. the task's passing test-run reference(s) (`test-runs/<iter>.<repo>`) to EVERY
+     acceptance criterion, and
+  2. each implementing commit's sha to the acceptance criterion/criteria whose id
+     token (e.g. `ac7`) appears — on a word boundary — in the commit message.
+
+`compute_evidence_links` is a pure planner: it never mutates the spec. It returns
+the links to add, already de-duplicated against the spec's existing evidence, so
+re-running finish is idempotent and manual `mship spec evidence` entries survive.
+The finish command applies the links via `spec_review.set_criterion_evidence` and
+persists with `SpecStore`.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# `\b` word boundaries make `ac7` match the standalone token `ac7` but never the
+# longer id `ac70` (`\d+` is greedy up to a boundary) nor an `ac7` buried inside
+# another word (e.g. `mac7book`). Case-insensitive so `AC7` in a subject matches.
+_AC_TOKEN_RE = re.compile(r"\bac\d+\b", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class EvidenceLink:
+    """One evidence entry to append to an acceptance criterion."""
+
+    criterion_id: str
+    kind: str  # "test" | "commit"
+    ref: str
+
+
+def extract_ac_ids(message: str) -> set[str]:
+    """Return the lowercased `ac<number>` tokens named on word boundaries in
+    `message` (e.g. `"fixes ac1 and AC3"` -> `{"ac1", "ac3"}`). Substring hits
+    inside a larger word (`mac7book`) and the longer id `ac70` when only `ac7`
+    is written are excluded by the word-boundary anchors."""
+    return {m.group(0).lower() for m in _AC_TOKEN_RE.finditer(message or "")}

--- a/src/mship/core/evidence_autolink.py
+++ b/src/mship/core/evidence_autolink.py
@@ -41,21 +41,37 @@ def extract_ac_ids(message: str) -> set[str]:
 
 
 def compute_evidence_links(spec, commits, test_run_refs) -> list[EvidenceLink]:
-    """Plan the evidence links to add for `spec` (pure -- no mutation).
+    """Plan the evidence links to add for `spec` (pure -- no mutation, no I/O).
 
     - every ref in `test_run_refs` -> a `test` link on EVERY acceptance criterion;
     - every `(sha, message)` in `commits` -> a `commit` link on each acceptance
       criterion whose id is named (word-boundary) in the message.
 
-    (De-duplication is added in the next task.)"""
+    De-duplicated against the spec's existing evidence and within the batch, so
+    the result never repeats an existing `(criterion, kind, ref)`. This is what
+    makes finish idempotent (ac6) and additive to manual evidence (ac7)."""
     id_by_lower = {c.id.lower(): c.id for c in spec.acceptance_criteria}
+    existing: set[tuple[str, str, str]] = {
+        (c.id, e.kind, e.ref)
+        for c in spec.acceptance_criteria
+        for e in c.evidence
+    }
+    seen: set[tuple[str, str, str]] = set()
     links: list[EvidenceLink] = []
+
+    def _add(criterion_id: str, kind: str, ref: str) -> None:
+        key = (criterion_id, kind, ref)
+        if key in existing or key in seen:
+            return
+        seen.add(key)
+        links.append(EvidenceLink(criterion_id=criterion_id, kind=kind, ref=ref))
+
     for ref in test_run_refs:
         for c in spec.acceptance_criteria:
-            links.append(EvidenceLink(criterion_id=c.id, kind="test", ref=ref))
+            _add(c.id, "test", ref)
     for sha, message in commits:
         for token in extract_ac_ids(message):
             criterion_id = id_by_lower.get(token)
             if criterion_id is not None:
-                links.append(EvidenceLink(criterion_id=criterion_id, kind="commit", ref=sha))
+                _add(criterion_id, "commit", sha)
     return links

--- a/tests/core/test_evidence_autolink.py
+++ b/tests/core/test_evidence_autolink.py
@@ -38,3 +38,49 @@ def test_testrun_refs_attach_to_every_criterion():
         EvidenceLink("ac1", "test", "test-runs/1.mothership"),
         EvidenceLink("ac2", "test", "test-runs/1.mothership"),
     }
+
+
+def test_commit_attaches_to_named_criterion():  # ac2
+    spec = _spec([AcceptanceCriterion(id="ac1", text="x"),
+                  AcceptanceCriterion(id="ac2", text="y")])
+    links = compute_evidence_links(spec, commits=[("sha1", "implement ac2 logic")],
+                                   test_run_refs=[])
+    assert links == [EvidenceLink("ac2", "commit", "sha1")]
+
+
+def test_commit_naming_multiple_ids_attaches_to_all():  # ac3
+    spec = _spec([AcceptanceCriterion(id="ac1", text="x"),
+                  AcceptanceCriterion(id="ac3", text="z")])
+    links = compute_evidence_links(spec, commits=[("sha1", "ac1 and ac3 together")],
+                                   test_run_refs=[])
+    assert set(links) == {EvidenceLink("ac1", "commit", "sha1"),
+                          EvidenceLink("ac3", "commit", "sha1")}
+
+
+def test_commit_naming_no_id_is_noop():  # ac4
+    spec = _spec([AcceptanceCriterion(id="ac1", text="x")])
+    links = compute_evidence_links(spec, commits=[("sha1", "refactor internals")],
+                                   test_run_refs=[])
+    assert links == []
+
+
+def test_word_boundary_ac7_does_not_attach_to_ac70():  # ac5
+    spec = _spec([AcceptanceCriterion(id="ac7", text="x"),
+                  AcceptanceCriterion(id="ac70", text="y")])
+    links = compute_evidence_links(spec, commits=[("sha1", "handles ac7")],
+                                   test_run_refs=[])
+    assert links == [EvidenceLink("ac7", "commit", "sha1")]
+
+
+def test_word_boundary_substring_is_not_a_reference():  # ac5
+    spec = _spec([AcceptanceCriterion(id="ac7", text="x")])
+    links = compute_evidence_links(spec, commits=[("sha1", "patch mac7book in reactor")],
+                                   test_run_refs=[])
+    assert links == []
+
+
+def test_unknown_ac_id_in_commit_is_ignored():  # ac5 (intersect with real ids)
+    spec = _spec([AcceptanceCriterion(id="ac1", text="x")])
+    links = compute_evidence_links(spec, commits=[("sha1", "touches ac9")],
+                                   test_run_refs=[])
+    assert links == []

--- a/tests/core/test_evidence_autolink.py
+++ b/tests/core/test_evidence_autolink.py
@@ -24,3 +24,17 @@ def test_extract_ac_ids_word_boundary_excludes_longer_id_and_substrings():
 
 def test_extract_ac_ids_empty_message():
     assert extract_ac_ids("") == set()
+
+
+from mship.core.evidence_autolink import EvidenceLink, compute_evidence_links
+
+
+def test_testrun_refs_attach_to_every_criterion():
+    spec = _spec([AcceptanceCriterion(id="ac1", text="x"),
+                  AcceptanceCriterion(id="ac2", text="y")])
+    links = compute_evidence_links(spec, commits=[],
+                                   test_run_refs=["test-runs/1.mothership"])
+    assert set(links) == {
+        EvidenceLink("ac1", "test", "test-runs/1.mothership"),
+        EvidenceLink("ac2", "test", "test-runs/1.mothership"),
+    }

--- a/tests/core/test_evidence_autolink.py
+++ b/tests/core/test_evidence_autolink.py
@@ -84,3 +84,39 @@ def test_unknown_ac_id_in_commit_is_ignored():  # ac5 (intersect with real ids)
     links = compute_evidence_links(spec, commits=[("sha1", "touches ac9")],
                                    test_run_refs=[])
     assert links == []
+
+
+from mship.core.spec_review import set_criterion_evidence
+
+
+def test_skips_evidence_that_already_exists():  # ac6 (dedup vs existing)
+    spec = _spec([AcceptanceCriterion(
+        id="ac1", text="x",
+        evidence=[AcceptanceEvidence(kind="test", ref="test-runs/1.mothership")])])
+    links = compute_evidence_links(spec, commits=[],
+                                   test_run_refs=["test-runs/1.mothership"])
+    assert links == []  # identical (criterion, kind, ref) already present
+
+
+def test_preserves_manual_evidence_and_only_adds():  # ac7
+    spec = _spec([AcceptanceCriterion(
+        id="ac1", text="x",
+        evidence=[AcceptanceEvidence(kind="artifact", ref="https://manual")])])
+    links = compute_evidence_links(spec, commits=[],
+                                   test_run_refs=["test-runs/1.mothership"])
+    assert links == [EvidenceLink("ac1", "test", "test-runs/1.mothership")]
+    # the planner never mutates: the manual entry is untouched
+    assert spec.acceptance_criteria[0].evidence == [
+        AcceptanceEvidence(kind="artifact", ref="https://manual")]
+
+
+def test_idempotent_when_links_applied_then_recomputed():  # ac6
+    spec = _spec([AcceptanceCriterion(id="ac1", text="x")])
+    commits = [("sha1", "implement ac1")]
+    refs = ["test-runs/1.mothership"]
+    first = compute_evidence_links(spec, commits, refs)
+    for link in first:
+        set_criterion_evidence(spec, link.criterion_id, link.kind, link.ref)
+    second = compute_evidence_links(spec, commits, refs)
+    assert second == []  # nothing new on the second pass
+    assert sorted(e.kind for e in spec.acceptance_criteria[0].evidence) == ["commit", "test"]

--- a/tests/core/test_evidence_autolink.py
+++ b/tests/core/test_evidence_autolink.py
@@ -120,3 +120,32 @@ def test_idempotent_when_links_applied_then_recomputed():  # ac6
     second = compute_evidence_links(spec, commits, refs)
     assert second == []  # nothing new on the second pass
     assert sorted(e.kind for e in spec.acceptance_criteria[0].evidence) == ["commit", "test"]
+
+
+from mship.core.evidence_autolink import test_run_refs_for_task
+from mship.core.state import Task, TestResult
+
+# `test_run_refs_for_task` is a production helper, not a pytest test; its `test_`
+# prefix would otherwise make pytest try to collect the imported symbol.
+test_run_refs_for_task.__test__ = False
+
+
+def _task(**kw):
+    base = dict(slug="t", description="d", phase="dev",
+                created_at=datetime(2026, 7, 18, tzinfo=timezone.utc),
+                affected_repos=["mothership"], branch="feat")
+    base.update(kw)
+    return Task(**base)
+
+
+def test_test_run_refs_only_for_passing_repos():  # ac10
+    now = datetime(2026, 7, 18, tzinfo=timezone.utc)
+    task = _task(test_iteration=3,
+                 test_results={"mothership": TestResult(status="pass", at=now),
+                               "web": TestResult(status="fail", at=now)})
+    assert test_run_refs_for_task(task) == ["test-runs/3.mothership"]
+
+
+def test_test_run_refs_empty_without_iteration():
+    task = _task(test_iteration=0, test_results={})
+    assert test_run_refs_for_task(task) == []

--- a/tests/core/test_evidence_autolink.py
+++ b/tests/core/test_evidence_autolink.py
@@ -1,7 +1,17 @@
 from datetime import datetime, timezone
+from pathlib import Path
 
-from mship.core.evidence_autolink import extract_ac_ids
+from mship.core.evidence_autolink import (
+    EvidenceLink,
+    commits_since_base,
+    compute_evidence_links,
+    extract_ac_ids,
+    passing_test_run_refs,
+)
 from mship.core.spec import AcceptanceCriterion, AcceptanceEvidence, Spec
+from mship.core.spec_review import set_criterion_evidence
+from mship.core.state import Task, TestResult
+from mship.util.shell import ShellResult
 
 
 def _spec(criteria):
@@ -24,9 +34,6 @@ def test_extract_ac_ids_word_boundary_excludes_longer_id_and_substrings():
 
 def test_extract_ac_ids_empty_message():
     assert extract_ac_ids("") == set()
-
-
-from mship.core.evidence_autolink import EvidenceLink, compute_evidence_links
 
 
 def test_testrun_refs_attach_to_every_criterion():
@@ -86,9 +93,6 @@ def test_unknown_ac_id_in_commit_is_ignored():  # ac5 (intersect with real ids)
     assert links == []
 
 
-from mship.core.spec_review import set_criterion_evidence
-
-
 def test_skips_evidence_that_already_exists():  # ac6 (dedup vs existing)
     spec = _spec([AcceptanceCriterion(
         id="ac1", text="x",
@@ -122,14 +126,6 @@ def test_idempotent_when_links_applied_then_recomputed():  # ac6
     assert sorted(e.kind for e in spec.acceptance_criteria[0].evidence) == ["commit", "test"]
 
 
-from mship.core.evidence_autolink import test_run_refs_for_task
-from mship.core.state import Task, TestResult
-
-# `test_run_refs_for_task` is a production helper, not a pytest test; its `test_`
-# prefix would otherwise make pytest try to collect the imported symbol.
-test_run_refs_for_task.__test__ = False
-
-
 def _task(**kw):
     base = dict(slug="t", description="d", phase="dev",
                 created_at=datetime(2026, 7, 18, tzinfo=timezone.utc),
@@ -143,18 +139,12 @@ def test_test_run_refs_only_for_passing_repos():  # ac10
     task = _task(test_iteration=3,
                  test_results={"mothership": TestResult(status="pass", at=now),
                                "web": TestResult(status="fail", at=now)})
-    assert test_run_refs_for_task(task) == ["test-runs/3.mothership"]
+    assert passing_test_run_refs(task) == ["test-runs/3.mothership"]
 
 
 def test_test_run_refs_empty_without_iteration():
     task = _task(test_iteration=0, test_results={})
-    assert test_run_refs_for_task(task) == []
-
-
-from pathlib import Path
-
-from mship.core.evidence_autolink import commits_since_base
-from mship.util.shell import ShellResult
+    assert passing_test_run_refs(task) == []
 
 
 class _FakeShell:

--- a/tests/core/test_evidence_autolink.py
+++ b/tests/core/test_evidence_autolink.py
@@ -1,0 +1,26 @@
+from datetime import datetime, timezone
+
+from mship.core.evidence_autolink import extract_ac_ids
+from mship.core.spec import AcceptanceCriterion, AcceptanceEvidence, Spec
+
+
+def _spec(criteria):
+    now = datetime(2026, 7, 18, tzinfo=timezone.utc)
+    return Spec(id="s1", title="S", status="approved", created_at=now,
+                updated_at=now, acceptance_criteria=criteria)
+
+
+def test_extract_ac_ids_standalone_tokens_lowercased():
+    assert extract_ac_ids("fixes ac1 and AC3") == {"ac1", "ac3"}
+
+
+def test_extract_ac_ids_word_boundary_excludes_longer_id_and_substrings():
+    # `ac7` written alone must not surface `ac70` (\d+ is greedy to a boundary);
+    # `ac7` buried in `mac7book` and the letters of `reactor` are not references.
+    assert extract_ac_ids("done ac7") == {"ac7"}
+    assert extract_ac_ids("done ac70") == {"ac70"}
+    assert extract_ac_ids("patch mac7book near the reactor") == set()
+
+
+def test_extract_ac_ids_empty_message():
+    assert extract_ac_ids("") == set()

--- a/tests/core/test_evidence_autolink.py
+++ b/tests/core/test_evidence_autolink.py
@@ -149,3 +149,34 @@ def test_test_run_refs_only_for_passing_repos():  # ac10
 def test_test_run_refs_empty_without_iteration():
     task = _task(test_iteration=0, test_results={})
     assert test_run_refs_for_task(task) == []
+
+
+from pathlib import Path
+
+from mship.core.evidence_autolink import commits_since_base
+from mship.util.shell import ShellResult
+
+
+class _FakeShell:
+    def __init__(self, result):
+        self._result = result
+        self.calls = []
+
+    def run(self, cmd, cwd=None, env=None):
+        self.calls.append((cmd, cwd))
+        return self._result
+
+
+def test_commits_since_base_parses_nul_separated_records():
+    # git separates records with \x1e and the sha from the (possibly multi-line)
+    # body with \x1f; a trailing newline per record is tolerated.
+    stdout = "sha1\x1fimplement ac1\nmore body\x1e\nsha2\x1ffix ac2\x1e\n"
+    shell = _FakeShell(ShellResult(returncode=0, stdout=stdout, stderr=""))
+    commits = commits_since_base(shell, Path("/repo"), "main", "feat")
+    assert commits == [("sha1", "implement ac1\nmore body"), ("sha2", "fix ac2")]
+    assert "origin/main..feat" in shell.calls[0][0]
+
+
+def test_commits_since_base_empty_on_git_failure():
+    shell = _FakeShell(ShellResult(returncode=128, stdout="", stderr="fatal"))
+    assert commits_since_base(shell, Path("/repo"), "main", "feat") == []

--- a/tests/test_finish_gate.py
+++ b/tests/test_finish_gate.py
@@ -464,3 +464,54 @@ def test_finish_autolink_noop_without_bound_spec(finish_gate_workspace):
     state = StateManager(workspace / ".mothership").load()
     assert state.tasks["auto-noop"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
     assert SpecStore(workspace / "specs").list() == []  # no spec created or touched
+
+
+def test_finish_pr_body_renders_autolinked_evidence(finish_gate_workspace):
+    """Spec 377 ac9: the PR body's acceptance block (unchanged renderer) shows the
+    auto-attached test:/commit: refs with a checked box."""
+    from mship.core.state import TestResult
+
+    workspace, mock_shell = finish_gate_workspace
+    wi = _seed_feature_with_ac(workspace)
+    runner.invoke(app, ["spawn", "--work-item", wi.id, "auto body", "--repos", "shared"])
+    _write_plan(workspace, "auto-body")
+
+    now = datetime.now(timezone.utc)
+
+    def _seed_tests(s):
+        t = s.tasks["auto-body"]
+        t.test_iteration = 1
+        t.test_results = {"shared": TestResult(status="pass", at=now)}
+
+    StateManager(workspace / ".mothership").mutate(_seed_tests)
+
+    sha = "0011223344556677889900112233445566778899"
+
+    def _run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc\trefs/heads/main\n", stderr="")
+        if "git log --format=%H" in cmd:
+            return ShellResult(returncode=0, stdout=f"{sha}\x1fimplement ac1\x1e\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
+        if "rev-list --count" in cmd:
+            return ShellResult(returncode=0, stdout="0\n", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://github.com/org/shared/pull/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell.run.side_effect = _run
+
+    result = runner.invoke(app, ["finish", "--task", "auto-body"])
+    assert result.exit_code == 0, result.output
+    create_cmds = [c.args[0] for c in mock_shell.run.call_args_list if "gh pr create" in c.args[0]]
+    assert create_cmds, "expected a gh pr create call"
+    body = create_cmds[0]
+    assert "## Acceptance criteria" in body
+    assert "test:test-runs/1.shared" in body   # test-run rendered
+    assert f"commit:{sha}" in body              # commit rendered
+    assert "[x]" in body and "ac1" in body      # criterion checked + listed

--- a/tests/test_finish_gate.py
+++ b/tests/test_finish_gate.py
@@ -437,3 +437,30 @@ def test_finish_autolinks_testrun_and_commit_evidence(finish_gate_workspace):
     refs = {(e.kind, e.ref) for e in spec.acceptance_criteria[0].evidence}
     assert ("test", "test-runs/1.shared") in refs  # ac1 + ac10
     assert ("commit", sha) in refs                  # ac2
+
+
+def test_finish_autolink_noop_without_bound_spec(finish_gate_workspace):
+    """Spec 377 ac8: a bug WI (no bound spec) finishes without any evidence work
+    and without error -- the `if bound_spec is not None` guard skips auto-link."""
+    from mship.core.state import TestResult
+
+    workspace, _ = finish_gate_workspace
+    items = WorkItemStore(workspace / ".mothership" / "workitems")
+    wi = items.create(title="fix it", kind="bug", workspace="ws",
+                      now=datetime.now(timezone.utc))
+    runner.invoke(app, ["spawn", "--work-item", wi.id, "auto noop", "--repos", "shared"])
+
+    now = datetime.now(timezone.utc)
+
+    def _seed_tests(s):
+        t = s.tasks["auto-noop"]
+        t.test_iteration = 1
+        t.test_results = {"shared": TestResult(status="pass", at=now)}
+
+    StateManager(workspace / ".mothership").mutate(_seed_tests)
+
+    result = runner.invoke(app, ["finish", "--task", "auto-noop"])
+    assert result.exit_code == 0, result.output
+    state = StateManager(workspace / ".mothership").load()
+    assert state.tasks["auto-noop"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
+    assert SpecStore(workspace / "specs").list() == []  # no spec created or touched

--- a/tests/test_finish_gate.py
+++ b/tests/test_finish_gate.py
@@ -388,3 +388,52 @@ def test_finish_appends_acceptance_block_to_pr_body(finish_gate_workspace):
     assert "Acceptance criteria" in create_cmds[0]      # block injected into the PR body
     assert "test:test-runs/1" in create_cmds[0]         # the evidence ref renders end-to-end
     assert "ac1" in create_cmds[0]                        # the criterion id is listed
+
+
+def test_finish_autolinks_testrun_and_commit_evidence(finish_gate_workspace):
+    """Spec 377 ac1/ac2/ac10: a spec-bound finish attaches the passing test-run to
+    every AC and each implementing commit to the AC(s) it names -- persisted."""
+    from mship.core.state import TestResult
+
+    workspace, mock_shell = finish_gate_workspace
+    wi = _seed_feature_with_ac(workspace)  # ev-spec, ac1, no evidence
+    runner.invoke(app, ["spawn", "--work-item", wi.id, "auto link", "--repos", "shared"])
+    _write_plan(workspace, "auto-link")
+
+    now = datetime.now(timezone.utc)
+
+    def _seed_tests(s):
+        t = s.tasks["auto-link"]
+        t.test_iteration = 1
+        t.test_results = {"shared": TestResult(status="pass", at=now)}
+
+    StateManager(workspace / ".mothership").mutate(_seed_tests)
+
+    sha = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+
+    def _run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc\trefs/heads/main\n", stderr="")
+        if "git log --format=%H" in cmd:
+            return ShellResult(returncode=0, stdout=f"{sha}\x1fimplement ac1 handling\x1e\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
+        if "rev-list --count" in cmd:
+            return ShellResult(returncode=0, stdout="0\n", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://github.com/org/shared/pull/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell.run.side_effect = _run
+
+    result = runner.invoke(app, ["finish", "--task", "auto-link"])
+    assert result.exit_code == 0, result.output
+
+    spec = SpecStore(workspace / "specs").find_by_id("ev-spec")
+    refs = {(e.kind, e.ref) for e in spec.acceptance_criteria[0].evidence}
+    assert ("test", "test-runs/1.shared") in refs  # ac1 + ac10
+    assert ("commit", sha) in refs                  # ac2

--- a/tests/test_finish_gate.py
+++ b/tests/test_finish_gate.py
@@ -515,3 +515,53 @@ def test_finish_pr_body_renders_autolinked_evidence(finish_gate_workspace):
     assert "test:test-runs/1.shared" in body   # test-run rendered
     assert f"commit:{sha}" in body              # commit rendered
     assert "[x]" in body and "ac1" in body      # criterion checked + listed
+
+
+def test_finish_autolink_idempotent_across_two_runs(finish_gate_workspace):
+    """Spec 377 ac6: running finish twice does not duplicate evidence for the same
+    (ref, kind, criterion)."""
+    from mship.core.state import TestResult
+
+    workspace, mock_shell = finish_gate_workspace
+    wi = _seed_feature_with_ac(workspace)
+    runner.invoke(app, ["spawn", "--work-item", wi.id, "auto idem", "--repos", "shared"])
+    _write_plan(workspace, "auto-idem")
+
+    now = datetime.now(timezone.utc)
+
+    def _seed_tests(s):
+        t = s.tasks["auto-idem"]
+        t.test_iteration = 1
+        t.test_results = {"shared": TestResult(status="pass", at=now)}
+
+    StateManager(workspace / ".mothership").mutate(_seed_tests)
+
+    sha = "ffeeddccbbaa99887766554433221100ffeeddcc"
+
+    def _run(cmd, cwd, env=None):
+        if "gh auth status" in cmd:
+            return ShellResult(returncode=0, stdout="Logged in", stderr="")
+        if "ls-remote" in cmd:
+            return ShellResult(returncode=0, stdout="abc\trefs/heads/main\n", stderr="")
+        if "git log --format=%H" in cmd:
+            return ShellResult(returncode=0, stdout=f"{sha}\x1fimplement ac1\x1e\n", stderr="")
+        if "rev-list --count" in cmd and "origin/" in cmd:
+            return ShellResult(returncode=0, stdout="1\n", stderr="")
+        if "rev-list --count" in cmd:
+            return ShellResult(returncode=0, stdout="0\n", stderr="")
+        if "git push" in cmd:
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if "gh pr create" in cmd:
+            return ShellResult(returncode=0, stdout="https://github.com/org/shared/pull/1\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    mock_shell.run.side_effect = _run
+
+    assert runner.invoke(app, ["finish", "--task", "auto-idem"]).exit_code == 0
+    assert runner.invoke(app, ["finish", "--task", "auto-idem"]).exit_code == 0
+
+    spec = SpecStore(workspace / "specs").find_by_id("ev-spec")
+    evidence = spec.acceptance_criteria[0].evidence
+    assert sorted(e.kind for e in evidence) == ["commit", "test"]  # exactly one each
+    assert [e.ref for e in evidence if e.kind == "test"] == ["test-runs/1.shared"]
+    assert [e.ref for e in evidence if e.kind == "commit"] == [sha]


### PR DESCRIPTION
Auto-link acceptance-criterion evidence at finish (#377)

Closes #377
---

## Acceptance criteria

- [x] `ac1` Given a spec-bound task finished with a passing test-run, after `mship finish` every acceptance criterion of the bound spec has that test-run reference attached as `test` evidence. — test:test-runs/1.mothership, commit:e8c60c0
- [x] `ac2` A commit whose message contains an acceptance-criterion id token (e.g. `ac7`) has that commit sha attached as `commit` evidence to exactly the AC(s) it names. — test:test-runs/1.mothership, commit:e8c60c0
- [x] `ac3` A commit message naming multiple AC ids (e.g. `ac1` and `ac3`) attaches that commit to all of the named ACs. — test:test-runs/1.mothership, commit:fa4f052
- [x] `ac4` A commit message naming no AC id attaches that commit to no AC and does not error. — test:test-runs/1.mothership, commit:fa4f052
- [x] `ac5` AC id matching is word-boundary safe: a message naming `ac7` does not attach to AC `ac70`, and an `ac7` substring inside another word (e.g. `reactor`) is not treated as a reference. — test:test-runs/1.mothership, commit:2e85c81
- [x] `ac6` Auto-population is idempotent: running `mship finish` twice does not create duplicate evidence entries for the same (ref, kind, criterion). — test:test-runs/1.mothership, commit:6f4e735
- [x] `ac7` Manually attached evidence (via `mship spec evidence`) is preserved — auto-linking only adds, never removes or overwrites existing evidence. — test:test-runs/1.mothership, commit:6f4e735
- [x] `ac8` The bound spec is resolved via the same path `mship finish` already uses (WorkItem `spec_id`, else approved-slug fallback); when no spec is bound, `mship finish` attaches nothing and does not error. — test:test-runs/1.mothership, commit:c65eabe
- [x] `ac9` After `mship finish`, the generated PR body's acceptance block renders the auto-attached evidence (checked criteria show their `test:`/`commit:` refs) using the existing renderer unchanged. — test:test-runs/1.mothership, commit:c4fda6d
- [x] `ac10` The test-run reference(s) attached match the task's recorded passing test-run iteration(s) for each affected repo. — test:test-runs/1.mothership, commit:f2112d8