### PR TITLE
fix(spec-store): list() skips only locked specs, propagates corrupt

### DIFF
--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -83,11 +83,23 @@ class SpecStore:
         return parse_spec(self._storage.decode_file(Path(path)))
 
     def list(self) -> list[Spec]:
-        # Resilient: skip a spec whose file is locked (encrypted, no key) or
-        # unreadable/unparseable, so one bad file never blocks the readable siblings
-        # (or every routed CLI op via find_by_id). read_all yields the parsed spec
-        # for decodable files and (None, id, path) for locked ones — take the specs.
-        return [spec for spec, _locked_id, _path in self._storage.read_all() if spec is not None]
+        # Skip LOCKED specs (encrypted, no key — an expected, graceful state) so one
+        # un-decryptable file doesn't block the readable siblings or every routed CLI
+        # op via find_by_id (Greptile #402 "one locked file blocks all"). But do NOT
+        # swallow a corrupt/unreadable store: a malformed spec PROPAGATES so it can't
+        # silently vanish from the list — which would let resolve_bound_spec return
+        # None and finish --require-evidence skip a required check (Greptile #341).
+        # (serve's LOCKED-aware display uses the fully-tolerant read_all; the gate's
+        # list must fail safe on corruption, so it only tolerates the locked case.)
+        from mship.core.spec_storage import SpecLocked
+        specs: list[Spec] = []
+        for path in self._storage.iter_physical():
+            try:
+                text = self._storage.decode_file(path)
+            except SpecLocked:
+                continue
+            specs.append(parse_spec(text))   # SpecParseError / read errors propagate
+        return specs
 
     def find_by_id(self, spec_id: str) -> Spec | None:
         for spec in self.list():

--- a/tests/core/test_spec_storage.py
+++ b/tests/core/test_spec_storage.py
@@ -190,10 +190,12 @@ def test_list_skips_locked_file_and_returns_readable_siblings(tmp_path: Path):
     assert plain.find_by_id("readable-one") is not None
 
 
-def test_read_strict_raises_locked_and_parse_but_resilient_list_skips(tmp_path: Path):
-    # Greptile "Malformed Specs Bypass Validation Output": read_strict must RAISE on
-    # a locked or malformed spec (so `mship spec validate` can report it), even though
-    # the resilient list() silently skips both.
+def test_read_strict_raises_and_list_skips_locked_but_propagates_malformed(tmp_path: Path):
+    # read_strict must RAISE on a locked OR malformed spec (so `mship spec validate`
+    # can report it). list() only tolerates the LOCKED case (encrypted, no key — an
+    # expected, graceful state); a MALFORMED spec PROPAGATES out of list() so a
+    # corrupt store can't silently vanish a spec from the gate (Greptile #341 —
+    # resolve_bound_spec must fail safe, not return None).
     enc = _store(tmp_path, "encrypted")
     enc.save(_spec())
     (tmp_path / ".mothership" / "spec-key").unlink()     # secret-thing.enc now LOCKED
@@ -207,5 +209,6 @@ def test_read_strict_raises_locked_and_parse_but_resilient_list_skips(tmp_path: 
     with pytest.raises(SpecParseError):
         store.read_strict("broken")
     assert store.read_strict("nope") is None            # genuinely-missing id
-    # list() stays resilient: neither the locked nor the malformed file aborts it
-    assert store.list() == []
+    # list() skips the locked file but must NOT swallow the malformed one:
+    with pytest.raises(SpecParseError):
+        store.list()


### PR DESCRIPTION
## Problem

PR #402 (spec-storage-visibility-policy) made `SpecStore.list()` resilient by routing through `read_all`, which skips **both** locked specs (encrypted, no key) **and** corrupt/unparseable specs. That over-broadened the tolerance and regressed a fail-safe from PR #341: a genuinely corrupt spec store must **propagate**, not silently vanish a spec from the list. When it vanishes, `resolve_bound_spec` returns `None` and `mship finish --require-evidence` skips a required check on a store it should have refused to read.

`test_resolve_bound_spec_propagates_corrupt_store_error` was red on `main` as a result.

## Fix

Narrow `list()` to skip **only** `SpecLocked` — the expected encrypted-no-key state that #402 actually targeted ("one locked file blocks all specs") — and let `SpecParseError` / read errors propagate.

- **Locked** (encrypted, no key) → graceful skip: a cloud worker without the Fernet key still lists its readable siblings.
- **Malformed** (corrupt on disk) → propagate: fail loud so the gate can't be silently bypassed.

`serve` wraps `list()` in `_safe(...)` and uses `read_all` directly for its LOCKED-aware display, so the phone still degrades gracefully rather than crashing.

## Tests

- `test_resolve_bound_spec_propagates_corrupt_store_error` now passes (was red on `main`).
- Renamed `test_read_strict_..._resilient_list_skips` → `..._list_skips_locked_but_propagates_malformed`; it now asserts `list()` raises `SpecParseError` on a malformed file while still skipping the locked one.
- `test_list_skips_locked_file_and_returns_readable_siblings` (the #402 case) still passes.
- Full `mship test` suite green.

Restores the #341 fail-safe that #402's resilient-list regressed.