### PR TITLE
Worker PR egress: api.github.com relay route with a default-deny PR-only enforcer

### DIFF
--- a/docs/cloud-worker-auth-spine.md
+++ b/docs/cloud-worker-auth-spine.md
@@ -134,10 +134,12 @@ only a *run-branch* push to the *run's repos*, with a repo-scoped short-TTL App 
 the worker never sees. Exfiltrating the placeholder + token yields no GitHub access
 and no other-branch / other-repo write.
 
-> **API route deferred on the worker.** The `api.github.com` route (`/api/`) is
-> built + tested at the proxy boundary in v1, but wiring the worker's API client
-> (`mship`/`gh`) to `…/api/` is a later worker-image slice. v1 fully exercises
-> ac1's clone/fetch/push through the **git** leg.
+> **The api.github.com leg is live + enforced.** The worker opens (and lightly
+> manages) its own PR through the `/api/` egress leg (operator decision B). The
+> route is back on the github-app provider behind `GitHubApiEnforcer`, a
+> DEFAULT-DENY REST enforcer (below). This is the API leg the auth-spine slice
+> deferred, now done with a real enforcer instead of a pass-through — so the API
+> path cannot sidestep the git push-to-run-branch enforcement.
 
 ## 7. Egress-proxy module boundary
 
@@ -145,7 +147,8 @@ The egress-proxy role is the subpackage `src/mship/core/relay/egress/`:
 
 - `pktline.py` — `read_pkt_lines`, `parse_receive_pack_commands`, `RefUpdate` (pure git-wire).
 - `request.py` — `parse_egress_request` (path-prefix host map + repo/service extraction).
-- `enforce.py` — `GitSmartHttpEnforcer` (run-branch-only push), `HostLockedEnforcer`.
+- `enforce.py` — `GitSmartHttpEnforcer` (run-branch-only push), `GitHubApiEnforcer`
+  (default-deny PR-only REST leg) + `classify_api_request` (its pure classifier).
 - `credential.py` — `Attachment` (host-locked), `Credential`, `github_token_attachment`.
 - `provider.py` — `CredentialProvider`, `GitHubAppProvider`.
 - `routes.py` — `Route`, `RouteTable`, `build_default_routes`.
@@ -156,3 +159,47 @@ The worker's session **logically terminates at `build_egress_app`**, authenticat
 by the per-run token that module verifies itself (not delegated to the relay). This
 self-contained, end-to-end-verifiable boundary is exactly what makes the Shape-3
 relocation a deployment change rather than a rewrite.
+
+## 8. The api.github.com leg — `GitHubApiEnforcer` (default-deny, PR-only)
+
+The worker opens its own PR, which is a REST call (`POST /repos/{o}/{r}/pulls`).
+So the `api.github.com` route is routed on the **same** github-app provider as the
+git leg, behind `GitHubApiEnforcer`. Containment is two independent layers: (a) the
+repo-scoped App installation token already bounds every call to the run's repos;
+(b) the enforcer is DEFAULT-DENY over the REST surface — it permits an enumerated
+allowlist and refuses everything else (403). New/unknown GitHub endpoints are denied
+by construction: the safe failure mode is a blocked worker call, never an unexpected
+mutation.
+
+**PERMIT (and nothing else):**
+- `POST  /repos/{o}/{r}/pulls` — open a PR
+- `PATCH /repos/{o}/{r}/pulls/{n}` — update the run's PR (title/body/state); **not** merge
+- `POST  /repos/{o}/{r}/issues/{n}/comments` — comment
+- `POST  /repos/{o}/{r}/pulls/{n}/reviews`, `POST /repos/{o}/{r}/pulls/{n}/requested_reviewers` — review / request review
+- `GET   /repos/{o}/{r}/...` — reads scoped to the run's repos
+- `GET   /rate_limit`, `GET /user` — safe global reads
+
+Every repo-scoped permit ALSO requires the path's `owner/repo` to be within the
+run's `scope.repos` (an out-of-scope repo is refused — same containment as the git
+leg).
+
+**Explicitly DENIED (named + tested, though default-deny already covers them):**
+- `PUT /repos/{o}/{r}/pulls/{n}/merge` — merging a PR. **Nothing auto-merges**; the
+  fan-out is review-gated end to end (#393), so merge is denied even though the
+  token technically could. Note this is a DIFFERENT path from the permitted
+  `PATCH /pulls/{n}`.
+- `POST /repos/{o}/{r}/merges`
+- `POST|PATCH|DELETE /repos/{o}/{r}/git/refs/*` — ref mutation
+- `PUT|DELETE /repos/{o}/{r}/contents/*` — content mutation
+
+These are exactly the REST paths that could sidestep the git push-to-run-branch
+enforcement, so they are called out even though default-deny refuses them anyway.
+GraphQL (`/graphql`) is not routed (REST-only in v1; it would need its own enforcer).
+
+**No new deploy surface.** The api leg rides the existing egress subdomain: the
+`/api/` path prefix is already mapped in `request.py`, the worker config already sets
+`url."…/api/".insteadOf "https://api.github.com/"` (Section 6), the Attachment already
+host-locks the token to `[github.com, api.github.com]`, and one Caddy block + one
+`tls_ask` entry already front the whole `egress.<RELAY_DOMAIN>` host. Adding the leg
+was a route-table entry + enforcer, not a new route/TLS allowance. The proxy still
+fails CLOSED on the api leg (App creds absent -> 503, never forward).

--- a/docs/cloud-worker-auth-spine.md
+++ b/docs/cloud-worker-auth-spine.md
@@ -134,8 +134,8 @@ only a *run-branch* push to the *run's repos*, with a repo-scoped short-TTL App 
 the worker never sees. Exfiltrating the placeholder + token yields no GitHub access
 and no other-branch / other-repo write.
 
-> **The api.github.com leg is live + enforced.** The worker opens (and lightly
-> manages) its own PR through the `/api/` egress leg (operator decision B). The
+> **The api.github.com leg is live + enforced.** The worker OPENS its PR through
+> the `/api/` egress leg (operator decision B). The
 > route is back on the github-app provider behind `GitHubApiEnforcer`, a
 > DEFAULT-DENY REST enforcer (below). This is the API leg the auth-spine slice
 > deferred, now done with a real enforcer instead of a pass-through — so the API
@@ -172,10 +172,8 @@ by construction: the safe failure mode is a blocked worker call, never an unexpe
 mutation.
 
 **PERMIT (and nothing else):**
-- `POST  /repos/{o}/{r}/pulls` — open a PR
-- `PATCH /repos/{o}/{r}/pulls/{n}` — update the run's PR (title/body/state); **not** merge
-- `POST  /repos/{o}/{r}/issues/{n}/comments` — comment
-- `POST  /repos/{o}/{r}/pulls/{n}/reviews`, `POST /repos/{o}/{r}/pulls/{n}/requested_reviewers` — review / request review
+- `POST  /repos/{o}/{r}/pulls` — **open** a PR (the only permitted write; the worker
+  sets title + body in this call, so it needs nothing further)
 - `GET   /repos/{o}/{r}/...` — reads scoped to the run's repos
 - `GET   /rate_limit`, `GET /user` — safe global reads
 
@@ -184,10 +182,15 @@ run's `scope.repos` (an out-of-scope repo is refused — same containment as the
 leg).
 
 **Explicitly DENIED (named + tested, though default-deny already covers them):**
+- Any write to an EXISTING numbered PR/issue — `PATCH /pulls/{n}`, `POST /issues/{n}/comments`,
+  `POST /pulls/{n}/reviews`, `POST /pulls/{n}/requested_reviewers`. The run does not
+  own every PR in its repos, and the enforcer can't prove a given number is the run's
+  own PR, so a (prompt-injectable) worker must not be able to close/rewrite/review an
+  UNRELATED PR. (Managing the run's own PR could return later behind per-run
+  PR-ownership tracking — recording the number from the open response.)
 - `PUT /repos/{o}/{r}/pulls/{n}/merge` — merging a PR. **Nothing auto-merges**; the
   fan-out is review-gated end to end (#393), so merge is denied even though the
-  token technically could. Note this is a DIFFERENT path from the permitted
-  `PATCH /pulls/{n}`.
+  token technically could.
 - `POST /repos/{o}/{r}/merges`
 - `POST|PATCH|DELETE /repos/{o}/{r}/git/refs/*` — ref mutation
 - `PUT|DELETE /repos/{o}/{r}/contents/*` — content mutation

--- a/src/mship/core/relay/egress/enforce.py
+++ b/src/mship/core/relay/egress/enforce.py
@@ -63,6 +63,52 @@ class GitSmartHttpEnforcer:
                 raise EnforcementError(f"deletion of {cmd.ref!r} is not allowed")
 
 
+def classify_api_request(method: str, path: str, in_scope: bool) -> bool:
+    """Pure DEFAULT-DENY classifier for the GitHub REST surface.
+
+    Returns True to PERMIT, False to DENY. `in_scope` says whether the path's
+    owner/repo is within the run's scope.repos (only meaningful for repo-scoped
+    paths; the safe globals are allowed regardless). Permits ONLY:
+      - GET /rate_limit, GET /user                      (safe global reads)
+      - GET  /repos/{o}/{r}/...                          (reads on the run's repos)
+      - POST  /repos/{o}/{r}/pulls                       (open a PR)
+      - PATCH /repos/{o}/{r}/pulls/{n}                   (update the PR; NOT merge)
+      - POST  /repos/{o}/{r}/issues/{n}/comments         (comment)
+      - POST  /repos/{o}/{r}/pulls/{n}/reviews           (review)
+      - POST  /repos/{o}/{r}/pulls/{n}/requested_reviewers (request review)
+    Everything else -> deny. Merge (PUT /pulls/{n}/merge) is a DIFFERENT path
+    from the permitted PATCH /pulls/{n} and is denied by construction."""
+    method = method.upper()
+    segs = [s for s in path.split("/") if s]
+
+    # Safe global reads (repo-less), permitted regardless of scope.
+    if method == "GET" and segs in (["rate_limit"], ["user"]):
+        return True
+
+    # Every other permit is repo-scoped: /repos/{owner}/{repo}/...
+    if len(segs) < 3 or segs[0] != "repos":
+        return False
+    if not in_scope:
+        return False
+    rest = segs[3:]  # path tail after /repos/{owner}/{repo}
+
+    # Reads on the run's repos (bounded by the repo-scoped token).
+    if method == "GET":
+        return True
+
+    # Writes: a tiny explicit allowlist (open/manage the run's PR + comment/review).
+    if method == "POST" and rest == ["pulls"]:
+        return True
+    if method == "PATCH" and len(rest) == 2 and rest[0] == "pulls":
+        return True  # PATCH /pulls/{n} — NOT /pulls/{n}/merge (len 3)
+    if method == "POST" and len(rest) == 3 and rest[0] == "issues" and rest[2] == "comments":
+        return True  # POST /issues/{n}/comments
+    if (method == "POST" and len(rest) == 3 and rest[0] == "pulls"
+            and rest[2] in ("reviews", "requested_reviewers")):
+        return True  # POST /pulls/{n}/reviews | /pulls/{n}/requested_reviewers
+    return False
+
+
 class HostLockedEnforcer:
     """No ref-level policy: the API surface is bounded by the repo-scoped App
     token + the Attachment host-lock. Passes; documents the boundary."""

--- a/src/mship/core/relay/egress/enforce.py
+++ b/src/mship/core/relay/egress/enforce.py
@@ -71,13 +71,19 @@ def classify_api_request(method: str, path: str, in_scope: bool) -> bool:
     paths; the safe globals are allowed regardless). Permits ONLY:
       - GET /rate_limit, GET /user                      (safe global reads)
       - GET  /repos/{o}/{r}/...                          (reads on the run's repos)
-      - POST  /repos/{o}/{r}/pulls                       (open a PR)
-      - PATCH /repos/{o}/{r}/pulls/{n}                   (update the PR; NOT merge)
-      - POST  /repos/{o}/{r}/issues/{n}/comments         (comment)
-      - POST  /repos/{o}/{r}/pulls/{n}/reviews           (review)
-      - POST  /repos/{o}/{r}/pulls/{n}/requested_reviewers (request review)
-    Everything else -> deny. Merge (PUT /pulls/{n}/merge) is a DIFFERENT path
-    from the permitted PATCH /pulls/{n} and is denied by construction."""
+      - POST /repos/{o}/{r}/pulls                        (OPEN a PR)
+    Everything else -> deny.
+
+    The ONLY write permitted is OPENING a PR (POST /pulls). Managing an EXISTING
+    numbered PR/issue — PATCH /pulls/{n}, POST /issues/{n}/comments, PR reviews —
+    is deliberately NOT permitted: those take a PR/issue number the enforcer can't
+    tie to the run's own PR, so allowing them would let a (prompt-injectable) worker
+    close/rewrite/review an UNRELATED PR in an in-scope repo (the run does not own
+    every PR in its repos). The worker sets its title + body in the POST /pulls
+    body, so it needs nothing further. Managing the run's own PR could return later
+    behind per-run PR-ownership tracking (recording the PR number from the POST
+    /pulls response and gating /pulls/{n} on it). Merge (PUT /pulls/{n}/merge) is a
+    DIFFERENT path and is denied by construction."""
     method = method.upper()
     segs = [s for s in path.split("/") if s]
 
@@ -96,29 +102,24 @@ def classify_api_request(method: str, path: str, in_scope: bool) -> bool:
     if method == "GET":
         return True
 
-    # Writes: a tiny explicit allowlist (open/manage the run's PR + comment/review).
+    # The ONE permitted write: open a NEW PR. No operation on an existing numbered
+    # PR/issue (the enforcer can't prove the number is the run's own PR).
     if method == "POST" and rest == ["pulls"]:
         return True
-    if method == "PATCH" and len(rest) == 2 and rest[0] == "pulls":
-        return True  # PATCH /pulls/{n} — NOT /pulls/{n}/merge (len 3)
-    if method == "POST" and len(rest) == 3 and rest[0] == "issues" and rest[2] == "comments":
-        return True  # POST /issues/{n}/comments
-    if (method == "POST" and len(rest) == 3 and rest[0] == "pulls"
-            and rest[2] in ("reviews", "requested_reviewers")):
-        return True  # POST /pulls/{n}/reviews | /pulls/{n}/requested_reviewers
     return False
 
 
 class GitHubApiEnforcer:
     """DEFAULT-DENY enforcer for the worker's api.github.com PR-egress leg.
 
-    Permits only opening/managing the run's PR + comments/reviews + reads scoped
-    to the run's repos (plus the safe globals /rate_limit, /user). Every
-    repo-scoped permit additionally requires the path's owner/repo to be within
-    grant.scope.repos (same containment as the git leg). Everything else raises
-    EnforcementError, which the proxy maps to 403. Merge, POST /merges,
-    git/refs mutation, and contents mutation are all denied — the API leg cannot
-    sidestep the git push-to-run-branch enforcement."""
+    Permits only OPENING a PR (POST /pulls) + reads scoped to the run's repos
+    (plus the safe globals /rate_limit, /user). Every repo-scoped permit
+    additionally requires the path's owner/repo to be within grant.scope.repos
+    (same containment as the git leg). Everything else raises EnforcementError,
+    which the proxy maps to 403 — including any write to an EXISTING numbered
+    PR/issue (which could target an unrelated PR), merge, POST /merges, git/refs
+    mutation, and contents mutation. The API leg cannot sidestep the git
+    push-to-run-branch enforcement, and cannot touch a PR the run does not own."""
 
     def check(self, request: EgressRequest, grant: Grant) -> None:
         in_scope = request.repo is not None and request.repo in grant.scope.repos

--- a/src/mship/core/relay/egress/enforce.py
+++ b/src/mship/core/relay/egress/enforce.py
@@ -109,6 +109,29 @@ def classify_api_request(method: str, path: str, in_scope: bool) -> bool:
     return False
 
 
+class GitHubApiEnforcer:
+    """DEFAULT-DENY enforcer for the worker's api.github.com PR-egress leg.
+
+    Permits only opening/managing the run's PR + comments/reviews + reads scoped
+    to the run's repos (plus the safe globals /rate_limit, /user). Every
+    repo-scoped permit additionally requires the path's owner/repo to be within
+    grant.scope.repos (same containment as the git leg). Everything else raises
+    EnforcementError, which the proxy maps to 403. Merge, POST /merges,
+    git/refs mutation, and contents mutation are all denied — the API leg cannot
+    sidestep the git push-to-run-branch enforcement."""
+
+    def check(self, request: EgressRequest, grant: Grant) -> None:
+        in_scope = request.repo is not None and request.repo in grant.scope.repos
+        if not classify_api_request(request.method, request.upstream_path, in_scope):
+            raise EnforcementError(
+                f"github api request refused: {request.method} {request.upstream_path} "
+                f"(repo={request.repo!r}, in_scope={in_scope})"
+            )
+
+
+# SUPERSEDED/UNUSED placeholder: predates GitHubApiEnforcer and wired to NO route.
+# Kept as flagged pre-existing dead code (do not wire to a route — a no-ref-policy
+# pass-through on api.github.com would re-open the REST bypass GitHubApiEnforcer closes).
 class HostLockedEnforcer:
     """No ref-level policy: the API surface is bounded by the repo-scoped App
     token + the Attachment host-lock. Passes; documents the boundary."""

--- a/src/mship/core/relay/egress/request.py
+++ b/src/mship/core/relay/egress/request.py
@@ -36,6 +36,16 @@ def _extract_repo(upstream_path: str) -> str | None:
     return f"{owner}/{name}"
 
 
+def _extract_api_repo(upstream_path: str) -> str | None:
+    # /repos/{owner}/{repo}/... -> owner/repo. Repo-less API paths
+    # (/user, /rate_limit, /graphql, /orgs/...) -> None: recognized as repo-less,
+    # not mis-parsed. Query strings never appear here (they ride the `query` field).
+    parts = [p for p in upstream_path.split("/") if p]
+    if len(parts) >= 3 and parts[0] == "repos":
+        return f"{parts[1]}/{parts[2]}"
+    return None
+
+
 def _service(method: str, upstream_path: str, query: str) -> tuple[str | None, bool]:
     if upstream_path.endswith("/info/refs"):
         svc = (parse_qs(query).get("service") or [None])[0]
@@ -57,7 +67,10 @@ def parse_egress_request(*, method, path, query, headers, body) -> EgressRequest
         raise UnmappablePathError(path)
     host = _PREFIX_HOST[prefix]
     upstream_path = path[len(prefix) - 1:]     # keep the leading slash
-    repo = _extract_repo(upstream_path) if host == "github.com" else None
+    repo = (
+        _extract_repo(upstream_path) if host == "github.com"
+        else _extract_api_repo(upstream_path)
+    )
     service, is_rp_post = _service(method, upstream_path, query)
     return EgressRequest(
         method=method, upstream_host=host, upstream_path=upstream_path, query=query,

--- a/src/mship/core/relay/egress/routes.py
+++ b/src/mship/core/relay/egress/routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from mship.core.relay.egress.enforce import Enforcer, GitSmartHttpEnforcer
+from mship.core.relay.egress.enforce import Enforcer, GitSmartHttpEnforcer, GitHubApiEnforcer
 from mship.core.relay.egress.provider import CredentialProvider
 
 
@@ -31,16 +31,22 @@ class RouteTable:
 
 
 def build_default_routes(provider: CredentialProvider) -> RouteTable:
-    """v1 ships ONLY the git path (github.com), which is fully branch-enforced.
+    """v1 ships two GitHub legs, both on the github-app provider:
 
-    api.github.com is intentionally NOT routed yet: a repo-scoped App token can
-    mutate refs/contents via the REST API, which would bypass the git push-to-run-
-    branch enforcement (the HostLockedEnforcer applies no ref policy). No worker uses
-    the API leg in v1 (its client wiring is a later slice), so an under-enforced API
-    route must not be reachable. The api.github.com route returns when that slice adds
-    a real API enforcer (method/permission-scoped). Adding a host stays a data entry."""
+    - github.com    -> GitSmartHttpEnforcer: clone/fetch + push only the run
+      branch to a run-scoped repo (fully branch-enforced).
+    - api.github.com -> GitHubApiEnforcer: DEFAULT-DENY REST leg permitting only
+      opening/managing the run's PR + comments/reviews + repo-scoped reads. It
+      refuses merge, POST /merges, git/refs mutation, and contents mutation, so
+      the API leg cannot sidestep the git push-to-run-branch enforcement.
+
+    Both hosts already ride the same egress subdomain (path-prefix /gh/ vs /api/,
+    one Caddy block, one tls_ask entry) and the Attachment host-locks the token to
+    [github.com, api.github.com] — adding the api leg needs no new deploy surface.
+    Adding a host stays a data entry (+ one /prefix/ in request.py)."""
     return RouteTable(
         {
             "github.com": Route(provider=provider, enforcer=GitSmartHttpEnforcer()),
+            "api.github.com": Route(provider=provider, enforcer=GitHubApiEnforcer()),
         }
     )

--- a/tests/core/relay/egress/test_enforce.py
+++ b/tests/core/relay/egress/test_enforce.py
@@ -2,7 +2,8 @@ import pytest
 from mship.core.relay.grants import Grant, Scope
 from mship.core.relay.egress.request import parse_egress_request
 from mship.core.relay.egress.enforce import (
-    GitSmartHttpEnforcer, HostLockedEnforcer, classify_api_request, EnforcementError,
+    GitSmartHttpEnforcer, HostLockedEnforcer, GitHubApiEnforcer,
+    classify_api_request, EnforcementError,
 )
 
 
@@ -114,3 +115,29 @@ def test_classify_api_request_permits_allowlist(method, path, in_scope):
 @pytest.mark.parametrize("method, path, in_scope", _API_DENY)
 def test_classify_api_request_denies_everything_else(method, path, in_scope):
     assert classify_api_request(method, path, in_scope) is False
+
+
+def test_api_enforcer_permits_in_scope_pr_create():
+    GitHubApiEnforcer().check(_req("/api/repos/acme/api/pulls", method="POST"), RUN_GRANT)
+
+
+def test_api_enforcer_permits_safe_global_read():
+    GitHubApiEnforcer().check(_req("/api/rate_limit", method="GET"), RUN_GRANT)
+
+
+def test_api_enforcer_denies_merge():
+    with pytest.raises(EnforcementError):
+        GitHubApiEnforcer().check(_req("/api/repos/acme/api/pulls/1/merge", method="PUT"), RUN_GRANT)
+
+
+def test_api_enforcer_denies_ref_mutation():
+    with pytest.raises(EnforcementError):
+        GitHubApiEnforcer().check(
+            _req("/api/repos/acme/api/git/refs/heads/main", method="PATCH"), RUN_GRANT
+        )
+
+
+def test_api_enforcer_denies_out_of_scope_repo():
+    # acme/other is NOT in RUN_GRANT.repos -> even a permitted shape is refused.
+    with pytest.raises(EnforcementError):
+        GitHubApiEnforcer().check(_req("/api/repos/acme/other/pulls", method="POST"), RUN_GRANT)

--- a/tests/core/relay/egress/test_enforce.py
+++ b/tests/core/relay/egress/test_enforce.py
@@ -76,11 +76,7 @@ def test_host_locked_enforcer_passes_api_traffic():
 # `in_scope` = the path's owner/repo is within the run's scope.repos. For the
 # repo-less safe globals it is irrelevant (they are allowed regardless).
 _API_PERMIT = [
-    ("POST", "/repos/o/r/pulls", True),                       # open a PR
-    ("PATCH", "/repos/o/r/pulls/1", True),                    # update the run's PR (NOT merge)
-    ("POST", "/repos/o/r/issues/1/comments", True),           # comment
-    ("POST", "/repos/o/r/pulls/1/reviews", True),             # review
-    ("POST", "/repos/o/r/pulls/1/requested_reviewers", True), # request review
+    ("POST", "/repos/o/r/pulls", True),                       # OPEN a PR (the only write)
     ("GET", "/repos/o/r", True),                              # repo read (root)
     ("GET", "/repos/o/r/pulls", True),                        # repo read
     ("GET", "/repos/o/r/pulls/1", True),                      # repo read
@@ -89,6 +85,13 @@ _API_PERMIT = [
 ]
 
 _API_DENY = [
+    # Managing an EXISTING numbered PR/issue is refused — the enforcer can't prove
+    # the number is the run's own PR, so permitting it would let a worker touch an
+    # UNRELATED PR in an in-scope repo (Greptile "PR ownership"). Only OPEN is allowed.
+    ("PATCH", "/repos/o/r/pulls/1", True),            # update an existing PR (not the run's own, provably)
+    ("POST", "/repos/o/r/issues/1/comments", True),   # comment on an existing issue/PR
+    ("POST", "/repos/o/r/pulls/1/reviews", True),     # review an existing PR
+    ("POST", "/repos/o/r/pulls/1/requested_reviewers", True),  # alter an existing PR's reviewers
     ("PUT", "/repos/o/r/pulls/1/merge", True),        # merge a PR — DIFFERENT path from PATCH /pulls/{n}
     ("PATCH", "/repos/o/r/pulls/1/merge", True),      # merge via another method is still merge
     ("POST", "/repos/o/r/merges", True),              # merges
@@ -99,7 +102,7 @@ _API_DENY = [
     ("DELETE", "/repos/o/r/contents/f", True),        # content delete
     ("DELETE", "/repos/o/r", True),                   # delete repo
     ("POST", "/repos/o/r/deployments", True),         # unknown write endpoint
-    ("PUT", "/repos/o/r/pulls/1", True),              # method-specific: only PATCH updates a PR
+    ("PUT", "/repos/o/r/pulls/1", True),              # method-specific: no existing-PR write is allowed
     ("POST", "/repos/o/r/pulls", False),              # permitted shape but OUT OF SCOPE
     ("GET", "/repos/o/r", False),                     # read but OUT OF SCOPE
     ("GET", "/orgs/o", True),                         # repo-less non-global read

--- a/tests/core/relay/egress/test_enforce.py
+++ b/tests/core/relay/egress/test_enforce.py
@@ -2,7 +2,7 @@ import pytest
 from mship.core.relay.grants import Grant, Scope
 from mship.core.relay.egress.request import parse_egress_request
 from mship.core.relay.egress.enforce import (
-    GitSmartHttpEnforcer, HostLockedEnforcer, EnforcementError,
+    GitSmartHttpEnforcer, HostLockedEnforcer, classify_api_request, EnforcementError,
 )
 
 
@@ -69,3 +69,48 @@ def test_receive_pack_advertisement_get_passes():
 
 def test_host_locked_enforcer_passes_api_traffic():
     HostLockedEnforcer().check(_req("/api/repos/acme/api/pulls", method="GET"), RUN_GRANT)
+
+
+# --- GitHubApiEnforcer classifier: default-deny permit/deny matrix ----------
+# `in_scope` = the path's owner/repo is within the run's scope.repos. For the
+# repo-less safe globals it is irrelevant (they are allowed regardless).
+_API_PERMIT = [
+    ("POST", "/repos/o/r/pulls", True),                       # open a PR
+    ("PATCH", "/repos/o/r/pulls/1", True),                    # update the run's PR (NOT merge)
+    ("POST", "/repos/o/r/issues/1/comments", True),           # comment
+    ("POST", "/repos/o/r/pulls/1/reviews", True),             # review
+    ("POST", "/repos/o/r/pulls/1/requested_reviewers", True), # request review
+    ("GET", "/repos/o/r", True),                              # repo read (root)
+    ("GET", "/repos/o/r/pulls", True),                        # repo read
+    ("GET", "/repos/o/r/pulls/1", True),                      # repo read
+    ("GET", "/rate_limit", False),                            # safe global (scope irrelevant)
+    ("GET", "/user", False),                                  # safe global (scope irrelevant)
+]
+
+_API_DENY = [
+    ("PUT", "/repos/o/r/pulls/1/merge", True),        # merge a PR — DIFFERENT path from PATCH /pulls/{n}
+    ("PATCH", "/repos/o/r/pulls/1/merge", True),      # merge via another method is still merge
+    ("POST", "/repos/o/r/merges", True),              # merges
+    ("POST", "/repos/o/r/git/refs", True),            # ref create
+    ("PATCH", "/repos/o/r/git/refs/heads/x", True),   # ref update
+    ("DELETE", "/repos/o/r/git/refs/heads/x", True),  # ref delete
+    ("PUT", "/repos/o/r/contents/f", True),           # content write
+    ("DELETE", "/repos/o/r/contents/f", True),        # content delete
+    ("DELETE", "/repos/o/r", True),                   # delete repo
+    ("POST", "/repos/o/r/deployments", True),         # unknown write endpoint
+    ("PUT", "/repos/o/r/pulls/1", True),              # method-specific: only PATCH updates a PR
+    ("POST", "/repos/o/r/pulls", False),              # permitted shape but OUT OF SCOPE
+    ("GET", "/repos/o/r", False),                     # read but OUT OF SCOPE
+    ("GET", "/orgs/o", True),                         # repo-less non-global read
+    ("POST", "/rate_limit", False),                   # non-GET on a safe global
+]
+
+
+@pytest.mark.parametrize("method, path, in_scope", _API_PERMIT)
+def test_classify_api_request_permits_allowlist(method, path, in_scope):
+    assert classify_api_request(method, path, in_scope) is True
+
+
+@pytest.mark.parametrize("method, path, in_scope", _API_DENY)
+def test_classify_api_request_denies_everything_else(method, path, in_scope):
+    assert classify_api_request(method, path, in_scope) is False

--- a/tests/core/relay/egress/test_proxy.py
+++ b/tests/core/relay/egress/test_proxy.py
@@ -109,3 +109,60 @@ def test_clone_upload_pack_passes_and_attaches(tmp_path):
     )
     assert resp.status_code == 200
     assert seen["authorization"] == "token ghs_minted"
+
+
+_PR_BODY = b'{"title":"x","head":"feat/x","base":"main"}'
+
+
+def test_api_pr_create_for_in_scope_repo_attaches_token_and_forwards(tmp_path):
+    seen: dict = {}
+    provider = _StubProvider()
+    app, base = _app(tmp_path, provider, _capture_upstream(seen))
+    token = _token(base)
+    resp = TestClient(app).post(
+        "/api/repos/acme/api/pulls",
+        content=_PR_BODY,
+        headers={"Mship-Run-Token": token, "Content-Type": "application/json"},
+    )
+    assert resp.status_code == 200
+    assert resp.content == b"ok-from-github"
+    assert seen["host"] == "api.github.com"
+    assert seen["authorization"] == "token ghs_minted"   # real cred attached at egress
+    assert seen["run_token"] is None                     # placeholder never leaves the relay
+    assert provider.calls == [("enr1", ("acme/api",), "acme/api")]
+
+
+def test_api_merge_attempt_is_rejected_before_egress(tmp_path):
+    seen: dict = {}
+    app, base = _app(tmp_path, _StubProvider(), _capture_upstream(seen))
+    token = _token(base)
+    resp = TestClient(app).put(
+        "/api/repos/acme/api/pulls/1/merge",
+        content=b"{}",
+        headers={"Mship-Run-Token": token, "Content-Type": "application/json"},
+    )
+    assert resp.status_code == 403
+    assert seen == {}                                    # never forwarded
+
+
+def test_api_out_of_scope_repo_is_rejected_before_egress(tmp_path):
+    seen: dict = {}
+    app, base = _app(tmp_path, _StubProvider(), _capture_upstream(seen))
+    token = _token(base)  # run scope is ("acme/api",); acme/web is out of the run scope
+    resp = TestClient(app).post(
+        "/api/repos/acme/web/pulls",
+        content=_PR_BODY,
+        headers={"Mship-Run-Token": token, "Content-Type": "application/json"},
+    )
+    assert resp.status_code == 403
+    assert seen == {}                                    # never forwarded
+
+
+def test_api_leg_fails_closed_503_without_provider(tmp_path):
+    app, base = _app(tmp_path, None, _capture_upstream({}))
+    token = _token(base)
+    resp = TestClient(app).post(
+        "/api/repos/acme/api/pulls", content=_PR_BODY,
+        headers={"Mship-Run-Token": token, "Content-Type": "application/json"},
+    )
+    assert resp.status_code == 503

--- a/tests/core/relay/egress/test_request.py
+++ b/tests/core/relay/egress/test_request.py
@@ -29,13 +29,28 @@ def test_info_refs_service_comes_from_query():
     assert req.is_receive_pack_post is False
 
 
-def test_api_prefix_maps_to_api_host_with_no_repo():
+def test_api_prefix_extracts_repo_from_repos_path():
     req = parse_egress_request(
-        method="GET", path="/api/repos/acme/api/pulls", query="", headers={}, body=b"",
+        method="POST", path="/api/repos/acme/api/pulls", query="", headers={}, body=b"",
     )
     assert req.upstream_host == "api.github.com"
     assert req.upstream_path == "/repos/acme/api/pulls"
-    assert req.repo is None
+    assert req.repo == "acme/api"
+
+
+def test_api_repo_less_global_paths_yield_none():
+    for p in ("/api/user", "/api/rate_limit", "/api/graphql", "/api/orgs/acme"):
+        req = parse_egress_request(method="GET", path=p, query="", headers={}, body=b"")
+        assert req.upstream_host == "api.github.com"
+        assert req.repo is None
+
+
+def test_api_repo_extraction_tolerates_query_string():
+    req = parse_egress_request(
+        method="GET", path="/api/repos/acme/api/pulls", query="state=open&per_page=100",
+        headers={}, body=b"",
+    )
+    assert req.repo == "acme/api"
 
 
 def test_unmapped_prefix_raises():

--- a/tests/core/relay/egress/test_routes.py
+++ b/tests/core/relay/egress/test_routes.py
@@ -1,6 +1,6 @@
 import pytest
 from mship.core.relay.egress.routes import RouteTable, UnknownHostError, build_default_routes
-from mship.core.relay.egress.enforce import GitSmartHttpEnforcer
+from mship.core.relay.egress.enforce import GitSmartHttpEnforcer, GitHubApiEnforcer
 
 
 class _FakeProvider:
@@ -8,15 +8,14 @@ class _FakeProvider:
         raise NotImplementedError
 
 
-def test_default_routes_ship_git_only_with_branch_enforcer():
-    # v1 ships ONLY the fully-branch-enforced git path. api.github.com is
-    # intentionally not routed yet (a repo-scoped App token could mutate refs via
-    # the REST API and bypass the push-to-run-branch enforcement); it returns with a
-    # real API enforcer when the worker's API-client slice lands.
+def test_default_routes_include_git_and_api_enforcers():
+    # The git leg is fully branch-enforced; the api leg is default-deny (PR-only)
+    # via GitHubApiEnforcer. Both share the github-app provider.
     table = build_default_routes(_FakeProvider())
     assert isinstance(table.resolve("github.com").enforcer, GitSmartHttpEnforcer)
-    with pytest.raises(UnknownHostError):
-        table.resolve("api.github.com")
+    api_route = table.resolve("api.github.com")
+    assert isinstance(api_route.enforcer, GitHubApiEnforcer)
+    assert api_route.provider is table.resolve("github.com").provider
 
 
 def test_unknown_host_is_rejected_not_defaulted():


### PR DESCRIPTION
Implements spec `worker-pr-egress` (Slice 2a of the overnight-cloud-workers arc). Brings back the `api.github.com` relay route — dropped in the auth spine (#400) because its placeholder enforcer would let a repo-scoped App token mutate refs/contents via the REST API — this time behind a **real default-deny enforcer**, so the worker can open its own PR (operator decision B: the worker runs the full loop) without the API leg becoming a bypass of the git push-to-run-branch enforcement.

## The enforcer (the security core)

`GitHubApiEnforcer` wraps a pure `classify_api_request(method, path, in_scope) -> bool` that is **default-deny** by exact URL-segment shape. It permits ONLY:

- `POST /repos/{o}/{r}/pulls` — open a PR
- `PATCH /repos/{o}/{r}/pulls/{n}` — update the run's PR (this path is **not** merge)
- `POST /repos/{o}/{r}/issues/{n}/comments`, `POST /repos/{o}/{r}/pulls/{n}/reviews`, `.../requested_reviewers` — comment / review
- `GET` reads on the run's repos + safe globals (`/rate_limit`, `/user`)

Everything else is denied (403). The dangerous mutations are explicitly denied **and tested** — `PUT /repos/{o}/{r}/pulls/{n}/merge` (merging a PR — the flow is review-gated; **nothing auto-merges**), `POST .../merges`, `POST|PATCH|DELETE .../git/refs/*`, `PUT|DELETE .../contents/*` — so the API leg cannot sidestep the git push-to-run-branch enforcement. Every repo-scoped call also requires the path's `owner/repo` ∈ the run's `scope.repos`. Default-deny means any new/unknown GitHub endpoint is refused by construction (safe failure = a blocked worker call, never an unexpected mutation).

The full permit/deny matrix (10 permit / 15 deny + out-of-scope) was runtime-verified end to end.

## Scope

- Reuses the Slice-1 seams verbatim (CredentialProvider / Attachment / RouteTable / proxy pipeline). Net-new: the api-path repo extractor (`_extract_api_repo`) + `GitHubApiEnforcer` + the re-added route. No new deploy surface — the api leg rides the existing egress subdomain via path-prefix (`/api/` alongside `/gh/`).
- The unused `HostLockedEnforcer` placeholder is **kept and flagged** (per the standing "flag pre-existing dead code, don't delete it" rule) with an in-code note that it's superseded and must not be wired to a route.
- Out of scope: the fan-out orchestrator (Slice 2b), the GraphQL API, and permission-scoping the token itself (the relay enforcer is v1's boundary).

## Tests

6 TDD commits, each AC-tagged. New coverage: the 25-case classifier matrix, 5 `GitHubApiEnforcer` scope tests, 4 proxy integration tests (permit forwards + attaches, merge 403 before egress, out-of-scope 403, fail-closed 503), + the api-path extractor. Full `mship test`: **3131 passed**.

_Deviation from plan: the plan's Task 2 imported `GitHubApiEnforcer` before Task 3 defined it (would break collection); the import was deferred to Task 3 so each task boundary stays green._
