### PR TITLE
fix mkdocs mermaid rendering

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,11 @@ markdown_extensions:
   - toc:
       permalink: true
   - pymdownx.highlight
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 
 exclude_docs: |
   plans/


### PR DESCRIPTION
## Summary

The mermaid diagrams in `concepts.md` rendered as plain code blocks on the docs site — `pymdownx.superfences` was enabled without the mermaid custom fence. Adds the standard Material configuration:

```yaml
- pymdownx.superfences:
    custom_fences:
      - name: mermaid
        class: mermaid
        format: !!python/name:pymdownx.superfences.fence_code_format
```

Verified in the built output: both concepts diagrams now emit `class="mermaid"` elements, and Material's bundle lazy-loads mermaid@11 to render them.

## Test plan

- `mkdocs build --strict` → exit 0.
- `grep -c 'class="mermaid"' site/concepts/index.html` → 2 (both diagrams).
- `mship test --repos mothership` → pass.
- Post-merge: confirm the lifecycle/object-model diagrams render on https://atomikpanda.github.io/mothership/concepts/.

https://claude.ai/code/session_014KE6RJkqUvU8eiAJNPgHLL