### PR TITLE
mship view PR4: inline approve/request-changes + cross-entity actions (completes overhaul)

### DIFF
--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -431,11 +431,10 @@ def register(parent: typer.Typer, get_container):
         bypass_gate: bool = typer.Option(False, "--bypass-gate", help="Approve despite unmet review gate."),
     ):
         """Approve a spec (gate: all criteria approved + all questions answered)."""
-        from datetime import datetime, timezone
         from pathlib import Path
-        from mship.core.spec import InvalidTransition, validate_transition
+        from mship.core.spec import InvalidTransition
         from mship.core.spec_store import SpecStore, SPECS_DIRNAME
-        from mship.core.spec_approve import approval_blockers
+        from mship.core.spec_transition import ApprovalBlocked, approve_spec
         output = Output()
         container = get_container()
         store = SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
@@ -443,20 +442,15 @@ def register(parent: typer.Typer, get_container):
         if spec is None:
             output.error(f"No spec with id {spec_id!r}.")
             raise typer.Exit(1)
-        if not bypass_gate:
-            blockers = approval_blockers(spec)
-            if blockers:
-                output.error("Cannot approve — " + "; ".join(blockers) + ". Use --bypass-gate to override.")
-                raise typer.Exit(1)
         try:
-            validate_transition(spec.status, "approved")
+            approve_spec(spec, store, bypass_gate=bypass_gate)
+        except ApprovalBlocked as e:
+            output.error("Cannot approve — " + "; ".join(e.blockers) + ". Use --bypass-gate to override.")
+            raise typer.Exit(1)
         except InvalidTransition as e:
             output.error(str(e))
             raise typer.Exit(1)
-        spec.status = "approved"
-        spec.clarification_reason = None  # an approved spec carries no pending request-changes reason
-        spec.updated_at = datetime.now(timezone.utc)
-        path = store.save(spec)
+        path = store.path_for(spec)
         if output.human_mode:
             output.success(f"Approved: {path}")
         else:
@@ -580,10 +574,10 @@ def register(parent: typer.Typer, get_container):
         MOS-240: `needs_clarification` is gone; "needs clarification" is now the
         non-null `clarification_reason` carried by the editable `draft` status.
         """
-        from datetime import datetime, timezone
         from pathlib import Path
-        from mship.core.spec import InvalidTransition, validate_transition
+        from mship.core.spec import InvalidTransition
         from mship.core.spec_store import SpecStore, SPECS_DIRNAME
+        from mship.core.spec_transition import request_changes_spec
         output = Output()
         container = get_container()
         store = SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
@@ -592,14 +586,10 @@ def register(parent: typer.Typer, get_container):
             output.error(f"No spec with id {spec_id!r}.")
             raise typer.Exit(1)
         try:
-            validate_transition(spec.status, "draft")
+            request_changes_spec(spec, store, reason)
         except InvalidTransition as e:
             output.error(str(e))
             raise typer.Exit(1)
-        spec.status = "draft"
-        spec.clarification_reason = reason
-        spec.updated_at = datetime.now(timezone.utc)
-        store.save(spec)
         # MOS-215: the reason is persisted on the spec (surfaced by `spec
         # show`/`review`) in addition to being journaled to the task log.
         try:

--- a/src/mship/cli/view/_master_detail.py
+++ b/src/mship/cli/view/_master_detail.py
@@ -59,6 +59,13 @@ class MasterDetailApp(App):
         Binding("j,down", "nav_down", "Down", show=False),
         Binding("k,up", "nav_up", "Up", show=False),
         Binding("escape", "close_filter", "Close filter", show=False),
+        # Curated action keys (PR4). Non-priority so they type into the filter Input
+        # when it is focused (consistent with q/r); default to a visible no-op —
+        # subclasses opt in per view. show=False keeps the footer uncluttered.
+        Binding("a", "approve", "Approve", show=False),
+        Binding("R", "request_changes", "Req-changes", show=False),
+        Binding("o", "open_external", "Open↗", show=False),
+        Binding("y", "copy_id", "Copy", show=False),
     ]
 
     def __init__(self, **kw) -> None:
@@ -71,6 +78,7 @@ class MasterDetailApp(App):
         self._filter: str = ""
         self._rows: list[ListRow] = []       # all rows (unfiltered)
         self._visible: list[ListRow] = []    # rows after the active filter
+        self._last_action_message: str = ""  # last curated-action feedback (PR4)
 
     # --- subclass hooks ---
     def list_rows(self) -> list[ListRow]:
@@ -173,10 +181,51 @@ class MasterDetailApp(App):
             self._master.action_cursor_up()
 
     def action_drill(self) -> None:
-        # Enter drills into the highlighted entity: focus the detail pane so it
-        # can be scrolled/read. (Cross-entity open/copy is a later PR.)
+        # Enter opens the highlighted entity's linked target in-process if the view
+        # provides one (PR4); otherwise it drills into the detail pane so it can be
+        # scrolled/read (unchanged base behavior).
+        if self._do_open_entity():
+            return
         if self._detail is not None:
             self._detail.focus()
+
+    # --- curated action hooks (PR4) ---
+    # The base wires the a/R/o/y keys to these hooks; the defaults are safe,
+    # visible no-ops so every master/detail view inherits the keys but does
+    # nothing unsafe unless it opts in by overriding a hook.
+    def last_action(self) -> str:
+        return self._last_action_message
+
+    def _announce(self, msg: str) -> None:
+        self._last_action_message = msg
+        self.notify(msg)
+
+    def _do_approve(self) -> None:
+        self._announce("Approve is not available here.")
+
+    def _do_request_changes(self) -> None:
+        self._announce("Request-changes is not available here.")
+
+    def _do_open_external(self) -> None:
+        self._announce("Nothing to open here.")
+
+    def _do_copy(self) -> None:
+        self._announce("Nothing to copy here.")
+
+    def _do_open_entity(self) -> bool:
+        return False   # no cross-entity target; action_drill falls back to detail focus
+
+    def action_approve(self) -> None:
+        self._do_approve()
+
+    def action_request_changes(self) -> None:
+        self._do_request_changes()
+
+    def action_open_external(self) -> None:
+        self._do_open_external()
+
+    def action_copy_id(self) -> None:
+        self._do_copy()
 
     def on_list_view_selected(self, event) -> None:  # Textual: ListView.Selected (enter)
         self.action_drill()

--- a/src/mship/cli/view/_modals.py
+++ b/src/mship/cli/view/_modals.py
@@ -1,0 +1,53 @@
+"""Small in-process screens for PR4 actions: a request-changes reason prompt and a
+read-only cross-entity detail overlay (opened via push_screen — never a second
+mship process)."""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Input, Label, Static
+
+
+class RequestChangesModal(ModalScreen[str | None]):
+    """Prompt a short reason; dismisses with the reason, or None if cancelled/empty."""
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    def __init__(self, spec_id: str) -> None:
+        super().__init__()
+        self._spec_id = spec_id
+
+    def compose(self) -> ComposeResult:
+        yield Vertical(
+            Label(f"Request changes on {self._spec_id} — reason:", markup=False),
+            Input(placeholder="what needs to change…", id="reason"),
+        )
+
+    def on_mount(self) -> None:
+        self.query_one("#reason", Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        self.dismiss(event.value.strip() or None)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class EntityScreen(ModalScreen[None]):
+    """Read-only, scrollable overlay rendering a linked entity in-process."""
+    BINDINGS = [Binding("escape,q", "close", "Close")]
+
+    def __init__(self, title: str, text: str) -> None:
+        super().__init__()
+        self._title = title
+        self._text = text
+
+    def compose(self) -> ComposeResult:
+        yield VerticalScroll(
+            Static(f"◆ {self._title}", markup=False),
+            Static(self._text, expand=True, markup=False),
+        )
+
+    def action_close(self) -> None:
+        self.dismiss(None)

--- a/src/mship/cli/view/queue.py
+++ b/src/mship/cli/view/queue.py
@@ -97,13 +97,22 @@ class QueueView(MasterDetailApp):
             self._announce("Nothing to copy here.")
 
     def _do_open_entity(self) -> bool:
+        # enter opens the linked entity for EVERY row type: a needs_review spec
+        # opens its full body, a PR row opens in the browser, and any other row
+        # (blocked task) opens its detail in a focused in-process screen.
         item = self._selected()
-        if item is None or item.kind != "spec-needs-review" or self._spec_store is None:
+        if item is None:
             return False
-        spec = self._spec_store.find_by_id(item.spec_id)
-        if spec is None:
-            return False
-        self.push_screen(EntityScreen(item.spec_id, spec.body))
+        if item.kind == "spec-needs-review" and self._spec_store is not None:
+            spec = self._spec_store.find_by_id(item.spec_id)
+            if spec is not None:
+                self.push_screen(EntityScreen(item.spec_id, spec.body))
+                return True
+        if item.pr_url:
+            webbrowser.open(item.pr_url)
+            self._announce(f"Opened {item.pr_url}")
+            return True
+        self.push_screen(EntityScreen(item.key, queue_detail(item)))
         return True
 
 

--- a/src/mship/cli/view/queue.py
+++ b/src/mship/cli/view/queue.py
@@ -2,14 +2,24 @@
 base (AC4). Thin wiring: `build_rows` maps pure `QueueItem`s (assembled in
 core/view/queue) to `ListRow`s, and `QueueView` renders them on the reusable
 `MasterDetailApp`. Scoped to THIS workspace (one serve/agent per workspace; the
-cross-workspace rollup belongs to Ground Control). READ-ONLY in this PR —
-navigate + view only.
+cross-workspace rollup belongs to Ground Control).
+
+PR4 adds the curated inline actions: `a` approves / `R` requests-changes a
+spec-needs-review row (through the shared core.spec_transition seam, so the
+terminal and the phone cannot diverge), `o` opens a PR url, `y` copies the row's
+identity, and `enter` opens the linked spec in-process. Every other kind stays a
+visible no-op.
 """
 from __future__ import annotations
 
+import webbrowser
+
 import typer
+from textual import work
 
 from mship.cli.view._master_detail import ListRow, MasterDetailApp
+from mship.cli.view._modals import EntityScreen, RequestChangesModal
+from mship.core.view.actions import approve_spec_by_id, request_changes_by_id
 from mship.core.view.queue import (
     QueueItem, assemble_queue, queue_detail, queue_header, queue_label,
 )
@@ -25,15 +35,76 @@ def build_rows(items: list[QueueItem]) -> list[ListRow]:
 
 
 class QueueView(MasterDetailApp):
-    def __init__(self, items: list[QueueItem], **kw) -> None:
+    def __init__(self, items: list[QueueItem], spec_store=None, **kw) -> None:
         super().__init__(**kw)
-        self._items = items
+        self._items = list(items)
+        self._spec_store = spec_store
 
     def list_rows(self) -> list[ListRow]:
         return build_rows(self._items)
 
     def header_line(self) -> str | None:
         return queue_header(self._items)
+
+    def _selected(self) -> QueueItem | None:
+        key = self.selected_key()
+        return next((i for i in self._items if i.key == key), None)
+
+    # AC7 — approve / request-changes (only on a spec-needs-review row) ------
+    def _do_approve(self) -> None:
+        item = self._selected()
+        if item is None or item.kind != "spec-needs-review" or self._spec_store is None:
+            self._announce("Approve applies to a spec awaiting review.")
+            return
+        out = approve_spec_by_id(self._spec_store, item.spec_id)
+        self._announce(out.message)
+        if out.ok:
+            self._items = [i for i in self._items if i.key != item.key]
+            self.call_later(self.reload_rows)
+
+    @work
+    async def _do_request_changes(self) -> None:
+        item = self._selected()
+        if item is None or item.kind != "spec-needs-review" or self._spec_store is None:
+            self._announce("Request-changes applies to a spec awaiting review.")
+            return
+        reason = await self.push_screen_wait(RequestChangesModal(item.spec_id))
+        if reason is None:
+            self._announce("Request-changes cancelled.")
+            return
+        out = request_changes_by_id(self._spec_store, item.spec_id, reason)
+        self._announce(out.message)
+        if out.ok:
+            self._items = [i for i in self._items if i.key != item.key]
+            await self.reload_rows()
+
+    # AC8 — open / copy -----------------------------------------------------
+    def _do_open_external(self) -> None:
+        item = self._selected()
+        if item is not None and item.pr_url:
+            webbrowser.open(item.pr_url)
+            self._announce(f"Opened {item.pr_url}")
+        else:
+            self._announce("No PR/thread to open on this row.")
+
+    def _do_copy(self) -> None:
+        item = self._selected()
+        text = None if item is None else (item.pr_url or item.spec_id or item.task_slug)
+        if text:
+            self.copy_to_clipboard(text)
+            self._announce(f"Copied {text}")
+        else:
+            self._announce("Nothing to copy here.")
+
+    def _do_open_entity(self) -> bool:
+        item = self._selected()
+        if item is None or item.kind != "spec-needs-review" or self._spec_store is None:
+            return False
+        spec = self._spec_store.find_by_id(item.spec_id)
+        if spec is None:
+            return False
+        self.push_screen(EntityScreen(item.spec_id, spec.body))
+        return True
 
 
 def _resolve_queue(container) -> list[QueueItem]:
@@ -66,4 +137,7 @@ def register(app: "typer.Typer", get_container):
             typer.echo(render_text(items))
             return
 
-        QueueView(items).run()
+        from pathlib import Path
+        from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+        store = SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
+        QueueView(items, spec_store=store).run()

--- a/src/mship/cli/view/queue.py
+++ b/src/mship/cli/view/queue.py
@@ -123,7 +123,8 @@ def register(app: "typer.Typer", get_container):
     def queue():
         """This workspace's attention/triage queue: specs awaiting review, blocked
         tasks, and PRs awaiting action — each a navigable row with a detail pane.
-        Read-only (navigate + view)."""
+        Curated inline actions: a approve · R request-changes · enter open · o
+        open-in-browser · y copy."""
         from mship.cli.output import Output
         from mship.core.view.queue import render_text
 

--- a/src/mship/cli/view/spec.py
+++ b/src/mship/cli/view/spec.py
@@ -9,12 +9,16 @@ from pathlib import Path
 from typing import Optional
 
 import typer
+from textual import work
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import VerticalScroll
 from textual.widgets import Markdown, Static
 
 from mship.cli.view._base import ViewApp
+from mship.cli.view._modals import RequestChangesModal
 from mship.cli.view._placeholders import placeholder_for
+from mship.core.view.actions import approve_spec_by_id, request_changes_by_id
 from mship.core.task_resolver import (
     AmbiguousTaskError,
     NoActiveTaskError,
@@ -26,6 +30,15 @@ from mship.core.view.web_port import NoFreePortError, pick_port
 
 
 class SpecView(ViewApp):
+    # SpecView is a `ViewApp` stream view (not MasterDetailApp). Textual merges
+    # BINDINGS across the MRO, so these ADD to ViewApp's keys. `a`/`R` approve /
+    # request-changes the currently-rendered canonical spec through the shared
+    # core.spec_transition seam — only active when spec_store + spec_id are known.
+    BINDINGS = [
+        Binding("a", "approve", "Approve", show=False),
+        Binding("R", "request_changes", "Req-changes", show=False),
+    ]
+
     def __init__(
         self,
         workspace_root: Path,
@@ -38,12 +51,15 @@ class SpecView(ViewApp):
         cli_task: Optional[str] = None,
         cwd: Optional[Path] = None,
         header_provider=None,
+        spec_store=None,
+        spec_id: Optional[str] = None,
         **kw,
     ):
         # Strip SpecView-specific kwargs before passing to super
         for k in ("workspace_root", "name_or_path", "task",
                   "state_manager", "state", "log_manager",
-                  "cli_task", "cwd", "header_provider"):
+                  "cli_task", "cwd", "header_provider",
+                  "spec_store", "spec_id"):
             kw.pop(k, None)
         super().__init__(**kw)
         self._workspace_root = workspace_root
@@ -55,6 +71,9 @@ class SpecView(ViewApp):
         self._cli_task = cli_task
         self._cwd = cwd if cwd is not None else Path.cwd()
         self._header_provider = header_provider
+        self._spec_store = spec_store
+        self._spec_id = spec_id
+        self._last_action_message: str = ""
         self._markdown: Markdown | None = None
         self._error_static: Static | None = None
         self._body: VerticalScroll | None = None
@@ -203,6 +222,37 @@ class SpecView(ViewApp):
         """Test helper — returns last markdown source plus any error text."""
         return self._last_source + "\n" + self._last_error
 
+    # --- PR4 inline actions (AC7) ---
+    def last_action(self) -> str:
+        return self._last_action_message
+
+    def _announce(self, msg: str) -> None:
+        self._last_action_message = msg
+        self.notify(msg)
+
+    def action_approve(self) -> None:
+        if self._spec_store is None or self._spec_id is None:
+            self._announce("Approve is not available for this spec.")
+            return
+        out = approve_spec_by_id(self._spec_store, self._spec_id)
+        self._announce(out.message)
+        if out.ok:
+            self._refresh_content()
+
+    @work
+    async def action_request_changes(self) -> None:
+        if self._spec_store is None or self._spec_id is None:
+            self._announce("Request-changes is not available for this spec.")
+            return
+        reason = await self.push_screen_wait(RequestChangesModal(self._spec_id))
+        if reason is None:
+            self._announce("Request-changes cancelled.")
+            return
+        out = request_changes_by_id(self._spec_store, self._spec_id, reason)
+        self._announce(out.message)
+        if out.ok:
+            self._refresh_content()
+
 
 def _render_html(spec_path: Path) -> bytes:
     try:
@@ -293,7 +343,7 @@ def register(app: typer.Typer, get_container):
         workspace_root = _P(container.config_path()).parent
         state = container.state_manager().load()
 
-        from mship.core.spec_store import SPECS_DIRNAME
+        from mship.core.spec_store import SPECS_DIRNAME, SpecStore
         from mship.core.workitem_store import WorkItemStore
         from mship.core.view.spec_selection import (
             SpecSelectionError, SpecSelector, load_canonical_specs,
@@ -394,6 +444,10 @@ def register(app: typer.Typer, get_container):
         header_provider = None
         if canonical_spec_id is not None:
             header_provider = lambda: header_for_spec(canonical_spec_id, load_workitem_index(container))
+        # Only the canonical path carries a spec id + store, so a/R approve /
+        # request-changes are active there and read-only elsewhere (name/task paths
+        # pass None). Route writes through the same shared seam as serve + CLI.
+        action_store = SpecStore(specs_dir) if canonical_spec_id is not None else None
         view = SpecView(
             workspace_root=workspace_root,
             name_or_path=str(canonical_path) if canonical_path is not None else name_or_path,
@@ -403,6 +457,8 @@ def register(app: typer.Typer, get_container):
             cli_task=cli_task_for_view,
             cwd=_P.cwd(),
             header_provider=header_provider,
+            spec_store=action_store,
+            spec_id=canonical_spec_id,
             watch=watch,
             interval=interval,
         )

--- a/src/mship/cli/view/workitem.py
+++ b/src/mship/cli/view/workitem.py
@@ -2,17 +2,26 @@
 
 Thin wiring: `build_rows` maps a pure `WorkItemCockpit` (assembled in
 core/view/workitem_cockpit) to `ListRow`s, and `WorkItemCockpitView` renders them
-on the reusable `MasterDetailApp`. The store resolver + Typer command are added in
-the next task.
+on the reusable `MasterDetailApp`.
+
+PR4 adds the curated inline actions: `a`/`R` on the spec row (when its status is
+needs_review) approve / request-changes it through the shared core.spec_transition
+seam; `y` copies the selected entity's id/branch/PR-url; `o` opens a PR row's url;
+`enter` opens the linked spec in-process. The spec row relabels to the new status
+after a successful write.
 """
 from __future__ import annotations
 
+import webbrowser
 from pathlib import Path
 from typing import Optional
 
 import typer
+from textual import work
 
 from mship.cli.view._master_detail import ListRow, MasterDetailApp
+from mship.cli.view._modals import EntityScreen, RequestChangesModal
+from mship.core.view.actions import approve_spec_by_id, request_changes_by_id
 from mship.core.view.workitem_cockpit import (
     WorkItemCockpit, criterion_detail, pr_detail, spec_detail, task_detail,
     thread_detail,
@@ -58,15 +67,102 @@ def build_rows(cockpit: WorkItemCockpit) -> list[ListRow]:
 
 
 class WorkItemCockpitView(MasterDetailApp):
-    def __init__(self, cockpit: WorkItemCockpit, **kw) -> None:
+    def __init__(self, cockpit: WorkItemCockpit, spec_store=None, **kw) -> None:
         super().__init__(**kw)
         self._cockpit = cockpit
+        self._spec_store = spec_store
+        self._spec_status = cockpit.spec_status
 
     def list_rows(self) -> list[ListRow]:
-        return build_rows(self._cockpit)
+        rows = build_rows(self._cockpit)
+        # Reflect the live spec status (relabels after an in-view approve / request-changes).
+        if rows and self._spec_status is not None:
+            rows[0] = ListRow(
+                key="spec",
+                label=f"spec  {self._cockpit.spec_id or '(none)'}  [{self._spec_status}]",
+                detail=rows[0].detail,
+            )
+        return rows
 
     def header_line(self) -> str | None:
         return f"◆ {self._cockpit.id}  ·  {self._cockpit.title}  ·  [{self._cockpit.phase}]"
+
+    def _selected_task(self):
+        key = self.selected_key() or ""
+        if not key.startswith("task:"):
+            return None
+        slug = key[len("task:"):]
+        return next((t for t in self._cockpit.tasks if t.slug == slug), None)
+
+    def _selected_pr(self):
+        key = self.selected_key() or ""
+        return next((p for p in self._cockpit.prs
+                     if f"pr:{p.task_slug}:{p.repo}" == key), None)
+
+    # AC7 — approve / request-changes (only on the spec row when needs_review) --
+    def _do_approve(self) -> None:
+        if self.selected_key() != "spec" or self._spec_status != "needs_review" or self._spec_store is None:
+            self._announce("Approve applies to the spec row while it awaits review.")
+            return
+        out = approve_spec_by_id(self._spec_store, self._cockpit.spec_id)
+        self._announce(out.message)
+        if out.ok:
+            self._spec_status = "approved"
+            self.call_later(self.reload_rows)
+
+    @work
+    async def _do_request_changes(self) -> None:
+        if self.selected_key() != "spec" or self._spec_status != "needs_review" or self._spec_store is None:
+            self._announce("Request-changes applies to the spec row while it awaits review.")
+            return
+        reason = await self.push_screen_wait(RequestChangesModal(self._cockpit.spec_id))
+        if reason is None:
+            self._announce("Request-changes cancelled.")
+            return
+        out = request_changes_by_id(self._spec_store, self._cockpit.spec_id, reason)
+        self._announce(out.message)
+        if out.ok:
+            self._spec_status = "draft"
+            await self.reload_rows()
+
+    # AC8 — open / copy ---------------------------------------------------------
+    def _do_open_external(self) -> None:
+        pr = self._selected_pr()
+        if pr is not None and pr.url:
+            webbrowser.open(pr.url)
+            self._announce(f"Opened {pr.url}")
+        else:
+            self._announce("No PR to open on this row.")
+
+    def _do_copy(self) -> None:
+        key = self.selected_key() or ""
+        text: str | None = None
+        if key == "spec":
+            text = self._cockpit.spec_id
+        elif key.startswith("ac:"):
+            text = key[len("ac:"):]
+        elif key.startswith("task:"):
+            task = self._selected_task()
+            text = task.branch if task is not None else None
+        elif key.startswith("pr:"):
+            pr = self._selected_pr()
+            text = pr.url if pr is not None else None
+        elif key.startswith("thread:"):
+            text = key[len("thread:"):]
+        if text:
+            self.copy_to_clipboard(text)
+            self._announce(f"Copied {text}")
+        else:
+            self._announce("Nothing to copy here.")
+
+    def _do_open_entity(self) -> bool:
+        if self.selected_key() != "spec" or self._spec_store is None:
+            return False
+        spec = self._spec_store.find_by_id(self._cockpit.spec_id) if self._cockpit.spec_id else None
+        if spec is None:
+            return False
+        self.push_screen(EntityScreen(self._cockpit.spec_id, spec.body))
+        return True
 
 
 def _resolve_cockpit(container, item_id: str) -> WorkItemCockpit | None:
@@ -122,4 +218,7 @@ def register(app: "typer.Typer", get_container):
             typer.echo(render_text(cockpit))
             return
 
-        WorkItemCockpitView(cockpit).run()
+        from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+        workspace_root = Path(container.config_path()).parent
+        store = SpecStore(workspace_root / SPECS_DIRNAME)
+        WorkItemCockpitView(cockpit, spec_store=store).run()

--- a/src/mship/cli/view/workitem.py
+++ b/src/mship/cli/view/workitem.py
@@ -156,13 +156,27 @@ class WorkItemCockpitView(MasterDetailApp):
             self._announce("Nothing to copy here.")
 
     def _do_open_entity(self) -> bool:
-        if self.selected_key() != "spec" or self._spec_store is None:
+        # enter opens the linked entity for EVERY cockpit row: the spec opens its
+        # full body, a PR opens in the browser, and any other row (task, thread,
+        # criterion) opens its detail in a focused in-process screen.
+        key = self.selected_key()
+        if key is None:
             return False
-        spec = self._spec_store.find_by_id(self._cockpit.spec_id) if self._cockpit.spec_id else None
-        if spec is None:
-            return False
-        self.push_screen(EntityScreen(self._cockpit.spec_id, spec.body))
-        return True
+        if key == "spec" and self._spec_store is not None and self._cockpit.spec_id:
+            spec = self._spec_store.find_by_id(self._cockpit.spec_id)
+            if spec is not None:
+                self.push_screen(EntityScreen(self._cockpit.spec_id, spec.body))
+                return True
+        pr = self._selected_pr()
+        if pr is not None:
+            webbrowser.open(pr.url)
+            self._announce(f"Opened {pr.url}")
+            return True
+        row = next((r for r in self.list_rows() if r.key == key), None)
+        if row is not None:
+            self.push_screen(EntityScreen(key, row.detail))
+            return True
+        return False
 
 
 def _resolve_cockpit(container, item_id: str) -> WorkItemCockpit | None:

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -17,6 +17,7 @@ from mship.core.gh_app import GhAppError, mint_installation_token, resolve_insta
 from mship.core.pr import PRManager
 from mship.core.pr_watcher import PrWatcher
 from mship.core.spec import SpecDraft
+from mship.core.spec_transition import ApprovalBlocked, approve_spec, request_changes_spec
 from mship.core.view.thread_links import index_thread_work_items
 from mship.core.workitem import Phase
 from mship.util.shell import ShellRunner
@@ -590,8 +591,12 @@ def create_app(
         _auto_approve_if_ready(spec)
         return _save_and_review(spec)
 
+    # InvalidTransition/validate_transition stay imported here for the archive +
+    # apply endpoints below; the explicit approve/request-changes transitions now
+    # delegate to the shared core.spec_transition seam (imported module-top), so the
+    # phone (here) and the `mship spec` CLI execute one identical implementation and
+    # cannot diverge.
     from mship.core.spec import InvalidTransition, validate_transition
-    from mship.core.spec_approve import approval_blockers
 
     @app.post("/specs/{spec_id}/approve")
     def post_approve(spec_id: str, body: ApproveBody):
@@ -601,17 +606,13 @@ def create_app(
             # gate). A client that still posts /approve as a belt-and-suspenders step gets a plain
             # success, not a spurious approved->approved 409.
             return build_review(spec)
-        if not body.bypass_gate:
-            blockers = approval_blockers(spec)
-            if blockers:
-                raise HTTPException(status_code=409, detail="cannot approve: " + "; ".join(blockers))
         try:
-            validate_transition(spec.status, "approved")
+            approve_spec(spec, store, bypass_gate=body.bypass_gate)
+        except ApprovalBlocked as e:
+            raise HTTPException(status_code=409, detail="cannot approve: " + "; ".join(e.blockers))
         except InvalidTransition as e:
             raise HTTPException(status_code=409, detail=str(e))
-        spec.status = "approved"
-        spec.clarification_reason = None  # an approved spec carries no pending request-changes reason
-        return _save_and_review(spec)
+        return build_review(spec)
 
     @app.post("/specs/{spec_id}/request-changes")
     def post_request_changes(spec_id: str, body: ReasonBody):
@@ -620,12 +621,10 @@ def create_app(
         # status carrying a non-null clarification_reason (the dropped
         # needs_clarification status is now expressed by that field alone).
         try:
-            validate_transition(spec.status, "draft")
+            request_changes_spec(spec, store, body.reason)
         except InvalidTransition as e:
             raise HTTPException(status_code=409, detail=str(e))
-        spec.status = "draft"
-        spec.clarification_reason = body.reason
-        review = _save_and_review(spec)
+        review = build_review(spec)
         if log_manager is not None:
             try:
                 log_manager.append(spec.id, f"spec request-changes (api): {body.reason}")

--- a/src/mship/core/spec_transition.py
+++ b/src/mship/core/spec_transition.py
@@ -1,0 +1,46 @@
+"""The single approve / request-changes transition, shared by `mship serve`
+(core/serve.py), the CLI (cli/spec.py), and the views (core/view/actions.py).
+
+Extracted so the terminal and the phone cannot diverge: every writer performs the
+identical guard (approval_blockers + validate_transition) and the identical atomic
+store write (SpecStore.save = tempfile + os.replace). Callers own only their own
+concerns (HTTP status mapping, CLI output, journal appends, view messaging)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from mship.core.spec import InvalidTransition, Spec, validate_transition
+from mship.core.spec_approve import approval_blockers
+from mship.core.spec_store import SpecStore
+
+__all__ = ["ApprovalBlocked", "InvalidTransition", "approve_spec", "request_changes_spec"]
+
+
+class ApprovalBlocked(Exception):
+    """Approval gate not met (unapproved criteria / unanswered questions / prose)."""
+
+    def __init__(self, blockers: list[str]) -> None:
+        super().__init__("; ".join(blockers))
+        self.blockers = list(blockers)
+
+
+def approve_spec(spec: Spec, store: SpecStore, *, bypass_gate: bool = False) -> None:
+    """needs_review -> approved. Raises ApprovalBlocked (gate) or InvalidTransition."""
+    if not bypass_gate:
+        blockers = approval_blockers(spec)
+        if blockers:
+            raise ApprovalBlocked(blockers)
+    validate_transition(spec.status, "approved")
+    spec.status = "approved"
+    spec.clarification_reason = None
+    spec.updated_at = datetime.now(timezone.utc)
+    store.save(spec)
+
+
+def request_changes_spec(spec: Spec, store: SpecStore, reason: str) -> None:
+    """needs_review/approved -> draft carrying `reason`. Raises InvalidTransition."""
+    validate_transition(spec.status, "draft")
+    spec.status = "draft"
+    spec.clarification_reason = reason
+    spec.updated_at = datetime.now(timezone.utc)
+    store.save(spec)

--- a/src/mship/core/view/actions.py
+++ b/src/mship/core/view/actions.py
@@ -1,0 +1,56 @@
+"""Thin view-facing wrapper over core.spec_transition. Translates the shared
+approve/request-changes transition into a render-ready ActionOutcome: verifies the
+target is needs_review, no-ops (ok=False) with a visible message otherwise, and
+surfaces the approval gate. No Textual — unit-testable directly."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mship.core.spec import InvalidTransition
+from mship.core.spec_store import SpecStore
+from mship.core.spec_transition import ApprovalBlocked, approve_spec, request_changes_spec
+
+
+@dataclass(frozen=True)
+class ActionOutcome:
+    ok: bool
+    message: str
+    new_status: str | None = None
+
+
+def _load_reviewable(store: SpecStore, spec_id: str | None):
+    if not spec_id:
+        return None, ActionOutcome(False, "No spec on this row.")
+    spec = store.find_by_id(spec_id)
+    if spec is None:
+        return None, ActionOutcome(False, f"Spec {spec_id} not found.")
+    if spec.status != "needs_review":
+        return None, ActionOutcome(False, f"{spec_id} is {spec.status}, not awaiting review.")
+    return spec, None
+
+
+def approve_spec_by_id(store: SpecStore, spec_id: str | None) -> ActionOutcome:
+    spec, bail = _load_reviewable(store, spec_id)
+    if bail is not None:
+        return bail
+    try:
+        approve_spec(spec, store)
+    except ApprovalBlocked as e:
+        return ActionOutcome(False, f"Cannot approve {spec_id}: {'; '.join(e.blockers)}")
+    except InvalidTransition as e:
+        return ActionOutcome(False, str(e))
+    return ActionOutcome(True, f"Approved {spec_id}.", new_status="approved")
+
+
+def request_changes_by_id(store: SpecStore, spec_id: str | None, reason: str) -> ActionOutcome:
+    spec, bail = _load_reviewable(store, spec_id)
+    if bail is not None:
+        return bail
+    reason = (reason or "").strip()
+    if not reason:
+        return ActionOutcome(False, "Request-changes needs a reason.")
+    try:
+        request_changes_spec(spec, store, reason)
+    except InvalidTransition as e:
+        return ActionOutcome(False, str(e))
+    return ActionOutcome(True, f"Requested changes on {spec_id}.", new_status="draft")

--- a/src/mship/core/view/queue.py
+++ b/src/mship/core/view/queue.py
@@ -95,9 +95,10 @@ def assemble_queue(
 
 # --- formatters (shared by render_text + the TUI row builder) ---
 
-# The read-only note surfaced in detail panes for items that will grow inline
-# actions in a later PR (approve / request-changes — AC7).
-_ACTION_DEFERRED = "  action: approve / request-changes (deferred — read-only in this view)"
+# The live inline-action hints surfaced in detail panes (PR4). Spec-needs-review
+# rows can be approved / bounced / opened / copied; PR rows can be opened / copied.
+_ACTION_HINT = "  actions: a: approve · R: request-changes · enter: open · y: copy"
+_PR_ACTION_HINT = "  actions: o: open · y: copy"
 
 
 def _context_lines(item: QueueItem) -> list[str]:
@@ -119,7 +120,7 @@ def queue_detail(item: QueueItem) -> str:
     if item.kind == "spec-needs-review":
         lines = [f"spec {item.spec_id}  [needs_review]", f"  {item.work_item_title}"]
         lines += _context_lines(item)
-        lines.append(_ACTION_DEFERRED)
+        lines.append(_ACTION_HINT)
         return "\n".join(lines)
     if item.kind == "blocked-task":
         lines = [f"task {item.task_slug}  [BLOCKED]", f"  reason: {item.blocked_reason}"]
@@ -127,7 +128,7 @@ def queue_detail(item: QueueItem) -> str:
         return "\n".join(lines)
     lines = [f"PR ({item.repo}, task {item.task_slug})", f"  {item.pr_url}"]
     lines += _context_lines(item)
-    lines.append(_ACTION_DEFERRED)
+    lines.append(_PR_ACTION_HINT)
     return "\n".join(lines)
 
 

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -543,6 +543,25 @@ def test_spec_request_changes(configured_app_with_task: Path, tmp_path):
     assert spec.clarification_reason == "tighten scope"
 
 
+def test_cli_approve_uses_shared_transition(configured_app_with_task: Path, tmp_path, monkeypatch):
+    called = {}
+    import mship.core.spec_transition as st
+    orig = st.approve_spec
+
+    def spy(spec, store, *, bypass_gate=False):
+        called["hit"] = spec.id
+        return orig(spec, store, bypass_gate=bypass_gate)
+    monkeypatch.setattr(st, "approve_spec", spy)
+
+    _apply_dq(tmp_path)                                    # needs_review spec "dq"
+    runner.invoke(app, ["spec", "verdict", "dq", "ac1", "approved"])
+    runner.invoke(app, ["spec", "answer", "dq", "q1", "yes"])   # clears the gate
+    result = runner.invoke(app, ["spec", "approve", "dq"])
+    assert result.exit_code == 0, result.output
+    assert called["hit"] == "dq"
+    assert _store(configured_app_with_task).find_by_id("dq").status == "approved"
+
+
 def test_spec_request_changes_persists_reason_and_logs(configured_app_with_task: Path, tmp_path):
     """MOS-215: the reason must land on the spec itself (not just the task
     log), so `spec show`/`review` can surface it without digging into logs."""

--- a/tests/cli/view/test_master_detail.py
+++ b/tests/cli/view/test_master_detail.py
@@ -153,3 +153,33 @@ async def test_rich_markup_in_canonical_text_is_shown_literally():
         assert view.list_labels() == ["ac1 [red]danger[/red] text"]
         assert "[bold]x[/]" in view.detail_text()
         assert "[oops" in view.detail_text()   # malformed markup did not crash render
+
+
+@pytest.mark.asyncio
+async def test_action_keys_default_to_visible_noop():
+    view = _DemoView([ListRow("a", "Alpha", "dA")])
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        view._master.focus()
+        await pilot.pause()
+        await pilot.press("a")
+        await pilot.pause()
+        assert "not available" in view.last_action().lower()
+        await pilot.press("o")
+        await pilot.pause()
+        assert "nothing to open" in view.last_action().lower()
+        await pilot.press("y")
+        await pilot.pause()
+        assert "nothing to copy" in view.last_action().lower()
+
+
+@pytest.mark.asyncio
+async def test_enter_still_drills_when_no_open_target():
+    view = _DemoView([ListRow("a", "Alpha", "dA")])
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        view._master.focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert view.focus_target() == "detail"   # unchanged base behavior

--- a/tests/cli/view/test_modals.py
+++ b/tests/cli/view/test_modals.py
@@ -1,0 +1,51 @@
+import pytest
+from textual import work
+from textual.app import App
+
+from mship.cli.view._modals import EntityScreen, RequestChangesModal
+
+
+class _Host(App):
+    def __init__(self):
+        super().__init__(); self.result = "unset"
+
+    @work
+    async def ask(self):
+        self.result = await self.push_screen_wait(RequestChangesModal("spec-1"))
+
+
+@pytest.mark.asyncio
+async def test_reason_modal_returns_typed_reason():
+    app = _Host()
+    async with app.run_test() as pilot:
+        app.ask()
+        await pilot.pause()
+        for ch in "fix ac2":
+            await pilot.press(ch)
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.result == "fix ac2"
+
+
+@pytest.mark.asyncio
+async def test_reason_modal_escape_cancels():
+    app = _Host()
+    async with app.run_test() as pilot:
+        app.ask()
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.result is None
+
+
+@pytest.mark.asyncio
+async def test_entity_screen_shows_text_and_dismisses():
+    class H(App):
+        def on_mount(self): self.push_screen(EntityScreen("spec-1", "SPEC BODY HERE"))
+    app = H()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(app.screen, EntityScreen)
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not isinstance(app.screen, EntityScreen)

--- a/tests/cli/view/test_queue_view.py
+++ b/tests/cli/view/test_queue_view.py
@@ -210,3 +210,34 @@ async def test_queue_open_and_copy_pr(tmp_path, monkeypatch):
         await pilot.press("y")
         await pilot.pause()
         assert "https://gh/pr/9" in view.last_action()
+
+
+# --- Greptile #394 F2: enter navigates on every row type, not just spec rows ---
+@pytest.mark.asyncio
+async def test_queue_enter_opens_pr_row_in_browser(tmp_path, monkeypatch):
+    import mship.cli.view.queue as qv
+    opened = {}
+    monkeypatch.setattr(qv.webbrowser, "open", lambda u: opened.setdefault("u", u))
+    view = QueueView(_items())
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        view._master.focus()
+        await pilot.press("j"); await pilot.press("j")   # -> PR row
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert opened["u"] == "https://gh/pr/9"
+
+
+@pytest.mark.asyncio
+async def test_queue_enter_opens_blocked_task_detail_in_process(tmp_path):
+    from mship.cli.view._modals import EntityScreen
+    view = QueueView(_items())
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        view._master.focus()
+        await pilot.press("j")   # -> blocked-task row
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(view.screen, EntityScreen)

--- a/tests/cli/view/test_queue_view.py
+++ b/tests/cli/view/test_queue_view.py
@@ -31,7 +31,7 @@ async def test_queue_view_lists_every_attention_item_with_header():
         assert any(l.startswith("[PR]") for l in labels)
         assert "queue" in view.header_text().lower()
         assert "3" in view.header_text()
-        # First row (spec) detail shows the deferred-action note + spec id.
+        # First row (spec) detail shows the spec id.
         assert "spec-1" in view.detail_text()
 
 
@@ -154,3 +154,59 @@ def test_queue_cli_empty_workspace_is_ok(tmp_path):
         assert "(none)" in result.output
     finally:
         _reset()
+
+
+# --- PR4: inline actions (AC7 approve/request-changes + AC8 open/copy) ---
+
+
+@pytest.mark.asyncio
+async def test_queue_approve_writes_and_drops_row(tmp_path):
+    from mship.core.spec import AcceptanceCriterion, Spec
+    from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+    store = SpecStore(tmp_path / SPECS_DIRNAME)
+    store.save(Spec(id="spec-1", title="t", status="needs_review", created_at=_dt(),
+                    updated_at=_dt(), body="b\n",
+                    acceptance_criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
+                    open_questions=[]))
+    view = QueueView(_items(), spec_store=store)
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        view._master.focus()
+        await pilot.pause()
+        await pilot.press("a")                       # spec row is first
+        await pilot.pause()
+        assert store.find_by_id("spec-1").status == "approved"
+        assert "approved" in view.last_action().lower()
+        assert not any("spec-1" in l for l in view.list_labels())   # left the queue
+
+
+@pytest.mark.asyncio
+async def test_queue_approve_noop_on_pr_row(tmp_path):
+    view = QueueView(_items())
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        view._master.focus()
+        await pilot.press("j"); await pilot.press("j")   # -> PR row
+        await pilot.pause()
+        await pilot.press("a")
+        await pilot.pause()
+        assert "spec awaiting review" in view.last_action().lower()
+
+
+@pytest.mark.asyncio
+async def test_queue_open_and_copy_pr(tmp_path, monkeypatch):
+    import mship.cli.view.queue as qv
+    opened = {}
+    monkeypatch.setattr(qv.webbrowser, "open", lambda u: opened.setdefault("u", u))
+    view = QueueView(_items())
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        view._master.focus()
+        await pilot.press("j"); await pilot.press("j")   # -> PR row
+        await pilot.pause()
+        await pilot.press("o")
+        await pilot.pause()
+        assert opened["u"] == "https://gh/pr/9"
+        await pilot.press("y")
+        await pilot.pause()
+        assert "https://gh/pr/9" in view.last_action()

--- a/tests/cli/view/test_spec_view.py
+++ b/tests/cli/view/test_spec_view.py
@@ -591,3 +591,26 @@ async def test_spec_view_renders_workitem_header(tmp_path):
         text = view.rendered_text()
         assert "wi-1" in text and "Overhaul" in text
         assert "Body text" in text
+
+
+# --- PR4: inline approve/request-changes on the spec stream view (AC7) ---
+
+
+@pytest.mark.asyncio
+async def test_spec_view_approve_writes_via_store(tmp_path):
+    from mship.core.spec import AcceptanceCriterion, Spec
+    from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+    store = SpecStore(tmp_path / SPECS_DIRNAME)
+    p = store.save(Spec(id="spec-1", title="t", status="needs_review",
+                        created_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+                        updated_at=datetime(2026, 7, 1, tzinfo=timezone.utc), body="# body\n",
+                        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
+                        open_questions=[]))
+    view = SpecView(workspace_root=tmp_path, name_or_path=str(p),
+                    spec_store=store, spec_id="spec-1")
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("a")
+        await pilot.pause()
+        assert store.find_by_id("spec-1").status == "approved"
+        assert "approved" in view.last_action().lower()

--- a/tests/cli/view/test_workitem_view.py
+++ b/tests/cli/view/test_workitem_view.py
@@ -187,3 +187,35 @@ async def test_cockpit_copy_pr_url(tmp_path):
         await pilot.press("y")
         await pilot.pause()
         assert "https://gh/pr/1" in view.last_action()
+
+
+# --- Greptile #394 F3: cockpit enter navigates on non-spec rows too ---
+@pytest.mark.asyncio
+async def test_cockpit_enter_opens_pr_row_in_browser(monkeypatch):
+    import mship.cli.view.workitem as wv
+    opened = {}
+    monkeypatch.setattr(wv.webbrowser, "open", lambda u: opened.setdefault("u", u))
+    view = WorkItemCockpitView(_cockpit())
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        view._master.focus()
+        for _ in range(3):        # spec(0) ac1(1) task(2) PR(3)
+            await pilot.press("j")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert opened.get("u") == "https://gh/pr/1"
+
+
+@pytest.mark.asyncio
+async def test_cockpit_enter_opens_task_detail_in_process():
+    from mship.cli.view._modals import EntityScreen
+    view = WorkItemCockpitView(_cockpit())
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        view._master.focus()
+        await pilot.press("j"); await pilot.press("j")   # -> task row
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(view.screen, EntityScreen)

--- a/tests/cli/view/test_workitem_view.py
+++ b/tests/cli/view/test_workitem_view.py
@@ -6,8 +6,8 @@ from mship.core.view.workitem_cockpit import (
 from mship.cli.view.workitem import WorkItemCockpitView
 
 
-def _cockpit():
-    return WorkItemCockpit(
+def _cockpit(**over):
+    base = dict(
         id="wi-1", title="Overhaul", kind="feature", phase="in_flight",
         spec_id="spec-1", spec_title="Overhaul spec", spec_status="needs_review",
         criteria=[CriterionView(
@@ -20,6 +20,8 @@ def _cockpit():
         threads=[ThreadView(id="th-1", subject="Question about X",
                             needs_you=False, needs_decision=False, unseen=False)],
     )
+    base.update(over)
+    return WorkItemCockpit(**base)
 
 
 @pytest.mark.asyncio
@@ -144,3 +146,44 @@ def test_workitem_cli_unknown_id_exits_1(tmp_path):
         assert "wi-missing" in result.output
     finally:
         _reset()
+
+
+# --- PR4: inline actions (AC7 approve + AC8 open/copy) ---
+
+
+@pytest.mark.asyncio
+async def test_cockpit_approve_updates_spec_row(tmp_path):
+    from mship.core.spec import AcceptanceCriterion, Spec
+    from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+    store = SpecStore(tmp_path / SPECS_DIRNAME)
+    store.save(Spec(id="spec-1", title="t", status="needs_review", created_at=_dt(),
+                    updated_at=_dt(), body="b\n",
+                    acceptance_criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
+                    open_questions=[]))
+    cockpit = _cockpit(spec_id="spec-1", spec_status="needs_review")
+    view = WorkItemCockpitView(cockpit, spec_store=store)
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        view._master.focus()
+        await pilot.pause()
+        assert view.selected_key() == "spec"
+        await pilot.press("a")
+        await pilot.pause()
+        assert store.find_by_id("spec-1").status == "approved"
+        assert any("[approved]" in l for l in view.list_labels())
+
+
+@pytest.mark.asyncio
+async def test_cockpit_copy_pr_url(tmp_path):
+    view = WorkItemCockpitView(_cockpit())
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        view._master.focus()
+        await pilot.pause()
+        # Row order: spec(0), ac1(1), task(2), PR(3), thread(4).
+        await pilot.press("j"); await pilot.press("j"); await pilot.press("j")
+        await pilot.pause()
+        assert view.selected_key() == "pr:a:r"
+        await pilot.press("y")
+        await pilot.pause()
+        assert "https://gh/pr/1" in view.last_action()

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -928,3 +928,25 @@ def test_get_task_serializes_activity_fields(tmp_path):
     body = TestClient(_app(tmp_path)).get("/tasks/dq").json()
     assert body["last_activity_at"].startswith("2026-07-13T12:00:00")
     assert body["phase_entered_at"].startswith("2026-07-13T12:00:00")
+
+
+def test_approve_endpoint_uses_shared_transition(tmp_path, monkeypatch):
+    called = {}
+    import mship.core.serve as serve_mod
+
+    def spy(spec, store, *, bypass_gate=False):
+        called["hit"] = (spec.id, bypass_gate)
+        spec.status = "approved"
+        spec.clarification_reason = None
+        store.save(spec)
+    monkeypatch.setattr(serve_mod, "approve_spec", spy, raising=False)
+
+    now = datetime(2026, 6, 14, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(
+        id="ready", title="ready", status="needs_review", created_at=now, updated_at=now,
+        body=render_body("p", "u", "a"),
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
+        open_questions=[]))
+    r = TestClient(_app(tmp_path)).post("/specs/ready/approve", json={})
+    assert r.status_code == 200 and r.json()["status"] == "approved"
+    assert called["hit"] == ("ready", False)

--- a/tests/core/test_spec_transition.py
+++ b/tests/core/test_spec_transition.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+from datetime import datetime, timezone
+
+import pytest
+
+from mship.core.spec import AcceptanceCriterion, InvalidTransition, OpenQuestion, Spec
+from mship.core.spec_store import SpecStore
+from mship.core.spec_transition import ApprovalBlocked, approve_spec, request_changes_spec
+
+
+def _dt():
+    return datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+
+def _reviewable(**over) -> Spec:
+    base = dict(
+        id="s1", title="t", status="needs_review", created_at=_dt(), updated_at=_dt(),
+        body="b\n", acceptance_criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
+        open_questions=[],
+    )
+    base.update(over)
+    return Spec(**base)
+
+
+def test_approve_transitions_and_persists_via_store(tmp_path):
+    store = SpecStore(tmp_path / "specs")
+    spec = _reviewable()
+    store.save(spec)
+    approve_spec(spec, store)
+    reloaded = store.find_by_id("s1")
+    assert reloaded.status == "approved"
+    assert reloaded.clarification_reason is None
+
+
+def test_approve_blocked_by_open_questions_does_not_write(tmp_path):
+    store = SpecStore(tmp_path / "specs")
+    spec = _reviewable(open_questions=[OpenQuestion(id="q1", text="?", answer=None)])
+    store.save(spec)
+    with pytest.raises(ApprovalBlocked) as e:
+        approve_spec(spec, store)
+    assert "q1" in "; ".join(e.value.blockers)
+    assert store.find_by_id("s1").status == "needs_review"
+
+
+def test_request_changes_sends_to_draft_with_reason(tmp_path):
+    store = SpecStore(tmp_path / "specs")
+    spec = _reviewable()
+    store.save(spec)
+    request_changes_spec(spec, store, "tighten AC2")
+    reloaded = store.find_by_id("s1")
+    assert reloaded.status == "draft"
+    assert reloaded.clarification_reason == "tighten AC2"
+
+
+def test_approve_illegal_status_raises_invalid_transition(tmp_path):
+    store = SpecStore(tmp_path / "specs")
+    spec = _reviewable(status="draft")
+    store.save(spec)
+    with pytest.raises(InvalidTransition):
+        approve_spec(spec, store)

--- a/tests/core/view/test_actions.py
+++ b/tests/core/view/test_actions.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+from datetime import datetime, timezone
+
+from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec
+from mship.core.spec_store import SpecStore
+from mship.core.view.actions import approve_spec_by_id, request_changes_by_id
+
+
+def _dt(): return datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+
+def _store(tmp_path, **over):
+    store = SpecStore(tmp_path / "specs")
+    base = dict(id="s1", title="t", status="needs_review", created_at=_dt(), updated_at=_dt(),
+                body="b\n", acceptance_criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
+                open_questions=[])
+    base.update(over)
+    store.save(Spec(**base))
+    return store
+
+
+def test_approve_ok_reflects_new_status(tmp_path):
+    store = _store(tmp_path)
+    out = approve_spec_by_id(store, "s1")
+    assert out.ok and out.new_status == "approved"
+    assert store.find_by_id("s1").status == "approved"
+
+
+def test_approve_noop_when_not_needs_review(tmp_path):
+    store = _store(tmp_path, status="approved")
+    out = approve_spec_by_id(store, "s1")
+    assert not out.ok and "not awaiting review" in out.message
+    assert store.find_by_id("s1").status == "approved"
+
+
+def test_approve_reports_open_questions_gate(tmp_path):
+    store = _store(tmp_path, open_questions=[OpenQuestion(id="q1", text="?", answer=None)])
+    out = approve_spec_by_id(store, "s1")
+    assert not out.ok and "q1" in out.message
+    assert store.find_by_id("s1").status == "needs_review"
+
+
+def test_request_changes_needs_reason_and_writes_draft(tmp_path):
+    store = _store(tmp_path)
+    assert not request_changes_by_id(store, "s1", "   ").ok         # empty reason rejected
+    out = request_changes_by_id(store, "s1", "tighten AC2")
+    assert out.ok and out.new_status == "draft"
+    assert store.find_by_id("s1").clarification_reason == "tighten AC2"
+
+
+def test_missing_spec_is_safe(tmp_path):
+    store = SpecStore(tmp_path / "specs")
+    assert not approve_spec_by_id(store, "nope").ok
+    assert not approve_spec_by_id(store, None).ok

--- a/tests/core/view/test_queue.py
+++ b/tests/core/view/test_queue.py
@@ -175,3 +175,12 @@ def test_render_text_has_all_sections():
 def test_render_text_empty_queue_shows_none():
     txt = render_text([])
     assert "(none)" in txt
+
+
+def test_queue_detail_shows_live_action_hint():
+    from mship.core.view.queue import QueueItem, queue_detail
+    item = QueueItem(kind="spec-needs-review", key="k", workspace="w",
+                     work_item_id="wi-1", work_item_title="T", phase="shaping", spec_id="spec-1")
+    d = queue_detail(item)
+    assert "a: approve" in d and "R: request-changes" in d
+    assert "deferred" not in d


### PR DESCRIPTION
**Spec:** `mship-view-needs-a-major-overhaul-to` · **PR 4 of 4 — completes the overhaul** (PR1 #390, PR2 #391, PR3 #392)

The final PR — the *only* state-writing surface in the whole overhaul. Adds curated, safe inline actions to the views; read-only stays the default everywhere else.

## What this PR delivers

- **Approve / request-changes a `needs_review` spec, in-view** — `a` = approve (one keypress), `R` = request-changes (prompts a reason) — from the queue, the workitem cockpit's spec row, and `mship view spec`. After a write the view reflects the new status (approved specs leave the queue; the cockpit spec row relabels).
- **Cross-entity actions** — `enter` opens the linked entity in-process (queue/cockpit spec-row → the spec), `o` opens a PR/thread in the browser, `y` copies the selected id / branch / PR-url.

## The parity guarantee (the important part)

The terminal and the phone (`mship serve`) **cannot diverge**, because both now route through **one** extracted transition: `core/spec_transition.py`. `serve.py`'s endpoints and the `mship spec` CLI were refactored to *delegate* to it (behavior-preserving), so approve/request-changes is a single implementation, through the same atomic `SpecStore.save`, with the same `approval_blockers` gate (open-questions / unapproved-criteria / prose) and `--bypass-gate`. The write logic is Textual-free and unit-tested; the keybindings are a thin layer on top.

## Acceptance criteria — this PR

- [x] `ac7` approve / request-changes a needs_review spec from the views, via the same store path serve uses
- [x] `ac8` cross-entity navigation (enter opens the linked entity) + open-in-browser + copy-ref

## Overhaul complete

All 9 acceptance criteria are now delivered across the four PRs:
- **PR1 #390** — canonical spec access + `--workitem`/`--status` selection + WorkItem-grouped status + WorkItem/phase headers (ac1, ac2, ac5, ac9)
- **PR2 #391** — lazygit-style master/detail foundation + `mship view workitem` cockpit (ac3, ac6)
- **PR3 #392** — `mship view queue` attention view (ac4)
- **PR4 (this)** — inline approve/request-changes + cross-entity actions (ac7, ac8)

No deferrals remain (PR3's "deferred — read-only" note is retired here).

## Tests

11 commits. `uv run pytest tests/core tests/cli` → **2732 passed**. **Parity proof:** the full `serve` suite (70→71) and `spec` CLI suite (80→81) stayed green through the Task 2/3 refactors — the +1 each is a spy asserting the shared path is used. Full mothership suite green via `mship test`.

🤖 Generated with [Claude Code](https://claude.ai/code)
