### PR TITLE
fix CWD-dependent net status CLI tests

### DIFF
--- a/tests/cli/test_net_status.py
+++ b/tests/cli/test_net_status.py
@@ -20,6 +20,18 @@ def _reset_settings():
     reset_output_settings()
 
 
+@pytest.fixture(autouse=True)
+def _in_a_workspace(workspace, monkeypatch):
+    """`mship net status` resolves its workspace config from the CURRENT
+    DIRECTORY, so without this the tests only pass when pytest happens to run
+    from inside an mship workspace — they failed in a bare clone of this repo,
+    where no `mothership.yaml` is discoverable, with a bare `SystemExit(1)`.
+
+    Same `workspace` + `chdir` pattern as tests/cli/test_doctor.py.
+    """
+    monkeypatch.chdir(workspace)
+
+
 def _fake_topology():
     return Topology(
         version=1, workspace="ws", probed_at="2026-07-25T16:00:00+00:00",


### PR DESCRIPTION
`tests/cli/test_net_status.py` (added in #411, merged) passed only when pytest happened to run from **inside** an mship workspace. In a bare clone of this repo all five tests fail.

## Why

`mship net status` resolves its workspace config from the **current directory**. My tests invoke the real CLI via `CliRunner`, so config discovery walks up from wherever pytest was launched. Inside a worktree under `mship-workspace/` it finds `mothership.yaml` and passes; from `/home/bailey/development/repos/mothership` (the plain checkout) there is no `mothership.yaml` above it, `ConfigLoader.load` fails, and the command exits 1 — `assert 1 == 0`.

Deterministic, not flaky: 5 failed in 0.3s from a non-workspace cwd.

## How it got merged

I found it by running the full suite in the plain checkout instead of my worktree. Nothing caught it earlier because **this repo has no CI workflow that runs pytest** — `.github/workflows/` contains only `docs.yml` and `version-bump.yml`. The green "build" check on #411 completed in 15s; it never ran a test. Worth knowing separately: a green PR here says nothing about the suite.

## Fix

The `workspace` + `monkeypatch.chdir` fixture pattern already used by `tests/cli/test_doctor.py` — an autouse fixture that puts each test in a temp workspace, so the CLI's config discovery has something to find regardless of where pytest runs.

## Verification

- From a non-workspace cwd: 5 failed → **5 passed**.
- From inside a workspace (the old passing condition): still passing.
- `tests/cli` (931 tests) and the full suite (3304) green — the chdir fixture doesn't leak into neighbours.
