### PR TITLE
WorkItem-focused zellij cockpit: mship layout focus + per-item tabs

### DIFF
--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Mapping, Optional
 
 import typer
 
@@ -106,6 +106,115 @@ def decide_focus_action(tab_name: str, existing_tab_names: list[str], *, is_done
     if is_done:
         return "close" if exists else "noop"
     return "go-to" if exists else "create"
+
+
+_PHASES = ("Plan", "Dev", "Review", "Run")
+
+_PHASE_FROM_WORKITEM = {
+    "inbox": "Plan", "shaping": "Plan", "ready": "Plan",
+    "in_flight": "Dev", "review": "Review", "done": "Run",
+}
+
+
+def default_phase_tab(workitem_phase: str) -> str:
+    """Map a WorkItem's derived phase to the sub-tab that opens focused."""
+    return _PHASE_FROM_WORKITEM.get(workitem_phase, "Plan")
+
+
+def resolve_chat_command(explicit: str | None, env: Mapping[str, str]) -> str | None:
+    """Configurable agent/chat command. None -> a bare pane = the operator's shell
+    in the tab cwd (mship does NOT hardcode a specific agent)."""
+    if explicit:
+        return explicit
+    return env.get("MSHIP_CHAT_COMMAND") or None
+
+
+def _mship_pane(name: str, tokens: list[str]) -> str:
+    args = " ".join(_kdl_quote(t) for t in tokens)
+    return (f'                pane name="{name}" command="mship" close_on_exit=false '
+            f'{{ args {args}; }}\n')
+
+
+def _phase_panes(phase: str, item_id: str, task_slug: str | None) -> str:
+    """The ambient view panes for one phase sub-tab, baking the item/task in. Panes
+    that need a task fall back to a Shell pane when the item has no task yet.
+
+    NOTE (deviation): `mship view logs` does not exist — the run/journal view is
+    registered as `view journal` (in cli/view/logs.py). The Run phase therefore
+    tails `view journal`, not a nonexistent `view logs`."""
+    shell = '                pane name="Shell"\n'
+    if phase == "Plan":
+        return (_mship_pane("Spec", ["view", "spec", "--workitem", item_id, "--watch"])
+                + _mship_pane("Item", ["view", "item", item_id]))
+    if phase == "Dev":
+        if task_slug is None:
+            return shell
+        return (_mship_pane("Diff", ["view", "diff", "--task", task_slug, "--watch"])
+                + _mship_pane("Journal", ["view", "journal", "--task", task_slug, "--watch"]))
+    if phase == "Review":
+        item = _mship_pane("Item", ["view", "item", item_id])
+        if task_slug is None:
+            return item
+        return _mship_pane("Diff", ["view", "diff", "--task", task_slug, "--watch"]) + item
+    if phase == "Run":
+        if task_slug is None:
+            return shell
+        return _mship_pane("Logs", ["view", "journal", "--task", task_slug, "--watch"]) + shell
+    return shell
+
+
+def _agent_pane(chat_command: str | None) -> str:
+    if chat_command is None:
+        return '            pane name="Agent" focus=true\n'
+    cmd = _kdl_quote(chat_command)
+    return ('            pane name="Agent" focus=true command="sh" close_on_exit=false '
+            f'{{ args "-c" {cmd}; }}\n')
+
+
+def _editor_pane() -> str:
+    return ('            pane name="Editor" command="sh" close_on_exit=false {\n'
+            '                args "-c" "${EDITOR:-$(command -v nvim || command -v vim || command -v vi)} ."\n'
+            '            }\n')
+
+
+def _phase_swap(phase: str, item_id: str, task_slug: str | None,
+                chat_command: str | None) -> str:
+    return (f'    swap_tiled_layout name="{phase}" {{\n'
+            '        tab {\n'
+            '            pane split_direction="vertical" {\n'
+            + _agent_pane(chat_command)
+            + '                pane split_direction="horizontal" size="50%" {\n'
+            + _phase_panes(phase, item_id, task_slug)
+            + '                }\n'
+            + '            }\n'
+            + _editor_pane()
+            + '        }\n'
+            '    }\n')
+
+
+def render_workitem_layout(
+    *, name: str, worktree: str, item_id: str, task_slug: str | None,
+    chat_command: str | None, default_phase: str,
+) -> str:
+    """A per-WorkItem tab KDL: chat-first Agent pane + Editor pane, all cd'd to the
+    worktree, with Plan/Dev/Review/Run phase sub-tabs (zellij swap layouts) whose
+    panes are the shipped `mship view` commands baked to this item/task. Reuses
+    _kdl_quote so paths/commands can't break out of the KDL string."""
+    base_phase = default_phase if default_phase in _PHASES else "Plan"
+    parts = [f'layout {{\n    cwd {_kdl_quote(worktree)}\n\n',
+             f'    tab name="{name}" focus=true {{\n',
+             '        pane split_direction="vertical" {\n',
+             _agent_pane(chat_command),
+             '            pane split_direction="horizontal" size="50%" {\n',
+             _phase_panes(base_phase, item_id, task_slug),
+             '            }\n',
+             '        }\n',
+             _editor_pane(),
+             '    }\n\n']
+    for phase in _PHASES:
+        parts.append(_phase_swap(phase, item_id, task_slug, chat_command))
+    parts.append('}\n')
+    return "".join(parts)
 
 
 def _serve_tab(serve_args: list[str]) -> str:

--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from pathlib import Path
 from typing import Mapping, Optional
 
@@ -286,6 +287,23 @@ def _serve_launch_path() -> Path:
     return Path.home() / ".config" / "zellij" / "mothership-serve-launch.kdl"
 
 
+def _in_zellij() -> bool:
+    """Seam: are we inside a zellij session? ($ZELLIJ is set by zellij)."""
+    return bool(os.environ.get("ZELLIJ"))
+
+
+def _query_tab_names() -> list[str]:
+    """Seam: the current session's tab names via `zellij action query-tab-names`."""
+    out = subprocess.run(["zellij", "action", "query-tab-names"],
+                         capture_output=True, text=True, check=False)
+    return [line for line in out.stdout.splitlines() if line.strip()]
+
+
+def _run_zellij_action(args: list[str]) -> None:
+    """Seam: run one `zellij action <args>`. Best-effort (check=False)."""
+    subprocess.run(["zellij", "action", *args], check=False)
+
+
 def register(app: typer.Typer, get_container):
     layout_app = typer.Typer(name="layout", help="Manage the zellij layout for mothership.", no_args_is_help=True)
 
@@ -338,5 +356,48 @@ def register(app: typer.Typer, get_container):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(kdl)
         os.execvp("zellij", ["zellij", "--layout", str(path)])
+
+    @layout_app.command()
+    def focus(
+        item_id: str = typer.Argument(..., help="WorkItem id to focus (e.g. wi-...)."),
+        chat_command: Optional[str] = typer.Option(
+            None, "--chat-command",
+            help="Command for the Agent pane. Default: your shell in the worktree."),
+    ):
+        """Open or switch to a WorkItem's zellij tab (chat-first, phase sub-tabs).
+
+        No-ops with a message when not inside a zellij session. Closes the tab
+        instead of opening it when the item has reached `done` (AC7)."""
+        if not _in_zellij():
+            typer.echo("Not inside a zellij session ($ZELLIJ unset); "
+                       "run `mship layout launch` first. (no-op)")
+            return
+        target = resolve_focus_target(get_container(), item_id)
+        if target is None:
+            typer.echo(f"Error: unknown work item: {item_id}", err=True)
+            raise typer.Exit(code=1)
+        summary, task_slug, worktree = target
+        name = tab_name_for(item_id)
+        action = decide_focus_action(name, _query_tab_names(), is_done=summary.phase == "done")
+        if action == "noop":
+            typer.echo(f"{item_id} is done; no tab to focus.")
+            return
+        if action == "close":
+            _run_zellij_action(["go-to-tab-name", name])
+            _run_zellij_action(["close-tab"])
+            typer.echo(f"Closed tab for done item {item_id}.")
+            return
+        if action == "go-to":
+            _run_zellij_action(["go-to-tab-name", name])
+            typer.echo(f"Switched to {item_id}.")
+            return
+        kdl = render_workitem_layout(
+            name=name, worktree=str(worktree), item_id=item_id, task_slug=task_slug,
+            chat_command=resolve_chat_command(chat_command, os.environ),
+            default_phase=default_phase_tab(summary.phase),
+        )
+        _run_zellij_action(["new-tab", "--layout-string", kdl, "--name", name,
+                            "--cwd", str(worktree)])
+        typer.echo(f"Opened {item_id}.")
 
     app.add_typer(layout_app, rich_help_panel="Setup")

--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -299,16 +299,21 @@ def _in_zellij() -> bool:
     return bool(os.environ.get("ZELLIJ"))
 
 
-def _query_tab_names() -> list[str]:
-    """Seam: the current session's tab names via `zellij action query-tab-names`."""
+def _query_tab_names() -> list[str] | None:
+    """Seam: the current session's tab names via `zellij action query-tab-names`.
+    Returns None if the query itself FAILED, so callers don't mistake a failure
+    for an empty session (which would create duplicate tabs / report wrong state)."""
     out = subprocess.run(["zellij", "action", "query-tab-names"],
                          capture_output=True, text=True, check=False)
+    if out.returncode != 0:
+        return None
     return [line for line in out.stdout.splitlines() if line.strip()]
 
 
-def _run_zellij_action(args: list[str]) -> None:
-    """Seam: run one `zellij action <args>`. Best-effort (check=False)."""
-    subprocess.run(["zellij", "action", *args], check=False)
+def _run_zellij_action(args: list[str]) -> bool:
+    """Seam: run one `zellij action <args>`; returns True on success (exit 0), so
+    callers can report real outcomes and never `close-tab` after a failed go-to."""
+    return subprocess.run(["zellij", "action", *args], check=False).returncode == 0
 
 
 def register(app: typer.Typer, get_container):
@@ -385,27 +390,39 @@ def register(app: typer.Typer, get_container):
             raise typer.Exit(code=1)
         summary, task_slug, worktree = target
         name = tab_name_for(item_id)
-        action = decide_focus_action(name, _query_tab_names(), is_done=summary.phase == "done")
+        existing = _query_tab_names()
+        if existing is None:
+            typer.echo("Error: could not query zellij tabs.", err=True)
+            raise typer.Exit(code=1)
+        action = decide_focus_action(name, existing, is_done=summary.phase == "done")
         if action == "noop":
             typer.echo(f"{item_id} is done; no tab to focus.")
             return
         if action == "close":
-            _run_zellij_action(["go-to-tab-name", name])
-            _run_zellij_action(["close-tab"])
-            typer.echo(f"Closed tab for done item {item_id}.")
-            return
+            # Only close AFTER a successful go-to, so a vanished/failed target can
+            # never make close-tab remove the currently-active (wrong) tab.
+            if _run_zellij_action(["go-to-tab-name", name]) and _run_zellij_action(["close-tab"]):
+                typer.echo(f"Closed tab for done item {item_id}.")
+                return
+            typer.echo(f"Error: could not close tab for {item_id}.", err=True)
+            raise typer.Exit(code=1)
         if action == "go-to":
-            _run_zellij_action(["go-to-tab-name", name])
-            typer.echo(f"Switched to {item_id}.")
-            return
+            if _run_zellij_action(["go-to-tab-name", name]):
+                typer.echo(f"Switched to {item_id}.")
+                return
+            typer.echo(f"Error: could not switch to {item_id}.", err=True)
+            raise typer.Exit(code=1)
         kdl = render_workitem_layout(
             name=name, worktree=str(worktree), item_id=item_id, task_slug=task_slug,
             chat_command=resolve_chat_command(chat_command, os.environ),
             default_phase=default_phase_tab(summary.phase),
         )
-        _run_zellij_action(["new-tab", "--layout-string", kdl, "--name", name,
-                            "--cwd", str(worktree)])
-        typer.echo(f"Opened {item_id}.")
+        if _run_zellij_action(["new-tab", "--layout-string", kdl, "--name", name,
+                               "--cwd", str(worktree)]):
+            typer.echo(f"Opened {item_id}.")
+            return
+        typer.echo(f"Error: could not open tab for {item_id}.", err=True)
+        raise typer.Exit(code=1)
 
     @layout_app.command()
     def close(
@@ -416,11 +433,19 @@ def register(app: typer.Typer, get_container):
             typer.echo("Not inside a zellij session ($ZELLIJ unset). (no-op)")
             return
         name = tab_name_for(item_id)
-        if name not in _query_tab_names():
+        existing = _query_tab_names()
+        if existing is None:
+            typer.echo("Error: could not query zellij tabs.", err=True)
+            raise typer.Exit(code=1)
+        if name not in existing:
             typer.echo(f"No open tab for {item_id}.")
             return
-        _run_zellij_action(["go-to-tab-name", name])
-        _run_zellij_action(["close-tab"])
-        typer.echo(f"Closed tab for {item_id}.")
+        # Close only after a successful go-to, so a failed go-to can't close the
+        # active tab (Overview or an unrelated item) instead of the target.
+        if _run_zellij_action(["go-to-tab-name", name]) and _run_zellij_action(["close-tab"]):
+            typer.echo(f"Closed tab for {item_id}.")
+            return
+        typer.echo(f"Error: could not close tab for {item_id}.", err=True)
+        raise typer.Exit(code=1)
 
     app.add_typer(layout_app, rich_help_panel="Setup")

--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -217,6 +217,39 @@ def render_workitem_layout(
     return "".join(parts)
 
 
+def resolve_focus_target(container, item_id: str):
+    """Resolve (WorkItemSummary, primary task_slug|None, worktree cwd) for an item,
+    or None if the id is unknown. Reuses load_workitem_index + dispatch.resolve_repo
+    (active_repo > sole worktree). Falls back to the workspace root when the item has
+    no usable worktree yet."""
+    from mship.cli.view._workitems import load_workitem_index
+    from mship.core.dispatch import resolve_repo
+
+    summary = next((s for s in load_workitem_index(container) if s.id == item_id), None)
+    if summary is None:
+        return None
+
+    state = container.state_manager().load()
+    task_slug: str | None = None
+    worktree: Path | None = None
+    for slug in summary.task_slugs:
+        task = state.tasks.get(slug)
+        if task is None:
+            continue
+        task_slug = task_slug or slug
+        try:
+            repo = resolve_repo(task, None)
+        except ValueError:
+            continue
+        worktree = Path(task.worktrees[repo])
+        task_slug = slug
+        break
+
+    if worktree is None:
+        worktree = Path(container.config_path()).parent
+    return summary, task_slug, worktree
+
+
 def _serve_tab(serve_args: list[str]) -> str:
     """The Serve tab KDL block: one pane running `mship serve <serve_args>`."""
     tokens = " ".join(_kdl_quote(a) for a in ["serve", *serve_args])

--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -407,4 +407,20 @@ def register(app: typer.Typer, get_container):
                             "--cwd", str(worktree)])
         typer.echo(f"Opened {item_id}.")
 
+    @layout_app.command()
+    def close(
+        item_id: str = typer.Argument(..., help="WorkItem id whose tab to close."),
+    ):
+        """Explicitly close a WorkItem's zellij tab so tabs don't accumulate (AC7)."""
+        if not _in_zellij():
+            typer.echo("Not inside a zellij session ($ZELLIJ unset). (no-op)")
+            return
+        name = tab_name_for(item_id)
+        if name not in _query_tab_names():
+            typer.echo(f"No open tab for {item_id}.")
+            return
+        _run_zellij_action(["go-to-tab-name", name])
+        _run_zellij_action(["close-tab"])
+        typer.echo(f"Closed tab for {item_id}.")
+
     app.add_typer(layout_app, rich_help_panel="Setup")

--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -17,7 +17,14 @@ layout {
         }
     }
 
-    tab name="Plan" focus=true {
+    tab name="Overview" focus=true {
+        pane split_direction="vertical" {
+            pane size="50%" name="Queue" command="mship" close_on_exit=false { args "view" "queue"; }
+            pane size="50%" name="Items" command="mship" close_on_exit=false { args "view" "items"; }
+        }
+    }
+
+    tab name="Plan" {
         pane split_direction="vertical" {
             pane size="50%" name="Agent"
             pane split_direction="horizontal" size="50%" {

--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -93,6 +93,21 @@ def _kdl_quote(s: str) -> str:
     return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
 
 
+def tab_name_for(item_id: str) -> str:
+    """Deterministic zellij tab name for a WorkItem. The id verbatim: the same
+    item always maps to the same tab, so focus reconciles rather than duplicates."""
+    return item_id
+
+
+def decide_focus_action(tab_name: str, existing_tab_names: list[str], *, is_done: bool) -> str:
+    """Pure go-vs-create-vs-close decision for `mship layout focus`.
+    Returns "close" | "noop" | "go-to" | "create"."""
+    exists = tab_name in existing_tab_names
+    if is_done:
+        return "close" if exists else "noop"
+    return "go-to" if exists else "create"
+
+
 def _serve_tab(serve_args: list[str]) -> str:
     """The Serve tab KDL block: one pane running `mship serve <serve_args>`."""
     tokens = " ".join(_kdl_quote(a) for a in ["serve", *serve_args])

--- a/src/mship/cli/view/__init__.py
+++ b/src/mship/cli/view/__init__.py
@@ -9,6 +9,7 @@ def register(parent: typer.Typer, get_container):
     from mship.cli.view import diff as _diff
     from mship.cli.view import spec as _spec
     from mship.cli.view import workitem as _workitem
+    from mship.cli.view import items as _items
     from mship.cli.view import queue as _queue
 
     _status.register(app, get_container)
@@ -16,6 +17,7 @@ def register(parent: typer.Typer, get_container):
     _diff.register(app, get_container)
     _spec.register(app, get_container)
     _workitem.register(app, get_container)
+    _items.register(app, get_container)
     _queue.register(app, get_container)
 
     parent.add_typer(app, name="view", rich_help_panel="Inspection")

--- a/src/mship/cli/view/items.py
+++ b/src/mship/cli/view/items.py
@@ -1,0 +1,62 @@
+"""`mship view items` — the workspace's WorkItems picker on the master/detail base
+(AC2). Reuses load_workitem_index + the pure items formatters. `enter` on a row
+composes with `mship layout focus <id>` (AC6)."""
+from __future__ import annotations
+
+import subprocess
+
+import typer
+
+from mship.cli.view._master_detail import ListRow, MasterDetailApp
+from mship.core.view.items import items_detail, items_label, items_render_text
+
+
+def _focus_workitem(item_id: str) -> None:
+    """Seam: fire `mship layout focus <id>` for the selected item. Best-effort;
+    a missing zellij / non-session degrades inside the focus command itself."""
+    subprocess.run(["mship", "layout", "focus", item_id], check=False)
+
+
+class ItemsView(MasterDetailApp):
+    def __init__(self, summaries, **kw) -> None:
+        super().__init__(**kw)
+        self._summaries = list(summaries)
+
+    def list_rows(self) -> list[ListRow]:
+        return [ListRow(key=s.id, label=items_label(s), detail=items_detail(s))
+                for s in self._summaries]
+
+    def header_line(self) -> str | None:
+        return f"WorkItems ({len(self._summaries)})"
+
+    def _do_open_entity(self) -> bool:
+        key = self.selected_key()
+        if key is None:
+            return False
+        _focus_workitem(key)
+        self._announce(f"Focusing {key}")
+        return True
+
+    def _do_copy(self) -> None:
+        key = self.selected_key()
+        if key:
+            self.copy_to_clipboard(key)
+            self._announce(f"Copied {key}")
+        else:
+            self._announce("Nothing to copy here.")
+
+
+def register(app: "typer.Typer", get_container):
+    @app.command()
+    def items():
+        """This workspace's WorkItems as a navigable picker: id, title, derived
+        phase, and attention. enter focuses the item's zellij tab · y copies id."""
+        from mship.cli.view._workitems import load_workitem_index
+        from mship.cli.output import Output
+
+        container = get_container()
+        summaries = load_workitem_index(container)
+        if not Output().is_tty:
+            typer.echo(items_render_text(summaries))
+            return
+        ItemsView(summaries).run()

--- a/src/mship/cli/view/items.py
+++ b/src/mship/cli/view/items.py
@@ -11,10 +11,10 @@ from mship.cli.view._master_detail import ListRow, MasterDetailApp
 from mship.core.view.items import items_detail, items_label, items_render_text
 
 
-def _focus_workitem(item_id: str) -> None:
-    """Seam: fire `mship layout focus <id>` for the selected item. Best-effort;
-    a missing zellij / non-session degrades inside the focus command itself."""
-    subprocess.run(["mship", "layout", "focus", item_id], check=False)
+def _focus_workitem(item_id: str) -> bool:
+    """Seam: fire `mship layout focus <id>` for the selected item; returns True on
+    success (exit 0) so the picker can report a real outcome, not a false success."""
+    return subprocess.run(["mship", "layout", "focus", item_id], check=False).returncode == 0
 
 
 class ItemsView(MasterDetailApp):
@@ -33,8 +33,10 @@ class ItemsView(MasterDetailApp):
         key = self.selected_key()
         if key is None:
             return False
-        _focus_workitem(key)
-        self._announce(f"Focusing {key}")
+        if _focus_workitem(key):
+            self._announce(f"Focusing {key}")
+        else:
+            self._announce(f"Could not focus {key} (is zellij running?)")
         return True
 
     def _do_copy(self) -> None:

--- a/src/mship/cli/view/workitem.py
+++ b/src/mship/cli/view/workitem.py
@@ -210,12 +210,7 @@ def _resolve_cockpit(container, item_id: str) -> WorkItemCockpit | None:
 
 
 def register(app: "typer.Typer", get_container):
-    @app.command()
-    def workitem(
-        item_id: str = typer.Argument(..., help="WorkItem id to open (e.g. wi-...)"),
-    ):
-        """Single-WorkItem cockpit: spec (status + phase), acceptance criteria with
-        evidence, tasks + worktrees, and linked PRs + threads."""
+    def _run_item_cockpit(item_id: str) -> None:
         from mship.cli.output import Output
         from mship.core.view.workitem_cockpit import render_text
 
@@ -236,3 +231,22 @@ def register(app: "typer.Typer", get_container):
         workspace_root = Path(container.config_path()).parent
         store = SpecStore(workspace_root / SPECS_DIRNAME)
         WorkItemCockpitView(cockpit, spec_store=store).run()
+
+    @app.command(name="item")
+    def item(
+        item_id: str = typer.Argument(..., help="WorkItem id to open (e.g. wi-...)"),
+    ):
+        """Single-WorkItem cockpit: spec (status + phase), acceptance criteria with
+        evidence, tasks + worktrees, and linked PRs + threads."""
+        _run_item_cockpit(item_id)
+
+    @app.command(name="workitem", hidden=True)
+    def workitem(
+        item_id: str = typer.Argument(..., help="Deprecated alias for `view item`."),
+    ):
+        """Deprecated: use `mship view item <id>`."""
+        typer.echo(
+            "Note: `mship view workitem` is deprecated; use `mship view item`.",
+            err=True,
+        )
+        _run_item_cockpit(item_id)

--- a/src/mship/core/view/items.py
+++ b/src/mship/core/view/items.py
@@ -1,0 +1,36 @@
+"""Pure row formatters for `mship view items` — the WorkItems picker. Mirrors
+core/view/queue.py: label/detail/render_text over the shared WorkItemSummary
+index (id/title/derived-phase/attention), no store wiring here."""
+from __future__ import annotations
+
+from mship.core.view.workitem_index import WorkItemSummary
+
+
+def _attention_marker(s: WorkItemSummary) -> str:
+    a = s.attention
+    if a.needs_approval or a.needs_decision or a.blocked or a.needs_review:
+        return "!"
+    return " "
+
+
+def items_label(s: WorkItemSummary) -> str:
+    return f"{_attention_marker(s)} {s.id}  {s.title or '(untitled)'}  [{s.phase}]"
+
+
+def items_detail(s: WorkItemSummary) -> str:
+    a = s.attention
+    lines = [
+        f"{s.id}  {s.title}",
+        f"phase: {s.phase}",
+        f"spec: {s.spec_id or '(none)'}",
+        f"tasks: {', '.join(s.task_slugs) or '(none)'}",
+        f"attention: approval={a.needs_approval} decision={a.needs_decision} "
+        f"blocked={a.blocked} review={a.needs_review}",
+    ]
+    return "\n".join(lines)
+
+
+def items_render_text(summaries: list[WorkItemSummary]) -> str:
+    if not summaries:
+        return "No work items."
+    return "\n".join(items_label(s) for s in summaries)

--- a/tests/cli/test_layout.py
+++ b/tests/cli/test_layout.py
@@ -58,9 +58,22 @@ def test_render_serve_layout_no_args_has_base_tabs_plus_serve():
         assert f'tab name="{name}"' in kdl
     assert 'command="mship"' in kdl
     assert 'args "serve";' in kdl
-    # Serve tab comes AFTER Run, and Plan keeps focus.
+    # Serve tab comes AFTER Run, and Overview is the launchpad and keeps focus.
+    assert 'tab name="Overview" focus=true' in kdl
     assert kdl.index('tab name="Run"') < kdl.index('tab name="Serve"')
-    assert 'tab name="Plan" focus=true' in kdl
+
+
+def test_template_has_overview_launchpad_tab():
+    assert 'tab name="Overview" focus=true' in _TEMPLATE
+    start = _TEMPLATE.index('tab name="Overview"')
+    end = _TEMPLATE.index('tab name="Plan"', start)
+    overview = _TEMPLATE[start:end]
+    assert '"view" "queue"' in overview
+    assert '"view" "items"' in overview
+
+
+def test_overview_precedes_plan():
+    assert _TEMPLATE.index('tab name="Overview"') < _TEMPLATE.index('tab name="Plan"')
 
 
 def test_render_serve_layout_threads_flags():

--- a/tests/cli/test_layout_focus.py
+++ b/tests/cli/test_layout_focus.py
@@ -162,3 +162,71 @@ def test_resolve_focus_target_no_worktree_falls_back_to_workspace_root(tmp_path)
         assert worktree == tmp_path   # workspace root (config_path parent)
     finally:
         _reset_focus()
+
+
+# --- Task 6: mship layout focus driver ---------------------------------------
+import mship.cli.layout as layout_mod
+from mship.cli import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _patch_zellij(monkeypatch, *, in_session, existing):
+    calls = []
+    monkeypatch.setattr(layout_mod, "_in_zellij", lambda: in_session)
+    monkeypatch.setattr(layout_mod, "_query_tab_names", lambda: list(existing))
+    monkeypatch.setattr(layout_mod, "_run_zellij_action", lambda args: calls.append(args))
+    return calls
+
+
+def test_focus_outside_zellij_noops_with_message(tmp_path, monkeypatch):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    calls = _patch_zellij(monkeypatch, in_session=False, existing=[])
+    try:
+        result = runner.invoke(app, ["layout", "focus", "wi-1"])
+        assert result.exit_code == 0, result.output
+        assert "zellij" in result.output.lower()
+        assert calls == []   # no zellij action attempted
+    finally:
+        _reset_focus()
+
+
+def test_focus_creates_tab_when_absent(tmp_path, monkeypatch):
+    wt = tmp_path / "wt-a"
+    _seed_focus(tmp_path, {"r": wt})
+    calls = _patch_zellij(monkeypatch, in_session=True, existing=["Overview"])
+    try:
+        result = runner.invoke(app, ["layout", "focus", "wi-1"])
+        assert result.exit_code == 0, result.output
+        assert len(calls) == 1
+        args = calls[0]
+        assert args[0] == "new-tab"
+        assert "--name" in args and "wi-1" in args
+        assert "--cwd" in args and str(wt) in args
+        kdl = args[args.index("--layout-string") + 1]
+        assert 'tab name="wi-1"' in kdl and 'name="Agent"' in kdl
+    finally:
+        _reset_focus()
+
+
+def test_focus_switches_to_existing_tab(tmp_path, monkeypatch):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    calls = _patch_zellij(monkeypatch, in_session=True, existing=["wi-1"])
+    try:
+        result = runner.invoke(app, ["layout", "focus", "wi-1"])
+        assert result.exit_code == 0, result.output
+        assert calls == [["go-to-tab-name", "wi-1"]]
+    finally:
+        _reset_focus()
+
+
+def test_focus_unknown_id_exits_1(tmp_path, monkeypatch):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    _patch_zellij(monkeypatch, in_session=True, existing=[])
+    try:
+        result = runner.invoke(app, ["layout", "focus", "wi-missing"])
+        assert result.exit_code == 1
+        assert "wi-missing" in result.output
+    finally:
+        _reset_focus()

--- a/tests/cli/test_layout_focus.py
+++ b/tests/cli/test_layout_focus.py
@@ -230,3 +230,54 @@ def test_focus_unknown_id_exits_1(tmp_path, monkeypatch):
         assert "wi-missing" in result.output
     finally:
         _reset_focus()
+
+
+# --- Task 8: explicit close + close-on-done lifecycle ------------------------
+def test_close_closes_existing_tab(tmp_path, monkeypatch):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    calls = _patch_zellij(monkeypatch, in_session=True, existing=["wi-1"])
+    try:
+        result = runner.invoke(app, ["layout", "close", "wi-1"])
+        assert result.exit_code == 0, result.output
+        assert calls == [["go-to-tab-name", "wi-1"], ["close-tab"]]
+    finally:
+        _reset_focus()
+
+
+def test_close_no_tab_is_noop(tmp_path, monkeypatch):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    calls = _patch_zellij(monkeypatch, in_session=True, existing=["Overview"])
+    try:
+        result = runner.invoke(app, ["layout", "close", "wi-1"])
+        assert result.exit_code == 0, result.output
+        assert calls == []
+    finally:
+        _reset_focus()
+
+
+def test_close_outside_zellij_noops(tmp_path, monkeypatch):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    calls = _patch_zellij(monkeypatch, in_session=False, existing=["wi-1"])
+    try:
+        result = runner.invoke(app, ["layout", "close", "wi-1"])
+        assert result.exit_code == 0
+        assert "zellij" in result.output.lower()
+        assert calls == []
+    finally:
+        _reset_focus()
+
+
+def test_focus_done_item_closes_its_tab(tmp_path, monkeypatch):
+    # A done item (terminal spec status) whose tab exists is closed, not re-opened.
+    from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    spec = SpecStore(tmp_path / SPECS_DIRNAME).find_by_id("spec-1")
+    SpecStore(tmp_path / SPECS_DIRNAME).save(spec.model_copy(update={"status": "archived"}))
+    calls = _patch_zellij(monkeypatch, in_session=True, existing=["wi-1"])
+    try:
+        result = runner.invoke(app, ["layout", "focus", "wi-1"])
+        assert result.exit_code == 0, result.output
+        assert calls == [["go-to-tab-name", "wi-1"], ["close-tab"]]
+        assert "done" in result.output.lower() or "closed" in result.output.lower()
+    finally:
+        _reset_focus()

--- a/tests/cli/test_layout_focus.py
+++ b/tests/cli/test_layout_focus.py
@@ -92,3 +92,73 @@ def test_kdl_without_task_degrades_task_scoped_panes():
     kdl = _kdl(task_slug=None)
     assert "--task" not in kdl
     assert 'name="Shell"' in kdl   # task-scoped panes fall back to a shell
+
+
+# --- Task 5: resolve_focus_target --------------------------------------------
+from datetime import datetime, timezone
+from pathlib import Path
+
+from mship.cli import container
+from mship.cli.layout import resolve_focus_target
+from mship.core.spec import Spec
+from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.workitem import WorkItem
+from mship.core.workitem_store import WorkItemStore
+
+
+def _dt():
+    return datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+
+def _seed_focus(tmp_path, worktrees):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    SpecStore(tmp_path / SPECS_DIRNAME).save(Spec(
+        id="spec-1", title="Overhaul", status="approved",
+        created_at=_dt(), updated_at=_dt(), body="b\n"))
+    WorkItemStore(state_dir / "workitems").save(WorkItem(
+        id="wi-1", title="Overhaul", workspace="t", kind="feature",
+        created_at=_dt(), updated_at=_dt(), spec_id="spec-1", task_slugs=["a"]))
+    StateManager(state_dir).save(WorkspaceState(tasks={"a": Task(
+        slug="a", description="d", phase="dev", created_at=_dt(),
+        affected_repos=["r"], branch="feat/a", worktrees=worktrees, work_item_id="wi-1")}))
+    container.config.reset(); container.state_manager.reset()
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(state_dir)
+
+
+def _reset_focus():
+    container.config_path.reset_override(); container.state_dir.reset_override()
+    container.config.reset_override(); container.config.reset()
+    container.state_manager.reset_override(); container.state_manager.reset()
+
+
+def test_resolve_focus_target_returns_worktree_and_task(tmp_path):
+    wt = tmp_path / "wt-a"
+    _seed_focus(tmp_path, {"r": wt})
+    try:
+        summary, task_slug, worktree = resolve_focus_target(container, "wi-1")
+        assert summary.id == "wi-1"
+        assert task_slug == "a"
+        assert worktree == wt
+    finally:
+        _reset_focus()
+
+
+def test_resolve_focus_target_unknown_id_is_none(tmp_path):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    try:
+        assert resolve_focus_target(container, "wi-missing") is None
+    finally:
+        _reset_focus()
+
+
+def test_resolve_focus_target_no_worktree_falls_back_to_workspace_root(tmp_path):
+    _seed_focus(tmp_path, {})
+    try:
+        summary, task_slug, worktree = resolve_focus_target(container, "wi-1")
+        assert worktree == tmp_path   # workspace root (config_path parent)
+    finally:
+        _reset_focus()

--- a/tests/cli/test_layout_focus.py
+++ b/tests/cli/test_layout_focus.py
@@ -20,3 +20,75 @@ def test_decision_close_when_done_and_present():
 
 def test_decision_noop_when_done_and_absent():
     assert decide_focus_action("wi-1", ["other"], is_done=True) == "noop"
+
+
+# --- Task 4: per-WorkItem KDL renderer ---------------------------------------
+from mship.cli.layout import (
+    default_phase_tab, render_workitem_layout, resolve_chat_command,
+)
+
+
+def test_resolve_chat_command_precedence():
+    assert resolve_chat_command("claude", {}) == "claude"
+    assert resolve_chat_command(None, {"MSHIP_CHAT_COMMAND": "my-agent"}) == "my-agent"
+    assert resolve_chat_command(None, {}) is None  # default: bare shell pane
+
+
+def test_default_phase_tab_mapping():
+    assert default_phase_tab("shaping") == "Plan"
+    assert default_phase_tab("ready") == "Plan"
+    assert default_phase_tab("in_flight") == "Dev"
+    assert default_phase_tab("review") == "Review"
+    assert default_phase_tab("done") == "Run"
+    assert default_phase_tab("something-else") == "Plan"
+
+
+def _kdl(**over):
+    base = dict(name="wi-1", worktree="/wt/a", item_id="wi-1", task_slug="a",
+                chat_command=None, default_phase="Dev")
+    base.update(over)
+    return render_workitem_layout(**base)
+
+
+def test_kdl_is_chat_first_with_editor_and_cwd():
+    kdl = _kdl()
+    assert 'tab name="wi-1" focus=true' in kdl
+    assert 'cwd "/wt/a"' in kdl
+    assert 'name="Agent"' in kdl
+    assert 'name="Editor"' in kdl
+    # Default chat command == bare shell pane (no command= on Agent).
+    assert 'name="Agent" focus=true {' not in kdl  # bare pane has no child block
+
+
+def test_kdl_configurable_chat_command():
+    kdl = _kdl(chat_command="claude")
+    assert 'name="Agent"' in kdl and 'command="sh"' in kdl
+    assert '"-c" "claude"' in kdl
+
+
+def test_kdl_has_all_four_phase_subtabs():
+    kdl = _kdl()
+    for phase in ("Plan", "Dev", "Review", "Run"):
+        assert f'swap_tiled_layout name="{phase}"' in kdl
+
+
+def test_kdl_bakes_shipped_view_commands_with_item_and_task():
+    kdl = _kdl()
+    assert '"view" "spec" "--workitem" "wi-1" "--watch"' in kdl   # Plan
+    assert '"view" "diff" "--task" "a" "--watch"' in kdl           # Dev/Review
+    assert '"view" "journal" "--task" "a" "--watch"' in kdl        # Dev + Run
+    assert '"view" "item" "wi-1"' in kdl                            # Review (PR/checks)
+    # NOTE: `mship view logs` does not exist — the only run/journal view command is
+    # `view journal` (logs.py registers it as `journal`). The Run sub-tab therefore
+    # tails `view journal` (asserted above), not a nonexistent `view logs`.
+
+
+def test_kdl_escapes_worktree_path():
+    kdl = _kdl(worktree='/wt/ba"d')
+    assert 'cwd "/wt/ba\\"d"' in kdl
+
+
+def test_kdl_without_task_degrades_task_scoped_panes():
+    kdl = _kdl(task_slug=None)
+    assert "--task" not in kdl
+    assert 'name="Shell"' in kdl   # task-scoped panes fall back to a shell

--- a/tests/cli/test_layout_focus.py
+++ b/tests/cli/test_layout_focus.py
@@ -172,11 +172,17 @@ from typer.testing import CliRunner
 runner = CliRunner()
 
 
-def _patch_zellij(monkeypatch, *, in_session, existing):
+def _patch_zellij(monkeypatch, *, in_session, existing, action_ok=True, query_ok=True):
     calls = []
+
+    def _run(args):
+        calls.append(args)
+        return action_ok
+
     monkeypatch.setattr(layout_mod, "_in_zellij", lambda: in_session)
-    monkeypatch.setattr(layout_mod, "_query_tab_names", lambda: list(existing))
-    monkeypatch.setattr(layout_mod, "_run_zellij_action", lambda args: calls.append(args))
+    monkeypatch.setattr(layout_mod, "_query_tab_names",
+                        lambda: (list(existing) if query_ok else None))
+    monkeypatch.setattr(layout_mod, "_run_zellij_action", _run)
     return calls
 
 
@@ -279,5 +285,51 @@ def test_focus_done_item_closes_its_tab(tmp_path, monkeypatch):
         assert result.exit_code == 0, result.output
         assert calls == [["go-to-tab-name", "wi-1"], ["close-tab"]]
         assert "done" in result.output.lower() or "closed" in result.output.lower()
+    finally:
+        _reset_focus()
+
+
+# --- Greptile #396: seams report failure; never close the wrong tab ---
+def test_focus_errors_when_tab_query_fails(tmp_path, monkeypatch):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    calls = _patch_zellij(monkeypatch, in_session=True, existing=[], query_ok=False)
+    try:
+        result = runner.invoke(app, ["layout", "focus", "wi-1"])
+        assert result.exit_code == 1
+        assert calls == []   # can't read tab state -> attempt nothing (no dup tab)
+    finally:
+        _reset_focus()
+
+
+def test_focus_new_tab_failure_reports_error(tmp_path, monkeypatch):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    _patch_zellij(monkeypatch, in_session=True, existing=["Overview"], action_ok=False)
+    try:
+        result = runner.invoke(app, ["layout", "focus", "wi-1"])
+        assert result.exit_code == 1
+        assert "could not open" in result.output.lower()
+    finally:
+        _reset_focus()
+
+
+def test_close_does_not_close_wrong_tab_when_go_to_fails(tmp_path, monkeypatch):
+    # go-to fails -> close-tab must NOT run (else it closes the active/wrong tab).
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    calls = _patch_zellij(monkeypatch, in_session=True, existing=["wi-1"], action_ok=False)
+    try:
+        result = runner.invoke(app, ["layout", "close", "wi-1"])
+        assert result.exit_code == 1
+        assert calls == [["go-to-tab-name", "wi-1"]]   # close-tab NOT called
+    finally:
+        _reset_focus()
+
+
+def test_close_errors_when_tab_query_fails(tmp_path, monkeypatch):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    calls = _patch_zellij(monkeypatch, in_session=True, existing=["wi-1"], query_ok=False)
+    try:
+        result = runner.invoke(app, ["layout", "close", "wi-1"])
+        assert result.exit_code == 1
+        assert calls == []
     finally:
         _reset_focus()

--- a/tests/cli/test_layout_focus.py
+++ b/tests/cli/test_layout_focus.py
@@ -1,0 +1,22 @@
+from mship.cli.layout import decide_focus_action, tab_name_for
+
+
+def test_tab_name_is_deterministic_and_id_based():
+    assert tab_name_for("wi-20260721-abc") == tab_name_for("wi-20260721-abc")
+    assert "wi-20260721-abc" in tab_name_for("wi-20260721-abc")
+
+
+def test_decision_create_when_absent():
+    assert decide_focus_action("wi-1", [], is_done=False) == "create"
+
+
+def test_decision_go_to_when_present():
+    assert decide_focus_action("wi-1", ["other", "wi-1"], is_done=False) == "go-to"
+
+
+def test_decision_close_when_done_and_present():
+    assert decide_focus_action("wi-1", ["wi-1"], is_done=True) == "close"
+
+
+def test_decision_noop_when_done_and_absent():
+    assert decide_focus_action("wi-1", ["other"], is_done=True) == "noop"

--- a/tests/cli/view/test_items_view.py
+++ b/tests/cli/view/test_items_view.py
@@ -75,3 +75,24 @@ async def test_items_view_lists_and_enter_focuses(tmp_path, monkeypatch):
         await pilot.press("enter")
         await pilot.pause()
         assert fired.get("id") == "wi-1"
+
+
+@pytest.mark.asyncio
+async def test_items_enter_announces_focus_failure(monkeypatch):
+    # Greptile #396: a failed `mship layout focus` must not report success.
+    from mship.core.view.workitem_index import Attention, WorkItemSummary
+    import mship.cli.view.items as iv
+
+    monkeypatch.setattr(iv, "_focus_workitem", lambda item_id: False)
+    s = WorkItemSummary(
+        id="wi-1", title="X", kind="feature", workspace="t", phase="in_flight",
+        attention=Attention(False, False, False, False, 0, 1),
+        created_at=_now(), updated_at=_now(), spec_id=None, task_slugs=[], thread_ids=[])
+    view = iv.ItemsView([s])
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        view._master.focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert "could not focus" in view.last_action().lower()

--- a/tests/cli/view/test_items_view.py
+++ b/tests/cli/view/test_items_view.py
@@ -1,0 +1,77 @@
+from datetime import datetime, timezone
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.spec import Spec
+from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.workitem import WorkItem
+from mship.core.workitem_store import WorkItemStore
+
+
+def _now():
+    return datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+
+def _seed(tmp_path):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    SpecStore(tmp_path / SPECS_DIRNAME).save(Spec(
+        id="spec-1", title="Overhaul", status="approved",
+        created_at=_now(), updated_at=_now(), body="b\n"))
+    WorkItemStore(state_dir / "workitems").save(WorkItem(
+        id="wi-1", title="Overhaul", workspace="t", kind="feature",
+        created_at=_now(), updated_at=_now(), spec_id="spec-1", task_slugs=["a"]))
+    StateManager(state_dir).save(WorkspaceState(tasks={"a": Task(
+        slug="a", description="d", phase="dev", created_at=_now(),
+        affected_repos=["r"], branch="feat/a", worktrees={}, work_item_id="wi-1")}))
+    container.config.reset(); container.state_manager.reset()
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(state_dir)
+
+
+def _reset():
+    container.config_path.reset_override(); container.state_dir.reset_override()
+    container.config.reset_override(); container.config.reset()
+    container.state_manager.reset_override(); container.state_manager.reset()
+
+
+def test_items_registered_in_view_help():
+    result = CliRunner().invoke(app, ["view", "--help"])
+    assert result.exit_code == 0
+    assert "items" in result.stdout
+
+
+def test_items_cli_renders_text(tmp_path):
+    _seed(tmp_path)
+    try:
+        result = CliRunner().invoke(app, ["view", "items"])
+        assert result.exit_code == 0, result.output
+        assert "wi-1" in result.output and "Overhaul" in result.output
+    finally:
+        _reset()
+
+
+@pytest.mark.asyncio
+async def test_items_view_lists_and_enter_focuses(tmp_path, monkeypatch):
+    from mship.core.view.workitem_index import Attention, WorkItemSummary
+    import mship.cli.view.items as iv
+
+    fired = {}
+    monkeypatch.setattr(iv, "_focus_workitem", lambda item_id: fired.setdefault("id", item_id))
+    s = WorkItemSummary(
+        id="wi-1", title="Overhaul", kind="feature", workspace="t", phase="in_flight",
+        attention=Attention(False, False, False, False, 0, 1),
+        created_at=_now(), updated_at=_now(), spec_id="spec-1", task_slugs=["a"], thread_ids=[])
+    view = iv.ItemsView([s])
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        assert any("wi-1" in l for l in view.list_labels())
+        view._master.focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert fired.get("id") == "wi-1"

--- a/tests/cli/view/test_workitem_view.py
+++ b/tests/cli/view/test_workitem_view.py
@@ -116,17 +116,29 @@ def _reset():
     container.state_manager.reset()
 
 
-def test_workitem_registered_in_view_help():
+def test_item_and_items_registered_in_view_help():
     result = CliRunner().invoke(app, ["view", "--help"])
     assert result.exit_code == 0
-    assert "workitem" in result.stdout
+    assert "item" in result.stdout
+
+
+def test_workitem_alias_still_renders_cockpit(tmp_path):
+    _seed_workspace(tmp_path)
+    try:
+        result = CliRunner().invoke(app, ["view", "workitem", "wi-1"])
+        assert result.exit_code == 0, result.output
+        assert "wi-1" in result.output and "Overhaul" in result.output
+        assert "deprecated" in result.output.lower()
+        assert "mship view item" in result.output
+    finally:
+        _reset()
 
 
 def test_workitem_cli_renders_cockpit_text(tmp_path):
     _seed_workspace(tmp_path)
     try:
         # CliRunner stdout is not a TTY -> non-TTY text short-circuit (no TUI hang).
-        result = CliRunner().invoke(app, ["view", "workitem", "wi-1"])
+        result = CliRunner().invoke(app, ["view", "item", "wi-1"])
         assert result.exit_code == 0, result.output
         assert "wi-1" in result.output and "Overhaul" in result.output
         assert "needs_review" in result.output
@@ -141,7 +153,7 @@ def test_workitem_cli_renders_cockpit_text(tmp_path):
 def test_workitem_cli_unknown_id_exits_1(tmp_path):
     _seed_workspace(tmp_path)
     try:
-        result = CliRunner().invoke(app, ["view", "workitem", "wi-missing"])
+        result = CliRunner().invoke(app, ["view", "item", "wi-missing"])
         assert result.exit_code == 1
         assert "wi-missing" in result.output
     finally:

--- a/tests/core/view/test_items.py
+++ b/tests/core/view/test_items.py
@@ -1,0 +1,41 @@
+from datetime import datetime, timezone
+
+from mship.core.view.items import items_detail, items_label, items_render_text
+from mship.core.view.workitem_index import Attention, WorkItemSummary
+
+
+def _summary(**over):
+    base = dict(
+        id="wi-1", title="Overhaul", kind="feature", workspace="t",
+        phase="in_flight",
+        attention=Attention(needs_approval=True, needs_decision=False, blocked=False,
+                            needs_review=False, blocked_tasks=0, total_tasks=1),
+        created_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        spec_id="spec-1", task_slugs=["a"], thread_ids=[],
+    )
+    base.update(over)
+    return WorkItemSummary(**base)
+
+
+def test_items_label_has_id_title_phase_and_attention_marker():
+    label = items_label(_summary())
+    assert "wi-1" in label and "Overhaul" in label and "[in_flight]" in label
+    assert "!" in label  # needs_approval surfaces an attention marker
+
+
+def test_items_label_no_attention_has_no_marker():
+    label = items_label(_summary(attention=Attention(
+        needs_approval=False, needs_decision=False, blocked=False,
+        needs_review=False, blocked_tasks=0, total_tasks=1)))
+    assert "!" not in label
+
+
+def test_items_detail_lists_links():
+    detail = items_detail(_summary())
+    assert "spec-1" in detail and "a" in detail
+
+
+def test_items_render_text_lists_all():
+    text = items_render_text([_summary(id="wi-1"), _summary(id="wi-2", title="Second")])
+    assert "wi-1" in text and "wi-2" in text and "Second" in text


### PR DESCRIPTION
**Spec:** `workitem-focused-zellij-cockpit` (all 7 ACs delivered in this PR)

The layout-integration follow-on to the `mship view` overhaul: turns the per-pane views into a **switchable, WorkItem-focused zellij cockpit**, driven entirely off the shipped `mship view` commands and the existing `mship layout` KDL renderer.

## What this PR delivers

- **`mship layout focus <item-id>`** — opens or switches to a WorkItem's zellij tab: `go-to-tab-name` if it exists, else `new-tab --layout-string <kdl>` with the tab cd'd to the item's task worktree; closes the tab instead when the item is `done`. No-ops with a clear message when not inside a zellij session.
- **Chat-first per-WorkItem tab** — a primary Agent pane running a **configurable** command (default: your shell in the worktree — no hardcoded agent), an Editor pane, and explicit **Plan/Dev/Review/Run phase sub-tabs** whose panes are the shipped views baked to the item (Plan: `view spec`/`view item`; Dev: `view diff`+`view journal`; Review: PR/checks + diff; Run: journal).
- **`mship view item <id>`** — the cockpit, renamed from `mship view workitem` (kept as a hidden deprecation alias), and **`mship view items`** — a WorkItems picker on the master/detail base; `enter` focuses an item's tab (composes with `mship layout focus`).
- **Overview launchpad tab** — `mship layout` now opens with an Overview tab (`view queue` + `view items`) as the driver; **`mship layout close <id>`** + close-on-done keep tabs from piling up.

## Design

All the logic that can be — tab-name derivation, the go/create/close decision, the per-item KDL rendering, cwd/task resolution, chat-command resolution — is **pure and unit-tested without a live zellij**; the actual `zellij action` subprocess sits behind three thin seams the tests mock. mship stays the ambient/orchestration layer: the agent conversation is the primary surface, the editor secondary.

## Acceptance criteria — all delivered

- [x] `ac1` `view item` (renamed, aliased) + `view items` registered
- [x] `ac2` `view items` WorkItems picker on master/detail
- [x] `ac3` `mship layout focus` go/create with worktree cwd; graceful no-op outside zellij
- [x] `ac4` chat-first tab: configurable Agent pane + phase sub-tabs + Editor
- [x] `ac5` each phase sub-tab = shipped view commands baked to the item
- [x] `ac6` Overview launchpad tab; picking an item focuses it
- [x] `ac7` tab closed on `done` / explicit close

## Tests

8 TDD commits. `uv run pytest tests/cli/view tests/core/view tests/cli/test_layout.py tests/cli/test_layout_focus.py` → **330 passed**. Full mothership suite green via `mship test`. One plan bug caught + fixed: `view logs` doesn't exist, so the Run sub-tab uses `view journal`.

🤖 Generated with [Claude Code](https://claude.ai/code)
