### PR TITLE
Fix cockpit focus tabs missing the tab-bar (add default_tab_template)

### DIFF
--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -38,6 +38,16 @@ _LAYOUT_HEAD = _TEMPLATE[:_close_idx]
 _BASE_TABS = ""
 _LAYOUT_TAIL = _TEMPLATE[_close_idx:]
 
+# The tab-bar (top) + status-bar (bottom) frame the base layout applies to every
+# tab via default_tab_template. A per-item focus tab (render_workitem_layout) is
+# opened with `new-tab --layout` from its OWN layout doc, so it must carry the same
+# block or it renders with NO tab bar — you'd lose the tab bar the moment you switch
+# into a focus tab. Sliced verbatim from _TEMPLATE so the two can never drift
+# (guarded by test_workitem_layout_tab_template_matches_base).
+_DEFAULT_TAB_TEMPLATE = _TEMPLATE[
+    _TEMPLATE.index("    default_tab_template {") : _TEMPLATE.index('    tab name="Overview"')
+]
+
 
 def serve_cli_args(
     *, host: Optional[str], port: Optional[int], relay: bool, relay_host: Optional[str]
@@ -166,10 +176,12 @@ def render_workitem_layout(
 ) -> str:
     """A per-WorkItem tab KDL: chat-first Agent pane + Editor pane, all cd'd to the
     worktree, with Plan/Dev/Review/Run phase sub-tabs (zellij swap layouts) whose
-    panes are the shipped `mship view` commands baked to this item/task. Reuses
-    _kdl_quote so paths/commands can't break out of the KDL string."""
+    panes are the shipped `mship view` commands baked to this item/task. Includes the
+    same default_tab_template as the base layout so the focus tab shows the tab-bar /
+    status-bar. Reuses _kdl_quote so paths/commands can't break out of the KDL string."""
     base_phase = default_phase if default_phase in _PHASES else "Plan"
     parts = [f'layout {{\n    cwd {_kdl_quote(worktree)}\n\n',
+             _DEFAULT_TAB_TEMPLATE,
              f'    tab name="{name}" focus=true {{\n',
              '        pane split_direction="vertical" {\n',
              _agent_pane(chat_command),

--- a/tests/cli/test_layout.py
+++ b/tests/cli/test_layout.py
@@ -6,6 +6,7 @@ from typer.testing import CliRunner
 from mship.cli import app
 from mship.cli.layout import (
     _BASE_TABS,
+    _DEFAULT_TAB_TEMPLATE,
     _LAYOUT_HEAD,
     _LAYOUT_TAIL,
     _TEMPLATE,
@@ -47,6 +48,30 @@ def test_render_workitem_layout_keeps_all_four_phase_subtabs():
         chat_command=None, default_phase="Dev")
     for phase in ("Plan", "Dev", "Review", "Run"):
         assert f'swap_tiled_layout name="{phase}"' in kdl
+
+
+def test_render_workitem_layout_has_tab_bar_framing():
+    # A focus tab is opened from this layout via `new-tab --layout`; without a
+    # default_tab_template it renders with NO tab bar/status bar (you lose the tab
+    # bar when switching into a focus tab). It must carry the same frame as the base.
+    kdl = render_workitem_layout(
+        name="wi-1", worktree="/wt/a", item_id="wi-1", task_slug="a",
+        chat_command=None, default_phase="Dev")
+    assert "default_tab_template {" in kdl
+    assert 'plugin location="zellij:tab-bar"' in kdl
+    assert 'plugin location="zellij:status-bar"' in kdl
+    # The template must come before the tab it frames.
+    assert kdl.index("default_tab_template") < kdl.index('tab name="wi-1"')
+
+
+def test_workitem_layout_tab_template_matches_base():
+    # The per-item frame is the SAME block the base layout uses — keep them in sync
+    # via the shared constant so the two can't drift.
+    assert _DEFAULT_TAB_TEMPLATE in _TEMPLATE
+    kdl = render_workitem_layout(
+        name="wi-1", worktree="/wt/a", item_id="wi-1", task_slug="a",
+        chat_command=None, default_phase="Dev")
+    assert _DEFAULT_TAB_TEMPLATE in kdl
 
 
 # --- Task 2: pure builders -----------------------------------------------------


### PR DESCRIPTION
Follow-up to #397. Per-item focus tabs (opened by `mship layout focus`) rendered **without the tab-bar / status-bar** — so switching into a focus tab lost the tab bar entirely.

## Root cause

The base layout applies a `default_tab_template` (a `zellij:tab-bar` pane on top, `zellij:status-bar` on the bottom) so every base tab is framed. A per-item focus tab is opened via `new-tab --layout` from `render_workitem_layout`'s own `layout { … }` document, which had **no `default_tab_template`** — so that tab had no bars.

## Fix

`render_workitem_layout` now includes the same `default_tab_template` as the base. To guarantee the two never drift, the template block is **sliced verbatim from `_TEMPLATE`** (`_DEFAULT_TAB_TEMPLATE`) rather than duplicated. The template frames the initial focus-tab view and its Plan/Dev/Review/Run swap layouts alike.

## Tests

- `render_workitem_layout` output now contains `default_tab_template`, `zellij:tab-bar`, and `zellij:status-bar`, with the template preceding the tab it frames.
- `_DEFAULT_TAB_TEMPLATE` is asserted to be a substring of both `_TEMPLATE` and the per-item layout (drift guard).
- Existing base-reconstruction and phase-subtab tests still pass. Full `mship test` green across both repos.
