### PR TITLE
mship view PR1: canonical spec access + WorkItem-aware status/headers

### DIFF
--- a/src/mship/cli/view/_workitems.py
+++ b/src/mship/cli/view/_workitems.py
@@ -14,18 +14,23 @@ from mship.core.workitem_store import WorkItemStore
 def load_workitem_index(container) -> list[WorkItemSummary]:
     """Build the WorkItem index (derived phase + attention + task_slugs + spec_id)
     from the canonical stores under the workspace root and state dir. Best-effort:
-    any store-scan failure degrades to an empty index so a view never crashes."""
+    a failure loading the core stores (workitems / specs / tasks) degrades to an
+    empty index so a view never crashes."""
     try:
         state_dir = Path(container.state_dir())
         workspace_root = Path(container.config_path()).parent
-        items = WorkItemStore(state_dir / "workitems")
-        specs = SpecStore(workspace_root / SPECS_DIRNAME)
-        msgs = MessageStore(state_dir / "messages")
-        return build_workitem_index(
-            items.list(),
-            {s.id: s for s in specs.list()},
-            dict(container.state_manager().load().tasks),
-            {t.id: t for t in msgs.list()},
-        )
+        items = WorkItemStore(state_dir / "workitems").list()
+        specs = {s.id: s for s in SpecStore(workspace_root / SPECS_DIRNAME).list()}
+        tasks = dict(container.state_manager().load().tasks)
+    except Exception:
+        return []
+    # Threads only add per-item thread links; a broken message store must NOT
+    # erase the WorkItem grouping/headers already built from items/specs/tasks.
+    try:
+        threads = {t.id: t for t in MessageStore(state_dir / "messages").list()}
+    except Exception:
+        threads = {}
+    try:
+        return build_workitem_index(items, specs, tasks, threads)
     except Exception:
         return []

--- a/src/mship/cli/view/_workitems.py
+++ b/src/mship/cli/view/_workitems.py
@@ -1,0 +1,31 @@
+"""Shared view-CLI helper: build the WorkItem summary index from the workspace-
+canonical stores. Reused by status/journal/diff/spec so each command wires the
+same phase-aware index (headers, grouping) without duplicating store wiring."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from mship.core.message_store import MessageStore
+from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+from mship.core.view.workitem_index import WorkItemSummary, build_workitem_index
+from mship.core.workitem_store import WorkItemStore
+
+
+def load_workitem_index(container) -> list[WorkItemSummary]:
+    """Build the WorkItem index (derived phase + attention + task_slugs + spec_id)
+    from the canonical stores under the workspace root and state dir. Best-effort:
+    any store-scan failure degrades to an empty index so a view never crashes."""
+    try:
+        state_dir = Path(container.state_dir())
+        workspace_root = Path(container.config_path()).parent
+        items = WorkItemStore(state_dir / "workitems")
+        specs = SpecStore(workspace_root / SPECS_DIRNAME)
+        msgs = MessageStore(state_dir / "messages")
+        return build_workitem_index(
+            items.list(),
+            {s.id: s for s in specs.list()},
+            dict(container.state_manager().load().tasks),
+            {t.id: t for t in msgs.list()},
+        )
+    except Exception:
+        return []

--- a/src/mship/cli/view/diff.py
+++ b/src/mship/cli/view/diff.py
@@ -59,9 +59,11 @@ class DiffView(ViewApp):
         scope_to_active_path: Path | None = None,
         resolve_paths: Callable[[], tuple[list[Path], Path | None]] | None = None,
         base_branch_by_path: dict[Path, str | None] | None = None,
+        header_provider: Callable[[], str | None] | None = None,
         **kw,
     ):
         super().__init__(**kw)
+        self._header_provider = header_provider
         self._resolve_paths = resolve_paths
         self._base_branch_by_path: dict[Path, str | None] = dict(base_branch_by_path or {})
         if resolve_paths is None:
@@ -89,17 +91,20 @@ class DiffView(ViewApp):
         self._test_override: dict[Path, WorktreeDiff] | None = None
 
         # Widget refs (populated in compose)
+        self._header: Static | None = None
         self._tree: Tree | None = None
         self._diff_static: Static | None = None
         self._diff_scroll: VerticalScroll | None = None
 
     # --- Textual lifecycle ---
     def compose(self) -> ComposeResult:
+        self._header = Static("")
         self._tree = Tree("diff", id="diff-tree")
         self._tree.root.expand()
         self._tree.show_root = False
         self._diff_static = Static("", expand=True)
         self._diff_scroll = VerticalScroll(self._diff_static)
+        yield self._header
         yield Horizontal(self._tree, self._diff_scroll)
 
     def on_mount(self) -> None:
@@ -123,6 +128,9 @@ class DiffView(ViewApp):
 
     # --- Refresh ---
     def _refresh_content(self) -> None:
+        if self._header is not None:
+            text = self._header_provider() if self._header_provider else None
+            self._header.update(text or "")
         if self._resolve_paths is not None:
             all_paths, scope_path = self._resolve_paths()
             self._paths = self._apply_scope(all_paths, scope_path)
@@ -314,6 +322,10 @@ class DiffView(ViewApp):
         assert self._diff_static is not None
         return str(self._diff_static.content)
 
+    def header_text(self) -> str:
+        assert self._header is not None
+        return str(self._header.content)
+
     def is_worktree_collapsed(self, worktree: Path) -> bool:
         assert self._tree is not None
         for child in self._tree.root.children:
@@ -366,9 +378,21 @@ def register(app: typer.Typer, get_container):
         base_by_path: dict[Path, str | None] = {}
         for p in t.worktrees.values():
             base_by_path[Path(p)] = t.base_branch
+
+        from mship.cli.view._workitems import load_workitem_index
+        from mship.core.view.headers import header_for_task
+
+        def _header() -> str | None:
+            fresh = state_mgr.load()
+            task_obj = fresh.tasks.get(target_task)
+            if task_obj is None:
+                return None
+            return header_for_task(target_task, task_obj.phase, load_workitem_index(container))
+
         view = DiffView(
             resolve_paths=_resolver,
             base_branch_by_path=base_by_path,
+            header_provider=_header,
             watch=watch,
             interval=interval,
         )

--- a/src/mship/cli/view/logs.py
+++ b/src/mship/cli/view/logs.py
@@ -12,6 +12,7 @@ from mship.core.task_resolver import (
     UnknownTaskError,
     resolve_task,
 )
+from mship.core.view.headers import header_for_task
 
 
 class LogsView(ViewApp):
@@ -25,6 +26,7 @@ class LogsView(ViewApp):
         all_: bool = False,
         cli_task: Optional[str] = None,
         cwd: Optional[Path] = None,
+        workitem_loader=None,
         **kw,
     ):
         super().__init__(**kw)
@@ -35,6 +37,14 @@ class LogsView(ViewApp):
         self._all = all_
         self._cli_task = cli_task
         self._cwd = cwd if cwd is not None else Path.cwd()
+        self._workitem_loader = workitem_loader
+
+    def _header(self, slug: str) -> str | None:
+        if self._workitem_loader is None:
+            return None
+        task = self._state_manager.load().tasks.get(slug)
+        phase = getattr(task, "phase", None) if task is not None else None
+        return header_for_task(slug, phase, self._workitem_loader())
 
     def _resolve_slug(self) -> str:
         """Return the task slug to render for this tick.
@@ -84,25 +94,28 @@ class LogsView(ViewApp):
         if scope is not None:
             entries = [e for e in entries if e.repo is None or e.repo == scope]
         if not entries:
-            return f"Log for {slug} is empty"
-        lines = []
-        for entry in entries:
-            ts = entry.timestamp.strftime("%Y-%m-%d %H:%M:%S")
-            meta_parts: list[str] = []
-            if entry.repo:
-                meta_parts.append(f"repo={entry.repo}")
-            if entry.iteration is not None:
-                meta_parts.append(f"iter={entry.iteration}")
-            if entry.test_state:
-                meta_parts.append(f"test={entry.test_state}")
-            if entry.action:
-                meta_parts.append(f"action={entry.action}")
-            meta = f"  [{' '.join(meta_parts)}]" if meta_parts else ""
-            lines.append(f"{ts}{meta}")
-            lines.append(f"  {entry.message}")
-            if entry.open_question:
-                lines.append(f"  ⚠ open: {entry.open_question}")
-        return "\n".join(lines)
+            body = f"Log for {slug} is empty"
+        else:
+            lines = []
+            for entry in entries:
+                ts = entry.timestamp.strftime("%Y-%m-%d %H:%M:%S")
+                meta_parts: list[str] = []
+                if entry.repo:
+                    meta_parts.append(f"repo={entry.repo}")
+                if entry.iteration is not None:
+                    meta_parts.append(f"iter={entry.iteration}")
+                if entry.test_state:
+                    meta_parts.append(f"test={entry.test_state}")
+                if entry.action:
+                    meta_parts.append(f"action={entry.action}")
+                meta = f"  [{' '.join(meta_parts)}]" if meta_parts else ""
+                lines.append(f"{ts}{meta}")
+                lines.append(f"  {entry.message}")
+                if entry.open_question:
+                    lines.append(f"  ⚠ open: {entry.open_question}")
+            body = "\n".join(lines)
+        header = self._header(slug)
+        return f"{header}\n\n{body}" if header else body
 
 
 def register(app: typer.Typer, get_container):
@@ -132,6 +145,7 @@ def register(app: typer.Typer, get_container):
             if not all_ and t.active_repo is not None:
                 scope = t.active_repo
 
+        from mship.cli.view._workitems import load_workitem_index
         view = LogsView(
             state_manager=container.state_manager(),
             log_manager=container.log_manager(),
@@ -140,6 +154,7 @@ def register(app: typer.Typer, get_container):
             all_=all_,
             cli_task=cli_task,
             cwd=Path.cwd(),
+            workitem_loader=lambda: load_workitem_index(container),
             watch=watch,
             interval=interval,
         )

--- a/src/mship/cli/view/spec.py
+++ b/src/mship/cli/view/spec.py
@@ -37,12 +37,13 @@ class SpecView(ViewApp):
         log_manager=None,
         cli_task: Optional[str] = None,
         cwd: Optional[Path] = None,
+        header_provider=None,
         **kw,
     ):
         # Strip SpecView-specific kwargs before passing to super
         for k in ("workspace_root", "name_or_path", "task",
                   "state_manager", "state", "log_manager",
-                  "cli_task", "cwd"):
+                  "cli_task", "cwd", "header_provider"):
             kw.pop(k, None)
         super().__init__(**kw)
         self._workspace_root = workspace_root
@@ -53,6 +54,7 @@ class SpecView(ViewApp):
         self._log_manager = log_manager
         self._cli_task = cli_task
         self._cwd = cwd if cwd is not None else Path.cwd()
+        self._header_provider = header_provider
         self._markdown: Markdown | None = None
         self._error_static: Static | None = None
         self._body: VerticalScroll | None = None
@@ -131,6 +133,9 @@ class SpecView(ViewApp):
                 state=state,
             )
             source = path.read_text()
+            header = self._header_provider() if self._header_provider else None
+            if header:
+                source = f"**{header}**\n\n{source}"
             self._last_source = source
             self._last_error = ""
             self._markdown.update(source)
@@ -271,6 +276,8 @@ def register(app: typer.Typer, get_container):
         web: bool = typer.Option(False, "--web", help="Serve rendered HTML on localhost"),
         port: Optional[int] = typer.Option(None, "--port", help="Explicit port for --web"),
         task: Optional[str] = typer.Option(None, "--task", help="Narrow to one task's worktrees"),
+        workitem: Optional[str] = typer.Option(None, "--workitem", help="Select the spec linked to this WorkItem id"),
+        status: Optional[str] = typer.Option(None, "--status", help="Select the newest spec with this status"),
     ):
         """Render a spec file (newest by default)."""
         from pathlib import Path as _P
@@ -286,13 +293,53 @@ def register(app: typer.Typer, get_container):
         workspace_root = _P(container.config_path()).parent
         state = container.state_manager().load()
 
+        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
+        from mship.core.workitem_store import WorkItemStore
+        from mship.core.view.spec_selection import (
+            SpecSelectionError, SpecSelector, load_canonical_specs, select_spec,
+        )
+        from mship.core.view.headers import header_for_spec
+        from mship.cli.view._workitems import load_workitem_index
+
+        active_selectors = [n for n, v in (("--workitem", workitem), ("--status", status)) if v is not None]
+        if len(active_selectors) > 1:
+            typer.echo("Error: --workitem and --status are mutually exclusive.", err=True)
+            raise typer.Exit(code=1)
+        if active_selectors and name_or_path is not None:
+            typer.echo(f"Error: {active_selectors[0]} and an explicit spec name are mutually exclusive.", err=True)
+            raise typer.Exit(code=1)
+        if active_selectors and task is not None:
+            typer.echo(f"Error: {active_selectors[0]} and --task are mutually exclusive.", err=True)
+            raise typer.Exit(code=1)
+
+        specs_dir = workspace_root / SPECS_DIRNAME
+        canonical_path: Optional[_P] = None
+        canonical_spec_id: Optional[str] = None
+        selector: Optional[SpecSelector] = None
+        if active_selectors:
+            selector = SpecSelector(work_item_id=workitem, status=status)
+        elif name_or_path is None and task is None and load_canonical_specs(specs_dir):
+            # AC1/AC2: deterministic canonical default (newest by created_at), not
+            # worktree/mtime. Only engages when the canonical store has real specs;
+            # otherwise fall through to the legacy task/worktree resolution below.
+            selector = SpecSelector()
+        if selector is not None:
+            items = WorkItemStore(_P(container.state_dir()) / "workitems")
+            try:
+                spec = select_spec(load_canonical_specs(specs_dir), items.list(), selector)
+            except SpecSelectionError as e:
+                typer.echo(f"Error: {e}", err=True)
+                raise typer.Exit(code=1)
+            canonical_path = SpecStore(specs_dir).path_for(spec)
+            canonical_spec_id = spec.id
+
         # Resolve target task. If the user specified an explicit spec name,
         # skip task resolution entirely (rendering is name-driven). If --watch
         # is set, defer task resolution into the view so resolver errors
         # become placeholder text instead of exit-1.
         resolved_task_slug: Optional[str] = None
         cli_task_for_view: Optional[str] = None
-        if name_or_path is None:
+        if canonical_path is None and name_or_path is None:
             if watch:
                 cli_task_for_view = task
             elif task is not None:
@@ -316,7 +363,7 @@ def register(app: typer.Typer, get_container):
         # --web still requires a resolvable spec path at request time.
         if web:
             try:
-                path = find_spec(
+                path = canonical_path or find_spec(
                     workspace_root, name_or_path, task=resolved_task_slug, state=state,
                 )
             except SpecNotFoundError as e:
@@ -331,7 +378,7 @@ def register(app: typer.Typer, get_container):
         from mship.cli.output import Output
         if not Output().is_tty:
             try:
-                path = find_spec(
+                path = canonical_path or find_spec(
                     workspace_root, name_or_path, task=resolved_task_slug, state=state,
                 )
             except SpecNotFoundError as e:
@@ -340,14 +387,18 @@ def register(app: typer.Typer, get_container):
             typer.echo(path.read_text(), nl=False)
             return
 
+        header_provider = None
+        if canonical_spec_id is not None:
+            header_provider = lambda: header_for_spec(canonical_spec_id, load_workitem_index(container))
         view = SpecView(
             workspace_root=workspace_root,
-            name_or_path=name_or_path,
+            name_or_path=str(canonical_path) if canonical_path is not None else name_or_path,
             task=resolved_task_slug,
             state_manager=container.state_manager(),
             log_manager=container.log_manager(),
             cli_task=cli_task_for_view,
             cwd=_P.cwd(),
+            header_provider=header_provider,
             watch=watch,
             interval=interval,
         )

--- a/src/mship/cli/view/spec.py
+++ b/src/mship/cli/view/spec.py
@@ -293,10 +293,11 @@ def register(app: typer.Typer, get_container):
         workspace_root = _P(container.config_path()).parent
         state = container.state_manager().load()
 
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
+        from mship.core.spec_store import SPECS_DIRNAME
         from mship.core.workitem_store import WorkItemStore
         from mship.core.view.spec_selection import (
-            SpecSelectionError, SpecSelector, load_canonical_specs, select_spec,
+            SpecSelectionError, SpecSelector, load_canonical_specs,
+            scan_canonical_specs, select_spec,
         )
         from mship.core.view.headers import header_for_spec
         from mship.cli.view._workitems import load_workitem_index
@@ -325,12 +326,15 @@ def register(app: typer.Typer, get_container):
             selector = SpecSelector()
         if selector is not None:
             items = WorkItemStore(_P(container.state_dir()) / "workitems")
+            scanned = scan_canonical_specs(specs_dir)
             try:
-                spec = select_spec(load_canonical_specs(specs_dir), items.list(), selector)
+                spec = select_spec([s for s, _ in scanned], items.list(), selector)
             except SpecSelectionError as e:
                 typer.echo(f"Error: {e}", err=True)
                 raise typer.Exit(code=1)
-            canonical_path = SpecStore(specs_dir).path_for(spec)
+            # Use the REAL path the spec was read from, not a reconstruction, so a
+            # file whose name diverges from <date>-<id>.md still renders.
+            canonical_path = next((p for s, p in scanned if s.id == spec.id), None)
             canonical_spec_id = spec.id
 
         # Resolve target task. If the user specified an explicit spec name,

--- a/src/mship/cli/view/status.py
+++ b/src/mship/cli/view/status.py
@@ -6,6 +6,12 @@ import typer
 from mship.cli.view._base import ViewApp
 from mship.core.state import Task, WorkspaceState
 from mship.core.view.task_index import build_task_index
+from mship.core.view.status_grouping import WorkItemTaskGroup, group_tasks_by_workitem
+
+
+def _render_group_header(group: WorkItemTaskGroup) -> str:
+    title = group.title or "(untitled)"
+    return f"◆ {group.work_item_id}  ·  {title}  ·  [{group.phase}]"
 
 
 def _render_task(task: Task, open_questions: list[str] | None = None) -> str:
@@ -48,12 +54,13 @@ def _render_task(task: Task, open_questions: list[str] | None = None) -> str:
 
 class StatusView(ViewApp):
     def __init__(self, state_manager, workspace_root: Path, task_filter: Optional[str],
-                 log_manager=None, **kw):
+                 log_manager=None, workitem_loader=None, **kw):
         super().__init__(**kw)
         self._state_manager = state_manager
         self._workspace_root = workspace_root
         self._task_filter = task_filter
         self._log_manager = log_manager
+        self._workitem_loader = workitem_loader
 
     def _open_questions(self, slug: str) -> list[str]:
         if self._log_manager is None:
@@ -74,8 +81,15 @@ class StatusView(ViewApp):
         index = build_task_index(state, self._workspace_root)
         if not index:
             return "No tasks. Run `mship spawn \"…\"` to start one."
-        blocks = [_render_task(state.tasks[s.slug], self._open_questions(s.slug)) for s in index]
-        return "\n\n─────────────\n\n".join(blocks)
+        workitems = self._workitem_loader() if self._workitem_loader is not None else []
+        groups = group_tasks_by_workitem(index, workitems)
+        blocks: list[str] = []
+        for g in groups:
+            body = "\n\n─────────────\n\n".join(
+                _render_task(state.tasks[t.slug], self._open_questions(t.slug)) for t in g.tasks
+            )
+            blocks.append(f"{_render_group_header(g)}\n\n{body}" if g.work_item_id is not None else body)
+        return "\n\n═════════════\n\n".join(blocks)
 
 
 def register(app: typer.Typer, get_container):
@@ -96,11 +110,13 @@ def register(app: typer.Typer, get_container):
             t = resolve_or_exit(state, task)
             task_slug = t.slug
         workspace_root = _P(container.config_path()).parent
+        from mship.cli.view._workitems import load_workitem_index
         view = StatusView(
             state_manager=container.state_manager(),
             workspace_root=workspace_root,
             task_filter=task_slug,
             log_manager=container.log_manager(),
+            workitem_loader=lambda: load_workitem_index(container),
             watch=watch,
             interval=interval,
         )

--- a/src/mship/core/view/headers.py
+++ b/src/mship/core/view/headers.py
@@ -1,0 +1,37 @@
+"""One-line WorkItem/phase-aware header strings for the view commands (AC9).
+
+Pure: operate on the `WorkItemSummary` index (already carries derived `phase`,
+`title`, `spec_id`, `task_slugs`). Return None when nothing links, so callers
+simply omit the header and keep their current output.
+"""
+from __future__ import annotations
+
+from mship.core.view.workitem_index import WorkItemSummary
+
+
+def _base(wi: WorkItemSummary) -> str:
+    parts = [f"◆ {wi.id}"]
+    if wi.title:
+        parts.append(wi.title)
+    parts.append(f"[{wi.phase}]")
+    return "  ·  ".join(parts)
+
+
+def header_for_task(task_slug: str, task_phase: str | None,
+                    workitems: list[WorkItemSummary]) -> str | None:
+    """Header for a task-scoped view (journal, diff). None when the task belongs
+    to no WorkItem. Appends the task's own phase when known."""
+    wi = next((w for w in workitems if task_slug in w.task_slugs), None)
+    if wi is None:
+        return None
+    line = _base(wi)
+    if task_phase is not None:
+        line += f"  —  task {task_slug} [{task_phase}]"
+    return line
+
+
+def header_for_spec(spec_id: str, workitems: list[WorkItemSummary]) -> str | None:
+    """Header for the spec view: the WorkItem that links this spec. None when
+    the spec is unlinked."""
+    wi = next((w for w in workitems if w.spec_id == spec_id), None)
+    return _base(wi) if wi is not None else None

--- a/src/mship/core/view/spec_selection.py
+++ b/src/mship/core/view/spec_selection.py
@@ -1,0 +1,86 @@
+"""Canonical spec resolution + selection for `mship view spec` (AC1, AC2).
+
+Pure over already-parsed `Spec`/`WorkItem` objects, plus one resilient reader of
+the workspace-canonical `<workspace_root>/specs` store. Deterministic: selection
+is by created_at + id, never filesystem mtime.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from mship.core.spec import Spec
+from mship.core.workitem import WorkItem
+
+
+class SpecSelectionError(Exception):
+    """No spec matched the requested selector (work item / status / default)."""
+
+
+def _sort_key(spec: Spec) -> tuple:
+    # Deterministic newest-first ordering: created_at, then id. NOT mtime.
+    return (spec.created_at, spec.id)
+
+
+def load_canonical_specs(specs_dir: Path) -> list[Spec]:
+    """Parse every spec in the canonical `<workspace_root>/specs` store, skipping
+    unparseable files. Reads ONLY the workspace-root store, never a per-task
+    worktree, so the result is branch/worktree independent (AC1). Sorted by
+    (created_at, id) ascending."""
+    from mship.core.spec_store import SpecParseError, parse_spec
+    if not specs_dir.is_dir():
+        return []
+    out: list[Spec] = []
+    for p in sorted(specs_dir.glob("*.md")):
+        try:
+            out.append(parse_spec(p.read_text()))
+        except SpecParseError:
+            continue
+    return sorted(out, key=_sort_key)
+
+
+@dataclass(frozen=True)
+class SpecSelector:
+    work_item_id: str | None = None
+    status: str | None = None
+
+
+def select_default(specs: list[Spec]) -> Spec:
+    """Documented default when `mship view spec` gets no selector: the most
+    recently CREATED non-archived spec (created_at, then id), from the canonical
+    store. Deterministic — never filesystem mtime (AC2)."""
+    pool = [s for s in specs if s.status != "archived"] or list(specs)
+    if not pool:
+        raise SpecSelectionError("No specs in the canonical store.")
+    return max(pool, key=_sort_key)
+
+
+def select_by_status(specs: list[Spec], status: str) -> Spec:
+    matches = [s for s in specs if s.status == status]
+    if not matches:
+        raise SpecSelectionError(f"No spec with status {status!r} in the canonical store.")
+    return max(matches, key=_sort_key)
+
+
+def select_by_workitem(specs: list[Spec], workitems: list[WorkItem], work_item_id: str) -> Spec:
+    item = next((w for w in workitems if w.id == work_item_id), None)
+    if item is None:
+        raise SpecSelectionError(f"Unknown work item: {work_item_id!r}")
+    if item.spec_id is None:
+        raise SpecSelectionError(f"Work item {work_item_id!r} has no linked spec.")
+    spec = next((s for s in specs if s.id == item.spec_id), None)
+    if spec is None:
+        raise SpecSelectionError(
+            f"Work item {work_item_id!r} links spec {item.spec_id!r}, absent from the store."
+        )
+    return spec
+
+
+def select_spec(specs: list[Spec], workitems: list[WorkItem], selector: SpecSelector) -> Spec:
+    """Resolve one spec per `selector` (AC2). Precedence: work item > status >
+    deterministic default. Raises SpecSelectionError on no match."""
+    if selector.work_item_id is not None:
+        return select_by_workitem(specs, workitems, selector.work_item_id)
+    if selector.status is not None:
+        return select_by_status(specs, selector.status)
+    return select_default(specs)

--- a/src/mship/core/view/spec_selection.py
+++ b/src/mship/core/view/spec_selection.py
@@ -22,21 +22,30 @@ def _sort_key(spec: Spec) -> tuple:
     return (spec.created_at, spec.id)
 
 
-def load_canonical_specs(specs_dir: Path) -> list[Spec]:
-    """Parse every spec in the canonical `<workspace_root>/specs` store, skipping
-    unparseable files. Reads ONLY the workspace-root store, never a per-task
-    worktree, so the result is branch/worktree independent (AC1). Sorted by
-    (created_at, id) ascending."""
+def scan_canonical_specs(specs_dir: Path) -> list[tuple[Spec, Path]]:
+    """Parse every spec in the canonical `<workspace_root>/specs` store and return
+    (spec, real_path) pairs sorted by (created_at, id). Skips files that are
+    unreadable (OSError), invalid UTF-8 (UnicodeError), or unparseable
+    (SpecParseError) so one bad file never aborts selection. Reads ONLY the
+    workspace-root store, never a per-task worktree, so the result is
+    branch/worktree independent (AC1). Returning the real path (not a
+    reconstruction) keeps rendering correct even if a file's name diverges from
+    `<date>-<id>.md`."""
     from mship.core.spec_store import SpecParseError, parse_spec
     if not specs_dir.is_dir():
         return []
-    out: list[Spec] = []
+    out: list[tuple[Spec, Path]] = []
     for p in sorted(specs_dir.glob("*.md")):
         try:
-            out.append(parse_spec(p.read_text()))
-        except SpecParseError:
+            out.append((parse_spec(p.read_text()), p))
+        except (OSError, UnicodeError, SpecParseError):
             continue
-    return sorted(out, key=_sort_key)
+    return sorted(out, key=lambda sp: _sort_key(sp[0]))
+
+
+def load_canonical_specs(specs_dir: Path) -> list[Spec]:
+    """The specs from `scan_canonical_specs`, without their paths (for selection)."""
+    return [spec for spec, _ in scan_canonical_specs(specs_dir)]
 
 
 @dataclass(frozen=True)

--- a/src/mship/core/view/status_grouping.py
+++ b/src/mship/core/view/status_grouping.py
@@ -1,0 +1,47 @@
+"""Group task summaries under their WorkItem for `mship view status` (AC5).
+
+Pure: takes the task index (list[TaskSummary]) and the WorkItem index
+(list[WorkItemSummary]) and returns ordered groups. Tasks keep their own phase;
+the group header carries the WorkItem's derived phase.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mship.core.view.task_index import TaskSummary
+from mship.core.view.workitem_index import WorkItemSummary
+
+
+@dataclass(frozen=True)
+class WorkItemTaskGroup:
+    work_item_id: str | None
+    title: str | None
+    phase: str | None
+    tasks: list[TaskSummary]
+
+
+def group_tasks_by_workitem(
+    tasks: list[TaskSummary],
+    workitems: list[WorkItemSummary],
+) -> list[WorkItemTaskGroup]:
+    """Group tasks under their WorkItem. WorkItem order follows `workitems`
+    (already active-before-done from build_workitem_index); tasks linked to no
+    WorkItem fall into a single trailing group with work_item_id=None. Each task
+    keeps its own `phase` (rendered by the caller)."""
+    by_slug = {t.slug: t for t in tasks}
+    groups: list[WorkItemTaskGroup] = []
+    claimed: set[str] = set()
+    for wi in workitems:
+        members = [by_slug[s] for s in wi.task_slugs if s in by_slug]
+        if not members:
+            continue
+        claimed.update(t.slug for t in members)
+        groups.append(WorkItemTaskGroup(
+            work_item_id=wi.id, title=wi.title, phase=wi.phase, tasks=members,
+        ))
+    ungrouped = [t for t in tasks if t.slug not in claimed]
+    if ungrouped:
+        groups.append(WorkItemTaskGroup(
+            work_item_id=None, title=None, phase=None, tasks=ungrouped,
+        ))
+    return groups

--- a/tests/cli/view/test_diff_view.py
+++ b/tests/cli/view/test_diff_view.py
@@ -312,3 +312,31 @@ def test_diff_cli_rejects_unknown_task(tmp_path: Path):
         container.config.reset()
         container.state_manager.reset_override()
         container.state_manager.reset()
+
+
+# --- PR1: WorkItem/phase header (AC9) ---
+@pytest.mark.asyncio
+async def test_diff_view_renders_workitem_header(tmp_path):
+    wa = tmp_path / "a"
+    view = DiffView(
+        worktree_paths=[wa], use_delta=False,
+        header_provider=lambda: "◆ wi-1  ·  Overhaul  ·  [in_flight]  —  task a [dev]",
+        watch=False, interval=1.0,
+    )
+    _seed(view, {wa: [_fd("f.py", "diff --git a/f.py b/f.py\n+++ b/f.py\n+x\n")]})
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        assert "wi-1" in view.header_text()
+        assert "Overhaul" in view.header_text()
+        # Tree/diff still populated as before.
+        assert any("f.py" in l for l in view.tree_labels())
+
+
+@pytest.mark.asyncio
+async def test_diff_view_no_header_by_default(tmp_path):
+    wa = tmp_path / "a"
+    view = DiffView(worktree_paths=[wa], use_delta=False, watch=False, interval=1.0)
+    _seed(view, {wa: [_fd("f.py", "diff --git a/f.py b/f.py\n+++ b/f.py\n+x\n")]})
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        assert view.header_text() == ""

--- a/tests/cli/view/test_logs_view.py
+++ b/tests/cli/view/test_logs_view.py
@@ -302,3 +302,61 @@ async def test_logs_view_non_watch_with_task_slug_does_not_call_resolver(tmp_pat
     async with view.run_test() as pilot:
         await pilot.pause()
         assert "ok" in view.rendered_text()
+
+
+# --- PR1: WorkItem/phase header (AC9) ---
+from datetime import datetime as _dt, timezone as _tz
+
+from mship.core.workitem import WorkItem as _WorkItem
+from mship.core.view.workitem_index import build_workitem_index as _bwi
+
+
+class _HeaderTask:
+    def __init__(self, slug, phase):
+        self.slug = slug
+        self.phase = phase
+
+
+class _HeaderState:
+    def __init__(self, task):
+        self.tasks = {task.slug: task}
+
+
+class _HeaderStateMgr:
+    def __init__(self, task):
+        self._task = task
+
+    def load(self):
+        return _HeaderState(self._task)
+
+
+def test_journal_prepends_workitem_header():
+    now = _dt(2026, 7, 1, tzinfo=_tz.utc)
+    entries = [_Entry(now, "did a thing")]
+    wi = _WorkItem(id="wi-1", title="Overhaul", workspace="ws", kind="feature",
+                   created_at=now, updated_at=now, task_slugs=["t1"])
+    workitems = _bwi([wi], {}, {}, {})
+    view = LogsView(
+        state_manager=_HeaderStateMgr(_HeaderTask("t1", "dev")),
+        log_manager=_FakeLogMgr(entries),
+        task_slug="t1",
+        workitem_loader=lambda: workitems,
+        watch=False, interval=1.0,
+    )
+    text = view.gather()
+    assert "wi-1" in text and "Overhaul" in text
+    assert "task t1 [dev]" in text
+    assert "did a thing" in text  # journal body preserved
+
+
+def test_journal_no_header_without_loader():
+    now = _dt(2026, 7, 1, tzinfo=_tz.utc)
+    view = LogsView(
+        state_manager=_FakeStateMgr(),
+        log_manager=_FakeLogMgr([_Entry(now, "hello")]),
+        task_slug="t1",
+        watch=False, interval=1.0,
+    )
+    text = view.gather()
+    assert "◆" not in text
+    assert "hello" in text

--- a/tests/cli/view/test_spec_view.py
+++ b/tests/cli/view/test_spec_view.py
@@ -471,3 +471,123 @@ def test_spec_cli_explicit_task_still_exits_on_unknown(tmp_path):
         assert "nope" in result.output
     finally:
         _reset_overrides()
+
+
+# --- PR1: canonical selection (AC1, AC2) + spec header (AC9) ---
+from mship.core.spec import Spec as _Spec
+from mship.core.spec_store import SPECS_DIRNAME as _SPECS_DIRNAME, SpecStore as _SpecStore
+from mship.core.state import Task as _Task
+from mship.core.workitem import WorkItem as _WorkItem
+from mship.core.workitem_store import WorkItemStore as _WorkItemStore
+
+
+def _seed_canonical(tmp_path, spec_id, *, status="draft", day=1, body="", wi_id=None):
+    now = datetime(2026, 7, day, tzinfo=timezone.utc)
+    _SpecStore(tmp_path / _SPECS_DIRNAME).save(_Spec(
+        id=spec_id, title=spec_id, status=status,
+        created_at=now, updated_at=now, body=body))
+    if wi_id is not None:
+        _WorkItemStore(tmp_path / ".mothership" / "workitems").save(_WorkItem(
+            id=wi_id, title=spec_id, workspace="t", kind="feature",
+            created_at=now, updated_at=now, spec_id=spec_id))
+
+
+def test_spec_cli_selects_by_workitem(tmp_path):
+    runner = CliRunner()
+    _setup_workspace(tmp_path)
+    _seed_canonical(tmp_path, "spec-wi", body="Canonical body for wi-7\n", wi_id="wi-7")
+    _seed_canonical(tmp_path, "spec-other", day=9, body="Other body\n")
+    try:
+        result = runner.invoke(app, ["view", "spec", "--workitem", "wi-7"])
+        assert result.exit_code == 0, result.output
+        assert "Canonical body for wi-7" in result.output
+        assert "Other body" not in result.output
+    finally:
+        _reset_overrides()
+
+
+def test_spec_cli_selects_by_status(tmp_path):
+    runner = CliRunner()
+    _setup_workspace(tmp_path)
+    _seed_canonical(tmp_path, "spec-review", status="needs_review", body="Review me\n")
+    _seed_canonical(tmp_path, "spec-approved", status="approved", day=9, body="Approved\n")
+    try:
+        result = runner.invoke(app, ["view", "spec", "--status", "needs_review"])
+        assert result.exit_code == 0, result.output
+        assert "Review me" in result.output
+        assert "Approved" not in result.output
+    finally:
+        _reset_overrides()
+
+
+def test_spec_cli_default_is_newest_by_created_at(tmp_path):
+    runner = CliRunner()
+    _setup_workspace(tmp_path)
+    _seed_canonical(tmp_path, "spec-old", day=1, body="Old body\n")
+    _seed_canonical(tmp_path, "spec-new", day=9, body="Newest body\n")
+    try:
+        result = runner.invoke(app, ["view", "spec"])
+        assert result.exit_code == 0, result.output
+        assert "Newest body" in result.output
+    finally:
+        _reset_overrides()
+
+
+def test_spec_cli_default_ignores_task_worktree(tmp_path):
+    """AC1: a spec that lives only in the canonical <root>/specs store renders
+    even though the (only) task's worktree has no specs dir."""
+    runner = CliRunner()
+    _setup_workspace(tmp_path)
+    wt = tmp_path / "wt-feature"
+    wt.mkdir()
+    StateManager(tmp_path / ".mothership").save(WorkspaceState(tasks={"a": _Task(
+        slug="a", description="d", phase="dev",
+        created_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        affected_repos=["r"], branch="feat/a", worktrees={"r": wt})}))
+    _seed_canonical(tmp_path, "spec-canonical", body="Only in canonical store\n")
+    try:
+        result = runner.invoke(app, ["view", "spec"])
+        assert result.exit_code == 0, result.output
+        assert "Only in canonical store" in result.output
+    finally:
+        _reset_overrides()
+
+
+def test_spec_cli_workitem_status_mutually_exclusive(tmp_path):
+    runner = CliRunner()
+    _setup_workspace(tmp_path)
+    try:
+        result = runner.invoke(app, ["view", "spec", "--workitem", "x", "--status", "y"])
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output.lower()
+    finally:
+        _reset_overrides()
+
+
+def test_spec_cli_unknown_workitem_exits_1(tmp_path):
+    runner = CliRunner()
+    _setup_workspace(tmp_path)
+    _seed_canonical(tmp_path, "spec-x", body="x\n")
+    try:
+        result = runner.invoke(app, ["view", "spec", "--workitem", "wi-missing"])
+        assert result.exit_code == 1, result.output
+        assert "wi-missing" in result.output
+    finally:
+        _reset_overrides()
+
+
+@pytest.mark.asyncio
+async def test_spec_view_renders_workitem_header(tmp_path):
+    specs = tmp_path / "docs" / "superpowers" / "specs"
+    specs.mkdir(parents=True)
+    (specs / "s.md").write_text("# Hello\n\nBody text.\n")
+    view = SpecView(
+        workspace_root=tmp_path, name_or_path=None,
+        header_provider=lambda: "◆ wi-1  ·  Overhaul  ·  [ready]",
+        watch=False, interval=1.0,
+    )
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        text = view.rendered_text()
+        assert "wi-1" in text and "Overhaul" in text
+        assert "Body text" in text

--- a/tests/cli/view/test_status_view.py
+++ b/tests/cli/view/test_status_view.py
@@ -230,3 +230,46 @@ def test_status_cli_rejects_unknown_task(tmp_path: Path):
         container.config.reset()
         container.state_manager.reset_override()
         container.state_manager.reset()
+
+
+# --- PR1: WorkItem grouping (AC5) ---
+from mship.core.workitem import WorkItem as _WorkItem
+from mship.core.view.workitem_index import build_workitem_index as _bwi
+
+
+def test_status_view_groups_tasks_under_workitem(tmp_path):
+    from mship.cli.view.status import StatusView
+    now = datetime.now(timezone.utc)
+    tasks = {"a": _task("a", phase="dev"), "b": _task("b", phase="review"),
+             "c": _task("c", phase="plan")}
+
+    class SM:
+        def load(self):
+            return WorkspaceState(tasks=tasks)
+
+    wi = _WorkItem(id="wi-1", title="Overhaul", workspace="ws", kind="feature",
+                   created_at=now, updated_at=now, task_slugs=["a", "b"])
+    workitems = _bwi([wi], {}, tasks, {})
+
+    view = StatusView(state_manager=SM(), workspace_root=tmp_path, task_filter=None,
+                      workitem_loader=lambda: workitems)
+    text = view.gather()
+    assert "wi-1" in text and "Overhaul" in text
+    # Grouped tasks appear with their own phase lines.
+    assert "Task:   a" in text and "Task:   b" in text
+    assert "Phase:  dev" in text and "Phase:  review" in text
+    # Unlinked task 'c' still shown (trailing ungrouped block).
+    assert "Task:   c" in text
+
+
+def test_status_view_without_loader_is_flat(tmp_path):
+    from mship.cli.view.status import StatusView
+
+    class SM:
+        def load(self):
+            return WorkspaceState(tasks={"a": _task("a"), "b": _task("b")})
+
+    view = StatusView(state_manager=SM(), workspace_root=tmp_path, task_filter=None)
+    text = view.gather()
+    assert "Task:   a" in text and "Task:   b" in text
+    assert "◆" not in text  # no WorkItem header without a loader

--- a/tests/cli/view/test_workitems_helper.py
+++ b/tests/cli/view/test_workitems_helper.py
@@ -1,0 +1,74 @@
+from datetime import datetime, timezone
+
+from mship.cli import container
+from mship.core.spec import Spec
+from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.workitem import WorkItem
+from mship.core.workitem_store import WorkItemStore
+from mship.cli.view._workitems import load_workitem_index
+
+
+def _now():
+    return datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+
+def _setup(tmp_path):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text("workspace: t\nrepos: {}\n")
+
+    SpecStore(tmp_path / SPECS_DIRNAME).save(Spec(
+        id="spec-1", title="Overhaul", status="approved",
+        created_at=_now(), updated_at=_now(), body="b\n"))
+    WorkItemStore(state_dir / "workitems").save(WorkItem(
+        id="wi-1", title="Overhaul", workspace="t", kind="feature",
+        created_at=_now(), updated_at=_now(), spec_id="spec-1", task_slugs=["a"]))
+    StateManager(state_dir).save(WorkspaceState(tasks={"a": Task(
+        slug="a", description="d", phase="dev", created_at=_now(),
+        affected_repos=["r"], branch="feat/a", worktrees={}, work_item_id="wi-1")}))
+
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+
+
+def _teardown():
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override()
+    container.config.reset()
+    container.state_manager.reset_override()
+    container.state_manager.reset()
+
+
+def test_load_workitem_index_builds_from_canonical_stores(tmp_path):
+    _setup(tmp_path)
+    try:
+        index = load_workitem_index(container)
+        assert [s.id for s in index] == ["wi-1"]
+        s = index[0]
+        assert s.task_slugs == ["a"]
+        assert s.spec_id == "spec-1"
+        # approved spec + one unfinished task -> in_flight (build_workitem_index).
+        assert s.phase == "in_flight"
+    finally:
+        _teardown()
+
+
+def test_load_workitem_index_empty_workspace_is_empty(tmp_path):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text("workspace: t\nrepos: {}\n")
+    StateManager(state_dir).save(WorkspaceState(tasks={}))
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    try:
+        assert load_workitem_index(container) == []
+    finally:
+        _teardown()

--- a/tests/cli/view/test_workitems_helper.py
+++ b/tests/cli/view/test_workitems_helper.py
@@ -72,3 +72,22 @@ def test_load_workitem_index_empty_workspace_is_empty(tmp_path):
         assert load_workitem_index(container) == []
     finally:
         _teardown()
+
+
+def test_load_workitem_index_survives_broken_message_store(tmp_path, monkeypatch):
+    # Greptile #390 (F3): a broken message store must degrade only thread-links,
+    # NOT erase the WorkItem grouping/headers built from items/specs/tasks.
+    _setup(tmp_path)
+    try:
+        from mship.core import message_store as _ms
+
+        def _boom(self):
+            raise ValueError("corrupt message entry")
+
+        monkeypatch.setattr(_ms.MessageStore, "list", _boom)
+        index = load_workitem_index(container)
+        assert [s.id for s in index] == ["wi-1"]   # grouping intact despite bad messages
+        assert index[0].task_slugs == ["a"]
+        assert index[0].spec_id == "spec-1"
+    finally:
+        _teardown()

--- a/tests/core/view/test_headers.py
+++ b/tests/core/view/test_headers.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timezone
+
+from mship.core.workitem import WorkItem
+from mship.core.view.workitem_index import build_workitem_index
+from mship.core.view.headers import header_for_spec, header_for_task
+
+
+def _now():
+    return datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+
+def _index(**kw):
+    base = dict(id="wi-1", title="View overhaul", workspace="ws", kind="feature",
+                created_at=_now(), updated_at=_now())
+    base.update(kw)
+    return build_workitem_index([WorkItem(**base)], {}, {}, {})
+
+
+def test_header_for_task_includes_workitem_and_phases():
+    workitems = _index(task_slugs=["demo"])
+    line = header_for_task("demo", "dev", workitems)
+    assert "wi-1" in line
+    assert "View overhaul" in line
+    # WorkItem derived phase (no children -> inbox) and the task's own phase.
+    assert "[inbox]" in line
+    assert "demo" in line and "[dev]" in line
+
+
+def test_header_for_task_none_when_task_unlinked():
+    workitems = _index(task_slugs=["other"])
+    assert header_for_task("demo", "dev", workitems) is None
+
+
+def test_header_for_task_omits_task_phase_when_none():
+    workitems = _index(task_slugs=["demo"])
+    line = header_for_task("demo", None, workitems)
+    assert "wi-1" in line
+    assert "task demo" not in line
+
+
+def test_header_for_spec_resolves_by_spec_id():
+    workitems = _index(spec_id="spec-9")
+    line = header_for_spec("spec-9", workitems)
+    assert "wi-1" in line and "View overhaul" in line and "[inbox]" in line
+
+
+def test_header_for_spec_none_when_unlinked():
+    workitems = _index(spec_id="spec-9")
+    assert header_for_spec("other-spec", workitems) is None

--- a/tests/core/view/test_spec_selection.py
+++ b/tests/core/view/test_spec_selection.py
@@ -95,3 +95,45 @@ def test_select_spec_precedence_workitem_over_status_over_default():
     assert select_spec(specs, items, SpecSelector(work_item_id="wi-1")).id == "s-wi"
     assert select_spec(specs, items, SpecSelector(status="needs_review")).id == "s-nr"
     assert select_spec(specs, items, SpecSelector()).id == "s-new"
+
+
+# --- Task 2: canonical read is branch/worktree independent (AC1) ---
+
+from mship.core.spec_store import SpecStore
+from mship.core.view.spec_selection import load_canonical_specs
+
+
+def _seed(store_dir, spec_id, *, created):
+    store = SpecStore(store_dir)
+    return store.save(Spec(id=spec_id, title=spec_id, status="draft",
+                           created_at=created, updated_at=created,
+                           body=f"Body of {spec_id}\n"))
+
+
+def test_load_canonical_specs_reads_only_the_workspace_store(tmp_path):
+    # Canonical store at <root>/specs.
+    _seed(tmp_path / "specs", "canonical-one", created=_dt(3))
+    # A task worktree with its OWN legacy specs dir that must be ignored (AC1).
+    wt_specs = tmp_path / "wt-feature" / "docs" / "superpowers" / "specs"
+    wt_specs.mkdir(parents=True)
+    (wt_specs / "worktree-only.md").write_text("# worktree only\n")
+
+    specs = load_canonical_specs(tmp_path / "specs")
+    assert [s.id for s in specs] == ["canonical-one"]
+
+
+def test_load_canonical_specs_skips_unparseable(tmp_path):
+    _seed(tmp_path / "specs", "good", created=_dt(2))
+    (tmp_path / "specs" / "raw-no-frontmatter.md").write_text("# no frontmatter\n")
+    assert [s.id for s in load_canonical_specs(tmp_path / "specs")] == ["good"]
+
+
+def test_load_canonical_specs_missing_dir_is_empty(tmp_path):
+    assert load_canonical_specs(tmp_path / "specs") == []
+
+
+def test_select_default_over_canonical_store_round_trip(tmp_path):
+    _seed(tmp_path / "specs", "older", created=_dt(1))
+    _seed(tmp_path / "specs", "newest", created=_dt(8))
+    specs = load_canonical_specs(tmp_path / "specs")
+    assert select_default(specs).id == "newest"

--- a/tests/core/view/test_spec_selection.py
+++ b/tests/core/view/test_spec_selection.py
@@ -1,0 +1,97 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from mship.core.spec import Spec
+from mship.core.workitem import WorkItem
+from mship.core.view.spec_selection import (
+    SpecSelectionError,
+    SpecSelector,
+    select_by_status,
+    select_by_workitem,
+    select_default,
+    select_spec,
+)
+
+
+def _spec(spec_id, *, status="draft", created):
+    return Spec(id=spec_id, title=spec_id, status=status,
+                created_at=created, updated_at=created)
+
+
+def _dt(day):
+    return datetime(2026, 7, day, tzinfo=timezone.utc)
+
+
+def _wi(item_id, *, spec_id=None):
+    now = _dt(1)
+    return WorkItem(id=item_id, title=item_id, workspace="ws", kind="feature",
+                    created_at=now, updated_at=now, spec_id=spec_id)
+
+
+def test_default_picks_newest_by_created_at_not_mtime():
+    specs = [_spec("old", created=_dt(1)), _spec("new", created=_dt(9)),
+             _spec("mid", created=_dt(5))]
+    assert select_default(specs).id == "new"
+
+
+def test_default_tie_breaks_on_id():
+    specs = [_spec("aaa", created=_dt(3)), _spec("zzz", created=_dt(3))]
+    assert select_default(specs).id == "zzz"
+
+
+def test_default_excludes_archived_unless_all_archived():
+    specs = [_spec("live", status="draft", created=_dt(1)),
+             _spec("gone", status="archived", created=_dt(9))]
+    assert select_default(specs).id == "live"
+    only_archived = [_spec("gone", status="archived", created=_dt(9))]
+    assert select_default(only_archived).id == "gone"
+
+
+def test_default_empty_raises():
+    with pytest.raises(SpecSelectionError):
+        select_default([])
+
+
+def test_select_by_status_returns_newest_match():
+    specs = [_spec("r1", status="needs_review", created=_dt(1)),
+             _spec("r2", status="needs_review", created=_dt(7)),
+             _spec("a1", status="approved", created=_dt(9))]
+    assert select_by_status(specs, "needs_review").id == "r2"
+
+
+def test_select_by_status_no_match_raises():
+    with pytest.raises(SpecSelectionError):
+        select_by_status([_spec("a", status="approved", created=_dt(1))], "needs_review")
+
+
+def test_select_by_workitem_follows_spec_id_link():
+    specs = [_spec("s-linked", created=_dt(1)), _spec("s-other", created=_dt(2))]
+    items = [_wi("wi-1", spec_id="s-linked")]
+    assert select_by_workitem(specs, items, "wi-1").id == "s-linked"
+
+
+def test_select_by_workitem_unknown_item_raises():
+    with pytest.raises(SpecSelectionError):
+        select_by_workitem([], [], "wi-missing")
+
+
+def test_select_by_workitem_item_without_spec_raises():
+    with pytest.raises(SpecSelectionError):
+        select_by_workitem([], [_wi("wi-1", spec_id=None)], "wi-1")
+
+
+def test_select_by_workitem_dangling_spec_raises():
+    items = [_wi("wi-1", spec_id="ghost")]
+    with pytest.raises(SpecSelectionError):
+        select_by_workitem([_spec("real", created=_dt(1))], items, "wi-1")
+
+
+def test_select_spec_precedence_workitem_over_status_over_default():
+    specs = [_spec("s-wi", status="draft", created=_dt(1)),
+             _spec("s-nr", status="needs_review", created=_dt(2)),
+             _spec("s-new", status="approved", created=_dt(9))]
+    items = [_wi("wi-1", spec_id="s-wi")]
+    assert select_spec(specs, items, SpecSelector(work_item_id="wi-1")).id == "s-wi"
+    assert select_spec(specs, items, SpecSelector(status="needs_review")).id == "s-nr"
+    assert select_spec(specs, items, SpecSelector()).id == "s-new"

--- a/tests/core/view/test_spec_selection.py
+++ b/tests/core/view/test_spec_selection.py
@@ -137,3 +137,32 @@ def test_select_default_over_canonical_store_round_trip(tmp_path):
     _seed(tmp_path / "specs", "newest", created=_dt(8))
     specs = load_canonical_specs(tmp_path / "specs")
     assert select_default(specs).id == "newest"
+
+
+# --- Greptile #390 hardening: unreadable file + real-path (F1, F2) ---
+from mship.core.spec_store import serialize_spec
+from mship.core.view.spec_selection import scan_canonical_specs
+
+
+def test_load_canonical_specs_skips_invalid_utf8(tmp_path):
+    # F1: a non-UTF-8 / unreadable file must be skipped, not crash the scan.
+    specs = tmp_path / "specs"
+    _seed(specs, "good", created=_dt(2))
+    (specs / "bad-bytes.md").write_bytes(b"\xff\xfe not utf8 \x80\x81")
+    assert [s.id for s in load_canonical_specs(specs)] == ["good"]
+
+
+def test_scan_returns_real_path_even_when_filename_diverges(tmp_path):
+    # F2: a hand-named file (not <date>-<id>.md) must resolve to its real path,
+    # not a reconstruction that would fail to read.
+    specs = tmp_path / "specs"
+    specs.mkdir()
+    spec = Spec(id="hand", title="hand", status="draft",
+                created_at=_dt(3), updated_at=_dt(3), body="Hand body\n")
+    (specs / "totally-different-name.md").write_text(serialize_spec(spec))
+    scanned = scan_canonical_specs(specs)
+    assert len(scanned) == 1
+    got_spec, got_path = scanned[0]
+    assert got_spec.id == "hand"
+    assert got_path.name == "totally-different-name.md"
+    assert got_path.read_text().startswith("---")  # the real, readable file

--- a/tests/core/view/test_status_grouping.py
+++ b/tests/core/view/test_status_grouping.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timezone
+
+from mship.core.state import Task, WorkspaceState
+from mship.core.workitem import WorkItem
+from mship.core.view.task_index import build_task_index
+from mship.core.view.workitem_index import build_workitem_index
+from mship.core.view.status_grouping import WorkItemTaskGroup, group_tasks_by_workitem
+
+
+def _now():
+    return datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+
+def _task(slug, phase):
+    return Task(slug=slug, description=slug, phase=phase, created_at=_now(),
+                affected_repos=["r"], branch=f"feat/{slug}", worktrees={})
+
+
+def _fixture(tmp_path):
+    tasks = {"a": _task("a", "dev"), "b": _task("b", "review"), "c": _task("c", "plan")}
+    state = WorkspaceState(tasks=tasks)
+    index = build_task_index(state, tmp_path)
+    wi = WorkItem(id="wi-1", title="Overhaul", workspace="ws", kind="feature",
+                  created_at=_now(), updated_at=_now(), task_slugs=["a", "b"])
+    workitems = build_workitem_index([wi], {}, tasks, {})
+    return index, workitems
+
+
+def test_groups_linked_tasks_under_workitem(tmp_path):
+    index, workitems = _fixture(tmp_path)
+    groups = group_tasks_by_workitem(index, workitems)
+    assert isinstance(groups[0], WorkItemTaskGroup)
+    assert groups[0].work_item_id == "wi-1"
+    assert {t.slug for t in groups[0].tasks} == {"a", "b"}
+    assert groups[0].title == "Overhaul"
+    assert groups[0].phase == "in_flight"  # a running task -> in_flight
+
+
+def test_unlinked_tasks_fall_into_trailing_none_group(tmp_path):
+    index, workitems = _fixture(tmp_path)
+    groups = group_tasks_by_workitem(index, workitems)
+    tail = groups[-1]
+    assert tail.work_item_id is None
+    assert [t.slug for t in tail.tasks] == ["c"]
+
+
+def test_each_task_retains_its_own_phase(tmp_path):
+    index, workitems = _fixture(tmp_path)
+    groups = group_tasks_by_workitem(index, workitems)
+    phases = {t.slug: t.phase for g in groups for t in g.tasks}
+    assert phases == {"a": "dev", "b": "review", "c": "plan"}
+
+
+def test_no_workitems_yields_single_ungrouped_bucket(tmp_path):
+    index, _ = _fixture(tmp_path)
+    groups = group_tasks_by_workitem(index, [])
+    assert len(groups) == 1
+    assert groups[0].work_item_id is None
+    assert {t.slug for t in groups[0].tasks} == {"a", "b", "c"}


### PR DESCRIPTION
**Spec:** `mship-view-needs-a-major-overhaul-to` · **PR 1 of a staged rollout**

First PR of the `mship view` overhaul — the concrete data/rendering fixes, no new TUI framework work. All logic lands as pure, unit-tested functions in `core/view/` with thin wiring into the existing view commands, so pre-existing view behavior is untouched.

## What this PR delivers

- **Canonical spec access** — `mship view spec` resolves specs from the workspace-canonical `specs/` store, so a spec renders regardless of which branch/worktree the pane is on (no more newest-file guessing).
- **Select by WorkItem / status** — `mship view spec --workitem <id>` / `--status <status>`, with a deterministic documented default (newest by `created_at`, not mtime).
- **WorkItem-grouped status** — `mship view status` groups tasks under their WorkItem, each with its phase.
- **WorkItem/phase headers** — `mship view spec` / `journal` / `diff` gain a WorkItem/phase-aware header; bodies otherwise unchanged.

## Acceptance criteria — this PR

- [x] `ac1` canonical spec resolution regardless of branch/worktree
- [x] `ac2` select by WorkItem or status; deterministic default (not mtime)
- [x] `ac5` `mship view status` groups tasks under their WorkItem with phase
- [x] `ac9` `journal` / `diff` (and `spec`) gain a WorkItem/phase header

## Deferred to later PRs (not in this PR)

- `ac3` `mship view workitem <id>` cockpit — **PR2** (master/detail foundation + cockpit)
- `ac6` master/detail keyboard navigation — **PR2**
- `ac4` `mship view queue` attention view — **PR3**
- `ac7` inline approve / request-changes actions — **PR4**
- `ac8` cross-entity navigation + open/copy — **PR4**

## Tests

9 TDD commits. `uv run pytest tests/core/view tests/cli/view` → **217 passed**. Full mothership suite green via `mship test`.

🤖 Generated with [Claude Code](https://claude.ai/code)
