### PR TITLE
Cloud-runner docs clarity pass

### DIFF
--- a/docs/adapters/claude-routine-runner.md
+++ b/docs/adapters/claude-routine-runner.md
@@ -1,4 +1,11 @@
-# Reference Adapter: a Claude Routine as the Unattended-Run Host
+# Pull-API runner: a Claude routine as the unattended-run host
+
+> **Where this fits:** this is the **pull** variant of the
+> [unattended cloud runner](../unattended-cloud-runner.md) — instead of
+> scheduling one routine per named spec, `mship item run-next` selects and
+> claims the next eligible item from a backlog. How the worker *authenticates*
+> is an independent choice (see Prerequisites below): any of the three auth
+> models works with this selection model.
 
 This documents **one concrete host** for the unattended runner (spec
 `unattended-runner`, AC8): a Claude routine on a cron schedule (or the
@@ -36,13 +43,23 @@ one-at-a-time; no parallel runs).
 - Two environment variables, set on the routine (not mship flags — these are
   adapter-level inputs the routine's shell body needs before it can call
   `mship` at all):
-  - **`GH_TOKEN`** (or `GITHUB_TOKEN`, checked in that order) — a GitHub
-    token with repo scope. `mship bootstrap` uses it to clone private member
-    repos and `mship finish` uses it to push branches + open PRs, in either
-    case only when no other git credential helper is already configured.
-    Both commands also accept an explicit `--token`, which wins over either
-    env var (`resolve_token`'s precedence: `--token` > `GH_TOKEN` >
-    `GITHUB_TOKEN`, `src/mship/core/gh_auth.py`).
+  - **GitHub auth for `bootstrap`/`finish`** — pick ONE of the three auth
+    models (full comparison: the runbook's
+    [Choosing your setup](../unattended-cloud-runner.md#choosing-your-setup)):
+    - **Raw env token** — set `GH_TOKEN` (or `GITHUB_TOKEN`; `--token` wins
+      over both, `src/mship/core/gh_auth.py`). Simplest; only for a trusted
+      execution environment, since the worker holds a real GitHub credential.
+    - **The `/gh-token` broker** — set `MSHIP_GH_BROKER_URL` +
+      `MSHIP_SERVE_TOKEN` and the worker pulls short-lived repo-scoped tokens
+      from `mship serve` at the moment of use
+      ([cloud-agent-auth.md](../cloud-agent-auth.md) §1).
+    - **Attach-at-relay** — the worker holds no GitHub credential at all;
+      `mship bootstrap --relay-url … --run-token …` routes git through the
+      credential-attaching egress proxy
+      ([cloud-worker-auth-spine.md](../cloud-worker-auth-spine.md)). Note the
+      PR-open caveat: with only a run token, `finish` must run `--push-only`
+      and the PR is opened in an attended step (runbook:
+      [Opening the PR](../unattended-cloud-runner.md#opening-the-pr-why-it-is-a-separate-step-today)).
   - **`WORKSPACE_GIT_URL`** — the git URL of the *workspace meta-repo* (the
     one containing `mothership.yaml`). This is an adapter convention, not an
     mship flag: `mship bootstrap` has no positional "clone this workspace"
@@ -70,7 +87,8 @@ If nothing matches, the tick is a clean no-op.
 set -euo pipefail
 
 # --- environment the routine must provide ---
-#   GH_TOKEN            GitHub token (repo scope); or GITHUB_TOKEN.
+#   <auth>              ONE of: GH_TOKEN / MSHIP_GH_BROKER_URL+MSHIP_SERVE_TOKEN
+#                       / relay --relay-url+--run-token (see Prerequisites).
 #   WORKSPACE_GIT_URL   git URL of the repo containing mothership.yaml.
 
 WORKDIR="${WORKDIR:-/work/workspace}"

--- a/docs/cloud-agent-auth.md
+++ b/docs/cloud-agent-auth.md
@@ -1,4 +1,11 @@
-# GitHub Auth for Cloud Agent Sessions
+# The /gh-token broker: GitHub auth for trusted cloud sessions
+
+> **Where this fits:** this is the **simpler** of the two worker-auth models for
+> the [unattended cloud runner](unattended-cloud-runner.md) — the worker pulls a
+> short-lived GitHub token from `mship serve` at the moment of use, so it briefly
+> holds a real credential. For untrusted overnight workers that must never hold
+> one, use [attach-at-relay](cloud-worker-auth-spine.md) instead. §2 below (the
+> GitHub App setup) is shared by **both** models.
 
 Cloud/CI agent containers need to push commits and open PRs without a locally
 logged-in `gh` CLI or a hand-copied personal access token (PAT) baked into the
@@ -6,8 +13,10 @@ routine, prompt, or logs. mship solves this with one token endpoint: the cloud
 container asks `mship serve` for a short-lived, repo-scoped token at the moment
 it needs one, instead of holding a long-lived credential itself.
 
-There is a single broker — `mship serve`'s `GET /gh-token` — with two backends,
-chosen automatically by whether a GitHub App is configured on the serve host:
+There is a single **token broker** — `mship serve`'s `GET /gh-token` (referred to
+as "the `/gh-token` broker" across these docs; distinct from the attach-at-relay
+egress proxy, which never hands the worker a token) — with two backends, chosen
+automatically by whether a GitHub App is configured on the serve host:
 
 - **App-backed (unattended + multi-account).** If `MSHIP_GH_APP_ID` +
   `MSHIP_GH_APP_KEY` are set on the serve host, serve mints short-lived GitHub

--- a/docs/cloud-worker-auth-spine.md
+++ b/docs/cloud-worker-auth-spine.md
@@ -1,8 +1,15 @@
-# Cloud-worker auth spine — attach-at-relay credential egress proxy (Shape 2)
+# Attach-at-relay: the credential egress proxy
 
-The overnight cloud-worker fan-out runs disposable, prompt-injectable workers that
+> **Where this fits:** this is the deep-dive on the **credential plane** of the
+> [unattended cloud runner](unattended-cloud-runner.md) — start there for the
+> workflow and setup. Siblings: [the `/gh-token` broker](cloud-agent-auth.md)
+> (the simpler, trusted-worker alternative to this proxy) and the
+> [pull-API runner](adapters/claude-routine-runner.md) (an alternative way to
+> *select* work; independent of how auth is done).
+
+The unattended cloud runner runs disposable, prompt-injectable workers that
 must clone/fetch/push across several repos — yet a worker must never hold a GitHub
-credential. This spine turns the relay into a scoped, credential-attaching **egress
+credential. Attach-at-relay turns the relay into a scoped, credential-attaching **egress
 proxy**: the worker points its git remote at the relay carrying only a low-value
 placeholder + per-run token; the relay attaches the real, repo-scoped GitHub App
 token at egress and enforces what the worker may do. The credential never lands on
@@ -23,8 +30,8 @@ Three trust tiers, least-trusted first:
   directly to `github.com`, is rejected (it is not a GitHub bearer); presented to
   the relay it unlocks only a push of the *run branch* to the *run's repos*.
 - **Relay / front door — trusted transport (in v1).** Terminates the worker's TLS
-  and forwards to the small trusted core. In Shape 2 the front door and the core
-  are co-located, so the relay is trusted.
+  and forwards to the small trusted core. In the co-located deployment the front
+  door and the core run on the same host, so the relay is trusted.
 - **Secrets-egress host — the small trusted core.** Does the exchange: verify the
   per-run token → resolve the enrollment ceiling → enforce the request → mint the
   repo-scoped App token → attach it host-locked → forward to GitHub.
@@ -38,7 +45,7 @@ Containment rests on four independent limits, so no single slip is catastrophic:
 4. the **Attachment is host-locked** — a route misconfig cannot send the credential
    to any host outside `github.com` / `api.github.com`.
 
-## 2. Attach-at-relay, Shape 2 (co-located)
+## 2. The co-located deployment (v1)
 
 All three roles run on the single relay the operator already runs. This is the
 deliberate v1 simplification: **some host must see the bearer credential in
@@ -47,7 +54,7 @@ bearer-token scheme. The design does not pretend otherwise; it *minimizes and
 isolates* that plaintext exposure to the small egress-proxy core and keeps it off
 the worker entirely.
 
-## 3. North star: the untrusted-relay 3-role split
+## 3. Deployment trust: trusted relay today, untrusted relay later
 
 The end-state splits the tiers onto separate hosts: **worker / blind relay /
 separate secrets-egress host**. Because the egress-proxy is a **distinct module**
@@ -57,11 +64,12 @@ that module onto its own host behind a now-blind relay is a **deployment / wirin
 change, not a channel rewrite**. The worker config, the token, the seams, and the
 enforcer are all unchanged by the move.
 
-**Shape 2 vs Shape 3 is a FORK, not a ladder.** They defend *different* adversaries:
+**The co-located shape (this doc) vs the untrusted-relay shape is a FORK, not a
+ladder** (internally: Shape 2 / Shape 3). They defend *different* adversaries:
 
-- **Shape 2 (this):** worker is least-trusted; the relay operator is trusted.
-- **Shape 3:** the *relay operator* is least-trusted (a blind courier), which needs
-  a second, separately-operated secrets-egress component.
+- **Co-located (this):** worker is least-trusted; the relay operator is trusted.
+- **Untrusted-relay:** the *relay operator* is least-trusted (a blind courier), which
+  needs a second, separately-operated secrets-egress component.
 
 You pick the fork by *which* party you distrust — you do not "graduate" from one to
 the other. Attach-at-relay **retires seal-to-worker / HPKE**: there is no longer any
@@ -134,12 +142,17 @@ only a *run-branch* push to the *run's repos*, with a repo-scoped short-TTL App 
 the worker never sees. Exfiltrating the placeholder + token yields no GitHub access
 and no other-branch / other-repo write.
 
-> **The api.github.com leg is live + enforced.** The worker OPENS its PR through
-> the `/api/` egress leg (operator decision B). The
-> route is back on the github-app provider behind `GitHubApiEnforcer`, a
-> DEFAULT-DENY REST enforcer (below). This is the API leg the auth-spine slice
-> deferred, now done with a real enforcer instead of a pass-through — so the API
-> path cannot sidestep the git push-to-run-branch enforcement.
+> **The api.github.com leg is live + enforced — but `mship finish` does not
+> route its PR-open through it yet.** The `/api/` route is deployed behind
+> `GitHubApiEnforcer`, a DEFAULT-DENY REST enforcer (below) whose only permitted
+> write is opening a PR. However `mship finish` has no `--relay-url`/`--run-token`
+> path today, so a run-token-only worker pushes with `mship finish --push-only`
+> and the PR is opened in an attended step. The canonical statement of what works
+> today is the runbook's
+> [Opening the PR](unattended-cloud-runner.md#opening-the-pr-why-it-is-a-separate-step-today)
+> — this section documents the enforcer that makes the future relay-routed
+> PR-open safe, so the API path can never sidestep the git push-to-run-branch
+> enforcement.
 
 ## 7. Egress-proxy module boundary
 
@@ -162,9 +175,12 @@ relocation a deployment change rather than a rewrite.
 
 ## 8. The api.github.com leg — `GitHubApiEnforcer` (default-deny, PR-only)
 
-The worker opens its own PR, which is a REST call (`POST /repos/{o}/{r}/pulls`).
-So the `api.github.com` route is routed on the **same** github-app provider as the
-git leg, behind `GitHubApiEnforcer`. Containment is two independent layers: (a) the
+Opening a PR is a REST call (`POST /repos/{o}/{r}/pulls`), and the plan of record
+is for the worker to open its own PR through this leg once `mship finish` can
+route its PR-open via the relay (today it cannot — see the runbook's
+[Opening the PR](unattended-cloud-runner.md#opening-the-pr-why-it-is-a-separate-step-today)).
+The `api.github.com` route is therefore already routed on the **same** github-app
+provider as the git leg, behind `GitHubApiEnforcer`. Containment is two independent layers: (a) the
 repo-scoped App installation token already bounds every call to the run's repos;
 (b) the enforcer is DEFAULT-DENY over the REST surface — it permits an enumerated
 allowlist and refuses everything else (403). New/unknown GitHub endpoints are denied

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,10 +22,10 @@ inbox for operator ↔ agent messaging.
 
 ## Cloud workers
 
-- **[Unattended cloud runner](unattended-cloud-runner.md)** — the end-to-end runbook: setup, per-run lifecycle, security guarantees.
-- **[Cloud worker auth spine](cloud-worker-auth-spine.md)** — attach-at-relay credential model.
-- **[Cloud agent auth](cloud-agent-auth.md)** — worker identity, enrollment, run tokens.
-- **[Claude routine runner](adapters/claude-routine-runner.md)** — the scheduled-routine adapter.
+- **[Unattended cloud runner](unattended-cloud-runner.md)** — the end-to-end runbook: setup, per-run lifecycle, security guarantees. Start here.
+- **[Attach-at-relay egress proxy](cloud-worker-auth-spine.md)** — the no-credential-on-worker auth model.
+- **[The /gh-token broker](cloud-agent-auth.md)** — the simpler trusted-session auth model + GitHub App setup.
+- **[Pull-API runner](adapters/claude-routine-runner.md)** — backlog-draining via a scheduled Claude routine.
 
 ## Install
 

--- a/docs/remote-run.md
+++ b/docs/remote-run.md
@@ -78,7 +78,7 @@ Bare `--remote` (no `=role`) auto-resolves in this order: the target repo's decl
 Two different credentials are in play, and they never mix:
 
 1. **Relay pairing token** (the run-host's own serve bearer token, handed to you via `mship pair`/`--pair-link` or `--url`/`--token`) — this is what YOUR box uses to authenticate to the REMOTE's `mship serve --relay`. It lives only in the gitignored `.mothership/run-hosts.yaml` on your machine, keyed by role.
-2. **The remote's own git credentials** — the remote box fetches the task branch using its own git auth (a normal git credential helper, SSH key, or the Phase-1 GitHub token broker for a credential-less/cloud remote). No GitHub token ever crosses the wire between your box and the remote.
+2. **The remote's own git credentials** — the remote box fetches the task branch using its own git auth (a normal git credential helper, SSH key, or the [`/gh-token` broker](cloud-agent-auth.md) for a credential-less/cloud remote). No GitHub token ever crosses the wire between your box and the remote.
 
 Nothing secret is ever committed to `mothership.yaml` — that file only ever holds role *names*.
 

--- a/docs/unattended-cloud-runner.md
+++ b/docs/unattended-cloud-runner.md
@@ -12,12 +12,12 @@ one-time go-live setup. It stitches together three deep-dive docs and one skill;
 each is linked at the point it becomes relevant, and their internals are not
 restated here.
 
-- **`cloud-worker-auth-spine.md`** — the attach-at-relay credential egress proxy
+- **`cloud-worker-auth-spine.md`** — attach-at-relay: the credential egress proxy
   (trust model, enforcers, module boundary).
-- **`cloud-agent-auth.md`** — the simpler `/gh-token` broker (the daytime/trusted
-  variant) and the GitHub App setup that both models share.
-- **`adapters/claude-routine-runner.md`** — the alternative pull-API host model
-  (`mship item run-next` selects + claims from a backlog).
+- **`cloud-agent-auth.md`** — the `/gh-token` broker: GitHub auth for trusted
+  cloud sessions, plus the GitHub App setup both auth models share.
+- **`adapters/claude-routine-runner.md`** — the pull-API runner: a Claude routine
+  as the unattended-run host (`mship item run-next` selects + claims from a backlog).
 - **skill `overnight-cloud-worker-routines`** — the agent-facing pattern for
   minting the token and standing up the routine.
 
@@ -32,9 +32,36 @@ restated here.
 | **Credential** | the relay egress proxy | Attaches the repo-scoped GitHub App token **at egress** and enforces the run's scope (which repos, which push branch). The worker never sees it. |
 
 The recommended path below is **attach-at-relay** (worker holds no credential),
-the model built for untrusted, prompt-injectable overnight workers. Two simpler
-variants — the `/gh-token` broker and the pull-API runner — are covered under
-[Variants](#variants-when-to-use-them).
+the model built for untrusted, prompt-injectable overnight workers. It is one
+point in a small decision space — see the next section before committing to a
+setup.
+
+---
+
+## Choosing your setup
+
+Two **independent** choices define a deployment. Pick one from each axis — any
+combination works.
+
+**Axis 1 — how the worker authenticates to GitHub:**
+
+| Model | Worker holds | Use when | Doc |
+|---|---|---|---|
+| Raw env token (`GH_TOKEN`) | a real GitHub token | trusted CI/container you fully control | [pull-API runner prerequisites](adapters/claude-routine-runner.md) |
+| The `/gh-token` broker | a serve bearer; pulls short-lived repo-scoped tokens on use | daytime/trusted runs; a machine with `mship serve` is awake | [cloud-agent-auth.md](cloud-agent-auth.md) |
+| Attach-at-relay (this runbook's default) | **no GitHub credential** — only a per-run relay token | untrusted, prompt-injectable overnight workers | [cloud-worker-auth-spine.md](cloud-worker-auth-spine.md) |
+
+**Axis 2 — how work is selected:**
+
+| Model | You schedule | Use when | Doc |
+|---|---|---|---|
+| Per-spec push (this runbook's default) | one routine per named approved spec | you decide each night what runs | this doc, [Per-run lifecycle](#per-run-lifecycle-once-per-approved-spec) |
+| Pull-API backlog | one recurring tick; `mship item run-next` picks + claims | you keep an `unattended`-flagged backlog and want it drained | [adapters/claude-routine-runner.md](adapters/claude-routine-runner.md) |
+
+One caveat couples the axes: with attach-at-relay the worker cannot open its own
+PR yet — `finish` runs `--push-only` and the PR is opened in an attended step
+([Opening the PR](#opening-the-pr-why-it-is-a-separate-step-today)). The other
+two auth models let `finish` open the PR directly.
 
 ---
 
@@ -228,7 +255,7 @@ run one of two ways:
 
 ## Variants: when to use them
 
-- **Daytime / trusted, zero App — the `/gh-token` broker.** If a workspace only
+- **The `/gh-token` broker (daytime / trusted, zero App).** If a workspace only
   runs while your own machine is awake, skip the App entirely: `mship serve`'s
   `/gh-token` proxies the host's `gh auth token`, and the worker pulls a
   short-lived token itself. Simpler, but single-identity and needs a machine
@@ -245,8 +272,8 @@ run one of two ways:
 
 ## See also
 
-- `cloud-worker-auth-spine.md` — attach-at-relay egress proxy (trust model, seams, enforcers).
-- `cloud-agent-auth.md` — GitHub App setup + the `/gh-token` broker variant.
-- `adapters/claude-routine-runner.md` — the pull-API host model + smoke test.
+- `cloud-worker-auth-spine.md` — attach-at-relay: the credential egress proxy (trust model, seams, enforcers).
+- `cloud-agent-auth.md` — the `/gh-token` broker + the GitHub App setup both auth models share.
+- `adapters/claude-routine-runner.md` — the pull-API runner (Claude routine host) + smoke test.
 - skill `overnight-cloud-worker-routines` — the agent-facing routine pattern.
 - specs: `cloud-worker-auth-spine`, `worker-pr-egress`, `relay-aware-worker-boot`, `cloud-agent-github-auth`, `unattended-runner`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,6 @@ nav:
       - Remote run: remote-run.md
   - Cloud workers:
       - Unattended cloud runner: unattended-cloud-runner.md
-      - Cloud worker auth spine: cloud-worker-auth-spine.md
-      - Cloud agent auth: cloud-agent-auth.md
-      - Claude routine runner (adapter): adapters/claude-routine-runner.md
+      - Attach-at-relay egress proxy: cloud-worker-auth-spine.md
+      - The /gh-token broker: cloud-agent-auth.md
+      - Pull-API runner (Claude routine): adapters/claude-routine-runner.md


### PR DESCRIPTION
## Summary

Editorial clarity pass over the four cloud-runner docs (no file renames, no code changes). Every changed factual claim was verified against this branch's CLI first: `mship finish` has `--push-only` and **no** `--relay-url`/`--run-token` path; `bootstrap`/`gh preflight` do have both flags.

- **Fixed the PR-open contradiction** — `cloud-worker-auth-spine.md` claimed "the worker OPENS its PR through the `/api/` leg"; in reality a run-token-only worker cannot open a PR (finish has no relay path). The spine's §6 callout and §8 intro now describe the enforcer as live infrastructure that finish doesn't route through yet, deferring to the runbook's "Opening the PR" as the canonical statement.
- **Modernized the pull-API adapter prerequisites** — no longer demands a raw `GH_TOKEN`; presents all three auth models (env token / `/gh-token` broker / attach-at-relay) with links and the PR-open caveat.
- **Added "Choosing your setup" to the runbook** — two-axis decision tables (auth model × work-selection model) with use-when guidance, plus the one caveat that couples the axes.
- **Consistent naming + navigation** — role-stating H1s ("Attach-at-relay: the credential egress proxy", "The /gh-token broker: …", "Pull-API runner: …"), "Where this fits" intros on all deep-dives, Shape-2/3 jargon out of headings (one prose parenthetical kept so old spec references still connect), "broker" disambiguated, `remote-run.md`'s stale "Phase-1 GitHub token broker" fixed, mkdocs nav + index labels aligned.

## Acceptance criteria

- [x] `ac1` One canonical PR-open statement (runbook), spine defers to it — commit aff3952, CLI-verified
- [x] `ac2` Adapter prerequisites offer all three auth options with links — commit 796f64e
- [x] `ac3` Runbook "Choosing your setup" two-axis decision table — commit a5da833
- [x] `ac4` Where-this-fits intros on all four docs; no Shape jargon in headings — commits aff3952/796f64e/3c28b0e
- [x] `ac5` One name per concept; remote-run stale broker name fixed — commit fecda6f
- [x] `ac6` `mkdocs build --strict` passes; nav labels match retitled pages — commit fecda6f

## Test plan

- `uv run --only-group docs mkdocs build --strict` → exit 0 (all new cross-links + anchors resolve).
- AC greps clean: no "worker opens its own PR" claims, no `^#.*Shape` headings, no "Phase-1 GitHub token broker".
- `mship test --repos mothership` → pass, exit 0 (docs-only).

https://claude.ai/code/session_014KE6RJkqUvU8eiAJNPgHLL