### PR TITLE
Connectivity topology + diagnosis layer

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,7 +113,8 @@ mship view status|journal|diff|spec [--watch]
 mship view spec --web                               # serve rendered spec on localhost
 mship graph
 mship worktrees
-mship doctor
+mship doctor [--no-network]                         # workspace health; --no-network skips connectivity probes
+mship net status [--no-network]                     # connectivity topology: serve, relay, run hosts, gh auth, egress
 ```
 
 ## Maintenance

--- a/docs/remote-run.md
+++ b/docs/remote-run.md
@@ -102,15 +102,31 @@ These are deliberately out of scope for the first cut. Know them before you lean
 
 ## Troubleshooting
 
-| Symptom | Meaning | Fix |
-|---|---|---|
-| `unknown run-host role '<role>'; not declared in this workspace's \`run_hosts:\` list` | You passed `--remote=<role>` (or a repo declared `run_host: <role>`) but that name isn't in `mothership.yaml`'s `run_hosts:` list — likely a typo. | Add the role to `run_hosts:` in `mothership.yaml`, or fix the typo. |
-| `ambiguous run-host: multiple roles are configured (...) and none was specified` | Bare `--remote` with 2+ roles in `run_hosts:` and no repo-declared default. | Pass `--remote=<role>` explicitly, or declare `run_host: <role>` on the repo. |
-| `run-host role '<role>' is declared but has no connection mapped on this machine; run \`mship run-host add <role>\`` | The role exists in `mothership.yaml`, but *this* machine never mapped it to a `{url, token}`. | `mship run-host add <role> --pair-link '...'` (get the link by running `mship pair` on the remote). |
-| `remote host at <url> is unreachable via relay (...)` | Couldn't even connect — the remote isn't running `mship serve --relay`, the relay is down, or the pairing is stale. | Confirm the remote is up and `mship serve --relay` is running there; re-pair if the relay subdomain changed. |
-| `remote workspace not bootstrapped at <url> (503)` | The remote's `mship serve --relay` is reachable, but that machine has no workspace config wired in (no `mothership.yaml`, or serve was started without one). | Bootstrap that machine as an mship workspace and restart `mship serve --relay` there. |
-| `remote host at <url> rejected the bearer token (401)` | The mapped token is wrong or was rotated on the remote. | Re-run `mship run-host add <role>` with a fresh pair link/token. |
-| `error: unknown repo(s) ...; known repos: ...` (streamed, then a non-zero exit) | The remote's own `mothership.yaml` doesn't have a repo of that name — usually a workspace mismatch between your box and the remote. | Confirm both workspaces declare the same repo names, or pass `--repos` naming a repo the remote actually has. |
-| A repo's task lines print, then `error: branch-materialize failed for repo '<repo>': ...` (then a non-zero exit) | The remote's `git fetch`/`git worktree add` for that repo's task branch failed — commonly the branch not pushed yet, or a dirty/locked worktree on the remote. | Push the task's branch, or clear the stuck worktree on the remote (`git worktree remove`/`prune`), then retry. |
-| Remote task's own output ends with a non-zero `__MSHIP_EXIT__ <code>` | The task itself failed on the remote — same as a local failure. The streamed output above the exit line is the task's real stdout/stderr. | Read the streamed output like any other failing `run`/`build`/`capture`. |
-| `--remote requires a resolvable task: ...` / `--remote requires an active task: ...` | You ran `--remote` with no active/resolvable task. Remote execution always needs a branch to check out. | Pass `--task <slug>`, or run from inside an active task's worktree. |
+Start with `mship net status`. It reports every connectivity edge on this machine
+— serve, relay, each run-host role, the GitHub auth model in effect, and whether
+git is routed through a relay egress — with a status code and the fix for each
+unhealthy one. `mship doctor` reports the same checks inline as a
+`connectivity/*` group, and `GET /net/topology` on serve returns the same JSON.
+
+```bash
+mship net status               # human topology view
+mship net status --json        # the same structure, for scripts
+mship net status --no-network  # configured state only, no probes
+```
+
+The table below is the reference for what each code means. The first six rows are
+states `mship net status` detects for you; the rest surface only while a remote
+task is running.
+
+| Symptom | Code | Meaning | Fix |
+|---|---|---|---|
+| `unknown run-host role '<role>'; not declared in this workspace's \`run_hosts:\` list` | `run_host_unknown_role` | You passed `--remote=<role>` (or a repo declared `run_host: <role>`) but that name isn't in `mothership.yaml`'s `run_hosts:` list — likely a typo. | Add the role to `run_hosts:` in `mothership.yaml`, or fix the typo. |
+| `ambiguous run-host: multiple roles are configured (...) and none was specified` | `run_hosts_ambiguous_default` | Bare `--remote` with 2+ roles in `run_hosts:` and no repo-declared default. | Pass `--remote=<role>` explicitly, or declare `run_host: <role>` on the repo. |
+| `run-host role '<role>' is declared but has no connection mapped on this machine; run \`mship run-host add <role>\`` | `run_host_unmapped` | The role exists in `mothership.yaml`, but *this* machine never mapped it to a `{url, token}`. | `mship run-host add <role> --pair-link '...'` (get the link by running `mship pair` on the remote). |
+| `remote host at <url> is unreachable via relay (...)` | `run_host_unreachable` | Couldn't even connect — the remote isn't running `mship serve --relay`, the relay is down, or the pairing is stale. | Confirm the remote is up and `mship serve --relay` is running there; re-pair if the relay subdomain changed. |
+| `remote workspace not bootstrapped at <url> (503)` | `run_host_not_bootstrapped` | The remote's `mship serve --relay` is reachable, but that machine has no workspace config wired in (no `mothership.yaml`, or serve was started without one). | Bootstrap that machine as an mship workspace and restart `mship serve --relay` there. |
+| `remote host at <url> rejected the bearer token (401)` | `run_host_stale_token` | The mapped token is wrong or was rotated on the remote. | Re-run `mship run-host add <role>` with a fresh pair link/token. |
+| `error: unknown repo(s) ...; known repos: ...` (streamed, then a non-zero exit) | — | The remote's own `mothership.yaml` doesn't have a repo of that name — usually a workspace mismatch between your box and the remote. | Confirm both workspaces declare the same repo names, or pass `--repos` naming a repo the remote actually has. |
+| A repo's task lines print, then `error: branch-materialize failed for repo '<repo>': ...` (then a non-zero exit) | — | The remote's `git fetch`/`git worktree add` for that repo's task branch failed — commonly the branch not pushed yet, or a dirty/locked worktree on the remote. | Push the task's branch, or clear the stuck worktree on the remote (`git worktree remove`/`prune`), then retry. |
+| Remote task's own output ends with a non-zero `__MSHIP_EXIT__ <code>` | — | The task itself failed on the remote — same as a local failure. The streamed output above the exit line is the task's real stdout/stderr. | Read the streamed output like any other failing `run`/`build`/`capture`. |
+| `--remote requires a resolvable task: ...` / `--remote requires an active task: ...` | — | You ran `--remote` with no active/resolvable task. Remote execution always needs a branch to check out. | Pass `--task <slug>`, or run from inside an active task's worktree. |

--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -128,6 +128,7 @@ from mship.cli import internal as _internal_mod
 from mship.cli import layout as _layout_mod
 from mship.cli import log as _log_mod
 from mship.cli import message as _message_mod
+from mship.cli import net as _net_mod
 from mship.cli import pair as _pair_mod
 from mship.cli import phase as _phase_mod
 from mship.cli import pr as _pr_mod
@@ -196,6 +197,7 @@ _phase_mod.register(app, get_container)
 _pr_mod.register(app, get_container)
 _prune_mod.register(app, get_container)
 _reconcile_mod.register(app, get_container)
+_net_mod.register(app, get_container)
 _relay_mod.register(app, get_container)
 _run_host_mod.register(app, get_container)
 _skill_mod.register(app, get_container)

--- a/src/mship/cli/doctor.py
+++ b/src/mship/cli/doctor.py
@@ -5,7 +5,12 @@ from mship.cli.output import Output
 
 def register(app: typer.Typer, get_container):
     @app.command(rich_help_panel="Inspection")
-    def doctor():
+    def doctor(
+        no_network: bool = typer.Option(
+            False, "--no-network",
+            help="Skip connectivity network probes (faster; config-level checks only).",
+        ),
+    ):
         """Check workspace health and configuration."""
         container = get_container()
         output = Output()
@@ -38,6 +43,7 @@ def register(app: typer.Typer, get_container):
             workspace_root=container.config_path().parent,
             config_path=config_path,
             config_source=config_source,
+            probe_network=not no_network,
         )
         report = checker.run()
 

--- a/src/mship/cli/net.py
+++ b/src/mship/cli/net.py
@@ -1,0 +1,69 @@
+"""`mship net` — report this machine's connectivity topology.
+
+A thin caller over `mship.core.topology.probe_topology`: the same structure the
+`doctor` connectivity group and `GET /net/topology` report, rendered for a
+terminal. Exits 0 even when every edge is broken — this command has to work
+precisely when connectivity does not.
+"""
+from __future__ import annotations
+
+import typer
+
+from mship.cli.output import Output
+
+_ICON = {"ok": "[green]OK[/green]", "warn": "[yellow]WARN[/yellow]",
+         "fail": "[red]FAIL[/red]", "absent": "[dim]--[/dim]"}
+
+
+def register(parent: typer.Typer, get_container):
+    net_app = typer.Typer(
+        name="net",
+        help="Inspect connectivity: serve, relay, run hosts, GitHub auth, egress.",
+        no_args_is_help=True,
+    )
+
+    @net_app.command("status")
+    def status(
+        no_network: bool = typer.Option(
+            False, "--no-network",
+            help="Skip network probes; report configured state only.",
+        ),
+    ):
+        """Show this machine's connectivity topology and per-edge health."""
+        from mship.core import topology as topo
+        from mship.core.config import ConfigLoader
+
+        out = Output()
+        container = get_container()
+        # require_paths=False so a half-configured workspace still reports its
+        # connectivity — the same reason `doctor` loads this way.
+        config = ConfigLoader.load(container.config_path(), require_paths=False)
+
+        result = topo.probe_topology(
+            config=config,
+            state_dir=container.state_dir(),
+            workspace_root=container.config_path().parent,
+            skip_network=no_network,
+        )
+
+        if out.json_mode:
+            out.json(topo.topology_payload(result))
+            return
+
+        out.print(f"[bold]Workspace:[/bold] {result.workspace}   "
+                  f"[dim]probed {result.probed_at}[/dim]\n")
+        out.table(
+            title="Connectivity",
+            columns=["", "Edge", "State", "Detail"],
+            rows=[
+                [_ICON.get(e.status, e.status), e.name, e.code, e.detail]
+                for e in result.edges
+            ],
+        )
+        fixes = [e for e in result.edges if e.fix and e.status in ("warn", "fail")]
+        if fixes:
+            out.print("\n[bold]Next steps:[/bold]")
+            for e in fixes:
+                out.print(f"  [yellow]{e.name}[/yellow]: {e.fix}")
+
+    parent.add_typer(net_app)

--- a/src/mship/cli/net.py
+++ b/src/mship/cli/net.py
@@ -66,4 +66,5 @@ def register(parent: typer.Typer, get_container):
             for e in fixes:
                 out.print(f"  [yellow]{e.name}[/yellow]: {e.fix}")
 
-    parent.add_typer(net_app)
+    # "Inspection" alongside `doctor`/`status`: this reports, it never mutates.
+    parent.add_typer(net_app, rich_help_panel="Inspection")

--- a/src/mship/core/doctor.py
+++ b/src/mship/core/doctor.py
@@ -121,6 +121,7 @@ class DoctorChecker:
         workspace_root: Path | None = None,
         config_path: Path | None = None,
         config_source: str | None = None,
+        probe_network: bool = True,
     ) -> None:
         self._config = config
         self._shell = shell
@@ -128,6 +129,7 @@ class DoctorChecker:
         self._workspace_root = workspace_root
         self._config_path = config_path
         self._config_source = config_source
+        self._probe_network = probe_network
 
     def run(self) -> DoctorReport:
         report = DoctorReport()
@@ -378,7 +380,49 @@ class DoctorChecker:
         if ws is not None and ws.is_dir():
             report.checks.extend(self._check_bundler_exclusions(ws))
 
+        # Connectivity group — sourced from the SINGLE topology implementation
+        # (`mship.core.topology.probe_topology`), the same one `mship net status`
+        # and `GET /net/topology` use. No probe logic lives here.
+        report.checks.extend(self._connectivity_checks())
+
         return report
+
+    #: topology edge status -> doctor check status. `absent` means "not
+    #: configured on this machine", which is not a problem to report.
+    _CONNECTIVITY_STATUS = {
+        "ok": "pass", "warn": "warn", "fail": "fail", "absent": "pass",
+    }
+
+    def _connectivity_checks(self) -> list[CheckResult]:
+        if self._state_dir is None or self._workspace_root is None:
+            return []
+        from mship.core import topology as topo
+
+        try:
+            result = topo.probe_topology(
+                config=self._config,
+                state_dir=self._state_dir,
+                workspace_root=self._workspace_root,
+                shell=self._shell,
+                skip_network=not self._probe_network,
+            )
+        except Exception as exc:
+            # probe_topology promises never to raise; don't let a bug there take
+            # down the checks that already ran.
+            return [CheckResult(
+                name="connectivity", status="warn",
+                message=f"connectivity probe failed: {exc}",
+            )]
+
+        checks: list[CheckResult] = []
+        for edge in result.edges:
+            message = edge.detail if edge.fix is None else f"{edge.detail} — {edge.fix}"
+            checks.append(CheckResult(
+                name=f"connectivity/{edge.name}",
+                status=self._CONNECTIVITY_STATUS.get(edge.status, "warn"),
+                message=message,
+            ))
+        return checks
 
     def _check_bundler_exclusions(self, ws: Path) -> list[CheckResult]:
         """WARN when a known asset-bundling config at the workspace root does not

--- a/src/mship/core/gh_auth.py
+++ b/src/mship/core/gh_auth.py
@@ -194,3 +194,44 @@ def get_default_branch_via_httpx(
             f"GitHub repo response for {owner}/{repo} had no default_branch"
         )
     return branch
+
+
+#: Auth models in precedence order, most specific first. Mirrors the token
+#: precedence documented on `resolve_token` (explicit > GH_TOKEN > GITHUB_TOKEN
+#: > broker), with relay-attach ahead of them all (a worker routed through the
+#: relay egress never holds a token of its own) and an App-backed serve ahead of
+#: the broker leg it implements.
+#:
+#: NOTE: `core.gh_preflight.run_preflight` branches on the same precedence for
+#: its STRICT, network-verifying check. That duplication is pre-existing and
+#: deliberately left alone here — this function is the *reporting* owner and must
+#: never raise or touch the network.
+GH_AUTH_MODELS = ("relay_attach", "app", "env_token", "broker", "none")
+
+
+def classify_gh_auth(
+    *,
+    app_configured: bool,
+    relay_url: str | None,
+    run_token: str | None,
+    explicit_token: str | None,
+    broker_url: str | None,
+) -> str:
+    """Which GitHub auth model is in effect, by name (one of GH_AUTH_MODELS).
+
+    Pure: no network, no environment reads (the caller supplies the values so
+    the same function serves a report, a test, and a future dry-run). Blank
+    strings count as absent.
+    """
+    def present(value: str | None) -> bool:
+        return bool(value and value.strip())
+
+    if present(relay_url) and present(run_token):
+        return "relay_attach"
+    if app_configured:
+        return "app"
+    if present(explicit_token):
+        return "env_token"
+    if present(broker_url):
+        return "broker"
+    return "none"

--- a/src/mship/core/gh_auth.py
+++ b/src/mship/core/gh_auth.py
@@ -196,22 +196,28 @@ def get_default_branch_via_httpx(
     return branch
 
 
-#: Auth models in precedence order, most specific first. Mirrors the token
-#: precedence documented on `resolve_token` (explicit > GH_TOKEN > GITHUB_TOKEN
-#: > broker), with relay-attach ahead of them all (a worker routed through the
-#: relay egress never holds a token of its own) and an App-backed serve ahead of
-#: the broker leg it implements.
+#: Auth models in precedence order, most specific first. Mirrors EXACTLY the
+#: token precedence documented on `resolve_token` (explicit > GH_TOKEN >
+#: GITHUB_TOKEN > broker), with relay-attach ahead of them all (a worker routed
+#: through the relay egress never holds a token of its own).
+#:
+#: A configured GitHub App is deliberately NOT a model here. App credentials are
+#: consumed only by serve's `GET /gh-token` to mint tokens for CALLERS (Broker
+#: B); the host's own git operations still resolve through `resolve_token`. So an
+#: App-backed serve that also has GH_TOKEN set uses GH_TOKEN, and reporting
+#: "app" would name a different model than the one bootstrap/finish actually
+#: use. Callers that care about the serve capability should report it separately
+#: (see `topology._gh_auth_edge`'s `serves_app_backed_tokens`).
 #:
 #: NOTE: `core.gh_preflight.run_preflight` branches on the same precedence for
 #: its STRICT, network-verifying check. That duplication is pre-existing and
 #: deliberately left alone here — this function is the *reporting* owner and must
 #: never raise or touch the network.
-GH_AUTH_MODELS = ("relay_attach", "app", "env_token", "broker", "none")
+GH_AUTH_MODELS = ("relay_attach", "env_token", "broker", "none")
 
 
 def classify_gh_auth(
     *,
-    app_configured: bool,
     relay_url: str | None,
     run_token: str | None,
     explicit_token: str | None,
@@ -228,8 +234,6 @@ def classify_gh_auth(
 
     if present(relay_url) and present(run_token):
         return "relay_attach"
-    if app_configured:
-        return "app"
     if present(explicit_token):
         return "env_token"
     if present(broker_url):

--- a/src/mship/core/relay/health.py
+++ b/src/mship/core/relay/health.py
@@ -1,5 +1,37 @@
 from __future__ import annotations
+from dataclasses import dataclass
 from typing import Callable
+
+
+@dataclass(frozen=True)
+class HealthProbe:
+    """Outcome of one `/health` request. Exactly one of `status_code` (a
+    response arrived) or `error` (transport/DNS/TLS failure) is set."""
+    ok: bool
+    status_code: int | None = None
+    error: str | None = None
+
+
+def probe_health(public_url: str, token: str, *, get: Callable | None = None,
+                 timeout: float = 8.0) -> HealthProbe:
+    """Probe `<public_url>/health` with the bearer token. Never raises.
+
+    The single reachability prober for the codebase: `verify_relay_reachable`
+    renders its prose from this, and `mship.core.topology` maps the status code
+    to a per-edge status + fix hint (a run-host 401 and a phone-pairing 401 need
+    different advice, so that mapping belongs with the caller, not here).
+    """
+    if get is None:
+        import httpx
+        get = lambda url, **kw: httpx.get(url, **kw)
+    url = public_url.rstrip("/") + "/health"
+    try:
+        r = get(url, headers={"Authorization": f"Bearer {token}"},
+                timeout=timeout, follow_redirects=True)
+    except Exception as e:  # transport/DNS/TLS error
+        return HealthProbe(ok=False, error=str(e))
+    code = r.status_code
+    return HealthProbe(ok=200 <= code < 300, status_code=code)
 
 
 def verify_relay_reachable(public_url: str, token: str, *, get: Callable | None = None,
@@ -10,21 +42,15 @@ def verify_relay_reachable(public_url: str, token: str, *, get: Callable | None 
     Any transport error → ok=False with the exception text (the real reason).
     `get` is injectable (defaults to httpx.get) for testing.
     """
-    if get is None:
-        import httpx
-        get = lambda url, **kw: httpx.get(url, **kw)
-    url = public_url.rstrip("/") + "/health"
-    try:
-        r = get(url, headers={"Authorization": f"Bearer {token}"},
-                timeout=timeout, follow_redirects=True)
-    except Exception as e:  # transport/DNS/TLS error
-        return False, f"could not reach relay URL: {e}"
-    if 200 <= r.status_code < 300:
+    p = probe_health(public_url, token, get=get, timeout=timeout)
+    if p.error is not None:
+        return False, f"could not reach relay URL: {p.error}"
+    if p.ok:
         return True, "ok"
-    if r.status_code in (401, 403):
-        return False, (f"relay reachable but auth failed (HTTP {r.status_code}) — "
+    if p.status_code in (401, 403):
+        return False, (f"relay reachable but auth failed (HTTP {p.status_code}) — "
                        "the paired phone's token is stale; re-scan the QR")
-    return False, f"relay returned HTTP {r.status_code}"
+    return False, f"relay returned HTTP {p.status_code}"
 
 
 # Phrase emitted by verify_relay_reachable on a 401/403. A stale token never

--- a/src/mship/core/relay/keys.py
+++ b/src/mship/core/relay/keys.py
@@ -22,6 +22,19 @@ def _read_secret_if_valid(path: Path) -> bytes | None:
     return data if len(data) >= _SUBDOMAIN_SECRET_LEN else None
 
 
+def subdomain_secret_path(home: Path) -> Path:
+    """Where the per-machine relay-subdomain HMAC secret lives. Read-only —
+    creates nothing, so a reporter (see `mship.core.topology`) can check for it
+    without generating one."""
+    return home / ".mothership" / "relay-subdomain-secret"
+
+
+def relay_key_path(home: Path) -> Path:
+    """Where this machine's relay ssh key lives (public key at `<path>.pub`).
+    Read-only — creates nothing."""
+    return home / ".mothership" / "relay_ed25519"
+
+
 def ensure_subdomain_secret(home: Path) -> bytes:
     """Return the per-machine relay-subdomain HMAC secret, generating it if absent.
 
@@ -35,7 +48,7 @@ def ensure_subdomain_secret(home: Path) -> bytes:
     winner's secret (so both derive the same subdomain) rather than crashing.
     A truncated/corrupt persisted file self-heals by regenerating.
     """
-    path = home / ".mothership" / "relay-subdomain-secret"
+    path = subdomain_secret_path(home)
     existing = _read_secret_if_valid(path)
     if existing is not None:
         return existing
@@ -67,7 +80,7 @@ def ensure_subdomain_secret(home: Path) -> bytes:
 
 def ensure_relay_key(home: Path, runner=_default_runner) -> Path:
     """Return home/.mothership/relay_ed25519, generating it via ssh-keygen if absent."""
-    path = home / ".mothership" / "relay_ed25519"
+    path = relay_key_path(home)
     if path.exists():
         return path
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -361,6 +361,30 @@ def create_app(
     def health():
         return {"status": "ok", "workspace": workspace_name}
 
+    @app.get("/net/topology")
+    def net_topology():
+        """This host's connectivity topology — the SAME payload `mship net
+        status --json` prints, from the same `probe_topology`.
+
+        This is the UI contract for the serve-host management console: it carries
+        a schema `version` and must stay renderable on its own, so no view logic
+        accumulates here.
+        """
+        from mship.core import topology as topo
+
+        if config is None:
+            raise HTTPException(
+                status_code=503,
+                detail=("this serve host has no workspace config wired in; "
+                        "bootstrap it as an mship workspace and restart serve"),
+            )
+        result = topo.probe_topology(
+            config=config,
+            state_dir=workspace_root / ".mothership",
+            workspace_root=workspace_root,
+        )
+        return topo.topology_payload(result)
+
     from mship.core.spec_review import build_review
 
     @app.get("/specs")

--- a/src/mship/core/topology.py
+++ b/src/mship/core/topology.py
@@ -47,10 +47,17 @@ RELAY_AUTH_FAILED = "relay_auth_failed"
 RELAY_SUBDOMAIN_DRIFT = "relay_subdomain_drift"
 RELAY_NOT_CONFIGURED = "relay_not_configured"
 RELAY_NOT_RUNNING = "relay_not_running"
+RELAY_NO_PUBLIC_URL = "relay_no_public_url"
+
+#: Probes were skipped (`--no-network`), so reachability is UNKNOWN. Distinct
+#: from `*_unreachable`, which asserts a probe ran and failed — a console that
+#: conflated them would report a healthy relay as down.
+PROBE_SKIPPED = "probe_skipped"
 
 RUN_HOSTS_NONE_DECLARED = "run_hosts_none_declared"
 RUN_HOSTS_AMBIGUOUS_DEFAULT = "run_hosts_ambiguous_default"
 RUN_HOSTS_OK = "run_hosts_ok"
+RUN_HOSTS_STORE_UNREADABLE = "run_hosts_store_unreadable"
 RUN_HOST_OK = "run_host_ok"
 RUN_HOST_UNKNOWN_ROLE = "run_host_unknown_role"
 RUN_HOST_UNMAPPED = "run_host_unmapped"
@@ -241,12 +248,21 @@ def _serve_and_relay_edges(
         )
         return [serve, relay]
 
-    if skip_network or not record.url:
+    if skip_network:
         relay = Edge(
-            kind="relay", name="relay", status="warn", code=RELAY_UNREACHABLE,
-            detail=("network probes skipped" if skip_network else
-                    "record carries no public url"),
+            kind="relay", name="relay", status="warn", code=PROBE_SKIPPED,
+            detail="network probes skipped; relay reachability unknown",
             fix="re-run without --no-network to probe the relay URL",
+            facts=facts,
+        )
+        return [serve, relay]
+
+    if not record.url:
+        relay = Edge(
+            kind="relay", name="relay", status="warn", code=RELAY_NO_PUBLIC_URL,
+            detail="the relay-serve record carries no public url to probe",
+            fix=("restart `mship serve --relay` so it re-publishes its public "
+                 "URL into the runtime record"),
             facts=facts,
         )
         return [serve, relay]
@@ -296,11 +312,33 @@ def _run_host_edges(
     declared = list(getattr(config, "run_hosts", ()) or ())
     repos = getattr(config, "repos", {}) or {}
     store = RunHostStore(state_dir)
+    edges: list[Edge] = []
     # Private read: `redacted_list()` drops the token entirely, but this edge
     # must report `token_configured` (a boolean) AND whether the effective value
     # came from the file or an env override — neither is derivable from it.
-    mapped = dict(store._read_all())
-    edges: list[Edge] = []
+    #
+    # A hand-edited run-hosts.yaml is a realistic broken input, and `_read_all`
+    # does not guard it: malformed YAML raises, and a non-mapping document
+    # returns a str whose `.get` would blow up. Neither may break a report whose
+    # whole job is to run when things are broken.
+    store_error: str | None = None
+    try:
+        raw = store._read_all()
+        mapped = dict(raw) if isinstance(raw, dict) else {}
+        if not isinstance(raw, dict):
+            store_error = "run-hosts.yaml is not a mapping of role -> {url, token}"
+    except Exception as exc:
+        mapped, store_error = {}, str(exc).splitlines()[0][:200]
+
+    if store_error is not None:
+        return [Edge(
+            kind="run_host", name="run_hosts", status="warn",
+            code=RUN_HOSTS_STORE_UNREADABLE,
+            detail=f"could not read the run-host store ({store_error})",
+            fix=(f"fix or remove `run-hosts.yaml` in {state_dir}, then re-map "
+                 f"roles with `mship run-host add <role>`"),
+            facts={"declared": declared, "store_path": str(state_dir / "run-hosts.yaml")},
+        )]
 
     repo_defaults = {
         name: getattr(r, "run_host", None)
@@ -379,7 +417,8 @@ def _run_host_edges(
         if skip_network:
             edges.append(Edge(
                 kind="run_host", name=f"run_host:{role}", status="warn",
-                code=RUN_HOST_UNREACHABLE, detail="network probes skipped",
+                code=PROBE_SKIPPED,
+                detail="network probes skipped; reachability unknown",
                 fix="re-run without --no-network to probe this run host",
                 facts=facts,
             ))

--- a/src/mship/core/topology.py
+++ b/src/mship/core/topology.py
@@ -66,11 +66,14 @@ RUN_HOST_NOT_BOOTSTRAPPED = "run_host_not_bootstrapped"
 RUN_HOST_STALE_TOKEN = "run_host_stale_token"
 RUN_HOST_ORPHAN_MAPPING = "run_host_orphan_mapping"
 
-GH_AUTH_APP = "gh_auth_app"
 GH_AUTH_BROKER = "gh_auth_broker"
 GH_AUTH_ENV_TOKEN = "gh_auth_env_token"
 GH_AUTH_RELAY_ATTACH = "gh_auth_relay_attach"
 GH_AUTH_NONE = "gh_auth_none"
+
+#: A misconfiguration, not a model: MSHIP_GH_APP_ID is set but its key file is
+#: unreadable, so `GET /gh-token` cannot mint App tokens for callers.
+GH_AUTH_APP_KEY_UNREADABLE = "gh_auth_app_key_unreadable"
 
 EGRESS_ROUTED = "egress_routed"
 EGRESS_ABSENT = "egress_absent"
@@ -135,13 +138,25 @@ def _default_probe(url: str, token: str, *, timeout: float = PROBE_TIMEOUT_SECON
     return probe_health(url, token, timeout=timeout)
 
 
-def _serve_token(workspace_root) -> str | None:
-    """This host's serve bearer, read WITHOUT creating one (`ensure_serve_token`
-    would mint a token as a side effect of reporting)."""
+def _serve_token(workspace_root, *, env) -> str | None:
+    """This host's serve bearer, read WITHOUT creating one.
+
+    Mirrors `relay.token.ensure_serve_token`'s precedence — env override BEFORE
+    the persisted file — minus the generate-on-absence step. The env value is
+    never written to the file, so reading only the file would probe a running
+    relay with a stale bearer and report a healthy tunnel as `relay_auth_failed`.
+
+    A corrupt (non-UTF-8) token file yields None rather than raising:
+    `UnicodeDecodeError` is a ValueError, not an OSError, so both are caught.
+    """
     from pathlib import Path
+
+    from_env = env.get("MSHIP_SERVE_TOKEN")
+    if from_env:
+        return from_env
     try:
         return Path(workspace_root).joinpath(".mothership", "serve-token").read_text().strip()
-    except OSError:
+    except (OSError, ValueError):
         return None
 
 
@@ -163,7 +178,8 @@ def _subdomain_drift(record, *, home) -> str | None:
     try:
         secret = subdomain_secret_path(home).read_bytes()
         pub = Path(str(relay_key_path(home)) + ".pub").read_text()
-    except OSError:
+    except (OSError, ValueError):
+        # ValueError covers UnicodeDecodeError on a binary/corrupt .pub file.
         return None
     try:
         expected = device_subdomain(record.workspace, device_id(pub), secret)
@@ -173,7 +189,7 @@ def _subdomain_drift(record, *, home) -> str | None:
 
 
 def _serve_and_relay_edges(
-    *, config, workspace_root, home, probe, pid_alive, skip_network, timeout,
+    *, config, workspace_root, home, env, probe, pid_alive, skip_network, timeout,
 ) -> list[Edge]:
     """The `serve --relay` process on this machine and the relay edge it owns.
 
@@ -267,7 +283,7 @@ def _serve_and_relay_edges(
         )
         return [serve, relay]
 
-    token = _serve_token(workspace_root)
+    token = _serve_token(workspace_root, env=env)
     result = probe(record.url, token or "", timeout=timeout)
     if result.ok:
         relay = Edge(
@@ -478,7 +494,6 @@ def _run_host_edges(
 
 _GH_AUTH_CODES = {
     "relay_attach": GH_AUTH_RELAY_ATTACH,
-    "app": GH_AUTH_APP,
     "env_token": GH_AUTH_ENV_TOKEN,
     "broker": GH_AUTH_BROKER,
     "none": GH_AUTH_NONE,
@@ -486,11 +501,18 @@ _GH_AUTH_CODES = {
 
 
 def _gh_auth_edge(*, env) -> Edge:
-    """Which GitHub auth model is in effect on this machine.
+    """How THIS machine authenticates to GitHub, plus whether it also serves
+    App-backed tokens to others.
 
-    Reports the MODEL and whether each credential is present/readable — never
-    the credential, and never the App id (an identifier tied to a specific
-    private key is not something a console needs to display).
+    Those are two different questions, and conflating them misreports the first.
+    A GitHub App configured here is consumed ONLY by `GET /gh-token` to mint
+    tokens for CALLERS (Broker B) — this host's own git operations still go
+    through `gh_auth.resolve_token`. So with GH_TOKEN set alongside App creds,
+    the model in effect is the env token, and the App is reported as the serve
+    capability it actually is (`serves_app_backed_tokens`).
+
+    Reports presence/readability, never a credential — and never the App id,
+    which identifies a specific private key.
     """
     from pathlib import Path
 
@@ -499,18 +521,19 @@ def _gh_auth_edge(*, env) -> Edge:
     app_id = env.get("MSHIP_GH_APP_ID") or None
     app_key_path = env.get("MSHIP_GH_APP_KEY") or None
     app_key_readable = bool(app_key_path) and Path(app_key_path).is_file()
+    serves_app_tokens = bool(app_id and app_key_readable)
     broker_url = env.get("MSHIP_GH_BROKER_URL") or None
     relay_url = env.get("MSHIP_RELAY_URL") or None
     run_token = env.get("MSHIP_RUN_TOKEN") or None
     explicit = env.get("GH_TOKEN") or env.get("GITHUB_TOKEN") or None
 
     model = classify_gh_auth(
-        app_configured=bool(app_id and app_key_readable),
         relay_url=relay_url, run_token=run_token,
         explicit_token=explicit, broker_url=broker_url,
     )
     facts = {
         "model": model,
+        "serves_app_backed_tokens": serves_app_tokens,
         "app_id_configured": bool(app_id),
         "app_key_readable": app_key_readable,
         "broker_url": broker_url,          # a URL, not a credential
@@ -518,26 +541,35 @@ def _gh_auth_edge(*, env) -> Edge:
         "run_token_configured": bool(run_token),
         "env_token_configured": bool(explicit),
     }
+    app_note = (
+        " This host also serves App-backed tokens via GET /gh-token."
+        if serves_app_tokens else ""
+    )
 
-    if model == "none":
-        return Edge(
-            kind="gh_auth", name="gh_auth", status="warn", code=GH_AUTH_NONE,
-            detail="no GitHub auth configured on this machine",
-            fix=("set MSHIP_GH_BROKER_URL + MSHIP_SERVE_TOKEN to use a broker, "
-                 "or GH_TOKEN/GITHUB_TOKEN for a direct token"),
-            facts=facts,
-        )
+    # A half-configured App is a real misconfiguration: serve refuses to start
+    # rather than silently pushing as a different identity, so say so plainly.
     if app_id and not app_key_readable:
         return Edge(
-            kind="gh_auth", name="gh_auth", status="fail", code=_GH_AUTH_CODES[model],
+            kind="gh_auth", name="gh_auth", status="fail",
+            code=GH_AUTH_APP_KEY_UNREADABLE,
             detail="MSHIP_GH_APP_ID is set but MSHIP_GH_APP_KEY is not a readable file",
             fix=("fix the MSHIP_GH_APP_KEY path, or unset it to fall back to "
                  "`gh auth token` deliberately"),
             facts=facts,
         )
+
+    if model == "none":
+        return Edge(
+            kind="gh_auth", name="gh_auth", status="warn", code=GH_AUTH_NONE,
+            detail="no GitHub auth configured for this machine's own git operations." + app_note,
+            fix=("set MSHIP_GH_BROKER_URL + MSHIP_SERVE_TOKEN to use a broker, "
+                 "or GH_TOKEN/GITHUB_TOKEN for a direct token"),
+            facts=facts,
+        )
     return Edge(
         kind="gh_auth", name="gh_auth", status="ok", code=_GH_AUTH_CODES[model],
-        detail=f"GitHub auth model in effect: {model}", fix=None, facts=facts,
+        detail=f"GitHub auth model in effect: {model}." + app_note,
+        fix=None, facts=facts,
     )
 
 
@@ -632,7 +664,7 @@ def probe_topology(
 
     edges: list[Edge] = []
     edges.extend(_serve_and_relay_edges(
-        config=config, workspace_root=Path(workspace_root), home=home,
+        config=config, workspace_root=Path(workspace_root), home=home, env=env,
         probe=probe, pid_alive=pid_alive, skip_network=skip_network,
         timeout=timeout,
     ))

--- a/src/mship/core/topology.py
+++ b/src/mship/core/topology.py
@@ -116,3 +116,496 @@ def topology_payload(topology: Topology) -> dict[str, Any]:
             for e in topology.edges
         ],
     }
+
+
+def _utc_now_iso() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _default_probe(url: str, token: str, *, timeout: float = PROBE_TIMEOUT_SECONDS):
+    from mship.core.relay.health import probe_health
+    return probe_health(url, token, timeout=timeout)
+
+
+def _serve_token(workspace_root) -> str | None:
+    """This host's serve bearer, read WITHOUT creating one (`ensure_serve_token`
+    would mint a token as a side effect of reporting)."""
+    from pathlib import Path
+    try:
+        return Path(workspace_root).joinpath(".mothership", "serve-token").read_text().strip()
+    except OSError:
+        return None
+
+
+def _subdomain_drift(record, *, home) -> str | None:
+    """The subdomain this machine derives NOW, when it differs from the running
+    record's — i.e. anything paired against the record is stale. None when they
+    agree, or when the inputs to derive it are missing/unreadable.
+
+    Strictly read-only: uses the key/secret PATHS, never the `ensure_*`
+    generators (which would create them as a side effect of reporting).
+    """
+    from pathlib import Path
+
+    from mship.core.relay.keys import relay_key_path, subdomain_secret_path
+    from mship.core.relay.tunnel import device_id, device_subdomain
+
+    if not record.subdomain or not record.workspace:
+        return None
+    try:
+        secret = subdomain_secret_path(home).read_bytes()
+        pub = Path(str(relay_key_path(home)) + ".pub").read_text()
+    except OSError:
+        return None
+    try:
+        expected = device_subdomain(record.workspace, device_id(pub), secret)
+    except Exception:
+        return None
+    return None if expected == record.subdomain else expected
+
+
+def _serve_and_relay_edges(
+    *, config, workspace_root, home, probe, pid_alive, skip_network, timeout,
+) -> list[Edge]:
+    """The `serve --relay` process on this machine and the relay edge it owns.
+
+    Both come from the same runtime record, so they are built together: the
+    relay edge is only meaningful when a live relay-serve wrote that record.
+    """
+    from mship.core.relay.runtime import read_runtime_record
+
+    record = read_runtime_record(workspace_root)
+    relay_configured = getattr(config, "relay", None) is not None
+
+    if record is None:
+        serve = Edge(
+            kind="serve", name="serve", status="absent", code=SERVE_RELAY_ABSENT,
+            detail="no relay-serve record on this machine",
+            fix=("start one with `mship serve --relay` (a local-only "
+                 "`mship serve` writes no record and needs no relay)"),
+            facts={"relay_configured": relay_configured},
+        )
+        relay = Edge(
+            kind="relay", name="relay", status="absent", code=RELAY_NOT_CONFIGURED,
+            detail=("relay configured but not running" if relay_configured
+                    else "no `relay:` block in mothership.yaml"),
+            fix=("run `mship serve --relay`" if relay_configured else
+                 "add a `relay:` block (host, ssh_port, user) to mothership.yaml, "
+                 "then `mship relay enroll` and `mship serve --relay`"),
+            facts={"relay_configured": relay_configured},
+        )
+        return [serve, relay]
+
+    alive = pid_alive(record.pid)
+    serve = Edge(
+        kind="serve", name="serve",
+        status="ok" if alive else "fail",
+        code=SERVE_RELAY_RUNNING if alive else SERVE_RELAY_STALE,
+        detail=(f"relay-serve pid {record.pid} running" if alive else
+                f"stale record: pid {record.pid} is gone"),
+        fix=None if alive else (
+            "the recorded relay-serve died; restart `mship serve --relay` "
+            "(the stale record is cleared on next start)"
+        ),
+        facts={
+            "mode": "relay", "pid": record.pid, "host": record.host,
+            "subdomain": record.subdomain, "url": record.url,
+            "workspace": record.workspace, "ssh_port": record.ssh_port,
+        },
+    )
+
+    facts = {"host": record.host, "subdomain": record.subdomain, "url": record.url}
+    drift = _subdomain_drift(record, home=home)
+    if drift is not None:
+        facts["expected_subdomain"] = drift
+
+    if not alive:
+        relay = Edge(
+            kind="relay", name="relay", status="fail", code=RELAY_NOT_RUNNING,
+            detail="no live relay-serve owns this tunnel",
+            fix="restart `mship serve --relay` on this machine",
+            facts=facts,
+        )
+        return [serve, relay]
+
+    if drift is not None:
+        relay = Edge(
+            kind="relay", name="relay", status="warn", code=RELAY_SUBDOMAIN_DRIFT,
+            detail=(f"running subdomain {record.subdomain!r} is not the one this "
+                    f"machine now derives ({drift!r})"),
+            fix=("anything paired against the old subdomain is stale — re-pair "
+                 "(`mship pair`, re-scan the QR) or restart `mship serve --relay` "
+                 "to publish the derived subdomain"),
+            facts=facts,
+        )
+        return [serve, relay]
+
+    if skip_network or not record.url:
+        relay = Edge(
+            kind="relay", name="relay", status="warn", code=RELAY_UNREACHABLE,
+            detail=("network probes skipped" if skip_network else
+                    "record carries no public url"),
+            fix="re-run without --no-network to probe the relay URL",
+            facts=facts,
+        )
+        return [serve, relay]
+
+    token = _serve_token(workspace_root)
+    result = probe(record.url, token or "", timeout=timeout)
+    if result.ok:
+        relay = Edge(
+            kind="relay", name="relay", status="ok", code=RELAY_OK,
+            detail=f"{record.url} reachable", fix=None, facts=facts,
+        )
+    elif result.status_code in (401, 403):
+        relay = Edge(
+            kind="relay", name="relay", status="fail", code=RELAY_AUTH_FAILED,
+            detail=(f"{record.url} reachable but rejected this host's bearer "
+                    f"(HTTP {result.status_code})"),
+            fix=("the tunnel is up but the token does not match — restart "
+                 "`mship serve --relay` and re-pair the phone"),
+            facts=facts,
+        )
+    else:
+        why = result.error or f"HTTP {result.status_code}"
+        relay = Edge(
+            kind="relay", name="relay", status="fail", code=RELAY_UNREACHABLE,
+            detail=f"{record.url} unreachable ({why})",
+            fix=("check `mship serve --relay` is running here and the relay host "
+                 "is up; an orphaned ssh tunnel duplicating this subdomain also "
+                 "presents as unreachable — kill it and restart serve"),
+            facts=facts,
+        )
+    return [serve, relay]
+
+
+
+def _run_host_edges(
+    *, config, state_dir, env, probe, skip_network, timeout,
+) -> list[Edge]:
+    """One edge per role — declared, mapped, reachable — plus aggregate edges
+    for "nothing declared" and "a bare --remote would be ambiguous".
+
+    Fix hints intentionally mirror `run_host.store.RunHostError` and
+    `remote_client._http_status_message`, so the CLI error an operator hits and
+    the topology hint they read say the same thing.
+    """
+    from mship.core.run_host.store import RunHostStore, _env_key
+
+    declared = list(getattr(config, "run_hosts", ()) or ())
+    repos = getattr(config, "repos", {}) or {}
+    store = RunHostStore(state_dir)
+    # Private read: `redacted_list()` drops the token entirely, but this edge
+    # must report `token_configured` (a boolean) AND whether the effective value
+    # came from the file or an env override — neither is derivable from it.
+    mapped = dict(store._read_all())
+    edges: list[Edge] = []
+
+    repo_defaults = {
+        name: getattr(r, "run_host", None)
+        for name, r in repos.items() if getattr(r, "run_host", None)
+    }
+
+    # --- aggregate: nothing declared / ambiguous bare --remote -------------
+    if not declared:
+        edges.append(Edge(
+            kind="run_host", name="run_hosts", status="absent",
+            code=RUN_HOSTS_NONE_DECLARED,
+            detail="no run_hosts declared in mothership.yaml",
+            fix=("add a `run_hosts:` list of role names to mothership.yaml "
+                 "before using --remote"),
+            facts={"declared": []},
+        ))
+    elif len(declared) > 1 and not repo_defaults:
+        edges.append(Edge(
+            kind="run_host", name="run_hosts", status="warn",
+            code=RUN_HOSTS_AMBIGUOUS_DEFAULT,
+            detail=(f"{len(declared)} roles declared ({', '.join(declared)}) and no "
+                    f"repo declares a default, so a bare `--remote` is ambiguous"),
+            fix=("pass --remote=<role> explicitly, or declare `run_host: <role>` "
+                 "on the repo"),
+            facts={"declared": declared},
+        ))
+    else:
+        edges.append(Edge(
+            kind="run_host", name="run_hosts", status="ok", code=RUN_HOSTS_OK,
+            detail=f"{len(declared)} role(s) declared", fix=None,
+            facts={"declared": declared, "repo_defaults": repo_defaults},
+        ))
+
+    # --- unknown roles: a repo points at a role that isn't declared --------
+    for repo_name, role in sorted(repo_defaults.items()):
+        if role in declared:
+            continue
+        edges.append(Edge(
+            kind="run_host", name=f"run_host:{role}", status="fail",
+            code=RUN_HOST_UNKNOWN_ROLE,
+            detail=(f"repo {repo_name!r} declares run_host {role!r}, which is not "
+                    f"in this workspace's run_hosts list"),
+            fix=(f"add {role!r} to `run_hosts:` in mothership.yaml, or fix the "
+                 f"typo on repo {repo_name!r}"),
+            facts={"declared_by_repo": repo_name, "known_roles": declared},
+        ))
+
+    # --- per declared role -------------------------------------------------
+    for role in declared:
+        entry = mapped.get(role, {})
+        url_env, token_env = _env_key(role, "URL"), _env_key(role, "TOKEN")
+        url = env.get(url_env) or entry.get("url")
+        token = env.get(token_env) or entry.get("token")
+        facts = {
+            "role": role,
+            "url": url,
+            "url_source": (f"env:{url_env}" if env.get(url_env)
+                           else "file" if entry.get("url") else None),
+            "token_configured": bool(token),
+            "token_source": (f"env:{token_env}" if env.get(token_env)
+                             else "file" if entry.get("token") else None),
+        }
+
+        if not url or not token:
+            edges.append(Edge(
+                kind="run_host", name=f"run_host:{role}", status="fail",
+                code=RUN_HOST_UNMAPPED,
+                detail=(f"role {role!r} is declared but has no connection mapped "
+                        f"on this machine"),
+                fix=(f"run `mship run-host add {role} --pair-link '...'` (get the "
+                     f"link by running `mship pair` on that machine)"),
+                facts=facts,
+            ))
+            continue
+
+        if skip_network:
+            edges.append(Edge(
+                kind="run_host", name=f"run_host:{role}", status="warn",
+                code=RUN_HOST_UNREACHABLE, detail="network probes skipped",
+                fix="re-run without --no-network to probe this run host",
+                facts=facts,
+            ))
+            continue
+
+        result = probe(url, token, timeout=timeout)
+        if result.ok:
+            edges.append(Edge(
+                kind="run_host", name=f"run_host:{role}", status="ok",
+                code=RUN_HOST_OK, detail=f"{url} reachable", fix=None, facts=facts,
+            ))
+        elif result.status_code == 503:
+            edges.append(Edge(
+                kind="run_host", name=f"run_host:{role}", status="fail",
+                code=RUN_HOST_NOT_BOOTSTRAPPED,
+                detail=f"{url} is reachable but has no workspace wired in (503)",
+                fix=("bootstrap that machine as an mship workspace and restart "
+                     "`mship serve --relay` there"),
+                facts=facts,
+            ))
+        elif result.status_code in (401, 403):
+            edges.append(Edge(
+                kind="run_host", name=f"run_host:{role}", status="fail",
+                code=RUN_HOST_STALE_TOKEN,
+                detail=(f"{url} rejected the mapped bearer token "
+                        f"(HTTP {result.status_code})"),
+                fix=(f"the mapping is stale — re-run `mship run-host add {role}` "
+                     f"with a fresh pair link/token"),
+                facts=facts,
+            ))
+        else:
+            why = result.error or f"HTTP {result.status_code}"
+            edges.append(Edge(
+                kind="run_host", name=f"run_host:{role}", status="fail",
+                code=RUN_HOST_UNREACHABLE,
+                detail=f"{url} unreachable ({why})",
+                fix=(f"confirm that machine is up with `mship serve --relay` "
+                     f"running; re-pair if its relay subdomain changed"),
+                facts=facts,
+            ))
+
+    # --- orphan mappings: mapped here, not declared anywhere ---------------
+    for role in sorted(set(mapped) - set(declared)):
+        edges.append(Edge(
+            kind="run_host", name=f"run_host:{role}", status="warn",
+            code=RUN_HOST_ORPHAN_MAPPING,
+            detail=(f"role {role!r} is mapped on this machine but not declared in "
+                    f"mothership.yaml, so nothing can select it"),
+            fix=(f"add {role!r} to `run_hosts:` in mothership.yaml, or drop the "
+                 f"mapping with `mship run-host remove {role}`"),
+            facts={"role": role},
+        ))
+
+    return edges
+
+
+
+_GH_AUTH_CODES = {
+    "relay_attach": GH_AUTH_RELAY_ATTACH,
+    "app": GH_AUTH_APP,
+    "env_token": GH_AUTH_ENV_TOKEN,
+    "broker": GH_AUTH_BROKER,
+    "none": GH_AUTH_NONE,
+}
+
+
+def _gh_auth_edge(*, env) -> Edge:
+    """Which GitHub auth model is in effect on this machine.
+
+    Reports the MODEL and whether each credential is present/readable — never
+    the credential, and never the App id (an identifier tied to a specific
+    private key is not something a console needs to display).
+    """
+    from pathlib import Path
+
+    from mship.core.gh_auth import classify_gh_auth
+
+    app_id = env.get("MSHIP_GH_APP_ID") or None
+    app_key_path = env.get("MSHIP_GH_APP_KEY") or None
+    app_key_readable = bool(app_key_path) and Path(app_key_path).is_file()
+    broker_url = env.get("MSHIP_GH_BROKER_URL") or None
+    relay_url = env.get("MSHIP_RELAY_URL") or None
+    run_token = env.get("MSHIP_RUN_TOKEN") or None
+    explicit = env.get("GH_TOKEN") or env.get("GITHUB_TOKEN") or None
+
+    model = classify_gh_auth(
+        app_configured=bool(app_id and app_key_readable),
+        relay_url=relay_url, run_token=run_token,
+        explicit_token=explicit, broker_url=broker_url,
+    )
+    facts = {
+        "model": model,
+        "app_id_configured": bool(app_id),
+        "app_key_readable": app_key_readable,
+        "broker_url": broker_url,          # a URL, not a credential
+        "relay_url": relay_url,
+        "run_token_configured": bool(run_token),
+        "env_token_configured": bool(explicit),
+    }
+
+    if model == "none":
+        return Edge(
+            kind="gh_auth", name="gh_auth", status="warn", code=GH_AUTH_NONE,
+            detail="no GitHub auth configured on this machine",
+            fix=("set MSHIP_GH_BROKER_URL + MSHIP_SERVE_TOKEN to use a broker, "
+                 "or GH_TOKEN/GITHUB_TOKEN for a direct token"),
+            facts=facts,
+        )
+    if app_id and not app_key_readable:
+        return Edge(
+            kind="gh_auth", name="gh_auth", status="fail", code=_GH_AUTH_CODES[model],
+            detail="MSHIP_GH_APP_ID is set but MSHIP_GH_APP_KEY is not a readable file",
+            fix=("fix the MSHIP_GH_APP_KEY path, or unset it to fall back to "
+                 "`gh auth token` deliberately"),
+            facts=facts,
+        )
+    return Edge(
+        kind="gh_auth", name="gh_auth", status="ok", code=_GH_AUTH_CODES[model],
+        detail=f"GitHub auth model in effect: {model}", fix=None, facts=facts,
+    )
+
+
+def _egress_edge(*, shell) -> Edge:
+    """Is this machine's git routed through a relay egress proxy?
+
+    Detected by reading git's global `insteadOf` rewrites — the ones
+    `relay.worker_config.relay_git_config_commands` installs — and recognizing
+    them via `relay.contract.PREFIX_HOST`, so detection cannot drift from
+    installation. Read-only (`git config --get-regexp` writes nothing).
+    """
+    from pathlib import Path
+
+    from mship.core.relay.contract import PREFIX_HOST
+
+    cmd = 'git config --global --get-regexp "^url\\..*\\.insteadof$"'
+    try:
+        result = shell.run(cmd, cwd=Path("."))
+    except Exception as exc:
+        return Edge(
+            kind="egress", name="egress", status="warn", code=EGRESS_UNKNOWN,
+            detail=f"could not read git global config ({exc})",
+            fix="ensure `git` is installed and on PATH to report egress routing",
+            facts={},
+        )
+
+    bases: set[str] = set()
+    for line in (getattr(result, "stdout", "") or "").splitlines():
+        key = line.strip().split(" ", 1)[0]
+        if not key.startswith("url.") or not key.lower().endswith(".insteadof"):
+            continue
+        rewritten = key[len("url."):-len(".insteadof")]
+        for prefix in PREFIX_HOST:
+            if rewritten.endswith(prefix):
+                bases.add(rewritten[: -len(prefix)])
+
+    if not bases:
+        return Edge(
+            kind="egress", name="egress", status="absent", code=EGRESS_ABSENT,
+            detail="git is not routed through a relay egress on this machine",
+            fix=None,
+            facts={"prefixes": sorted(PREFIX_HOST)},
+        )
+    base = sorted(bases)[0]
+    return Edge(
+        kind="egress", name="egress", status="ok", code=EGRESS_ROUTED,
+        detail=f"git is routed through {base}", fix=None,
+        facts={"relay_base": base, "prefixes": sorted(PREFIX_HOST)},
+    )
+
+
+def probe_topology(
+    *,
+    config,
+    state_dir,
+    workspace_root,
+    home=None,
+    env=None,
+    probe=None,
+    pid_alive=None,
+    shell=None,
+    now=None,
+    skip_network: bool = False,
+    timeout: float = PROBE_TIMEOUT_SECONDS,
+) -> Topology:
+    """This machine's connectivity topology. Read-only; never raises.
+
+    Every collaborator is injectable so the suite needs no live network, no real
+    home directory, and no running serve:
+      `probe`     -> `relay.health.probe_health`
+      `pid_alive` -> `relay.runtime._pid_alive`
+      `shell`     -> `util.shell.ShellRunner`
+      `now`       -> UTC ISO-8601 clock
+      `env`       -> `os.environ`
+
+    `skip_network=True` reports config-level state only (used by `mship doctor
+    --no-network` so a previously-fast command stays fast).
+    """
+    import os
+    from pathlib import Path
+
+    from mship.core.relay.runtime import _pid_alive
+
+    env = os.environ if env is None else env
+    home = Path.home() if home is None else Path(home)
+    probe = _default_probe if probe is None else probe
+    pid_alive = _pid_alive if pid_alive is None else pid_alive
+    now = _utc_now_iso if now is None else now
+    if shell is None:
+        from mship.util.shell import ShellRunner
+        shell = ShellRunner()
+
+    edges: list[Edge] = []
+    edges.extend(_serve_and_relay_edges(
+        config=config, workspace_root=Path(workspace_root), home=home,
+        probe=probe, pid_alive=pid_alive, skip_network=skip_network,
+        timeout=timeout,
+    ))
+    edges.extend(_run_host_edges(
+        config=config, state_dir=Path(state_dir), env=env, probe=probe,
+        skip_network=skip_network, timeout=timeout,
+    ))
+    edges.append(_gh_auth_edge(env=env))
+    edges.append(_egress_edge(shell=shell))
+    return Topology(
+        version=SCHEMA_VERSION,
+        workspace=getattr(config, "workspace", "") or "",
+        probed_at=now(),
+        edges=edges,
+    )

--- a/src/mship/core/topology.py
+++ b/src/mship/core/topology.py
@@ -1,0 +1,118 @@
+"""Read-only connectivity topology: what this machine is wired to, and whether
+each edge is healthy.
+
+ONE implementation, three thin callers — `mship net status`, `mship doctor`'s
+connectivity group, and `GET /net/topology` on serve — so probe logic lives in
+exactly one module.
+
+Two invariants the callers depend on:
+
+1. **Read-only.** Nothing here creates, writes, or rotates state. That rules out
+   the `ensure_*` helpers in `relay.keys` and `relay.token` (they generate on
+   absence) — this module reads their paths instead.
+2. **Never raises.** A broken environment is the EXPECTED input; this tool is
+   most needed exactly when connectivity is broken. Every failure becomes an
+   edge status plus a fix hint, and every network probe is timeout-bounded.
+
+`GET /net/topology`'s payload is the UI contract for the serve-host console, so
+it carries `version` (SCHEMA_VERSION) and must be renderable on its own — no
+companion in-process data.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+#: Bound on every network probe. Short on purpose: `doctor` was fast before
+#: connectivity checks existed, and an unreachable edge must not stall it.
+PROBE_TIMEOUT_SECONDS = 3.0
+
+#: `absent` = not configured on this machine (nothing to fix), distinct from
+#: `fail` = configured but broken.
+STATUSES = ("ok", "warn", "fail", "absent")
+
+# --- status codes ---------------------------------------------------------
+# One code per distinguishable state so a UI can branch without parsing prose.
+# The prose lives in `Edge.detail` / `Edge.fix`.
+
+SERVE_RELAY_RUNNING = "serve_relay_running"
+SERVE_RELAY_STALE = "serve_relay_stale"
+SERVE_RELAY_ABSENT = "serve_relay_absent"
+
+RELAY_OK = "relay_ok"
+RELAY_UNREACHABLE = "relay_unreachable"
+RELAY_AUTH_FAILED = "relay_auth_failed"
+RELAY_SUBDOMAIN_DRIFT = "relay_subdomain_drift"
+RELAY_NOT_CONFIGURED = "relay_not_configured"
+RELAY_NOT_RUNNING = "relay_not_running"
+
+RUN_HOSTS_NONE_DECLARED = "run_hosts_none_declared"
+RUN_HOSTS_AMBIGUOUS_DEFAULT = "run_hosts_ambiguous_default"
+RUN_HOSTS_OK = "run_hosts_ok"
+RUN_HOST_OK = "run_host_ok"
+RUN_HOST_UNKNOWN_ROLE = "run_host_unknown_role"
+RUN_HOST_UNMAPPED = "run_host_unmapped"
+RUN_HOST_UNREACHABLE = "run_host_unreachable"
+RUN_HOST_NOT_BOOTSTRAPPED = "run_host_not_bootstrapped"
+RUN_HOST_STALE_TOKEN = "run_host_stale_token"
+RUN_HOST_ORPHAN_MAPPING = "run_host_orphan_mapping"
+
+GH_AUTH_APP = "gh_auth_app"
+GH_AUTH_BROKER = "gh_auth_broker"
+GH_AUTH_ENV_TOKEN = "gh_auth_env_token"
+GH_AUTH_RELAY_ATTACH = "gh_auth_relay_attach"
+GH_AUTH_NONE = "gh_auth_none"
+
+EGRESS_ROUTED = "egress_routed"
+EGRESS_ABSENT = "egress_absent"
+EGRESS_UNKNOWN = "egress_unknown"
+
+
+@dataclass(frozen=True)
+class Edge:
+    """One connectivity edge (or node) and its health.
+
+    `facts` holds REDACTED, source-annotated values only — urls, hostnames,
+    booleans, and where an effective value came from. Never a token, key, or
+    credential body (see `tests/core/test_topology_redaction.py`).
+    """
+    kind: str          # serve | relay | run_host | gh_auth | egress
+    name: str          # "serve", "relay", "run_host:mac-studio", ...
+    status: str        # one of STATUSES
+    code: str          # one of the module's status-code constants
+    detail: str        # human summary
+    fix: str | None    # actionable next step; None when there is nothing to fix
+    facts: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Topology:
+    version: int
+    workspace: str
+    probed_at: str     # ISO-8601, UTC
+    edges: list[Edge]
+
+
+def topology_payload(topology: Topology) -> dict[str, Any]:
+    """The JSON body shared by `mship net status --json` and
+    `GET /net/topology` — ONE serializer, so the CLI and the endpoint can never
+    disagree about the contract."""
+    return {
+        "version": topology.version,
+        "workspace": topology.workspace,
+        "probed_at": topology.probed_at,
+        "edges": [
+            {
+                "kind": e.kind,
+                "name": e.name,
+                "status": e.status,
+                "code": e.code,
+                "detail": e.detail,
+                "fix": e.fix,
+                "facts": dict(e.facts),
+            }
+            for e in topology.edges
+        ],
+    }

--- a/tests/cli/test_net_status.py
+++ b/tests/cli/test_net_status.py
@@ -1,0 +1,73 @@
+import json
+
+from typer.testing import CliRunner
+
+from mship.cli import app
+from mship.core.topology import Edge, Topology
+
+runner = CliRunner()
+
+
+def _fake_topology():
+    return Topology(
+        version=1, workspace="ws", probed_at="2026-07-25T16:00:00+00:00",
+        edges=[
+            Edge(kind="serve", name="serve", status="ok", code="serve_relay_running",
+                 detail="relay-serve pid 1 running", fix=None, facts={"mode": "relay"}),
+            Edge(kind="run_host", name="run_host:mac", status="fail",
+                 code="run_host_unmapped", detail="no connection mapped",
+                 fix="run `mship run-host add mac`", facts={}),
+        ],
+    )
+
+
+def test_json_mode_emits_the_payload(monkeypatch):
+    monkeypatch.setattr("mship.core.topology.probe_topology", lambda **kw: _fake_topology())
+    result = runner.invoke(app, ["net", "status"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["version"] == 1
+    assert payload["edges"][1]["code"] == "run_host_unmapped"
+
+
+def test_human_mode_shows_status_and_fix(monkeypatch):
+    monkeypatch.setattr("mship.core.topology.probe_topology", lambda **kw: _fake_topology())
+    # MSHIP_JSON=0 forces human output on a pipe (CliRunner is never a TTY).
+    monkeypatch.setenv("MSHIP_JSON", "0")
+    result = runner.invoke(app, ["net", "status"])
+    assert result.exit_code == 0
+    # Assert on rendering only human mode produces — the edge name and the fix
+    # text also appear in the JSON body, so they alone would pass vacuously.
+    assert "Connectivity" in result.stdout          # the table title
+    assert "Next steps:" in result.stdout           # the fix section
+    assert "run-host add mac" in result.stdout
+
+
+def test_global_json_flag_forces_the_payload(monkeypatch):
+    monkeypatch.setattr("mship.core.topology.probe_topology", lambda **kw: _fake_topology())
+    monkeypatch.setenv("MSHIP_JSON", "0")           # human by env...
+    result = runner.invoke(app, ["--json", "net", "status"])   # ...overridden by the flag
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["version"] == 1
+
+
+def test_exits_zero_even_when_everything_is_broken(monkeypatch):
+    """AC4: this command must work precisely when connectivity is broken."""
+    broken = Topology(version=1, workspace="ws", probed_at="t", edges=[
+        Edge(kind="relay", name="relay", status="fail", code="relay_unreachable",
+             detail="down", fix="restart serve", facts={}),
+    ])
+    monkeypatch.setattr("mship.core.topology.probe_topology", lambda **kw: broken)
+    assert runner.invoke(app, ["net", "status"]).exit_code == 0
+
+
+def test_no_network_flag_is_passed_through(monkeypatch):
+    seen = {}
+
+    def spy(**kw):
+        seen.update(kw)
+        return _fake_topology()
+
+    monkeypatch.setattr("mship.core.topology.probe_topology", spy)
+    assert runner.invoke(app, ["net", "status", "--no-network"]).exit_code == 0
+    assert seen["skip_network"] is True

--- a/tests/cli/test_net_status.py
+++ b/tests/cli/test_net_status.py
@@ -1,11 +1,23 @@
 import json
 
+import pytest
 from typer.testing import CliRunner
 
 from mship.cli import app
+from mship.cli.output import reset_output_settings
 from mship.core.topology import Edge, Topology
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings():
+    """`configure_output` writes process-global state, so a `--json` invocation
+    here would otherwise force JSON mode for every later test in the run (the
+    same pattern as tests/cli/test_output_flags.py)."""
+    reset_output_settings()
+    yield
+    reset_output_settings()
 
 
 def _fake_topology():

--- a/tests/core/relay/test_health.py
+++ b/tests/core/relay/test_health.py
@@ -1,4 +1,8 @@
-from mship.core.relay.health import verify_relay_reachable, wait_until_reachable
+from mship.core.relay.health import (
+    probe_health,
+    verify_relay_reachable,
+    wait_until_reachable,
+)
 
 class _Resp:
     def __init__(self, status): self.status_code = status
@@ -80,3 +84,22 @@ def test_wait_does_not_retry_on_auth_failure():
     assert ok is False and "token" in detail.lower()
     assert len(calls) == 1          # no retry
     assert clk.t == 0               # never slept
+
+
+# --- probe_health: the one prober, with the status code exposed ---
+
+def test_probe_health_reports_status_code():
+    p = probe_health("https://w-ab12.relay", "tok", get=lambda *a, **k: _Resp(503))
+    assert p.ok is False
+    assert p.status_code == 503
+    assert p.error is None
+
+def test_probe_health_ok_on_2xx():
+    p = probe_health("https://w-ab12.relay", "tok", get=lambda *a, **k: _Resp(204))
+    assert p.ok is True and p.status_code == 204
+
+def test_probe_health_carries_transport_error_and_never_raises():
+    def boom(*a, **k): raise RuntimeError("name resolution failed")
+    p = probe_health("https://w-ab12.relay", "tok", get=boom)
+    assert p.ok is False and p.status_code is None
+    assert "name resolution failed" in p.error

--- a/tests/core/relay/test_keys.py
+++ b/tests/core/relay/test_keys.py
@@ -1,5 +1,11 @@
 from pathlib import Path
-from mship.core.relay.keys import ensure_relay_key, ensure_subdomain_secret, relay_public_key
+from mship.core.relay.keys import (
+    ensure_relay_key,
+    ensure_subdomain_secret,
+    relay_key_path,
+    relay_public_key,
+    subdomain_secret_path,
+)
 
 
 def test_ensure_subdomain_secret_creates_stable_0600_secret(tmp_path):
@@ -50,3 +56,17 @@ def test_idempotent_when_present(tmp_path):
     path = ensure_relay_key(home=tmp_path, runner=fake_run)
     assert len(calls) == 0, "runner must NOT be called when key already exists"
     assert path == key_path
+
+
+# --- read-only path accessors (a reporter must not generate keys) ---
+
+def test_paths_are_readable_without_creating_anything(tmp_path):
+    assert subdomain_secret_path(tmp_path) == tmp_path / ".mothership" / "relay-subdomain-secret"
+    assert relay_key_path(tmp_path) == tmp_path / ".mothership" / "relay_ed25519"
+    # Read-only: asking for the paths must not create the dir or the files.
+    assert not (tmp_path / ".mothership").exists()
+
+
+def test_ensure_secret_writes_at_the_declared_path(tmp_path):
+    secret = ensure_subdomain_secret(home=tmp_path)
+    assert subdomain_secret_path(tmp_path).read_bytes() == secret

--- a/tests/core/test_doctor.py
+++ b/tests/core/test_doctor.py
@@ -710,3 +710,88 @@ def test_doctor_accepts_taskfile_yaml_only(tmp_path: Path):
     tf = next(c for c in report.checks if c.name == "svc/taskfile")
     assert tf.status == "pass"
     assert "Taskfile.yaml" in tf.message
+
+
+# --- connectivity group (sourced from core.topology.probe_topology) ---
+
+def _shell_ok():
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.return_value = ShellResult(
+        returncode=0, stdout="test\nrun\nlint\nsetup\n", stderr="",
+    )
+    return mock_shell
+
+
+def test_doctor_reports_connectivity_from_probe_topology(workspace: Path, monkeypatch):
+    """AC3: doctor's connectivity checks come from probe_topology, not from a
+    second copy of the probe logic."""
+    from mship.core import topology as topo
+
+    called = {}
+
+    def fake_probe(**kw):
+        called.update(kw)
+        return topo.Topology(version=1, workspace="ws", probed_at="t", edges=[
+            topo.Edge(kind="relay", name="relay", status="fail",
+                      code="relay_unreachable", detail="down",
+                      fix="restart `mship serve --relay`", facts={}),
+            topo.Edge(kind="egress", name="egress", status="absent",
+                      code="egress_absent", detail="not routed", fix=None, facts={}),
+        ])
+
+    monkeypatch.setattr(topo, "probe_topology", fake_probe)
+
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    report = DoctorChecker(
+        config, _shell_ok(), state_dir=workspace / ".mothership",
+        workspace_root=workspace,
+    ).run()
+
+    conn = [c for c in report.checks if c.name.startswith("connectivity/")]
+    assert [c.name for c in conn] == ["connectivity/relay", "connectivity/egress"]
+    assert conn[0].status == "fail"
+    assert "restart `mship serve --relay`" in conn[0].message
+    # `absent` is not a problem to fix -> reported as a pass
+    assert conn[1].status == "pass"
+    assert called["skip_network"] is False
+
+
+def test_doctor_can_skip_network_probes(workspace: Path, monkeypatch):
+    from mship.core import topology as topo
+
+    seen = {}
+
+    def fake_probe(**kw):
+        seen.update(kw)
+        return topo.Topology(version=1, workspace="ws", probed_at="t", edges=[])
+
+    monkeypatch.setattr(topo, "probe_topology", fake_probe)
+
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    DoctorChecker(
+        config, _shell_ok(), state_dir=workspace / ".mothership",
+        workspace_root=workspace, probe_network=False,
+    ).run()
+    assert seen["skip_network"] is True
+
+
+def test_doctor_survives_a_topology_failure(workspace: Path, monkeypatch):
+    """probe_topology promises never to raise; doctor must not depend on that
+    promise being kept — a connectivity bug can't take down the other checks."""
+    from mship.core import topology as topo
+
+    def boom(**kw):
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr(topo, "probe_topology", boom)
+
+    config = ConfigLoader.load(workspace / "mothership.yaml")
+    report = DoctorChecker(
+        config, _shell_ok(), state_dir=workspace / ".mothership",
+        workspace_root=workspace,
+    ).run()
+    conn = [c for c in report.checks if c.name == "connectivity"]
+    assert conn and conn[0].status == "warn"
+    assert "probe exploded" in conn[0].message
+    # the other checks still ran
+    assert any(c.name.endswith("/path") for c in report.checks)

--- a/tests/core/test_gh_auth_classify.py
+++ b/tests/core/test_gh_auth_classify.py
@@ -1,0 +1,51 @@
+from mship.core.gh_auth import classify_gh_auth
+
+
+def test_relay_attach_wins():
+    assert classify_gh_auth(
+        app_configured=True, relay_url="https://r", run_token="rt",
+        explicit_token="ghp_x", broker_url="https://b",
+    ) == "relay_attach"
+
+
+def test_app_beats_env_token_and_broker():
+    assert classify_gh_auth(
+        app_configured=True, relay_url=None, run_token=None,
+        explicit_token="ghp_x", broker_url="https://b",
+    ) == "app"
+
+
+def test_env_token_beats_broker():
+    assert classify_gh_auth(
+        app_configured=False, relay_url=None, run_token=None,
+        explicit_token="ghp_x", broker_url="https://b",
+    ) == "env_token"
+
+
+def test_broker_when_only_broker():
+    assert classify_gh_auth(
+        app_configured=False, relay_url=None, run_token=None,
+        explicit_token=None, broker_url="https://b",
+    ) == "broker"
+
+
+def test_none_when_nothing_configured():
+    assert classify_gh_auth(
+        app_configured=False, relay_url=None, run_token=None,
+        explicit_token=None, broker_url=None,
+    ) == "none"
+
+
+def test_half_configured_relay_is_not_relay_attach():
+    # relay-attach needs BOTH url and run token (mirrors relay_flags_error).
+    assert classify_gh_auth(
+        app_configured=False, relay_url="https://r", run_token=None,
+        explicit_token=None, broker_url=None,
+    ) == "none"
+
+
+def test_blank_strings_do_not_count_as_configured():
+    assert classify_gh_auth(
+        app_configured=False, relay_url=None, run_token=None,
+        explicit_token="   ", broker_url="",
+    ) == "none"

--- a/tests/core/test_gh_auth_classify.py
+++ b/tests/core/test_gh_auth_classify.py
@@ -3,35 +3,46 @@ from mship.core.gh_auth import classify_gh_auth
 
 def test_relay_attach_wins():
     assert classify_gh_auth(
-        app_configured=True, relay_url="https://r", run_token="rt",
+        relay_url="https://r", run_token="rt",
         explicit_token="ghp_x", broker_url="https://b",
     ) == "relay_attach"
 
 
-def test_app_beats_env_token_and_broker():
-    assert classify_gh_auth(
-        app_configured=True, relay_url=None, run_token=None,
-        explicit_token="ghp_x", broker_url="https://b",
-    ) == "app"
+def test_an_app_is_not_a_client_model():
+    """App creds only back serve's `GET /gh-token` for CALLERS; this host's own
+    ops still use the env token. Reporting "app" here would name a model that
+    bootstrap/finish never use (Greptile, PR #411)."""
+    from mship.core.gh_auth import GH_AUTH_MODELS
+
+    assert "app" not in GH_AUTH_MODELS
+
+
+def test_precedence_matches_resolve_tokens_documented_order():
+    """The classifier is the reporting mirror of `resolve_token`: an env token
+    outranks the broker, and nothing outranks relay-attach."""
+    from mship.core.gh_auth import GH_AUTH_MODELS
+
+    assert GH_AUTH_MODELS.index("relay_attach") < GH_AUTH_MODELS.index("env_token")
+    assert GH_AUTH_MODELS.index("env_token") < GH_AUTH_MODELS.index("broker")
 
 
 def test_env_token_beats_broker():
     assert classify_gh_auth(
-        app_configured=False, relay_url=None, run_token=None,
+        relay_url=None, run_token=None,
         explicit_token="ghp_x", broker_url="https://b",
     ) == "env_token"
 
 
 def test_broker_when_only_broker():
     assert classify_gh_auth(
-        app_configured=False, relay_url=None, run_token=None,
+        relay_url=None, run_token=None,
         explicit_token=None, broker_url="https://b",
     ) == "broker"
 
 
 def test_none_when_nothing_configured():
     assert classify_gh_auth(
-        app_configured=False, relay_url=None, run_token=None,
+        relay_url=None, run_token=None,
         explicit_token=None, broker_url=None,
     ) == "none"
 
@@ -39,13 +50,13 @@ def test_none_when_nothing_configured():
 def test_half_configured_relay_is_not_relay_attach():
     # relay-attach needs BOTH url and run token (mirrors relay_flags_error).
     assert classify_gh_auth(
-        app_configured=False, relay_url="https://r", run_token=None,
+        relay_url="https://r", run_token=None,
         explicit_token=None, broker_url=None,
     ) == "none"
 
 
 def test_blank_strings_do_not_count_as_configured():
     assert classify_gh_auth(
-        app_configured=False, relay_url=None, run_token=None,
+        relay_url=None, run_token=None,
         explicit_token="   ", broker_url="",
     ) == "none"

--- a/tests/core/test_serve_net_topology.py
+++ b/tests/core/test_serve_net_topology.py
@@ -1,0 +1,88 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from mship.core.serve import create_app
+
+
+class Cfg:
+    workspace = "ws"
+    run_hosts = ()
+    repos = {}
+    relay = None
+    spec_storage = "committed"
+
+
+@pytest.fixture(autouse=True)
+def _no_pr_watch(monkeypatch):
+    # The lifespan starts a PrWatcher loop; 0 disables it for these tests.
+    monkeypatch.setenv("MSHIP_PR_WATCH_INTERVAL", "0")
+
+
+@pytest.fixture
+def app_factory(tmp_path):
+    def build(*, config, token="tok"):
+        specs = tmp_path / "specs"
+        specs.mkdir(exist_ok=True)
+        (tmp_path / ".mothership").mkdir(exist_ok=True)
+
+        class _State:
+            def load(self):
+                class S:
+                    tasks = {}
+                return S()
+
+        return create_app(
+            specs_dir=specs, state_manager=_State(), log_manager=None,
+            workspace_root=tmp_path, workspace_name="ws", auth_token=token,
+            config=config,
+        )
+    return build
+
+
+def test_requires_the_bearer(app_factory):
+    with TestClient(app_factory(config=Cfg())) as client:
+        assert client.get("/net/topology").status_code == 401
+
+
+def test_returns_the_payload_with_a_version(app_factory):
+    with TestClient(app_factory(config=Cfg())) as client:
+        r = client.get("/net/topology", headers={"Authorization": "Bearer tok"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["version"] == 1
+    assert body["workspace"] == "ws"
+    assert body["probed_at"]
+    assert isinstance(body["edges"], list)
+
+
+def test_payload_is_renderable_on_its_own(app_factory):
+    """AC6: every field the console renders comes from this response — no
+    in-process-only data. If the console needs a field, it is asserted here."""
+    with TestClient(app_factory(config=Cfg())) as client:
+        body = client.get(
+            "/net/topology", headers={"Authorization": "Bearer tok"}
+        ).json()
+
+    assert set(body) >= {"version", "workspace", "probed_at", "edges"}
+    assert body["edges"], "expected at least one edge to render"
+    for edge in body["edges"]:
+        assert set(edge) == {"kind", "name", "status", "code", "detail", "fix", "facts"}
+        assert edge["status"] in ("ok", "warn", "fail", "absent")
+
+
+def test_503_when_serve_has_no_workspace_config(app_factory):
+    with TestClient(app_factory(config=None)) as client:
+        r = client.get("/net/topology", headers={"Authorization": "Bearer tok"})
+    assert r.status_code == 503
+    assert "bootstrap" in r.json()["detail"].lower()
+
+
+def test_never_500s_on_a_broken_environment(app_factory):
+    class Broken(Cfg):
+        run_hosts = ("mac", "linux")
+
+    with TestClient(app_factory(config=Broken())) as client:
+        r = client.get("/net/topology", headers={"Authorization": "Bearer tok"})
+    assert r.status_code == 200
+    codes = {e["code"] for e in r.json()["edges"]}
+    assert "run_host_unmapped" in codes

--- a/tests/core/test_topology_model.py
+++ b/tests/core/test_topology_model.py
@@ -1,0 +1,60 @@
+import json
+
+from mship.core.topology import (
+    SCHEMA_VERSION,
+    STATUSES,
+    Edge,
+    Topology,
+    topology_payload,
+)
+
+
+def _edge(**kw):
+    base = dict(
+        kind="relay", name="relay", status="fail",
+        code="relay_unreachable", detail="could not reach https://x/health",
+        fix="check the relay is up", facts={"host": "relay.example.com"},
+    )
+    base.update(kw)
+    return Edge(**base)
+
+
+def test_payload_carries_schema_version_and_edges():
+    t = Topology(
+        version=SCHEMA_VERSION,
+        workspace="mship-workspace",
+        probed_at="2026-07-25T16:00:00+00:00",
+        edges=[_edge()],
+    )
+    payload = topology_payload(t)
+
+    assert payload["version"] == SCHEMA_VERSION
+    assert payload["workspace"] == "mship-workspace"
+    assert payload["probed_at"] == "2026-07-25T16:00:00+00:00"
+    assert payload["edges"][0] == {
+        "kind": "relay",
+        "name": "relay",
+        "status": "fail",
+        "code": "relay_unreachable",
+        "detail": "could not reach https://x/health",
+        "fix": "check the relay is up",
+        "facts": {"host": "relay.example.com"},
+    }
+
+
+def test_payload_is_json_serializable():
+    t = Topology(version=SCHEMA_VERSION, workspace="w", probed_at="t", edges=[_edge()])
+    assert json.loads(json.dumps(topology_payload(t)))["version"] == SCHEMA_VERSION
+
+
+def test_healthy_edge_has_no_fix():
+    e = _edge(status="ok", code="relay_ok", fix=None)
+    assert topology_payload(
+        Topology(version=SCHEMA_VERSION, workspace="w", probed_at="t", edges=[e])
+    )["edges"][0]["fix"] is None
+
+
+def test_status_values_are_constrained():
+    # The four statuses a caller may branch on; `absent` means "not configured
+    # on this machine", which is not a problem to fix.
+    assert STATUSES == ("ok", "warn", "fail", "absent")

--- a/tests/core/test_topology_probe.py
+++ b/tests/core/test_topology_probe.py
@@ -1,0 +1,369 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from mship.core.relay.health import HealthProbe
+from mship.core.relay.runtime import RelayRuntimeRecord, write_runtime_record
+from mship.core.topology import (
+    EGRESS_ABSENT,
+    EGRESS_ROUTED,
+    EGRESS_UNKNOWN,
+    GH_AUTH_APP,
+    GH_AUTH_BROKER,
+    GH_AUTH_NONE,
+    GH_AUTH_RELAY_ATTACH,
+    RELAY_AUTH_FAILED,
+    RELAY_NOT_CONFIGURED,
+    RELAY_NOT_RUNNING,
+    RELAY_OK,
+    RELAY_UNREACHABLE,
+    RUN_HOST_NOT_BOOTSTRAPPED,
+    RUN_HOST_OK,
+    RUN_HOST_ORPHAN_MAPPING,
+    RUN_HOST_STALE_TOKEN,
+    RUN_HOST_UNKNOWN_ROLE,
+    RUN_HOST_UNMAPPED,
+    RUN_HOST_UNREACHABLE,
+    RUN_HOSTS_AMBIGUOUS_DEFAULT,
+    RUN_HOSTS_NONE_DECLARED,
+    SERVE_RELAY_ABSENT,
+    SERVE_RELAY_RUNNING,
+    probe_topology,
+)
+
+
+@dataclass
+class FakeConfig:
+    workspace: str = "ws"
+    run_hosts: tuple = ()
+    repos: dict = None
+    relay: object = None
+
+    def __post_init__(self):
+        if self.repos is None:
+            self.repos = {}
+
+
+@dataclass
+class FakeRepo:
+    run_host: str | None = None
+
+
+class FakeShell:
+    def __init__(self, stdout="", returncode=0, raises=None):
+        self._stdout, self._rc, self._raises = stdout, returncode, raises
+        self.calls = []
+
+    def run(self, cmd, cwd=None, **kw):
+        self.calls.append(cmd)
+        if self._raises:
+            raise self._raises
+        stdout, rc = self._stdout, self._rc
+
+        class R:
+            pass
+
+        R.stdout, R.stderr, R.returncode = stdout, "", rc
+        return R()
+
+
+def _probe(**by_url):
+    """Return a probe fn serving canned HealthProbes keyed by url."""
+    def fn(url, token, *, timeout=None):
+        return by_url.get(url, HealthProbe(ok=False, error="no route"))
+    return fn
+
+
+def _edges(t, kind):
+    return [e for e in t.edges if e.kind == kind]
+
+
+def _run(tmp_path, config, *, probe=None, env=None, shell=None, **kw):
+    return probe_topology(
+        config=config, state_dir=tmp_path / ".mothership", workspace_root=tmp_path,
+        home=tmp_path, env=env or {}, probe=probe or _probe(), now=lambda: "t",
+        pid_alive=lambda pid: True, shell=shell or FakeShell(), **kw,
+    )
+
+
+# --- serve + relay edges ---------------------------------------------------
+
+def test_relay_absent_when_no_relay_configured(tmp_path: Path):
+    t = _run(tmp_path, FakeConfig())
+    relay = _edges(t, "relay")[0]
+    assert relay.status == "absent" and relay.code == RELAY_NOT_CONFIGURED
+    assert relay.fix is not None          # tells you how to configure one
+    serve = _edges(t, "serve")[0]
+    assert serve.code == SERVE_RELAY_ABSENT
+
+
+def test_relay_reachable_reports_ok_and_no_fix(tmp_path: Path):
+    write_runtime_record(tmp_path, RelayRuntimeRecord(
+        host="relay.example.com", pid=1, subdomain="abc-123456",
+        url="https://abc-123456.relay.example.com", workspace="ws",
+    ))
+    t = _run(
+        tmp_path, FakeConfig(relay=object()),
+        probe=_probe(**{
+            "https://abc-123456.relay.example.com": HealthProbe(ok=True, status_code=200)
+        }),
+    )
+    relay = _edges(t, "relay")[0]
+    assert relay.status == "ok" and relay.code == RELAY_OK and relay.fix is None
+    assert _edges(t, "serve")[0].code == SERVE_RELAY_RUNNING
+
+
+def test_relay_unreachable_carries_fix(tmp_path: Path):
+    write_runtime_record(tmp_path, RelayRuntimeRecord(
+        host="relay.example.com", pid=1, subdomain="abc-123456",
+        url="https://abc-123456.relay.example.com",
+    ))
+    t = _run(tmp_path, FakeConfig(relay=object()), probe=_probe())
+    relay = _edges(t, "relay")[0]
+    assert relay.status == "fail" and relay.code == RELAY_UNREACHABLE
+    assert "serve --relay" in relay.fix
+
+
+def test_relay_401_is_auth_failed_not_unreachable(tmp_path: Path):
+    write_runtime_record(tmp_path, RelayRuntimeRecord(
+        host="relay.example.com", pid=1, subdomain="s", url="https://s.relay",
+    ))
+    t = _run(tmp_path, FakeConfig(relay=object()),
+             probe=_probe(**{"https://s.relay": HealthProbe(ok=False, status_code=401)}))
+    assert _edges(t, "relay")[0].code == RELAY_AUTH_FAILED
+
+
+def test_dead_pid_reports_not_running_and_skips_the_probe(tmp_path: Path):
+    write_runtime_record(tmp_path, RelayRuntimeRecord(
+        host="relay.example.com", pid=999999, subdomain="s", url="https://s.relay",
+    ))
+    calls = []
+
+    def counting_probe(url, token, *, timeout=None):
+        calls.append(url)
+        return HealthProbe(ok=True, status_code=200)
+
+    t = probe_topology(
+        config=FakeConfig(relay=object()), state_dir=tmp_path / ".mothership",
+        workspace_root=tmp_path, home=tmp_path, env={},
+        probe=counting_probe, now=lambda: "t", pid_alive=lambda pid: False,
+        shell=FakeShell(),
+    )
+    assert _edges(t, "relay")[0].code == RELAY_NOT_RUNNING
+    assert calls == []          # no point probing a tunnel whose serve is gone
+
+
+def test_skip_network_never_probes(tmp_path: Path):
+    write_runtime_record(tmp_path, RelayRuntimeRecord(
+        host="relay.example.com", pid=1, subdomain="s", url="https://s.relay",
+    ))
+    calls = []
+
+    def counting_probe(url, token, *, timeout=None):
+        calls.append(url)
+        return HealthProbe(ok=True, status_code=200)
+
+    t = _run(tmp_path, FakeConfig(relay=object()), probe=counting_probe,
+             skip_network=True)
+    assert calls == []
+    assert _edges(t, "relay")[0].status in ("warn", "absent")
+
+
+def test_probed_at_and_version_present(tmp_path: Path):
+    t = _run(tmp_path, FakeConfig(), probe=_probe())
+    assert t.probed_at == "t"
+    assert t.version == 1 and t.workspace == "ws"
+
+
+# --- run-host edges --------------------------------------------------------
+
+def _map_role(tmp_path: Path, role: str, url: str, token: str = "tok"):
+    from mship.core.run_host.config import RunHostConnection
+    from mship.core.run_host.store import RunHostStore
+    RunHostStore(tmp_path / ".mothership").set(role, RunHostConnection(url=url, token=token))
+
+
+def _named(t, name):
+    return [e for e in t.edges if e.name == name][0]
+
+
+def test_no_roles_declared_is_an_absent_aggregate_edge(tmp_path: Path):
+    t = _run(tmp_path, FakeConfig())
+    agg = _named(t, "run_hosts")
+    assert agg.status == "absent" and agg.code == RUN_HOSTS_NONE_DECLARED
+
+
+def test_declared_but_unmapped_role_names_run_host_add(tmp_path: Path):
+    t = _run(tmp_path, FakeConfig(run_hosts=("mac",)))
+    edge = _named(t, "run_host:mac")
+    assert edge.status == "fail" and edge.code == RUN_HOST_UNMAPPED
+    assert "mship run-host add mac" in edge.fix
+
+
+def test_mapped_and_reachable_role_is_ok_with_source(tmp_path: Path):
+    _map_role(tmp_path, "mac", "https://mac.relay")
+    t = _run(tmp_path, FakeConfig(run_hosts=("mac",)),
+             probe=_probe(**{"https://mac.relay": HealthProbe(ok=True, status_code=200)}))
+    edge = _named(t, "run_host:mac")
+    assert edge.status == "ok" and edge.code == RUN_HOST_OK
+    assert edge.facts["url"] == "https://mac.relay"
+    assert edge.facts["url_source"] == "file"
+    assert edge.facts["token_configured"] is True
+
+
+def test_env_override_is_reported_as_the_effective_source(tmp_path: Path):
+    _map_role(tmp_path, "mac", "https://from-file")
+    t = _run(
+        tmp_path, FakeConfig(run_hosts=("mac",)),
+        env={"MSHIP_RUN_HOST_MAC_URL": "https://from-env"},
+        probe=_probe(**{"https://from-env": HealthProbe(ok=True, status_code=200)}),
+    )
+    edge = _named(t, "run_host:mac")
+    assert edge.facts["url"] == "https://from-env"
+    assert edge.facts["url_source"] == "env:MSHIP_RUN_HOST_MAC_URL"
+
+
+def test_503_is_not_bootstrapped(tmp_path: Path):
+    _map_role(tmp_path, "mac", "https://mac.relay")
+    t = _run(tmp_path, FakeConfig(run_hosts=("mac",)),
+             probe=_probe(**{"https://mac.relay": HealthProbe(ok=False, status_code=503)}))
+    edge = _named(t, "run_host:mac")
+    assert edge.code == RUN_HOST_NOT_BOOTSTRAPPED
+    assert "bootstrap" in edge.fix
+
+
+def test_401_is_stale_token(tmp_path: Path):
+    _map_role(tmp_path, "mac", "https://mac.relay")
+    t = _run(tmp_path, FakeConfig(run_hosts=("mac",)),
+             probe=_probe(**{"https://mac.relay": HealthProbe(ok=False, status_code=401)}))
+    edge = _named(t, "run_host:mac")
+    assert edge.code == RUN_HOST_STALE_TOKEN
+    assert "mship run-host add mac" in edge.fix
+
+
+def test_transport_error_is_unreachable(tmp_path: Path):
+    _map_role(tmp_path, "mac", "https://mac.relay")
+    t = _run(tmp_path, FakeConfig(run_hosts=("mac",)), probe=_probe())
+    assert _named(t, "run_host:mac").code == RUN_HOST_UNREACHABLE
+
+
+def test_repo_declaring_an_undeclared_role_is_unknown_role(tmp_path: Path):
+    cfg = FakeConfig(run_hosts=("mac",), repos={"api": FakeRepo(run_host="typo")})
+    t = _run(tmp_path, cfg)
+    edge = _named(t, "run_host:typo")
+    assert edge.status == "fail" and edge.code == RUN_HOST_UNKNOWN_ROLE
+    assert "api" in edge.detail          # names the repo that points at it
+
+
+def test_ambiguous_default_when_two_roles_and_no_repo_default(tmp_path: Path):
+    _map_role(tmp_path, "mac", "https://mac")
+    _map_role(tmp_path, "linux", "https://linux")
+    t = _run(tmp_path, FakeConfig(run_hosts=("mac", "linux")))
+    agg = _named(t, "run_hosts")
+    assert agg.status == "warn" and agg.code == RUN_HOSTS_AMBIGUOUS_DEFAULT
+    assert "--remote=<role>" in agg.fix
+
+
+def test_mapping_for_an_undeclared_role_is_an_orphan_warning(tmp_path: Path):
+    _map_role(tmp_path, "gone", "https://gone")
+    t = _run(tmp_path, FakeConfig(run_hosts=("mac",)))
+    edge = _named(t, "run_host:gone")
+    assert edge.status == "warn" and edge.code == RUN_HOST_ORPHAN_MAPPING
+
+
+def test_unmapped_role_is_never_probed(tmp_path: Path):
+    calls = []
+
+    def counting(url, token, *, timeout=None):
+        calls.append(url)
+        return HealthProbe(ok=True, status_code=200)
+
+    _run(tmp_path, FakeConfig(run_hosts=("mac",)), probe=counting)
+    assert calls == []
+
+
+# --- gh auth + egress edges ------------------------------------------------
+
+def test_gh_auth_none_when_nothing_configured(tmp_path: Path):
+    t = _run(tmp_path, FakeConfig(), shell=FakeShell())
+    edge = _edges(t, "gh_auth")[0]
+    assert edge.code == GH_AUTH_NONE and edge.status == "warn"
+    assert "MSHIP_GH_BROKER_URL" in edge.fix
+
+
+def test_gh_auth_reports_app_without_leaking_the_key(tmp_path: Path):
+    key = tmp_path / "app.pem"
+    key.write_text("-----BEGIN PRIVATE KEY-----\nsupersecret\n")
+    t = _run(
+        tmp_path, FakeConfig(), shell=FakeShell(),
+        env={"MSHIP_GH_APP_ID": "12345", "MSHIP_GH_APP_KEY": str(key)},
+    )
+    edge = _edges(t, "gh_auth")[0]
+    assert edge.code == GH_AUTH_APP and edge.status == "ok"
+    assert edge.facts["app_key_readable"] is True
+    assert "supersecret" not in json.dumps(edge.facts)
+    assert "12345" not in json.dumps(edge.facts)   # an App id is credential-adjacent
+
+
+def test_gh_auth_broker_and_relay_attach(tmp_path: Path):
+    t = _run(tmp_path, FakeConfig(), shell=FakeShell(),
+             env={"MSHIP_GH_BROKER_URL": "https://b", "MSHIP_SERVE_TOKEN": "s"})
+    assert _edges(t, "gh_auth")[0].code == GH_AUTH_BROKER
+
+    t2 = _run(tmp_path, FakeConfig(), shell=FakeShell(),
+              env={"MSHIP_RELAY_URL": "https://r", "MSHIP_RUN_TOKEN": "rt"})
+    assert _edges(t2, "gh_auth")[0].code == GH_AUTH_RELAY_ATTACH
+
+
+def test_egress_routed_when_git_config_has_the_rewrite(tmp_path: Path):
+    shell = FakeShell(stdout=(
+        "url.https://egress.example.com/gh/.insteadof https://github.com/\n"
+        "url.https://egress.example.com/api/.insteadof https://api.github.com/\n"
+    ))
+    t = _run(tmp_path, FakeConfig(), shell=shell)
+    edge = _edges(t, "egress")[0]
+    assert edge.code == EGRESS_ROUTED and edge.status == "ok"
+    assert edge.facts["relay_base"] == "https://egress.example.com"
+
+
+def test_egress_absent_when_git_config_is_clean(tmp_path: Path):
+    t = _run(tmp_path, FakeConfig(), shell=FakeShell(stdout="", returncode=1))
+    edge = _edges(t, "egress")[0]
+    assert edge.code == EGRESS_ABSENT and edge.status == "absent"
+
+
+def test_egress_unknown_when_git_is_unavailable(tmp_path: Path):
+    t = _run(tmp_path, FakeConfig(), shell=FakeShell(raises=OSError("no git")))
+    edge = _edges(t, "egress")[0]
+    assert edge.code == EGRESS_UNKNOWN and edge.status == "warn"
+
+
+def test_fully_broken_environment_still_returns_every_edge(tmp_path: Path):
+    """AC4: serve down, relay unreachable, no run hosts mapped, no git,
+    no auth — probe_topology must return a report, not raise."""
+    cfg = FakeConfig(run_hosts=("mac", "linux"), relay=object())
+    t = probe_topology(
+        config=cfg, state_dir=tmp_path / "nope", workspace_root=tmp_path / "nope",
+        home=tmp_path / "nope", env={}, probe=_probe(),
+        shell=FakeShell(raises=OSError("boom")), now=lambda: "t",
+        pid_alive=lambda pid: False,
+    )
+    assert {e.kind for e in t.edges} == {"serve", "relay", "run_host", "gh_auth", "egress"}
+    # every unhealthy edge offers a next step
+    assert all(e.fix for e in t.edges if e.status in ("fail", "warn"))
+
+
+def test_every_probe_call_is_timeout_bounded(tmp_path: Path):
+    seen = []
+
+    def recording(url, token, *, timeout=None):
+        seen.append(timeout)
+        return HealthProbe(ok=True, status_code=200)
+
+    _map_role(tmp_path, "mac", "https://mac")
+    write_runtime_record(tmp_path, RelayRuntimeRecord(
+        host="h", pid=1, subdomain="s", url="https://s.relay", workspace="ws",
+    ))
+    _run(tmp_path, FakeConfig(run_hosts=("mac",), relay=object()),
+         probe=recording, shell=FakeShell())
+    assert seen and all(isinstance(x, float) and x > 0 for x in seen)

--- a/tests/core/test_topology_probe.py
+++ b/tests/core/test_topology_probe.py
@@ -415,3 +415,61 @@ def test_no_unhealthy_edge_is_ever_left_without_a_fix(tmp_path: Path):
     assert unhealthy, "expected this fixture to produce unhealthy edges"
     missing = [e.name for e in unhealthy if not e.fix]
     assert missing == [], f"edges with no fix hint: {missing}"
+
+
+# --- not-probed is its own state, and a corrupt store cannot crash the probe ---
+
+def test_skipped_probe_is_not_reported_as_unreachable(tmp_path: Path):
+    """A UI branching on `relay_unreachable` must not light up merely because
+    probes were skipped — "not probed" is a different state from "down"."""
+    from mship.core.topology import PROBE_SKIPPED
+
+    _map_role(tmp_path, "mac", "https://mac.relay")
+    write_runtime_record(tmp_path, RelayRuntimeRecord(
+        host="h", pid=1, subdomain="s", url="https://s.relay", workspace="ws",
+    ))
+    t = _run(tmp_path, FakeConfig(run_hosts=("mac",), relay=object()),
+             skip_network=True)
+
+    assert _named(t, "relay").code == PROBE_SKIPPED
+    assert _named(t, "run_host:mac").code == PROBE_SKIPPED
+    assert RELAY_UNREACHABLE not in {e.code for e in t.edges}
+    assert RUN_HOST_UNREACHABLE not in {e.code for e in t.edges}
+
+
+def test_relay_record_without_a_url_is_its_own_state(tmp_path: Path):
+    from mship.core.topology import RELAY_NO_PUBLIC_URL
+
+    write_runtime_record(tmp_path, RelayRuntimeRecord(
+        host="h", pid=1, subdomain="s", url=None, workspace="ws",
+    ))
+    t = _run(tmp_path, FakeConfig(relay=object()))
+    assert _named(t, "relay").code == RELAY_NO_PUBLIC_URL
+
+
+def test_corrupt_run_host_store_does_not_raise(tmp_path: Path):
+    """AC4: a broken environment is the expected input. A hand-edited
+    run-hosts.yaml must degrade to a reported edge, not a traceback."""
+    from mship.core.topology import RUN_HOSTS_STORE_UNREADABLE
+
+    state = tmp_path / ".mothership"
+    state.mkdir(parents=True)
+    (state / "run-hosts.yaml").write_text("mac: {url: [unclosed\n")
+
+    t = _run(tmp_path, FakeConfig(run_hosts=("mac",)))
+    edge = _named(t, "run_hosts")
+    assert edge.status == "warn" and edge.code == RUN_HOSTS_STORE_UNREADABLE
+    assert "run-hosts.yaml" in edge.fix
+    # the other edge kinds still reported
+    assert {e.kind for e in t.edges} >= {"serve", "relay", "gh_auth", "egress"}
+
+
+def test_non_mapping_run_host_store_does_not_raise(tmp_path: Path):
+    from mship.core.topology import RUN_HOSTS_STORE_UNREADABLE
+
+    state = tmp_path / ".mothership"
+    state.mkdir(parents=True)
+    (state / "run-hosts.yaml").write_text("just a string\n")
+
+    t = _run(tmp_path, FakeConfig(run_hosts=("mac",)))
+    assert _named(t, "run_hosts").code == RUN_HOSTS_STORE_UNREADABLE

--- a/tests/core/test_topology_probe.py
+++ b/tests/core/test_topology_probe.py
@@ -367,3 +367,51 @@ def test_every_probe_call_is_timeout_bounded(tmp_path: Path):
     _run(tmp_path, FakeConfig(run_hosts=("mac",), relay=object()),
          probe=recording, shell=FakeShell())
     assert seen and all(isinstance(x, float) and x > 0 for x in seen)
+
+
+# --- code vocabulary guards ------------------------------------------------
+
+def test_documented_failure_modes_have_distinct_codes():
+    """AC8: docs/remote-run.md's troubleshooting rows map 1:1 onto codes."""
+    documented = {
+        "unknown role": RUN_HOST_UNKNOWN_ROLE,
+        "ambiguous run-host": RUN_HOSTS_AMBIGUOUS_DEFAULT,
+        "role unmapped on this machine": RUN_HOST_UNMAPPED,
+        "relay unreachable": RUN_HOST_UNREACHABLE,
+        "remote not bootstrapped (503)": RUN_HOST_NOT_BOOTSTRAPPED,
+        "stale token (401)": RUN_HOST_STALE_TOKEN,
+    }
+    assert len(set(documented.values())) == len(documented)
+
+
+def test_every_status_code_constant_is_unique():
+    """A copy-pasted constant would silently merge two states in the UI."""
+    from mship.core import topology as topo
+
+    codes = [
+        v for k, v in vars(topo).items()
+        if k.isupper() and isinstance(v, str) and not k.startswith("_")
+        and k != "SCHEMA_VERSION"
+    ]
+    assert len(codes) == len(set(codes)), "duplicate status-code value"
+
+
+def test_no_unhealthy_edge_is_ever_left_without_a_fix(tmp_path: Path):
+    """Across every unhealthy shape this module can produce, `fix` is set —
+    a status code with no next step is a dead end for the operator."""
+    cfg = FakeConfig(run_hosts=("mac", "linux"), relay=object(),
+                     repos={"api": FakeRepo(run_host="typo")})
+    _map_role(tmp_path, "linux", "https://linux.relay")
+    _map_role(tmp_path, "orphan", "https://orphan.relay")
+    write_runtime_record(tmp_path, RelayRuntimeRecord(
+        host="h", pid=1, subdomain="s", url="https://s.relay", workspace="ws",
+    ))
+    t = _run(
+        tmp_path, cfg,
+        probe=_probe(**{"https://linux.relay": HealthProbe(ok=False, status_code=503)}),
+        shell=FakeShell(raises=OSError("no git")),
+    )
+    unhealthy = [e for e in t.edges if e.status in ("warn", "fail")]
+    assert unhealthy, "expected this fixture to produce unhealthy edges"
+    missing = [e.name for e in unhealthy if not e.fix]
+    assert missing == [], f"edges with no fix hint: {missing}"

--- a/tests/core/test_topology_probe.py
+++ b/tests/core/test_topology_probe.py
@@ -8,7 +8,7 @@ from mship.core.topology import (
     EGRESS_ABSENT,
     EGRESS_ROUTED,
     EGRESS_UNKNOWN,
-    GH_AUTH_APP,
+    GH_AUTH_ENV_TOKEN,
     GH_AUTH_BROKER,
     GH_AUTH_NONE,
     GH_AUTH_RELAY_ATTACH,
@@ -291,7 +291,7 @@ def test_gh_auth_none_when_nothing_configured(tmp_path: Path):
     assert "MSHIP_GH_BROKER_URL" in edge.fix
 
 
-def test_gh_auth_reports_app_without_leaking_the_key(tmp_path: Path):
+def test_gh_auth_reports_the_app_capability_without_leaking_the_key(tmp_path: Path):
     key = tmp_path / "app.pem"
     key.write_text("-----BEGIN PRIVATE KEY-----\nsupersecret\n")
     t = _run(
@@ -299,7 +299,7 @@ def test_gh_auth_reports_app_without_leaking_the_key(tmp_path: Path):
         env={"MSHIP_GH_APP_ID": "12345", "MSHIP_GH_APP_KEY": str(key)},
     )
     edge = _edges(t, "gh_auth")[0]
-    assert edge.code == GH_AUTH_APP and edge.status == "ok"
+    assert edge.facts["serves_app_backed_tokens"] is True
     assert edge.facts["app_key_readable"] is True
     assert "supersecret" not in json.dumps(edge.facts)
     assert "12345" not in json.dumps(edge.facts)   # an App id is credential-adjacent
@@ -473,3 +473,113 @@ def test_non_mapping_run_host_store_does_not_raise(tmp_path: Path):
 
     t = _run(tmp_path, FakeConfig(run_hosts=("mac",)))
     assert _named(t, "run_hosts").code == RUN_HOSTS_STORE_UNREADABLE
+
+
+# --- Greptile P1 findings ---------------------------------------------------
+
+def test_relay_probe_uses_the_env_serve_token_when_set(tmp_path: Path):
+    """Greptile P1: `ensure_serve_token` is env-override > file, and the env
+    value is never written to the file. Probing with the file value would 401 on
+    a healthy relay and report relay_auth_failed."""
+    state = tmp_path / ".mothership"
+    state.mkdir(parents=True)
+    (state / "serve-token").write_text("stale-file-token\n")
+    write_runtime_record(tmp_path, RelayRuntimeRecord(
+        host="h", pid=1, subdomain="s", url="https://s.relay", workspace="ws",
+    ))
+    seen = {}
+
+    def recording(url, token, *, timeout=None):
+        seen["token"] = token
+        return HealthProbe(ok=True, status_code=200)
+
+    t = _run(tmp_path, FakeConfig(relay=object()), probe=recording,
+             env={"MSHIP_SERVE_TOKEN": "live-env-token"})
+    assert seen["token"] == "live-env-token"
+    assert _named(t, "relay").code == RELAY_OK
+
+
+def test_relay_probe_falls_back_to_the_file_token(tmp_path: Path):
+    state = tmp_path / ".mothership"
+    state.mkdir(parents=True)
+    (state / "serve-token").write_text("file-token\n")
+    write_runtime_record(tmp_path, RelayRuntimeRecord(
+        host="h", pid=1, subdomain="s", url="https://s.relay", workspace="ws",
+    ))
+    seen = {}
+
+    def recording(url, token, *, timeout=None):
+        seen["token"] = token
+        return HealthProbe(ok=True, status_code=200)
+
+    _run(tmp_path, FakeConfig(relay=object()), probe=recording, env={})
+    assert seen["token"] == "file-token"
+
+
+def test_non_utf8_serve_token_does_not_raise(tmp_path: Path):
+    """Greptile P1: read_text raises UnicodeDecodeError (a ValueError, NOT an
+    OSError) on a corrupt token, which an OSError-only handler misses."""
+    state = tmp_path / ".mothership"
+    state.mkdir(parents=True)
+    (state / "serve-token").write_bytes(b"\xff\xfe not utf-8 \x00")
+    write_runtime_record(tmp_path, RelayRuntimeRecord(
+        host="h", pid=1, subdomain="s", url="https://s.relay", workspace="ws",
+    ))
+    t = _run(tmp_path, FakeConfig(relay=object()))
+    assert {e.kind for e in t.edges} >= {"serve", "relay"}
+
+
+def test_non_utf8_relay_pubkey_does_not_raise(tmp_path: Path):
+    """Same hole in the drift check's read of the public key."""
+    state = tmp_path / ".mothership"
+    state.mkdir(parents=True)
+    (state / "relay-subdomain-secret").write_bytes(b"x" * 32)
+    (state / "relay_ed25519.pub").write_bytes(b"\xff\xfe binary")
+    write_runtime_record(tmp_path, RelayRuntimeRecord(
+        host="h", pid=1, subdomain="s", url="https://s.relay", workspace="ws",
+    ))
+    t = _run(tmp_path, FakeConfig(relay=object()))
+    assert _named(t, "relay").code in {RELAY_OK, RELAY_UNREACHABLE}
+
+
+def test_env_token_wins_over_app_creds_in_the_reported_model(tmp_path: Path):
+    """Greptile P1: App creds serve `GET /gh-token` for CALLERS (Broker B) —
+    they are not how this machine authenticates its own git ops. With GH_TOKEN
+    set, `resolve_token` uses GH_TOKEN, so that is the model in effect."""
+    from mship.core.topology import GH_AUTH_ENV_TOKEN
+
+    key = tmp_path / "app.pem"
+    key.write_text("-----BEGIN PRIVATE KEY-----\nx\n")
+    t = _run(tmp_path, FakeConfig(), env={
+        "MSHIP_GH_APP_ID": "1", "MSHIP_GH_APP_KEY": str(key),
+        "GH_TOKEN": "ghp_x",
+    })
+    edge = _edges(t, "gh_auth")[0]
+    assert edge.code == GH_AUTH_ENV_TOKEN
+    # the App capability is still reported, as what it actually is
+    assert edge.facts["serves_app_backed_tokens"] is True
+
+
+def test_app_creds_alone_report_the_broker_capability_not_a_client_model(tmp_path: Path):
+    from mship.core.topology import GH_AUTH_NONE
+
+    key = tmp_path / "app.pem"
+    key.write_text("-----BEGIN PRIVATE KEY-----\nx\n")
+    t = _run(tmp_path, FakeConfig(), env={
+        "MSHIP_GH_APP_ID": "1", "MSHIP_GH_APP_KEY": str(key),
+    })
+    edge = _edges(t, "gh_auth")[0]
+    # This host mints App tokens for others but has no client auth of its own.
+    assert edge.code == GH_AUTH_NONE
+    assert edge.facts["serves_app_backed_tokens"] is True
+    assert "App-backed" in edge.detail
+
+
+def test_unreadable_app_key_is_a_distinct_failure(tmp_path: Path):
+    from mship.core.topology import GH_AUTH_APP_KEY_UNREADABLE
+
+    t = _run(tmp_path, FakeConfig(), env={
+        "MSHIP_GH_APP_ID": "1", "MSHIP_GH_APP_KEY": str(tmp_path / "missing.pem"),
+    })
+    edge = _edges(t, "gh_auth")[0]
+    assert edge.status == "fail" and edge.code == GH_AUTH_APP_KEY_UNREADABLE

--- a/tests/core/test_topology_redaction.py
+++ b/tests/core/test_topology_redaction.py
@@ -1,0 +1,99 @@
+"""AC7: no secret material in any topology output.
+
+Plant a unique sentinel in every secret-bearing input topology reads, then
+assert none survive into the serialized payload. Serializing the WHOLE payload
+(not per-field) is deliberate: a new edge that leaks a token fails this test
+without anyone remembering to extend it.
+"""
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from mship.core.relay.health import HealthProbe
+from mship.core.run_host.config import RunHostConnection
+from mship.core.run_host.store import RunHostStore
+from mship.core.topology import probe_topology, topology_payload
+
+SECRETS = {
+    "run_host_token": "SENTINEL-runhost-token",
+    "serve_token": "SENTINEL-serve-token",
+    "env_run_host_token": "SENTINEL-env-runhost-token",
+    "gh_token": "SENTINEL-gh-token",
+    "run_token": "SENTINEL-run-token",
+    "serve_token_env": "SENTINEL-serve-token-env",
+    "app_key_body": "SENTINEL-app-private-key-body",
+    "subdomain_secret": "SENTINEL-subdomain-secret-bytes",
+}
+
+
+@dataclass
+class Cfg:
+    workspace: str = "ws"
+    run_hosts: tuple = ("mac",)
+    repos: dict = None
+    relay: object = None
+
+    def __post_init__(self):
+        self.repos = self.repos or {}
+
+
+class Shell:
+    def run(self, cmd, cwd=None, **kw):
+        class R:
+            stdout, stderr, returncode = "", "", 1
+        return R()
+
+
+def _ok_probe(url, token, *, timeout=None):
+    return HealthProbe(ok=True, status_code=200)
+
+
+def test_no_secret_reaches_the_payload(tmp_path: Path):
+    state = tmp_path / ".mothership"
+    state.mkdir(parents=True)
+    (state / "serve-token").write_text(SECRETS["serve_token"])
+    (state / "relay-subdomain-secret").write_bytes(
+        SECRETS["subdomain_secret"].encode() * 2
+    )
+    RunHostStore(state).set("mac", RunHostConnection(
+        url="https://mac.relay", token=SECRETS["run_host_token"],
+    ))
+    key = tmp_path / "app.pem"
+    key.write_text(f"-----BEGIN PRIVATE KEY-----\n{SECRETS['app_key_body']}\n")
+
+    env = {
+        "MSHIP_RUN_HOST_MAC_TOKEN": SECRETS["env_run_host_token"],
+        "GH_TOKEN": SECRETS["gh_token"],
+        "MSHIP_RUN_TOKEN": SECRETS["run_token"],
+        "MSHIP_SERVE_TOKEN": SECRETS["serve_token_env"],
+        "MSHIP_GH_APP_ID": "999",
+        "MSHIP_GH_APP_KEY": str(key),
+        "MSHIP_RELAY_URL": "https://relay.example.com",
+    }
+
+    topology = probe_topology(
+        config=Cfg(relay=object()), state_dir=state, workspace_root=tmp_path,
+        home=tmp_path, env=env, shell=Shell(), now=lambda: "t",
+        pid_alive=lambda pid: True, probe=_ok_probe,
+    )
+    blob = json.dumps(topology_payload(topology))
+
+    leaked = [name for name, value in SECRETS.items() if value in blob]
+    assert leaked == [], f"topology payload leaked: {leaked}"
+
+
+def test_token_presence_is_still_reported_as_a_boolean(tmp_path: Path):
+    """Redaction must not cost the operator the information they need: the
+    payload says a token IS configured, without saying what it is."""
+    state = tmp_path / ".mothership"
+    state.mkdir(parents=True)
+    RunHostStore(state).set("mac", RunHostConnection(
+        url="https://mac.relay", token=SECRETS["run_host_token"],
+    ))
+    topology = probe_topology(
+        config=Cfg(), state_dir=state, workspace_root=tmp_path, home=tmp_path,
+        env={}, shell=Shell(), now=lambda: "t", pid_alive=lambda pid: True,
+        probe=_ok_probe,
+    )
+    edge = [e for e in topology.edges if e.name == "run_host:mac"][0]
+    assert edge.facts["token_configured"] is True


### PR DESCRIPTION
Adds one read-only `probe_topology()` that reports this machine's connectivity graph with a machine-readable status code and an actionable fix per edge, surfaced by three thin callers. Prerequisite for the serve-host management console (spec `serve-host-management-ui`), whose only coupling to the backend is this payload.

## What you get

```
$ mship net status
ok      serve       serve_relay_running      relay-serve pid 1684145 running
ok      relay       relay_ok                 https://…mship-relay.atomikpanda.com reachable
absent  run_hosts   run_hosts_none_declared  no run_hosts declared in mothership.yaml
warn    gh_auth     gh_auth_none             no GitHub auth configured on this machine
absent  egress      egress_absent            git is not routed through a relay egress
```

Same structure from `mship doctor` (a `connectivity/*` group) and `GET /net/topology` (JSON, behind the existing bearer).

## Reused rather than reinvented

- **`relay.health`** stays the single reachability prober. `probe_health()` is extracted from `verify_relay_reachable` to expose the status code — that is what lets 401 (stale token), 503 (not bootstrapped), and a transport failure become *distinct* codes instead of prose to grep. `verify_relay_reachable` delegates to it and its 7 existing tests still pass unchanged.
- **Fix-hint wording** comes from where those errors already live: `run_host.store.RunHostError` and `remote_client._http_status_message`. The CLI error an operator hits and the topology hint they read now say the same thing.
- **`relay.contract.PREFIX_HOST`** recognizes the egress `insteadOf` rewrites, so detection can't drift from what `relay_git_config_commands` installs. Verified against real `git config` output, not just a fake.

## Read-only, and never raises

`ensure_subdomain_secret` / `ensure_relay_key` / `ensure_serve_token` all **generate on absence**, so a reporter must not call them — new read-only path accessors (`subdomain_secret_path`, `relay_key_path`) are used instead, and the serve token is read directly. Verified against real state: probing this workspace wrote nothing (the only churn in the window was the phone's long-poll and the state lock, reproduced by a control run with no probe).

Two flaws found in self-review and fixed here:

1. `--no-network` reused `relay_unreachable` / `run_host_unreachable`, so a console branching on those codes would have reported a healthy relay as **down**. Not-probed is now its own `probe_skipped`, and a record with no public URL is `relay_no_public_url`.
2. `RunHostStore._read_all` doesn't guard malformed YAML (raises) or a non-mapping document (returns a `str`) — which would break the never-raises contract on exactly the hand-edited-config input this report exists to explain. Now degrades to a reported edge with a fix.

## Deviations from the spec text, called out

- **ac1 "serve (running/bind/mode)"** — mode, pid, host, subdomain, and public URL are reported from the relay runtime record; the *bind address* is not, because `create_app` never receives host/port and the record carries only the public URL. Reporting it would mean threading bind state into serve purely for display.
- **ac1 "pairing freshness"** — implemented as **subdomain drift**: the running subdomain is compared against the one this machine derives now. A mismatch means anything paired against it is stale, which distinguishes a stale pairing from a tunnel fault. There is no way to observe the phone's token locally, so this is the honest local signal.
- **ac2 "--json"** — served by the existing global `--json` flag (and the non-TTY default); no per-command flag was added.

## Not in scope

Deliberately left alone: `gh_preflight.run_preflight` duplicates the auth precedence for its strict, network-verifying check. `classify_gh_auth` is the new *reporting* owner; refactoring an untested strict-auth path is not this change's job, so the duplication is flagged in a comment rather than silently unified.

## Deploy note

Merging does **not** deploy the endpoint — the live `mship serve` runs the installed uv tool. `GET /net/topology` 404s until `scripts/redeploy-serve.sh` runs.

## Verification

- Full suite: **3296 passed**, 0 failed.
- `mkdocs build --strict`: clean.
- `mship net status`, `mship doctor`, and `--no-network` all exercised against this workspace's live relay (`relay_ok` end-to-end).
- One test-hygiene fix: my `--json` invocation leaked process-global output settings into later tests (`tests/cli/test_output.py` failed downstream while passing in isolation) — reset via the same fixture pattern `test_output_flags.py` already uses.
