### PR TITLE
Spec storage & visibility policy: committed / local / encrypted specs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "segno>=1.6.6",
     "httpx>=0.27",
     "pyjwt[crypto]>=2.8",
+    "cryptography>=42",
 ]
 
 [project.scripts]

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -19,6 +19,16 @@ def register(parent: typer.Typer, get_container):
         no_args_is_help=True,
     )
 
+    def _spec_store():
+        """The workspace's spec store in its configured `spec_storage` mode
+        (spec-storage-visibility-policy). SpecStore resolves the mode from the
+        workspace config by default, so every verb reads + writes through the same
+        mode-aware SpecStorage — committed/local/encrypted alike."""
+        from pathlib import Path
+        from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+        container = get_container()
+        return SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
+
     @spec_app.command("new")
     def new(
         title: Optional[str] = typer.Option(None, "--title", help="Spec title (required unless --task is given)."),
@@ -28,14 +38,11 @@ def register(parent: typer.Typer, get_container):
     ):
         """Create a structured spec at `<workspace>/specs/YYYY-MM-DD-<id>.md`."""
         from datetime import datetime, timezone
-        from pathlib import Path
         from mship.core.spec_draft import new_spec
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
 
         container = get_container()
         output = Output()
-        workspace_root = Path(container.config_path()).parent
-        store = SpecStore(workspace_root / SPECS_DIRNAME)
+        store = _spec_store()
 
         affected_repos: list[str] = []
         task_slug: Optional[str] = None
@@ -93,7 +100,6 @@ def register(parent: typer.Typer, get_container):
         Supply one of those options to embed your intent directly in the prompt.
         """
         from pathlib import Path
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
         from mship.core.spec_draft import build_draft_prompt
 
         output = Output()
@@ -101,9 +107,7 @@ def register(parent: typer.Typer, get_container):
             output.error("Provide only one of --from-text or --from-file, not both.")
             raise typer.Exit(1)
 
-        container = get_container()
-        workspace_root = Path(container.config_path()).parent
-        store = SpecStore(workspace_root / SPECS_DIRNAME)
+        store = _spec_store()
         if store.find_by_id(spec_id) is None:
             output.error(f"No spec with id {spec_id!r}. Create it first with `mship spec new`.")
             raise typer.Exit(1)
@@ -146,7 +150,6 @@ def register(parent: typer.Typer, get_container):
         from pydantic import ValidationError
         from mship.core.spec import SpecDraft, InvalidTransition, validate_transition
         from mship.core.spec_draft import apply_draft, parse_spec_markdown
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
 
         output = Output()
 
@@ -182,8 +185,7 @@ def register(parent: typer.Typer, get_container):
             raise typer.Exit(1)
 
         container = get_container()
-        workspace_root = Path(container.config_path()).parent
-        store = SpecStore(workspace_root / SPECS_DIRNAME)
+        store = _spec_store()
         spec = store.find_by_id(spec_id)
         if spec is None:
             output.error(f"No spec with id {spec_id!r}.")
@@ -220,14 +222,10 @@ def register(parent: typer.Typer, get_container):
         spec_id: str = typer.Argument(..., help="Spec id to review."),
     ):
         """Emit a spec's review units (criteria + questions + read-only context)."""
-        from pathlib import Path
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
         from mship.core.spec_review import build_review
 
         output = Output()
-        container = get_container()
-        workspace_root = Path(container.config_path()).parent
-        store = SpecStore(workspace_root / SPECS_DIRNAME)
+        store = _spec_store()
         spec = store.find_by_id(spec_id)
         if spec is None:
             output.error(f"No spec with id {spec_id!r}.")
@@ -260,14 +258,10 @@ def register(parent: typer.Typer, get_container):
     ):
         """Record a verdict on one acceptance criterion (no status change)."""
         from datetime import datetime, timezone
-        from pathlib import Path
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
         from mship.core.spec_review import set_criterion_verdict
 
         output = Output()
-        container = get_container()
-        workspace_root = Path(container.config_path()).parent
-        store = SpecStore(workspace_root / SPECS_DIRNAME)
+        store = _spec_store()
         spec = store.find_by_id(spec_id)
         if spec is None:
             output.error(f"No spec with id {spec_id!r}.")
@@ -300,14 +294,10 @@ def register(parent: typer.Typer, get_container):
     ):
         """Attach an evidence entry to one acceptance criterion (no status change)."""
         from datetime import datetime, timezone
-        from pathlib import Path
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
         from mship.core.spec_review import infer_evidence_kind, set_criterion_evidence
 
         output = Output()
-        container = get_container()
-        workspace_root = Path(container.config_path()).parent
-        store = SpecStore(workspace_root / SPECS_DIRNAME)
+        store = _spec_store()
         spec = store.find_by_id(spec_id)
         if spec is None:
             output.error(f"No spec with id {spec_id!r}.")
@@ -333,27 +323,18 @@ def register(parent: typer.Typer, get_container):
     ):
         """Check a spec conforms: frontmatter validates + canonical body sections present."""
         from pathlib import Path
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME, SpecParseError, parse_spec
+        from mship.core.spec_store import SPECS_DIRNAME
         from mship.core.spec_body import validate_body_structure
 
         output = Output()
         container = get_container()
         workspace_root = Path(container.config_path()).parent
-        specs_dir = workspace_root / SPECS_DIRNAME
-
-        matches = sorted(specs_dir.glob(f"*-{spec_id}.md"))
-        if not matches:
-            output.error(f"No spec file for id {spec_id!r} in {specs_dir}.")
-            raise typer.Exit(1)
-
-        try:
-            spec = parse_spec(matches[0].read_text())
-        except SpecParseError as e:
-            output.error(f"{spec_id}: invalid frontmatter — {e}")
-            raise typer.Exit(1)
-
-        if spec.id != spec_id:
-            output.error(f"{spec_id}: file {matches[0].name} has mismatched id {spec.id!r}.")
+        # Route through the storage layer so an encrypted `.md.enc` spec is decoded
+        # and validated, not missed by a raw `*.md` glob (spec-storage-visibility-policy).
+        store = _spec_store()
+        spec = store.find_by_id(spec_id)
+        if spec is None:
+            output.error(f"No spec file for id {spec_id!r} in {workspace_root / SPECS_DIRNAME}.")
             raise typer.Exit(1)
 
         missing = validate_body_structure(spec.body)
@@ -369,11 +350,9 @@ def register(parent: typer.Typer, get_container):
     @spec_app.command("questions")
     def questions(spec_id: str = typer.Argument(..., help="Spec id.")):
         """List a spec's open questions."""
-        from pathlib import Path
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
         from mship.core.spec_questions import list_questions
-        output = Output(); container = get_container()
-        store = SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
+        output = Output()
+        store = _spec_store()
         spec = store.find_by_id(spec_id)
         if spec is None:
             output.error(f"No spec with id {spec_id!r}."); raise typer.Exit(1)
@@ -388,11 +367,9 @@ def register(parent: typer.Typer, get_container):
     def ask(spec_id: str = typer.Argument(...), text: str = typer.Argument(..., help="Question text.")):
         """Add an open question to a spec."""
         from datetime import datetime, timezone
-        from pathlib import Path
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
         from mship.core.spec_questions import add_question
-        output = Output(); container = get_container()
-        store = SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
+        output = Output()
+        store = _spec_store()
         spec = store.find_by_id(spec_id)
         if spec is None:
             output.error(f"No spec with id {spec_id!r}."); raise typer.Exit(1)
@@ -407,11 +384,9 @@ def register(parent: typer.Typer, get_container):
     def answer(spec_id: str = typer.Argument(...), q_id: str = typer.Argument(...), answer_text: str = typer.Argument(..., metavar="ANSWER")):
         """Answer an open question (does not change status)."""
         from datetime import datetime, timezone
-        from pathlib import Path
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
         from mship.core.spec_questions import answer_question
-        output = Output(); container = get_container()
-        store = SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
+        output = Output()
+        store = _spec_store()
         spec = store.find_by_id(spec_id)
         if spec is None:
             output.error(f"No spec with id {spec_id!r}."); raise typer.Exit(1)
@@ -431,13 +406,10 @@ def register(parent: typer.Typer, get_container):
         bypass_gate: bool = typer.Option(False, "--bypass-gate", help="Approve despite unmet review gate."),
     ):
         """Approve a spec (gate: all criteria approved + all questions answered)."""
-        from pathlib import Path
         from mship.core.spec import InvalidTransition
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
         from mship.core.spec_transition import ApprovalBlocked, approve_spec
         output = Output()
-        container = get_container()
-        store = SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
+        store = _spec_store()
         spec = store.find_by_id(spec_id)
         if spec is None:
             output.error(f"No spec with id {spec_id!r}.")
@@ -466,11 +438,9 @@ def register(parent: typer.Typer, get_container):
         from pathlib import Path
         from mship.core.message_store import MessageStore
         from mship.core.spec_draft import build_draft_prompt, new_spec
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
 
         container = get_container()
         output = Output()
-        workspace_root = Path(container.config_path()).parent
         messages = MessageStore(Path(container.state_dir()) / "messages")
         thread = messages.get(thread_id)
         if thread is None:
@@ -478,7 +448,7 @@ def register(parent: typer.Typer, get_container):
             raise typer.Exit(1)
 
         now = datetime.now(timezone.utc)
-        spec_store = SpecStore(workspace_root / SPECS_DIRNAME)
+        spec_store = _spec_store()
 
         # A thread spawns at most one spec. If from-thread runs again (agent
         # retry, accidental re-invocation), reuse the already-linked spec rather
@@ -518,14 +488,13 @@ def register(parent: typer.Typer, get_container):
         """
         from datetime import datetime, timezone
         from pathlib import Path
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
         from mship.core.spec_dispatch import DispatchError, dispatch_spec
         from mship.core.workitem_store import WorkItemStore
 
         output = Output()
         container = get_container()
         workspace_root = Path(container.config_path()).parent
-        store = SpecStore(workspace_root / SPECS_DIRNAME)
+        store = _spec_store()
         workitems = WorkItemStore(workspace_root / ".mothership" / "workitems")
         spec = store.find_by_id(spec_id)
         if spec is None:
@@ -574,13 +543,11 @@ def register(parent: typer.Typer, get_container):
         MOS-240: `needs_clarification` is gone; "needs clarification" is now the
         non-null `clarification_reason` carried by the editable `draft` status.
         """
-        from pathlib import Path
         from mship.core.spec import InvalidTransition
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
         from mship.core.spec_transition import request_changes_spec
         output = Output()
         container = get_container()
-        store = SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
+        store = _spec_store()
         spec = store.find_by_id(spec_id)
         if spec is None:
             output.error(f"No spec with id {spec_id!r}.")
@@ -604,13 +571,8 @@ def register(parent: typer.Typer, get_container):
     @spec_app.command("list")
     def list_specs():
         """List all specs (TTY: table; non-TTY: JSON envelope)."""
-        from pathlib import Path
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
-
         output = Output()
-        container = get_container()
-        workspace_root = Path(container.config_path()).parent
-        store = SpecStore(workspace_root / SPECS_DIRNAME)
+        store = _spec_store()
         specs = store.list()
         items = [
             {
@@ -645,13 +607,8 @@ def register(parent: typer.Typer, get_container):
         spec_id: str = typer.Argument(..., help="Spec id to show."),
     ):
         """Show structured detail for a spec (non-TTY: pure JSON)."""
-        from pathlib import Path
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
-
         output = Output()
-        container = get_container()
-        workspace_root = Path(container.config_path()).parent
-        store = SpecStore(workspace_root / SPECS_DIRNAME)
+        store = _spec_store()
         spec = store.find_by_id(spec_id)
         if spec is None:
             output.error(f"No spec with id {spec_id!r}.")
@@ -698,13 +655,10 @@ def register(parent: typer.Typer, get_container):
     def _simple_transition(target_status: str, spec_id: str) -> None:
         """Shared logic for implemented/archive: validate transition and save."""
         from datetime import datetime, timezone
-        from pathlib import Path
         from mship.core.spec import InvalidTransition, validate_transition
-        from mship.core.spec_store import SpecStore, SPECS_DIRNAME
 
         output = Output()
-        container = get_container()
-        store = SpecStore(Path(container.config_path()).parent / SPECS_DIRNAME)
+        store = _spec_store()
         spec = store.find_by_id(spec_id)
         if spec is None:
             output.error(f"No spec with id {spec_id!r}.")

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -334,6 +334,7 @@ def register(parent: typer.Typer, get_container):
         # Strict read: report a locked or malformed spec clearly instead of the
         # resilient list silently skipping it.
         from mship.core.spec_storage import SpecLocked
+        from mship.core.spec_store import SpecParseError
         store = _spec_store()
         try:
             spec = store.read_strict(spec_id)

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -690,4 +690,66 @@ def register(parent: typer.Typer, get_container):
         """Advance an implemented spec to archived."""
         _simple_transition("archived", spec_id)
 
+    @spec_app.command("migrate-storage")
+    def migrate_storage():
+        """Re-materialise every spec into the workspace's current `spec_storage`
+        mode, removing the old representation (git rm the plaintext when moving to
+        local/encrypted, git rm the ciphertext when moving back). Run after editing
+        `spec_storage` in mothership.yaml — it reads the target mode from config."""
+        from pathlib import Path
+        from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+        from mship.core.spec_storage import SpecStorage
+        from mship.util.git import GitRunner
+
+        output = Output()
+        container = get_container()
+        workspace_root = Path(container.config_path()).parent
+        specs_dir = workspace_root / SPECS_DIRNAME
+        target = container.config().spec_storage
+        git = GitRunner()
+
+        # Read every current file suffix-agnostically (needs the key for any .md.enc);
+        # write each into the target representation.
+        reader = SpecStorage(specs_dir, workspace_root=workspace_root)
+        target_storage = SpecStorage(specs_dir, mode=target, workspace_root=workspace_root)
+        target_store = SpecStore(specs_dir, storage=target_storage)
+
+        migrated = 0
+        for spec, locked_id, old_path in reader.read_all():
+            if spec is None:
+                output.error(
+                    f"Cannot migrate {locked_id!r}: it is encrypted and no key is present. "
+                    f"Restore `.mothership/spec-key` first."
+                )
+                raise typer.Exit(1)
+            new_path = target_store.save(spec)  # writes the target representation
+            if new_path.resolve() != old_path.resolve():
+                # Suffix changed (.md <-> .md.enc): drop the old file from disk + index
+                # so no spec is left readable in a mode that should hide it.
+                try:
+                    git.rm(workspace_root, old_path)
+                except Exception:
+                    old_path.unlink(missing_ok=True)
+            if target in ("committed", "encrypted"):
+                if target == "committed":
+                    # local/encrypted -> committed: specs are public again.
+                    git.remove_from_gitignore(workspace_root, f"{SPECS_DIRNAME}/*.md")
+                try:
+                    git.add(workspace_root, new_path)  # track the new representation
+                except Exception:
+                    pass
+            elif target == "local":
+                # committed -> local: same .md path, but stop tracking it (save()
+                # already gitignored specs/*.md).
+                try:
+                    git.rm(workspace_root, new_path, cached=True)
+                except Exception:
+                    pass
+            migrated += 1
+
+        if output.human_mode:
+            output.success(f"Migrated {migrated} spec(s) to spec_storage={target!r}.")
+        else:
+            output.json({"migrated": migrated, "spec_storage": target})
+
     parent.add_typer(spec_app, rich_help_panel="Work items & specs")

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -331,8 +331,19 @@ def register(parent: typer.Typer, get_container):
         workspace_root = Path(container.config_path()).parent
         # Route through the storage layer so an encrypted `.md.enc` spec is decoded
         # and validated, not missed by a raw `*.md` glob (spec-storage-visibility-policy).
+        # Strict read: report a locked or malformed spec clearly instead of the
+        # resilient list silently skipping it.
+        from mship.core.spec_storage import SpecLocked
         store = _spec_store()
-        spec = store.find_by_id(spec_id)
+        try:
+            spec = store.read_strict(spec_id)
+        except SpecLocked:
+            output.error(f"{spec_id}: encrypted and no key present — cannot validate. "
+                         f"Restore `.mothership/spec-key` first.")
+            raise typer.Exit(1)
+        except SpecParseError as e:
+            output.error(f"{spec_id}: invalid spec — {e}")
+            raise typer.Exit(1)
         if spec is None:
             output.error(f"No spec file for id {spec_id!r} in {workspace_root / SPECS_DIRNAME}.")
             raise typer.Exit(1)
@@ -723,28 +734,38 @@ def register(parent: typer.Typer, get_container):
                 )
                 raise typer.Exit(1)
             new_path = target_store.save(spec)  # writes the target representation
-            if new_path.resolve() != old_path.resolve():
-                # Suffix changed (.md <-> .md.enc): drop the old file from disk + index
-                # so no spec is left readable in a mode that should hide it.
-                try:
-                    git.rm(workspace_root, old_path)
-                except Exception:
-                    old_path.unlink(missing_ok=True)
-            if target in ("committed", "encrypted"):
+            # Every git step below FAILS LOUD: a swallowed failure could report a
+            # successful migration while leaving plaintext indexed/tracked (a leak) or
+            # the new representation untracked (a clean/clone loses the migrated spec).
+            # `is_tracked` guards keep it idempotent (re-migrating to the same mode is
+            # a no-op, not a spurious error).
+            try:
+                if new_path.resolve() != old_path.resolve():
+                    # Suffix changed (.md <-> .md.enc): the old file must leave BOTH the
+                    # working tree AND the index, or a mode meant to hide it keeps a
+                    # readable/restorable copy.
+                    if git.is_tracked(workspace_root, old_path):
+                        git.rm(workspace_root, old_path, force=True)   # index + working tree
+                    elif old_path.exists():
+                        old_path.unlink()                          # untracked: just the file
                 if target == "committed":
-                    # local/encrypted -> committed: specs are public again.
                     git.remove_from_gitignore(workspace_root, f"{SPECS_DIRNAME}/*.md")
-                try:
-                    git.add(workspace_root, new_path)  # track the new representation
-                except Exception:
-                    pass
-            elif target == "local":
-                # committed -> local: same .md path, but stop tracking it (save()
-                # already gitignored specs/*.md).
-                try:
-                    git.rm(workspace_root, new_path, cached=True)
-                except Exception:
-                    pass
+                    git.add(workspace_root, new_path)              # public + tracked again
+                elif target == "encrypted":
+                    git.add(workspace_root, new_path)              # track the ciphertext
+                elif target == "local":
+                    # committed -> local: same .md path; stop TRACKING it (save() already
+                    # gitignored specs/*.md). Untrack only if currently tracked.
+                    if git.is_tracked(workspace_root, new_path):
+                        git.rm(workspace_root, new_path, cached=True, force=True)
+            except Exception as e:
+                output.error(
+                    f"Migration of {spec.id!r} to {target!r} FAILED at a git step: {e}. "
+                    f"The store may be half-migrated — resolve the git state "
+                    f"(check `git status` for staged/uncommitted spec changes) and re-run. "
+                    f"No migration was reported as complete."
+                )
+                raise typer.Exit(1)
             migrated += 1
 
         if output.human_mode:

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -332,6 +332,14 @@ class WorkspaceConfig(BaseModel):
     # - "none": require explicit --repos; no-flag spawn errors with the repo list.
     # - list[str]: use those repos as the default. See #74.
     default_scope: str | list[str] = "all"
+    # Where this workspace's specs live on disk + who can read them
+    # (spec-storage-visibility-policy). `committed` (default) = today's behaviour:
+    # plaintext `specs/<date>-<id>.md`, committed + pushed. `local` = same plaintext
+    # file but git-ignored (kept on this machine, never pushed). `encrypted` =
+    # Fernet ciphertext `specs/<date>-<id>.md.enc`, committed to the repo but
+    # unreadable without `.mothership/spec-key`. Applied transparently by
+    # core/spec_storage.py; an invalid value fails loud at config load.
+    spec_storage: Literal["committed", "local", "encrypted"] = "committed"
     # If set and the effective spawn scope exceeds N repos AND no --repos was
     # passed, require confirmation (TTY) or --yes (non-TTY). See #74.
     spawn_confirm_threshold: int | None = None

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -285,10 +285,17 @@ def create_app(
     from fastapi import Depends, FastAPI, HTTPException
 
     from mship.core.spec_store import SpecStore
+    from mship.core.spec_storage import SpecStorage
     from mship.core.message_store import MessageStore
     from mship.core.workitem_store import WorkItemStore
 
-    store = SpecStore(specs_dir)
+    # Mode-aware spec store (spec-storage-visibility-policy): under encrypted mode
+    # `store` decrypts `.md.enc` with the local key for display; `_spec_storage`
+    # exposes read_all() so the list/detail endpoints can render a LOCKED marker
+    # (never ciphertext, never a 500) when the key is absent on this host.
+    _spec_mode = getattr(config, "spec_storage", "committed") if config is not None else "committed"
+    _spec_storage = SpecStorage(specs_dir, mode=_spec_mode, workspace_root=workspace_root)
+    store = SpecStore(specs_dir, storage=_spec_storage)
     pr_manager = PRManager(ShellRunner())
     # Separate ShellRunner instance for GET /gh-token (Broker A) rather than
     # reaching into pr_manager's private `_shell` — same class, own lifetime,
@@ -358,17 +365,42 @@ def create_app(
 
     @app.get("/specs")
     def list_specs():
-        return [
-            {"id": s.id, "title": s.title, "status": s.status, "task_slug": s.task_slug, "affected_repos": s.affected_repos}
-            for s in store.list()
-        ]
+        out = []
+        for spec, locked_id, _path in _spec_storage.read_all():
+            if spec is None:
+                # Encrypted spec, no key on this host: surface a LOCKED marker so
+                # Ground Control can show it without ever leaking ciphertext.
+                out.append({
+                    "id": locked_id, "locked": True, "status": "locked",
+                    "title": None, "task_slug": None, "affected_repos": [],
+                })
+            else:
+                out.append({
+                    "id": spec.id, "title": spec.title, "status": spec.status,
+                    "task_slug": spec.task_slug, "affected_repos": spec.affected_repos,
+                    "locked": False,
+                })
+        return out
 
     @app.get("/specs/{spec_id}")
     def get_spec(spec_id: str):
-        spec = store.find_by_id(spec_id)
+        # Resolve via the LOCKED-aware seam (not store.find_by_id, which loads
+        # EVERY file and would raise on a sibling locked spec — making a coexisting
+        # plaintext spec unreachable). A locked match returns a marker (200), not
+        # ciphertext and not a 500.
+        spec = None
+        for candidate, locked_id, _path in _spec_storage.read_all():
+            if candidate is None:
+                if locked_id == spec_id:
+                    return {"id": spec_id, "locked": True, "status": "locked"}
+                continue
+            if candidate.id == spec_id:
+                spec = candidate
+                break
         if spec is None:
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
         data = spec.model_dump(mode="json")
+        data["locked"] = False
         # Resolve the linked WorkItem's kind (feature/bug/chore) so the Queue review cards can show
         # it alongside the spec title + affected_repos. Best-effort: the kind is decorative, so a
         # missing OR corrupt/unreadable WorkItem must never 500 the spec detail — any lookup failure

--- a/src/mship/core/spec_key.py
+++ b/src/mship/core/spec_key.py
@@ -7,7 +7,9 @@ the run token is injected. Losing it loses every encrypted spec — there is no 
 """
 from __future__ import annotations
 
+import os
 import sys
+import tempfile
 from pathlib import Path
 
 from cryptography.fernet import Fernet
@@ -63,9 +65,25 @@ def load_or_generate_key(workspace_root: Path, *, git: GitRunner | None = None) 
     path = keyfile_path(workspace_root)
     path.parent.mkdir(parents=True, exist_ok=True)
     key = Fernet.generate_key()
-    # Write then tighten perms so the key is never briefly world-readable.
-    path.write_bytes(key)
-    path.chmod(0o600)
+    # Generate atomically + race-safe: write to a 0600 temp (mkstemp is 0600), then
+    # os.link it into place. link is atomic and REFUSES to clobber (FileExistsError),
+    # so under concurrent first-writes exactly one key wins and every other writer
+    # reuses the winner's key — never two split keys, and the destination only ever
+    # appears fully-written + 0600 (no world-readable window, no partial read).
+    fd, tmp = tempfile.mkstemp(dir=path.parent)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(key)
+        try:
+            os.link(tmp, path)
+        except FileExistsError:
+            # Lost the race (or it appeared meanwhile): use the persisted winner's key.
+            won = load_key(workspace_root)
+            if won is not None:
+                return won
+            raise  # keyfile vanished between link and read — surface, never plaintext
+    finally:
+        Path(tmp).unlink(missing_ok=True)
 
     _ensure_gitignored(Path(workspace_root), git or GitRunner())
     print(_GENERATED_NOTICE.format(path=path), file=sys.stderr)

--- a/src/mship/core/spec_key.py
+++ b/src/mship/core/spec_key.py
@@ -1,0 +1,88 @@
+"""Per-workspace Fernet key for encrypted-mode specs (spec-storage-visibility-policy).
+
+The key lives at `<workspace_root>/.mothership/spec-key` (git-ignored — `.mothership/`
+is already ignored in an mship workspace; we ensure it defensively). It is a single
+symmetric key: the operator holds it and injects it into agents/workers the same way
+the run token is injected. Losing it loses every encrypted spec — there is no escrow.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+
+from mship.util.git import GitRunner
+
+KEYFILE_RELPATH = Path(".mothership") / "spec-key"
+
+_GENERATED_NOTICE = (
+    "\n"
+    "  mship generated a new spec encryption key at:\n"
+    "    {path}\n"
+    "  BACK THIS FILE UP. It is the ONLY key to your encrypted specs.\n"
+    "  Losing it makes every encrypted spec permanently unrecoverable — there is\n"
+    "  no escrow or recovery. It is git-ignored and never committed or pushed.\n"
+)
+
+
+class SpecKeyMissing(Exception):
+    """Encrypted-mode operation needs the key but `.mothership/spec-key` is absent."""
+
+
+def keyfile_path(workspace_root: Path) -> Path:
+    return Path(workspace_root) / KEYFILE_RELPATH
+
+
+def load_key(workspace_root: Path) -> bytes | None:
+    """The raw Fernet key bytes, or None when no keyfile exists (no generation)."""
+    path = keyfile_path(workspace_root)
+    if not path.is_file():
+        return None
+    return path.read_bytes()
+
+
+def require_key(workspace_root: Path) -> bytes:
+    """The key, or raise SpecKeyMissing (fail loud — never fall back to plaintext)."""
+    key = load_key(workspace_root)
+    if key is None:
+        raise SpecKeyMissing(
+            f"encrypted spec_storage requires a key at {keyfile_path(workspace_root)}, "
+            f"but none was found. Generate one with an encrypted write, or restore your backup."
+        )
+    return key
+
+
+def load_or_generate_key(workspace_root: Path, *, git: GitRunner | None = None) -> bytes:
+    """Return the existing key, else generate + persist one (0600), ensure it is
+    git-ignored, and print a loud one-time backup notice to stderr."""
+    existing = load_key(workspace_root)
+    if existing is not None:
+        return existing
+
+    path = keyfile_path(workspace_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    key = Fernet.generate_key()
+    # Write then tighten perms so the key is never briefly world-readable.
+    path.write_bytes(key)
+    path.chmod(0o600)
+
+    _ensure_gitignored(Path(workspace_root), git or GitRunner())
+    print(_GENERATED_NOTICE.format(path=path), file=sys.stderr)
+    return key
+
+
+def _ensure_gitignored(workspace_root: Path, git: GitRunner) -> None:
+    pattern = str(KEYFILE_RELPATH)
+    # `.mothership/` is already ignored in a real workspace, so is_ignored is True
+    # and we skip. In a bare tmp dir (tests, fresh repo) it is not — append it.
+    if not git.is_ignored(workspace_root, pattern):
+        git.add_to_gitignore(workspace_root, pattern)
+
+
+def encrypt(key: bytes, text: str) -> bytes:
+    return Fernet(key).encrypt(text.encode("utf-8"))
+
+
+def decrypt(key: bytes, blob: bytes) -> str:
+    return Fernet(key).decrypt(blob).decode("utf-8")

--- a/src/mship/core/spec_storage.py
+++ b/src/mship/core/spec_storage.py
@@ -113,8 +113,10 @@ class SpecStorage:
 
     def read_all(self) -> Iterator[tuple[object | None, str | None, Path]]:
         """Yield (spec_or_None, locked_id_or_None, path) for every spec file.
-        Locked (undecryptable) files yield (None, <id>, path); unparseable files
-        are skipped. Used by LOCKED-aware readers (serve)."""
+        Locked (undecryptable — no key) files yield (None, <id>, path); files that
+        are unreadable (OSError), invalid UTF-8 (UnicodeError), or unparseable
+        (SpecParseError) are skipped so one bad file never aborts a scan. Used by
+        the LOCKED-aware serve reader and the resilient view readers."""
         from mship.core.spec_store import SpecParseError, parse_spec
 
         for path in self.iter_physical():
@@ -122,6 +124,8 @@ class SpecStorage:
                 text = self.decode_file(path)
             except SpecLocked as locked:
                 yield (None, locked.spec_id, path)
+                continue
+            except (OSError, UnicodeError):
                 continue
             try:
                 yield (parse_spec(text), None, path)
@@ -162,21 +166,10 @@ def resolve_mode(workspace_root: Path) -> SpecMode:
 def storage_from_workspace(specs_dir: Path, *, git: GitRunner | None = None) -> "SpecStorage":
     """Build a `SpecStorage` whose mode is resolved from the workspace config at
     `specs_dir.parent`. The DEFAULT construction path for `SpecStore` (no explicit
-    storage), so every construction site is mode-correct by construction."""
+    storage), so every construction site is mode-correct by construction — a writer
+    under an encrypted workspace can never accidentally emit plaintext."""
     specs_dir = Path(specs_dir)
     workspace_root = specs_dir.parent
     return SpecStorage(
         specs_dir, mode=resolve_mode(workspace_root), workspace_root=workspace_root, git=git
     )
-
-
-def spec_store_from_config(workspace_root: Path, config) -> "SpecStore":
-    """Build a mode-aware SpecStore from an already-loaded WorkspaceConfig. Single
-    source of the mode->store mapping for callers that already hold the config
-    (spec CLI verbs, serve); avoids re-reading mothership.yaml."""
-    from mship.core.spec_store import SPECS_DIRNAME, SpecStore
-
-    specs_dir = Path(workspace_root) / SPECS_DIRNAME
-    mode = getattr(config, "spec_storage", "committed")
-    storage = SpecStorage(specs_dir, mode=mode, workspace_root=Path(workspace_root))
-    return SpecStore(specs_dir, storage=storage)

--- a/src/mship/core/spec_storage.py
+++ b/src/mship/core/spec_storage.py
@@ -1,0 +1,182 @@
+"""Transparent per-workspace spec storage policy (spec-storage-visibility-policy).
+
+`SpecStorage` decides each spec's on-disk filename + encoding from the workspace
+`spec_storage` mode. WRITES honour the mode:
+  - committed -> plaintext `specs/<date>-<id>.md`
+  - local     -> plaintext `specs/<date>-<id>.md` + ensure `specs/*.md` gitignored
+  - encrypted -> Fernet ciphertext `specs/<date>-<id>.md.enc`
+READS are suffix-driven, NOT mode-driven: a `.md` is always plaintext, a `.md.enc`
+is always decrypted with the key (or reported LOCKED without it). That keeps
+half-migrated stores and keyless serve readers correct regardless of the mode.
+
+The mode is a single source of truth: the workspace `spec_storage` config. Every
+`SpecStore` built WITHOUT an explicit storage resolves its mode from that config
+(`storage_from_workspace`), so every construction site — the spec CLI verbs, serve,
+the lifecycle persisters, `cli/worktree.py` — is mode-correct by construction and a
+writer under an encrypted workspace can never accidentally emit plaintext.
+"""
+from __future__ import annotations
+
+import re
+import tempfile
+from pathlib import Path
+from typing import Iterator, Literal
+
+from mship.core import spec_key
+from mship.util.git import GitRunner
+
+SpecMode = Literal["committed", "local", "encrypted"]
+
+# Physical encrypted file is `<date>-<id>.md.enc` (the logical stem keeps `.md`).
+ENC_SUFFIX = ".enc"
+
+_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-(?P<id>.+)$")
+
+
+class SpecLocked(Exception):
+    """A `.md.enc` spec could not be decoded because no key is present."""
+
+    def __init__(self, spec_id: str) -> None:
+        super().__init__(f"spec {spec_id!r} is encrypted and no key is available")
+        self.spec_id = spec_id
+
+
+def spec_id_from_filename(path: Path) -> str:
+    """`2026-07-22-foo-bar.md[.enc]` -> `foo-bar`. Best-effort: strips the suffix
+    and the leading `YYYY-MM-DD-`, so a locked spec's id is still knowable."""
+    name = path.name
+    if name.endswith(ENC_SUFFIX):
+        name = name[: -len(ENC_SUFFIX)]
+    if name.endswith(".md"):
+        name = name[: -len(".md")]
+    m = _ID_RE.match(name)
+    return m.group("id") if m else name
+
+
+class SpecStorage:
+    def __init__(
+        self,
+        specs_dir: Path,
+        mode: SpecMode = "committed",
+        *,
+        workspace_root: Path | None = None,
+        git: GitRunner | None = None,
+    ) -> None:
+        self.specs_dir = Path(specs_dir)
+        self.mode: SpecMode = mode
+        # specs_dir is `<workspace_root>/specs`; derive the root when not given so
+        # read-only callers (spec_discovery/spec_selection) need no extra plumbing.
+        self.workspace_root = Path(workspace_root) if workspace_root else self.specs_dir.parent
+        self._git = git or GitRunner()
+
+    # --- path resolution -------------------------------------------------
+    def physical_path(self, stem: Path) -> Path:
+        """Map a logical `.md` stem (from SpecStore.path_for) to the on-disk file
+        for the current WRITE mode."""
+        stem = Path(stem)
+        if self.mode == "encrypted":
+            return stem.with_name(stem.name + ENC_SUFFIX)
+        return stem
+
+    def iter_physical(self) -> list[Path]:
+        """Every on-disk spec file, both plaintext and ciphertext, sorted."""
+        if not self.specs_dir.is_dir():
+            return []
+        return sorted(
+            [*self.specs_dir.glob("*.md"), *self.specs_dir.glob("*.md" + ENC_SUFFIX)]
+        )
+
+    # --- write -----------------------------------------------------------
+    def write(self, stem: Path, text: str) -> Path:
+        self.specs_dir.mkdir(parents=True, exist_ok=True)
+        physical = self.physical_path(stem)
+        if self.mode == "encrypted":
+            key = spec_key.load_or_generate_key(self.workspace_root, git=self._git)
+            self._atomic_write_bytes(physical, spec_key.encrypt(key, text))
+        else:
+            self._atomic_write_text(physical, text)
+            if self.mode == "local":
+                self._git.add_to_gitignore(self.workspace_root, f"{self.specs_dir.name}/*.md")
+        return physical
+
+    # --- read ------------------------------------------------------------
+    def decode_file(self, path: Path) -> str:
+        """Plaintext of an on-disk spec file. Raises SpecLocked for a `.md.enc`
+        with no key — never returns ciphertext or plaintext-fallback."""
+        path = Path(path)
+        if path.name.endswith(".md" + ENC_SUFFIX):
+            key = spec_key.load_key(self.workspace_root)
+            if key is None:
+                raise SpecLocked(spec_id_from_filename(path))
+            return spec_key.decrypt(key, path.read_bytes())
+        return path.read_text()
+
+    def read_all(self) -> Iterator[tuple[object | None, str | None, Path]]:
+        """Yield (spec_or_None, locked_id_or_None, path) for every spec file.
+        Locked (undecryptable) files yield (None, <id>, path); unparseable files
+        are skipped. Used by LOCKED-aware readers (serve)."""
+        from mship.core.spec_store import SpecParseError, parse_spec
+
+        for path in self.iter_physical():
+            try:
+                text = self.decode_file(path)
+            except SpecLocked as locked:
+                yield (None, locked.spec_id, path)
+                continue
+            try:
+                yield (parse_spec(text), None, path)
+            except SpecParseError:
+                continue
+
+    # --- atomic write helpers (mirror SpecStore.save) --------------------
+    def _atomic_write_text(self, path: Path, text: str) -> None:
+        self._atomic_write_bytes(path, text.encode("utf-8"))
+
+    def _atomic_write_bytes(self, path: Path, data: bytes) -> None:
+        fd, tmp = tempfile.mkstemp(dir=self.specs_dir, suffix=".tmp")
+        try:
+            with open(fd, "wb") as f:
+                f.write(data)
+            Path(tmp).replace(path)
+        except Exception:
+            Path(tmp).unlink(missing_ok=True)
+            raise
+
+
+def resolve_mode(workspace_root: Path) -> SpecMode:
+    """Best-effort read of `spec_storage` from the workspace's mothership.yaml.
+
+    Single source of truth for the mode when no explicit config object is on hand.
+    No mothership.yaml (tests, bare dirs) -> committed (today's behaviour); an
+    invalid `spec_storage` value fails LOUD via the config model (never silently
+    downgrades to plaintext)."""
+    cfg_path = Path(workspace_root) / "mothership.yaml"
+    if not cfg_path.is_file():
+        return "committed"
+    from mship.core.config import ConfigLoader
+
+    config = ConfigLoader.load(cfg_path, require_paths=False)
+    return getattr(config, "spec_storage", "committed")
+
+
+def storage_from_workspace(specs_dir: Path, *, git: GitRunner | None = None) -> "SpecStorage":
+    """Build a `SpecStorage` whose mode is resolved from the workspace config at
+    `specs_dir.parent`. The DEFAULT construction path for `SpecStore` (no explicit
+    storage), so every construction site is mode-correct by construction."""
+    specs_dir = Path(specs_dir)
+    workspace_root = specs_dir.parent
+    return SpecStorage(
+        specs_dir, mode=resolve_mode(workspace_root), workspace_root=workspace_root, git=git
+    )
+
+
+def spec_store_from_config(workspace_root: Path, config) -> "SpecStore":
+    """Build a mode-aware SpecStore from an already-loaded WorkspaceConfig. Single
+    source of the mode->store mapping for callers that already hold the config
+    (spec CLI verbs, serve); avoids re-reading mothership.yaml."""
+    from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+
+    specs_dir = Path(workspace_root) / SPECS_DIRNAME
+    mode = getattr(config, "spec_storage", "committed")
+    storage = SpecStorage(specs_dir, mode=mode, workspace_root=Path(workspace_root))
+    return SpecStore(specs_dir, storage=storage)

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import tempfile
 import yaml
 from pathlib import Path
 from pydantic import ValidationError
@@ -47,41 +46,44 @@ def serialize_spec(spec: Spec) -> str:
 
 
 class SpecStore:
-    """Filesystem registry for markdown-canonical specs under `specs/`."""
+    """Filesystem registry for markdown-canonical specs under `specs/`.
 
-    def __init__(self, specs_dir: Path) -> None:
+    All on-disk representation (plaintext vs Fernet ciphertext, filename suffix,
+    gitignore) is delegated to a `SpecStorage` (spec-storage-visibility-policy).
+    When no `storage` is passed the mode is resolved from the workspace
+    `spec_storage` config (`storage_from_workspace`) — so EVERY construction site
+    (the spec CLI verbs, serve, the lifecycle persisters, `cli/worktree.py`) is
+    mode-correct by construction: a writer under an encrypted workspace can never
+    accidentally emit plaintext. A workspace with no config defaults to committed
+    — today's behaviour — so existing call sites and tests are unchanged.
+    """
+
+    def __init__(self, specs_dir: Path, storage=None) -> None:
         self._dir = Path(specs_dir)
+        if storage is None:
+            from mship.core.spec_storage import storage_from_workspace
+            storage = storage_from_workspace(self._dir)
+        self._storage = storage
 
     def path_for(self, spec: Spec) -> Path:
-        """Path for a spec's file: `<specs_dir>/<created_at date>-<id>.md`.
+        """Logical `.md` stem for a spec: `<specs_dir>/<created_at date>-<id>.md`.
 
-        Saving again with the same id + creation date overwrites the file
-        (this is the intended update mechanism).
+        The physical filename (e.g. `.md.enc` under encrypted mode) is resolved by
+        the storage layer at write time. Saving again with the same id + creation
+        date overwrites the file (this is the intended update mechanism).
         """
         if not spec.id or "/" in spec.id or "\\" in spec.id or spec.id in (".", "..") or spec.id.startswith("."):
             raise ValueError(f"unsafe spec id for filename: {spec.id!r}")
         return self._dir / f"{spec.created_at:%Y-%m-%d}-{spec.id}.md"
 
     def save(self, spec: Spec) -> Path:
-        self._dir.mkdir(parents=True, exist_ok=True)
-        path = self.path_for(spec)
-        fd, tmp = tempfile.mkstemp(dir=self._dir, suffix=".md.tmp")
-        try:
-            with open(fd, "w") as f:
-                f.write(serialize_spec(spec))
-            Path(tmp).replace(path)
-        except Exception:
-            Path(tmp).unlink(missing_ok=True)
-            raise
-        return path
+        return self._storage.write(self.path_for(spec), serialize_spec(spec))
 
     def load(self, path: Path) -> Spec:
-        return parse_spec(Path(path).read_text())
+        return parse_spec(self._storage.decode_file(Path(path)))
 
     def list(self) -> list[Spec]:
-        if not self._dir.is_dir():
-            return []
-        return [self.load(p) for p in sorted(self._dir.glob("*.md"))]
+        return [self.load(p) for p in self._storage.iter_physical()]
 
     def find_by_id(self, spec_id: str) -> Spec | None:
         for spec in self.list():

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -83,10 +83,26 @@ class SpecStore:
         return parse_spec(self._storage.decode_file(Path(path)))
 
     def list(self) -> list[Spec]:
-        return [self.load(p) for p in self._storage.iter_physical()]
+        # Resilient: skip a spec whose file is locked (encrypted, no key) or
+        # unreadable/unparseable, so one bad file never blocks the readable siblings
+        # (or every routed CLI op via find_by_id). read_all yields the parsed spec
+        # for decodable files and (None, id, path) for locked ones — take the specs.
+        return [spec for spec, _locked_id, _path in self._storage.read_all() if spec is not None]
 
     def find_by_id(self, spec_id: str) -> Spec | None:
         for spec in self.list():
             if spec.id == spec_id:
                 return spec
+        return None
+
+    def read_strict(self, spec_id: str) -> Spec | None:
+        """Strictly read ONE spec by id: returns the parsed Spec, None if no file
+        exists for the id, and RAISES SpecLocked (encrypted, no key) or
+        SpecParseError (malformed) rather than swallowing them — for callers like
+        `mship spec validate` that must report locked/invalid, not silently skip
+        (the resilient `list`/`find_by_id` skip both)."""
+        from mship.core.spec_storage import spec_id_from_filename
+        for path in self._storage.iter_physical():
+            if spec_id_from_filename(path) == spec_id:
+                return parse_spec(self._storage.decode_file(path))
         return None

--- a/src/mship/core/view/spec_discovery.py
+++ b/src/mship/core/view/spec_discovery.py
@@ -24,21 +24,22 @@ SPECS_DIR = Path(SPECS_DIRNAME)
 
 def _find_in_specs_dir(workspace_root: Path, *, spec_id=None, task_slug=None):
     """Return the path of a spec file in `<workspace_root>/specs` matching
-    `spec_id` (frontmatter id) or `task_slug` (bound task), else None."""
+    `spec_id` (frontmatter id) or `task_slug` (bound task), else None. Suffix-aware
+    (plaintext `.md` + encrypted `.md.enc`) via the storage layer; a locked
+    encrypted spec (no key) is skipped, since its frontmatter can't be matched."""
     # imported lazily to keep this discovery module loosely coupled to the store
-    from mship.core.spec_store import SpecParseError, parse_spec
+    from mship.core.spec_storage import SpecStorage
     specs_dir = workspace_root / SPECS_DIR
     if not specs_dir.is_dir():
         return None
-    for p in sorted(specs_dir.glob("*.md")):
-        try:
-            spec = parse_spec(p.read_text())
-        except SpecParseError:
-            continue
+    storage = SpecStorage(specs_dir, workspace_root=workspace_root)
+    for spec, _locked_id, path in storage.read_all():
+        if spec is None:
+            continue  # locked: cannot match on frontmatter
         if spec_id is not None and spec.id == spec_id:
-            return p
+            return path
         if task_slug is not None and spec.task_slug == task_slug:
-            return p
+            return path
     return None
 
 

--- a/src/mship/core/view/spec_selection.py
+++ b/src/mship/core/view/spec_selection.py
@@ -24,22 +24,23 @@ def _sort_key(spec: Spec) -> tuple:
 
 def scan_canonical_specs(specs_dir: Path) -> list[tuple[Spec, Path]]:
     """Parse every spec in the canonical `<workspace_root>/specs` store and return
-    (spec, real_path) pairs sorted by (created_at, id). Skips files that are
-    unreadable (OSError), invalid UTF-8 (UnicodeError), or unparseable
-    (SpecParseError) so one bad file never aborts selection. Reads ONLY the
-    workspace-root store, never a per-task worktree, so the result is
-    branch/worktree independent (AC1). Returning the real path (not a
-    reconstruction) keeps rendering correct even if a file's name diverges from
-    `<date>-<id>.md`."""
-    from mship.core.spec_store import SpecParseError, parse_spec
+    (spec, real_path) pairs sorted by (created_at, id). Suffix-aware via the storage
+    layer: reads plaintext `.md` and decrypts `.md.enc` with the workspace key; a
+    locked encrypted spec (no key) is skipped, as are files that are unreadable
+    (OSError), invalid UTF-8 (UnicodeError), or unparseable (SpecParseError) so one
+    bad file never aborts selection. Reads ONLY the workspace-root store, never a
+    per-task worktree, so the result is branch/worktree independent (AC1).
+    Returning the real path (not a reconstruction) keeps rendering correct even if
+    a file's name diverges from `<date>-<id>.md`."""
+    from mship.core.spec_storage import SpecStorage
     if not specs_dir.is_dir():
         return []
+    storage = SpecStorage(specs_dir)  # workspace_root defaults to specs_dir.parent
     out: list[tuple[Spec, Path]] = []
-    for p in sorted(specs_dir.glob("*.md")):
-        try:
-            out.append((parse_spec(p.read_text()), p))
-        except (OSError, UnicodeError, SpecParseError):
-            continue
+    for spec, _locked_id, path in storage.read_all():
+        if spec is None:
+            continue  # locked: no key, skip
+        out.append((spec, path))
     return sorted(out, key=lambda sp: _sort_key(sp[0]))
 
 

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -122,6 +122,35 @@ Review a spec without the CLI via `mship view spec [--web]`, or over HTTP via `m
 
 **The approval gate.** With `require_approved_spec: true` in `mothership.yaml`, `mship phase dev` is **hard-blocked** until a bound, approved spec exists — escape with `mship phase dev --bypass-spec-gate`. **This is opt-in: the default is OFF**, so by default `phase dev` only warns when no spec is found. Spec-first is the recommended methodology regardless of the gate.
 
+## Spec storage & visibility (`spec_storage`)
+
+A workspace's `spec_storage:` policy in `mothership.yaml` controls where specs live
+and who can read them. The `mship spec` UX is identical across all modes — only the
+on-disk representation changes.
+
+- `committed` (default): plaintext `specs/<date>-<id>.md`, committed + pushed. A public
+  design record. Existing workspaces are unchanged.
+- `local`: the same plaintext file, but git-ignored (`specs/*.md`). Present + fully
+  usable on your machine, never committed or pushed.
+- `encrypted`: Fernet ciphertext `specs/<date>-<id>.md.enc`, committed to the repo.
+  It round-trips through clone/pull like any file, but a repo-reader without the key
+  sees only ciphertext. This also delivers specs to cloud workers: a worker holding
+  the key clones the repo and decrypts.
+
+The key is a single per-workspace Fernet key at `.mothership/spec-key` (git-ignored),
+generated on the first encrypted write. `mship serve`/Ground Control decrypt for
+display with the local key and show a LOCKED state when the key is absent.
+
+**⚠ Back up `.mothership/spec-key`.** It is the ONLY key to your encrypted specs.
+Losing it makes every encrypted spec permanently unrecoverable — there is no escrow
+or recovery. Rotation is manual: generate a new key and re-encrypt (re-run
+`mship spec migrate-storage`).
+
+**Switching modes:** edit `spec_storage:` in `mothership.yaml`, then run
+`mship spec migrate-storage`. It re-materialises every spec into the new mode and
+git-removes the old representation, so no spec is left readable in a mode that should
+hide it.
+
 ## Work items: the cross-artifact spine (`mship item`)
 
 A **work item** is the durable unit of intent that outlives any single spec, task, or thread. Where a `spec` is the design and a `task` is one worktree of execution, a work item groups everything about one piece of work — its spec, its task(s), the phone thread(s) discussing it, and external links (GitHub/Linear/Notion/Jira/url) — so it can drive a phase-aware cockpit (the Ground Control home). Use it when a piece of work spans more than one of those artifacts, or when you want a stable id to hang external tracker links off.

--- a/src/mship/util/git.py
+++ b/src/mship/util/git.py
@@ -111,6 +111,32 @@ class GitRunner:
         )
         return result.returncode == 0
 
+    def add(self, repo_path: Path, path: Path) -> None:
+        """Stage a path (spec-storage-visibility-policy migrate-storage: track the
+        newly-materialised spec representation so it lands in the next commit)."""
+        subprocess.run(
+            ["git", "add", "--", str(path)],
+            cwd=repo_path, check=True, capture_output=True, text=True,
+        )
+
+    def rm(self, repo_path: Path, path: Path, *, cached: bool = False) -> None:
+        """Remove `path` from the index (and the working tree unless `cached`).
+        Used by migrate-storage to drop a spec's old on-disk representation."""
+        args = ["git", "rm", "-q"]
+        if cached:
+            args.append("--cached")
+        args += ["--", str(path)]
+        subprocess.run(args, cwd=repo_path, check=True, capture_output=True, text=True)
+
+    def remove_from_gitignore(self, repo_path: Path, pattern: str) -> None:
+        """Drop `pattern` from `.gitignore` (inverse of add_to_gitignore). Used when
+        migrating back to `committed` so specs become public + trackable again."""
+        gitignore = repo_path / ".gitignore"
+        if not gitignore.exists():
+            return
+        kept = [ln for ln in gitignore.read_text().splitlines() if ln.strip() != pattern]
+        gitignore.write_text("\n".join(kept) + ("\n" if kept else ""))
+
     def add_to_gitignore(self, repo_path: Path, pattern: str) -> None:
         gitignore = repo_path / ".gitignore"
         if gitignore.exists():

--- a/src/mship/util/git.py
+++ b/src/mship/util/git.py
@@ -119,14 +119,33 @@ class GitRunner:
             cwd=repo_path, check=True, capture_output=True, text=True,
         )
 
-    def rm(self, repo_path: Path, path: Path, *, cached: bool = False) -> None:
+    def rm(self, repo_path: Path, path: Path, *, cached: bool = False, force: bool = False) -> None:
         """Remove `path` from the index (and the working tree unless `cached`).
-        Used by migrate-storage to drop a spec's old on-disk representation."""
+        Used by migrate-storage to drop a spec's old on-disk representation.
+
+        `force` (git rm -f) overrides git's staged/working-tree-changes safety —
+        correct for migration, where the old representation's content is already
+        preserved in the freshly-written new representation, so removing it can
+        never lose data. Still raises CalledProcessError on a GENUINE failure (the
+        caller must NOT swallow it, or a spec could be left readable in a mode
+        meant to hide it)."""
         args = ["git", "rm", "-q"]
         if cached:
             args.append("--cached")
+        if force:
+            args.append("-f")
         args += ["--", str(path)]
         subprocess.run(args, cwd=repo_path, check=True, capture_output=True, text=True)
+
+    def is_tracked(self, repo_path: Path, path: Path) -> bool:
+        """True when `path` is tracked in the index (git ls-files --error-unmatch).
+        Lets migrate-storage act only when needed (idempotent) while still failing
+        loud on a genuine git error, rather than blanket-swallowing failures."""
+        result = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", "--", str(path)],
+            cwd=repo_path, capture_output=True, text=True, check=False,
+        )
+        return result.returncode == 0
 
     def remove_from_gitignore(self, repo_path: Path, pattern: str) -> None:
         """Drop `pattern` from `.gitignore` (inverse of add_to_gitignore). Used when

--- a/tests/cli/test_spec_migrate_storage.py
+++ b/tests/cli/test_spec_migrate_storage.py
@@ -1,0 +1,77 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+
+runner = CliRunner()
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=root, capture_output=True, text=True, check=True)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path):
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "mothership.yaml").write_text("workspace: demo\nspec_storage: committed\n")
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    container.config.reset(); container.state_manager.reset(); container.log_manager.reset()
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    # Create + commit a committed spec.
+    runner.invoke(app, ["spec", "new", "--title", "Design X", "--id", "design-x"])
+    _git(tmp_path, "add", "specs")
+    _git(tmp_path, "commit", "-q", "-m", "add spec")
+    yield tmp_path
+    container.config_path.reset_override(); container.state_dir.reset_override(); container.config.reset()
+    container.state_manager.reset(); container.log_manager.reset()
+
+
+def _set_mode(root: Path, mode: str) -> None:
+    (root / "mothership.yaml").write_text(f"workspace: demo\nspec_storage: {mode}\n")
+    container.config.reset()
+
+
+def test_migrate_committed_to_encrypted(workspace: Path):
+    _set_mode(workspace, "encrypted")
+    res = runner.invoke(app, ["spec", "migrate-storage"])
+    assert res.exit_code == 0, res.output
+    specs = workspace / "specs"
+    enc = list(specs.glob("*.md.enc"))
+    assert len(enc) == 1 and b"Design X" not in enc[0].read_bytes()
+    # Plaintext removed from disk AND from the git index.
+    assert list(specs.glob("*.md")) == []
+    tracked = _git(workspace, "ls-files", "specs").stdout
+    assert "design-x.md" not in tracked or "design-x.md.enc" in tracked
+    assert ".enc" in _git(workspace, "ls-files", "specs").stdout
+
+
+def test_migrate_committed_to_local(workspace: Path):
+    _set_mode(workspace, "local")
+    res = runner.invoke(app, ["spec", "migrate-storage"])
+    assert res.exit_code == 0, res.output
+    md = list((workspace / "specs").glob("*.md"))
+    assert len(md) == 1 and "Design X" in md[0].read_text()  # still readable locally
+    # Untracked + gitignored now.
+    assert "design-x" not in _git(workspace, "ls-files", "specs").stdout
+    check = subprocess.run(
+        ["git", "check-ignore", "-q", str(md[0].relative_to(workspace))], cwd=workspace
+    )
+    assert check.returncode == 0
+
+
+def test_migrate_encrypted_back_to_committed(workspace: Path):
+    _set_mode(workspace, "encrypted")
+    runner.invoke(app, ["spec", "migrate-storage"])
+    _set_mode(workspace, "committed")
+    res = runner.invoke(app, ["spec", "migrate-storage"])
+    assert res.exit_code == 0, res.output
+    md = list((workspace / "specs").glob("*.md"))
+    assert len(md) == 1 and "Design X" in md[0].read_text()
+    assert list((workspace / "specs").glob("*.md.enc")) == []  # ciphertext gone

--- a/tests/cli/test_spec_storage_cli.py
+++ b/tests/cli/test_spec_storage_cli.py
@@ -67,3 +67,23 @@ def test_spec_validate_under_encrypted(encrypted_workspace: Path):
     # validate found + decoded the ENCRYPTED spec rather than reporting "no spec
     # file" (which is what a raw *.md glob would do against a *.md.enc store).
     assert "No spec file for id" not in res.output
+
+
+def test_spec_validate_reports_malformed_not_nameerror(tmp_path: Path):
+    # Greptile "Import The Parse Error": `mship spec validate` on a malformed spec
+    # must report the invalid-spec message (via read_strict raising SpecParseError),
+    # NOT crash with a NameError because SpecParseError wasn't imported in cli/spec.py.
+    (tmp_path / "mothership.yaml").write_text("workspace: demo\n")  # committed mode
+    state_dir = tmp_path / ".mothership"; state_dir.mkdir()
+    (tmp_path / "specs").mkdir()
+    (tmp_path / "specs" / "2026-07-22-broken.md").write_text("this is not a valid spec")
+    container.config.reset(); container.state_manager.reset(); container.log_manager.reset()
+    container.config_path.override(tmp_path / "mothership.yaml"); container.state_dir.override(state_dir)
+    try:
+        res = runner.invoke(app, ["spec", "validate", "broken"])
+        assert res.exit_code != 0
+        assert "NameError" not in res.output and (res.exception is None or not isinstance(res.exception, NameError))
+        assert "invalid spec" in res.output.lower()
+    finally:
+        container.config_path.reset_override(); container.state_dir.reset_override()
+        container.config.reset(); container.state_manager.reset(); container.log_manager.reset()

--- a/tests/cli/test_spec_storage_cli.py
+++ b/tests/cli/test_spec_storage_cli.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def encrypted_workspace(tmp_path: Path):
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: demo\nspec_storage: encrypted\n"
+    )
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    container.config.reset()
+    container.state_manager.reset()
+    container.log_manager.reset()
+    container.config_path.override(tmp_path / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    yield tmp_path
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset()
+    container.state_manager.reset()
+    container.log_manager.reset()
+
+
+def test_spec_new_under_encrypted_writes_ciphertext(encrypted_workspace: Path):
+    res = runner.invoke(app, ["--json", "spec", "new", "--title", "Hidden plan", "--id", "hidden-plan"])
+    assert res.exit_code == 0, res.output
+    enc = list((encrypted_workspace / "specs").glob("*.md.enc"))
+    assert len(enc) == 1
+    assert b"Hidden plan" not in enc[0].read_bytes()
+    # No plaintext committed path exists.
+    assert list((encrypted_workspace / "specs").glob("*.md")) == []
+
+
+def test_spec_show_decrypts_with_key(encrypted_workspace: Path):
+    runner.invoke(app, ["spec", "new", "--title", "Hidden plan", "--id", "hidden-plan"])
+    res = runner.invoke(app, ["--json", "spec", "show", "hidden-plan"])
+    assert res.exit_code == 0, res.output
+    data = json.loads(res.output)
+    assert data["title"] == "Hidden plan"
+
+
+def test_spec_list_under_encrypted(encrypted_workspace: Path):
+    runner.invoke(app, ["spec", "new", "--title", "Hidden plan", "--id", "hidden-plan"])
+    res = runner.invoke(app, ["--json", "spec", "list"])
+    assert res.exit_code == 0, res.output
+    ids = [s["id"] for s in json.loads(res.output)["specs"]]
+    assert "hidden-plan" in ids
+
+
+def test_spec_validate_under_encrypted(encrypted_workspace: Path):
+    """`validate` reads the spec file directly today; under encrypted mode it must
+    still decode via the storage layer, not choke on ciphertext."""
+    runner.invoke(app, [
+        "spec", "new", "--title", "Hidden plan", "--id", "hidden-plan",
+    ])
+    # Give it canonical body sections so validate has something to check.
+    res = runner.invoke(app, ["--json", "spec", "validate", "hidden-plan"])
+    # A freshly-scaffolded spec may be missing body sections; the point is that
+    # validate found + decoded the ENCRYPTED spec rather than reporting "no spec
+    # file" (which is what a raw *.md glob would do against a *.md.enc store).
+    assert "No spec file for id" not in res.output

--- a/tests/core/test_config_spec_storage.py
+++ b/tests/core/test_config_spec_storage.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from mship.core.config import ConfigLoader, WorkspaceConfig
+
+
+def test_spec_storage_defaults_to_committed():
+    cfg = WorkspaceConfig(workspace="demo")
+    assert cfg.spec_storage == "committed"
+
+
+def test_spec_storage_accepts_each_mode():
+    for mode in ("committed", "local", "encrypted"):
+        assert WorkspaceConfig(workspace="demo", spec_storage=mode).spec_storage == mode
+
+
+def test_invalid_spec_storage_value_rejected_by_model():
+    with pytest.raises(ValidationError):
+        WorkspaceConfig(workspace="demo", spec_storage="public")
+
+
+def test_invalid_spec_storage_fails_at_config_load(tmp_path: Path):
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: demo\nspec_storage: public\n"
+    )
+    with pytest.raises(ValidationError):
+        ConfigLoader.load(tmp_path / "mothership.yaml", require_paths=False)

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -45,7 +45,7 @@ def test_list_specs(tmp_path):
     _seed_spec(tmp_path)
     r = TestClient(_app(tmp_path)).get("/specs")
     assert r.status_code == 200
-    assert r.json() == [{"id": "dq", "title": "Decision queue", "status": "needs_review", "task_slug": "dq", "affected_repos": []}]
+    assert r.json() == [{"id": "dq", "title": "Decision queue", "status": "needs_review", "task_slug": "dq", "affected_repos": [], "locked": False}]
 
 
 def test_get_spec_and_404(tmp_path):

--- a/tests/core/test_serve_spec_locked.py
+++ b/tests/core/test_serve_spec_locked.py
@@ -1,0 +1,67 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from mship.core import spec_key
+from mship.core.config import WorkspaceConfig
+from mship.core.serve import create_app
+from mship.core.spec import Spec
+from mship.core.spec_storage import SpecStorage
+from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+
+
+class _NullState:
+    def load(self):
+        from mship.core.state import WorkspaceState
+        return WorkspaceState(tasks={})
+
+
+def _write_encrypted_spec(root: Path) -> None:
+    now = datetime(2026, 7, 22, tzinfo=timezone.utc)
+    spec = Spec(id="locked-one", title="Locked one", status="needs_review",
+                created_at=now, updated_at=now, body="## Problem\n\nSECRET\n")
+    storage = SpecStorage(root / SPECS_DIRNAME, mode="encrypted", workspace_root=root)
+    SpecStore(root / SPECS_DIRNAME, storage=storage).save(spec)
+
+
+def _client(root: Path) -> TestClient:
+    cfg = WorkspaceConfig(workspace="demo", spec_storage="encrypted")
+    app = create_app(
+        specs_dir=root / SPECS_DIRNAME,
+        state_manager=_NullState(),
+        log_manager=None,
+        workspace_root=root,
+        config=cfg,
+    )
+    return TestClient(app)
+
+
+def test_serve_decrypts_specs_with_key(tmp_path: Path):
+    _write_encrypted_spec(tmp_path)
+    body = _client(tmp_path).get("/specs").json()
+    row = next(s for s in body if s["id"] == "locked-one")
+    assert row["title"] == "Locked one"
+    assert row.get("locked") is False
+
+
+def test_serve_shows_locked_state_without_key(tmp_path: Path):
+    _write_encrypted_spec(tmp_path)
+    spec_key.keyfile_path(tmp_path).unlink()
+    body = _client(tmp_path).get("/specs").json()
+    row = next(s for s in body if s["id"] == "locked-one")
+    assert row["locked"] is True
+    assert row["status"] == "locked"
+    assert row["title"] is None
+    # No ciphertext leaked into the response.
+    assert "gAAAA" not in str(body)
+
+
+def test_serve_get_locked_spec_returns_marker_not_error(tmp_path: Path):
+    _write_encrypted_spec(tmp_path)
+    spec_key.keyfile_path(tmp_path).unlink()
+    resp = _client(tmp_path).get("/specs/locked-one")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == "locked-one" and data["locked"] is True
+    assert "SECRET" not in resp.text

--- a/tests/core/test_skills_cli_refresh.py
+++ b/tests/core/test_skills_cli_refresh.py
@@ -19,7 +19,7 @@ STALE_PATHS = ["~/.config/superpowers", "docs/superpowers/"]
 REAL_SPEC_SUBCOMMANDS = {
     "new", "draft", "apply", "validate", "review", "verdict",
     "questions", "ask", "answer", "approve", "request-changes", "dispatch",
-    "from-thread",
+    "from-thread", "migrate-storage",
 }
 
 

--- a/tests/core/test_spec_key.py
+++ b/tests/core/test_spec_key.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import pytest
+
+from mship.core import spec_key
+from mship.core.spec_key import SpecKeyMissing
+
+
+def test_load_key_returns_none_when_absent(tmp_path: Path):
+    assert spec_key.load_key(tmp_path) is None
+
+
+def test_require_key_raises_when_absent(tmp_path: Path):
+    with pytest.raises(SpecKeyMissing):
+        spec_key.require_key(tmp_path)
+
+
+def test_generate_creates_gitignored_keyfile_with_loud_notice(tmp_path: Path, capsys):
+    key = spec_key.load_or_generate_key(tmp_path)
+    keyfile = spec_key.keyfile_path(tmp_path)
+    assert keyfile.is_file()
+    assert keyfile.read_bytes() == key
+    # 0600 perms so a stray key isn't world-readable.
+    assert (keyfile.stat().st_mode & 0o077) == 0
+    # Loud, one-time backup notice on first generation (stderr).
+    err = capsys.readouterr().err
+    assert "BACK THIS FILE UP" in err
+    assert "unrecoverable" in err.lower()
+    # Ensured gitignored: an entry exists (this tmp dir is not a git repo, so the
+    # module falls back to appending to .gitignore).
+    assert ".mothership/spec-key" in (tmp_path / ".gitignore").read_text()
+
+
+def test_generate_is_idempotent_and_quiet_second_time(tmp_path: Path, capsys):
+    first = spec_key.load_or_generate_key(tmp_path)
+    capsys.readouterr()  # drain the first-generation notice
+    second = spec_key.load_or_generate_key(tmp_path)
+    assert first == second
+    assert "BACK THIS FILE UP" not in capsys.readouterr().err
+
+
+def test_encrypt_output_excludes_plaintext_and_round_trips(tmp_path: Path):
+    key = spec_key.load_or_generate_key(tmp_path)
+    plaintext = "## Problem\n\nsecret design intent\n"
+    blob = spec_key.encrypt(key, plaintext)
+    assert b"secret design intent" not in blob
+    assert spec_key.decrypt(key, blob) == plaintext

--- a/tests/core/test_spec_key.py
+++ b/tests/core/test_spec_key.py
@@ -45,3 +45,37 @@ def test_encrypt_output_excludes_plaintext_and_round_trips(tmp_path: Path):
     blob = spec_key.encrypt(key, plaintext)
     assert b"secret design intent" not in blob
     assert spec_key.decrypt(key, blob) == plaintext
+
+
+def test_generated_key_is_0600(tmp_path: Path):
+    # Greptile: the key must be 0600 from creation (no world-readable window).
+    import os, stat
+    spec_key.load_or_generate_key(tmp_path)
+    mode = stat.S_IMODE(os.stat(spec_key.keyfile_path(tmp_path)).st_mode)
+    assert mode == 0o600
+
+
+def test_generate_when_key_exists_reuses_it(tmp_path: Path):
+    # Greptile: a second first-write must reuse the existing key, never split.
+    k1 = spec_key.load_or_generate_key(tmp_path)
+    k2 = spec_key.load_or_generate_key(tmp_path)
+    assert k1 == k2
+
+
+def test_generate_lost_race_reuses_winners_key(tmp_path: Path, monkeypatch):
+    # Greptile "Concurrent Writers Split The Key": if the keyfile appears between the
+    # load-None check and the atomic link (a concurrent winner), the loser reuses the
+    # winner's key rather than clobbering it with a second key.
+    import os as _os
+    winner = spec_key.Fernet.generate_key()
+    real_link = _os.link
+
+    def racing_link(src, dst):
+        p = spec_key.keyfile_path(tmp_path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        if not p.exists():
+            p.write_bytes(winner)
+        return real_link(src, dst)  # raises FileExistsError
+
+    monkeypatch.setattr(_os, "link", racing_link)
+    assert spec_key.load_or_generate_key(tmp_path) == winner

--- a/tests/core/test_spec_storage.py
+++ b/tests/core/test_spec_storage.py
@@ -154,8 +154,8 @@ def test_no_module_serializes_specs_outside_storage_layer():
       - core/spec_store.py: the codec itself + SpecStore.save (goes through storage)
       - core/export.py:     writes a redacted `spec.md` into an EXPORT BUNDLE, never
                             the `specs/` store.
-    A new caller trips this test — route it through spec_store_from_config /
-    SpecStore instead of serializing + writing by hand.
+    A new caller trips this test — route it through SpecStore (which delegates to
+    the mode-aware SpecStorage) instead of serializing + writing by hand.
     """
     import mship
 

--- a/tests/core/test_spec_storage.py
+++ b/tests/core/test_spec_storage.py
@@ -170,3 +170,42 @@ def test_no_module_serializes_specs_outside_storage_layer():
     assert offenders == [], (
         f"modules serialize specs outside the storage layer: {offenders}"
     )
+
+
+def test_list_skips_locked_file_and_returns_readable_siblings(tmp_path: Path):
+    # Greptile "One Locked File Blocks All Specs": a locked .md.enc must not abort
+    # list()/find_by_id — the readable plaintext siblings still come back.
+    from datetime import datetime, timezone
+    from mship.core.spec import Spec
+    enc = _store(tmp_path, "encrypted")
+    enc.save(_spec())                                   # writes a .md.enc + a key
+    (tmp_path / ".mothership" / "spec-key").unlink()    # now that .enc is LOCKED
+    plain = _store(tmp_path, "committed")
+    now = datetime(2026, 7, 22, 10, 0, 0, tzinfo=timezone.utc)
+    plain.save(Spec(id="readable-one", title="Readable", status="draft",
+                    created_at=now, updated_at=now, body="## Problem\n\nok\n"))
+    ids = {s.id for s in plain.list()}
+    assert "readable-one" in ids                        # readable sibling survives
+    assert "secret-thing" not in ids                    # the locked one is skipped, not crashing
+    assert plain.find_by_id("readable-one") is not None
+
+
+def test_read_strict_raises_locked_and_parse_but_resilient_list_skips(tmp_path: Path):
+    # Greptile "Malformed Specs Bypass Validation Output": read_strict must RAISE on
+    # a locked or malformed spec (so `mship spec validate` can report it), even though
+    # the resilient list() silently skips both.
+    enc = _store(tmp_path, "encrypted")
+    enc.save(_spec())
+    (tmp_path / ".mothership" / "spec-key").unlink()     # secret-thing.enc now LOCKED
+    # a malformed plaintext spec (no parseable frontmatter)
+    (tmp_path / SPECS_DIRNAME).mkdir(parents=True, exist_ok=True)
+    (tmp_path / SPECS_DIRNAME / "2026-07-22-broken.md").write_text("not a valid spec at all")
+    store = _store(tmp_path, "committed")
+    from mship.core.spec_store import SpecParseError
+    with pytest.raises(SpecLocked):
+        store.read_strict("secret-thing")
+    with pytest.raises(SpecParseError):
+        store.read_strict("broken")
+    assert store.read_strict("nope") is None            # genuinely-missing id
+    # list() stays resilient: neither the locked nor the malformed file aborts it
+    assert store.list() == []

--- a/tests/core/test_spec_storage.py
+++ b/tests/core/test_spec_storage.py
@@ -1,0 +1,172 @@
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from mship.core import spec_key
+from mship.core.spec import Spec
+from mship.core.spec_storage import SpecLocked, SpecStorage, spec_id_from_filename
+from mship.core.spec_store import SPECS_DIRNAME, SpecStore, serialize_spec
+
+
+def _spec():
+    now = datetime(2026, 7, 22, 10, 0, 0, tzinfo=timezone.utc)
+    return Spec(
+        id="secret-thing", title="Secret thing", status="draft",
+        created_at=now, updated_at=now,
+        body="## Problem\n\nTHE-SECRET-MARKER design intent\n",
+    )
+
+
+def _git_init(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=root, check=True)
+
+
+def _store(root: Path, mode: str) -> SpecStore:
+    specs_dir = root / SPECS_DIRNAME
+    storage = SpecStorage(specs_dir, mode=mode, workspace_root=root)
+    return SpecStore(specs_dir, storage=storage)
+
+
+def test_committed_write_is_byte_identical_to_serialize(tmp_path: Path):
+    spec = _spec()
+    path = _store(tmp_path, "committed").save(spec)
+    assert path.name == "2026-07-22-secret-thing.md"
+    assert path.read_text() == serialize_spec(spec)
+
+
+def test_committed_round_trips(tmp_path: Path):
+    store = _store(tmp_path, "committed")
+    store.save(_spec())
+    assert store.find_by_id("secret-thing").body.startswith("## Problem")
+
+
+def test_encrypted_write_leaves_ciphertext_on_disk(tmp_path: Path):
+    """SECURITY: the plaintext markdown must NOT appear in the committed file, and
+    the plaintext `.md` path must never be written under encrypted mode."""
+    store = _store(tmp_path, "encrypted")
+    path = store.save(_spec())
+    assert path.name == "2026-07-22-secret-thing.md.enc"
+    blob = path.read_bytes()
+    assert b"THE-SECRET-MARKER" not in blob
+    assert b"## Problem" not in blob
+    # The plaintext committed path was never created.
+    assert not (tmp_path / SPECS_DIRNAME / "2026-07-22-secret-thing.md").exists()
+
+
+def test_encrypted_round_trips_with_key(tmp_path: Path):
+    store = _store(tmp_path, "encrypted")
+    store.save(_spec())
+    loaded = store.find_by_id("secret-thing")
+    assert "THE-SECRET-MARKER" in loaded.body
+
+
+def test_no_key_holder_cannot_read_encrypted_spec(tmp_path: Path):
+    """SECURITY: after the key is removed, decoding yields SpecLocked, never plaintext."""
+    store = _store(tmp_path, "encrypted")
+    path = store.save(_spec())
+    spec_key.keyfile_path(tmp_path).unlink()
+    storage = SpecStorage(tmp_path / SPECS_DIRNAME, mode="encrypted", workspace_root=tmp_path)
+    with pytest.raises(SpecLocked) as exc:
+        storage.decode_file(path)
+    assert exc.value.spec_id == "secret-thing"
+
+
+def test_encrypted_read_without_key_never_returns_plaintext(tmp_path: Path):
+    store = _store(tmp_path, "encrypted")
+    path = store.save(_spec())
+    spec_key.keyfile_path(tmp_path).unlink()
+    # Nothing on disk or reachable exposes the marker.
+    assert b"THE-SECRET-MARKER" not in path.read_bytes()
+
+
+def test_local_write_is_plaintext_but_gitignored_and_untracked(tmp_path: Path):
+    """SECURITY: local mode is fully readable locally yet never a committable file."""
+    _git_init(tmp_path)
+    store = _store(tmp_path, "local")
+    path = store.save(_spec())
+    assert path.name == "2026-07-22-secret-thing.md"
+    assert "THE-SECRET-MARKER" in path.read_text()  # plaintext, usable locally
+    # Gitignored:
+    check = subprocess.run(
+        ["git", "check-ignore", "-q", str(path.relative_to(tmp_path))], cwd=tmp_path
+    )
+    assert check.returncode == 0
+    # And absent from `git status` as a trackable file:
+    status = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=tmp_path, capture_output=True, text=True
+    ).stdout
+    assert "secret-thing" not in status
+
+
+def test_read_is_suffix_driven_across_mixed_store(tmp_path: Path):
+    """A committed .md and an encrypted .md.enc coexist (mid-migration); list() surfaces both."""
+    _store(tmp_path, "committed").save(_spec())
+    other = _spec()
+    other.id = "also-secret"
+    _store(tmp_path, "encrypted").save(other)
+    ids = {s.id for s in _store(tmp_path, "committed").list()}
+    assert ids == {"secret-thing", "also-secret"}
+
+
+def test_spec_id_from_filename():
+    assert spec_id_from_filename(Path("2026-07-22-foo-bar.md")) == "foo-bar"
+    assert spec_id_from_filename(Path("2026-07-22-foo-bar.md.enc")) == "foo-bar"
+
+
+# --- SECURITY OVERRIDE: writer-funnel guard (default-construction is mode-aware) ---
+
+def test_direct_specstore_construction_is_config_mode_aware(tmp_path: Path):
+    """SECURITY GUARD (writer-funnel): a SpecStore built with NO explicit storage
+    under an encrypted-config workspace must still write ciphertext. This is what
+    makes EVERY `SpecStore(specs_dir)` construction site (cli/worktree.py, the
+    spec_lifecycle / workitem_lifecycle persisters, ...) mode-correct by
+    construction — never an accidental plaintext leak."""
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: demo\nspec_storage: encrypted\n"
+    )
+    store = SpecStore(tmp_path / SPECS_DIRNAME)  # no explicit storage
+    path = store.save(_spec())
+    assert path.name.endswith(".md.enc")
+    assert b"THE-SECRET-MARKER" not in path.read_bytes()
+    # No plaintext committed representation was written.
+    assert list((tmp_path / SPECS_DIRNAME).glob("*.md")) == []
+
+
+def test_direct_specstore_construction_defaults_committed_without_config(tmp_path: Path):
+    """No mothership.yaml (tests, bare dirs) -> committed, preserving today's
+    plaintext behaviour."""
+    store = SpecStore(tmp_path / SPECS_DIRNAME)  # no config, no explicit storage
+    path = store.save(_spec())
+    assert path.name == "2026-07-22-secret-thing.md"
+    assert "THE-SECRET-MARKER" in path.read_text()
+
+
+def test_no_module_serializes_specs_outside_storage_layer():
+    """SECURITY GUARD: the ONLY on-disk spec writer is SpecStore.save -> SpecStorage.
+
+    `serialize_spec` is the single spec codec; any module that calls it to persist
+    a spec would bypass the storage layer and, under encrypted mode, emit
+    plaintext — the exact leak this feature prevents. Allowlist:
+      - core/spec_store.py: the codec itself + SpecStore.save (goes through storage)
+      - core/export.py:     writes a redacted `spec.md` into an EXPORT BUNDLE, never
+                            the `specs/` store.
+    A new caller trips this test — route it through spec_store_from_config /
+    SpecStore instead of serializing + writing by hand.
+    """
+    import mship
+
+    src_root = Path(mship.__file__).parent
+    allowed = {"core/spec_store.py", "core/export.py"}
+    offenders = [
+        py.relative_to(src_root).as_posix()
+        for py in src_root.rglob("*.py")
+        if py.relative_to(src_root).as_posix() not in allowed
+        and "serialize_spec(" in py.read_text()
+    ]
+    assert offenders == [], (
+        f"modules serialize specs outside the storage layer: {offenders}"
+    )

--- a/tests/core/view/test_spec_readers_encrypted.py
+++ b/tests/core/view/test_spec_readers_encrypted.py
@@ -1,0 +1,49 @@
+"""The two view readers that bypass SpecStore (spec_discovery, spec_selection)
+must be suffix-aware: an encrypted `.md.enc` spec is discoverable + decrypted,
+and a locked (keyless) encrypted spec is simply skipped — never a raw-ciphertext
+parse error (spec-storage-visibility-policy ac2)."""
+from datetime import datetime, timezone
+from pathlib import Path
+
+from mship.core import spec_key
+from mship.core.spec import Spec
+from mship.core.spec_storage import SpecStorage
+from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+from mship.core.view.spec_discovery import _find_in_specs_dir
+from mship.core.view.spec_selection import scan_canonical_specs
+
+
+def _write_encrypted(root: Path, spec_id: str, task_slug: str | None = None) -> None:
+    now = datetime(2026, 7, 22, tzinfo=timezone.utc)
+    spec = Spec(id=spec_id, title=spec_id, status="draft",
+                created_at=now, updated_at=now, task_slug=task_slug,
+                body="## Problem\n\nENCRYPTED-BODY\n")
+    storage = SpecStorage(root / SPECS_DIRNAME, mode="encrypted", workspace_root=root)
+    SpecStore(root / SPECS_DIRNAME, storage=storage).save(spec)
+
+
+def test_scan_canonical_specs_surfaces_encrypted_spec(tmp_path: Path):
+    _write_encrypted(tmp_path, "enc-one")
+    pairs = scan_canonical_specs(tmp_path / SPECS_DIRNAME)
+    ids = [s.id for s, _ in pairs]
+    assert ids == ["enc-one"]
+    assert "ENCRYPTED-BODY" in pairs[0][0].body
+
+
+def test_scan_canonical_specs_skips_locked_spec(tmp_path: Path):
+    _write_encrypted(tmp_path, "enc-one")
+    spec_key.keyfile_path(tmp_path).unlink()
+    # No key: the encrypted spec is skipped, not surfaced as ciphertext/garbage.
+    assert scan_canonical_specs(tmp_path / SPECS_DIRNAME) == []
+
+
+def test_find_in_specs_dir_finds_encrypted_by_id(tmp_path: Path):
+    _write_encrypted(tmp_path, "enc-two")
+    found = _find_in_specs_dir(tmp_path, spec_id="enc-two")
+    assert found is not None and found.name.endswith(".md.enc")
+
+
+def test_find_in_specs_dir_finds_encrypted_by_task_slug(tmp_path: Path):
+    _write_encrypted(tmp_path, "enc-three", task_slug="my-task")
+    found = _find_in_specs_dir(tmp_path, task_slug="my-task")
+    assert found is not None and found.name.endswith(".md.enc")


### PR DESCRIPTION
Implements spec `spec-storage-visibility-policy`. Gives each workspace a **spec storage & visibility policy** — so specs can be a public design record, kept-but-uncommitted, or encrypted-in-the-repo — while the `mship spec` workflow stays identical.

## The three modes (`spec_storage` in mothership.yaml, default `committed`)

- **committed** (default — today's behavior): plaintext `specs/<date>-<id>.md`, committed + pushed. Public design record.
- **local**: plaintext but git-ignored — present + usable on your machine, never committed/pushed.
- **encrypted**: Fernet ciphertext `specs/<date>-<id>.md.enc`, committed to the repo — *in* the repo (round-trips through clone/pull) but **unreadable by a repo-reader without the key**. An open-source repo no longer leaks your specs. This mode also *doubles as the cloud-worker spec-delivery path*: a worker holding the key clones the repo and decrypts its spec.

## Security-critical design (verified)

- **Transparent + single-funnelled.** All spec I/O goes through a `SpecStorage` layer. `SpecStore` resolves its mode from the workspace config **by default** — so *every* construction site (the spec CLI verbs, serve, the lifecycle persisters, `cli/worktree.py`, exports) is mode-correct **by construction**. A writer under an encrypted workspace **cannot accidentally emit plaintext**. Guard test asserts a bare `SpecStore(dir)` under encrypted config writes ciphertext, plus a source-scan test that nothing serializes specs outside the layer.
- **No plaintext leak.** Encrypted write leaves ciphertext only (the plaintext markdown never appears on disk, and the plaintext `.md` path is never created). Reads are suffix-driven: `.md` plaintext, `.md.enc` decrypt-or-`SpecLocked` — **never** a ciphertext or plaintext-fallback.
- **Fail loud.** The key is one per-workspace Fernet key at `.mothership/spec-key` (0600, git-ignored), generated on first encrypted write with a loud "back this up — no escrow" notice; encrypted mode with no key fails loud rather than writing plaintext.
- **Migration is safe.** `mship spec migrate-storage` (config-driven) re-materializes every spec into the target mode and **git-removes the old representation** so nothing is left readable in a mode meant to hide it.
- **serve/GC.** serve decrypts for the operator's (trusted) Ground Control given the local key, and returns a `LOCKED` marker (`title: null`, `status: "locked"`) — never ciphertext, never an error — without it. (Rendering that LOCKED row in the GC Android UI is a separate GC-repo change.)

I directly runtime-verified the encrypted-mode invariants end-to-end (writer-funnel, ciphertext-only, no plaintext path, keyless `SpecLocked`, round-trip, the key-loss warning).

## Scope

- `cryptography` added as an explicit dependency (it was only transitive, via `pyjwt[crypto]`).
- Out of scope: per-recipient keys (v1 is one symmetric key), encrypting plans/journal (specs only), automated key rotation/escrow, and the cloud-worker delivery mechanics (a separate worker-boot concern; this provides the storage + crypto it builds on).

## Tests

7 TDD commits, each AC-tagged. Security battery: ciphertext-on-disk (plaintext absent), no-key `SpecLocked`, writer-funnel by-construction, local gitignored+untracked, per-transition migration removes the old representation, serve LOCKED state. Full `mship test`: **3166 passed, 0 regressions**.
