### PR TITLE
Cockpit v2: single shared agent pane + focus-following stacked views

### DIFF
--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -403,27 +403,32 @@ def register(app: typer.Typer, get_container):
 
     @layout_app.command()
     def launch(
-        serve: bool = typer.Option(False, "--serve", help="Open the serve layout (adds a Serve tab running `mship serve`)."),
+        serve: bool = typer.Option(False, "--serve", help="Add a Serve tab running `mship serve`."),
         host: Optional[str] = typer.Option(None, "--host", help="serve --host (implies --serve)."),
         port: Optional[int] = typer.Option(None, "--port", help="serve --port (implies --serve)."),
-        relay: bool = typer.Option(False, "--relay", help="serve --relay (implies --serve). Collides with a separately-running serve."),
+        relay: bool = typer.Option(False, "--relay", help="serve --relay (implies --serve)."),
         relay_host: Optional[str] = typer.Option(None, "--relay-host", help="serve --relay-host (implies --serve)."),
+        chat_command: Optional[str] = typer.Option(
+            None, "--chat-command", help="Command for the Agent pane. Default: your shell."),
     ):
-        """Launch zellij with the mothership layout (replaces current process).
+        """Launch zellij with the v2 cockpit layout (replaces current process).
 
-        With --serve (or any serve flag) launches the serve layout — the normal
-        tabs plus a Serve tab running `mship serve <flags>`. WARNING: starting a
-        serve here collides with a separately-running `mship serve` (same relay
-        subdomain / bind), so use it only when no standalone serve is up.
-        """
+        Renders an effective cockpit: the Agent pane runs your shell (or
+        --chat-command / $MSHIP_CHAT_COMMAND) beside the fixed rich stack of
+        `mship view … --follow` panes. With any serve flag, also adds a Serve tab
+        running `mship serve`."""
         serve_selected = (
             serve or host is not None or port is not None or relay or relay_host is not None
         )
-        if not serve_selected:
-            os.execvp("zellij", ["zellij", "--layout", "mothership"])
-            return
-        args = serve_cli_args(host=host, port=port, relay=relay, relay_host=relay_host)
-        kdl = render_serve_layout(args)
+        kdl = render_cockpit_layout(
+            chat_command=resolve_chat_command(chat_command, os.environ),
+        )
+        if serve_selected:
+            args = serve_cli_args(host=host, port=port, relay=relay, relay_host=relay_host)
+            # Splice the Serve tab in exactly as render_serve_layout does.
+            close_idx = kdl.rindex("\n}\n") + 1
+            kdl = kdl[:close_idx] + _serve_tab(args) + kdl[close_idx:]
+
         path = _serve_launch_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(kdl)

--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -1,53 +1,10 @@
 import os
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Optional
 
 import typer
-
-_TEMPLATE = """\
-layout {
-    default_tab_template {
-        pane size=1 borderless=true {
-            plugin location="zellij:tab-bar"
-        }
-        children
-        pane size=2 borderless=true {
-            plugin location="zellij:status-bar"
-        }
-    }
-
-    tab name="Overview" focus=true {
-        pane split_direction="vertical" {
-            pane size="50%" name="Queue" command="mship" close_on_exit=false { args "view" "queue"; }
-            pane size="50%" name="Items" command="mship" close_on_exit=false { args "view" "items"; }
-        }
-    }
-}
-"""
-
-# Composable parts, sliced from _TEMPLATE at stable markers so the normal layout
-# is reconstructed byte-for-byte (_LAYOUT_HEAD + _BASE_TABS + _LAYOUT_TAIL == _TEMPLATE)
-# while the serve layout can splice a Serve tab in before the layout close. The base
-# has NO phase tabs anymore — Overview is the only base tab (the Plan/Dev/Review/Run
-# phase sub-tabs live inside each WorkItem's dedicated tab, see render_workitem_layout).
-# The final layout-closing "}" is the only brace at column 0, so `\n}\n` locates it
-# uniquely; _BASE_TABS is therefore empty and the head is everything up to that brace.
-_close_idx = _TEMPLATE.rindex("\n}\n") + 1
-_LAYOUT_HEAD = _TEMPLATE[:_close_idx]
-_BASE_TABS = ""
-_LAYOUT_TAIL = _TEMPLATE[_close_idx:]
-
-# The tab-bar (top) + status-bar (bottom) frame the base layout applies to every
-# tab via default_tab_template. A per-item focus tab (render_workitem_layout) is
-# opened with `new-tab --layout` from its OWN layout doc, so it must carry the same
-# block or it renders with NO tab bar — you'd lose the tab bar the moment you switch
-# into a focus tab. Sliced verbatim from _TEMPLATE so the two can never drift
-# (guarded by test_workitem_layout_tab_template_matches_base).
-_DEFAULT_TAB_TEMPLATE = _TEMPLATE[
-    _TEMPLATE.index("    default_tab_template {") : _TEMPLATE.index('    tab name="Overview"')
-]
-
 
 def serve_cli_args(
     *, host: Optional[str], port: Optional[int], relay: bool, relay_host: Optional[str]
@@ -69,6 +26,116 @@ def _kdl_quote(s: str) -> str:
     """Quote a string as a KDL string literal, escaping backslash and double-quote
     so user-supplied values (e.g. --host) can't produce malformed KDL."""
     return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+@dataclass(frozen=True)
+class ViewPaneSpec:
+    """One right-side stack member: a display name + the `mship <args>` it runs
+    (always a `mship view … --follow` command)."""
+    name: str
+    view_args: list[str]
+
+
+# The right-side stack is ONE fixed rich set, the same regardless of the focused
+# item's phase (operator decision, option A). ac4's "dynamic per phase" is met by
+# every member running `--follow`: each re-scopes to the focused item and renders
+# phase-appropriate content (or its own empty/hint state). The Item pane carries the
+# item/PR/checks composite. No phase-conditional membership, no rebuild on switch.
+_COCKPIT_VIEW_SPECS = [
+    ViewPaneSpec("Spec", ["view", "spec", "--follow"]),
+    ViewPaneSpec("Diff", ["view", "diff", "--follow"]),
+    ViewPaneSpec("Journal", ["view", "journal", "--follow"]),
+    ViewPaneSpec("Status", ["view", "status", "--follow"]),
+    ViewPaneSpec("Item", ["view", "item", "--follow"]),
+]
+
+
+def cockpit_view_specs() -> list[ViewPaneSpec]:
+    """The fixed rich set of right-side stack members (ac4). Always the same — the
+    panes follow focus; membership never depends on phase."""
+    return list(_COCKPIT_VIEW_SPECS)
+
+
+_FRAME = """\
+    default_tab_template {
+        pane size=1 borderless=true {
+            plugin location="zellij:tab-bar"
+        }
+        children
+        pane size=2 borderless=true {
+            plugin location="zellij:status-bar"
+        }
+    }
+"""
+
+_OVERVIEW_TAB = """\
+    tab name="Overview" {
+        pane split_direction="vertical" {
+            pane size="50%" name="Queue" command="mship" close_on_exit=false { args "view" "queue"; }
+            pane size="50%" name="Items" command="mship" close_on_exit=false { args "view" "items"; }
+        }
+    }
+"""
+
+
+def _cockpit_agent_pane(chat_command: str | None) -> str:
+    """The fixed left Agent pane — a bare shell (operator's session) by default, or a
+    configured command. size 40%, focus=true, sibling of (NOT inside) the stack."""
+    if chat_command is None:
+        return '            pane size="40%" name="Agent" focus=true\n'
+    cmd = _kdl_quote(chat_command)
+    return ('            pane size="40%" name="Agent" focus=true command="sh" close_on_exit=false '
+            f'{{ args "-c" {cmd}; }}\n')
+
+
+def _view_pane_kdl(spec: "ViewPaneSpec") -> str:
+    args = " ".join(_kdl_quote(t) for t in spec.view_args)
+    return (f'                pane name="{spec.name}" command="mship" close_on_exit=false '
+            f'{{ args {args}; }}\n')
+
+
+def _cockpit_tab(chat_command: str | None) -> str:
+    panes = "".join(_view_pane_kdl(s) for s in cockpit_view_specs())
+    return ('    tab name="Cockpit" focus=true {\n'
+            '        pane split_direction="vertical" {\n'
+            + _cockpit_agent_pane(chat_command)
+            + '            pane stacked=true {\n'
+            + panes
+            + '            }\n'
+            + '        }\n'
+            + '    }\n')
+
+
+def render_cockpit_layout(*, chat_command: str | None = None) -> str:
+    """The v2 cockpit layout document (ac3): the frame, an Overview launchpad tab
+    (queue + items), and a single Cockpit tab = fixed Agent pane beside a stacked
+    group of the fixed rich set of `mship view … --follow` panes (Spec, Diff,
+    Journal, Status, Item). Membership never depends on phase; the panes follow
+    focus."""
+    return ("layout {\n"
+            + _FRAME + "\n"
+            + _OVERVIEW_TAB + "\n"
+            + _cockpit_tab(chat_command)
+            + "}\n")
+
+
+_TEMPLATE = render_cockpit_layout()
+
+# Serve splices a Serve tab before the final layout-closing brace. The only
+# column-0 brace is the layout close, so `\n}\n` locates it uniquely.
+_close_idx = _TEMPLATE.rindex("\n}\n") + 1
+_LAYOUT_HEAD = _TEMPLATE[:_close_idx]
+_BASE_TABS = ""
+_LAYOUT_TAIL = _TEMPLATE[_close_idx:]
+
+# The tab-bar (top) + status-bar (bottom) frame every tab via default_tab_template.
+# A per-item focus tab (render_workitem_layout) is opened with `new-tab --layout`
+# from its OWN layout doc, so it must carry the same block or it renders with NO
+# tab bar. Sliced verbatim from _TEMPLATE so the two can never drift. (Dead after
+# Task 12 removes render_workitem_layout.)
+_DEFAULT_TAB_TEMPLATE = _TEMPLATE[
+    _TEMPLATE.index("    default_tab_template {") : _TEMPLATE.index('    tab name="Overview"')
+]
 
 
 def tab_name_for(item_id: str) -> str:

--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Optional
@@ -128,43 +127,6 @@ _LAYOUT_HEAD = _TEMPLATE[:_close_idx]
 _BASE_TABS = ""
 _LAYOUT_TAIL = _TEMPLATE[_close_idx:]
 
-# The tab-bar (top) + status-bar (bottom) frame every tab via default_tab_template.
-# A per-item focus tab (render_workitem_layout) is opened with `new-tab --layout`
-# from its OWN layout doc, so it must carry the same block or it renders with NO
-# tab bar. Sliced verbatim from _TEMPLATE so the two can never drift. (Dead after
-# Task 12 removes render_workitem_layout.)
-_DEFAULT_TAB_TEMPLATE = _TEMPLATE[
-    _TEMPLATE.index("    default_tab_template {") : _TEMPLATE.index('    tab name="Overview"')
-]
-
-
-def tab_name_for(item_id: str) -> str:
-    """Deterministic zellij tab name for a WorkItem. The id verbatim: the same
-    item always maps to the same tab, so focus reconciles rather than duplicates."""
-    return item_id
-
-
-def decide_focus_action(tab_name: str, existing_tab_names: list[str], *, is_done: bool) -> str:
-    """Pure go-vs-create-vs-close decision for `mship layout focus`.
-    Returns "close" | "noop" | "go-to" | "create"."""
-    exists = tab_name in existing_tab_names
-    if is_done:
-        return "close" if exists else "noop"
-    return "go-to" if exists else "create"
-
-
-_PHASES = ("Plan", "Dev", "Review", "Run")
-
-_PHASE_FROM_WORKITEM = {
-    "inbox": "Plan", "shaping": "Plan", "ready": "Plan",
-    "in_flight": "Dev", "review": "Review", "done": "Run",
-}
-
-
-def default_phase_tab(workitem_phase: str) -> str:
-    """Map a WorkItem's derived phase to the sub-tab that opens focused."""
-    return _PHASE_FROM_WORKITEM.get(workitem_phase, "Plan")
-
 
 def resolve_chat_command(explicit: str | None, env: Mapping[str, str]) -> str | None:
     """Configurable agent/chat command. None -> a bare pane = the operator's shell
@@ -172,96 +134,6 @@ def resolve_chat_command(explicit: str | None, env: Mapping[str, str]) -> str | 
     if explicit:
         return explicit
     return env.get("MSHIP_CHAT_COMMAND") or None
-
-
-def _mship_pane(name: str, tokens: list[str]) -> str:
-    args = " ".join(_kdl_quote(t) for t in tokens)
-    return (f'                pane name="{name}" command="mship" close_on_exit=false '
-            f'{{ args {args}; }}\n')
-
-
-def _phase_panes(phase: str, item_id: str, task_slug: str | None) -> str:
-    """The ambient view panes for one phase sub-tab, baking the item/task in. Panes
-    that need a task fall back to a Shell pane when the item has no task yet.
-
-    NOTE (deviation): `mship view logs` does not exist — the run/journal view is
-    registered as `view journal` (in cli/view/logs.py). The Run phase therefore
-    tails `view journal`, not a nonexistent `view logs`."""
-    shell = '                pane name="Shell"\n'
-    if phase == "Plan":
-        return (_mship_pane("Spec", ["view", "spec", "--workitem", item_id, "--watch"])
-                + _mship_pane("Item", ["view", "item", item_id]))
-    if phase == "Dev":
-        if task_slug is None:
-            return shell
-        return (_mship_pane("Diff", ["view", "diff", "--task", task_slug, "--watch"])
-                + _mship_pane("Journal", ["view", "journal", "--task", task_slug, "--watch"]))
-    if phase == "Review":
-        item = _mship_pane("Item", ["view", "item", item_id])
-        if task_slug is None:
-            return item
-        return _mship_pane("Diff", ["view", "diff", "--task", task_slug, "--watch"]) + item
-    if phase == "Run":
-        if task_slug is None:
-            return shell
-        return _mship_pane("Logs", ["view", "journal", "--task", task_slug, "--watch"]) + shell
-    return shell
-
-
-def _agent_pane(chat_command: str | None) -> str:
-    if chat_command is None:
-        return '            pane name="Agent" focus=true\n'
-    cmd = _kdl_quote(chat_command)
-    return ('            pane name="Agent" focus=true command="sh" close_on_exit=false '
-            f'{{ args "-c" {cmd}; }}\n')
-
-
-def _editor_pane() -> str:
-    return ('            pane name="Editor" command="sh" close_on_exit=false {\n'
-            '                args "-c" "${EDITOR:-$(command -v nvim || command -v vim || command -v vi)} ."\n'
-            '            }\n')
-
-
-def _phase_swap(phase: str, item_id: str, task_slug: str | None,
-                chat_command: str | None) -> str:
-    return (f'    swap_tiled_layout name="{phase}" {{\n'
-            '        tab {\n'
-            '            pane split_direction="vertical" {\n'
-            + _agent_pane(chat_command)
-            + '                pane split_direction="horizontal" size="50%" {\n'
-            + _phase_panes(phase, item_id, task_slug)
-            + '                }\n'
-            + '            }\n'
-            + _editor_pane()
-            + '        }\n'
-            '    }\n')
-
-
-def render_workitem_layout(
-    *, name: str, worktree: str, item_id: str, task_slug: str | None,
-    chat_command: str | None, default_phase: str,
-) -> str:
-    """A per-WorkItem tab KDL: chat-first Agent pane + Editor pane, all cd'd to the
-    worktree, with Plan/Dev/Review/Run phase sub-tabs (zellij swap layouts) whose
-    panes are the shipped `mship view` commands baked to this item/task. Includes the
-    same default_tab_template as the base layout so the focus tab shows the tab-bar /
-    status-bar. Reuses _kdl_quote so paths/commands can't break out of the KDL string."""
-    base_phase = default_phase if default_phase in _PHASES else "Plan"
-    parts = [f'layout {{\n    cwd {_kdl_quote(worktree)}\n\n',
-             _DEFAULT_TAB_TEMPLATE,
-             f'    tab name="{name}" focus=true {{\n',
-             '        pane split_direction="vertical" {\n',
-             _agent_pane(chat_command),
-             '            pane split_direction="horizontal" size="50%" {\n',
-             _phase_panes(base_phase, item_id, task_slug),
-             '            }\n',
-             '        }\n',
-             _editor_pane(),
-             '    }\n\n']
-    for phase in _PHASES:
-        parts.append(_phase_swap(phase, item_id, task_slug, chat_command))
-    parts.append('}\n')
-    return "".join(parts)
 
 
 def resolve_focus_target(container, item_id: str):
@@ -333,47 +205,9 @@ def _serve_launch_path() -> Path:
     return Path.home() / ".config" / "zellij" / "mothership-serve-launch.kdl"
 
 
-def _layout_cache_dir() -> Path:
-    """mship-owned cache dir for per-WorkItem layout KDL files that `zellij action
-    new-tab --layout <name> --layout-dir <dir>` resolves by name."""
-    return Path.home() / ".cache" / "mship" / "layouts"
-
-
-def write_workitem_layout_file(item_id: str, kdl: str) -> tuple[str, Path]:
-    """Write a WorkItem's layout KDL to a stable cache file and return
-    (layout_name, layout_dir) for `new-tab --layout <name> --layout-dir <dir>`.
-
-    Delivering the KDL via a file (resolved by name) rather than `--layout-string`
-    keeps this portable to older zellij that lack `--layout-string` (the operator's
-    version). The path is stable and keyed by item_id (overwritten on re-focus) — NOT
-    a delete-on-close tempfile — so zellij's server can read it after we return
-    without racing a cleanup delete."""
-    cache_dir = _layout_cache_dir()
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    (cache_dir / f"{item_id}.kdl").write_text(kdl)
-    return item_id, cache_dir
-
-
 def _in_zellij() -> bool:
     """Seam: are we inside a zellij session? ($ZELLIJ is set by zellij)."""
     return bool(os.environ.get("ZELLIJ"))
-
-
-def _query_tab_names() -> list[str] | None:
-    """Seam: the current session's tab names via `zellij action query-tab-names`.
-    Returns None if the query itself FAILED, so callers don't mistake a failure
-    for an empty session (which would create duplicate tabs / report wrong state)."""
-    out = subprocess.run(["zellij", "action", "query-tab-names"],
-                         capture_output=True, text=True, check=False)
-    if out.returncode != 0:
-        return None
-    return [line for line in out.stdout.splitlines() if line.strip()]
-
-
-def _run_zellij_action(args: list[str]) -> bool:
-    """Seam: run one `zellij action <args>`; returns True on success (exit 0), so
-    callers can report real outcomes and never `close-tab` after a failed go-to."""
-    return subprocess.run(["zellij", "action", *args], check=False).returncode == 0
 
 
 def register(app: typer.Typer, get_container):
@@ -478,29 +312,5 @@ def register(app: typer.Typer, get_container):
         if not _in_zellij():
             typer.echo("Not inside a zellij session; run `mship layout launch` "
                        "to open the cockpit. (focus recorded)")
-
-    @layout_app.command()
-    def close(
-        item_id: str = typer.Argument(..., help="WorkItem id whose tab to close."),
-    ):
-        """Explicitly close a WorkItem's zellij tab so tabs don't accumulate (AC7)."""
-        if not _in_zellij():
-            typer.echo("Not inside a zellij session ($ZELLIJ unset). (no-op)")
-            return
-        name = tab_name_for(item_id)
-        existing = _query_tab_names()
-        if existing is None:
-            typer.echo("Error: could not query zellij tabs.", err=True)
-            raise typer.Exit(code=1)
-        if name not in existing:
-            typer.echo(f"No open tab for {item_id}.")
-            return
-        # Close only after a successful go-to, so a failed go-to can't close the
-        # active tab (Overview or an unrelated item) instead of the target.
-        if _run_zellij_action(["go-to-tab-name", name]) and _run_zellij_action(["close-tab"]):
-            typer.echo(f"Closed tab for {item_id}.")
-            return
-        typer.echo(f"Error: could not close tab for {item_id}.", err=True)
-        raise typer.Exit(code=1)
 
     app.add_typer(layout_app, rich_help_panel="Setup")

--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -194,15 +194,17 @@ def _serve_target_path() -> Path:
     return Path.home() / ".config" / "zellij" / "layouts" / "mothership-serve.kdl"
 
 
-def _serve_launch_path() -> Path:
-    """Deterministic per-user path for the launch-time effective serve layout.
+def _launch_layout_path() -> Path:
+    """Per-PROCESS path for the launch-time effective cockpit layout, keyed by PID.
 
-    A fixed path (overwritten each launch, outside the layouts/ picker dir) rather
-    than a unique tempfile: `os.execvp` replaces the process, so no cleanup runs
-    after it — a unique temp would orphan one .kdl per launch. Overwriting one file
-    keeps it bounded.
+    Two concurrent `mship layout launch` invocations (different --chat-command /
+    serve args) are different processes with different PIDs, so they write to
+    DIFFERENT files and can't race on a shared path before zellij reads it. `os.execvp`
+    replaces the process so no cleanup runs after it, but keying on the PID (rather
+    than a unique tempfile) keeps the set of orphaned .kdl files bounded — PIDs
+    recycle and each launch overwrites its own file.
     """
-    return Path.home() / ".config" / "zellij" / "mothership-serve-launch.kdl"
+    return Path.home() / ".config" / "zellij" / f"mothership-launch-{os.getpid()}.kdl"
 
 
 def _in_zellij() -> bool:
@@ -263,7 +265,7 @@ def register(app: typer.Typer, get_container):
             close_idx = kdl.rindex("\n}\n") + 1
             kdl = kdl[:close_idx] + _serve_tab(args) + kdl[close_idx:]
 
-        path = _serve_launch_path()
+        path = _launch_layout_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(kdl)
         os.execvp("zellij", ["zellij", "--layout", str(path)])

--- a/src/mship/cli/layout.py
+++ b/src/mship/cli/layout.py
@@ -364,62 +364,48 @@ def register(app: typer.Typer, get_container):
 
     @layout_app.command()
     def focus(
-        item_id: str = typer.Argument(..., help="WorkItem id to focus (e.g. wi-...)."),
-        chat_command: Optional[str] = typer.Option(
-            None, "--chat-command",
-            help="Command for the Agent pane. Default: your shell in the worktree."),
+        item_id: Optional[str] = typer.Argument(
+            None, help="WorkItem id to focus (e.g. wi-...)."),
+        show: bool = typer.Option(
+            False, "--show", help="Print the current focus and exit."),
     ):
-        """Open or switch to a WorkItem's zellij tab (chat-first, phase sub-tabs).
+        """Record <id> as the workspace CURRENT FOCUS (cockpit-v2, ac1).
 
-        No-ops with a message when not inside a zellij session. Closes the tab
-        instead of opening it when the item has reached `done` (AC7)."""
-        if not _in_zellij():
-            typer.echo("Not inside a zellij session ($ZELLIJ unset); "
-                       "run `mship layout launch` first. (no-op)")
+        Writes the focus file — it does NOT open/switch a zellij tab; the cockpit's
+        right-side `--follow` views re-scope to the new focus on their next tick.
+        `--show` prints the current focus. Works in any pane; when not inside a
+        zellij session it still writes the file and just adds an advisory."""
+        from mship.core.focus import focus_path, read_focus, write_focus
+        from mship.cli.view._workitems import load_workitem_index
+
+        container = get_container()
+        state_dir = container.state_dir()
+
+        if show:
+            current = read_focus(focus_path(state_dir))
+            if current is None:
+                typer.echo("No WorkItem focused. Run `mship layout focus <id>`.")
+            else:
+                typer.echo(f"Focused: {current.work_item_id}")
             return
-        target = resolve_focus_target(get_container(), item_id)
-        if target is None:
+
+        if item_id is None:
+            typer.echo("Error: provide a WorkItem id, or --show.", err=True)
+            raise typer.Exit(code=1)
+
+        summary = next((s for s in load_workitem_index(container) if s.id == item_id), None)
+        if summary is None:
             typer.echo(f"Error: unknown work item: {item_id}", err=True)
             raise typer.Exit(code=1)
-        summary, task_slug, worktree = target
-        name = tab_name_for(item_id)
-        existing = _query_tab_names()
-        if existing is None:
-            typer.echo("Error: could not query zellij tabs.", err=True)
-            raise typer.Exit(code=1)
-        action = decide_focus_action(name, existing, is_done=summary.phase == "done")
-        if action == "noop":
-            typer.echo(f"{item_id} is done; no tab to focus.")
-            return
-        if action == "close":
-            # Only close AFTER a successful go-to, so a vanished/failed target can
-            # never make close-tab remove the currently-active (wrong) tab.
-            if _run_zellij_action(["go-to-tab-name", name]) and _run_zellij_action(["close-tab"]):
-                typer.echo(f"Closed tab for done item {item_id}.")
-                return
-            typer.echo(f"Error: could not close tab for {item_id}.", err=True)
-            raise typer.Exit(code=1)
-        if action == "go-to":
-            if _run_zellij_action(["go-to-tab-name", name]):
-                typer.echo(f"Switched to {item_id}.")
-                return
-            typer.echo(f"Error: could not switch to {item_id}.", err=True)
-            raise typer.Exit(code=1)
-        kdl = render_workitem_layout(
-            name=name, worktree=str(worktree), item_id=item_id, task_slug=task_slug,
-            chat_command=resolve_chat_command(chat_command, os.environ),
-            default_phase=default_phase_tab(summary.phase),
-        )
-        # Deliver the KDL via a cache file (`--layout <name> --layout-dir <dir>`)
-        # rather than `--layout-string`, which older zellij (the operator's) lacks.
-        layout_name, layout_dir = write_workitem_layout_file(item_id, kdl)
-        if _run_zellij_action(["new-tab", "--layout", layout_name,
-                               "--layout-dir", str(layout_dir),
-                               "--name", name, "--cwd", str(worktree)]):
-            typer.echo(f"Opened {item_id}.")
-            return
-        typer.echo(f"Error: could not open tab for {item_id}.", err=True)
-        raise typer.Exit(code=1)
+
+        write_focus(focus_path(state_dir), item_id)
+        if summary.phase == "done":
+            typer.echo(f"Focused {item_id} (note: this item is done).")
+        else:
+            typer.echo(f"Focused {item_id}.")
+        if not _in_zellij():
+            typer.echo("Not inside a zellij session; run `mship layout launch` "
+                       "to open the cockpit. (focus recorded)")
 
     @layout_app.command()
     def close(

--- a/src/mship/cli/view/_follow.py
+++ b/src/mship/cli/view/_follow.py
@@ -1,0 +1,25 @@
+"""Shared `--follow` resolution for the view commands (spec cockpit-v2, ac2).
+
+`--follow` points a view at the workspace CURRENT FOCUS (written by
+`mship layout focus`) instead of a fixed --task/--workitem, re-resolving at render
+time so a focus change re-scopes the pane. This module owns the two shared pieces:
+reading the focused id from the focus file, and the single empty-state hint string
+every follow view shows when nothing is focused.
+"""
+from __future__ import annotations
+
+from mship.core.focus import focus_path, read_focus
+
+
+def read_focused_id(container) -> str | None:
+    """The currently-focused WorkItem id for this workspace, or None when nothing
+    is focused (or the focus file is missing/corrupt)."""
+    state = read_focus(focus_path(container.state_dir()))
+    return state.work_item_id if state is not None else None
+
+
+def follow_hint() -> str:
+    """The clear empty state shown by a `--follow` view when no WorkItem is focused
+    (ac2) — never an error."""
+    return ("No WorkItem focused. Press enter on an item in the Overview tab, "
+            "or run `mship layout focus <id>`.")

--- a/src/mship/cli/view/diff.py
+++ b/src/mship/cli/view/diff.py
@@ -354,12 +354,81 @@ def register(app: typer.Typer, get_container):
         watch: bool = typer.Option(False, "--watch"),
         interval: float = typer.Option(2.0, "--interval"),
         all_: bool = typer.Option(False, "--all", help="Show all worktrees, ignore active_repo"),
+        follow: bool = typer.Option(False, "--follow", help="Track the workspace CURRENT FOCUS (cockpit-v2)."),
     ):
         """Live per-worktree git diff."""
         from mship.cli._resolve import resolve_or_exit
 
         container = get_container()
         state_mgr = container.state_manager()
+
+        if follow and task is not None:
+            typer.echo("Error: --follow and --task are mutually exclusive.", err=True)
+            raise typer.Exit(code=1)
+
+        from mship.cli.view._workitems import load_workitem_index
+        from mship.core.view.headers import header_for_task
+
+        if follow:
+            from mship.cli.view._follow import follow_hint, read_focused_id
+            from mship.cli.layout import resolve_focus_target
+            from mship.cli.output import Output
+
+            def _followed_task() -> Optional[str]:
+                item_id = read_focused_id(container)
+                if item_id is None:
+                    return None
+                target = resolve_focus_target(container, item_id)
+                if target is None:
+                    return None
+                return target[1]  # task_slug (may be None)
+
+            if not Output().is_tty:
+                slug = _followed_task()
+                if slug is None:
+                    typer.echo(follow_hint())
+                    return
+                task_obj = state_mgr.load().tasks.get(slug)
+                paths = list((task_obj.worktrees.values() if task_obj else []))
+                lines = []
+                for p in paths:
+                    try:
+                        wd = collect_worktree_diff(Path(p), base_branch=None)
+                        adds = sum(f.additions for f in wd.files)
+                        dels = sum(f.deletions for f in wd.files)
+                        lines.append(f"{p}: {len(wd.files)} files  +{adds} -{dels}")
+                    except Exception as e:  # noqa: BLE001
+                        lines.append(f"{p}: (error: {e})")
+                typer.echo("\n".join(lines) if lines else "No changes.")
+                return
+
+            def _resolver() -> tuple[list[Path], Path | None]:
+                slug = _followed_task()
+                if slug is None:
+                    return [], None
+                task_obj = state_mgr.load().tasks.get(slug)
+                if task_obj is None:
+                    return [], None
+                all_paths = [Path(p) for p in task_obj.worktrees.values()]
+                scope: Path | None = None
+                if not all_ and task_obj.active_repo is not None and task_obj.active_repo in task_obj.worktrees:
+                    scope = Path(task_obj.worktrees[task_obj.active_repo])
+                return all_paths, scope
+
+            def _header() -> str | None:
+                item_id = read_focused_id(container)
+                if item_id is None:
+                    return follow_hint()
+                slug = _followed_task()
+                if slug is None:
+                    return follow_hint()
+                task_obj = state_mgr.load().tasks.get(slug)
+                phase = getattr(task_obj, "phase", None) if task_obj else None
+                return header_for_task(slug, phase, load_workitem_index(container)) or follow_hint()
+
+            DiffView(resolve_paths=_resolver, header_provider=_header,
+                     watch=True, interval=interval).run()
+            return
 
         t = resolve_or_exit(state_mgr.load(), task)
         target_task = t.slug
@@ -378,9 +447,6 @@ def register(app: typer.Typer, get_container):
         base_by_path: dict[Path, str | None] = {}
         for p in t.worktrees.values():
             base_by_path[Path(p)] = t.base_branch
-
-        from mship.cli.view._workitems import load_workitem_index
-        from mship.core.view.headers import header_for_task
 
         def _header() -> str | None:
             fresh = state_mgr.load()

--- a/src/mship/cli/view/items.py
+++ b/src/mship/cli/view/items.py
@@ -27,19 +27,19 @@ class ItemsView(MasterDetailApp):
                 for s in self._summaries]
 
     def header_line(self) -> str | None:
-        # Visible affordance: the operator kept not realizing enter opens the tab
-        # (the hint used to live only in the command docstring).
+        # Visible affordance: enter sets the workspace CURRENT FOCUS; the cockpit's
+        # --follow panes re-scope to it (no tab is opened anymore, cockpit-v2 ac5a/ac6).
         return (f"WorkItems ({len(self._summaries)})  ·  "
-                "enter: open cockpit tab · y: copy id")
+                "enter: set focus · y: copy id")
 
     def _do_open_entity(self) -> bool:
         key = self.selected_key()
         if key is None:
             return False
         if _focus_workitem(key):
-            self._announce(f"Focusing {key}")
+            self._announce(f"Focused {key}")
         else:
-            self._announce(f"Could not focus {key} (is zellij running?)")
+            self._announce(f"Could not focus {key} (unknown id?)")
         return True
 
     def _do_copy(self) -> None:
@@ -55,7 +55,8 @@ def register(app: "typer.Typer", get_container):
     @app.command()
     def items():
         """This workspace's WorkItems as a navigable picker: id, title, derived
-        phase, and attention. enter focuses the item's zellij tab · y copies id."""
+        phase, and attention. enter sets this item as the workspace CURRENT FOCUS ·
+        y copies id."""
         from mship.cli.view._workitems import load_workitem_index
         from mship.cli.output import Output
 

--- a/src/mship/cli/view/logs.py
+++ b/src/mship/cli/view/logs.py
@@ -27,6 +27,7 @@ class LogsView(ViewApp):
         cli_task: Optional[str] = None,
         cwd: Optional[Path] = None,
         workitem_loader=None,
+        slug_provider=None,
         **kw,
     ):
         super().__init__(**kw)
@@ -38,6 +39,7 @@ class LogsView(ViewApp):
         self._cli_task = cli_task
         self._cwd = cwd if cwd is not None else Path.cwd()
         self._workitem_loader = workitem_loader
+        self._slug_provider = slug_provider
 
     def _header(self, slug: str) -> str | None:
         if self._workitem_loader is None:
@@ -69,10 +71,16 @@ class LogsView(ViewApp):
         return task.slug
 
     def gather(self) -> str:
-        try:
-            slug = self._resolve_slug()
-        except (NoActiveTaskError, AmbiguousTaskError, UnknownTaskError) as err:
-            return placeholder_for(err)
+        if self._slug_provider is not None:
+            slug = self._slug_provider()
+            if slug is None:
+                from mship.cli.view._follow import follow_hint
+                return follow_hint()
+        else:
+            try:
+                slug = self._resolve_slug()
+            except (NoActiveTaskError, AmbiguousTaskError, UnknownTaskError) as err:
+                return placeholder_for(err)
 
         scope = self._scope_to_repo
         # Watch mode re-reads state per tick so scoping follows `mship switch`.
@@ -125,9 +133,43 @@ def register(app: typer.Typer, get_container):
         watch: bool = typer.Option(False, "--watch"),
         interval: float = typer.Option(2.0, "--interval"),
         all_: bool = typer.Option(False, "--all", help="Show all log entries, ignore active_repo"),
+        follow: bool = typer.Option(False, "--follow", help="Track the workspace CURRENT FOCUS (cockpit-v2)."),
     ):
         """Live tail of a task's journal."""
         container = get_container()
+        from mship.cli.view._workitems import load_workitem_index
+
+        if follow:
+            if task is not None:
+                typer.echo("Error: --follow and --task are mutually exclusive.", err=True)
+                raise typer.Exit(code=1)
+            from mship.cli.view._follow import follow_hint, read_focused_id
+            from mship.cli.layout import resolve_focus_target
+            from mship.cli.output import Output
+
+            def _slug() -> Optional[str]:
+                item_id = read_focused_id(container)
+                if item_id is None:
+                    return None
+                target = resolve_focus_target(container, item_id)
+                return target[1] if target is not None else None
+
+            view = LogsView(
+                state_manager=container.state_manager(),
+                log_manager=container.log_manager(),
+                task_slug=None,
+                all_=all_,
+                cwd=Path.cwd(),
+                workitem_loader=lambda: load_workitem_index(container),
+                slug_provider=_slug,
+                watch=True,
+                interval=interval,
+            )
+            if not Output().is_tty:
+                typer.echo(view.gather())
+                return
+            view.run()
+            return
 
         if watch:
             # Watch mode: defer task resolution into the view so resolver
@@ -145,7 +187,6 @@ def register(app: typer.Typer, get_container):
             if not all_ and t.active_repo is not None:
                 scope = t.active_repo
 
-        from mship.cli.view._workitems import load_workitem_index
         view = LogsView(
             state_manager=container.state_manager(),
             log_manager=container.log_manager(),

--- a/src/mship/cli/view/spec.py
+++ b/src/mship/cli/view/spec.py
@@ -53,13 +53,14 @@ class SpecView(ViewApp):
         header_provider=None,
         spec_store=None,
         spec_id: Optional[str] = None,
+        path_provider=None,
         **kw,
     ):
         # Strip SpecView-specific kwargs before passing to super
         for k in ("workspace_root", "name_or_path", "task",
                   "state_manager", "state", "log_manager",
                   "cli_task", "cwd", "header_provider",
-                  "spec_store", "spec_id"):
+                  "spec_store", "spec_id", "path_provider"):
             kw.pop(k, None)
         super().__init__(**kw)
         self._workspace_root = workspace_root
@@ -73,6 +74,7 @@ class SpecView(ViewApp):
         self._header_provider = header_provider
         self._spec_store = spec_store
         self._spec_id = spec_id
+        self._path_provider = path_provider
         self._last_action_message: str = ""
         self._markdown: Markdown | None = None
         self._error_static: Static | None = None
@@ -120,6 +122,27 @@ class SpecView(ViewApp):
         assert self._body is not None
         was_at_end = self._body.scroll_y >= (self._body.max_scroll_y - 1)
         prev_y = self._body.scroll_y
+
+        if self._path_provider is not None:
+            from mship.cli.view._follow import follow_hint
+            path = self._path_provider()
+            if path is None:
+                self._last_source = follow_hint()
+                self._last_error = ""
+                self._markdown.update(follow_hint())
+                self._error_static.update("")
+                self.call_after_refresh(self._restore_scroll, prev_y, was_at_end)
+                return
+            source = path.read_text()
+            header = self._header_provider() if self._header_provider else None
+            if header:
+                source = f"**{header}**\n\n{source}"
+            self._last_source = source
+            self._last_error = ""
+            self._markdown.update(source)
+            self._error_static.update("")
+            self.call_after_refresh(self._restore_scroll, prev_y, was_at_end)
+            return
 
         state = self._current_state()
 
@@ -328,6 +351,7 @@ def register(app: typer.Typer, get_container):
         task: Optional[str] = typer.Option(None, "--task", help="Narrow to one task's worktrees"),
         workitem: Optional[str] = typer.Option(None, "--workitem", help="Select the spec linked to this WorkItem id"),
         status: Optional[str] = typer.Option(None, "--status", help="Select the newest spec with this status"),
+        follow: bool = typer.Option(False, "--follow", help="Track the workspace CURRENT FOCUS (cockpit-v2)."),
     ):
         """Render a spec file (newest by default)."""
         from pathlib import Path as _P
@@ -362,6 +386,68 @@ def register(app: typer.Typer, get_container):
         if active_selectors and task is not None:
             typer.echo(f"Error: {active_selectors[0]} and --task are mutually exclusive.", err=True)
             raise typer.Exit(code=1)
+
+        if follow:
+            conflicts = [n for n, v in (("--task", task), ("--workitem", workitem),
+                                        ("--status", status), ("name", name_or_path)) if v is not None]
+            if conflicts or web:
+                typer.echo(f"Error: --follow and {conflicts[0] if conflicts else '--web'} "
+                           "are mutually exclusive.", err=True)
+                raise typer.Exit(code=1)
+
+            from mship.core.view.spec_selection import (
+                SpecSelectionError, SpecSelector, scan_canonical_specs, select_spec)
+            from mship.core.spec_store import SPECS_DIRNAME
+            from mship.core.workitem_store import WorkItemStore
+            from mship.core.view.headers import header_for_spec
+            from mship.cli.view._follow import read_focused_id
+            from mship.cli.view._workitems import load_workitem_index
+            from mship.cli.output import Output
+
+            specs_dir = workspace_root / SPECS_DIRNAME
+            items = WorkItemStore(_P(container.state_dir()) / "workitems")
+
+            def _spec_path():
+                item_id = read_focused_id(container)
+                if item_id is None:
+                    return None
+                scanned = scan_canonical_specs(specs_dir)
+                try:
+                    chosen = select_spec([s for s, _ in scanned], items.list(),
+                                         SpecSelector(work_item_id=item_id))
+                except SpecSelectionError:
+                    return None
+                return next((p for s, p in scanned if s.id == chosen.id), None)
+
+            if not Output().is_tty:
+                path = _spec_path()
+                if path is None:
+                    from mship.cli.view._follow import follow_hint
+                    typer.echo(follow_hint())
+                    return
+                typer.echo(path.read_text(), nl=False)
+                return
+
+            def _header():
+                item_id = read_focused_id(container)
+                if item_id is None:
+                    return None
+                idx = load_workitem_index(container)
+                wi = next((w for w in idx if w.id == item_id), None)
+                return header_for_spec(wi.spec_id, idx) if (wi and wi.spec_id) else None
+
+            SpecView(
+                workspace_root=workspace_root,
+                name_or_path=None,
+                state_manager=container.state_manager(),
+                log_manager=container.log_manager(),
+                cwd=_P.cwd(),
+                header_provider=_header,
+                path_provider=_spec_path,
+                watch=True,
+                interval=interval,
+            ).run()
+            return
 
         specs_dir = workspace_root / SPECS_DIRNAME
         canonical_path: Optional[_P] = None

--- a/src/mship/cli/view/spec.py
+++ b/src/mship/cli/view/spec.py
@@ -133,7 +133,19 @@ class SpecView(ViewApp):
                 self._error_static.update("")
                 self.call_after_refresh(self._restore_scroll, prev_y, was_at_end)
                 return
-            source = path.read_text()
+            try:
+                source = path.read_text()
+            except OSError:
+                # The spec file can be deleted/renamed/replaced between the provider
+                # resolving it and this read (spec transitions rewrite the file). Show
+                # the hint and keep following — the next tick re-resolves; never raise
+                # out of the timer callback (that would stop the pane refreshing).
+                self._last_source = follow_hint()
+                self._last_error = ""
+                self._markdown.update(follow_hint())
+                self._error_static.update("")
+                self.call_after_refresh(self._restore_scroll, prev_y, was_at_end)
+                return
             header = self._header_provider() if self._header_provider else None
             if header:
                 source = f"**{header}**\n\n{source}"

--- a/src/mship/cli/view/status.py
+++ b/src/mship/cli/view/status.py
@@ -54,13 +54,14 @@ def _render_task(task: Task, open_questions: list[str] | None = None) -> str:
 
 class StatusView(ViewApp):
     def __init__(self, state_manager, workspace_root: Path, task_filter: Optional[str],
-                 log_manager=None, workitem_loader=None, **kw):
+                 log_manager=None, workitem_loader=None, task_provider=None, **kw):
         super().__init__(**kw)
         self._state_manager = state_manager
         self._workspace_root = workspace_root
         self._task_filter = task_filter
         self._log_manager = log_manager
         self._workitem_loader = workitem_loader
+        self._task_provider = task_provider
 
     def _open_questions(self, slug: str) -> list[str]:
         if self._log_manager is None:
@@ -73,10 +74,16 @@ class StatusView(ViewApp):
 
     def gather(self) -> str:
         state: WorkspaceState = self._state_manager.load()
-        if self._task_filter is not None:
-            task = state.tasks.get(self._task_filter)
+        task_filter = self._task_filter
+        if self._task_provider is not None:
+            task_filter = self._task_provider()
+            if task_filter is None:
+                from mship.cli.view._follow import follow_hint
+                return follow_hint()
+        if task_filter is not None:
+            task = state.tasks.get(task_filter)
             if task is None:
-                return f"Unknown task: {self._task_filter}"
+                return f"Unknown task: {task_filter}"
             return _render_task(task, self._open_questions(task.slug))
         index = build_task_index(state, self._workspace_root)
         if not index:
@@ -98,19 +105,52 @@ def register(app: typer.Typer, get_container):
         task: Optional[str] = typer.Option(None, "--task", help="Narrow to one task slug"),
         watch: bool = typer.Option(False, "--watch"),
         interval: float = typer.Option(2.0, "--interval"),
+        follow: bool = typer.Option(False, "--follow", help="Track the workspace CURRENT FOCUS (cockpit-v2)."),
     ):
         """Live workspace status view (all tasks by default)."""
         from pathlib import Path as _P
         from mship.cli._resolve import resolve_or_exit
+        from mship.cli.view._workitems import load_workitem_index
 
         container = get_container()
+        workspace_root = _P(container.config_path()).parent
+
+        if follow:
+            if task is not None:
+                typer.echo("Error: --follow and --task are mutually exclusive.", err=True)
+                raise typer.Exit(code=1)
+            from mship.cli.view._follow import read_focused_id
+            from mship.cli.layout import resolve_focus_target
+            from mship.cli.output import Output
+
+            def _task_provider() -> Optional[str]:
+                item_id = read_focused_id(container)
+                if item_id is None:
+                    return None
+                target = resolve_focus_target(container, item_id)
+                return target[1] if target is not None else None
+
+            view = StatusView(
+                state_manager=container.state_manager(),
+                workspace_root=workspace_root,
+                task_filter=None,
+                log_manager=container.log_manager(),
+                workitem_loader=lambda: load_workitem_index(container),
+                task_provider=_task_provider,
+                watch=True,
+                interval=interval,
+            )
+            if not Output().is_tty:
+                typer.echo(view.gather())
+                return
+            view.run()
+            return
+
         task_slug: Optional[str] = None
         if task is not None:
             state = container.state_manager().load()
             t = resolve_or_exit(state, task)
             task_slug = t.slug
-        workspace_root = _P(container.config_path()).parent
-        from mship.cli.view._workitems import load_workitem_index
         view = StatusView(
             state_manager=container.state_manager(),
             workspace_root=workspace_root,

--- a/src/mship/cli/view/workitem.py
+++ b/src/mship/cli/view/workitem.py
@@ -67,13 +67,16 @@ def build_rows(cockpit: WorkItemCockpit) -> list[ListRow]:
 
 
 class WorkItemCockpitView(MasterDetailApp):
-    def __init__(self, cockpit: WorkItemCockpit, spec_store=None, **kw) -> None:
+    def __init__(self, cockpit: WorkItemCockpit | None, spec_store=None, **kw) -> None:
         super().__init__(**kw)
         self._cockpit = cockpit
         self._spec_store = spec_store
-        self._spec_status = cockpit.spec_status
+        self._spec_status = cockpit.spec_status if cockpit is not None else None
 
     def list_rows(self) -> list[ListRow]:
+        if self._cockpit is None:
+            from mship.cli.view._follow import follow_hint
+            return [ListRow(key="hint", label=follow_hint(), detail=follow_hint())]
         rows = build_rows(self._cockpit)
         # Reflect the live spec status (relabels after an in-view approve / request-changes).
         if rows and self._spec_status is not None:
@@ -85,6 +88,9 @@ class WorkItemCockpitView(MasterDetailApp):
         return rows
 
     def header_line(self) -> str | None:
+        if self._cockpit is None:
+            from mship.cli.view._follow import follow_hint
+            return follow_hint()
         return f"◆ {self._cockpit.id}  ·  {self._cockpit.title}  ·  [{self._cockpit.phase}]"
 
     def _selected_task(self):
@@ -179,6 +185,25 @@ class WorkItemCockpitView(MasterDetailApp):
         return False
 
 
+class FollowedItemView(WorkItemCockpitView):
+    """`mship view item --follow`: re-resolve the focused WorkItem's cockpit on a
+    timer so the pane re-scopes on focus change AND re-renders on data change (ac2)."""
+    def __init__(self, provider, interval: float = 2.0, spec_store=None, **kw) -> None:
+        super().__init__(cockpit=None, spec_store=spec_store, **kw)
+        self._provider = provider
+        self._follow_interval = interval
+
+    async def on_mount(self) -> None:
+        await self._follow_tick()
+        self.set_interval(self._follow_interval, self._follow_tick)
+
+    async def _follow_tick(self) -> None:
+        cockpit = self._provider()
+        self._cockpit = cockpit
+        self._spec_status = cockpit.spec_status if cockpit is not None else None
+        await self.reload_rows()
+
+
 def _resolve_cockpit(container, item_id: str) -> WorkItemCockpit | None:
     """Resolve one WorkItem's cockpit from the canonical stores, or None if the id
     is unknown. Single entry point is the `WorkItemSummary` (from PR1's
@@ -232,12 +257,43 @@ def register(app: "typer.Typer", get_container):
         store = SpecStore(workspace_root / SPECS_DIRNAME)
         WorkItemCockpitView(cockpit, spec_store=store).run()
 
+    def _run_followed_item(interval: float) -> None:
+        from mship.cli.output import Output
+        from mship.cli.view._follow import follow_hint, read_focused_id
+        from mship.core.view.workitem_cockpit import render_text
+        from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+
+        container = get_container()
+
+        def _provider():
+            item_id = read_focused_id(container)
+            if item_id is None:
+                return None
+            return _resolve_cockpit(container, item_id)
+
+        if not Output().is_tty:
+            cockpit = _provider()
+            typer.echo(follow_hint() if cockpit is None else render_text(cockpit))
+            return
+
+        workspace_root = Path(container.config_path()).parent
+        store = SpecStore(workspace_root / SPECS_DIRNAME)
+        FollowedItemView(provider=_provider, interval=interval, spec_store=store).run()
+
     @app.command(name="item")
     def item(
-        item_id: str = typer.Argument(..., help="WorkItem id to open (e.g. wi-...)"),
+        item_id: Optional[str] = typer.Argument(None, help="WorkItem id to open (e.g. wi-...)"),
+        follow: bool = typer.Option(False, "--follow", help="Track the workspace CURRENT FOCUS (cockpit-v2)."),
+        interval: float = typer.Option(2.0, "--interval"),
     ):
         """Single-WorkItem cockpit: spec (status + phase), acceptance criteria with
         evidence, tasks + worktrees, and linked PRs + threads."""
+        if follow:
+            _run_followed_item(interval)
+            return
+        if item_id is None:
+            typer.echo("Error: provide a WorkItem id, or --follow.", err=True)
+            raise typer.Exit(code=1)
         _run_item_cockpit(item_id)
 
     @app.command(name="workitem", hidden=True)

--- a/src/mship/core/focus.py
+++ b/src/mship/core/focus.py
@@ -7,6 +7,7 @@ directly. `mship layout focus` writes it; `mship view … --follow` reads it.
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -31,9 +32,13 @@ def write_focus(path: Path, work_item_id: str, *, now: datetime | None = None) -
     ts = now if now is not None else datetime.now(timezone.utc)
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps({"work_item_id": work_item_id, "updated_at": ts.isoformat()}) + "\n"
-    )
+    payload = json.dumps({"work_item_id": work_item_id, "updated_at": ts.isoformat()}) + "\n"
+    # Write atomically: the five --follow panes poll this file independently, so a
+    # plain truncating write would let a reader see a half-written (→ "no focus")
+    # file mid-switch. Write a sibling temp then os.replace (atomic on POSIX).
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(payload)
+    os.replace(tmp, path)
     return FocusState(work_item_id=work_item_id, updated_at=ts)
 
 

--- a/src/mship/core/focus.py
+++ b/src/mship/core/focus.py
@@ -1,0 +1,55 @@
+"""Persisted CURRENT FOCUS for the v2 cockpit (spec cockpit-v2, ac1).
+
+A tiny per-workspace file holding the focused WorkItem id + a monotonic
+timestamp. Pure over a Path — no container, no Textual — so it is unit-testable
+directly. `mship layout focus` writes it; `mship view … --follow` reads it.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+FOCUS_FILENAME = "cockpit-focus.json"
+
+
+@dataclass(frozen=True)
+class FocusState:
+    work_item_id: str
+    updated_at: datetime
+
+
+def focus_path(state_dir) -> Path:
+    """The focus file inside a workspace's state dir."""
+    return Path(state_dir) / FOCUS_FILENAME
+
+
+def write_focus(path: Path, work_item_id: str, *, now: datetime | None = None) -> FocusState:
+    """Record `work_item_id` as focused with a monotonic UTC timestamp; returns the
+    written state. Creates parent dirs so the first focus in a fresh workspace works."""
+    ts = now if now is not None else datetime.now(timezone.utc)
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"work_item_id": work_item_id, "updated_at": ts.isoformat()}) + "\n"
+    )
+    return FocusState(work_item_id=work_item_id, updated_at=ts)
+
+
+def read_focus(path: Path) -> FocusState | None:
+    """Read the focus state, or None when the file is absent/unreadable/malformed —
+    a missing or corrupt focus file must degrade to 'no focus', never raise."""
+    try:
+        raw = Path(path).read_text()
+    except (FileNotFoundError, OSError):
+        return None
+    try:
+        data = json.loads(raw)
+        work_item_id = data["work_item_id"]
+        updated_at = datetime.fromisoformat(data["updated_at"])
+    except (ValueError, KeyError, TypeError):
+        return None
+    if not isinstance(work_item_id, str) or not work_item_id:
+        return None
+    return FocusState(work_item_id=work_item_id, updated_at=updated_at)

--- a/tests/cli/test_layout.py
+++ b/tests/cli/test_layout.py
@@ -34,11 +34,12 @@ def test_template_reconstructs_from_parts():
 
 def test_base_layout_has_no_phase_tabs():
     # The legacy Plan/Dev/Review/Run base tabs were removed: the base is Overview
-    # only (the phase sub-tabs now live inside each WorkItem's dedicated tab).
+    # (launchpad) + the focus-driven Cockpit tab.
     assert _BASE_TABS == ""
     for name in ("Plan", "Dev", "Review", "Run"):
         assert f'tab name="{name}"' not in _TEMPLATE
-    assert 'tab name="Overview" focus=true' in _TEMPLATE
+    assert 'tab name="Overview"' in _TEMPLATE
+    assert 'tab name="Cockpit" focus=true' in _TEMPLATE
 
 
 def test_render_workitem_layout_keeps_all_four_phase_subtabs():
@@ -92,19 +93,20 @@ def test_serve_cli_args_mapping():
 
 def test_render_serve_layout_no_args_is_overview_plus_serve():
     kdl = render_serve_layout([])
-    # Base is Overview only; serve appends a Serve tab. No legacy phase tabs.
-    assert 'tab name="Overview" focus=true' in kdl
+    # Base is Overview (launchpad) + Cockpit; serve appends a Serve tab. No phase tabs.
+    assert 'tab name="Overview"' in kdl
+    assert 'tab name="Cockpit"' in kdl
     assert 'tab name="Serve"' in kdl
     for name in ("Plan", "Dev", "Review", "Run"):
         assert f'tab name="{name}"' not in kdl
     assert 'command="mship"' in kdl
     assert 'args "serve";' in kdl
-    # Serve tab comes AFTER Overview, and Overview is the launchpad and keeps focus.
+    # Serve tab comes AFTER Overview.
     assert kdl.index('tab name="Overview"') < kdl.index('tab name="Serve"')
 
 
 def test_template_has_overview_launchpad_tab():
-    assert 'tab name="Overview" focus=true' in _TEMPLATE
+    assert 'tab name="Overview"' in _TEMPLATE
     assert '"view" "queue"' in _TEMPLATE
     assert '"view" "items"' in _TEMPLATE
 
@@ -227,3 +229,64 @@ def test_launch_serve_flag_implies_serve(tmp_path, monkeypatch):
 # Review tab, which no longer exists (base is Overview-only). The per-item Review
 # phase sub-tab's journal/diff panes are covered by test_layout_focus.py
 # (test_kdl_bakes_shipped_view_commands_with_item_and_task).
+
+
+# --- cockpit-v2 Task 9: single-cockpit builder (ONE fixed rich stack) ---
+from mship.cli.layout import (
+    ViewPaneSpec, cockpit_view_specs, render_cockpit_layout,
+)
+
+
+def test_cockpit_view_specs_is_the_fixed_rich_set_in_order():
+    # A single fixed member set, same regardless of phase: Spec, Diff, Journal,
+    # Status, Item/PR — every member is a `mship view … --follow` command.
+    specs = cockpit_view_specs()
+    assert [s.name for s in specs] == ["Spec", "Diff", "Journal", "Status", "Item"]
+    assert [s.view_args for s in specs] == [
+        ["view", "spec", "--follow"],
+        ["view", "diff", "--follow"],
+        ["view", "journal", "--follow"],
+        ["view", "status", "--follow"],
+        ["view", "item", "--follow"],
+    ]
+
+
+def test_cockpit_view_specs_takes_no_arguments():
+    # No phase parameter — membership never depends on the focused item's phase.
+    import inspect
+    assert list(inspect.signature(cockpit_view_specs).parameters) == []
+
+
+def test_cockpit_agent_pane_is_outside_the_stack():
+    kdl = render_cockpit_layout()
+    assert 'name="Agent" focus=true' in kdl
+    # Agent is declared before the stacked group and never inside it.
+    assert kdl.index('name="Agent"') < kdl.index('pane stacked=true {')
+
+
+def test_cockpit_has_stacked_group_of_all_five_follow_views():
+    kdl = render_cockpit_layout()
+    assert 'pane stacked=true {' in kdl
+    assert '"view" "spec" "--follow"' in kdl
+    assert '"view" "diff" "--follow"' in kdl
+    assert '"view" "journal" "--follow"' in kdl
+    assert '"view" "status" "--follow"' in kdl
+    assert '"view" "item" "--follow"' in kdl
+
+
+def test_cockpit_keeps_overview_launchpad():
+    kdl = render_cockpit_layout()
+    assert 'tab name="Overview"' in kdl
+    assert '"view" "queue"' in kdl and '"view" "items"' in kdl
+    assert 'tab name="Cockpit" focus=true' in kdl
+
+
+def test_cockpit_chat_command_threaded():
+    kdl = render_cockpit_layout(chat_command="claude")
+    assert 'name="Agent" focus=true command="sh"' in kdl
+    assert '"-c" "claude"' in kdl
+
+
+def test_cockpit_membership_is_identical_regardless_of_call():
+    # The stack is fixed: two builds produce the same member set (no phase input).
+    assert render_cockpit_layout() == render_cockpit_layout()

--- a/tests/cli/test_layout.py
+++ b/tests/cli/test_layout.py
@@ -191,11 +191,29 @@ def _capture_launch(monkeypatch, argv):
     return captured
 
 
-def test_layout_launch_execs_zellij(tmp_path, monkeypatch):
+def test_launch_renders_cockpit_temp_layout(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     cap = _capture_launch(monkeypatch, ["layout", "launch"])
-    assert cap["file"] == "zellij"
-    assert cap["args"] == ["zellij", "--layout", "mothership"]
+    assert cap["args"][0:2] == ["zellij", "--layout"]
+    body = Path(cap["args"][2]).read_text()
+    assert 'tab name="Cockpit" focus=true' in body
+    assert 'pane stacked=true {' in body
+    assert '"view" "diff" "--follow"' in body
+
+
+def test_launch_threads_chat_command(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cap = _capture_launch(monkeypatch, ["layout", "launch", "--chat-command", "claude"])
+    body = Path(cap["args"][2]).read_text()
+    assert '"-c" "claude"' in body
+
+
+def test_launch_serve_still_adds_serve_tab(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cap = _capture_launch(monkeypatch, ["layout", "launch", "--serve"])
+    body = Path(cap["args"][2]).read_text()
+    assert 'tab name="Serve"' in body
+    assert 'tab name="Cockpit"' in body
 
 
 def test_launch_serve_renders_temp_layout(tmp_path, monkeypatch):

--- a/tests/cli/test_layout.py
+++ b/tests/cli/test_layout.py
@@ -97,6 +97,18 @@ def test_layout_init_writes_file(tmp_path: Path, monkeypatch):
     assert _expected_path(tmp_path).read_text() == _TEMPLATE
 
 
+def test_launch_layout_path_is_process_keyed(tmp_path: Path, monkeypatch):
+    # Per-PID path so two concurrent `mship layout launch` processes write DIFFERENT
+    # files and can't race on a shared path before zellij reads it.
+    import os as _os
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mship.cli.layout import _launch_layout_path
+    p = _launch_layout_path()
+    assert str(_os.getpid()) in p.name
+    assert p.suffix == ".kdl"
+    assert "mothership-serve-launch.kdl" not in str(p)  # not the old shared path
+
+
 def test_init_writes_both_layouts(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     result = runner.invoke(app, ["layout", "init"])

--- a/tests/cli/test_layout.py
+++ b/tests/cli/test_layout.py
@@ -6,12 +6,10 @@ from typer.testing import CliRunner
 from mship.cli import app
 from mship.cli.layout import (
     _BASE_TABS,
-    _DEFAULT_TAB_TEMPLATE,
     _LAYOUT_HEAD,
     _LAYOUT_TAIL,
     _TEMPLATE,
     render_serve_layout,
-    render_workitem_layout,
     serve_cli_args,
 )
 
@@ -40,39 +38,6 @@ def test_base_layout_has_no_phase_tabs():
         assert f'tab name="{name}"' not in _TEMPLATE
     assert 'tab name="Overview"' in _TEMPLATE
     assert 'tab name="Cockpit" focus=true' in _TEMPLATE
-
-
-def test_render_workitem_layout_keeps_all_four_phase_subtabs():
-    # Removing the base phase tabs must NOT remove the per-item phase sub-tabs.
-    kdl = render_workitem_layout(
-        name="wi-1", worktree="/wt/a", item_id="wi-1", task_slug="a",
-        chat_command=None, default_phase="Dev")
-    for phase in ("Plan", "Dev", "Review", "Run"):
-        assert f'swap_tiled_layout name="{phase}"' in kdl
-
-
-def test_render_workitem_layout_has_tab_bar_framing():
-    # A focus tab is opened from this layout via `new-tab --layout`; without a
-    # default_tab_template it renders with NO tab bar/status bar (you lose the tab
-    # bar when switching into a focus tab). It must carry the same frame as the base.
-    kdl = render_workitem_layout(
-        name="wi-1", worktree="/wt/a", item_id="wi-1", task_slug="a",
-        chat_command=None, default_phase="Dev")
-    assert "default_tab_template {" in kdl
-    assert 'plugin location="zellij:tab-bar"' in kdl
-    assert 'plugin location="zellij:status-bar"' in kdl
-    # The template must come before the tab it frames.
-    assert kdl.index("default_tab_template") < kdl.index('tab name="wi-1"')
-
-
-def test_workitem_layout_tab_template_matches_base():
-    # The per-item frame is the SAME block the base layout uses — keep them in sync
-    # via the shared constant so the two can't drift.
-    assert _DEFAULT_TAB_TEMPLATE in _TEMPLATE
-    kdl = render_workitem_layout(
-        name="wi-1", worktree="/wt/a", item_id="wi-1", task_slug="a",
-        chat_command=None, default_phase="Dev")
-    assert _DEFAULT_TAB_TEMPLATE in kdl
 
 
 # --- Task 2: pure builders -----------------------------------------------------

--- a/tests/cli/test_layout_focus.py
+++ b/tests/cli/test_layout_focus.py
@@ -1,97 +1,11 @@
-from mship.cli.layout import decide_focus_action, tab_name_for
-
-
-def test_tab_name_is_deterministic_and_id_based():
-    assert tab_name_for("wi-20260721-abc") == tab_name_for("wi-20260721-abc")
-    assert "wi-20260721-abc" in tab_name_for("wi-20260721-abc")
-
-
-def test_decision_create_when_absent():
-    assert decide_focus_action("wi-1", [], is_done=False) == "create"
-
-
-def test_decision_go_to_when_present():
-    assert decide_focus_action("wi-1", ["other", "wi-1"], is_done=False) == "go-to"
-
-
-def test_decision_close_when_done_and_present():
-    assert decide_focus_action("wi-1", ["wi-1"], is_done=True) == "close"
-
-
-def test_decision_noop_when_done_and_absent():
-    assert decide_focus_action("wi-1", ["other"], is_done=True) == "noop"
-
-
-# --- Task 4: per-WorkItem KDL renderer ---------------------------------------
-from mship.cli.layout import (
-    default_phase_tab, render_workitem_layout, resolve_chat_command,
-)
+# --- resolve_chat_command (kept: used by cockpit launch) ---------------------
+from mship.cli.layout import resolve_chat_command
 
 
 def test_resolve_chat_command_precedence():
     assert resolve_chat_command("claude", {}) == "claude"
     assert resolve_chat_command(None, {"MSHIP_CHAT_COMMAND": "my-agent"}) == "my-agent"
     assert resolve_chat_command(None, {}) is None  # default: bare shell pane
-
-
-def test_default_phase_tab_mapping():
-    assert default_phase_tab("shaping") == "Plan"
-    assert default_phase_tab("ready") == "Plan"
-    assert default_phase_tab("in_flight") == "Dev"
-    assert default_phase_tab("review") == "Review"
-    assert default_phase_tab("done") == "Run"
-    assert default_phase_tab("something-else") == "Plan"
-
-
-def _kdl(**over):
-    base = dict(name="wi-1", worktree="/wt/a", item_id="wi-1", task_slug="a",
-                chat_command=None, default_phase="Dev")
-    base.update(over)
-    return render_workitem_layout(**base)
-
-
-def test_kdl_is_chat_first_with_editor_and_cwd():
-    kdl = _kdl()
-    assert 'tab name="wi-1" focus=true' in kdl
-    assert 'cwd "/wt/a"' in kdl
-    assert 'name="Agent"' in kdl
-    assert 'name="Editor"' in kdl
-    # Default chat command == bare shell pane (no command= on Agent).
-    assert 'name="Agent" focus=true {' not in kdl  # bare pane has no child block
-
-
-def test_kdl_configurable_chat_command():
-    kdl = _kdl(chat_command="claude")
-    assert 'name="Agent"' in kdl and 'command="sh"' in kdl
-    assert '"-c" "claude"' in kdl
-
-
-def test_kdl_has_all_four_phase_subtabs():
-    kdl = _kdl()
-    for phase in ("Plan", "Dev", "Review", "Run"):
-        assert f'swap_tiled_layout name="{phase}"' in kdl
-
-
-def test_kdl_bakes_shipped_view_commands_with_item_and_task():
-    kdl = _kdl()
-    assert '"view" "spec" "--workitem" "wi-1" "--watch"' in kdl   # Plan
-    assert '"view" "diff" "--task" "a" "--watch"' in kdl           # Dev/Review
-    assert '"view" "journal" "--task" "a" "--watch"' in kdl        # Dev + Run
-    assert '"view" "item" "wi-1"' in kdl                            # Review (PR/checks)
-    # NOTE: `mship view logs` does not exist — the only run/journal view command is
-    # `view journal` (logs.py registers it as `journal`). The Run sub-tab therefore
-    # tails `view journal` (asserted above), not a nonexistent `view logs`.
-
-
-def test_kdl_escapes_worktree_path():
-    kdl = _kdl(worktree='/wt/ba"d')
-    assert 'cwd "/wt/ba\\"d"' in kdl
-
-
-def test_kdl_without_task_degrades_task_scoped_panes():
-    kdl = _kdl(task_slug=None)
-    assert "--task" not in kdl
-    assert 'name="Shell"' in kdl   # task-scoped panes fall back to a shell
 
 
 # --- Task 5: resolve_focus_target --------------------------------------------
@@ -172,92 +86,13 @@ from typer.testing import CliRunner
 runner = CliRunner()
 
 
-def _patch_zellij(monkeypatch, *, in_session, existing, action_ok=True, query_ok=True):
-    calls = []
-
-    def _run(args):
-        calls.append(args)
-        return action_ok
-
+def _patch_zellij(monkeypatch, *, in_session, existing=None, action_ok=True, query_ok=True):
+    """Cockpit-v2: `layout focus` no longer runs any zellij action, so the only seam
+    left to control is `_in_zellij`. Returns an always-empty `calls` list so the
+    Task-2 tests can still assert 'no zellij action was attempted'."""
+    calls: list = []
     monkeypatch.setattr(layout_mod, "_in_zellij", lambda: in_session)
-    monkeypatch.setattr(layout_mod, "_query_tab_names",
-                        lambda: (list(existing) if query_ok else None))
-    monkeypatch.setattr(layout_mod, "_run_zellij_action", _run)
     return calls
-
-
-def test_write_workitem_layout_file_writes_stable_named_kdl(tmp_path, monkeypatch):
-    # The pure helper: writes <cache>/<item_id>.kdl and returns (name, dir) that
-    # `new-tab --layout <name> --layout-dir <dir>` resolves by name.
-    from mship.cli.layout import write_workitem_layout_file
-
-    monkeypatch.setenv("HOME", str(tmp_path))
-    name, cache_dir = write_workitem_layout_file("wi-1", "layout { }\n")
-    assert name == "wi-1"
-    assert (cache_dir / "wi-1.kdl").read_text() == "layout { }\n"
-    # Re-writing overwrites the same stable path (no accumulation, no delete-race).
-    name2, cache_dir2 = write_workitem_layout_file("wi-1", "layout { changed }\n")
-    assert cache_dir2 == cache_dir
-    assert (cache_dir / "wi-1.kdl").read_text() == "layout { changed }\n"
-
-
-# --- Task 8: explicit close + close-on-done lifecycle ------------------------
-def test_close_closes_existing_tab(tmp_path, monkeypatch):
-    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
-    calls = _patch_zellij(monkeypatch, in_session=True, existing=["wi-1"])
-    try:
-        result = runner.invoke(app, ["layout", "close", "wi-1"])
-        assert result.exit_code == 0, result.output
-        assert calls == [["go-to-tab-name", "wi-1"], ["close-tab"]]
-    finally:
-        _reset_focus()
-
-
-def test_close_no_tab_is_noop(tmp_path, monkeypatch):
-    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
-    calls = _patch_zellij(monkeypatch, in_session=True, existing=["Overview"])
-    try:
-        result = runner.invoke(app, ["layout", "close", "wi-1"])
-        assert result.exit_code == 0, result.output
-        assert calls == []
-    finally:
-        _reset_focus()
-
-
-def test_close_outside_zellij_noops(tmp_path, monkeypatch):
-    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
-    calls = _patch_zellij(monkeypatch, in_session=False, existing=["wi-1"])
-    try:
-        result = runner.invoke(app, ["layout", "close", "wi-1"])
-        assert result.exit_code == 0
-        assert "zellij" in result.output.lower()
-        assert calls == []
-    finally:
-        _reset_focus()
-
-
-# --- Greptile #396: seams report failure; never close the wrong tab ---
-def test_close_does_not_close_wrong_tab_when_go_to_fails(tmp_path, monkeypatch):
-    # go-to fails -> close-tab must NOT run (else it closes the active/wrong tab).
-    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
-    calls = _patch_zellij(monkeypatch, in_session=True, existing=["wi-1"], action_ok=False)
-    try:
-        result = runner.invoke(app, ["layout", "close", "wi-1"])
-        assert result.exit_code == 1
-        assert calls == [["go-to-tab-name", "wi-1"]]   # close-tab NOT called
-    finally:
-        _reset_focus()
-
-
-def test_close_errors_when_tab_query_fails(tmp_path, monkeypatch):
-    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
-    calls = _patch_zellij(monkeypatch, in_session=True, existing=["wi-1"], query_ok=False)
-    try:
-        result = runner.invoke(app, ["layout", "close", "wi-1"])
-        assert result.exit_code == 1
-        assert calls == []
-    finally:
-        _reset_focus()
 
 
 # --- cockpit-v2 Task 2: focus sets the focus file, no tabs ---

--- a/tests/cli/test_layout_focus.py
+++ b/tests/cli/test_layout_focus.py
@@ -186,45 +186,6 @@ def _patch_zellij(monkeypatch, *, in_session, existing, action_ok=True, query_ok
     return calls
 
 
-def test_focus_outside_zellij_noops_with_message(tmp_path, monkeypatch):
-    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
-    calls = _patch_zellij(monkeypatch, in_session=False, existing=[])
-    try:
-        result = runner.invoke(app, ["layout", "focus", "wi-1"])
-        assert result.exit_code == 0, result.output
-        assert "zellij" in result.output.lower()
-        assert calls == []   # no zellij action attempted
-    finally:
-        _reset_focus()
-
-
-def test_focus_creates_tab_when_absent(tmp_path, monkeypatch):
-    # HOME is isolated so the layout KDL cache write lands in tmp, not real ~/.cache.
-    monkeypatch.setenv("HOME", str(tmp_path))
-    wt = tmp_path / "wt-a"
-    _seed_focus(tmp_path, {"r": wt})
-    calls = _patch_zellij(monkeypatch, in_session=True, existing=["Overview"])
-    try:
-        result = runner.invoke(app, ["layout", "focus", "wi-1"])
-        assert result.exit_code == 0, result.output
-        assert len(calls) == 1
-        args = calls[0]
-        assert args[0] == "new-tab"
-        assert "--name" in args and "wi-1" in args
-        assert "--cwd" in args and str(wt) in args
-        # Portable delivery: KDL goes via a cache FILE (--layout <name> --layout-dir
-        # <dir>), never --layout-string (which older zellij lacks).
-        assert "--layout-string" not in args
-        assert "--layout" in args and "--layout-dir" in args
-        layout_name = args[args.index("--layout") + 1]
-        layout_dir = Path(args[args.index("--layout-dir") + 1])
-        assert layout_name == "wi-1"
-        kdl = (layout_dir / f"{layout_name}.kdl").read_text()
-        assert 'tab name="wi-1"' in kdl and 'name="Agent"' in kdl
-    finally:
-        _reset_focus()
-
-
 def test_write_workitem_layout_file_writes_stable_named_kdl(tmp_path, monkeypatch):
     # The pure helper: writes <cache>/<item_id>.kdl and returns (name, dir) that
     # `new-tab --layout <name> --layout-dir <dir>` resolves by name.
@@ -238,28 +199,6 @@ def test_write_workitem_layout_file_writes_stable_named_kdl(tmp_path, monkeypatc
     name2, cache_dir2 = write_workitem_layout_file("wi-1", "layout { changed }\n")
     assert cache_dir2 == cache_dir
     assert (cache_dir / "wi-1.kdl").read_text() == "layout { changed }\n"
-
-
-def test_focus_switches_to_existing_tab(tmp_path, monkeypatch):
-    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
-    calls = _patch_zellij(monkeypatch, in_session=True, existing=["wi-1"])
-    try:
-        result = runner.invoke(app, ["layout", "focus", "wi-1"])
-        assert result.exit_code == 0, result.output
-        assert calls == [["go-to-tab-name", "wi-1"]]
-    finally:
-        _reset_focus()
-
-
-def test_focus_unknown_id_exits_1(tmp_path, monkeypatch):
-    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
-    _patch_zellij(monkeypatch, in_session=True, existing=[])
-    try:
-        result = runner.invoke(app, ["layout", "focus", "wi-missing"])
-        assert result.exit_code == 1
-        assert "wi-missing" in result.output
-    finally:
-        _reset_focus()
 
 
 # --- Task 8: explicit close + close-on-done lifecycle ------------------------
@@ -297,46 +236,7 @@ def test_close_outside_zellij_noops(tmp_path, monkeypatch):
         _reset_focus()
 
 
-def test_focus_done_item_closes_its_tab(tmp_path, monkeypatch):
-    # A done item (terminal spec status) whose tab exists is closed, not re-opened.
-    from mship.core.spec_store import SPECS_DIRNAME, SpecStore
-    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
-    spec = SpecStore(tmp_path / SPECS_DIRNAME).find_by_id("spec-1")
-    SpecStore(tmp_path / SPECS_DIRNAME).save(spec.model_copy(update={"status": "archived"}))
-    calls = _patch_zellij(monkeypatch, in_session=True, existing=["wi-1"])
-    try:
-        result = runner.invoke(app, ["layout", "focus", "wi-1"])
-        assert result.exit_code == 0, result.output
-        assert calls == [["go-to-tab-name", "wi-1"], ["close-tab"]]
-        assert "done" in result.output.lower() or "closed" in result.output.lower()
-    finally:
-        _reset_focus()
-
-
 # --- Greptile #396: seams report failure; never close the wrong tab ---
-def test_focus_errors_when_tab_query_fails(tmp_path, monkeypatch):
-    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
-    calls = _patch_zellij(monkeypatch, in_session=True, existing=[], query_ok=False)
-    try:
-        result = runner.invoke(app, ["layout", "focus", "wi-1"])
-        assert result.exit_code == 1
-        assert calls == []   # can't read tab state -> attempt nothing (no dup tab)
-    finally:
-        _reset_focus()
-
-
-def test_focus_new_tab_failure_reports_error(tmp_path, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path))
-    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
-    _patch_zellij(monkeypatch, in_session=True, existing=["Overview"], action_ok=False)
-    try:
-        result = runner.invoke(app, ["layout", "focus", "wi-1"])
-        assert result.exit_code == 1
-        assert "could not open" in result.output.lower()
-    finally:
-        _reset_focus()
-
-
 def test_close_does_not_close_wrong_tab_when_go_to_fails(tmp_path, monkeypatch):
     # go-to fails -> close-tab must NOT run (else it closes the active/wrong tab).
     _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
@@ -356,5 +256,79 @@ def test_close_errors_when_tab_query_fails(tmp_path, monkeypatch):
         result = runner.invoke(app, ["layout", "close", "wi-1"])
         assert result.exit_code == 1
         assert calls == []
+    finally:
+        _reset_focus()
+
+
+# --- cockpit-v2 Task 2: focus sets the focus file, no tabs ---
+from mship.core.focus import focus_path, read_focus
+
+
+def test_focus_writes_focus_file_no_zellij(tmp_path, monkeypatch):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    calls = _patch_zellij(monkeypatch, in_session=True, existing=["Overview"])
+    try:
+        result = runner.invoke(app, ["layout", "focus", "wi-1"])
+        assert result.exit_code == 0, result.output
+        assert read_focus(focus_path(tmp_path / ".mothership")).work_item_id == "wi-1"
+        assert calls == []   # NEVER touches zellij tabs anymore
+    finally:
+        _reset_focus()
+
+
+def test_focus_show_prints_current_focus(tmp_path, monkeypatch):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    try:
+        runner.invoke(app, ["layout", "focus", "wi-1"])
+        result = runner.invoke(app, ["layout", "focus", "--show"])
+        assert result.exit_code == 0, result.output
+        assert "wi-1" in result.output
+    finally:
+        _reset_focus()
+
+
+def test_focus_show_when_none(tmp_path, monkeypatch):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    try:
+        result = runner.invoke(app, ["layout", "focus", "--show"])
+        assert result.exit_code == 0, result.output
+        assert "no workitem" in result.output.lower()
+    finally:
+        _reset_focus()
+
+
+def test_focus_unknown_id_exits_1_no_write(tmp_path, monkeypatch):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    try:
+        result = runner.invoke(app, ["layout", "focus", "wi-missing"])
+        assert result.exit_code == 1
+        assert "wi-missing" in result.output
+        assert read_focus(focus_path(tmp_path / ".mothership")) is None
+    finally:
+        _reset_focus()
+
+
+def test_focus_done_item_is_flagged_but_written(tmp_path, monkeypatch):
+    from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    store = SpecStore(tmp_path / SPECS_DIRNAME)
+    store.save(store.find_by_id("spec-1").model_copy(update={"status": "archived"}))
+    try:
+        result = runner.invoke(app, ["layout", "focus", "wi-1"])
+        assert result.exit_code == 0, result.output
+        assert "done" in result.output.lower()
+        assert read_focus(focus_path(tmp_path / ".mothership")).work_item_id == "wi-1"
+    finally:
+        _reset_focus()
+
+
+def test_focus_outside_zellij_still_writes_with_advisory(tmp_path, monkeypatch):
+    _seed_focus(tmp_path, {"r": tmp_path / "wt-a"})
+    monkeypatch.setattr("mship.cli.layout._in_zellij", lambda: False)
+    try:
+        result = runner.invoke(app, ["layout", "focus", "wi-1"])
+        assert result.exit_code == 0, result.output
+        assert read_focus(focus_path(tmp_path / ".mothership")).work_item_id == "wi-1"
+        assert "zellij" in result.output.lower()   # advisory, not an error
     finally:
         _reset_focus()

--- a/tests/cli/view/test_diff_view.py
+++ b/tests/cli/view/test_diff_view.py
@@ -340,3 +340,65 @@ async def test_diff_view_no_header_by_default(tmp_path):
     async with view.run_test() as pilot:
         await pilot.pause()
         assert view.header_text() == ""
+
+
+# --- cockpit-v2 Task 4: diff --follow ---
+from datetime import datetime, timezone
+from typer.testing import CliRunner as _CliRunner
+
+from mship.cli import app, container
+from mship.core.focus import focus_path, write_focus
+from mship.core.spec import Spec
+from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.workitem import WorkItem
+from mship.core.workitem_store import WorkItemStore
+
+
+def _now_dt():
+    return datetime(2026, 7, 21, tzinfo=timezone.utc)
+
+
+def _seed_follow(tmp_path, worktrees):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    SpecStore(tmp_path / SPECS_DIRNAME).save(Spec(
+        id="spec-1", title="T", status="approved",
+        created_at=_now_dt(), updated_at=_now_dt(), body="b\n"))
+    WorkItemStore(state_dir / "workitems").save(WorkItem(
+        id="wi-1", title="T", workspace="t", kind="feature",
+        created_at=_now_dt(), updated_at=_now_dt(), spec_id="spec-1", task_slugs=["a"]))
+    StateManager(state_dir).save(WorkspaceState(tasks={"a": Task(
+        slug="a", description="d", phase="dev", created_at=_now_dt(),
+        affected_repos=["r"], branch="feat/a", worktrees=worktrees, work_item_id="wi-1")}))
+    container.config.reset(); container.state_manager.reset()
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    return state_dir
+
+
+def _reset_follow():
+    container.config_path.reset_override(); container.state_dir.reset_override()
+    container.config.reset_override(); container.config.reset()
+    container.state_manager.reset_override(); container.state_manager.reset()
+
+
+def test_diff_follow_no_focus_prints_hint(tmp_path):
+    _seed_follow(tmp_path, {"r": tmp_path})
+    try:
+        result = _CliRunner().invoke(app, ["view", "diff", "--follow"])
+        assert result.exit_code == 0, result.output
+        assert "no workitem focused" in result.output.lower()
+    finally:
+        _reset_follow()
+
+
+def test_diff_follow_and_watch_are_exclusive(tmp_path):
+    _seed_follow(tmp_path, {"r": tmp_path})
+    try:
+        result = _CliRunner().invoke(app, ["view", "diff", "--follow", "--task", "a"])
+        assert result.exit_code == 1
+        assert "mutually exclusive" in result.output.lower()
+    finally:
+        _reset_follow()

--- a/tests/cli/view/test_follow.py
+++ b/tests/cli/view/test_follow.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timezone
+
+from mship.cli import container
+from mship.cli.view._follow import follow_hint, read_focused_id
+from mship.core.focus import focus_path, write_focus
+
+
+def _bind_state_dir(tmp_path):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    container.state_dir.override(state_dir)
+    return state_dir
+
+
+def _unbind():
+    container.state_dir.reset_override()
+
+
+def test_read_focused_id_none_when_no_file(tmp_path):
+    _bind_state_dir(tmp_path)
+    try:
+        assert read_focused_id(container) is None
+    finally:
+        _unbind()
+
+
+def test_read_focused_id_returns_written_id(tmp_path):
+    state_dir = _bind_state_dir(tmp_path)
+    try:
+        write_focus(focus_path(state_dir), "wi-42",
+                    now=datetime(2026, 7, 21, tzinfo=timezone.utc))
+        assert read_focused_id(container) == "wi-42"
+    finally:
+        _unbind()
+
+
+def test_follow_hint_mentions_focus_and_is_not_empty():
+    hint = follow_hint()
+    assert hint.strip()
+    assert "focus" in hint.lower()

--- a/tests/cli/view/test_items_view.py
+++ b/tests/cli/view/test_items_view.py
@@ -78,12 +78,9 @@ async def test_items_view_lists_and_enter_focuses(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_items_view_shows_enter_and_copy_hint():
-    # The operator kept not realizing enter opens the tab — the hint must be
-    # visible on-screen, not just in the command docstring.
+async def test_items_view_header_says_set_focus():
     from mship.core.view.workitem_index import Attention, WorkItemSummary
     import mship.cli.view.items as iv
-
     s = WorkItemSummary(
         id="wi-1", title="Overhaul", kind="feature", workspace="t", phase="in_flight",
         attention=Attention(False, False, False, False, 0, 1),
@@ -91,9 +88,9 @@ async def test_items_view_shows_enter_and_copy_hint():
     view = iv.ItemsView([s])
     async with view.run_test() as pilot:
         await pilot.pause()
-        header = view.header_text()
-        assert "enter" in header.lower()
-        assert "copy" in header.lower()
+        header = view.header_text().lower()
+        assert "focus" in header
+        assert "copy" in header
 
 
 @pytest.mark.asyncio

--- a/tests/cli/view/test_logs_view.py
+++ b/tests/cli/view/test_logs_view.py
@@ -360,3 +360,66 @@ def test_journal_no_header_without_loader():
     text = view.gather()
     assert "◆" not in text
     assert "hello" in text
+
+
+# --- cockpit-v2 Task 5: journal --follow ---
+from typer.testing import CliRunner as _CliRunner
+
+from mship.cli import app as _app, container as _c5
+from mship.core.focus import focus_path, write_focus
+from mship.core.spec import Spec as _Spec5
+from mship.core.spec_store import SPECS_DIRNAME as _SPECS5, SpecStore as _SpecStore5
+from mship.core.state import StateManager as _SM5, Task as _Task5, WorkspaceState as _WS5
+from mship.core.workitem import WorkItem as _WI5
+from mship.core.workitem_store import WorkItemStore as _WIS5
+
+
+def _now_dt5():
+    return datetime(2026, 7, 21, tzinfo=timezone.utc)
+
+
+def _seed_follow(tmp_path, worktrees):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    _SpecStore5(tmp_path / _SPECS5).save(_Spec5(
+        id="spec-1", title="T", status="approved",
+        created_at=_now_dt5(), updated_at=_now_dt5(), body="b\n"))
+    _WIS5(state_dir / "workitems").save(_WI5(
+        id="wi-1", title="T", workspace="t", kind="feature",
+        created_at=_now_dt5(), updated_at=_now_dt5(), spec_id="spec-1", task_slugs=["a"]))
+    _SM5(state_dir).save(_WS5(tasks={"a": _Task5(
+        slug="a", description="d", phase="dev", created_at=_now_dt5(),
+        affected_repos=["r"], branch="feat/a", worktrees=worktrees, work_item_id="wi-1")}))
+    _c5.config.reset(); _c5.state_manager.reset()
+    _c5.config_path.override(tmp_path / "mothership.yaml")
+    _c5.state_dir.override(state_dir)
+    return state_dir
+
+
+def _reset_follow():
+    _c5.config_path.reset_override(); _c5.state_dir.reset_override()
+    _c5.config.reset_override(); _c5.config.reset()
+    _c5.state_manager.reset_override(); _c5.state_manager.reset()
+
+
+def test_journal_follow_no_focus_prints_hint(tmp_path):
+    _seed_follow(tmp_path, {"r": tmp_path})
+    try:
+        result = _CliRunner().invoke(_app, ["view", "journal", "--follow"])
+        assert result.exit_code == 0, result.output
+        assert "no workitem focused" in result.output.lower()
+    finally:
+        _reset_follow()
+
+
+def test_journal_follow_renders_focused_task_journal(tmp_path):
+    state_dir = _seed_follow(tmp_path, {"r": tmp_path})
+    write_focus(focus_path(state_dir), "wi-1")
+    _c5.log_manager().append("a", "hello journal")   # LogManager append API
+    try:
+        result = _CliRunner().invoke(_app, ["view", "journal", "--follow"])
+        assert result.exit_code == 0, result.output
+        assert "hello journal" in result.output
+    finally:
+        _reset_follow()

--- a/tests/cli/view/test_spec_view.py
+++ b/tests/cli/view/test_spec_view.py
@@ -27,6 +27,22 @@ async def test_spec_view_missing_spec(tmp_path: Path):
         assert "Spec not found" in view.rendered_text()
 
 
+@pytest.mark.asyncio
+async def test_spec_follow_survives_spec_file_vanishing(tmp_path: Path):
+    # A --follow spec path can be deleted/renamed/replaced between the provider
+    # resolving it and the read (spec transitions rewrite the file). The pane must
+    # show the follow hint, not raise out of the timer callback (which would stop
+    # the pane from ever refreshing again).
+    from mship.cli.view._follow import follow_hint
+
+    missing = tmp_path / "gone-spec.md"  # provider hands back a path that isn't there
+    view = SpecView(workspace_root=tmp_path, name_or_path=None, watch=False,
+                    interval=1.0, path_provider=lambda: missing)
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        assert view._last_source == follow_hint()
+
+
 def test_serve_spec_web_serves_rendered_html(tmp_path: Path):
     spec = tmp_path / "s.md"
     spec.write_text("# Title\n\nBody.\n")

--- a/tests/cli/view/test_spec_view.py
+++ b/tests/cli/view/test_spec_view.py
@@ -614,3 +614,75 @@ async def test_spec_view_approve_writes_via_store(tmp_path):
         await pilot.pause()
         assert store.find_by_id("spec-1").status == "approved"
         assert "approved" in view.last_action().lower()
+
+
+# --- cockpit-v2 Task 7: spec --follow ---
+from typer.testing import CliRunner as _CliRunner
+
+from mship.cli import app as _app7, container as _c7
+from mship.core.focus import focus_path, write_focus
+from mship.core.spec import Spec as _Spec7
+from mship.core.spec_store import SPECS_DIRNAME as _SPECS7, SpecStore as _SpecStore7
+from mship.core.state import StateManager as _SM7, Task as _Task7, WorkspaceState as _WS7
+from mship.core.workitem import WorkItem as _WI7
+from mship.core.workitem_store import WorkItemStore as _WIS7
+
+
+def _now_dt7():
+    return datetime(2026, 7, 21, tzinfo=timezone.utc)
+
+
+def _seed_follow_spec(tmp_path):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    _SpecStore7(tmp_path / _SPECS7).save(_Spec7(
+        id="spec-1", title="Overhaul", status="approved",
+        created_at=_now_dt7(), updated_at=_now_dt7(), body="Overhaul body\n"))
+    _WIS7(state_dir / "workitems").save(_WI7(
+        id="wi-1", title="Overhaul", workspace="t", kind="feature",
+        created_at=_now_dt7(), updated_at=_now_dt7(), spec_id="spec-1", task_slugs=["a"]))
+    _SM7(state_dir).save(_WS7(tasks={"a": _Task7(
+        slug="a", description="d", phase="dev", created_at=_now_dt7(),
+        affected_repos=["r"], branch="feat/a", worktrees={"r": tmp_path}, work_item_id="wi-1")}))
+    _c7.config.reset(); _c7.state_manager.reset()
+    _c7.config_path.override(tmp_path / "mothership.yaml")
+    _c7.state_dir.override(state_dir)
+    return state_dir
+
+
+def _reset_follow():
+    _c7.config_path.reset_override(); _c7.state_dir.reset_override()
+    _c7.config.reset_override(); _c7.config.reset()
+    _c7.state_manager.reset_override(); _c7.state_manager.reset()
+
+
+def test_spec_follow_no_focus_prints_hint(tmp_path):
+    _seed_follow_spec(tmp_path)   # writes specs/<id>.md + workitem + state, binds container
+    try:
+        result = _CliRunner().invoke(_app7, ["view", "spec", "--follow"])
+        assert result.exit_code == 0, result.output
+        assert "no workitem focused" in result.output.lower()
+    finally:
+        _reset_follow()
+
+
+def test_spec_follow_renders_focused_items_spec(tmp_path):
+    state_dir = _seed_follow_spec(tmp_path)
+    write_focus(focus_path(state_dir), "wi-1")
+    try:
+        result = _CliRunner().invoke(_app7, ["view", "spec", "--follow"])
+        assert result.exit_code == 0, result.output
+        assert "Overhaul body" in result.output   # the linked spec's body text
+    finally:
+        _reset_follow()
+
+
+def test_spec_follow_conflicts_with_workitem(tmp_path):
+    _seed_follow_spec(tmp_path)
+    try:
+        result = _CliRunner().invoke(_app7, ["view", "spec", "--follow", "--workitem", "wi-1"])
+        assert result.exit_code == 1
+        assert "mutually exclusive" in result.output.lower()
+    finally:
+        _reset_follow()

--- a/tests/cli/view/test_status_view.py
+++ b/tests/cli/view/test_status_view.py
@@ -273,3 +273,65 @@ def test_status_view_without_loader_is_flat(tmp_path):
     text = view.gather()
     assert "Task:   a" in text and "Task:   b" in text
     assert "◆" not in text  # no WorkItem header without a loader
+
+
+# --- cockpit-v2 Task 6: status --follow ---
+from typer.testing import CliRunner as _CliRunner
+
+from mship.cli import app as _app6, container as _c6
+from mship.core.focus import focus_path, write_focus
+from mship.core.spec import Spec as _Spec6
+from mship.core.spec_store import SPECS_DIRNAME as _SPECS6, SpecStore as _SpecStore6
+from mship.core.state import StateManager as _SM6, Task as _Task6, WorkspaceState as _WS6
+from mship.core.workitem import WorkItem as _WI6
+from mship.core.workitem_store import WorkItemStore as _WIS6
+
+
+def _now_dt6():
+    return datetime(2026, 7, 21, tzinfo=timezone.utc)
+
+
+def _seed_follow(tmp_path, worktrees):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    _SpecStore6(tmp_path / _SPECS6).save(_Spec6(
+        id="spec-1", title="T", status="approved",
+        created_at=_now_dt6(), updated_at=_now_dt6(), body="b\n"))
+    _WIS6(state_dir / "workitems").save(_WI6(
+        id="wi-1", title="T", workspace="t", kind="feature",
+        created_at=_now_dt6(), updated_at=_now_dt6(), spec_id="spec-1", task_slugs=["a"]))
+    _SM6(state_dir).save(_WS6(tasks={"a": _Task6(
+        slug="a", description="d", phase="dev", created_at=_now_dt6(),
+        affected_repos=["r"], branch="feat/a", worktrees=worktrees, work_item_id="wi-1")}))
+    _c6.config.reset(); _c6.state_manager.reset()
+    _c6.config_path.override(tmp_path / "mothership.yaml")
+    _c6.state_dir.override(state_dir)
+    return state_dir
+
+
+def _reset_follow():
+    _c6.config_path.reset_override(); _c6.state_dir.reset_override()
+    _c6.config.reset_override(); _c6.config.reset()
+    _c6.state_manager.reset_override(); _c6.state_manager.reset()
+
+
+def test_status_follow_no_focus_prints_hint(tmp_path):
+    _seed_follow(tmp_path, {"r": tmp_path})
+    try:
+        result = _CliRunner().invoke(_app6, ["view", "status", "--follow"])
+        assert result.exit_code == 0, result.output
+        assert "no workitem focused" in result.output.lower()
+    finally:
+        _reset_follow()
+
+
+def test_status_follow_scopes_to_focused_task(tmp_path):
+    state_dir = _seed_follow(tmp_path, {"r": tmp_path})
+    write_focus(focus_path(state_dir), "wi-1")
+    try:
+        result = _CliRunner().invoke(_app6, ["view", "status", "--follow"])
+        assert result.exit_code == 0, result.output
+        assert "feat/a" in result.output   # the focused task's branch
+    finally:
+        _reset_follow()

--- a/tests/cli/view/test_workitem_view.py
+++ b/tests/cli/view/test_workitem_view.py
@@ -231,3 +231,64 @@ async def test_cockpit_enter_opens_task_detail_in_process():
         await pilot.press("enter")
         await pilot.pause()
         assert isinstance(view.screen, EntityScreen)
+
+
+# --- cockpit-v2 Task 8: item --follow ---
+from typer.testing import CliRunner as _CliRunner
+
+from mship.core.focus import focus_path, write_focus
+
+
+def _seed_follow(tmp_path, worktrees):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    SpecStore(tmp_path / SPECS_DIRNAME).save(Spec(
+        id="spec-1", title="T", status="approved",
+        created_at=_dt(), updated_at=_dt(), body="b\n"))
+    WorkItemStore(state_dir / "workitems").save(WorkItem(
+        id="wi-1", title="T", workspace="t", kind="feature",
+        created_at=_dt(), updated_at=_dt(), spec_id="spec-1", task_slugs=["a"]))
+    StateManager(state_dir).save(WorkspaceState(tasks={"a": Task(
+        slug="a", description="d", phase="dev", created_at=_dt(),
+        affected_repos=["r"], branch="feat/a", worktrees=worktrees, work_item_id="wi-1")}))
+    container.config.reset(); container.state_manager.reset()
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    return state_dir
+
+
+def _reset_follow():
+    container.config_path.reset_override(); container.state_dir.reset_override()
+    container.config.reset_override(); container.config.reset()
+    container.state_manager.reset_override(); container.state_manager.reset()
+
+
+def test_item_follow_no_focus_prints_hint(tmp_path):
+    _seed_follow(tmp_path, {"r": tmp_path})   # non-TTY path -> render_text/hint
+    try:
+        result = _CliRunner().invoke(app, ["view", "item", "--follow"])
+        assert result.exit_code == 0, result.output
+        assert "no workitem focused" in result.output.lower()
+    finally:
+        _reset_follow()
+
+
+def test_item_follow_renders_focused_cockpit(tmp_path):
+    state_dir = _seed_follow(tmp_path, {"r": tmp_path})
+    write_focus(focus_path(state_dir), "wi-1")
+    try:
+        result = _CliRunner().invoke(app, ["view", "item", "--follow"])
+        assert result.exit_code == 0, result.output
+        assert "wi-1" in result.output
+    finally:
+        _reset_follow()
+
+
+@pytest.mark.asyncio
+async def test_followed_item_view_shows_hint_row_when_none():
+    from mship.cli.view.workitem import FollowedItemView
+    view = FollowedItemView(provider=lambda: None, interval=999)
+    async with view.run_test() as pilot:
+        await pilot.pause()
+        assert "no workitem focused" in " ".join(view.list_labels()).lower()

--- a/tests/core/test_focus.py
+++ b/tests/core/test_focus.py
@@ -15,6 +15,16 @@ def test_write_then_read_roundtrips(tmp_path):
     assert read_focus(p) == FocusState(work_item_id="wi-1", updated_at=now)
 
 
+def test_write_is_atomic_leaves_no_temp_file(tmp_path):
+    # Atomic write (temp + os.replace): only the final focus file remains, no
+    # leftover *.tmp — a reader polling the dir never catches a half-written file.
+    p = focus_path(tmp_path)
+    write_focus(p, "wi-1")
+    write_focus(p, "wi-2")  # overwrite path also atomic
+    assert read_focus(p).work_item_id == "wi-2"
+    assert [f.name for f in tmp_path.iterdir()] == [FOCUS_FILENAME]
+
+
 def test_write_creates_parent_dirs(tmp_path):
     p = tmp_path / "nested" / FOCUS_FILENAME
     write_focus(p, "wi-2")

--- a/tests/core/test_focus.py
+++ b/tests/core/test_focus.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timezone
+
+from mship.core.focus import FocusState, focus_path, read_focus, write_focus, FOCUS_FILENAME
+
+
+def test_focus_path_is_under_state_dir(tmp_path):
+    assert focus_path(tmp_path) == tmp_path / FOCUS_FILENAME
+
+
+def test_write_then_read_roundtrips(tmp_path):
+    p = focus_path(tmp_path)
+    now = datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc)
+    written = write_focus(p, "wi-1", now=now)
+    assert written == FocusState(work_item_id="wi-1", updated_at=now)
+    assert read_focus(p) == FocusState(work_item_id="wi-1", updated_at=now)
+
+
+def test_write_creates_parent_dirs(tmp_path):
+    p = tmp_path / "nested" / FOCUS_FILENAME
+    write_focus(p, "wi-2")
+    assert read_focus(p).work_item_id == "wi-2"
+
+
+def test_read_missing_file_is_none(tmp_path):
+    assert read_focus(focus_path(tmp_path)) is None
+
+
+def test_read_corrupt_json_is_none(tmp_path):
+    p = focus_path(tmp_path)
+    p.write_text("{ not json")
+    assert read_focus(p) is None
+
+
+def test_read_missing_key_is_none(tmp_path):
+    p = focus_path(tmp_path)
+    p.write_text('{"updated_at": "2026-07-21T00:00:00+00:00"}')
+    assert read_focus(p) is None
+
+
+def test_write_defaults_now_to_utc(tmp_path):
+    before = datetime.now(timezone.utc)
+    s = write_focus(focus_path(tmp_path), "wi-3")
+    assert s.updated_at >= before
+    assert s.updated_at.tzinfo is not None


### PR DESCRIPTION
Implements spec `cockpit-v2` — the cockpit reframe. Replaces the v1 tab-per-WorkItem model (each tab carrying its own agent pane) with a single shared cockpit: **one fixed agent pane on the left + a focus-following rich stack of views on the right**.

## What changed

- **CURRENT FOCUS (`core/focus.py`).** A per-workspace focus file (`<state_dir>/cockpit-focus.json`) records the focused WorkItem id + a monotonic timestamp. `mship layout focus <id>` now *sets focus* (writes the file) instead of opening a zellij tab; `mship layout focus --show` prints it; unknown ids error; done items are flagged.
- **`--follow` view mode.** `mship view {spec,diff,journal,status,item} --follow` resolves the CURRENT FOCUS instead of a fixed `--workitem`/`--task`, re-renders when the focus or the underlying data changes, and shows a clear hint when nothing is focused (shared resolver in `cli/view/_follow.py`).
- **Single-cockpit layout.** `mship layout` renders one shared `Cockpit` tab: a fixed left **Agent** pane (configurable command; default a shell in the workspace root) beside a zellij `pane stacked=true` group of the **fixed rich set — Spec · Diff · Journal · Status · Item**, every member running `--follow`. The agent pane is a sibling *outside* the stack, so flipping views or switching WorkItems never touches it. The Overview launchpad tab (queue + items) stays.
- **Switch WorkItems two ways** — enter on an item in the Overview picker (= set focus) or `mship layout focus <id>` from the CLI/agent. Either re-scopes the whole right stack; the agent is untouched.
- **Fixed rich stack (operator decision A).** The stack is the same 5 views regardless of phase — everything one flip away, all following focus — rather than phase-conditional membership (which would require disruptive pane rebuilds).
- **v1 machinery removed.** `render_workitem_layout`, the per-item tab new-tab/go-to/close-tab focus flow, `close-on-done` teardown, and the `mship layout close` command are gone; stale tests updated/removed.

## Tests

- 12 TDD commits (one per plan task), each AC-tagged. Full `mship test`: **3035 passed**.
- New: focus-file roundtrip/corruption; the `--follow` resolver + empty-state; per-view `--follow` scoping; the cockpit KDL (agent outside the stack, all 5 follow views inside, tab-bar frame, Overview + Cockpit tabs); items enter = set-focus; no dangling refs after the v1 removal.
- Not verifiable here: zellij's actual visual rendering of `pane stacked=true` — covered by string-level KDL unit tests and a manual `mship layout launch` smoke check on a real terminal.
