### PR TITLE
User-journey docs: getting-started tutorial + guides section

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,125 @@
+# Getting started
+
+By the end of this page you'll have a working mship workspace, one finished
+task, and one merged PR — the full loop you'll repeat for everything else.
+
+## Install
+
+```bash
+uv tool install git+https://github.com/atomikpanda/mothership.git
+```
+
+Requires Python 3.14+ and [uv](https://docs.astral.sh/uv/). Optional but
+recommended: [go-task](https://taskfile.dev) (task execution) and
+[gh](https://cli.github.com) (`mship finish` uses it to open PRs).
+
+## Create a workspace
+
+From the directory that contains your repo(s) — one repo, several, or a
+monorepo:
+
+```bash
+cd my-project
+mship init --name my-project --detect
+```
+
+`--detect` scans the current directory for git repos and registers them. This
+writes two things:
+
+- **`mothership.yaml`** — the workspace config: your repos, their dependency
+  order, test/run targets. Committed, shared with the team. Full reference:
+  [Configuration](configuration.md).
+- **`.mothership/`** — local state (active tasks, journals). Gitignored.
+
+## Create a work item
+
+```bash
+mship item new "hello world" --kind chore
+# wi-20260725. . . created
+```
+
+Every task belongs to a **work item** — the durable record of *why* the work
+exists. It's the first of mship's [three gates](concepts.md#the-three-gates):
+`chore` and `bug` items go straight to work; `feature` items ask for a design
+first (see [Ship a feature](guides/ship-a-feature.md)).
+
+## Spawn the task
+
+```bash
+mship spawn "add hello world" --work-item <the-wi-id>
+# task 'add-hello-world' spawned
+#   my-project: .worktrees/add-hello-world/my-project  (branch feat/add-hello-world)
+```
+
+A **task** is the execution unit: mship creates a git **worktree** per affected
+repo, all on a shared feature branch, isolated from `main`. Move into it:
+
+```bash
+cd $(mship status | jq -r '.resolved_task.worktrees | to_entries[0].value')
+```
+
+## Do the work
+
+Edit files normally inside the worktree, then commit:
+
+```bash
+echo 'print("hello")' > hello.py
+git add hello.py && git commit -m "feat: hello world"
+```
+
+While a task is active, mship's guards refuse commits and (for Claude Code
+sessions) edits to the repo's *main checkout* — parallel tasks can't collide,
+and nothing lands on `main` by accident.
+
+## Test
+
+```bash
+mship test
+# my-project: pass (12 passed)  — diff vs previous run: no regressions
+```
+
+With several repos, `mship test` runs them in **dependency order** — schemas
+before the services that consume them — and reports per-repo results.
+
+## Finish
+
+```bash
+mship finish --body-file - <<'EOF'
+## Summary
+First mship task.
+## Test plan
+- [x] Runs locally.
+EOF
+# my-project: PR opened https://github.com/you/my-project/pull/1
+```
+
+`finish` pushes the branch and opens the PR (PRs, plural, in dependency order
+for multi-repo tasks). It also runs the gates: the work item must exist, and
+for feature items an approved spec and plan (details:
+[Concepts](concepts.md#the-three-gates)).
+
+## Merge, then close
+
+Merge the PR however you normally do (web UI or `gh pr merge`). Then:
+
+```bash
+mship close
+# Closed: completed (1 prs merged): add-hello-world
+```
+
+`close` verifies the PR state, tears down the worktrees, and clears the task
+from `.mothership/state.yaml`. The loop is complete.
+
+## Where next
+
+- **[Ship a feature](guides/ship-a-feature.md)** — the spec-first loop for work
+  that deserves a design.
+- **[Fix a bug](guides/fix-a-bug.md)** — the shortest safe path to a merged fix.
+- **[Multi-repo tasks](guides/multi-repo-tasks.md)** — one change across several
+  repos, PRs that land coherently.
+- **[Run & observe](guides/run-and-observe.md)** — bring the stack up and see
+  what's real.
+- **[Phone control](guides/phone-control.md)** — approve specs and merge PRs
+  from your phone.
+- **[Agent-driven development](guides/agent-driven-development.md)** — let an AI
+  agent do the building, safely.

--- a/docs/guides/agent-driven-development.md
+++ b/docs/guides/agent-driven-development.md
@@ -1,0 +1,63 @@
+# Agent-driven development
+
+**When you need this:** an AI coding agent does the building, and you want it
+operating safely inside the workspace instead of improvising with raw git.
+
+## Install the skills
+
+```bash
+mship skill install
+```
+
+This installs the mship skill bundle for Claude Code, including
+**`working-with-mothership`** — the canonical operating guide an agent loads
+when it works in an mship workspace: how to resolve the active task, when to
+journal, how phases and gates behave, how to finish.
+
+## What the guardrails give you
+
+An agent in an mship workspace can't rationalize its way into the classic
+failure modes, because the boundaries are enforced, not suggested
+([Concepts](../concepts.md#the-three-gates)):
+
+- **It can't edit or commit to `main`** while a task is active — the pre-commit
+  hook and the editor guard refuse, pointing at the task's worktree instead.
+- **It can't ship undesigned features** — `phase dev` and `finish` check the
+  work item, the approved spec, and the plan for feature work.
+- **It can't lose the thread** — `mship status` / `mship context` give it
+  structured state instead of shell archaeology, and the journal records what
+  happened for the next session.
+
+## Orchestrator + subagents
+
+The pattern that scales: one **orchestrator** session owns the task — spec,
+plan, integration, `mship finish` — and dispatches fresh **subagents** to
+implement one plan task each:
+
+```bash
+mship dispatch --task <slug> --plan-task 3
+```
+
+This prints a self-contained prompt: which worktree to `cd` into, the branch
+state, recent journal lines, and exactly one plan task — so the subagent needs
+no inherited context. Between subagents, the orchestrator reviews (spec
+compliance first, code quality second) before dispatching the next.
+
+Two rules of thumb:
+
+- **Keep mship-state writes serial.** Parallel subagents editing code in
+  different worktrees is fine; parallel writes to task state (journal, test,
+  finish) race.
+- **Commit early, journal always.** `mship journal "<what happened>"` after
+  each meaningful step is what lets any future session — human or agent —
+  reconstruct the work without replaying it.
+
+## Sharing state with another session
+
+```bash
+mship export            # bundle the task: journal, plan, spec, diffs
+mship export --redacted # same, with opt-in secret redaction
+```
+
+Hand the bundle to a reviewer, a teammate, or another agent — everything needed
+to evaluate or continue the task, in one artifact.

--- a/docs/guides/fix-a-bug.md
+++ b/docs/guides/fix-a-bug.md
@@ -1,0 +1,49 @@
+# Fix a bug
+
+**When you need this:** something's broken and you want the shortest safe path
+to a merged fix.
+
+## The fast path
+
+Bugs and chores skip the design gates — no spec, no plan, just an isolated
+worktree and a PR:
+
+```bash
+mship item new "500 on empty search" --kind bug
+mship spawn "fix empty search 500" --work-item <wi-id>
+cd $(mship status | jq -r '.resolved_task.worktrees | to_entries[0].value')
+
+# reproduce, fix, commit
+mship test
+mship finish
+```
+
+That's the whole loop. The work item takes seconds and keeps the fix findable
+later (what was broken, which task fixed it, which PR shipped it).
+
+## Emergencies
+
+If even `item new` is too much ceremony right now:
+
+```bash
+mship spawn "hotfix prod 500" --hotfix
+```
+
+`--hotfix` bypasses the work-item requirement for this task (and
+`mship finish --hotfix` does the same at finish time). Bypasses aren't silent —
+each one is recorded to `.mothership/bypass-log.jsonl`, so the escape hatch
+leaves a trail.
+
+## What stays enforced
+
+The fast path skips *design* gates, not safety:
+
+- **Worktree isolation** — the fix still happens on a feature branch in its own
+  worktree, never directly on `main`.
+- **The edit guard** — commits (and agent edits) to a repo's main checkout are
+  still refused while a task is active.
+- **Test visibility** — `mship finish` still surfaces failing tests in any
+  affected repo before you ship.
+
+If the "bug fix" starts growing a design (new behavior, new surface area),
+promote it: create a spec and follow [Ship a feature](ship-a-feature.md).

--- a/docs/guides/multi-repo-tasks.md
+++ b/docs/guides/multi-repo-tasks.md
@@ -1,0 +1,65 @@
+# Multi-repo tasks
+
+**When you need this:** one change spans several repos — a schema, the services
+that consume it, the client — and the PRs have to land coherently.
+
+This is the problem mship was built for: the task, not the repo, is the unit of
+work.
+
+## One task, many worktrees
+
+```bash
+mship spawn "propagate user schema v2" --work-item <wi-id> \
+  --repos schemas,svc-users,svc-billing,api,api-client
+```
+
+One worktree per repo, all on a shared feature branch
+(`feat/propagate-user-schema-v2`). The task tracks which files across which
+repos belong to it; `main` stays untouched everywhere.
+
+## Moving between repos
+
+```bash
+mship switch svc-users
+```
+
+`switch` changes the active repo within the task and prints an orientation
+handoff — where you are, the branch state, what changed recently — so you (or
+an agent picking up mid-task) don't lose the thread.
+
+## Testing in dependency order
+
+```bash
+mship test
+# schemas:      pass
+# svc-users:    pass
+# svc-billing:  FAIL (2 failed)  ← the contract break, caught before any PR
+# api:          skipped (upstream failed)
+```
+
+Dependency order comes from `mothership.yaml` (see
+[Configuration](../configuration.md)): upstream repos test first, so a break in
+a consumer is attributed to the change that caused it. Each run also diffs
+against the previous iteration — fixes, regressions, and new passes are called
+out.
+
+## Task-to-task dependencies
+
+Independent tasks can depend on each other, too:
+
+```bash
+mship spawn "client codegen" --work-item <wi-id> --depends-on propagate-user-schema-v2
+mship depends list                 # see the edges
+mship finish --bypass-deps         # ship a downstream anyway, explicitly
+```
+
+## Finishing: PRs that land coherently
+
+```bash
+mship finish
+```
+
+PRs open in dependency order, each body carrying a coordination block that
+links the others — reviewers see the whole change, not five disconnected
+diffs. Before finishing, `mship audit` reports per-repo drift (uncommitted
+files, unexpected branch state) so nothing ships half-tracked.

--- a/docs/guides/phone-control.md
+++ b/docs/guides/phone-control.md
@@ -1,0 +1,56 @@
+# Phone control
+
+**When you need this:** you want to steer the work — approve specs, answer an
+agent's questions, review and merge PRs — away from your desk.
+
+mship's phone app is **Ground Control** (Android). The workspace side is just
+`mship serve`; everything below rides on it.
+
+## 1. Start serve
+
+```bash
+mship serve            # reachable on your LAN / tailnet
+mship serve --relay    # reachable from anywhere, via a reverse tunnel
+```
+
+`--relay` dials out to a relay host and gets a stable per-device URL, so NAT
+and coffee-shop Wi-Fi don't matter. You can use a self-hosted relay
+([Relay hosting](../relay-hosting.md)); serving over a tailnet works too
+([Serve over Tailscale](../mship-serve-tailscale.md)).
+
+## 2. Pair the phone
+
+```bash
+mship pair
+```
+
+Prints a `groundcontrol://` deep link and a QR code carrying the serve URL and
+token. Scan it in Ground Control and the workspace appears in the app. Repeat
+per workspace — the app is multi-workspace.
+
+## 3. What you can do from the phone
+
+- **Capture ideas.** A thought typed on the phone becomes a thread the agent
+  can brainstorm with you and shape into a spec — capture is a conversation,
+  not a one-shot form.
+- **Review and approve specs.** Specs in `needs_review` surface in the
+  **Queue** as swipeable cards: acceptance criteria, open questions, verdicts.
+  Approve, or request changes with a reason — approval is what unlocks feature
+  development ([Ship a feature](ship-a-feature.md)).
+- **Answer decisions.** When the agent hits a fork it can't resolve alone, it
+  posts a **decision card** — a question with tappable options. One tap
+  unblocks the build.
+- **Chat with the agent.** Every work item has its threads; messages are
+  durable, so the agent answers when it wakes even if it wasn't running when
+  you wrote.
+- **Watch progress.** Work items show their phase (inbox → shaping → ready →
+  in flight → review → done) as the linked spec, tasks, and PRs advance.
+- **Review and merge PRs.** Merged PRs flow back as events — the agent sees the
+  merge and closes out the task.
+
+## 4. How the agent hears you
+
+Messages land in a durable mailbox on the workspace. A running agent listens
+between turns (`mship inbox wait`) and drains the inbox at each turn boundary,
+then answers with `mship reply` or posts options with `mship ask`. Nothing is
+lost if either side is offline — it's store-and-forward, not a live socket.

--- a/docs/guides/run-and-observe.md
+++ b/docs/guides/run-and-observe.md
@@ -1,0 +1,67 @@
+# Run & observe
+
+**When you need this:** you (or your agent) need the system actually running to
+see a change work — not just unit tests passing.
+
+## Bring the stack up
+
+```bash
+mship run
+```
+
+`run` starts the task's services in **dependency order**, waiting on each
+repo's healthcheck before starting its dependents — `tcp`, `http`, `sleep`, or
+a custom task, declared per repo in `mothership.yaml`
+([Configuration](../configuration.md)). Long-running services
+(`start_mode: background`) stay alive so you can interact with them.
+
+Ports and URLs are **task-scoped**: two tasks running in parallel don't fight
+over `localhost:3000`. Filter to part of the stack with `--repos`:
+
+```bash
+mship run --repos api,svc-users
+```
+
+## Build artifacts
+
+```bash
+mship build
+```
+
+Same dependency ordering, running each repo's `build` target — schemas generate
+before the services that import them compile.
+
+## See what's real
+
+The observation commands answer questions agents otherwise guess at:
+
+```bash
+mship status      # active task, phase, branch, per-repo test results, drift
+mship context     # full JSON snapshot of workspace state (built for agents)
+mship journal     # the task's log: what was done, when, why
+mship graph       # the repo dependency graph
+mship worktrees   # every active worktree, grouped by task
+```
+
+All of these emit JSON when stdout isn't a TTY (or with `mship --json …`), so
+an agent gets structured answers — which log belongs to which service, which
+URL to hit, which test command runs where — without `find`/`ps`/`lsof`
+archaeology.
+
+## Capturing what's on screen
+
+For UI repos, `mship capture` drives the repo's capture target (simulator
+screenshots, layout dumps) and files artifacts under
+`.mothership/captures/<task>/`.
+
+## Running on another machine
+
+A run target that needs hardware you don't have (an iOS simulator on a Mac, an
+Android box, a beefier builder) can execute on a **run host**:
+
+```bash
+mship run --remote=ios-sim-host
+```
+
+Same commands, same env contract, output streamed back live. Setup and
+troubleshooting: [Remote run](../remote-run.md).

--- a/docs/guides/ship-a-feature.md
+++ b/docs/guides/ship-a-feature.md
@@ -1,0 +1,105 @@
+# Ship a feature
+
+**When you need this:** you're building something new that deserves a design —
+you want the *what and why* agreed before code exists.
+
+## The loop at a glance
+
+```
+work item (feature) → spec → review + approve → plan → build → finish
+```
+
+Feature work items pass through mship's design gates before development; the
+[Concepts page](../concepts.md#the-lifecycle) has the full lifecycle diagram.
+Bugs and chores skip the design gates — that faster loop is
+[Fix a bug](fix-a-bug.md).
+
+## 1. Create the work item
+
+```bash
+mship item new "Search across projects" --kind feature
+# wi-. . . created
+```
+
+## 2. Write the spec
+
+A **spec** is the approved design: problem, user story, approach, acceptance
+criteria. It lives at `specs/<date>-<id>.md` in the workspace.
+
+```bash
+mship spec new --title "Search across projects" --id search-across-projects
+mship spec draft search-across-projects
+```
+
+`spec draft` prints a drafting prompt — run it through your agent (or fill the
+JSON yourself), then apply the result:
+
+```bash
+cat draft.json | mship spec apply search-across-projects --from-json -
+# status: needs_review
+```
+
+Link it to the work item if it isn't already:
+
+```bash
+mship item link-spec <wi-id> search-across-projects
+```
+
+## 3. Review and approve
+
+```bash
+mship spec review search-across-projects    # criteria + open questions, one unit at a time
+mship spec approve search-across-projects   # gate: all criteria approved, all questions answered
+```
+
+Prefer the phone? Specs in `needs_review` surface in Ground Control's Queue for
+one-tap approval — see [Phone control](phone-control.md). To send one back:
+`mship spec request-changes <id> --reason "..."`.
+
+## 4. Plan
+
+Features need an implementation plan before development — a bite-sized,
+TDD-oriented breakdown at `<docs_dir>/plans/<date>-<slug>.md`, with each task
+wrapped in `mship:task` anchors so it can be handed to an agent one task at a
+time. The `writing-plans` skill (installed via `mship skill install`) is the
+canonical way to produce one. Link it:
+
+```bash
+mship item link-plan <wi-id> docs/plans/2026-07-25-search-across-projects.md
+```
+
+## 5. Build
+
+Two equivalent entry points:
+
+```bash
+mship spec dispatch search-across-projects   # binds the approved spec to a new task + emits a handoff
+# or
+mship spawn "search across projects" --work-item <wi-id>
+```
+
+Then move the task into development:
+
+```bash
+mship phase dev
+```
+
+`phase dev` is where the three gates fire: the task must belong to a work item,
+a feature's spec must be approved, and its plan must exist. If a gate blocks
+you, it says exactly which link is missing
+([Concepts → the three gates](../concepts.md#the-three-gates)).
+
+Build inside the task's worktrees as usual — edit, `mship test`,
+`mship journal` as you go. Working with an agent?
+[Agent-driven development](agent-driven-development.md) covers dispatching plan
+tasks to subagents.
+
+## 6. Finish
+
+```bash
+mship finish
+```
+
+The same gates run at finish. The PR body carries the spec's acceptance
+criteria, so reviewers see what the change promises. After the merge:
+`mship close`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,36 +1,51 @@
 # mship
 
-A structured interface between AI coding agents and a running multi-repo system.
+A structured interface between AI coding agents and a running multi-repo
+system. mship owns the coordination an agent is bad at — isolated worktrees per
+task, dependency-ordered tests and PRs across repos, a running stack with
+healthchecks — and exposes it all as structured state instead of shell
+guesswork. You (or your phone) steer; the agent builds; nothing lands on `main`
+by accident.
 
 > Pre-1.0. API may change. Pin a commit if you need stability.
 
-mship coordinates feature work that spans multiple repos: phase-based workflow,
-per-task worktrees, dependency-ordered execution, healthchecks, and a phone
-inbox for operator ↔ agent messaging.
+## Start here
 
-## Where to start
-
-- **[Concepts](concepts.md)** — the mental model: workspaces, work items, tasks, phases.
-- **[Configuration](configuration.md)** — `mothership.yaml` reference.
-- **[CLI reference](cli.md)** — every `mship` command.
-
-## Remote access
-
-- **[Serve over Tailscale](mship-serve-tailscale.md)** — expose `mship serve` on your tailnet.
-- **[Relay hosting](relay-hosting.md)** — self-hosted sish relay with per-device subdomains.
-- **[Remote run](remote-run.md)** — trigger runs from anywhere.
-
-## Cloud workers
-
-- **[Unattended cloud runner](unattended-cloud-runner.md)** — the end-to-end runbook: setup, per-run lifecycle, security guarantees. Start here.
-- **[Attach-at-relay egress proxy](cloud-worker-auth-spine.md)** — the no-credential-on-worker auth model.
-- **[The /gh-token broker](cloud-agent-auth.md)** — the simpler trusted-session auth model + GitHub App setup.
-- **[Pull-API runner](adapters/claude-routine-runner.md)** — backlog-draining via a scheduled Claude routine.
-
-## Install
+**[Getting started](getting-started.md)** — install, create a workspace, and
+take one task from spawn to a merged PR. Ten minutes, the whole loop.
 
 ```bash
 uv tool install git+https://github.com/atomikpanda/mothership.git
 ```
 
-See the [repository README](https://github.com/atomikpanda/mothership#readme) for the full quickstart.
+## Guides, by goal
+
+- **[Ship a feature](guides/ship-a-feature.md)** — the spec-first loop: design
+  agreed, plan written, gates enforced.
+- **[Fix a bug](guides/fix-a-bug.md)** — the shortest safe path to a merged
+  fix (and the `--hotfix` escape hatch).
+- **[Multi-repo tasks](guides/multi-repo-tasks.md)** — one change across
+  several repos, PRs that land coherently.
+- **[Run & observe](guides/run-and-observe.md)** — bring the stack up with
+  healthchecks; see what's real instead of guessing.
+- **[Phone control](guides/phone-control.md)** — approve specs, answer
+  decisions, and merge PRs from Ground Control.
+- **[Agent-driven development](guides/agent-driven-development.md)** — skills,
+  guardrails, and the orchestrator/subagent pattern.
+
+## Understand it
+
+**[Concepts](concepts.md)** — the object model (WorkItem, Spec, Plan, Task,
+worktrees), the lifecycle, and the three gates, with diagrams.
+
+## Reference
+
+- **[CLI reference](cli.md)** — every `mship` command.
+- **[Configuration](configuration.md)** — the `mothership.yaml` reference.
+
+## Advanced
+
+- **Remote access** — [serve over Tailscale](mship-serve-tailscale.md),
+  [self-hosted relay](relay-hosting.md), [remote run hosts](remote-run.md).
+- **Cloud workers** — the [unattended cloud runner](unattended-cloud-runner.md)
+  runbook and its auth models.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,10 +35,19 @@ exclude_docs: |
   superpowers/
 
 nav:
-  - Getting started: index.md
+  - Home: index.md
+  - Getting started: getting-started.md
+  - Guides:
+      - Ship a feature: guides/ship-a-feature.md
+      - Fix a bug: guides/fix-a-bug.md
+      - Multi-repo tasks: guides/multi-repo-tasks.md
+      - Run & observe: guides/run-and-observe.md
+      - Phone control: guides/phone-control.md
+      - Agent-driven development: guides/agent-driven-development.md
   - Concepts: concepts.md
-  - Configuration: configuration.md
-  - CLI reference: cli.md
+  - Reference:
+      - CLI reference: cli.md
+      - Configuration: configuration.md
   - Remote access:
       - Serve over Tailscale: mship-serve-tailscale.md
       - Relay hosting: relay-hosting.md


### PR DESCRIPTION
## Summary

Adds the user-journey layer to the docs site — the "how do I actually use this" documentation the site lacked. New pages only; existing reference/internals pages are untouched except for nav position. Every featured command was verified against the current CLI (`--help`) before being written down.

- **`docs/getting-started.md`** — install → init → work item → spawn → edit → test → finish → merge → close, with expected output excerpts at each step and links into concepts for the "why".
- **`docs/guides/`** — six task-oriented how-tos, each opening with a "When you need this" line: ship-a-feature (the spec-first loop end to end), fix-a-bug (the fast path, `--hotfix`, and what stays enforced), multi-repo-tasks (spawn `--repos`, switch, dependency-ordered test/finish, depends), run-and-observe (run/build/capture, healthchecks, task-scoped state, `--remote` pointer), phone-control (serve/pair, Ground Control's stable flows), agent-driven-development (skills, guardrails, orchestrator/subagent pattern, journal discipline).
- **`docs/index.md`** — rewritten journey-first: what mship is in one paragraph, Start here → tutorial, guides by goal, then Concepts / Reference / Advanced.
- **`mkdocs.yml`** — nav restructured to Home / Getting started / Guides / Concepts / Reference / Remote access / Cloud workers; every pre-existing page remains reachable.

## Test plan

- `uv run --only-group docs mkdocs build --strict` → exit 0 (all cross-links resolve).
- Six guide files, all six carry the when-you-need-this opener (grep-verified); search index contains guide content.
- No internals in new pages: grep for module paths / enforcer / trust-model language across the new pages is clean.
- `mship test --repos mothership` → pass, exit 0 (docs-only).
- Post-merge: the docs workflow deploys the updated site automatically.

https://claude.ai/code/session_014KE6RJkqUvU8eiAJNPgHLL