### PR TITLE
Cloud-worker auth spine: attach-at-relay credential egress proxy (Shape 2)

### DIFF
--- a/docker/relay/Caddyfile
+++ b/docker/relay/Caddyfile
@@ -32,6 +32,16 @@ enroll.{$RELAY_DOMAIN} {
 	}
 }
 
+# Egress proxy — worker git/API traffic, credential attached at egress.
+egress.{$RELAY_DOMAIN} {
+	tls {
+		on_demand
+	}
+	reverse_proxy 127.0.0.1:47280 {
+		header_up Host {host}
+	}
+}
+
 # Per-device serve subdomains -> sish (Host preserved). The more-specific
 # enroll.<domain> site above takes precedence over this wildcard.
 *.{$RELAY_DOMAIN} {

--- a/docker/relay/docker-compose.yml
+++ b/docker/relay/docker-compose.yml
@@ -2,6 +2,13 @@
 # Caddy owns public :80/:443 (on-demand TLS, enroll route hardened).
 # sish handles SSH tunnels (:2222) and serves HTTP internally (:8080 loopback).
 # Requires: a wildcard DNS record *.RELAY_DOMAIN -> this host, ports 80/443/2222 open.
+#
+# Egress proxy (run on the host: `mship relay egress-server`) needs, in its env:
+#   MSHIP_GH_APP_ID   — the GitHub App numeric id
+#   MSHIP_GH_APP_KEY  — PATH to the App private-key .pem (refuse-on-unreadable)
+# and persistent dirs for --grant-store-dir and --run-token-dir alongside pubkeys/.
+# Caddy fronts egress.<RELAY_DOMAIN> -> 127.0.0.1:47280 (see Caddyfile); the
+# egress-server, like enroll-server, runs as a host process, not a compose service.
 services:
   sish:
     image: antoniomika/sish:latest

--- a/docs/cloud-worker-auth-spine.md
+++ b/docs/cloud-worker-auth-spine.md
@@ -1,0 +1,158 @@
+# Cloud-worker auth spine — attach-at-relay credential egress proxy (Shape 2)
+
+The overnight cloud-worker fan-out runs disposable, prompt-injectable workers that
+must clone/fetch/push across several repos — yet a worker must never hold a GitHub
+credential. This spine turns the relay into a scoped, credential-attaching **egress
+proxy**: the worker points its git remote at the relay carrying only a low-value
+placeholder + per-run token; the relay attaches the real, repo-scoped GitHub App
+token at egress and enforces what the worker may do. The credential never lands on
+the worker.
+
+Modules: `src/mship/core/relay/egress/*` (proxy role), `src/mship/core/relay/grants.py`
+(typed ceiling), `src/mship/core/relay/run_token.py` (per-run token). CLI:
+`mship relay grant`, `mship relay issue-run-token`, `mship relay egress-server`.
+
+## 1. Trust model
+
+Three trust tiers, least-trusted first:
+
+- **Worker — least trusted.** Disposable and prompt-injectable. It holds only a
+  *placeholder* (a git `insteadOf` URL rewrite — not a secret) and a *low-value
+  per-run token*. It never holds a GitHub credential. If the worker is fully
+  compromised, the attacker gets the per-run token — and that token, presented
+  directly to `github.com`, is rejected (it is not a GitHub bearer); presented to
+  the relay it unlocks only a push of the *run branch* to the *run's repos*.
+- **Relay / front door — trusted transport (in v1).** Terminates the worker's TLS
+  and forwards to the small trusted core. In Shape 2 the front door and the core
+  are co-located, so the relay is trusted.
+- **Secrets-egress host — the small trusted core.** Does the exchange: verify the
+  per-run token → resolve the enrollment ceiling → enforce the request → mint the
+  repo-scoped App token → attach it host-locked → forward to GitHub.
+
+Containment rests on four independent limits, so no single slip is catastrophic:
+1. the credential is never on the worker (attached only at egress);
+2. the git-smart-HTTP **receive-pack enforcer** restricts pushes to the run branch
+   for a run-scoped repo (clone/fetch pass; other branches, other repos, and
+   branch *deletes* are refused);
+3. the minted App token is **repo-scoped and short-TTL** (built-in blast-radius cap);
+4. the **Attachment is host-locked** — a route misconfig cannot send the credential
+   to any host outside `github.com` / `api.github.com`.
+
+## 2. Attach-at-relay, Shape 2 (co-located)
+
+All three roles run on the single relay the operator already runs. This is the
+deliberate v1 simplification: **some host must see the bearer credential in
+plaintext to attach it to an outbound request** — that is unavoidable for any
+bearer-token scheme. The design does not pretend otherwise; it *minimizes and
+isolates* that plaintext exposure to the small egress-proxy core and keeps it off
+the worker entirely.
+
+## 3. North star: the untrusted-relay 3-role split
+
+The end-state splits the tiers onto separate hosts: **worker / blind relay /
+separate secrets-egress host**. Because the egress-proxy is a **distinct module**
+whose worker session *logically terminates at it* — authenticated end-to-end by the
+per-run token the module verifies itself, not by "the relay says so" — relocating
+that module onto its own host behind a now-blind relay is a **deployment / wiring
+change, not a channel rewrite**. The worker config, the token, the seams, and the
+enforcer are all unchanged by the move.
+
+**Shape 2 vs Shape 3 is a FORK, not a ladder.** They defend *different* adversaries:
+
+- **Shape 2 (this):** worker is least-trusted; the relay operator is trusted.
+- **Shape 3:** the *relay operator* is least-trusted (a blind courier), which needs
+  a second, separately-operated secrets-egress component.
+
+You pick the fork by *which* party you distrust — you do not "graduate" from one to
+the other. Attach-at-relay **retires seal-to-worker / HPKE**: there is no longer any
+need to encrypt a credential *to* the worker, because the worker never receives one.
+
+## 4. The four seams (and how they admit GitLab / static secrets with ZERO worker change)
+
+The proxy core is `route → provider → enforce → attach → forward`. Four seams make
+it extensible without touching the worker or the core:
+
+- **`CredentialProvider`** (`egress/provider.py`) — `resolve(identity, grant, request)
+  -> Credential`. v1 ships `GitHubAppProvider` (wraps `core/gh_app.py`). Add a
+  `GitLabProvider` or `StaticSecretProvider` implementing the same method.
+- **`Attachment`** (`egress/credential.py`) — *how* a credential rides on the wire
+  plus a host-lock. GitHub App = `Authorization: token <value>` locked to
+  github.com/api.github.com. A different provider supplies a different header/lock,
+  e.g. `Authorization: Bearer <value>` locked to `api.openai.com`.
+- **`RouteTable`** (`egress/routes.py`) — destination host → `{provider, enforcer}`
+  as data. Adding a host is a new entry (+ one `/prefix/` in `request.py`, one
+  `tls_ask` allowance, one Caddy block) — **no `github.com` special-case in code**.
+- **Typed `Grant`s** (`grants.py`) — a new provider scope on the enrollment ceiling.
+
+**Security asymmetry (why the generalization *strengthens* attach-at-relay):** a
+GitHub App token has built-in TTL + repo scope, so even a leaked minted token self-
+limits. A static third-party API key (OpenAI, etc.) has **no** built-in TTL or scope
+— so the off-box egress boundary is its *only* backstop. Generalizing the four seams
+to such secrets makes the attach-at-egress boundary more load-bearing, not less.
+
+## 5. Operator setup
+
+```bash
+# 1. Approve the worker's enrollment (existing enroll flow).
+mship relay approve <enrollment-id>
+
+# 2. Set the CEILING — the repos this enrollment may EVER touch.
+mship relay grant <enrollment-id> --provider github-app --repos owner/a,owner/b
+
+# 3. Issue a PER-RUN token (repos ⊆ ceiling, one push branch). Printed ONCE.
+mship relay issue-run-token <enrollment-id> --repos owner/a --push-branch feat/<slug>
+
+# 4. Run the egress proxy with the App creds in its env (refuse-on-unreadable key).
+MSHIP_GH_APP_ID=<app-id> MSHIP_GH_APP_KEY=/path/to/app.pem \
+  mship relay egress-server --grant-store-dir ./grants-store --run-token-dir ./run-tokens-store
+```
+
+Caddy fronts `egress.<RELAY_DOMAIN>` → `127.0.0.1:47280` (on-demand TLS; the
+`egress` label is allow-listed in `tls_ask`). With no App creds the egress-server
+**fails closed** — every request returns 503, it never forwards unauthenticated.
+
+## 6. Worker config (the placeholder — holds NO usable GitHub credential)
+
+```bash
+# URL rewrite (the "placeholder" — NOT a secret): git resolves
+#   https://github.com/<owner>/<repo>.git -> https://egress.<RELAY_DOMAIN>/gh/<owner>/<repo>.git
+git config --global url."https://egress.<RELAY_DOMAIN>/gh/".insteadOf   "https://github.com/"
+git config --global url."https://egress.<RELAY_DOMAIN>/api/".insteadOf "https://api.github.com/"
+
+# The per-run token on the worker->relay leg (LOW value: NOT a GitHub credential).
+git config --global http."https://egress.<RELAY_DOMAIN>/".extraHeader "Mship-Run-Token: <token_id>.<secret>"
+```
+
+git then requests `…/gh/owner/repo.git/info/refs?service=git-receive-pack` and
+`POST …/gh/owner/repo.git/git-receive-pack`; the relay strips `Mship-Run-Token` +
+the inbound `Host`, attaches the minted `Authorization: token <ghs…>`, and forwards
+to `github.com`.
+
+State it plainly: **the worker holds no usable GitHub credential.** The per-run
+token presented directly to GitHub is rejected; presented to the relay it unlocks
+only a *run-branch* push to the *run's repos*, with a repo-scoped short-TTL App token
+the worker never sees. Exfiltrating the placeholder + token yields no GitHub access
+and no other-branch / other-repo write.
+
+> **API route deferred on the worker.** The `api.github.com` route (`/api/`) is
+> built + tested at the proxy boundary in v1, but wiring the worker's API client
+> (`mship`/`gh`) to `…/api/` is a later worker-image slice. v1 fully exercises
+> ac1's clone/fetch/push through the **git** leg.
+
+## 7. Egress-proxy module boundary
+
+The egress-proxy role is the subpackage `src/mship/core/relay/egress/`:
+
+- `pktline.py` — `read_pkt_lines`, `parse_receive_pack_commands`, `RefUpdate` (pure git-wire).
+- `request.py` — `parse_egress_request` (path-prefix host map + repo/service extraction).
+- `enforce.py` — `GitSmartHttpEnforcer` (run-branch-only push), `HostLockedEnforcer`.
+- `credential.py` — `Attachment` (host-locked), `Credential`, `github_token_attachment`.
+- `provider.py` — `CredentialProvider`, `GitHubAppProvider`.
+- `routes.py` — `Route`, `RouteTable`, `build_default_routes`.
+- `proxy.py` — `build_egress_app` (verify → route → enforce → provider → attach →
+  forward; fail-closed when no provider).
+
+The worker's session **logically terminates at `build_egress_app`**, authenticated
+by the per-run token that module verifies itself (not delegated to the relay). This
+self-contained, end-to-end-verifiable boundary is exactly what makes the Shape-3
+relocation a deployment change rather than a rewrite.

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -189,6 +189,69 @@ def register(parent: typer.Typer, get_container):
             out.error(f"no pending request {rid!r} (unknown, already resolved, or expired)")
             raise typer.Exit(1)
 
+    # ---- typed grants + per-run tokens (cloud-worker-auth-spine) ----
+
+    @relay_app.command("grant")
+    def grant_cmd(
+        rid: str = typer.Argument(..., help="Approved enrollment id to grant repos to."),
+        provider: str = typer.Option("github-app", "--provider", help="Credential provider."),
+        repos: str = typer.Option(..., "--repos", help="Ceiling repos owner/a,owner/b."),
+        store_dir: str = typer.Option("./pending-store", "--store-dir",
+                                      help="Enroll request store (to confirm approval)."),
+        grant_store_dir: str = typer.Option("./grants-store", "--grant-store-dir",
+                                            help="Directory for the typed-grant store."),
+    ):
+        """Set/update an enrollment's typed grant (the repo CEILING it may ever touch)."""
+        from pathlib import Path
+
+        from mship.core.relay.enroll import RequestStore
+        from mship.core.relay.grants import Grant, GrantStore, Scope
+
+        out = Output()
+        if RequestStore(Path(store_dir)).get(rid) != "approved":
+            out.error(f"enrollment {rid!r} is not an approved enrollment")
+            raise typer.Exit(1)
+        repo_list = tuple(r.strip() for r in repos.split(",") if r.strip())
+        if not repo_list:
+            out.error("--repos must list at least one owner/repo")
+            raise typer.Exit(1)
+        GrantStore(Path(grant_store_dir)).set_grant(
+            rid, Grant(provider=provider, scope=Scope(repos=repo_list))
+        )
+        out.success(f"granted {provider} {list(repo_list)} to enrollment {rid}")
+
+    @relay_app.command("issue-run-token")
+    def issue_run_token_cmd(
+        rid: str = typer.Argument(..., help="Approved+granted enrollment id."),
+        repos: str = typer.Option(..., "--repos", help="Run repos (⊆ the grant ceiling)."),
+        push_branch: str = typer.Option(..., "--push-branch", help="The run's branch, e.g. feat/<slug>."),
+        ttl: int = typer.Option(86400, "--ttl", help="Token TTL in seconds (default 24h)."),
+        grant_store_dir: str = typer.Option("./grants-store", "--grant-store-dir",
+                                            help="Directory for the typed-grant store."),
+        run_token_dir: str = typer.Option("./run-tokens-store", "--run-token-dir",
+                                           help="Directory for per-run token records."),
+    ):
+        """Issue a per-run token {repos ⊆ ceiling, push_branch}; prints plaintext ONCE."""
+        from pathlib import Path
+
+        from mship.core.relay.grants import GrantStore, Scope
+        from mship.core.relay.run_token import issue_run_token
+
+        out = Output()
+        ceiling = next((g for g in GrantStore(Path(grant_store_dir)).get_grants(rid)
+                        if g.provider == "github-app"), None)
+        if ceiling is None:
+            out.error(f"enrollment {rid!r} has no github-app grant; run `mship relay grant` first")
+            raise typer.Exit(1)
+        run_scope = Scope(repos=tuple(r.strip() for r in repos.split(",") if r.strip()),
+                          push_branch=push_branch)
+        if not ceiling.scope.covers(run_scope):
+            out.error(f"requested repos exceed the grant ceiling {list(ceiling.scope.repos)}")
+            raise typer.Exit(1)
+        token = issue_run_token(Path(run_token_dir), enrollment_id=rid,
+                                scope=run_scope, ttl_seconds=ttl)
+        out.print(f"run token (store on the worker, shown once): {token}")
+
     # -------------------------------------------------------------------------
     # Requester-side: enroll (new device)
     # -------------------------------------------------------------------------

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -252,6 +252,55 @@ def register(parent: typer.Typer, get_container):
                                 scope=run_scope, ttl_seconds=ttl)
         out.print(f"run token (store on the worker, shown once): {token}")
 
+    @relay_app.command("egress-server")
+    def egress_server(
+        grant_store_dir: str = typer.Option("./grants-store", "--grant-store-dir",
+                                             help="Directory for the typed-grant store."),
+        run_token_dir: str = typer.Option("./run-tokens-store", "--run-token-dir",
+                                           help="Directory for per-run token records."),
+        port: int = typer.Option(47280, "--port", help="Port to listen on (Caddy fronts it)."),
+        host: str = typer.Option("127.0.0.1", "--host", help="Interface to bind (loopback)."),
+    ):
+        """Run the credential-attaching egress proxy (worker git/API traffic terminates here)."""
+        import os
+        from pathlib import Path
+
+        from mship.core.relay.grants import GrantStore
+        from mship.core.relay.egress.provider import GitHubAppProvider
+        from mship.core.relay.egress.routes import build_default_routes
+        from mship.core.relay.egress.proxy import build_egress_app
+
+        out = Output()
+        app_id = os.environ.get("MSHIP_GH_APP_ID") or None
+        app_key = None
+        key_path = os.environ.get("MSHIP_GH_APP_KEY")
+        if key_path:
+            p = Path(key_path)
+            if not p.is_file():
+                out.error(
+                    f"MSHIP_GH_APP_KEY is set but not a readable file ({key_path!r}). "
+                    "Refusing to start: silently forwarding without a real credential "
+                    "would defeat attach-at-relay."
+                )
+                raise typer.Exit(1)
+            app_key = p.read_text()
+
+        # Fail closed: no App creds => no provider => the app 503s every request.
+        routes = None
+        if app_id and app_key:
+            provider = GitHubAppProvider(app_id=app_id, private_key=app_key)
+            routes = build_default_routes(provider)
+        else:
+            out.warning("no App creds (MSHIP_GH_APP_ID/MSHIP_GH_APP_KEY) — egress will "
+                        "refuse to forward (503) until configured.")
+
+        app = build_egress_app(
+            grant_store=GrantStore(Path(grant_store_dir)),
+            run_token_dir=Path(run_token_dir), routes=routes,
+        )
+        out.print(f"egress-server → http://{host}:{port}")
+        _run_uvicorn(app, host, port)
+
     # -------------------------------------------------------------------------
     # Requester-side: enroll (new device)
     # -------------------------------------------------------------------------

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -205,15 +205,16 @@ def register(parent: typer.Typer, get_container):
         from pathlib import Path
 
         from mship.core.relay.enroll import RequestStore
-        from mship.core.relay.grants import Grant, GrantStore, Scope
+        from mship.core.relay.grants import Grant, GrantStore, RepoSpecError, Scope, parse_repos
 
         out = Output()
         if RequestStore(Path(store_dir)).get(rid) != "approved":
             out.error(f"enrollment {rid!r} is not an approved enrollment")
             raise typer.Exit(1)
-        repo_list = tuple(r.strip() for r in repos.split(",") if r.strip())
-        if not repo_list:
-            out.error("--repos must list at least one owner/repo")
+        try:
+            repo_list = parse_repos(repos)
+        except RepoSpecError as e:
+            out.error(f"--repos {e}")
             raise typer.Exit(1)
         GrantStore(Path(grant_store_dir)).set_grant(
             rid, Grant(provider=provider, scope=Scope(repos=repo_list))
@@ -234,17 +235,27 @@ def register(parent: typer.Typer, get_container):
         """Issue a per-run token {repos ⊆ ceiling, push_branch}; prints plaintext ONCE."""
         from pathlib import Path
 
-        from mship.core.relay.grants import GrantStore, Scope
+        from mship.core.relay.grants import GrantStore, RepoSpecError, Scope, parse_repos
         from mship.core.relay.run_token import issue_run_token
 
         out = Output()
+        if ttl <= 0:
+            out.error("--ttl must be a positive number of seconds")
+            raise typer.Exit(1)
+        if not push_branch.strip():
+            out.error("--push-branch must be a non-empty branch name")
+            raise typer.Exit(1)
         ceiling = next((g for g in GrantStore(Path(grant_store_dir)).get_grants(rid)
                         if g.provider == "github-app"), None)
         if ceiling is None:
             out.error(f"enrollment {rid!r} has no github-app grant; run `mship relay grant` first")
             raise typer.Exit(1)
-        run_scope = Scope(repos=tuple(r.strip() for r in repos.split(",") if r.strip()),
-                          push_branch=push_branch)
+        try:
+            run_repos = parse_repos(repos)
+        except RepoSpecError as e:
+            out.error(f"--repos {e}")
+            raise typer.Exit(1)
+        run_scope = Scope(repos=run_repos, push_branch=push_branch.strip())
         if not ceiling.scope.covers(run_scope):
             out.error(f"requested repos exceed the grant ceiling {list(ceiling.scope.repos)}")
             raise typer.Exit(1)

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -245,6 +245,10 @@ def register(parent: typer.Typer, get_container):
         if not push_branch.strip():
             out.error("--push-branch must be a non-empty branch name")
             raise typer.Exit(1)
+        if push_branch.strip().startswith("refs/") and not push_branch.strip().startswith("refs/heads/"):
+            out.error("--push-branch must be a branch (bare name or refs/heads/...), "
+                      "not a tag or other ref")
+            raise typer.Exit(1)
         ceiling = next((g for g in GrantStore(Path(grant_store_dir)).get_grants(rid)
                         if g.provider == "github-app"), None)
         if ceiling is None:

--- a/src/mship/core/relay/egress/credential.py
+++ b/src/mship/core/relay/egress/credential.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class AttachmentHostError(Exception):
+    """Refused to attach a credential to a host outside the Attachment's lock."""
+
+
+@dataclass(frozen=True)
+class Attachment:
+    """HOW a credential rides on the wire, decoupled from WHAT it is, plus a
+    host-lock so a route misconfig can never send a credential to the wrong
+    host."""
+    header: str
+    template: str            # contains `{value}`
+    hosts: tuple[str, ...]
+
+    def render(self, value: str) -> str:
+        return self.template.format(value=value)
+
+    def apply(self, headers: dict, *, host: str, value: str) -> None:
+        if host not in self.hosts:
+            raise AttachmentHostError(
+                f"refusing to attach {self.header} to {host!r}; "
+                f"allowed hosts: {list(self.hosts)}"
+            )
+        headers[self.header] = self.render(value)
+
+
+@dataclass(frozen=True)
+class Credential:
+    value: str
+    expires_at: str | None
+    attach: Attachment
+
+
+def github_token_attachment() -> Attachment:
+    """GitHub App token rides as `Authorization: token <value>`, locked to
+    github.com + api.github.com."""
+    return Attachment(
+        header="Authorization",
+        template="token {value}",
+        hosts=("github.com", "api.github.com"),
+    )

--- a/src/mship/core/relay/egress/enforce.py
+++ b/src/mship/core/relay/egress/enforce.py
@@ -38,8 +38,19 @@ class GitSmartHttpEnforcer:
             )
         if not scope.push_branch:
             raise EnforcementError("run scope carries no push_branch; refusing all pushes")
+        # push_branch must resolve to a BRANCH ref only. A bare name is a branch;
+        # an explicit refs/heads/... is a branch; any other fully-qualified ref
+        # (refs/tags/…, refs/notes/…) is refused — the run may push its branch, never
+        # a tag or other ref (a token minted with refs/tags/v1 would otherwise
+        # authorize a tag update).
         want = scope.push_branch
-        if not want.startswith("refs/"):
+        if want.startswith("refs/heads/"):
+            pass
+        elif want.startswith("refs/"):
+            raise EnforcementError(
+                f"run push_branch {want!r} is not a branch; only refs/heads/ is allowed"
+            )
+        else:
             want = f"refs/heads/{want}"
 
         commands = parse_receive_pack_commands(request.body)

--- a/src/mship/core/relay/egress/enforce.py
+++ b/src/mship/core/relay/egress/enforce.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from mship.core.relay.grants import Grant
+from mship.core.relay.egress.pktline import parse_receive_pack_commands
+from mship.core.relay.egress.request import EgressRequest
+
+_ZERO_OID = "0" * 40
+
+
+class EnforcementError(Exception):
+    """A request violated the route's policy and must not reach the provider."""
+
+
+@runtime_checkable
+class Enforcer(Protocol):
+    def check(self, request: EgressRequest, grant: Grant) -> None: ...
+
+
+class GitSmartHttpEnforcer:
+    """Permit clone/fetch (upload-pack) and the receive-pack advertisement;
+    permit a receive-pack POST only when every ref-update targets the run's
+    branch for a repo inside the run's scope. Everything else is refused."""
+
+    def check(self, request: EgressRequest, grant: Grant) -> None:
+        if request.service == "git-upload-pack":
+            return
+        if request.service == "git-receive-pack" and not request.is_receive_pack_post:
+            return                                   # ref advertisement (read-only)
+        if not request.is_receive_pack_post:
+            raise EnforcementError(f"unsupported git request: {request.upstream_path}")
+
+        scope = grant.scope
+        if request.repo not in scope.repos:
+            raise EnforcementError(
+                f"push to {request.repo!r} outside run repos {list(scope.repos)}"
+            )
+        if not scope.push_branch:
+            raise EnforcementError("run scope carries no push_branch; refusing all pushes")
+        want = scope.push_branch
+        if not want.startswith("refs/"):
+            want = f"refs/heads/{want}"
+
+        commands = parse_receive_pack_commands(request.body)
+        if not commands:
+            raise EnforcementError("receive-pack POST had no parseable ref updates")
+        for cmd in commands:
+            if cmd.ref != want:
+                raise EnforcementError(f"push to {cmd.ref!r}; only {want!r} is allowed")
+            if cmd.new_oid == _ZERO_OID:
+                raise EnforcementError(f"deletion of {cmd.ref!r} is not allowed")
+
+
+class HostLockedEnforcer:
+    """No ref-level policy: the API surface is bounded by the repo-scoped App
+    token + the Attachment host-lock. Passes; documents the boundary."""
+
+    def check(self, request: EgressRequest, grant: Grant) -> None:
+        return

--- a/src/mship/core/relay/egress/pktline.py
+++ b/src/mship/core/relay/egress/pktline.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RefUpdate:
+    old_oid: str
+    new_oid: str
+    ref: str
+
+
+def read_pkt_lines(data: bytes) -> list[bytes]:
+    """Return the pkt-line payloads up to (not including) the first flush-pkt.
+
+    Reads the receive-pack command list without touching the packfile that
+    follows the flush. 4-hex length frames the line and INCLUDES the 4 length
+    bytes; `0000` is the flush-pkt. Malformed framing stops the scan (fail
+    closed — the enforcer treats an empty/short command list as a rejectable
+    push, never a pass)."""
+    out: list[bytes] = []
+    i, n = 0, len(data)
+    while i + 4 <= n:
+        try:
+            length = int(data[i : i + 4], 16)
+        except ValueError:
+            break
+        if length == 0:            # flush-pkt: command list ends, packfile follows
+            break
+        if length < 4 or i + length > n:
+            break
+        out.append(data[i + 4 : i + length])
+        i += length
+    return out
+
+
+def parse_receive_pack_commands(body: bytes) -> list[RefUpdate]:
+    """Parse the receive-pack POST body's command list into RefUpdates.
+
+    Each command is `<old> <new> <ref>`; the first carries a trailing
+    `\\0<caps>` and every line a trailing `\\n` — both stripped from the ref."""
+    cmds: list[RefUpdate] = []
+    for line in read_pkt_lines(body):
+        text = line.rstrip(b"\n")
+        text = text.split(b"\x00", 1)[0]      # drop capabilities on the first line
+        parts = text.split(b" ")
+        if len(parts) < 3:
+            continue
+        old, new, ref = parts[0], parts[1], b" ".join(parts[2:])
+        cmds.append(
+            RefUpdate(
+                old_oid=old.decode("ascii", "replace"),
+                new_oid=new.decode("ascii", "replace"),
+                ref=ref.decode("utf-8", "replace"),
+            )
+        )
+    return cmds

--- a/src/mship/core/relay/egress/provider.py
+++ b/src/mship/core/relay/egress/provider.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import httpx
+
+from mship.core.gh_app import GhAppError, mint_installation_token, resolve_installation
+from mship.core.relay.grants import Grant
+from mship.core.relay.egress.credential import Credential, github_token_attachment
+from mship.core.relay.egress.request import EgressRequest
+
+
+class ProviderError(Exception):
+    """The provider could not resolve a credential for this request."""
+
+
+@runtime_checkable
+class CredentialProvider(Protocol):
+    def resolve(self, identity: str, grant: Grant, request: EgressRequest) -> Credential: ...
+
+
+class GitHubAppProvider:
+    """Resolve a GitHub App installation token scoped to the grant's repos.
+
+    A future StaticSecretProvider / GitLabProvider implements the same
+    `resolve(identity, grant, request)` and returns a Credential — the proxy
+    core does not change."""
+
+    def __init__(self, *, app_id: str, private_key: str, client: httpx.Client | None = None):
+        self._app_id = app_id
+        self._private_key = private_key
+        self._client = client
+
+    def resolve(self, identity: str, grant: Grant, request: EgressRequest) -> Credential:
+        repos = list(grant.scope.repos)
+        if not repos:
+            raise ProviderError("refusing to mint an unscoped token — grant has no repos")
+        if request.repo is not None and request.repo not in repos:
+            raise ProviderError(f"repo {request.repo!r} is outside the grant {repos}")
+
+        owners = {r.split("/", 1)[0] for r in repos}
+        if len(owners) > 1:
+            raise ProviderError(f"grant repos span multiple owners {sorted(owners)}")
+        owner = owners.pop()
+        short_names = [r.split("/", 1)[1] for r in repos]
+        try:
+            installation_id = resolve_installation(
+                app_id=self._app_id, private_key=self._private_key,
+                owner=owner, repo=short_names[0], client=self._client,
+            )
+            minted = mint_installation_token(
+                app_id=self._app_id, private_key=self._private_key,
+                installation_id=installation_id, repos=short_names, client=self._client,
+            )
+        except GhAppError as e:
+            raise ProviderError(str(e)) from e
+        return Credential(
+            value=minted["token"],
+            expires_at=minted.get("expires_at"),
+            attach=github_token_attachment(),
+        )

--- a/src/mship/core/relay/egress/provider.py
+++ b/src/mship/core/relay/egress/provider.py
@@ -38,6 +38,9 @@ class GitHubAppProvider:
         if request.repo is not None and request.repo not in repos:
             raise ProviderError(f"repo {request.repo!r} is outside the grant {repos}")
 
+        malformed = [r for r in repos if "/" not in r]
+        if malformed:
+            raise ProviderError(f"malformed repo(s), expected owner/repo: {malformed}")
         owners = {r.split("/", 1)[0] for r in repos}
         if len(owners) > 1:
             raise ProviderError(f"grant repos span multiple owners {sorted(owners)}")

--- a/src/mship/core/relay/egress/proxy.py
+++ b/src/mship/core/relay/egress/proxy.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import httpx
+from fastapi import FastAPI, Request, Response
+
+from mship.core.relay.grants import Grant, GrantStore, Scope
+from mship.core.relay.run_token import verify_run_token
+from mship.core.relay.egress.credential import AttachmentHostError
+from mship.core.relay.egress.enforce import EnforcementError
+from mship.core.relay.egress.provider import ProviderError
+from mship.core.relay.egress.request import parse_egress_request, UnmappablePathError
+from mship.core.relay.egress.routes import RouteTable, UnknownHostError
+
+# Headers we must never pass upstream: the worker's placeholder token, the
+# worker-facing Host, and length/encoding httpx recomputes for the new body.
+_STRIP = {"mship-run-token", "host", "content-length", "authorization",
+          "transfer-encoding", "connection"}
+
+
+def build_egress_app(
+    *, grant_store: GrantStore, run_token_dir, routes: RouteTable | None,
+    client: httpx.Client | None = None, upstream_scheme: str = "https",
+) -> FastAPI:
+    """The egress-proxy role. `routes=None` (App creds absent) => fail closed:
+    every request 503, never forward — mirrors serve's refuse-on-unreadable-key."""
+    app = FastAPI(title="mship egress proxy")
+    http = client or httpx.Client(timeout=60)
+
+    @app.api_route("/{full_path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
+    async def egress(full_path: str, request: Request) -> Response:
+        if routes is None:
+            return Response("egress: no credential provider configured (App creds "
+                            "absent) — refusing to forward", status_code=503)
+
+        presented = request.headers.get("Mship-Run-Token")
+        if not presented:
+            return Response("missing run token", status_code=401)
+        rt = verify_run_token(run_token_dir, presented)
+        if rt is None:
+            return Response("invalid or expired run token", status_code=401)
+
+        body = await request.body()
+        try:
+            egress_req = parse_egress_request(
+                method=request.method, path=request.url.path,
+                query=request.url.query, headers=dict(request.headers), body=body,
+            )
+        except UnmappablePathError:
+            return Response("unmapped path", status_code=404)
+
+        # Ceiling: the enrollment's typed grant for this provider.
+        ceiling = next((g for g in grant_store.get_grants(rt.enrollment_id)
+                        if g.provider == "github-app"), None)
+        if ceiling is None:
+            return Response("no grant for enrollment", status_code=403)
+        # Per-run scope must be within the ceiling.
+        if not ceiling.scope.covers(rt.scope):
+            return Response("run scope exceeds enrollment grant", status_code=403)
+        effective = Grant("github-app", rt.scope)
+
+        try:
+            route = routes.resolve(egress_req.upstream_host)
+            route.enforcer.check(egress_req, effective)
+            cred = route.provider.resolve(
+                identity=rt.enrollment_id, grant=effective, request=egress_req,
+            )
+        except UnknownHostError:
+            return Response("no route for host", status_code=404)
+        except EnforcementError as e:
+            return Response(f"rejected: {e}", status_code=403)
+        except ProviderError as e:
+            return Response(f"provider error: {e}", status_code=502)
+
+        upstream_headers = {k: v for k, v in egress_req.headers.items()
+                            if k.lower() not in _STRIP}
+        try:
+            cred.attach.apply(upstream_headers, host=egress_req.upstream_host, value=cred.value)
+        except AttachmentHostError as e:
+            return Response(f"attach refused: {e}", status_code=500)
+
+        url = f"{upstream_scheme}://{egress_req.upstream_host}{egress_req.upstream_path}"
+        if egress_req.query:
+            url = f"{url}?{egress_req.query}"
+        upstream = http.request(request.method, url, headers=upstream_headers, content=body)
+        # Pass the upstream response back verbatim (drop hop-by-hop headers).
+        resp_headers = {k: v for k, v in upstream.headers.items()
+                        if k.lower() not in ("content-length", "transfer-encoding", "connection")}
+        return Response(content=upstream.content, status_code=upstream.status_code,
+                        headers=resp_headers)
+
+    return app

--- a/src/mship/core/relay/egress/request.py
+++ b/src/mship/core/relay/egress/request.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import parse_qs
+
+# Path prefix -> upstream host. Adding a host = one entry here + one route
+# (routes.py) + one tls_ask/Caddy allowance. No github.com special-case in code.
+_PREFIX_HOST = {"/gh/": "github.com", "/api/": "api.github.com"}
+
+
+class UnmappablePathError(Exception):
+    """Incoming path did not start with a known egress prefix (/gh/, /api/)."""
+
+
+@dataclass(frozen=True)
+class EgressRequest:
+    method: str
+    upstream_host: str
+    upstream_path: str
+    query: str
+    headers: dict
+    body: bytes
+    repo: str | None            # owner/repo for git hosts; None for the API host
+    service: str | None         # git-upload-pack | git-receive-pack | None
+    is_receive_pack_post: bool
+
+
+def _extract_repo(upstream_path: str) -> str | None:
+    # /acme/api.git/info/refs -> acme/api ; /acme/api.git/git-receive-pack -> acme/api
+    parts = [p for p in upstream_path.split("/") if p]
+    if len(parts) < 2:
+        return None
+    owner, name = parts[0], parts[1]
+    if name.endswith(".git"):
+        name = name[: -len(".git")]
+    return f"{owner}/{name}"
+
+
+def _service(method: str, upstream_path: str, query: str) -> tuple[str | None, bool]:
+    if upstream_path.endswith("/info/refs"):
+        svc = (parse_qs(query).get("service") or [None])[0]
+        return svc, False
+    if upstream_path.endswith("/git-receive-pack"):
+        return "git-receive-pack", method.upper() == "POST"
+    if upstream_path.endswith("/git-upload-pack"):
+        return "git-upload-pack", False
+    return None, False
+
+
+def parse_egress_request(*, method, path, query, headers, body) -> EgressRequest:
+    """Map a worker-facing path to its upstream host + repo + smart-HTTP service.
+
+    Fails loud at the boundary: a path outside the known prefixes raises rather
+    than defaulting to a host (a mis-forward could leak a credential)."""
+    prefix = next((p for p in _PREFIX_HOST if path.startswith(p)), None)
+    if prefix is None:
+        raise UnmappablePathError(path)
+    host = _PREFIX_HOST[prefix]
+    upstream_path = path[len(prefix) - 1:]     # keep the leading slash
+    repo = _extract_repo(upstream_path) if host == "github.com" else None
+    service, is_rp_post = _service(method, upstream_path, query)
+    return EgressRequest(
+        method=method, upstream_host=host, upstream_path=upstream_path, query=query,
+        headers=headers, body=body, repo=repo, service=service,
+        is_receive_pack_post=is_rp_post,
+    )

--- a/src/mship/core/relay/egress/routes.py
+++ b/src/mship/core/relay/egress/routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from mship.core.relay.egress.enforce import Enforcer, GitSmartHttpEnforcer, HostLockedEnforcer
+from mship.core.relay.egress.enforce import Enforcer, GitSmartHttpEnforcer
 from mship.core.relay.egress.provider import CredentialProvider
 
 
@@ -31,9 +31,16 @@ class RouteTable:
 
 
 def build_default_routes(provider: CredentialProvider) -> RouteTable:
+    """v1 ships ONLY the git path (github.com), which is fully branch-enforced.
+
+    api.github.com is intentionally NOT routed yet: a repo-scoped App token can
+    mutate refs/contents via the REST API, which would bypass the git push-to-run-
+    branch enforcement (the HostLockedEnforcer applies no ref policy). No worker uses
+    the API leg in v1 (its client wiring is a later slice), so an under-enforced API
+    route must not be reachable. The api.github.com route returns when that slice adds
+    a real API enforcer (method/permission-scoped). Adding a host stays a data entry."""
     return RouteTable(
         {
             "github.com": Route(provider=provider, enforcer=GitSmartHttpEnforcer()),
-            "api.github.com": Route(provider=provider, enforcer=HostLockedEnforcer()),
         }
     )

--- a/src/mship/core/relay/egress/routes.py
+++ b/src/mship/core/relay/egress/routes.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mship.core.relay.egress.enforce import Enforcer, GitSmartHttpEnforcer, HostLockedEnforcer
+from mship.core.relay.egress.provider import CredentialProvider
+
+
+class UnknownHostError(Exception):
+    """No route for this destination host (fail closed, never default)."""
+
+
+@dataclass(frozen=True)
+class Route:
+    provider: CredentialProvider
+    enforcer: Enforcer
+
+
+class RouteTable:
+    """Destination host -> {provider, enforcer} as data. No github.com
+    special-case in code — adding a host is a new entry."""
+
+    def __init__(self, routes: dict[str, Route]):
+        self._routes = dict(routes)
+
+    def resolve(self, host: str) -> Route:
+        try:
+            return self._routes[host]
+        except KeyError:
+            raise UnknownHostError(host)
+
+
+def build_default_routes(provider: CredentialProvider) -> RouteTable:
+    return RouteTable(
+        {
+            "github.com": Route(provider=provider, enforcer=GitSmartHttpEnforcer()),
+            "api.github.com": Route(provider=provider, enforcer=HostLockedEnforcer()),
+        }
+    )

--- a/src/mship/core/relay/grants.py
+++ b/src/mship/core/relay/grants.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Scope:
+    """A repo set, optionally narrowed to one push branch.
+
+    Used twice: as an enrollment's CEILING (push_branch=None — which repos the
+    enrollment may ever touch) and as a PER-RUN scope (repos ⊆ ceiling +
+    push_branch = the run's branch). `repos` are full `owner/repo` names.
+    """
+    repos: tuple[str, ...] = field(default_factory=tuple)
+    push_branch: str | None = None
+
+    def covers(self, other: "Scope") -> bool:
+        """True when `other`'s repos are a subset of this scope's repos.
+        Branch is not part of the ceiling check (the ceiling has no branch)."""
+        return set(other.repos) <= set(self.repos)
+
+
+@dataclass(frozen=True)
+class Grant:
+    """A typed authorization: one provider + its scope. v1: provider='github-app'."""
+    provider: str
+    scope: Scope

--- a/src/mship/core/relay/grants.py
+++ b/src/mship/core/relay/grants.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
+import json
+import re
 from dataclasses import dataclass, field
+from pathlib import Path
+
+# Enroll ids are secrets.token_hex(16) (hex); [0-9a-z] also admits the
+# lowercase-alpha stand-ins used in tests while still rejecting every
+# path-traversal metacharacter (., /, \) — this is the traversal guard, not an
+# id-format contract.
+_ID_RE = re.compile(r"\A[0-9a-z]{1,64}\Z")
 
 
 @dataclass(frozen=True)
@@ -25,3 +34,62 @@ class Grant:
     """A typed authorization: one provider + its scope. v1: provider='github-app'."""
     provider: str
     scope: Scope
+
+
+class GrantStore:
+    """Filesystem-backed typed grants, one file per enrollment: grants/<id>.json.
+    Atomic writes (tmp + replace), like RequestStore."""
+
+    def __init__(self, base_dir):
+        self._dir = Path(base_dir) / "grants"
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, enrollment_id: str) -> Path:
+        if not _ID_RE.match(enrollment_id):
+            raise ValueError(f"invalid enrollment id {enrollment_id!r}")
+        return self._dir / f"{enrollment_id}.json"
+
+    def _write_atomic(self, path: Path, rec: dict) -> None:
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(rec))
+        tmp.replace(path)
+
+    def set_grant(self, enrollment_id: str, grant: Grant) -> None:
+        """Set/replace the grant for `grant.provider` on this enrollment."""
+        path = self._path(enrollment_id)
+        grants = {g.provider: g for g in self.get_grants(enrollment_id)}
+        grants[grant.provider] = grant
+        self._write_atomic(
+            path,
+            {
+                "enrollment_id": enrollment_id,
+                "grants": [
+                    {
+                        "provider": g.provider,
+                        "scope": {"repos": list(g.scope.repos),
+                                  "push_branch": g.scope.push_branch},
+                    }
+                    for g in grants.values()
+                ],
+            },
+        )
+
+    def get_grants(self, enrollment_id: str) -> list[Grant]:
+        path = self._path(enrollment_id)
+        if not path.exists():
+            return []
+        try:
+            rec = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return []
+        out: list[Grant] = []
+        for g in rec.get("grants", []):
+            sc = g.get("scope", {})
+            out.append(
+                Grant(
+                    provider=g["provider"],
+                    scope=Scope(repos=tuple(sc.get("repos", [])),
+                                push_branch=sc.get("push_branch")),
+                )
+            )
+        return out

--- a/src/mship/core/relay/grants.py
+++ b/src/mship/core/relay/grants.py
@@ -11,6 +11,35 @@ from pathlib import Path
 # id-format contract.
 _ID_RE = re.compile(r"\A[0-9a-z]{1,64}\Z")
 
+# owner/repo: exactly one slash, non-empty halves, no whitespace. This is what
+# GitHubAppProvider later splits on `owner, name = r.split("/", 1)`, so validating
+# it here (at grant/issue time) turns a malformed `--repos api` into a clear up-front
+# error instead of a later IndexError / 500 at mint time.
+_REPO_RE = re.compile(r"\A[^/\s]+/[^/\s]+\Z")
+
+
+class RepoSpecError(ValueError):
+    """A `--repos` value is empty, malformed, or spans multiple owners."""
+
+
+def parse_repos(csv: str) -> tuple[str, ...]:
+    """Parse a comma-separated `owner/repo,owner/repo` list into a validated tuple.
+
+    Raises RepoSpecError when the list is empty, any entry is not `owner/repo`, or
+    the entries span more than one owner (mship mints one installation token per
+    single account — matching `mship serve`'s single-owner /gh-token contract)."""
+    repos = tuple(r.strip() for r in csv.split(",") if r.strip())
+    if not repos:
+        raise RepoSpecError("must list at least one owner/repo")
+    bad = [r for r in repos if not _REPO_RE.match(r)]
+    if bad:
+        raise RepoSpecError(f"malformed repo(s), expected owner/repo: {bad}")
+    owners = {r.split("/", 1)[0] for r in repos}
+    if len(owners) > 1:
+        raise RepoSpecError(f"repos span multiple owners {sorted(owners)}; "
+                            "a run is single-account")
+    return repos
+
 
 @dataclass(frozen=True)
 class Scope:

--- a/src/mship/core/relay/run_token.py
+++ b/src/mship/core/relay/run_token.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+import secrets
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from mship.core.relay.grants import Scope
+
+_ID_RE = re.compile(r"\A[0-9a-f]{1,32}\Z")
+
+
+@dataclass(frozen=True)
+class RunToken:
+    token_id: str
+    enrollment_id: str
+    scope: Scope
+
+
+def _dir(base_dir) -> Path:
+    d = Path(base_dir) / "run-tokens"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _hash(secret: str) -> str:
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()
+
+
+def issue_run_token(
+    base_dir, *, enrollment_id: str, scope: Scope, ttl_seconds: int,
+    clock: Callable[[], float] = time.time,
+) -> str:
+    """Mint a per-run token, persist only its hash, return `<token_id>.<secret>`
+    (the plaintext — printed once by the caller; never re-derivable)."""
+    d = _dir(base_dir)
+    token_id = secrets.token_hex(8)
+    secret = secrets.token_urlsafe(32)
+    rec = {
+        "token_id": token_id,
+        "enrollment_id": enrollment_id,
+        "repos": list(scope.repos),
+        "push_branch": scope.push_branch,
+        "secret_hash": _hash(secret),
+        "expires_at": clock() + ttl_seconds,
+    }
+    path = d / f"{token_id}.json"
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(rec))
+    tmp.replace(path)
+    return f"{token_id}.{secret}"
+
+
+def verify_run_token(
+    base_dir, presented: str, *, clock: Callable[[], float] = time.time,
+) -> RunToken | None:
+    """Return the RunToken for a valid, unexpired presented token, else None."""
+    if "." not in presented:
+        return None
+    token_id, secret = presented.split(".", 1)
+    if not _ID_RE.match(token_id):
+        return None
+    path = _dir(base_dir) / f"{token_id}.json"
+    try:
+        rec = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not hmac.compare_digest(_hash(secret), rec.get("secret_hash", "")):
+        return None
+    if clock() >= rec.get("expires_at", 0):
+        return None
+    return RunToken(
+        token_id=token_id,
+        enrollment_id=rec["enrollment_id"],
+        scope=Scope(repos=tuple(rec.get("repos", [])), push_branch=rec.get("push_branch")),
+    )

--- a/src/mship/core/relay/tls_ask.py
+++ b/src/mship/core/relay/tls_ask.py
@@ -28,6 +28,6 @@ def tls_ask_allowed(domain: str, relay_domain: str) -> bool:
     label = domain[: -len(suffix)]
     if not label or "." in label:        # no nested subdomain levels
         return False
-    if label == "enroll":
+    if label in ("enroll", "egress"):
         return True
     return len(label) <= 63 and _SERVE_LABEL.fullmatch(label) is not None

--- a/tests/cli/test_relay_egress_server.py
+++ b/tests/cli/test_relay_egress_server.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import typer
+from typer.testing import CliRunner
+
+from mship.cli import relay as relay_cli
+
+
+def _app():
+    app = typer.Typer()
+    relay_cli.register(app, get_container=lambda: None)
+    return app
+
+
+def test_egress_server_builds_provider_and_hands_off_to_uvicorn(tmp_path, monkeypatch):
+    captured = {}
+    monkeypatch.setattr(relay_cli, "_run_uvicorn",
+                        lambda app, host, port: captured.update(app=app, host=host, port=port))
+    monkeypatch.setenv("MSHIP_GH_APP_ID", "123")
+    key = tmp_path / "app.pem"
+    key.write_text("-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n")
+    monkeypatch.setenv("MSHIP_GH_APP_KEY", str(key))
+    result = CliRunner().invoke(_app(), [
+        "relay", "egress-server",
+        "--grant-store-dir", str(tmp_path / "grants-store"),
+        "--run-token-dir", str(tmp_path / "run-tokens-store"),
+        "--port", "47280",
+    ])
+    assert result.exit_code == 0, result.output
+    assert captured["port"] == 47280 and captured["app"] is not None
+
+
+def test_egress_server_refuses_unreadable_key(tmp_path, monkeypatch):
+    monkeypatch.setattr(relay_cli, "_run_uvicorn", lambda *a, **k: None)
+    monkeypatch.setenv("MSHIP_GH_APP_ID", "123")
+    monkeypatch.setenv("MSHIP_GH_APP_KEY", str(tmp_path / "does-not-exist.pem"))
+    result = CliRunner().invoke(_app(), [
+        "relay", "egress-server",
+        "--grant-store-dir", str(tmp_path / "grants-store"),
+        "--run-token-dir", str(tmp_path / "run-tokens-store"),
+    ])
+    assert result.exit_code != 0

--- a/tests/cli/test_relay_grant.py
+++ b/tests/cli/test_relay_grant.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from typer.testing import CliRunner
+import typer
+
+from mship.cli import relay as relay_cli
+from mship.core.relay.enroll import RequestStore
+from mship.core.relay.grants import GrantStore
+from mship.core.relay.run_token import verify_run_token
+
+
+def _app():
+    app = typer.Typer()
+    relay_cli.register(app, get_container=lambda: None)
+    return app
+
+
+def _approved_enrollment(tmp_path: Path) -> str:
+    """Create + approve an enrollment so its id resolves as 'approved'."""
+    store = RequestStore(tmp_path / "pending-store")
+    # A shape-valid ed25519 pubkey (real header + base64-valid body). validate_pubkey
+    # checks shape only — approval, not this string, is the security boundary.
+    rid = store.create(
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI" + "A" * 43, "worker",
+    )
+    store.approve(rid, tmp_path / "pubkeys")
+    return rid
+
+
+def test_grant_sets_typed_grant_for_approved_enrollment(tmp_path: Path):
+    rid = _approved_enrollment(tmp_path)
+    result = CliRunner().invoke(_app(), [
+        "relay", "grant", rid,
+        "--provider", "github-app", "--repos", "acme/api,acme/web",
+        "--store-dir", str(tmp_path / "pending-store"),
+        "--grant-store-dir", str(tmp_path / "grants-store"),
+    ])
+    assert result.exit_code == 0, result.output
+    grants = GrantStore(tmp_path / "grants-store").get_grants(rid)
+    assert set(grants[0].scope.repos) == {"acme/api", "acme/web"}
+
+
+def test_grant_rejects_unknown_enrollment(tmp_path: Path):
+    result = CliRunner().invoke(_app(), [
+        "relay", "grant", "deadbeef",
+        "--provider", "github-app", "--repos", "acme/api",
+        "--store-dir", str(tmp_path / "pending-store"),
+        "--grant-store-dir", str(tmp_path / "grants-store"),
+    ])
+    assert result.exit_code != 0
+
+
+def test_issue_run_token_within_ceiling_prints_token(tmp_path: Path):
+    rid = _approved_enrollment(tmp_path)
+    GrantStore(tmp_path / "grants-store").set_grant(
+        rid, __import__("mship.core.relay.grants", fromlist=["Grant", "Scope"]).Grant(
+            "github-app",
+            __import__("mship.core.relay.grants", fromlist=["Scope"]).Scope(repos=("acme/api", "acme/web")),
+        ),
+    )
+    result = CliRunner().invoke(_app(), [
+        "relay", "issue-run-token", rid,
+        "--repos", "acme/api", "--push-branch", "feat/x",
+        "--grant-store-dir", str(tmp_path / "grants-store"),
+        "--run-token-dir", str(tmp_path / "run-tokens-store"),
+    ])
+    assert result.exit_code == 0, result.output
+    token = result.output.strip().split()[-1]              # last token printed
+    rt = verify_run_token(tmp_path / "run-tokens-store", token)
+    assert rt is not None and rt.enrollment_id == rid
+
+
+def test_issue_run_token_repo_outside_ceiling_fails(tmp_path: Path):
+    rid = _approved_enrollment(tmp_path)
+    GrantStore(tmp_path / "grants-store").set_grant(
+        rid, __import__("mship.core.relay.grants", fromlist=["Grant", "Scope"]).Grant(
+            "github-app",
+            __import__("mship.core.relay.grants", fromlist=["Scope"]).Scope(repos=("acme/api",)),
+        ),
+    )
+    result = CliRunner().invoke(_app(), [
+        "relay", "issue-run-token", rid,
+        "--repos", "acme/secret", "--push-branch", "feat/x",
+        "--grant-store-dir", str(tmp_path / "grants-store"),
+        "--run-token-dir", str(tmp_path / "run-tokens-store"),
+    ])
+    assert result.exit_code != 0

--- a/tests/cli/test_relay_grant.py
+++ b/tests/cli/test_relay_grant.py
@@ -138,3 +138,12 @@ def test_issue_run_token_rejects_empty_branch(tmp_path: Path):
     _grant(tmp_path, rid, ("acme/api",))
     result = _issue_cmd(tmp_path, rid, branch="   ")
     assert result.exit_code != 0
+
+
+def test_issue_run_token_rejects_non_branch_ref(tmp_path: Path):
+    # A fully-qualified non-branch ref (refs/tags/…) would authorize a tag update —
+    # reject it at issue time; the run may push only its branch (Greptile).
+    rid = _approved_enrollment(tmp_path)
+    _grant(tmp_path, rid, ("acme/api",))
+    result = _issue_cmd(tmp_path, rid, branch="refs/tags/v1")
+    assert result.exit_code != 0

--- a/tests/cli/test_relay_grant.py
+++ b/tests/cli/test_relay_grant.py
@@ -84,3 +84,57 @@ def test_issue_run_token_repo_outside_ceiling_fails(tmp_path: Path):
         "--run-token-dir", str(tmp_path / "run-tokens-store"),
     ])
     assert result.exit_code != 0
+
+
+def _grant(tmp_path: Path, rid: str, repos: tuple[str, ...]) -> None:
+    from mship.core.relay.grants import Grant, Scope
+    GrantStore(tmp_path / "grants-store").set_grant(rid, Grant("github-app", Scope(repos=repos)))
+
+
+def _grant_cmd(tmp_path: Path, rid: str, repos: str):
+    return CliRunner().invoke(_app(), [
+        "relay", "grant", rid, "--provider", "github-app", "--repos", repos,
+        "--store-dir", str(tmp_path / "pending-store"),
+        "--grant-store-dir", str(tmp_path / "grants-store"),
+    ])
+
+
+def test_grant_rejects_malformed_repo(tmp_path: Path):
+    # A slashless `--repos api` would be accepted then IndexError at mint time —
+    # reject it up front with a clear error (Greptile).
+    rid = _approved_enrollment(tmp_path)
+    result = _grant_cmd(tmp_path, rid, "api")
+    assert result.exit_code != 0
+    assert not GrantStore(tmp_path / "grants-store").get_grants(rid)
+
+
+def test_grant_rejects_multi_owner(tmp_path: Path):
+    rid = _approved_enrollment(tmp_path)
+    result = _grant_cmd(tmp_path, rid, "org-a/api,org-b/web")
+    assert result.exit_code != 0
+    assert not GrantStore(tmp_path / "grants-store").get_grants(rid)
+
+
+def _issue_cmd(tmp_path: Path, rid: str, *, repos="acme/api", branch="feat/x", ttl="86400"):
+    return CliRunner().invoke(_app(), [
+        "relay", "issue-run-token", rid,
+        "--repos", repos, "--push-branch", branch, "--ttl", ttl,
+        "--grant-store-dir", str(tmp_path / "grants-store"),
+        "--run-token-dir", str(tmp_path / "run-tokens-store"),
+    ])
+
+
+def test_issue_run_token_rejects_nonpositive_ttl(tmp_path: Path):
+    # A non-positive TTL mints an immediately-expired (useless) token — reject it,
+    # do not print a "success" secret (Greptile).
+    rid = _approved_enrollment(tmp_path)
+    _grant(tmp_path, rid, ("acme/api",))
+    result = _issue_cmd(tmp_path, rid, ttl="0")
+    assert result.exit_code != 0
+
+
+def test_issue_run_token_rejects_empty_branch(tmp_path: Path):
+    rid = _approved_enrollment(tmp_path)
+    _grant(tmp_path, rid, ("acme/api",))
+    result = _issue_cmd(tmp_path, rid, branch="   ")
+    assert result.exit_code != 0

--- a/tests/core/relay/egress/test_credential.py
+++ b/tests/core/relay/egress/test_credential.py
@@ -1,0 +1,28 @@
+import pytest
+from mship.core.relay.egress.credential import (
+    Attachment, AttachmentHostError, github_token_attachment, Credential,
+)
+
+
+def test_apply_sets_authorization_header_for_allowed_host():
+    headers: dict = {}
+    github_token_attachment().apply(headers, host="github.com", value="ghs_secret")
+    assert headers["Authorization"] == "token ghs_secret"
+
+
+def test_apply_refuses_host_outside_lock():
+    with pytest.raises(AttachmentHostError):
+        github_token_attachment().apply({}, host="evil.example.com", value="ghs_secret")
+
+
+def test_render_formats_value():
+    att = Attachment(header="Authorization", template="token {value}",
+                     hosts=("github.com",))
+    assert att.render("abc") == "token abc"
+
+
+def test_credential_carries_value_ttl_and_attachment():
+    cred = Credential(value="ghs_x", expires_at="2026-07-22T02:00:00Z",
+                      attach=github_token_attachment())
+    assert cred.value == "ghs_x"
+    assert cred.attach.header == "Authorization"

--- a/tests/core/relay/egress/test_enforce.py
+++ b/tests/core/relay/egress/test_enforce.py
@@ -1,0 +1,60 @@
+import pytest
+from mship.core.relay.grants import Grant, Scope
+from mship.core.relay.egress.request import parse_egress_request
+from mship.core.relay.egress.enforce import (
+    GitSmartHttpEnforcer, HostLockedEnforcer, EnforcementError,
+)
+
+
+def pkt(payload: bytes) -> bytes:
+    return b"%04x" % (len(payload) + 4) + payload
+
+
+def _push_body(new_oid: str, ref: str) -> bytes:
+    line = f"{'0'*40} {new_oid} {ref}\x00 report-status-v2\n".encode()
+    return pkt(line) + b"0000" + b"PACKxxxx"
+
+
+RUN_GRANT = Grant("github-app", Scope(repos=("acme/api", "acme/web"), push_branch="feat/x"))
+
+
+def _req(path, method="POST", query="", body=b""):
+    return parse_egress_request(method=method, path=path, query=query, headers={}, body=body)
+
+
+def test_push_to_run_branch_is_allowed():
+    body = _push_body("a" * 40, "refs/heads/feat/x")
+    GitSmartHttpEnforcer().check(_req("/gh/acme/api.git/git-receive-pack", body=body), RUN_GRANT)
+
+
+def test_push_to_other_branch_is_rejected():
+    body = _push_body("a" * 40, "refs/heads/main")
+    with pytest.raises(EnforcementError):
+        GitSmartHttpEnforcer().check(_req("/gh/acme/api.git/git-receive-pack", body=body), RUN_GRANT)
+
+
+def test_push_to_repo_outside_run_is_rejected():
+    body = _push_body("a" * 40, "refs/heads/feat/x")
+    with pytest.raises(EnforcementError):
+        GitSmartHttpEnforcer().check(_req("/gh/acme/other.git/git-receive-pack", body=body), RUN_GRANT)
+
+
+def test_delete_of_run_branch_is_rejected():
+    body = _push_body("0" * 40, "refs/heads/feat/x")   # new-oid all-zero = delete
+    with pytest.raises(EnforcementError):
+        GitSmartHttpEnforcer().check(_req("/gh/acme/api.git/git-receive-pack", body=body), RUN_GRANT)
+
+
+def test_clone_fetch_upload_pack_passes():
+    e = GitSmartHttpEnforcer()
+    e.check(_req("/gh/acme/api.git/info/refs", method="GET", query="service=git-upload-pack"), RUN_GRANT)
+    e.check(_req("/gh/acme/api.git/git-upload-pack", method="POST", body=b"0011want.."), RUN_GRANT)
+
+
+def test_receive_pack_advertisement_get_passes():
+    e = GitSmartHttpEnforcer()
+    e.check(_req("/gh/acme/api.git/info/refs", method="GET", query="service=git-receive-pack"), RUN_GRANT)
+
+
+def test_host_locked_enforcer_passes_api_traffic():
+    HostLockedEnforcer().check(_req("/api/repos/acme/api/pulls", method="GET"), RUN_GRANT)

--- a/tests/core/relay/egress/test_enforce.py
+++ b/tests/core/relay/egress/test_enforce.py
@@ -39,6 +39,17 @@ def test_push_to_repo_outside_run_is_rejected():
         GitSmartHttpEnforcer().check(_req("/gh/acme/other.git/git-receive-pack", body=body), RUN_GRANT)
 
 
+def test_tag_push_branch_authorizes_no_ref():
+    # A run scoped to a non-branch ref (refs/tags/v1) must NOT authorize that tag
+    # update — the enforcer only ever allows refs/heads/ (Greptile). Both the
+    # matching tag ref and any branch are refused.
+    tag_grant = Grant("github-app", Scope(repos=("acme/api",), push_branch="refs/tags/v1"))
+    for ref in ("refs/tags/v1", "refs/heads/feat/x"):
+        body = _push_body("a" * 40, ref)
+        with pytest.raises(EnforcementError):
+            GitSmartHttpEnforcer().check(_req("/gh/acme/api.git/git-receive-pack", body=body), tag_grant)
+
+
 def test_delete_of_run_branch_is_rejected():
     body = _push_body("0" * 40, "refs/heads/feat/x")   # new-oid all-zero = delete
     with pytest.raises(EnforcementError):

--- a/tests/core/relay/egress/test_pktline.py
+++ b/tests/core/relay/egress/test_pktline.py
@@ -1,0 +1,51 @@
+from mship.core.relay.egress.pktline import (
+    read_pkt_lines, parse_receive_pack_commands, RefUpdate,
+)
+
+ZERO = "0" * 40
+
+
+def pkt(payload: bytes) -> bytes:
+    """Frame a payload as a pkt-line: 4-hex length (incl. the 4 prefix bytes)."""
+    return b"%04x" % (len(payload) + 4) + payload
+
+
+FLUSH = b"0000"
+
+# Real client receive-pack command line (git 2.43): create feat/demo.
+_CMD = (
+    b"0000000000000000000000000000000000000000 "
+    b"0cee56ac428e99ad3c1a55a8c6913250e9172578 "
+    b"refs/heads/feat/demo\x00 report-status-v2 side-band-64k quiet "
+    b"object-format=sha1 agent=git/2.43.0\n"
+)
+
+
+def test_read_pkt_lines_stops_at_flush_and_ignores_packfile_bytes():
+    body = pkt(_CMD) + FLUSH + b"PACK\x00\x00garbage-packfile-bytes"
+    lines = read_pkt_lines(body)
+    assert lines == [_CMD]
+
+
+def test_parse_receive_pack_commands_strips_caps_and_newline():
+    body = pkt(_CMD) + FLUSH + b"PACKxxxx"
+    cmds = parse_receive_pack_commands(body)
+    assert cmds == [
+        RefUpdate(
+            old_oid=ZERO,
+            new_oid="0cee56ac428e99ad3c1a55a8c6913250e9172578",
+            ref="refs/heads/feat/demo",
+        )
+    ]
+
+
+def test_parse_multiple_commands_atomic_push():
+    line2 = (
+        b"1111111111111111111111111111111111111111 "
+        b"2222222222222222222222222222222222222222 "
+        b"refs/heads/feat/demo\n"
+    )
+    body = pkt(_CMD) + pkt(line2) + FLUSH
+    cmds = parse_receive_pack_commands(body)
+    assert [c.ref for c in cmds] == ["refs/heads/feat/demo", "refs/heads/feat/demo"]
+    assert cmds[1].old_oid == "1" * 40

--- a/tests/core/relay/egress/test_provider.py
+++ b/tests/core/relay/egress/test_provider.py
@@ -57,3 +57,15 @@ def test_resolve_refuses_empty_repo_scope(rsa_pem):
     provider = GitHubAppProvider(app_id="1", private_key=rsa_pem, client=_mock_github({}))
     with pytest.raises(ProviderError):
         provider.resolve(identity="enr1", grant=grant, request=_req())
+
+
+def test_resolve_refuses_malformed_repo_with_controlled_error(rsa_pem):
+    # A slashless repo in the grant must raise a controlled ProviderError (-> 502),
+    # NOT an uncaught IndexError from r.split("/", 1)[1] (-> 500). Defence in depth
+    # behind the grant-time validation (Greptile). The requested repo (acme/api) is
+    # in-grant so the out-of-grant check passes and the malformed guard is what fires.
+    grant = Grant("github-app", Scope(repos=("acme/api", "nope"), push_branch="feat/x"))
+    provider = GitHubAppProvider(app_id="1", private_key=rsa_pem, client=_mock_github({}))
+    with pytest.raises(ProviderError):
+        provider.resolve(identity="enr1", grant=grant,
+                         request=_req("/gh/acme/api.git/git-receive-pack"))

--- a/tests/core/relay/egress/test_provider.py
+++ b/tests/core/relay/egress/test_provider.py
@@ -1,0 +1,59 @@
+import httpx
+import pytest
+from mship.core.relay.grants import Grant, Scope
+from mship.core.relay.egress.request import parse_egress_request
+from mship.core.relay.egress.provider import GitHubAppProvider, ProviderError
+
+
+def _req(repo_path="/gh/acme/api.git/git-receive-pack"):
+    return parse_egress_request(method="POST", path=repo_path, query="", headers={}, body=b"")
+
+
+def _mock_github(mint_capture: dict) -> httpx.Client:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/installation"):
+            return httpx.Response(200, json={"id": 42})
+        if request.url.path.endswith("/access_tokens"):
+            import json
+            mint_capture["repositories"] = json.loads(request.content)["repositories"]
+            return httpx.Response(201, json={"token": "ghs_minted", "expires_at": "2026-07-22T02:00:00Z"})
+        return httpx.Response(404)
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+# A throwaway RSA key so _app_jwt can sign; not a real GitHub App key.
+@pytest.fixture(scope="module")
+def rsa_pem():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+
+def test_resolve_mints_token_scoped_to_run_repos(rsa_pem):
+    captured: dict = {}
+    grant = Grant("github-app", Scope(repos=("acme/api",), push_branch="feat/x"))
+    provider = GitHubAppProvider(app_id="1", private_key=rsa_pem, client=_mock_github(captured))
+    cred = provider.resolve(identity="enr1", grant=grant, request=_req())
+    assert cred.value == "ghs_minted"
+    assert cred.expires_at == "2026-07-22T02:00:00Z"
+    assert captured["repositories"] == ["api"]          # short name, scoped to the grant
+    assert cred.attach.header == "Authorization"
+
+
+def test_resolve_refuses_repo_outside_grant(rsa_pem):
+    grant = Grant("github-app", Scope(repos=("acme/web",), push_branch="feat/x"))
+    provider = GitHubAppProvider(app_id="1", private_key=rsa_pem, client=_mock_github({}))
+    with pytest.raises(ProviderError):
+        provider.resolve(identity="enr1", grant=grant, request=_req("/gh/acme/api.git/git-receive-pack"))
+
+
+def test_resolve_refuses_empty_repo_scope(rsa_pem):
+    grant = Grant("github-app", Scope(repos=(), push_branch="feat/x"))
+    provider = GitHubAppProvider(app_id="1", private_key=rsa_pem, client=_mock_github({}))
+    with pytest.raises(ProviderError):
+        provider.resolve(identity="enr1", grant=grant, request=_req())

--- a/tests/core/relay/egress/test_proxy.py
+++ b/tests/core/relay/egress/test_proxy.py
@@ -1,0 +1,111 @@
+import httpx
+from fastapi.testclient import TestClient
+from mship.core.relay.grants import Grant, GrantStore, Scope
+from mship.core.relay.run_token import issue_run_token
+from mship.core.relay.egress.credential import Credential, github_token_attachment
+from mship.core.relay.egress.routes import build_default_routes
+from mship.core.relay.egress.proxy import build_egress_app
+
+
+def pkt(payload: bytes) -> bytes:
+    return b"%04x" % (len(payload) + 4) + payload
+
+
+def _push_body(ref="refs/heads/feat/x") -> bytes:
+    line = f"{'0'*40} {'a'*40} {ref}\x00 report-status-v2\n".encode()
+    return pkt(line) + b"0000" + b"PACKxxxx"
+
+
+class _StubProvider:
+    """Returns a fixed credential without touching GitHub (gh_app is tested in
+    Task 6). Records that resolve() was called with the run's repo."""
+    def __init__(self):
+        self.calls = []
+
+    def resolve(self, identity, grant, request):
+        self.calls.append((identity, tuple(grant.scope.repos), request.repo))
+        return Credential(value="ghs_minted", expires_at=None, attach=github_token_attachment())
+
+
+def _capture_upstream(seen: dict) -> httpx.Client:
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["host"] = request.url.host
+        seen["authorization"] = request.headers.get("Authorization")
+        seen["run_token"] = request.headers.get("Mship-Run-Token")
+        return httpx.Response(200, content=b"ok-from-github")
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def _app(tmp_path, provider, client):
+    gs = GrantStore(tmp_path)
+    gs.set_grant("enr1", Grant("github-app", Scope(repos=("acme/api", "acme/web"))))
+    routes = build_default_routes(provider) if provider else None
+    return build_egress_app(
+        grant_store=gs, run_token_dir=tmp_path, routes=routes, client=client,
+    ), tmp_path
+
+
+def _token(tmp_path):
+    return issue_run_token(tmp_path, enrollment_id="enr1",
+                           scope=Scope(repos=("acme/api",), push_branch="feat/x"),
+                           ttl_seconds=3600)
+
+
+def test_push_to_run_branch_attaches_token_and_strips_placeholder(tmp_path):
+    seen: dict = {}
+    provider = _StubProvider()
+    app, base = _app(tmp_path, provider, _capture_upstream(seen))
+    token = _token(base)
+    client = TestClient(app)
+    resp = client.post(
+        "/gh/acme/api.git/git-receive-pack",
+        content=_push_body(),
+        headers={"Mship-Run-Token": token, "Content-Type": "application/x-git-receive-pack-request"},
+    )
+    assert resp.status_code == 200
+    assert resp.content == b"ok-from-github"
+    assert seen["host"] == "github.com"
+    assert seen["authorization"] == "token ghs_minted"     # real cred attached at egress
+    assert seen["run_token"] is None                       # placeholder never leaves the relay
+    assert provider.calls == [("enr1", ("acme/api",), "acme/api")]
+
+
+def test_push_to_other_branch_is_rejected_before_egress(tmp_path):
+    seen: dict = {}
+    app, base = _app(tmp_path, _StubProvider(), _capture_upstream(seen))
+    token = _token(base)
+    resp = TestClient(app).post(
+        "/gh/acme/api.git/git-receive-pack",
+        content=_push_body(ref="refs/heads/main"),
+        headers={"Mship-Run-Token": token},
+    )
+    assert resp.status_code == 403
+    assert seen == {}                                       # never forwarded
+
+
+def test_missing_or_invalid_run_token_is_401(tmp_path):
+    app, base = _app(tmp_path, _StubProvider(), _capture_upstream({}))
+    c = TestClient(app)
+    assert c.post("/gh/acme/api.git/git-receive-pack", content=_push_body()).status_code == 401
+    assert c.post("/gh/acme/api.git/git-receive-pack", content=_push_body(),
+                  headers={"Mship-Run-Token": "bogus.secret"}).status_code == 401
+
+
+def test_no_provider_fails_closed_503(tmp_path):
+    app, base = _app(tmp_path, None, _capture_upstream({}))
+    token = _token(base)
+    resp = TestClient(app).post("/gh/acme/api.git/git-receive-pack",
+                                content=_push_body(), headers={"Mship-Run-Token": token})
+    assert resp.status_code == 503
+
+
+def test_clone_upload_pack_passes_and_attaches(tmp_path):
+    seen: dict = {}
+    app, base = _app(tmp_path, _StubProvider(), _capture_upstream(seen))
+    token = _token(base)
+    resp = TestClient(app).get(
+        "/gh/acme/api.git/info/refs?service=git-upload-pack",
+        headers={"Mship-Run-Token": token},
+    )
+    assert resp.status_code == 200
+    assert seen["authorization"] == "token ghs_minted"

--- a/tests/core/relay/egress/test_request.py
+++ b/tests/core/relay/egress/test_request.py
@@ -1,0 +1,43 @@
+import pytest
+from mship.core.relay.egress.request import parse_egress_request, UnmappablePathError
+
+
+def test_gh_prefix_maps_to_github_and_extracts_repo_and_receive_service():
+    req = parse_egress_request(
+        method="POST",
+        path="/gh/acme/api.git/git-receive-pack",
+        query="",
+        headers={},
+        body=b"",
+    )
+    assert req.upstream_host == "github.com"
+    assert req.upstream_path == "/acme/api.git/git-receive-pack"
+    assert req.repo == "acme/api"
+    assert req.service == "git-receive-pack"
+    assert req.is_receive_pack_post is True
+
+
+def test_info_refs_service_comes_from_query():
+    req = parse_egress_request(
+        method="GET",
+        path="/gh/acme/api.git/info/refs",
+        query="service=git-upload-pack",
+        headers={},
+        body=b"",
+    )
+    assert req.service == "git-upload-pack"
+    assert req.is_receive_pack_post is False
+
+
+def test_api_prefix_maps_to_api_host_with_no_repo():
+    req = parse_egress_request(
+        method="GET", path="/api/repos/acme/api/pulls", query="", headers={}, body=b"",
+    )
+    assert req.upstream_host == "api.github.com"
+    assert req.upstream_path == "/repos/acme/api/pulls"
+    assert req.repo is None
+
+
+def test_unmapped_prefix_raises():
+    with pytest.raises(UnmappablePathError):
+        parse_egress_request(method="GET", path="/evil/x", query="", headers={}, body=b"")

--- a/tests/core/relay/egress/test_routes.py
+++ b/tests/core/relay/egress/test_routes.py
@@ -1,0 +1,21 @@
+import pytest
+from mship.core.relay.egress.routes import RouteTable, UnknownHostError, build_default_routes
+from mship.core.relay.egress.enforce import GitSmartHttpEnforcer, HostLockedEnforcer
+
+
+class _FakeProvider:
+    def resolve(self, identity, grant, request):  # pragma: no cover - not called here
+        raise NotImplementedError
+
+
+def test_default_routes_map_github_and_api_hosts():
+    table = build_default_routes(_FakeProvider())
+    assert isinstance(table.resolve("github.com").enforcer, GitSmartHttpEnforcer)
+    assert isinstance(table.resolve("api.github.com").enforcer, HostLockedEnforcer)
+    assert table.resolve("github.com").provider is table.resolve("api.github.com").provider
+
+
+def test_unknown_host_is_rejected_not_defaulted():
+    table = build_default_routes(_FakeProvider())
+    with pytest.raises(UnknownHostError):
+        table.resolve("evil.example.com")

--- a/tests/core/relay/egress/test_routes.py
+++ b/tests/core/relay/egress/test_routes.py
@@ -1,6 +1,6 @@
 import pytest
 from mship.core.relay.egress.routes import RouteTable, UnknownHostError, build_default_routes
-from mship.core.relay.egress.enforce import GitSmartHttpEnforcer, HostLockedEnforcer
+from mship.core.relay.egress.enforce import GitSmartHttpEnforcer
 
 
 class _FakeProvider:
@@ -8,11 +8,15 @@ class _FakeProvider:
         raise NotImplementedError
 
 
-def test_default_routes_map_github_and_api_hosts():
+def test_default_routes_ship_git_only_with_branch_enforcer():
+    # v1 ships ONLY the fully-branch-enforced git path. api.github.com is
+    # intentionally not routed yet (a repo-scoped App token could mutate refs via
+    # the REST API and bypass the push-to-run-branch enforcement); it returns with a
+    # real API enforcer when the worker's API-client slice lands.
     table = build_default_routes(_FakeProvider())
     assert isinstance(table.resolve("github.com").enforcer, GitSmartHttpEnforcer)
-    assert isinstance(table.resolve("api.github.com").enforcer, HostLockedEnforcer)
-    assert table.resolve("github.com").provider is table.resolve("api.github.com").provider
+    with pytest.raises(UnknownHostError):
+        table.resolve("api.github.com")
 
 
 def test_unknown_host_is_rejected_not_defaulted():

--- a/tests/core/relay/test_grants.py
+++ b/tests/core/relay/test_grants.py
@@ -1,0 +1,19 @@
+from mship.core.relay.grants import Scope, Grant
+
+
+def test_scope_covers_is_repo_subset_ignoring_push_branch():
+    ceiling = Scope(repos=("acme/api", "acme/web"))               # ceiling: push_branch None
+    run = Scope(repos=("acme/api",), push_branch="feat/x")        # per-run subset
+    assert ceiling.covers(run) is True
+
+
+def test_scope_does_not_cover_repo_outside_ceiling():
+    ceiling = Scope(repos=("acme/api",))
+    run = Scope(repos=("acme/api", "acme/secret"), push_branch="feat/x")
+    assert ceiling.covers(run) is False
+
+
+def test_grant_carries_provider_and_scope():
+    g = Grant(provider="github-app", scope=Scope(repos=("acme/api",)))
+    assert g.provider == "github-app"
+    assert g.scope.repos == ("acme/api",)

--- a/tests/core/relay/test_grants.py
+++ b/tests/core/relay/test_grants.py
@@ -1,4 +1,25 @@
-from mship.core.relay.grants import Scope, Grant
+import pytest
+
+from mship.core.relay.grants import Scope, Grant, RepoSpecError, parse_repos
+
+
+def test_parse_repos_accepts_owner_repo_list():
+    assert parse_repos("acme/api, acme/web") == ("acme/api", "acme/web")
+
+
+def test_parse_repos_rejects_empty():
+    with pytest.raises(RepoSpecError):
+        parse_repos("  , ,")
+
+
+def test_parse_repos_rejects_slashless():
+    with pytest.raises(RepoSpecError):
+        parse_repos("acme/api,api")
+
+
+def test_parse_repos_rejects_multi_owner():
+    with pytest.raises(RepoSpecError):
+        parse_repos("org-a/api,org-b/web")
 
 
 def test_scope_covers_is_repo_subset_ignoring_push_branch():

--- a/tests/core/relay/test_grants.py
+++ b/tests/core/relay/test_grants.py
@@ -17,3 +17,29 @@ def test_grant_carries_provider_and_scope():
     g = Grant(provider="github-app", scope=Scope(repos=("acme/api",)))
     assert g.provider == "github-app"
     assert g.scope.repos == ("acme/api",)
+
+
+from pathlib import Path
+from mship.core.relay.grants import GrantStore
+
+
+def test_set_and_get_grant_roundtrip(tmp_path: Path):
+    store = GrantStore(tmp_path)
+    store.set_grant("enr1", Grant("github-app", Scope(repos=("acme/api", "acme/web"))))
+    grants = store.get_grants("enr1")
+    assert len(grants) == 1
+    assert grants[0].provider == "github-app"
+    assert set(grants[0].scope.repos) == {"acme/api", "acme/web"}
+
+
+def test_set_grant_replaces_same_provider(tmp_path: Path):
+    store = GrantStore(tmp_path)
+    store.set_grant("enr1", Grant("github-app", Scope(repos=("acme/api",))))
+    store.set_grant("enr1", Grant("github-app", Scope(repos=("acme/api", "acme/web"))))
+    grants = store.get_grants("enr1")
+    assert len(grants) == 1
+    assert set(grants[0].scope.repos) == {"acme/api", "acme/web"}
+
+
+def test_get_grants_unknown_enrollment_is_empty(tmp_path: Path):
+    assert GrantStore(tmp_path).get_grants("nope") == []

--- a/tests/core/relay/test_run_token.py
+++ b/tests/core/relay/test_run_token.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from mship.core.relay.grants import Scope
+from mship.core.relay.run_token import issue_run_token, verify_run_token
+
+
+def test_issue_returns_plaintext_and_verify_accepts(tmp_path: Path):
+    clock = lambda: 1000.0
+    token = issue_run_token(
+        tmp_path, enrollment_id="enr1",
+        scope=Scope(repos=("acme/api", "acme/web"), push_branch="feat/x"),
+        ttl_seconds=3600, clock=clock,
+    )
+    assert "." in token
+    rt = verify_run_token(tmp_path, token, clock=clock)
+    assert rt is not None
+    assert rt.enrollment_id == "enr1"
+    assert set(rt.scope.repos) == {"acme/api", "acme/web"}
+    assert rt.scope.push_branch == "feat/x"
+
+
+def test_only_hash_persisted_not_plaintext(tmp_path: Path):
+    token = issue_run_token(tmp_path, enrollment_id="enr1",
+                            scope=Scope(repos=("acme/api",), push_branch="feat/x"),
+                            ttl_seconds=3600)
+    _id, secret = token.split(".", 1)
+    for f in (tmp_path / "run-tokens").glob("*.json"):
+        assert secret not in f.read_text()
+
+
+def test_verify_rejects_tampered_secret(tmp_path: Path):
+    token = issue_run_token(tmp_path, enrollment_id="enr1",
+                            scope=Scope(repos=("acme/api",), push_branch="feat/x"),
+                            ttl_seconds=3600)
+    token_id, _secret = token.split(".", 1)
+    assert verify_run_token(tmp_path, f"{token_id}.wrong") is None
+
+
+def test_verify_rejects_expired(tmp_path: Path):
+    token = issue_run_token(tmp_path, enrollment_id="enr1",
+                            scope=Scope(repos=("acme/api",), push_branch="feat/x"),
+                            ttl_seconds=100, clock=lambda: 1000.0)
+    assert verify_run_token(tmp_path, token, clock=lambda: 2000.0) is None
+
+
+def test_verify_rejects_unknown_token(tmp_path: Path):
+    (tmp_path / "run-tokens").mkdir(parents=True, exist_ok=True)
+    assert verify_run_token(tmp_path, "deadbeef.secret") is None

--- a/tests/core/relay/test_tls_ask.py
+++ b/tests/core/relay/test_tls_ask.py
@@ -61,3 +61,7 @@ def test_rejects_leading_hyphen_label():
 def test_rejects_double_leading_hyphen_label():
     # base must start alphanumeric; a lone-hyphen base must not slip through
     assert tls_ask_allowed(f"--abcdef.{RELAY}", RELAY) is False
+
+
+def test_egress_label_is_allowed():
+    assert tls_ask_allowed("egress.relay.example.com", "relay.example.com") is True


### PR DESCRIPTION
Implements spec `cloud-worker-auth-spine` (Slice 1 of #393). Turns the relay into a scoped, credential-attaching **egress proxy** so a disposable, prompt-injectable cloud worker can clone/fetch/push cross-repo carrying only a **placeholder** — the real GitHub App token is attached and enforced at the relay's egress and **never lands on the worker**.

## The model (attach-at-relay, Shape 2)

The worker rewrites its git remotes (`url.insteadOf` → `egress.<relay>/gh/…`) and carries a low-value `Mship-Run-Token` header — no usable GitHub credential. Its git smart-HTTP + API traffic flows through the relay, which per request: verifies the run token (its own end-to-end auth), maps the path prefix → upstream host, checks the per-run scope ⊆ the enrollment's grant ceiling, **enforces** (git smart-HTTP: rejects any push except to the run's branch for a run-scoped repo; clone/fetch pass), **mints** a repo-scoped App token, **attaches** it host-locked, strips the placeholder + `Host` + inbound `Authorization`, and forwards to GitHub.

**Two-layer scope makes cross-repo work:** the enrollment grant is the repo **ceiling**; a **per-run token** narrows to `{repos ⊆ ceiling, push_branch}`. Since a task has one branch name (`feat/<slug>`) across all its repos, one per-run token authorizes that branch across repos A/B/C and nothing else, anywhere.

**Four seams** go in from day one (`CredentialProvider` / `Attachment` / `RouteTable` / typed grants) so GitLab or a static secret (e.g. an OpenAI key) is later a relay-side plugin with zero worker change. The egress-proxy is a distinct module whose worker session terminates at it, so the future untrusted-relay 3-role split is a deployment change, not a rewrite.

**Transport (operator decision A):** the disposable worker reaches the relay over outbound HTTPS authenticated by the per-run token — no SSH key on the worker.

## Security-critical behavior (runtime-verified)

- Enforcer: push to the run branch **allowed**; push to any other ref, a repo outside the run's repos, or a branch **delete** (zero new-oid) **rejected**; `upload-pack` (clone/fetch) and the receive-pack advertisement pass; an empty/unparseable push body is **rejected** (fail-closed).
- Proxy fails **closed**: no App creds → 503 (never forwards); missing/invalid run token → 401; enforcement reject → 403 **before** any token is minted; scope exceeds ceiling → 403.
- Attachment is **host-locked**: refuses to set `Authorization` for any host outside `[github.com, api.github.com]`.

## Scope

- v1 ships: `github-app` provider + git-smart-http enforcer + route table + typed grants + per-run token + `mship relay grant` / `issue-run-token` / `egress-server` + Caddy/tls_ask/docker wiring + trust-model docs.
- Out of v1 (seams in place): the fan-out orchestrator (Slice 2), the worker image (Slice 3), non-GitHub providers, the untrusted-relay split, and the worker's API-client wiring to `/api/` (the api route is built + tested at the proxy; clone/fetch/push is fully exercised via the git leg).

## Tests

13 TDD commits (one per plan task), each AC-tagged. Security-critical git-wire/enforcer/proxy paths tested hard; boundaries mocked (gh_app + httpx upstream via `MockTransport`) — no live relay, GitHub, or App key. Full `mship test`: **3084 passed**.

_Note: the Caddyfile block mirrors the adjacent working `enroll.` block but wasn't machine-validated (no `caddy` in the build sandbox); the sync-httpx-in-async-route + body buffering is journaled as a later streaming/perf follow-up._
