### PR TITLE
Fix WorkItem cockpit: portable zellij tab + drop legacy base tabs + picker affordances

### DIFF
--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -23,59 +23,19 @@ layout {
             pane size="50%" name="Items" command="mship" close_on_exit=false { args "view" "items"; }
         }
     }
-
-    tab name="Plan" {
-        pane split_direction="vertical" {
-            pane size="50%" name="Agent"
-            pane split_direction="horizontal" size="50%" {
-                pane name="Specs" command="mship" close_on_exit=false { args "view" "spec" "--watch"; }
-                pane name="Status" command="mship" close_on_exit=false { args "view" "status" "--watch"; }
-            }
-        }
-    }
-
-    tab name="Dev" {
-        pane split_direction="vertical" {
-            pane size="60%" name="Editor" command="sh" close_on_exit=false {
-                args "-c" "${EDITOR:-$(command -v nvim || command -v vim || command -v vi)} ."
-            }
-            pane split_direction="horizontal" size="40%" {
-                pane name="Journal" command="mship" close_on_exit=false { args "view" "journal" "--watch"; }
-                pane name="Status" command="mship" close_on_exit=false { args "view" "status" "--watch"; }
-            }
-        }
-    }
-
-    tab name="Review" {
-        pane split_direction="vertical" {
-            pane size="70%" name="Diff" command="mship" close_on_exit=false { args "view" "diff" "--watch"; }
-            pane size="30%" split_direction="horizontal" {
-                pane name="Shell"
-                pane name="Journal" command="mship" close_on_exit=false { args "view" "journal" "--watch"; }
-            }
-        }
-    }
-
-    tab name="Run" {
-        pane split_direction="vertical" {
-            pane size="60%" name="Shell"
-            pane split_direction="horizontal" size="40%" {
-                pane name="Journal" command="mship" close_on_exit=false { args "view" "journal" "--watch"; }
-                pane name="Status" command="mship" close_on_exit=false { args "view" "status" "--watch"; }
-            }
-        }
-    }
 }
 """
 
 # Composable parts, sliced from _TEMPLATE at stable markers so the normal layout
 # is reconstructed byte-for-byte (_LAYOUT_HEAD + _BASE_TABS + _LAYOUT_TAIL == _TEMPLATE)
-# while the serve layout can reuse the base tabs and append a Serve tab. The final
-# layout-closing "}" is the only brace at column 0, so `\n}\n` locates it uniquely.
-_plan_idx = _TEMPLATE.index('    tab name="Plan"')
+# while the serve layout can splice a Serve tab in before the layout close. The base
+# has NO phase tabs anymore — Overview is the only base tab (the Plan/Dev/Review/Run
+# phase sub-tabs live inside each WorkItem's dedicated tab, see render_workitem_layout).
+# The final layout-closing "}" is the only brace at column 0, so `\n}\n` locates it
+# uniquely; _BASE_TABS is therefore empty and the head is everything up to that brace.
 _close_idx = _TEMPLATE.rindex("\n}\n") + 1
-_LAYOUT_HEAD = _TEMPLATE[:_plan_idx]
-_BASE_TABS = _TEMPLATE[_plan_idx:_close_idx]
+_LAYOUT_HEAD = _TEMPLATE[:_close_idx]
+_BASE_TABS = ""
 _LAYOUT_TAIL = _TEMPLATE[_close_idx:]
 
 
@@ -294,6 +254,27 @@ def _serve_launch_path() -> Path:
     return Path.home() / ".config" / "zellij" / "mothership-serve-launch.kdl"
 
 
+def _layout_cache_dir() -> Path:
+    """mship-owned cache dir for per-WorkItem layout KDL files that `zellij action
+    new-tab --layout <name> --layout-dir <dir>` resolves by name."""
+    return Path.home() / ".cache" / "mship" / "layouts"
+
+
+def write_workitem_layout_file(item_id: str, kdl: str) -> tuple[str, Path]:
+    """Write a WorkItem's layout KDL to a stable cache file and return
+    (layout_name, layout_dir) for `new-tab --layout <name> --layout-dir <dir>`.
+
+    Delivering the KDL via a file (resolved by name) rather than `--layout-string`
+    keeps this portable to older zellij that lack `--layout-string` (the operator's
+    version). The path is stable and keyed by item_id (overwritten on re-focus) — NOT
+    a delete-on-close tempfile — so zellij's server can read it after we return
+    without racing a cleanup delete."""
+    cache_dir = _layout_cache_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / f"{item_id}.kdl").write_text(kdl)
+    return item_id, cache_dir
+
+
 def _in_zellij() -> bool:
     """Seam: are we inside a zellij session? ($ZELLIJ is set by zellij)."""
     return bool(os.environ.get("ZELLIJ"))
@@ -417,8 +398,12 @@ def register(app: typer.Typer, get_container):
             chat_command=resolve_chat_command(chat_command, os.environ),
             default_phase=default_phase_tab(summary.phase),
         )
-        if _run_zellij_action(["new-tab", "--layout-string", kdl, "--name", name,
-                               "--cwd", str(worktree)]):
+        # Deliver the KDL via a cache file (`--layout <name> --layout-dir <dir>`)
+        # rather than `--layout-string`, which older zellij (the operator's) lacks.
+        layout_name, layout_dir = write_workitem_layout_file(item_id, kdl)
+        if _run_zellij_action(["new-tab", "--layout", layout_name,
+                               "--layout-dir", str(layout_dir),
+                               "--name", name, "--cwd", str(worktree)]):
             typer.echo(f"Opened {item_id}.")
             return
         typer.echo(f"Error: could not open tab for {item_id}.", err=True)

--- a/src/mship/cli/view/items.py
+++ b/src/mship/cli/view/items.py
@@ -27,7 +27,10 @@ class ItemsView(MasterDetailApp):
                 for s in self._summaries]
 
     def header_line(self) -> str | None:
-        return f"WorkItems ({len(self._summaries)})"
+        # Visible affordance: the operator kept not realizing enter opens the tab
+        # (the hint used to live only in the command docstring).
+        return (f"WorkItems ({len(self._summaries)})  ·  "
+                "enter: open cockpit tab · y: copy id")
 
     def _do_open_entity(self) -> bool:
         key = self.selected_key()

--- a/src/mship/core/view/items.py
+++ b/src/mship/core/view/items.py
@@ -13,15 +13,26 @@ def _attention_marker(s: WorkItemSummary) -> str:
     return " "
 
 
+# A done WorkItem has no cockpit tab (tabs auto-close on done, so `mship layout
+# focus` is a no-op) — mark it so pressing enter on it isn't a silent surprise.
+_DONE_MARKER = "· done (no tab)"
+
+
 def items_label(s: WorkItemSummary) -> str:
-    return f"{_attention_marker(s)} {s.id}  {s.title or '(untitled)'}  [{s.phase}]"
+    label = f"{_attention_marker(s)} {s.id}  {s.title or '(untitled)'}  [{s.phase}]"
+    if s.phase == "done":
+        label += f"  {_DONE_MARKER}"
+    return label
 
 
 def items_detail(s: WorkItemSummary) -> str:
     a = s.attention
+    phase_line = f"phase: {s.phase}"
+    if s.phase == "done":
+        phase_line += "  (done — no cockpit tab; enter is a no-op)"
     lines = [
         f"{s.id}  {s.title}",
-        f"phase: {s.phase}",
+        phase_line,
         f"spec: {s.spec_id or '(none)'}",
         f"tasks: {', '.join(s.task_slugs) or '(none)'}",
         f"attention: approval={a.needs_approval} decision={a.needs_decision} "

--- a/tests/cli/test_layout.py
+++ b/tests/cli/test_layout.py
@@ -10,6 +10,7 @@ from mship.cli.layout import (
     _LAYOUT_TAIL,
     _TEMPLATE,
     render_serve_layout,
+    render_workitem_layout,
     serve_cli_args,
 )
 
@@ -30,10 +31,22 @@ def test_template_reconstructs_from_parts():
     assert _TEMPLATE == _LAYOUT_HEAD + _BASE_TABS + _LAYOUT_TAIL
 
 
-def test_base_tabs_has_all_four_tabs():
+def test_base_layout_has_no_phase_tabs():
+    # The legacy Plan/Dev/Review/Run base tabs were removed: the base is Overview
+    # only (the phase sub-tabs now live inside each WorkItem's dedicated tab).
+    assert _BASE_TABS == ""
     for name in ("Plan", "Dev", "Review", "Run"):
-        assert f'tab name="{name}"' in _BASE_TABS
-    assert 'name="Serve"' not in _BASE_TABS
+        assert f'tab name="{name}"' not in _TEMPLATE
+    assert 'tab name="Overview" focus=true' in _TEMPLATE
+
+
+def test_render_workitem_layout_keeps_all_four_phase_subtabs():
+    # Removing the base phase tabs must NOT remove the per-item phase sub-tabs.
+    kdl = render_workitem_layout(
+        name="wi-1", worktree="/wt/a", item_id="wi-1", task_slug="a",
+        chat_command=None, default_phase="Dev")
+    for phase in ("Plan", "Dev", "Review", "Run"):
+        assert f'swap_tiled_layout name="{phase}"' in kdl
 
 
 # --- Task 2: pure builders -----------------------------------------------------
@@ -52,28 +65,23 @@ def test_serve_cli_args_mapping():
     ]
 
 
-def test_render_serve_layout_no_args_has_base_tabs_plus_serve():
+def test_render_serve_layout_no_args_is_overview_plus_serve():
     kdl = render_serve_layout([])
-    for name in ("Plan", "Dev", "Review", "Run", "Serve"):
-        assert f'tab name="{name}"' in kdl
+    # Base is Overview only; serve appends a Serve tab. No legacy phase tabs.
+    assert 'tab name="Overview" focus=true' in kdl
+    assert 'tab name="Serve"' in kdl
+    for name in ("Plan", "Dev", "Review", "Run"):
+        assert f'tab name="{name}"' not in kdl
     assert 'command="mship"' in kdl
     assert 'args "serve";' in kdl
-    # Serve tab comes AFTER Run, and Overview is the launchpad and keeps focus.
-    assert 'tab name="Overview" focus=true' in kdl
-    assert kdl.index('tab name="Run"') < kdl.index('tab name="Serve"')
+    # Serve tab comes AFTER Overview, and Overview is the launchpad and keeps focus.
+    assert kdl.index('tab name="Overview"') < kdl.index('tab name="Serve"')
 
 
 def test_template_has_overview_launchpad_tab():
     assert 'tab name="Overview" focus=true' in _TEMPLATE
-    start = _TEMPLATE.index('tab name="Overview"')
-    end = _TEMPLATE.index('tab name="Plan"', start)
-    overview = _TEMPLATE[start:end]
-    assert '"view" "queue"' in overview
-    assert '"view" "items"' in overview
-
-
-def test_overview_precedes_plan():
-    assert _TEMPLATE.index('tab name="Overview"') < _TEMPLATE.index('tab name="Plan"')
+    assert '"view" "queue"' in _TEMPLATE
+    assert '"view" "items"' in _TEMPLATE
 
 
 def test_render_serve_layout_threads_flags():
@@ -190,16 +198,7 @@ def test_launch_serve_flag_implies_serve(tmp_path, monkeypatch):
     assert 'args "serve" "--relay";' in body
 
 
-# --- pre-existing structural assertion ----------------------------------------
-
-def test_review_tab_has_journal_pane():
-    """The Review tab must include a Shell pane and a Journal pane wired to
-    `mship view journal --watch`."""
-    assert 'tab name="Review"' in _TEMPLATE
-    start = _TEMPLATE.index('tab name="Review"')
-    end = _TEMPLATE.index('tab name="Run"', start)
-    review_block = _TEMPLATE[start:end]
-
-    assert 'name="Shell"' in review_block, review_block
-    assert 'name="Journal"' in review_block, review_block
-    assert '"view" "journal" "--watch"' in review_block, review_block
+# The former `test_review_tab_has_journal_pane` asserted on the base _TEMPLATE
+# Review tab, which no longer exists (base is Overview-only). The per-item Review
+# phase sub-tab's journal/diff panes are covered by test_layout_focus.py
+# (test_kdl_bakes_shipped_view_commands_with_item_and_task).

--- a/tests/cli/test_layout_focus.py
+++ b/tests/cli/test_layout_focus.py
@@ -199,6 +199,8 @@ def test_focus_outside_zellij_noops_with_message(tmp_path, monkeypatch):
 
 
 def test_focus_creates_tab_when_absent(tmp_path, monkeypatch):
+    # HOME is isolated so the layout KDL cache write lands in tmp, not real ~/.cache.
+    monkeypatch.setenv("HOME", str(tmp_path))
     wt = tmp_path / "wt-a"
     _seed_focus(tmp_path, {"r": wt})
     calls = _patch_zellij(monkeypatch, in_session=True, existing=["Overview"])
@@ -210,10 +212,32 @@ def test_focus_creates_tab_when_absent(tmp_path, monkeypatch):
         assert args[0] == "new-tab"
         assert "--name" in args and "wi-1" in args
         assert "--cwd" in args and str(wt) in args
-        kdl = args[args.index("--layout-string") + 1]
+        # Portable delivery: KDL goes via a cache FILE (--layout <name> --layout-dir
+        # <dir>), never --layout-string (which older zellij lacks).
+        assert "--layout-string" not in args
+        assert "--layout" in args and "--layout-dir" in args
+        layout_name = args[args.index("--layout") + 1]
+        layout_dir = Path(args[args.index("--layout-dir") + 1])
+        assert layout_name == "wi-1"
+        kdl = (layout_dir / f"{layout_name}.kdl").read_text()
         assert 'tab name="wi-1"' in kdl and 'name="Agent"' in kdl
     finally:
         _reset_focus()
+
+
+def test_write_workitem_layout_file_writes_stable_named_kdl(tmp_path, monkeypatch):
+    # The pure helper: writes <cache>/<item_id>.kdl and returns (name, dir) that
+    # `new-tab --layout <name> --layout-dir <dir>` resolves by name.
+    from mship.cli.layout import write_workitem_layout_file
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    name, cache_dir = write_workitem_layout_file("wi-1", "layout { }\n")
+    assert name == "wi-1"
+    assert (cache_dir / "wi-1.kdl").read_text() == "layout { }\n"
+    # Re-writing overwrites the same stable path (no accumulation, no delete-race).
+    name2, cache_dir2 = write_workitem_layout_file("wi-1", "layout { changed }\n")
+    assert cache_dir2 == cache_dir
+    assert (cache_dir / "wi-1.kdl").read_text() == "layout { changed }\n"
 
 
 def test_focus_switches_to_existing_tab(tmp_path, monkeypatch):
@@ -302,6 +326,7 @@ def test_focus_errors_when_tab_query_fails(tmp_path, monkeypatch):
 
 
 def test_focus_new_tab_failure_reports_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
     _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
     _patch_zellij(monkeypatch, in_session=True, existing=["Overview"], action_ok=False)
     try:

--- a/tests/cli/view/test_items_view.py
+++ b/tests/cli/view/test_items_view.py
@@ -78,6 +78,25 @@ async def test_items_view_lists_and_enter_focuses(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_items_view_shows_enter_and_copy_hint():
+    # The operator kept not realizing enter opens the tab — the hint must be
+    # visible on-screen, not just in the command docstring.
+    from mship.core.view.workitem_index import Attention, WorkItemSummary
+    import mship.cli.view.items as iv
+
+    s = WorkItemSummary(
+        id="wi-1", title="Overhaul", kind="feature", workspace="t", phase="in_flight",
+        attention=Attention(False, False, False, False, 0, 1),
+        created_at=_now(), updated_at=_now(), spec_id="spec-1", task_slugs=["a"], thread_ids=[])
+    view = iv.ItemsView([s])
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        header = view.header_text()
+        assert "enter" in header.lower()
+        assert "copy" in header.lower()
+
+
+@pytest.mark.asyncio
 async def test_items_enter_announces_focus_failure(monkeypatch):
     # Greptile #396: a failed `mship layout focus` must not report success.
     from mship.core.view.workitem_index import Attention, WorkItemSummary

--- a/tests/core/view/test_items.py
+++ b/tests/core/view/test_items.py
@@ -39,3 +39,22 @@ def test_items_detail_lists_links():
 def test_items_render_text_lists_all():
     text = items_render_text([_summary(id="wi-1"), _summary(id="wi-2", title="Second")])
     assert "wi-1" in text and "wi-2" in text and "Second" in text
+
+
+def test_done_item_label_marked_as_no_tab():
+    # A done WorkItem has no cockpit tab; the row must say so, non-done rows must not.
+    done = items_label(_summary(phase="done"))
+    assert "done (no tab)" in done
+    not_done = items_label(_summary(phase="in_flight"))
+    assert "no tab" not in not_done
+
+
+def test_done_item_render_text_marked_as_no_tab():
+    text = items_render_text([_summary(id="wi-1", phase="done")])
+    assert "done (no tab)" in text
+
+
+def test_done_item_detail_explains_no_tab():
+    detail = items_detail(_summary(phase="done"))
+    assert "no cockpit tab" in detail
+    assert "no cockpit tab" not in items_detail(_summary(phase="in_flight"))


### PR DESCRIPTION
Fixes the just-shipped WorkItem cockpit, which failed on older zellij and had two UX gaps the operator hit while using it.

## Changes

- **Portable tab creation (the blocker).** `mship layout focus` used `zellij action new-tab --layout-string`, which only exists on newer zellij — on the operator's older build it errored and no tab ever opened (making the base tabs look stale). It now writes the per-item layout KDL to a stable cache file (`~/.cache/mship/layouts/<item_id>.kdl`) and opens the tab via `new-tab --layout <name> --layout-dir <dir>` (both flags present on older zellij). The KDL content is unchanged — only the delivery mechanism.
- **Removed the legacy Plan/Dev/Review/Run base tabs.** The base layout is now `Overview` (+ `Serve` when serving) only. Those phase tabs were vestigial: they were scoped to the current-task and couldn't follow an Overview selection, so selecting a WorkItem never refreshed them. The phase sub-tabs still live inside each WorkItem's own dedicated tab (`render_workitem_layout`), which is where per-item work happens.
- **Self-explanatory items picker.** The Overview items view now shows an on-screen hint — `enter: open cockpit tab · y: copy id` — instead of leaving it only in the command docstring.
- **Done items marked.** A done WorkItem has no cockpit tab (tabs auto-close on done, so `mship layout focus` is a no-op); the picker now marks done rows `· done (no tab)` so pressing enter on one isn't a silent surprise.

## Tests

- Base-layout reconstruction still holds byte-for-byte with `_BASE_TABS == ""`; `render_serve_layout([])` = `Overview` + `Serve`; `render_workitem_layout` still emits all four phase swap layouts (the per-item sub-tabs survive the base-tab removal).
- Focus argv asserts `--layout`/`--layout-dir` present and `--layout-string` absent; the cache-file write is covered.
- Items picker enter/copy hint + done-marker unit tests.
- Full `mship test` green across both repos.
