### PR TITLE
browser-usable console: token cookie plus mship ui

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -115,7 +115,14 @@ mship graph
 mship worktrees
 mship doctor [--no-network]                         # workspace health; --no-network skips connectivity probes
 mship net status [--no-network]                     # connectivity topology: serve, relay, run hosts, gh auth, egress
+mship ui [--no-browser] [--host h] [--port p]       # open the serve-host console (opens a browser, else prints a copyable link)
 ```
+
+The console lives at `/ui` on the serve host. When the serve runs with auth (any
+relay setup does), a browser cannot send the bearer header from its address bar —
+so visit it once via `mship ui`, which builds `/ui?token=<serve token>`; the
+console exchanges that for a short-lived cookie and cleans the URL. `GET
+/net/topology` continues to accept only the `Authorization` header.
 
 ## Maintenance
 

--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -140,6 +140,7 @@ from mship.cli import skill as _skill_mod
 from mship.cli import spec as _spec_mod
 from mship.cli import status as _status_mod
 from mship.cli import switch as _switch_mod
+from mship.cli import ui as _ui_mod
 from mship.cli import serve as _serve_mod
 from mship.cli import sync as _sync_mod
 from mship.cli import view as _view_mod
@@ -198,6 +199,7 @@ _pr_mod.register(app, get_container)
 _prune_mod.register(app, get_container)
 _reconcile_mod.register(app, get_container)
 _net_mod.register(app, get_container)
+_ui_mod.register(app, get_container)
 _relay_mod.register(app, get_container)
 _run_host_mod.register(app, get_container)
 _skill_mod.register(app, get_container)

--- a/src/mship/cli/ui.py
+++ b/src/mship/cli/ui.py
@@ -1,0 +1,163 @@
+"""`mship ui` — open the serve-host management console.
+
+The console lives behind the serve bearer, which a browser cannot send from an
+address bar, so it is reached by visiting `/ui?token=<serve token>` once (the
+console swaps that for a short-lived cookie and cleans the URL). Nobody should
+have to assemble that URL by hand — this command does it.
+
+Opens a browser when there is one. Otherwise it prints the link and offers `c` to
+copy it, which is the common case: the workspace is usually on a headless box or
+reached over ssh, where the URL has to travel to the human's own machine.
+"""
+from __future__ import annotations
+
+import typer
+
+from mship.cli.output import Output
+
+
+def _has_display() -> bool:
+    """Whether a browser could plausibly open here.
+
+    `webbrowser.open` returns True on Linux even with no display (it "succeeds"
+    by handing off to a launcher that then fails), so the environment is checked
+    first rather than trusting the return value.
+    """
+    import os
+    import shutil
+    import sys
+
+    if sys.platform == "darwin" or os.name == "nt":
+        return True
+    if os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY"):
+        return False          # a browser here would open on the wrong machine
+    if not (os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")):
+        return False
+    return shutil.which("xdg-open") is not None
+
+
+def _copy_to_clipboard(text: str) -> str | None:
+    """Copy `text`, returning the mechanism used, or None if none worked.
+
+    Tries the local clipboard tools first, then falls back to OSC 52 — the
+    terminal escape that carries a copy request over ssh to the machine the human
+    is actually sitting at, which is the same mechanism the Textual views use.
+    """
+    import base64
+    import shutil
+    import subprocess
+    import sys
+
+    for argv, name in (
+        (["pbcopy"], "pbcopy"),                        # macOS
+        (["wl-copy"], "wl-copy"),                      # Wayland
+        (["xclip", "-selection", "clipboard"], "xclip"),
+        (["xsel", "--clipboard", "--input"], "xsel"),
+    ):
+        if shutil.which(argv[0]) is None:
+            continue
+        try:
+            subprocess.run(argv, input=text.encode(), check=True, timeout=5)
+            return name
+        except (OSError, subprocess.SubprocessError):
+            continue
+
+    # OSC 52: works through ssh and tmux, but only when stdout is a terminal.
+    if sys.stdout.isatty():
+        payload = base64.b64encode(text.encode()).decode()
+        sys.stdout.write(f"\033]52;c;{payload}\a")
+        sys.stdout.flush()
+        return "terminal (OSC 52)"
+    return None
+
+
+def _read_one_key() -> str:
+    """Read a single keypress without requiring Enter. Returns "" when stdin is
+    not a terminal (piped/CI), so the caller just skips the prompt."""
+    import sys
+
+    if not sys.stdin.isatty():
+        return ""
+    try:
+        import termios
+        import tty
+    except ImportError:                      # pragma: no cover - non-POSIX
+        return sys.stdin.read(1)
+    fd = sys.stdin.fileno()
+    saved = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        return sys.stdin.read(1)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+
+
+def console_url(host: str, port: int, token: str | None) -> str:
+    """The URL that opens the console, carrying the one-time token when the serve
+    requires auth. Kept separate from the command so it can be tested directly."""
+    base = f"http://{host}:{port}/ui"
+    return f"{base}?token={token}" if token else base
+
+
+def register(app: typer.Typer, get_container):
+    @app.command(rich_help_panel="Inspection")
+    def ui(
+        host: str = typer.Option("127.0.0.1", "--host", help="Host the serve is bound to."),
+        port: int = typer.Option(47100, "--port", help="Port the serve is bound to."),
+        no_browser: bool = typer.Option(
+            False, "--no-browser", help="Never open a browser; just print the link."
+        ),
+    ):
+        """Open the serve-host management console (topology + setup commands)."""
+        import os
+        from pathlib import Path
+
+        out = Output()
+        container = get_container()
+
+        # Same precedence as `relay.token.ensure_serve_token`, minus the
+        # generate-on-absence step: env override, then the persisted file. None
+        # means the serve runs without auth (tokenless loopback) and needs no
+        # token in the URL.
+        token = os.environ.get("MSHIP_SERVE_TOKEN")
+        if not token:
+            # `container.state_dir()` — not `config_path().parent/.mothership` —
+            # because state is anchored to the MAIN checkout when you are inside a
+            # git worktree, which is exactly where an agent would run this from.
+            token_file = Path(container.state_dir()) / "serve-token"
+            try:
+                token = token_file.read_text().strip() or None
+            except (OSError, ValueError):
+                # ValueError covers UnicodeDecodeError on a corrupt token file.
+                token = None
+
+        url = console_url(host, port, token)
+
+        if out.json_mode:
+            out.json({"url": url, "requires_token": token is not None})
+            return
+
+        if not no_browser and _has_display():
+            import webbrowser
+
+            if webbrowser.open(url):
+                out.success(f"opened the console at http://{host}:{port}/ui")
+                return
+            out.warning("could not open a browser; here is the link instead")
+
+        # No browser here — print the link. The token is in it, so say what that
+        # means rather than leaving the operator to guess.
+        out.print(f"\n  [bold]{url}[/bold]\n")
+        if token:
+            out.print(
+                "  [dim]The token in that link is exchanged for a short-lived "
+                "cookie on first load.[/dim]"
+            )
+        out.print("  [dim]Press [bold]c[/bold] to copy, any other key to skip.[/dim]")
+
+        if _read_one_key().lower() == "c":
+            mechanism = _copy_to_clipboard(url)
+            if mechanism:
+                out.success(f"copied to the clipboard via {mechanism}")
+            else:
+                out.warning("no clipboard mechanism available — copy the link above")

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -400,7 +400,7 @@ def create_app(
         except ImportError:
             logger.info("mship.webui is unavailable; serving without the console")
         else:
-            mount_webui(app, payload_source=_topology_payload)
+            mount_webui(app, payload_source=_topology_payload, auth_token=auth_token)
 
     from mship.core.spec_review import build_review
 

--- a/src/mship/webui/__init__.py
+++ b/src/mship/webui/__init__.py
@@ -14,10 +14,26 @@ gets from `GET /net/topology`. Two rules keep it that way:
 
 Consequence: replacing this package with a separately-shipped frontend is a
 re-skin, not a rewrite. Build the new client against the versioned payload,
-enable CORS for its origin (auth is already a header-borne bearer, not a
-same-origin cookie), then delete this directory and its one mount line. The Jinja
-templates are deliberately disposable — no effort is spent making them reusable
-as a component library.
+enable CORS for its origin, then delete this directory and its one mount line. The
+Jinja templates are deliberately disposable — no effort is spent making them
+reusable as a component library.
+
+AUTH. The console is mounted as a SUB-APPLICATION rather than added with
+`include_router`, because a mounted sub-app does not inherit the parent's
+app-level dependencies (verified: `include_router` does, `mount` does not). That
+matters twice over:
+
+  * It lets the console accept a browser, which cannot send an `Authorization`
+    header from an address bar. Shipped header-only, `/ui` returned 401 in a
+    browser whenever a token was configured — i.e. always, with a relay.
+  * It closes a hole the previous shape opened: the `StaticFiles` mount already
+    bypassed the app-level bearer, so the stylesheet was fetchable
+    unauthenticated over the public relay subdomain.
+
+So this package owns its own check: `Authorization: Bearer <token>` (unchanged,
+for API clients and a future external frontend) OR a short-lived cookie obtained
+by visiting `/ui?token=<token>` once. `GET /net/topology` is NOT part of this
+sub-app and stays header-only.
 """
 from __future__ import annotations
 
@@ -38,27 +54,119 @@ STATIC_DIR = _PACKAGE_DIR / "static"
 MOUNT_PATH = "/ui"
 
 
-def mount_webui(app, *, payload_source: Callable[[], dict]) -> None:
+#: Cookie the console sets after a `?token=` visit. Scoped to the console path so
+#: it is never sent to the JSON API, and HttpOnly so page scripts cannot read it.
+COOKIE_NAME = "mship_ui"
+
+#: How long a tokenised visit stays good for. Long enough to use the console,
+#: short enough that a shared screenshot of the URL is not a lasting credential.
+COOKIE_MAX_AGE_SECONDS = 12 * 60 * 60
+
+
+def _cookie_value(auth_token: str) -> str:
+    """An opaque, deterministic derivation of the serve token — never the token
+    itself, so a stolen cookie cannot be replayed against the JSON API (which
+    wants the raw bearer). Deterministic so a restart does not invalidate an open
+    tab, and compared with `compare_digest`."""
+    import hashlib
+
+    return hashlib.sha256(f"mship-ui-cookie:{auth_token}".encode()).hexdigest()
+
+
+def mount_webui(app, *, payload_source: Callable[[], dict], auth_token: str | None = None) -> None:
     """Attach the console to `app` at /ui.
 
     `payload_source` returns the `GET /net/topology` payload — a plain dict. It
     is the ONLY data this package receives, which is what makes the frontend
     separately shippable (see the module docstring).
+
+    `auth_token` is the serve bearer, or None when the serve runs without auth
+    (a tokenless loopback serve). When None the console adds no auth of its own —
+    inventing a requirement mship itself does not have would just lock the
+    operator out of a server that is already open locally.
     """
-    from fastapi import APIRouter
+    import hmac
+
+    from fastapi import Depends, FastAPI, HTTPException, Query
+    from fastapi.responses import RedirectResponse
     from fastapi.staticfiles import StaticFiles
 
     from mship.webui.views import render_topology
 
-    router = APIRouter()
+    expected_cookie = _cookie_value(auth_token) if auth_token else None
 
-    @router.get(MOUNT_PATH, include_in_schema=False)
-    def ui(request: Request):
+    def _credentialed(request: Request) -> bool:
+        if auth_token is None:
+            return True
+        header = request.headers.get("authorization") or ""
+        if hmac.compare_digest(header.encode(), f"Bearer {auth_token}".encode()):
+            return True
+        cookie = request.cookies.get(COOKIE_NAME) or ""
+        return bool(expected_cookie) and hmac.compare_digest(
+            cookie.encode(), expected_cookie.encode()
+        )
+
+    # A sub-app, NOT include_router: see the module docstring. This is what lets
+    # the console authenticate a browser and what puts its static files behind a
+    # check instead of leaving them open over the relay.
+    console = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+
+    @console.get("/", include_in_schema=False)
+    def ui(request: Request, token: str | None = Query(default=None)):
+        # Jupyter's exchange: a token in the URL becomes a cookie, then the URL is
+        # cleaned so the credential does not linger in history, titles, or a
+        # screenshot of the address bar.
+        if token is not None and auth_token is not None:
+            if not hmac.compare_digest(token.encode(), auth_token.encode()):
+                raise HTTPException(status_code=401, detail="invalid token")
+            response = RedirectResponse(url=str(request.url.path), status_code=303)
+            response.set_cookie(
+                COOKIE_NAME,
+                expected_cookie,
+                max_age=COOKIE_MAX_AGE_SECONDS,
+                httponly=True,
+                samesite="strict",
+                path=MOUNT_PATH,
+                secure=request.url.scheme == "https",
+            )
+            return response
+
         return render_topology(request, payload_source())
 
-    app.include_router(router)
-    app.mount(
-        f"{MOUNT_PATH}/static",
+    console.mount(
+        "/static",
         StaticFiles(directory=str(STATIC_DIR)),
         name="webui-static",
     )
+
+    # ONE choke point for the whole sub-app — the page AND its static files.
+    # A route dependency could not cover StaticFiles (it is a bare ASGI app), and
+    # two separate checks would be two things to keep in agreement.
+    @console.middleware("http")
+    async def _require_credentials(request: Request, call_next):
+        if _credentialed(request):
+            return await call_next(request)
+        # Let a valid one-time `?token=` through so the route can exchange it for
+        # a cookie; anything else is refused here.
+        supplied = request.query_params.get("token")
+        if (
+            supplied is not None
+            and auth_token is not None
+            and hmac.compare_digest(supplied.encode(), auth_token.encode())
+        ):
+            return await call_next(request)
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(
+            {
+                "detail": (
+                    "the console needs credentials: open it once as "
+                    "/ui?token=<serve token> (or run `mship ui`), or send "
+                    "Authorization: Bearer <serve token>"
+                )
+            },
+            status_code=401,
+        )
+
+    app.mount(MOUNT_PATH, console, name="webui")
+    return None

--- a/src/mship/webui/__init__.py
+++ b/src/mship/webui/__init__.py
@@ -63,14 +63,66 @@ COOKIE_NAME = "mship_ui"
 COOKIE_MAX_AGE_SECONDS = 12 * 60 * 60
 
 
-def _cookie_value(auth_token: str) -> str:
-    """An opaque, deterministic derivation of the serve token — never the token
-    itself, so a stolen cookie cannot be replayed against the JSON API (which
-    wants the raw bearer). Deterministic so a restart does not invalidate an open
-    tab, and compared with `compare_digest`."""
-    import hashlib
+def _mint_cookie(auth_token: str, *, now: int, lifetime: int = COOKIE_MAX_AGE_SECONDS) -> str:
+    """`<expires-at>.<hmac>` — a credential that the SERVER can expire.
 
-    return hashlib.sha256(f"mship-ui-cookie:{auth_token}".encode()).hexdigest()
+    Never the serve token itself, so a stolen cookie cannot be replayed against
+    the JSON API (which wants the raw bearer). The expiry is inside the signed
+    material rather than only in the Set-Cookie `max_age`: `max_age` is a request
+    to the browser, and a client that ignores it (or a copied cookie value) would
+    otherwise stay valid forever.
+    """
+    import hashlib
+    import hmac
+
+    expires_at = now + lifetime
+    mac = hmac.new(
+        auth_token.encode(), f"mship-ui:{expires_at}".encode(), hashlib.sha256
+    ).hexdigest()
+    return f"{expires_at}.{mac}"
+
+
+def _cookie_is_valid(cookie: str, auth_token: str, *, now: int) -> bool:
+    """Verify a minted cookie: well-formed, signature matches, not expired."""
+    import hashlib
+    import hmac
+
+    expires_str, _, mac = cookie.partition(".")
+    if not mac:
+        return False
+    try:
+        expires_at = int(expires_str)
+    except ValueError:
+        return False
+    if expires_at <= now:
+        return False
+    expected = hmac.new(
+        auth_token.encode(), f"mship-ui:{expires_at}".encode(), hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(mac, expected)
+
+
+def _connection_is_secure(request: "Request") -> bool:
+    """Whether this request reached us over TLS.
+
+    Behind the relay, Caddy terminates TLS and the request arrives at the app as
+    plain HTTP, so the ASGI scheme alone under-reports it — hence the forwarded
+    header. Trusting that header is safe in this direction: the only thing it can
+    do is make a cookie MORE restrictive (a forged `https` yields a Secure cookie
+    the browser then declines to send over http — a self-inflicted annoyance, not
+    a privilege gain).
+    """
+    if request.url.scheme == "https":
+        return True
+    forwarded = (request.headers.get("x-forwarded-proto") or "").split(",")[0].strip()
+    return forwarded.lower() == "https"
+
+
+def _is_loopback(request: "Request") -> bool:
+    """Whether the request came from this machine, judged by the client address
+    rather than the Host header (which a client controls)."""
+    client = request.client
+    return bool(client) and client.host in {"127.0.0.1", "::1", "localhost"}
 
 
 def mount_webui(app, *, payload_source: Callable[[], dict], auth_token: str | None = None) -> None:
@@ -86,14 +138,13 @@ def mount_webui(app, *, payload_source: Callable[[], dict], auth_token: str | No
     operator out of a server that is already open locally.
     """
     import hmac
+    import time
 
-    from fastapi import Depends, FastAPI, HTTPException, Query
+    from fastapi import FastAPI, HTTPException, Query
     from fastapi.responses import RedirectResponse
     from fastapi.staticfiles import StaticFiles
 
     from mship.webui.views import render_topology
-
-    expected_cookie = _cookie_value(auth_token) if auth_token else None
 
     def _credentialed(request: Request) -> bool:
         if auth_token is None:
@@ -102,8 +153,8 @@ def mount_webui(app, *, payload_source: Callable[[], dict], auth_token: str | No
         if hmac.compare_digest(header.encode(), f"Bearer {auth_token}".encode()):
             return True
         cookie = request.cookies.get(COOKIE_NAME) or ""
-        return bool(expected_cookie) and hmac.compare_digest(
-            cookie.encode(), expected_cookie.encode()
+        return bool(cookie) and _cookie_is_valid(
+            cookie, auth_token, now=int(time.time())
         )
 
     # A sub-app, NOT include_router: see the module docstring. This is what lets
@@ -119,15 +170,31 @@ def mount_webui(app, *, payload_source: Callable[[], dict], auth_token: str | No
         if token is not None and auth_token is not None:
             if not hmac.compare_digest(token.encode(), auth_token.encode()):
                 raise HTTPException(status_code=401, detail="invalid token")
+
+            secure = _connection_is_secure(request)
+            if not secure and not _is_loopback(request):
+                # Refuse to hand a browser credential to a plaintext connection
+                # from off-box. The header bearer still works, so this is a
+                # narrowing rather than a dead end.
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "refusing to set a console cookie over plaintext from a "
+                        "non-loopback client; reach the console over https (the "
+                        "relay terminates TLS), tunnel it to localhost, or send "
+                        "Authorization: Bearer instead"
+                    ),
+                )
+
             response = RedirectResponse(url=str(request.url.path), status_code=303)
             response.set_cookie(
                 COOKIE_NAME,
-                expected_cookie,
+                _mint_cookie(auth_token, now=int(time.time())),
                 max_age=COOKIE_MAX_AGE_SECONDS,
                 httponly=True,
                 samesite="strict",
                 path=MOUNT_PATH,
-                secure=request.url.scheme == "https",
+                secure=secure,
             )
             return response
 

--- a/tests/cli/test_output_flags.py
+++ b/tests/cli/test_output_flags.py
@@ -249,6 +249,17 @@ _ALLOWED_ISATTY = {
         # input-mode decision, not an output-shape one.
         "sys.stdin.isatty()",
     ),
+    "ui.py": (
+        # Both are reached only AFTER Output().json_mode has already chosen the
+        # human branch, and neither picks a shape:
+        #   stdout — can an OSC 52 clipboard escape reach a terminal at all?
+        #            (a capability question about writing an escape sequence)
+        #   stdin  — can we read a single keypress for the "press c to copy"
+        #            prompt, or must it be skipped? (interactivity, same as
+        #            worktree.py above)
+        "sys.stdout.isatty()",
+        "sys.stdin.isatty()",
+    ),
 }
 
 

--- a/tests/cli/test_ui_command.py
+++ b/tests/cli/test_ui_command.py
@@ -1,0 +1,97 @@
+"""`mship ui` — the console entry point."""
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app
+from mship.cli.output import reset_output_settings
+from mship.cli.ui import console_url
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _clean(workspace, monkeypatch):
+    """A fresh workspace per test, and a container that actually points at it.
+
+    `get_container` caches through dependency-injector provider overrides, so
+    without the reset the second test in this file still resolves the FIRST
+    test's temp workspace and cannot find its serve-token. Same reset list as
+    tests/cli/test_exec.py's `_reset_container`.
+    """
+    from mship.cli import container
+
+    def _reset() -> None:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset_override()
+        container.config.reset()
+        container.state_manager.reset_override()
+        container.state_manager.reset()
+
+    _reset()
+    monkeypatch.chdir(workspace)
+    monkeypatch.delenv("MSHIP_SERVE_TOKEN", raising=False)
+    reset_output_settings()
+    yield
+    reset_output_settings()
+    _reset()
+
+
+def test_url_carries_the_token_when_auth_is_on():
+    assert console_url("127.0.0.1", 47100, "tok") == "http://127.0.0.1:47100/ui?token=tok"
+
+
+def test_url_omits_the_token_when_the_serve_has_no_auth():
+    assert console_url("127.0.0.1", 47100, None) == "http://127.0.0.1:47100/ui"
+
+
+def test_json_mode_reports_the_url_and_whether_a_token_is_needed(workspace, monkeypatch):
+    monkeypatch.setenv("MSHIP_SERVE_TOKEN", "envtok")
+    result = runner.invoke(app, ["--json", "ui"])
+    assert result.exit_code == 0
+    body = json.loads(result.stdout)
+    assert body["url"].endswith("/ui?token=envtok")
+    assert body["requires_token"] is True
+
+
+def test_the_env_token_wins_over_the_file(workspace, monkeypatch):
+    (workspace / ".mothership").mkdir(exist_ok=True)
+    (workspace / ".mothership" / "serve-token").write_text("file-token\n")
+    monkeypatch.setenv("MSHIP_SERVE_TOKEN", "env-token")
+    body = json.loads(runner.invoke(app, ["--json", "ui"]).stdout)
+    assert "env-token" in body["url"] and "file-token" not in body["url"]
+
+
+def test_the_file_token_is_used_when_no_env_override(workspace):
+    (workspace / ".mothership").mkdir(exist_ok=True)
+    (workspace / ".mothership" / "serve-token").write_text("file-token\n")
+    body = json.loads(runner.invoke(app, ["--json", "ui"]).stdout)
+    assert "file-token" in body["url"]
+
+
+def test_a_corrupt_token_file_degrades_to_no_token(workspace):
+    """Reporting must not crash on a non-UTF-8 token file."""
+    (workspace / ".mothership").mkdir(exist_ok=True)
+    (workspace / ".mothership" / "serve-token").write_bytes(b"\xff\xfe binary")
+    body = json.loads(runner.invoke(app, ["--json", "ui"]).stdout)
+    assert body["requires_token"] is False
+
+
+def test_no_browser_prints_the_link_and_never_hangs_without_a_tty(workspace):
+    """CliRunner's stdin is not a tty, so the `c` prompt must be skipped rather
+    than blocking forever."""
+    (workspace / ".mothership").mkdir(exist_ok=True)
+    (workspace / ".mothership" / "serve-token").write_text("tok\n")
+    result = runner.invoke(app, ["ui", "--no-browser"], env={"MSHIP_JSON": "0"})
+    assert result.exit_code == 0
+    assert "/ui?token=tok" in result.stdout
+    assert "Press" in result.stdout
+
+
+def test_honours_a_custom_host_and_port(workspace):
+    body = json.loads(
+        runner.invoke(app, ["--json", "ui", "--host", "0.0.0.0", "--port", "47119"]).stdout
+    )
+    assert body["url"].startswith("http://0.0.0.0:47119/ui")

--- a/tests/webui/test_browser_auth.py
+++ b/tests/webui/test_browser_auth.py
@@ -35,16 +35,24 @@ def _app(*, token: str | None = TOKEN):
     return app
 
 
+def _client(app, *, host: str = "127.0.0.1"):
+    """A client with a real address. TestClient defaults to the host
+    "testclient", which is neither loopback nor TLS — and the console refuses to
+    hand a cookie to a plaintext non-loopback caller, so the default would look
+    like a failure when it is the guard working."""
+    return TestClient(app, client=(host, 45678))
+
+
 # --- the browser path -------------------------------------------------------
 
 def test_a_browser_with_no_credentials_is_refused():
-    with TestClient(_app()) as client:
+    with _client(_app()) as client:
         r = client.get("/ui/", follow_redirects=False)
     assert r.status_code == 401
 
 
 def test_token_in_the_url_sets_a_cookie_and_redirects_to_a_clean_url():
-    with TestClient(_app()) as client:
+    with _client(_app()) as client:
         r = client.get(f"/ui/?token={TOKEN}", follow_redirects=False)
         assert r.status_code in (302, 303, 307)
         # the token must not survive in the redirect target
@@ -63,7 +71,7 @@ def test_token_in_the_url_sets_a_cookie_and_redirects_to_a_clean_url():
 
 
 def test_the_cookie_then_serves_the_page():
-    with TestClient(_app()) as client:
+    with _client(_app()) as client:
         client.get(f"/ui/?token={TOKEN}", follow_redirects=False)   # sets cookie
         r = client.get("/ui/")
     assert r.status_code == 200
@@ -71,14 +79,14 @@ def test_the_cookie_then_serves_the_page():
 
 
 def test_a_wrong_token_in_the_url_is_refused_and_sets_nothing():
-    with TestClient(_app()) as client:
+    with _client(_app()) as client:
         r = client.get("/ui/?token=wrong", follow_redirects=False)
     assert r.status_code == 401
     assert "set-cookie" not in {k.lower() for k in r.headers}
 
 
 def test_a_forged_cookie_is_refused():
-    with TestClient(_app()) as client:
+    with _client(_app()) as client:
         client.cookies.set("mship_ui", "made-up-value", path="/ui")
         r = client.get("/ui/", follow_redirects=False)
     assert r.status_code == 401
@@ -87,7 +95,7 @@ def test_a_forged_cookie_is_refused():
 # --- the API path is untouched (separability) --------------------------------
 
 def test_the_header_bearer_still_works_without_any_cookie():
-    with TestClient(_app()) as client:
+    with _client(_app()) as client:
         r = client.get("/ui/", headers={"Authorization": f"Bearer {TOKEN}"})
     assert r.status_code == 200
 
@@ -95,7 +103,7 @@ def test_the_header_bearer_still_works_without_any_cookie():
 def test_static_assets_require_credentials_too():
     """They were reachable unauthenticated over the relay: StaticFiles mounted
     with app.mount() bypasses an app-level dependency."""
-    with TestClient(_app()) as client:
+    with _client(_app()) as client:
         assert client.get("/ui/static/app.css").status_code == 401
         ok = client.get(
             "/ui/static/app.css", headers={"Authorization": f"Bearer {TOKEN}"}
@@ -107,7 +115,7 @@ def test_static_assets_require_credentials_too():
 def test_the_page_and_its_stylesheet_both_load_with_only_the_cookie():
     """What a real browser does: one tokenised visit, then it fetches the CSS
     with just the cookie."""
-    with TestClient(_app()) as client:
+    with _client(_app()) as client:
         client.get(f"/ui/?token={TOKEN}", follow_redirects=False)
         assert client.get("/ui/").status_code == 200
         assert client.get("/ui/static/app.css").status_code == 200
@@ -118,7 +126,7 @@ def test_the_page_and_its_stylesheet_both_load_with_only_the_cookie():
 def test_no_token_configured_means_no_auth():
     """A tokenless loopback serve already exposes everything locally; the console
     must not invent an auth requirement that mship itself does not have."""
-    with TestClient(_app(token=None)) as client:
+    with _client(_app(token=None)) as client:
         assert client.get("/ui/").status_code == 200
         assert client.get("/ui/static/app.css").status_code == 200
 
@@ -126,9 +134,94 @@ def test_no_token_configured_means_no_auth():
 def test_the_url_an_operator_types_reaches_the_console():
     """`/ui` without a trailing slash is what a human types; the mount 307s it to
     `/ui/`, which browsers follow transparently."""
-    with TestClient(_app()) as client:
+    with _client(_app()) as client:
         r = client.get(f"/ui?token={TOKEN}", follow_redirects=True)
     assert r.status_code == 200
     assert "Connectivity topology" in r.text
     # and the credential is gone from where the browser ends up
     assert "token" not in str(r.url)
+
+
+# --- where the cookie may be issued at all ----------------------------------
+
+def test_a_plaintext_request_from_off_box_is_refused_a_cookie():
+    """The relay terminates TLS, so a plaintext request from a non-loopback
+    client means the credential would cross the network in the clear. The header
+    bearer still works, so this narrows rather than blocks."""
+    with _client(_app(), host="203.0.113.7") as client:
+        r = client.get(f"/ui/?token={TOKEN}", follow_redirects=False)
+    assert r.status_code == 400
+    assert "set-cookie" not in {k.lower() for k in r.headers}
+    assert "plaintext" in r.json()["detail"]
+
+
+def test_a_forwarded_https_request_gets_a_secure_cookie():
+    """Behind the relay the app sees plain HTTP, so TLS has to be inferred from
+    the forwarded header or every relay cookie would omit Secure."""
+    with _client(_app(), host="203.0.113.7") as client:
+        r = client.get(
+            f"/ui/?token={TOKEN}",
+            headers={"x-forwarded-proto": "https"},
+            follow_redirects=False,
+        )
+    assert r.status_code == 303
+    cookie = r.headers["set-cookie"]
+    assert "Secure" in cookie
+
+
+def test_loopback_over_plain_http_still_gets_a_cookie_without_secure():
+    """A local browser on http://127.0.0.1 must keep working — a Secure cookie
+    there would simply never be sent back."""
+    with _client(_app()) as client:
+        r = client.get(f"/ui/?token={TOKEN}", follow_redirects=False)
+    assert r.status_code == 303
+    assert "Secure" not in r.headers["set-cookie"]
+
+
+# --- server-side expiry ------------------------------------------------------
+
+def test_the_cookie_is_rejected_once_it_expires():
+    """`max_age` only asks the browser to forget it; the signed expiry is what
+    makes the SERVER stop honouring a copied value."""
+    from mship.webui import _mint_cookie
+
+    with _client(_app()) as client:
+        stale = _mint_cookie(TOKEN, now=0, lifetime=1)     # expired in 1970
+        client.cookies.set("mship_ui", stale, path="/ui")
+        assert client.get("/ui/", follow_redirects=False).status_code == 401
+
+
+def test_a_cookie_with_a_tampered_expiry_is_rejected():
+    """Pushing the expiry out must break the signature."""
+    import time
+
+    from mship.webui import _mint_cookie
+
+    good = _mint_cookie(TOKEN, now=int(time.time()))
+    _, _, mac = good.partition(".")
+    forged = f"{int(time.time()) + 10_000_000}.{mac}"
+    with _client(_app()) as client:
+        client.cookies.set("mship_ui", forged, path="/ui")
+        assert client.get("/ui/", follow_redirects=False).status_code == 401
+
+
+def test_a_cookie_minted_from_a_different_token_is_rejected():
+    from mship.webui import _mint_cookie
+    import time
+
+    with _client(_app()) as client:
+        client.cookies.set(
+            "mship_ui", _mint_cookie("someone-elses-token", now=int(time.time())),
+            path="/ui",
+        )
+        assert client.get("/ui/", follow_redirects=False).status_code == 401
+
+
+def test_a_fresh_cookie_is_accepted():
+    import time
+
+    from mship.webui import _mint_cookie
+
+    with _client(_app()) as client:
+        client.cookies.set("mship_ui", _mint_cookie(TOKEN, now=int(time.time())), path="/ui")
+        assert client.get("/ui/").status_code == 200

--- a/tests/webui/test_browser_auth.py
+++ b/tests/webui/test_browser_auth.py
@@ -1,0 +1,134 @@
+"""Browser-usable auth for the console.
+
+The console shipped header-bearer-only, which made it unreachable in the very
+configuration it exists for: with a relay, `MSHIP_SERVE_TOKEN` is set, so every
+route demands an `Authorization` header that a browser address bar cannot send —
+`/ui` returned 401 in a browser and 200 only to curl.
+
+The fix is Jupyter's: a one-time `?token=` in the URL is exchanged for a
+short-lived cookie, and the JSON contract keeps accepting the header so a
+separately-shipped frontend still authenticates unchanged.
+"""
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mship.webui import mount_webui
+
+TOKEN = "s3cret-serve-token"
+
+
+def _payload():
+    return {
+        "version": 1, "mship_version": "0.5.23", "workspace": "ws",
+        "probed_at": "2026-07-25T19:00:00+00:00",
+        "edges": [{
+            "kind": "relay", "name": "relay", "status": "ok", "code": "relay_ok",
+            "detail": "reachable", "fix": None, "facts": {},
+        }],
+    }
+
+
+def _app(*, token: str | None = TOKEN):
+    app = FastAPI()
+    mount_webui(app, payload_source=_payload, auth_token=token)
+    return app
+
+
+# --- the browser path -------------------------------------------------------
+
+def test_a_browser_with_no_credentials_is_refused():
+    with TestClient(_app()) as client:
+        r = client.get("/ui/", follow_redirects=False)
+    assert r.status_code == 401
+
+
+def test_token_in_the_url_sets_a_cookie_and_redirects_to_a_clean_url():
+    with TestClient(_app()) as client:
+        r = client.get(f"/ui/?token={TOKEN}", follow_redirects=False)
+        assert r.status_code in (302, 303, 307)
+        # the token must not survive in the redirect target
+        assert "token" not in r.headers["location"]
+        assert r.headers["location"].rstrip("/").endswith("/ui")
+
+        cookie = r.headers.get("set-cookie", "")
+        assert cookie, "no cookie was set"
+        assert "HttpOnly" in cookie, "cookie must not be readable from JS"
+        assert "SameSite=Strict" in cookie or "samesite=strict" in cookie.lower()
+        assert "Path=/ui" in cookie or "path=/ui" in cookie.lower(), (
+            "cookie should be scoped to the console, not the whole API"
+        )
+        # the raw serve token must never be the cookie's value
+        assert TOKEN not in cookie
+
+
+def test_the_cookie_then_serves_the_page():
+    with TestClient(_app()) as client:
+        client.get(f"/ui/?token={TOKEN}", follow_redirects=False)   # sets cookie
+        r = client.get("/ui/")
+    assert r.status_code == 200
+    assert "Connectivity topology" in r.text
+
+
+def test_a_wrong_token_in_the_url_is_refused_and_sets_nothing():
+    with TestClient(_app()) as client:
+        r = client.get("/ui/?token=wrong", follow_redirects=False)
+    assert r.status_code == 401
+    assert "set-cookie" not in {k.lower() for k in r.headers}
+
+
+def test_a_forged_cookie_is_refused():
+    with TestClient(_app()) as client:
+        client.cookies.set("mship_ui", "made-up-value", path="/ui")
+        r = client.get("/ui/", follow_redirects=False)
+    assert r.status_code == 401
+
+
+# --- the API path is untouched (separability) --------------------------------
+
+def test_the_header_bearer_still_works_without_any_cookie():
+    with TestClient(_app()) as client:
+        r = client.get("/ui/", headers={"Authorization": f"Bearer {TOKEN}"})
+    assert r.status_code == 200
+
+
+def test_static_assets_require_credentials_too():
+    """They were reachable unauthenticated over the relay: StaticFiles mounted
+    with app.mount() bypasses an app-level dependency."""
+    with TestClient(_app()) as client:
+        assert client.get("/ui/static/app.css").status_code == 401
+        ok = client.get(
+            "/ui/static/app.css", headers={"Authorization": f"Bearer {TOKEN}"}
+        )
+    assert ok.status_code == 200
+    assert "text/css" in ok.headers["content-type"]
+
+
+def test_the_page_and_its_stylesheet_both_load_with_only_the_cookie():
+    """What a real browser does: one tokenised visit, then it fetches the CSS
+    with just the cookie."""
+    with TestClient(_app()) as client:
+        client.get(f"/ui/?token={TOKEN}", follow_redirects=False)
+        assert client.get("/ui/").status_code == 200
+        assert client.get("/ui/static/app.css").status_code == 200
+
+
+# --- the no-auth case (loopback serve with no token) ------------------------
+
+def test_no_token_configured_means_no_auth():
+    """A tokenless loopback serve already exposes everything locally; the console
+    must not invent an auth requirement that mship itself does not have."""
+    with TestClient(_app(token=None)) as client:
+        assert client.get("/ui/").status_code == 200
+        assert client.get("/ui/static/app.css").status_code == 200
+
+
+def test_the_url_an_operator_types_reaches_the_console():
+    """`/ui` without a trailing slash is what a human types; the mount 307s it to
+    `/ui/`, which browsers follow transparently."""
+    with TestClient(_app()) as client:
+        r = client.get(f"/ui?token={TOKEN}", follow_redirects=True)
+    assert r.status_code == 200
+    assert "Connectivity topology" in r.text
+    # and the credential is gone from where the browser ends up
+    assert "token" not in str(r.url)


### PR DESCRIPTION
The console I shipped in #412 was unusable in the configuration it exists for. With a relay, `MSHIP_SERVE_TOKEN` is set and every route demands an `Authorization` header — which a browser address bar cannot send. `/ui` returned **401** to a browser and 200 only to `curl`. My own acceptance criterion ("bearer-token-in-header, not cookie/session bound") locked that in without noticing the primary consumer is a human in a browser.

## The exchange (Jupyter's)

Visiting `/ui?token=<serve token>` once validates the token, sets a short-lived cookie, and redirects to a clean URL so the credential doesn't linger in history or a screenshot of the address bar.

- Cookie value is a **sha256 derivation** of the serve token, never the token — a stolen cookie can't be replayed against the JSON API, which wants the raw bearer.
- `HttpOnly`, `SameSite=Strict`, `Path=/ui`, `Secure` over https.
- `Authorization: Bearer` **still works unchanged**, and `GET /net/topology` stays header-only — so the separability constraint holds and a separately-shipped frontend is unaffected.
- A tokenless loopback serve adds no auth: the console must not invent a requirement mship itself doesn't have.

## A hole this also closes

Found while fixing the above: **`StaticFiles` mounted via `app.mount()` bypasses an app-level dependency.** The console's stylesheet was fetchable with **no credentials over the public relay subdomain**. Only CSS and a copy helper, so nothing secret leaked — but it was unintended.

Verified on the live serve: `GET /ui/static/app.css` with no auth returned **200 before, 401 after**.

The console is now a mounted **sub-app** rather than an `include_router` route — mounts don't inherit parent dependencies, `include_router` does (I verified both directions). That's what makes browser auth possible *and* puts the assets behind a check, with **one middleware choke point** covering page and assets instead of two checks to keep in agreement.

## `mship ui`

Builds that URL so nobody assembles it by hand:

- Opens a browser when there plausibly is one — and deliberately **not** over ssh, where it would open on the wrong machine.
- Otherwise prints the link and offers **`c` to copy**: pbcopy / wl-copy / xclip / xsel, falling back to **OSC 52** so the copy still reaches the human's own machine through ssh (the same mechanism the Textual views use).
- Reads the token with the same env-then-file precedence as `ensure_serve_token`, minus the generate step, via `container.state_dir()` — so it works from inside a task worktree, where state is anchored to the main checkout.
- Skips the keypress prompt when stdin isn't a TTY, so it can't hang in a script.

## Verification

End-to-end against a live token-protected serve:

| Request | Result |
|---|---|
| no credentials | 401 |
| tokenised link, redirects followed | 200 |
| cookie only, no token | 200 |
| stylesheet with cookie | 200 |
| stylesheet without cookie | 401 *(was 200)* |
| `GET /net/topology` with header | 200 |

Full suite **3365 passed**; `mkdocs build --strict` clean.

## Two conventions respected rather than routed around

- `mship ui` is registered under the **Inspection** help panel — the repo has a test forbidding a flat command list.
- Its two `isatty` uses are added to the **MOS-206 allow-list with reasons**. Both are interactivity/capability questions (can I read one keypress? can an OSC 52 escape reach a terminal?) made *after* `Output().json_mode` has already fixed the output shape — exactly the category that list exists for, rather than an output-shape branch.
