### PR TITLE
Artifact evidence: capture into review, blob route, and PR embed

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,14 +150,16 @@ Each repo needs a `Taskfile.yml` with standard task names. Mothership calls `tas
 
 ## Evidence storage (`evidence_storage`)
 
-Storage mode for acceptance-criterion artifact evidence: `committed`, `local`,
-or `encrypted`. When unset it **inherits `spec_storage`**, which is what you
-want unless the cost profiles genuinely differ — prose is bytes, screenshots
-are megabytes, so `spec_storage: committed` with `evidence_storage: local` is
-a reasonable pairing.
+Storage mode for acceptance-criterion artifact evidence: `published`, `local`,
+or `encrypted`. When unset it **inherits `spec_storage`**, mapping that field's
+`committed` to `published` — a spec is committed into the workspace repo's
+tree, whereas evidence is published onto an orphan branch in the repo whose PR
+embeds it. Inheriting is what you want unless the cost profiles genuinely
+differ — prose is bytes, screenshots are megabytes, so `spec_storage:
+committed` with `evidence_storage: local` is a reasonable pairing.
 
 Evidence may never be **more exposed** than its spec. Ordering the modes
-`committed` > `encrypted` > `local`, a configuration where evidence outranks
+`published` > `encrypted` > `local`, a configuration where evidence outranks
 the spec is refused at config load: a plaintext screenshot beside an encrypted
 spec discloses exactly what the encryption was protecting.
 
@@ -165,10 +167,10 @@ spec discloses exactly what the encryption was protecting.
 evidence_storage: local   # inherits spec_storage when omitted
 ```
 
-Embedding evidence in a pull-request body requires `committed` — the other two
+Embedding evidence in a pull-request body requires `published` — the other two
 modes aren't fetchable by GitHub, so the PR names the artifact instead of
 showing it. Embedding therefore means the screenshots are readable by anyone
-who can read the workspace repo.
+who can read the repo the pull request targets.
 
 ## Workspace-level fields
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,6 +148,28 @@ repos:
 
 Each repo needs a `Taskfile.yml` with standard task names. Mothership calls `task <name>` in each repo. Override names per repo in the `tasks` mapping. Default tasks: `test`, `run`, `lint`, `logs`, `setup`. Missing tasks are skipped gracefully.
 
+## Evidence storage (`evidence_storage`)
+
+Storage mode for acceptance-criterion artifact evidence: `committed`, `local`,
+or `encrypted`. When unset it **inherits `spec_storage`**, which is what you
+want unless the cost profiles genuinely differ — prose is bytes, screenshots
+are megabytes, so `spec_storage: committed` with `evidence_storage: local` is
+a reasonable pairing.
+
+Evidence may never be **more exposed** than its spec. Ordering the modes
+`committed` > `encrypted` > `local`, a configuration where evidence outranks
+the spec is refused at config load: a plaintext screenshot beside an encrypted
+spec discloses exactly what the encryption was protecting.
+
+```yaml
+evidence_storage: local   # inherits spec_storage when omitted
+```
+
+Embedding evidence in a pull-request body requires `committed` — the other two
+modes aren't fetchable by GitHub, so the PR names the artifact instead of
+showing it. Embedding therefore means the screenshots are readable by anyone
+who can read the workspace repo.
+
 ## Workspace-level fields
 
 Top-level keys on `mothership.yaml` (alongside `workspace`, `env_runner`, `branch_pattern`, `audit`, and `repos`, all covered above):

--- a/docs/guides/run-and-observe.md
+++ b/docs/guides/run-and-observe.md
@@ -73,6 +73,11 @@ revision it was taken from — marked when that revision is an uncommitted tree,
 a reviewer can tell work-in-progress evidence from a screenshot taken at a real
 commit.
 
+Artifacts are capped at 8 MiB each — a phone fetches these over the relay, and a
+screenshot or layout dump larger than that is a capture bug, not evidence. An
+over-cap artifact is refused when it is stored (the capture itself still
+succeeds) and refused again if one ever reaches the store another way.
+
 **What travels:** the phone fetches evidence from `mship serve` over the relay.
 The PR body embeds it when the bytes are fetchable on GitHub — which means
 `evidence_storage: committed` **and** the evidence commit pushed. Otherwise the

--- a/docs/guides/run-and-observe.md
+++ b/docs/guides/run-and-observe.md
@@ -86,8 +86,8 @@ succeeds) and refused again if one ever reaches the store another way.
 
 **What travels:** the phone fetches evidence from `mship serve` over the relay.
 The PR body embeds it when the bytes are fetchable on GitHub, which means
-`evidence_storage: committed` **and** the artifact published. You do not have to
-arrange that second half: under `committed` storage `mship finish` publishes the
+`evidence_storage: published` **and** the bytes actually on a ref GitHub serves.
+You do not have to arrange that second half: under `published` storage `mship finish` publishes the
 referenced artifacts to an **`mship-evidence` orphan branch in the repo the pull
 request targets**, and embeds a raw URL pinned to that branch's commit.
 

--- a/docs/guides/run-and-observe.md
+++ b/docs/guides/run-and-observe.md
@@ -79,9 +79,25 @@ over-cap artifact is refused when it is stored (the capture itself still
 succeeds) and refused again if one ever reaches the store another way.
 
 **What travels:** the phone fetches evidence from `mship serve` over the relay.
-The PR body embeds it when the bytes are fetchable on GitHub — which means
-`evidence_storage: committed` **and** the evidence commit pushed. Otherwise the
-PR names the artifact instead of showing it, and `mship finish` says so.
+The PR body embeds it when the bytes are fetchable on GitHub, which means
+`evidence_storage: committed` **and** the artifact present in a pushed workspace
+commit. You do not have to arrange that second half: under `committed` storage
+`mship finish` commits the referenced artifacts and pushes the workspace repo
+itself, because otherwise the URL in the PR body would point at a file nobody
+ever committed.
+
+That is the one place mship writes to your workspace repo, and it stays narrow:
+only files under `specs/evidence/<spec-id>/` that a criterion references, staged
+and committed by explicit pathspec, so work you have in flight — untracked,
+edited, or already staged — is never swept into it. Nothing is forced: a
+gitignored evidence directory, a detached HEAD, a diverged branch, an
+unreachable origin, or a branch origin does not already have all stop the
+publish rather than push past it.
+
+Every failure there degrades and none of them block the PR: `finish` warns,
+names the artifact instead of embedding it, and carries on opening the PR. It
+also warns under `local` or `encrypted` storage, where the bytes are not on
+GitHub in readable form at all and nothing is committed or pushed.
 
 **What does not travel:** secrets, platform state, and anything else git cannot
 carry.

--- a/docs/guides/run-and-observe.md
+++ b/docs/guides/run-and-observe.md
@@ -82,19 +82,23 @@ succeeds) and refused again if one ever reaches the store another way.
 
 **What travels:** the phone fetches evidence from `mship serve` over the relay.
 The PR body embeds it when the bytes are fetchable on GitHub, which means
-`evidence_storage: committed` **and** the artifact present in a pushed workspace
-commit. You do not have to arrange that second half: under `committed` storage
-`mship finish` commits the referenced artifacts and pushes the workspace repo
-itself, because otherwise the URL in the PR body would point at a file nobody
-ever committed.
+`evidence_storage: committed` **and** the artifact published. You do not have to
+arrange that second half: under `committed` storage `mship finish` publishes the
+referenced artifacts to an **`mship-evidence` orphan branch in the repo the pull
+request targets**, and embeds a raw URL pinned to that branch's commit.
 
-That is the one place mship writes to your workspace repo, and it stays narrow:
-only files under `specs/evidence/<spec-id>/` that a criterion references, staged
-and committed by explicit pathspec, so work you have in flight — untracked,
-edited, or already staged — is never swept into it. Nothing is forced: a
-gitignored evidence directory, a detached HEAD, a diverged branch, an
-unreachable origin, or a branch origin does not already have all stop the
-publish rather than push past it.
+An orphan branch shares no history with your default branch, so the binaries
+never enter `main`'s tree and a clone of the product is unaffected. `finish`
+pushes that branch and nothing else — never `main`, never your workspace repo —
+and when a task spans several repos, each repo that gets a PR publishes to its
+own branch, so every PR is self-contained. Published artifacts accumulate on the
+branch; nothing prunes them for you.
+
+The publication is built with git plumbing, not a checkout, so your working
+tree, index, HEAD and branches are untouched: work you have in flight —
+untracked, edited, or already staged — cannot be swept into it. Nothing is
+forced: a rejected push, an unreachable origin, or a repo with no GitHub origin
+all stop the publish rather than push past it.
 
 Every failure there degrades and none of them block the PR: `finish` warns,
 names the artifact instead of embedding it, and carries on opening the PR. It

--- a/docs/guides/run-and-observe.md
+++ b/docs/guides/run-and-observe.md
@@ -67,13 +67,17 @@ evidence for that acceptance criterion:
 mship capture --evidence my-spec:ac3
 ```
 
-The artifact is copied into `specs/evidence/<spec-id>/` under a content-hashed
-name, attached to the criterion as `kind=artifact`, and recorded with the
-revision it was taken from — marked when that revision is an uncommitted working
+The artifact is copied into `.mothership/evidence/<spec-id>/` under a
+content-hashed name, attached to the criterion as `kind=artifact`, and recorded
+with the revision it was taken from — marked when that revision is an uncommitted working
 tree, and separately marked when the revision itself is not a commit on any
 branch (a detached HEAD, or a throwaway ref materialized for a remote capture),
 so a reviewer can tell work-in-progress or throwaway evidence from a screenshot
 taken at a real, committed revision. Both markers can appear together.
+
+The store is machine-local and gitignored, so it behaves identically whether
+your workspace is a metarepo, a monorepo, or a single repo — nothing is ever
+committed into your product's history by capturing evidence.
 
 Artifacts are capped at 8 MiB each — a phone fetches these over the relay, and a
 screenshot or layout dump larger than that is a capture bug, not evidence. An
@@ -103,7 +107,7 @@ all stop the publish rather than push past it.
 Every failure there degrades and none of them block the PR: `finish` warns,
 names the artifact instead of embedding it, and carries on opening the PR. It
 also warns under `local` or `encrypted` storage, where the bytes are not on
-GitHub in readable form at all and nothing is committed or pushed.
+GitHub in readable form at all and nothing is published.
 
 **What does not travel:** secrets, platform state, and anything else git cannot
 carry.

--- a/docs/guides/run-and-observe.md
+++ b/docs/guides/run-and-observe.md
@@ -69,9 +69,11 @@ mship capture --evidence my-spec:ac3
 
 The artifact is copied into `specs/evidence/<spec-id>/` under a content-hashed
 name, attached to the criterion as `kind=artifact`, and recorded with the
-revision it was taken from — marked when that revision is an uncommitted tree, so
-a reviewer can tell work-in-progress evidence from a screenshot taken at a real
-commit.
+revision it was taken from — marked when that revision is an uncommitted working
+tree, and separately marked when the revision itself is not a commit on any
+branch (a detached HEAD, or a throwaway ref materialized for a remote capture),
+so a reviewer can tell work-in-progress or throwaway evidence from a screenshot
+taken at a real, committed revision. Both markers can appear together.
 
 Artifacts are capped at 8 MiB each — a phone fetches these over the relay, and a
 screenshot or layout dump larger than that is a capture bug, not evidence. An

--- a/docs/guides/run-and-observe.md
+++ b/docs/guides/run-and-observe.md
@@ -54,6 +54,33 @@ For UI repos, `mship capture` drives the repo's capture target (simulator
 screenshots, layout dumps) and files artifacts under
 `.mothership/captures/<task>/`.
 
+### Promoting a capture to evidence
+
+Most captures are part of the develop–verify–iterate loop: screenshot, look,
+adjust, capture again. Those stay ephemeral — `mship capture` writes them under
+`.mothership/captures/`, which is gitignored, and nothing else happens.
+
+Passing `--evidence <spec-id>:<criterion-id>` promotes a capture into durable
+evidence for that acceptance criterion:
+
+```bash
+mship capture --evidence my-spec:ac3
+```
+
+The artifact is copied into `specs/evidence/<spec-id>/` under a content-hashed
+name, attached to the criterion as `kind=artifact`, and recorded with the
+revision it was taken from — marked when that revision is an uncommitted tree, so
+a reviewer can tell work-in-progress evidence from a screenshot taken at a real
+commit.
+
+**What travels:** the phone fetches evidence from `mship serve` over the relay.
+The PR body embeds it when the bytes are fetchable on GitHub — which means
+`evidence_storage: committed` **and** the evidence commit pushed. Otherwise the
+PR names the artifact instead of showing it, and `mship finish` says so.
+
+**What does not travel:** secrets, platform state, and anything else git cannot
+carry.
+
 ## Running on another machine
 
 A run target that needs hardware you don't have (an iOS simulator on a Mac, an

--- a/src/mship/cli/capture.py
+++ b/src/mship/cli/capture.py
@@ -41,6 +41,59 @@ class _RemoteFlagCommand(TyperCommand):
         return super().parse_args(ctx, args)
 
 
+def _attach_evidence(
+    *, artifacts, evidence: str, container, output, worktree: Path, platform: str | None
+) -> None:
+    """Promote captured artifacts into acceptance-criterion evidence.
+
+    Fail-open: the capture already succeeded, so a storage or spec failure warns
+    and returns. It must never turn a good capture into a bad exit code — the
+    same posture as `spawn`'s --closes issue linking.
+    """
+    from mship.core.evidence_attach import parse_evidence_target, provenance_note
+    from mship.core.evidence_store import resolve_evidence_mode, store_artifact
+    from mship.core.spec import AcceptanceEvidence
+    from mship.core.spec_store import SpecStore
+
+    try:
+        target = parse_evidence_target(evidence)
+        workspace_root = Path(container.config_path()).parent
+        mode = resolve_evidence_mode(container.config())
+        store = SpecStore(workspace_root / "specs")
+        spec = store.find_by_id(target.spec_id)
+        if spec is None:
+            output.warning(f"could not attach evidence: no spec {target.spec_id!r}")
+            return
+        crit = next((c for c in spec.acceptance_criteria if c.id == target.criterion_id), None)
+        if crit is None:
+            output.warning(
+                f"could not attach evidence: {target.spec_id!r} has no criterion "
+                f"{target.criterion_id!r}"
+            )
+            return
+        note_where = provenance_note(worktree, container.shell())
+        for a in artifacts:
+            ref = store_artifact(workspace_root, target.spec_id, a.path, mode=mode)
+            crit.evidence.append(
+                AcceptanceEvidence(
+                    kind="artifact",
+                    ref=ref,
+                    note=f"{a.kind} · {platform or 'default'} · {note_where}",
+                )
+            )
+        store.save(spec)
+        # human_mode only: `success` writes to STDOUT, which in JSON mode already
+        # carries the capture payload — a confirmation line there would corrupt
+        # it for `| jq`. Warnings above are safe (they go to stderr in JSON mode).
+        if output.human_mode:
+            output.success(
+                f"attached {len(artifacts)} artifact(s) to "
+                f"{target.spec_id}:{target.criterion_id}"
+            )
+    except Exception as e:
+        output.warning(f"could not attach evidence: {e}")
+
+
 def register(app: typer.Typer, get_container):
     @app.command(cls=_RemoteFlagCommand, rich_help_panel="Runtime")
     def capture(
@@ -49,6 +102,13 @@ def register(app: typer.Typer, get_container):
         platform: Optional[str] = typer.Option(None, "--platform", help="Platform to capture (required when the repo exposes more than one)."),
         kind: str = typer.Option("all", "--kind", help="Artifact kind: image | layout | all."),
         out: Optional[Path] = typer.Option(None, "--out", help="Output directory (default: .mothership/captures/<task-or-_adhoc>/<ts>-<platform>/)."),
+        evidence: Optional[str] = typer.Option(
+            None, "--evidence", metavar="SPEC:AC",
+            help="Attach the captured artifact(s) to an acceptance criterion as "
+                 "kind=artifact evidence, e.g. --evidence my-spec:ac3. Without "
+                 "this flag the capture stays an ephemeral develop-verify-iterate "
+                 "artifact and nothing is stored or attached.",
+        ),
         remote: Optional[str] = typer.Option(
             None, "--remote",
             help="Execute the capture on a mapped run-host role instead of "
@@ -203,6 +263,11 @@ def register(app: typer.Typer, get_container):
                         "resolved_task": t.slug if t is not None else None,
                         "resolution_source": source.value if source is not None else None,
                     })
+                if evidence:
+                    _attach_evidence(
+                        artifacts=landed, evidence=evidence, container=container,
+                        output=output, worktree=worktree, platform=resolved_platform,
+                    )
             raise typer.Exit(code=code)
 
         try:
@@ -230,3 +295,9 @@ def register(app: typer.Typer, get_container):
                 "resolved_task": t.slug if t is not None else None,
                 "resolution_source": source.value if source is not None else None,
             })
+
+        if evidence:
+            _attach_evidence(
+                artifacts=artifacts, evidence=evidence, container=container,
+                output=output, worktree=worktree, platform=resolved_platform,
+            )

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1560,6 +1560,7 @@ def register(app: typer.Typer, get_container):
             if repo_path not in _acceptance_blocks:
                 block, evidence_warning = acceptance_block_for_finish(
                     bound_spec, workspace_root, repo_path, shell, config,
+                    token=gh_token,
                 )
                 _acceptance_blocks[repo_path] = block
                 if evidence_warning is not None and evidence_warning not in _acceptance_warnings:

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1542,9 +1542,12 @@ def register(app: typer.Typer, get_container):
 
         # Render the acceptance-criteria PR-body section once (reuses bound_spec
         # from the gate above). Empty string when there's no bound spec or no ACs.
-        # Embeds image evidence when the workspace's evidence commit is fetchable
-        # from GitHub; otherwise names it and warns here, BEFORE any PR is opened,
-        # so the operator can abort and push rather than fix it up after the fact.
+        # Under `committed` evidence storage this also COMMITS AND PUSHES the
+        # referenced artifacts in the workspace repo (pathspec-scoped to
+        # specs/evidence/<spec>/ — see evidence_url.publish_evidence), because
+        # nothing else does and an unpublished artifact embeds as a 404. Every
+        # failure in there degrades to naming the artifact plus this warning,
+        # raised BEFORE any PR is opened; opening the PR never depends on it.
         from mship.core.pr import acceptance_block_for_finish
         acceptance_block = ""
         if bound_spec is not None:

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1542,8 +1542,17 @@ def register(app: typer.Typer, get_container):
 
         # Render the acceptance-criteria PR-body section once (reuses bound_spec
         # from the gate above). Empty string when there's no bound spec or no ACs.
-        from mship.core.pr import build_acceptance_block
-        acceptance_block = build_acceptance_block(bound_spec) if bound_spec is not None else ""
+        # Embeds image evidence when the workspace's evidence commit is fetchable
+        # from GitHub; otherwise names it and warns here, BEFORE any PR is opened,
+        # so the operator can abort and push rather than fix it up after the fact.
+        from mship.core.pr import acceptance_block_for_finish
+        acceptance_block = ""
+        if bound_spec is not None:
+            acceptance_block, evidence_warning = acceptance_block_for_finish(
+                bound_spec, workspace_root, shell, config,
+            )
+            if evidence_warning is not None:
+                output.warning(evidence_warning)
 
         pr_list: list[dict] = []
         repushed_repos: list[str] = []  # repos where --force re-pushed commits

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1540,22 +1540,32 @@ def register(app: typer.Typer, get_container):
                 bound_spec.updated_at = _dt_al.now(_tz_al.utc)
                 SpecStore(workspace_root / SPECS_DIRNAME).save(bound_spec)
 
-        # Render the acceptance-criteria PR-body section once (reuses bound_spec
-        # from the gate above). Empty string when there's no bound spec or no ACs.
-        # Under `committed` evidence storage this also COMMITS AND PUSHES the
-        # referenced artifacts in the workspace repo (pathspec-scoped to
-        # specs/evidence/<spec>/ — see evidence_url.publish_evidence), because
-        # nothing else does and an unpublished artifact embeds as a 404. Every
-        # failure in there degrades to naming the artifact plus this warning,
-        # raised BEFORE any PR is opened; opening the PR never depends on it.
+        # The acceptance-criteria PR-body section is rendered PER REPO, because
+        # under `published` evidence storage rendering it also publishes the
+        # referenced artifacts to THAT repo's `mship-evidence` orphan branch (see
+        # core/evidence_url.py): every PR then embeds from the repo its reviewer
+        # already has open, and no reviewer needs read access to a sibling repo.
+        # Memoised per repo path, so a repo is published to once however many
+        # groups map onto it, and each distinct warning is shown once. Every
+        # failure in there degrades to naming the artifact plus that warning,
+        # emitted before that repo's PR is created; opening the PR never depends
+        # on it. Empty string when there's no bound spec or no ACs.
         from mship.core.pr import acceptance_block_for_finish
-        acceptance_block = ""
-        if bound_spec is not None:
-            acceptance_block, evidence_warning = acceptance_block_for_finish(
-                bound_spec, workspace_root, shell, config,
-            )
-            if evidence_warning is not None:
-                output.warning(evidence_warning)
+        _acceptance_blocks: dict[Path, str] = {}
+        _acceptance_warnings: set[str] = set()
+
+        def acceptance_block_for(repo_path: Path) -> str:
+            if bound_spec is None:
+                return ""
+            if repo_path not in _acceptance_blocks:
+                block, evidence_warning = acceptance_block_for_finish(
+                    bound_spec, workspace_root, repo_path, shell, config,
+                )
+                _acceptance_blocks[repo_path] = block
+                if evidence_warning is not None and evidence_warning not in _acceptance_warnings:
+                    _acceptance_warnings.add(evidence_warning)
+                    output.warning(evidence_warning)
+            return _acceptance_blocks[repo_path]
 
         pr_list: list[dict] = []
         repushed_repos: list[str] = []  # repos where --force re-pushed commits
@@ -1716,6 +1726,7 @@ def register(app: typer.Typer, get_container):
                     from mship.core.issue_refs import append_linked_closes
                     pr_body = append_linked_closes(
                         pr_body, linked_issue_canonicals, slug_for_path(group.rep_path))
+                acceptance_block = acceptance_block_for(group.rep_path)
                 if acceptance_block:
                     pr_body = pr_body + acceptance_block
 

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -344,10 +344,13 @@ class WorkspaceConfig(BaseModel):
     # Storage mode for acceptance-criterion artifact evidence. `None` inherits
     # `spec_storage` — the safe default, so evidence is governed exactly like the
     # spec it backs unless an operator deliberately diverges (prose is bytes,
-    # screenshots are megabytes). Resolved by
+    # screenshots are megabytes). The vocabulary differs by one word: a spec is
+    # `committed` into the workspace repo's tree, whereas evidence is `published`
+    # onto an orphan branch in the repo whose PR embeds it, so inheritance maps
+    # `committed` to `published`. Resolved by
     # core/evidence_store.py::resolve_evidence_mode, which also enforces that
     # evidence is never MORE exposed than its spec.
-    evidence_storage: Literal["committed", "local", "encrypted"] | None = None
+    evidence_storage: Literal["published", "local", "encrypted"] | None = None
     # If set and the effective spawn scope exceeds N repos AND no --repos was
     # passed, require confirmation (TTY) or --yes (non-TTY). See #74.
     spawn_confirm_threshold: int | None = None

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -340,6 +340,13 @@ class WorkspaceConfig(BaseModel):
     # unreadable without `.mothership/spec-key`. Applied transparently by
     # core/spec_storage.py; an invalid value fails loud at config load.
     spec_storage: Literal["committed", "local", "encrypted"] = "committed"
+    # Storage mode for acceptance-criterion artifact evidence. `None` inherits
+    # `spec_storage` — the safe default, so evidence is governed exactly like the
+    # spec it backs unless an operator deliberately diverges (prose is bytes,
+    # screenshots are megabytes). Resolved by
+    # core/evidence_store.py::resolve_evidence_mode, which also enforces that
+    # evidence is never MORE exposed than its spec.
+    evidence_storage: Literal["committed", "local", "encrypted"] | None = None
     # If set and the effective spawn scope exceeds N repos AND no --repos was
     # passed, require confirmation (TTY) or --yes (non-TTY). See #74.
     spawn_confirm_threshold: int | None = None

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -5,6 +5,7 @@ from typing import Literal
 import yaml
 from pydantic import BaseModel, field_validator, model_validator
 
+from mship.core.evidence_store import EvidenceModeError, resolve_evidence_mode
 from mship.core.relay.config import RelayConfig
 
 
@@ -440,6 +441,19 @@ class WorkspaceConfig(BaseModel):
                     f"default_scope references unknown repos: {unknown}. "
                     f"Valid repos: {sorted(self.repos.keys())}"
                 )
+        return self
+
+    @model_validator(mode="after")
+    def validate_evidence_exposure(self) -> "WorkspaceConfig":
+        """evidence_storage may never be more exposed than spec_storage — a
+        screenshot discloses exactly what encrypted/local spec prose was
+        protecting. Reuse resolve_evidence_mode (core/evidence_store.py) as the
+        single source of truth for the exposure ordering rather than
+        reimplementing the comparison here."""
+        try:
+            resolve_evidence_mode(self)
+        except EvidenceModeError as e:
+            raise ValueError(str(e)) from e
         return self
 
     @model_validator(mode="after")

--- a/src/mship/core/evidence_attach.py
+++ b/src/mship/core/evidence_attach.py
@@ -26,10 +26,32 @@ def parse_evidence_target(raw: str) -> EvidenceTarget:
     return EvidenceTarget(spec_id=parts[0], criterion_id=parts[1])
 
 
+def _on_a_branch(sha: str, worktree: Path, shell) -> bool:
+    """True iff some branch — local or remote-tracking — contains `sha`.
+
+    `git branch --all --contains <sha>` lists every branch reachable from
+    `sha`, but on a detached HEAD it ALSO always emits a synthetic
+    `* (HEAD detached at/from ...)` line even when no real branch contains the
+    commit — so "empty output" isn't the right test. Filter that pseudo-entry
+    out (it starts with `(`) and check whether any real branch name remains.
+    `--all` (not just local) matters because a worktree can be a detached
+    checkout of a commit that's the tip of a REMOTE branch with no local
+    branch pointing at it — that commit is still "on a branch", just not one
+    with a local ref.
+    """
+    result = shell.run(f"git branch --all --contains {sha}", cwd=worktree)
+    for line in (result.stdout or "").splitlines():
+        name = line[2:].strip()  # strip the leading "* " / "  " marker column
+        if name and not name.startswith("("):
+            return True
+    return False
+
+
 def provenance_note(worktree: Path, shell) -> str:
-    """Where the capture was taken from. A capture of uncommitted work or of a
-    throwaway run ref is still useful evidence, but a reviewer must be able to
-    see that is what it is.
+    """Where the capture was taken from. A capture of uncommitted work, or of
+    a commit that isn't on any branch (a detached HEAD, or a throwaway run
+    ref materialized for a remote capture), is still useful evidence — but a
+    reviewer must be able to see that is what it is.
 
     `shell` is util/shell.py::Shell — its `run` takes a command STRING (it uses
     shell=True), not an argv list.
@@ -38,4 +60,13 @@ def provenance_note(worktree: Path, shell) -> str:
     sha = (rev.stdout or "").strip() or "unknown"
     status = shell.run("git status --porcelain", cwd=worktree)
     dirty = bool((status.stdout or "").strip())
-    return f"at {sha} (uncommitted working tree)" if dirty else f"at {sha}"
+
+    markers = []
+    if dirty:
+        markers.append("uncommitted working tree")
+    if sha != "unknown" and not _on_a_branch(sha, worktree, shell):
+        markers.append("not on any branch")
+
+    if markers:
+        return f"at {sha} ({', '.join(markers)})"
+    return f"at {sha}"

--- a/src/mship/core/evidence_attach.py
+++ b/src/mship/core/evidence_attach.py
@@ -1,0 +1,41 @@
+"""Promote a capture into acceptance-criterion evidence.
+
+Bare `mship capture` is untouched: it writes to the ephemeral, gitignored
+captures directory and nothing here runs. Only `--evidence` promotes artifacts
+into the durable, spec-scoped, mode-governed store.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class EvidenceTarget:
+    spec_id: str
+    criterion_id: str
+
+
+def parse_evidence_target(raw: str) -> EvidenceTarget:
+    """`<spec-id>:<ac-id>` -> EvidenceTarget. Raises ValueError otherwise."""
+    parts = (raw or "").split(":")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError(
+            f"--evidence expects <spec-id>:<criterion-id> (e.g. my-spec:ac3), got {raw!r}"
+        )
+    return EvidenceTarget(spec_id=parts[0], criterion_id=parts[1])
+
+
+def provenance_note(worktree: Path, shell) -> str:
+    """Where the capture was taken from. A capture of uncommitted work or of a
+    throwaway run ref is still useful evidence, but a reviewer must be able to
+    see that is what it is.
+
+    `shell` is util/shell.py::Shell — its `run` takes a command STRING (it uses
+    shell=True), not an argv list.
+    """
+    rev = shell.run("git rev-parse --short HEAD", cwd=worktree)
+    sha = (rev.stdout or "").strip() or "unknown"
+    status = shell.run("git status --porcelain", cwd=worktree)
+    dirty = bool((status.stdout or "").strip())
+    return f"at {sha} (uncommitted working tree)" if dirty else f"at {sha}"

--- a/src/mship/core/evidence_store.py
+++ b/src/mship/core/evidence_store.py
@@ -67,11 +67,33 @@ CONTENT_TYPES: dict[str, str] = {
 }
 IMAGE_EXTS: frozenset[str] = frozenset({".png", ".jpg", ".jpeg", ".webp"})
 
+# What a screenshot or layout dump plausibly weighs: a phone PNG at 3x is a few
+# MB and an XML dump far less, so 8 MiB accepts every real artifact with room to
+# spare while keeping a single blob small enough for a phone to fetch over the
+# relay. This is a ceiling on the ARTIFACT, checked both when storing (so the
+# operator hears about it at capture time) and when serving (the check that
+# actually bounds a response, since a file can reach the store by other means).
+MAX_EVIDENCE_BYTES = 8 * 1024 * 1024
+# On-disk ceiling for an encrypted artifact, whose file is Fernet ciphertext:
+# base64 over a 57-byte envelope plus AES padding, so under 1.4x the plaintext.
+# 2x is the round number that keeps a just-under-cap artifact servable while
+# still bounding what the blob route decrypts into memory.
+_CIPHERTEXT_SLACK = 2
+
 _HASH_CHARS = 12
 
 
+def stored_size_cap(ref: str) -> int:
+    """The largest on-disk size this ref may have. Encrypted refs get the
+    ciphertext allowance; everything else is the artifact cap itself."""
+    if ref.endswith(ENC_SUFFIX):
+        return MAX_EVIDENCE_BYTES * _CIPHERTEXT_SLACK
+    return MAX_EVIDENCE_BYTES
+
+
 class EvidenceStoreError(Exception):
-    """An artifact could not be stored (unsupported extension, unreadable)."""
+    """An artifact could not be stored (unsupported extension, too large,
+    unreadable)."""
 
 
 def evidence_dir(workspace_root: Path, spec_id: str) -> Path:
@@ -103,6 +125,13 @@ def store_artifact(
         raise EvidenceStoreError(
             f"unsupported evidence extension {ext!r}; expected one of "
             f"{', '.join(sorted(CONTENT_TYPES))}"
+        )
+    size = src.stat().st_size
+    if size > MAX_EVIDENCE_BYTES:
+        raise EvidenceStoreError(
+            f"evidence artifact is {size} bytes, over the "
+            f"{MAX_EVIDENCE_BYTES}-byte limit; a screenshot or layout dump this "
+            f"large is a capture bug, and the blob route would refuse to serve it"
         )
     ref = f"{_digest(src)}{ext}"
     dest_dir = evidence_dir(workspace_root, spec_id)

--- a/src/mship/core/evidence_store.py
+++ b/src/mship/core/evidence_store.py
@@ -167,6 +167,17 @@ def store_artifact(
 _REF_RE = re.compile(r"[0-9a-f]{%d}\.[a-z0-9]{2,5}(\.enc)?" % _HASH_CHARS)
 
 
+def is_stored_ref(ref: str) -> bool:
+    """True when `ref` has the shape this store produces (a content hash plus a
+    known extension), as opposed to a hand-written path from before
+    `capture --evidence` existed.
+
+    The public answer to "did we store this?", so callers never need the regex
+    itself: ref shape stays one module's business.
+    """
+    return isinstance(ref, str) and _REF_RE.fullmatch(ref) is not None
+
+
 class BadEvidenceRef(Exception):
     """A ref was malformed, escaped its spec's evidence directory, or is absent."""
 
@@ -179,7 +190,7 @@ def resolve_ref(workspace_root: Path, spec_id: str, ref: str) -> Path:
     blob route, so both are validated here: `ref` must be a bare hash filename,
     and `spec_id` must name a direct child of the workspace's evidence store.
     """
-    if not isinstance(ref, str) or not _REF_RE.fullmatch(ref):
+    if not is_stored_ref(ref):
         raise BadEvidenceRef(f"malformed evidence ref {ref!r}")
     # A full-length hash with an extension we do not serve (`deadbeefcafe.exe`)
     # is refused here, not by the regex. An encrypted ref carries a trailing

--- a/src/mship/core/evidence_store.py
+++ b/src/mship/core/evidence_store.py
@@ -11,6 +11,8 @@ primary defence is that the data model cannot say "elsewhere".
 """
 from __future__ import annotations
 
+import hashlib
+import shutil
 from pathlib import Path
 from typing import Literal
 
@@ -42,3 +44,63 @@ def resolve_evidence_mode(config) -> EvidenceMode:
             f"{', '.join(m for m in _EXPOSURE if _EXPOSURE[m] <= _EXPOSURE[spec_mode])}."
         )
     return declared
+
+
+SPECS_DIRNAME = "specs"
+EVIDENCE_DIRNAME = "evidence"
+ENC_SUFFIX = ".enc"
+
+# Extensions we are willing to store and serve. Anything else is refused rather
+# than guessed at — a served blob's content-type is derived from this.
+CONTENT_TYPES: dict[str, str] = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".xml": "application/xml",
+    ".json": "application/json",
+    ".html": "text/html",
+}
+IMAGE_EXTS: frozenset[str] = frozenset({".png", ".jpg", ".jpeg", ".webp"})
+
+_HASH_CHARS = 12
+
+
+class EvidenceStoreError(Exception):
+    """An artifact could not be stored (unsupported extension, unreadable)."""
+
+
+def evidence_dir(workspace_root: Path, spec_id: str) -> Path:
+    """The one directory a spec's artifact evidence may live in."""
+    return Path(workspace_root) / SPECS_DIRNAME / EVIDENCE_DIRNAME / spec_id
+
+
+def _digest(src: Path) -> str:
+    h = hashlib.sha256()
+    with open(src, "rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()[:_HASH_CHARS]
+
+
+def store_artifact(
+    workspace_root: Path, spec_id: str, src: Path, *, mode: EvidenceMode
+) -> str:
+    """Copy `src` into the spec's evidence directory under a content-hashed
+    name. Returns the BARE FILENAME to persist as the evidence ref.
+
+    `mode` is accepted here and honoured in full by a later change (gitignore for
+    `local`, ciphertext for `encrypted`); this path is the plaintext copy.
+    """
+    src = Path(src)
+    ext = src.suffix.lower()
+    if ext not in CONTENT_TYPES:
+        raise EvidenceStoreError(
+            f"unsupported evidence extension {ext!r}; expected one of "
+            f"{', '.join(sorted(CONTENT_TYPES))}"
+        )
+    ref = f"{_digest(src)}{ext}"
+    dest_dir = evidence_dir(workspace_root, spec_id)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dest_dir / ref)
+    return ref

--- a/src/mship/core/evidence_store.py
+++ b/src/mship/core/evidence_store.py
@@ -1,0 +1,44 @@
+"""Where acceptance-criterion artifact evidence lives, and how a ref resolves
+back to it.
+
+Single owner of the path math: both `mship capture --evidence` and serve's blob
+route go through this module, so nothing else computes an evidence path.
+
+The persisted ref is a BARE FILENAME, never a path. Because the resolver joins
+exactly one root — the spec's own evidence directory — a ref has no way to
+express a location outside it. Validation still rejects malformed names, but the
+primary defence is that the data model cannot say "elsewhere".
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+EvidenceMode = Literal["committed", "local", "encrypted"]
+
+# Ordered least-exposed to most-exposed. `local` never leaves the machine;
+# `encrypted` leaves but is unreadable without the key; `committed` leaves in the
+# clear. Evidence may never rank above the spec it backs.
+_EXPOSURE: dict[str, int] = {"local": 0, "encrypted": 1, "committed": 2}
+
+
+class EvidenceModeError(Exception):
+    """The configured evidence_storage is more exposed than spec_storage."""
+
+
+def resolve_evidence_mode(config) -> EvidenceMode:
+    """The effective evidence mode. `evidence_storage` unset inherits
+    `spec_storage`; set, it must not be more exposed than the spec's mode."""
+    spec_mode: EvidenceMode = getattr(config, "spec_storage", "committed")
+    declared = getattr(config, "evidence_storage", None)
+    if declared is None:
+        return spec_mode
+    if _EXPOSURE[declared] > _EXPOSURE[spec_mode]:
+        raise EvidenceModeError(
+            f"evidence_storage={declared!r} is more exposed than "
+            f"spec_storage={spec_mode!r}. A screenshot discloses what the spec "
+            f"prose was protecting, so evidence may never be less protected "
+            f"than its spec. Use one of: "
+            f"{', '.join(m for m in _EXPOSURE if _EXPOSURE[m] <= _EXPOSURE[spec_mode])}."
+        )
+    return declared

--- a/src/mship/core/evidence_store.py
+++ b/src/mship/core/evidence_store.py
@@ -50,7 +50,14 @@ def resolve_evidence_mode(config) -> EvidenceMode:
     return declared
 
 
-SPECS_DIRNAME = "specs"
+# The store is machine-local and lives under the workspace's gitignored state
+# directory, NOT in any git repo's tracked tree. That is what makes it behave
+# identically in a multi-repo workspace, a monorepo and a single repo: where the
+# workspace root happens to BE a product repo, evidence bytes still never enter
+# that repo's history. Getting bytes to GitHub for a PR embed is a separate,
+# explicit step at finish (core/evidence_url.py), not a property of where the
+# file sits.
+STATE_DIRNAME = ".mothership"
 EVIDENCE_DIRNAME = "evidence"
 ENC_SUFFIX = ".enc"
 
@@ -104,9 +111,14 @@ class EvidenceStoreError(Exception):
     unreadable)."""
 
 
+def evidence_root(workspace_root: Path) -> Path:
+    """The store. Every spec's evidence directory is a direct child of this."""
+    return Path(workspace_root) / STATE_DIRNAME / EVIDENCE_DIRNAME
+
+
 def evidence_dir(workspace_root: Path, spec_id: str) -> Path:
     """The one directory a spec's artifact evidence may live in."""
-    return Path(workspace_root) / SPECS_DIRNAME / EVIDENCE_DIRNAME / spec_id
+    return evidence_root(workspace_root) / spec_id
 
 
 def _digest(src: Path) -> str:
@@ -123,9 +135,10 @@ def store_artifact(
     """Copy `src` into the spec's evidence directory under a content-hashed
     name. Returns the BARE FILENAME to persist as the evidence ref.
 
-    `mode` is honoured in full: `local` plaintext-copies and gitignores the
-    evidence store, `encrypted` writes ciphertext under an `.enc`-suffixed ref
-    (never plaintext), `committed` plaintext-copies with no gitignore entry.
+    `mode` is honoured in full: `encrypted` writes ciphertext under an
+    `.enc`-suffixed ref and never plaintext; the other modes plaintext-copy. The
+    store is gitignored in every mode — the modes differ only in what LEAVES the
+    machine, which is decided at publication (core/evidence_url.py), not here.
     """
     src = Path(src)
     ext = src.suffix.lower()
@@ -154,10 +167,6 @@ def store_artifact(
         return ref
 
     shutil.copyfile(src, dest_dir / ref)
-    if mode == "local":
-        GitRunner().add_to_gitignore(
-            Path(workspace_root), f"{SPECS_DIRNAME}/{EVIDENCE_DIRNAME}/"
-        )
     return ref
 
 
@@ -199,9 +208,7 @@ def resolve_ref(workspace_root: Path, spec_id: str, ref: str) -> Path:
     if Path(logical).suffix.lower() not in CONTENT_TYPES:
         raise BadEvidenceRef(f"unsupported evidence extension in {ref!r}")
 
-    store_root = Path(os.path.realpath(
-        Path(workspace_root) / SPECS_DIRNAME / EVIDENCE_DIRNAME
-    ))
+    store_root = Path(os.path.realpath(evidence_root(workspace_root)))
     root = Path(os.path.realpath(evidence_dir(workspace_root, spec_id)))
     # realpath normalises `..` away, so a spec id like `../other-spec` lands
     # somewhere whose parent is not the store — one spec can never read another's.

--- a/src/mship/core/evidence_store.py
+++ b/src/mship/core/evidence_store.py
@@ -18,6 +18,8 @@ import shutil
 from pathlib import Path
 from typing import Literal
 
+from mship.util.git import GitRunner
+
 EvidenceMode = Literal["committed", "local", "encrypted"]
 
 # Ordered least-exposed to most-exposed. `local` never leaves the machine;
@@ -91,8 +93,9 @@ def store_artifact(
     """Copy `src` into the spec's evidence directory under a content-hashed
     name. Returns the BARE FILENAME to persist as the evidence ref.
 
-    `mode` is accepted here and honoured in full by a later change (gitignore for
-    `local`, ciphertext for `encrypted`); this path is the plaintext copy.
+    `mode` is honoured in full: `local` plaintext-copies and gitignores the
+    evidence store, `encrypted` writes ciphertext under an `.enc`-suffixed ref
+    (never plaintext), `committed` plaintext-copies with no gitignore entry.
     """
     src = Path(src)
     ext = src.suffix.lower()
@@ -104,14 +107,27 @@ def store_artifact(
     ref = f"{_digest(src)}{ext}"
     dest_dir = evidence_dir(workspace_root, spec_id)
     dest_dir.mkdir(parents=True, exist_ok=True)
+
+    if mode == "encrypted":
+        from mship.core import spec_key
+
+        ref = ref + ENC_SUFFIX
+        key = spec_key.load_or_generate_key(Path(workspace_root), git=GitRunner())
+        (dest_dir / ref).write_bytes(spec_key.encrypt_bytes(key, src.read_bytes()))
+        return ref
+
     shutil.copyfile(src, dest_dir / ref)
+    if mode == "local":
+        GitRunner().add_to_gitignore(
+            Path(workspace_root), f"{SPECS_DIRNAME}/{EVIDENCE_DIRNAME}/"
+        )
     return ref
 
 
 # A ref is exactly a content hash plus a known extension. `fullmatch` and not a
 # `$`-anchored `match`, because `$` would also accept a trailing newline.
 # Nothing that fails this ever reaches the filesystem.
-_REF_RE = re.compile(r"[0-9a-f]{%d}\.[a-z0-9]{2,5}" % _HASH_CHARS)
+_REF_RE = re.compile(r"[0-9a-f]{%d}\.[a-z0-9]{2,5}(\.enc)?" % _HASH_CHARS)
 
 
 class BadEvidenceRef(Exception):
@@ -128,10 +144,11 @@ def resolve_ref(workspace_root: Path, spec_id: str, ref: str) -> Path:
     """
     if not isinstance(ref, str) or not _REF_RE.fullmatch(ref):
         raise BadEvidenceRef(f"malformed evidence ref {ref!r}")
-    # The regex admits one dot only, so the suffix is unambiguous. A full-length
-    # hash with an extension we do not serve (`deadbeefcafe.exe`) is refused
-    # here, not by the regex.
-    if Path(ref).suffix not in CONTENT_TYPES:
+    # A full-length hash with an extension we do not serve (`deadbeefcafe.exe`)
+    # is refused here, not by the regex. An encrypted ref carries a trailing
+    # `.enc`, so the extension we care about is the one beneath that.
+    logical = ref[: -len(ENC_SUFFIX)] if ref.endswith(ENC_SUFFIX) else ref
+    if Path(logical).suffix.lower() not in CONTENT_TYPES:
         raise BadEvidenceRef(f"unsupported evidence extension in {ref!r}")
 
     store_root = Path(os.path.realpath(

--- a/src/mship/core/evidence_store.py
+++ b/src/mship/core/evidence_store.py
@@ -12,6 +12,8 @@ primary defence is that the data model cannot say "elsewhere".
 from __future__ import annotations
 
 import hashlib
+import os
+import re
 import shutil
 from pathlib import Path
 from typing import Literal
@@ -104,3 +106,53 @@ def store_artifact(
     dest_dir.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(src, dest_dir / ref)
     return ref
+
+
+# A ref is exactly a content hash plus a known extension. `fullmatch` and not a
+# `$`-anchored `match`, because `$` would also accept a trailing newline.
+# Nothing that fails this ever reaches the filesystem.
+_REF_RE = re.compile(r"[0-9a-f]{%d}\.[a-z0-9]{2,5}" % _HASH_CHARS)
+
+
+class BadEvidenceRef(Exception):
+    """A ref was malformed, escaped its spec's evidence directory, or is absent."""
+
+
+def resolve_ref(workspace_root: Path, spec_id: str, ref: str) -> Path:
+    """The on-disk path for a stored ref. Raises BadEvidenceRef for anything
+    malformed, absent, or resolving outside the spec's evidence directory.
+
+    Both arguments after `workspace_root` arrive from an HTTP path in serve's
+    blob route, so both are validated here: `ref` must be a bare hash filename,
+    and `spec_id` must name a direct child of the workspace's evidence store.
+    """
+    if not isinstance(ref, str) or not _REF_RE.fullmatch(ref):
+        raise BadEvidenceRef(f"malformed evidence ref {ref!r}")
+    # The regex admits one dot only, so the suffix is unambiguous. A full-length
+    # hash with an extension we do not serve (`deadbeefcafe.exe`) is refused
+    # here, not by the regex.
+    if Path(ref).suffix not in CONTENT_TYPES:
+        raise BadEvidenceRef(f"unsupported evidence extension in {ref!r}")
+
+    store_root = Path(os.path.realpath(
+        Path(workspace_root) / SPECS_DIRNAME / EVIDENCE_DIRNAME
+    ))
+    root = Path(os.path.realpath(evidence_dir(workspace_root, spec_id)))
+    # realpath normalises `..` away, so a spec id like `../other-spec` lands
+    # somewhere whose parent is not the store — one spec can never read another's.
+    if root.parent != store_root:
+        raise BadEvidenceRef(f"malformed spec id {spec_id!r}")
+
+    candidate = root / ref
+    # `root` is fully resolved and `ref` is a bare filename, so `candidate` is a
+    # direct child of this spec's store; the only way it could still name
+    # something else is a symlink at the final component, which is exactly what
+    # realpath differing from the path we built detects. A link pointing back
+    # INSIDE the store is refused too: a ref attests the content hash of a
+    # regular file, so a link there is an integrity violation, and honouring one
+    # would make containment depend on where it points at read time.
+    if Path(os.path.realpath(candidate)) != candidate:
+        raise BadEvidenceRef(f"evidence ref {ref!r} is a link, not stored content")
+    if not candidate.is_file():
+        raise BadEvidenceRef(f"no evidence at {ref!r}")
+    return candidate

--- a/src/mship/core/evidence_store.py
+++ b/src/mship/core/evidence_store.py
@@ -54,16 +54,24 @@ SPECS_DIRNAME = "specs"
 EVIDENCE_DIRNAME = "evidence"
 ENC_SUFFIX = ".enc"
 
-# Extensions we are willing to store and serve. Anything else is refused rather
-# than guessed at — a served blob's content-type is derived from this.
+# Extensions we are willing to store, mapped to the content-type we SERVE them
+# as. Anything else is refused rather than guessed at.
+#
+# The non-image entries are the layout dumps `mship capture` produces
+# (core/capture.py::KIND_FILENAMES: layout.xml/.json/.html), and they are
+# deliberately served as text/plain rather than their true type: their content
+# comes from the app under test, so serving it as text/html would let a rendered
+# UI string execute script on the API's own origin — a stored-XSS shape. Only
+# the image types, which no browser executes, keep a rendering content-type.
+_TEXT = "text/plain; charset=utf-8"
 CONTENT_TYPES: dict[str, str] = {
     ".png": "image/png",
     ".jpg": "image/jpeg",
     ".jpeg": "image/jpeg",
     ".webp": "image/webp",
-    ".xml": "application/xml",
-    ".json": "application/json",
-    ".html": "text/html",
+    ".xml": _TEXT,
+    ".json": _TEXT,
+    ".html": _TEXT,
 }
 IMAGE_EXTS: frozenset[str] = frozenset({".png", ".jpg", ".jpeg", ".webp"})
 

--- a/src/mship/core/evidence_store.py
+++ b/src/mship/core/evidence_store.py
@@ -20,12 +20,27 @@ from typing import Literal
 
 from mship.util.git import GitRunner
 
-EvidenceMode = Literal["committed", "local", "encrypted"]
+# `published` and not `committed`: evidence is never committed where the spec is.
+# The spec's own bytes are committed to the workspace repo's tracked tree, while
+# an artifact is only ever PUBLISHED — copied onto an orphan branch in the repo
+# whose PR embeds it (core/evidence_url.py). Same exposure, different mechanism,
+# so it gets its own word.
+EvidenceMode = Literal["published", "local", "encrypted"]
 
 # Ordered least-exposed to most-exposed. `local` never leaves the machine;
-# `encrypted` leaves but is unreadable without the key; `committed` leaves in the
+# `encrypted` leaves but is unreadable without the key; `published` leaves in the
 # clear. Evidence may never rank above the spec it backs.
-_EXPOSURE: dict[str, int] = {"local": 0, "encrypted": 1, "committed": 2}
+_EXPOSURE: dict[str, int] = {"local": 0, "encrypted": 1, "published": 2}
+
+# `spec_storage` keeps its own vocabulary — it is not this feature's field to
+# rename — so inheritance maps its values onto the evidence ones. Only the
+# most-exposed name differs; the mapping is explicit so the two vocabularies can
+# never drift into a silent KeyError or a wrong exposure comparison.
+_INHERITED: dict[str, EvidenceMode] = {
+    "committed": "published",
+    "local": "local",
+    "encrypted": "encrypted",
+}
 
 
 class EvidenceModeError(Exception):
@@ -34,18 +49,20 @@ class EvidenceModeError(Exception):
 
 def resolve_evidence_mode(config) -> EvidenceMode:
     """The effective evidence mode. `evidence_storage` unset inherits
-    `spec_storage`; set, it must not be more exposed than the spec's mode."""
-    spec_mode: EvidenceMode = getattr(config, "spec_storage", "committed")
+    `spec_storage` (mapping `committed` to `published`); set, it must not be more
+    exposed than the spec's mode."""
+    spec_mode: str = getattr(config, "spec_storage", "committed")
+    inherited = _INHERITED[spec_mode]
     declared = getattr(config, "evidence_storage", None)
     if declared is None:
-        return spec_mode
-    if _EXPOSURE[declared] > _EXPOSURE[spec_mode]:
+        return inherited
+    if _EXPOSURE[declared] > _EXPOSURE[inherited]:
         raise EvidenceModeError(
             f"evidence_storage={declared!r} is more exposed than "
             f"spec_storage={spec_mode!r}. A screenshot discloses what the spec "
             f"prose was protecting, so evidence may never be less protected "
             f"than its spec. Use one of: "
-            f"{', '.join(m for m in _EXPOSURE if _EXPOSURE[m] <= _EXPOSURE[spec_mode])}."
+            f"{', '.join(m for m in _EXPOSURE if _EXPOSURE[m] <= _EXPOSURE[inherited])}."
         )
     return declared
 

--- a/src/mship/core/evidence_store.py
+++ b/src/mship/core/evidence_store.py
@@ -118,7 +118,7 @@ _HASH_CHARS = 12
 def stored_size_cap(ref: str) -> int:
     """The largest on-disk size this ref may have. Encrypted refs get the
     ciphertext allowance; everything else is the artifact cap itself."""
-    if ref.endswith(ENC_SUFFIX):
+    if is_encrypted_ref(ref):
         return MAX_EVIDENCE_BYTES * _CIPHERTEXT_SLACK
     return MAX_EVIDENCE_BYTES
 
@@ -193,6 +193,13 @@ def store_artifact(
 _REF_RE = re.compile(r"[0-9a-f]{%d}\.[a-z0-9]{2,5}(\.enc)?" % _HASH_CHARS)
 
 
+def _logical_ref(ref: str) -> str:
+    """The ref with any encryption suffix stripped. `<hash>.png.enc` names a PNG
+    whose stored bytes happen to be ciphertext, so anything asking about the
+    ARTIFACT asks it of this, never of the on-disk filename."""
+    return ref[: -len(ENC_SUFFIX)] if is_encrypted_ref(ref) else ref
+
+
 def is_stored_ref(ref: str) -> bool:
     """True when `ref` has the shape this store produces (a content hash plus a
     known extension), as opposed to a hand-written path from before
@@ -202,6 +209,27 @@ def is_stored_ref(ref: str) -> bool:
     itself: ref shape stays one module's business.
     """
     return isinstance(ref, str) and _REF_RE.fullmatch(ref) is not None
+
+
+def is_image_ref(ref: str) -> bool:
+    """True when `ref` names an image this store produced, encrypted or not.
+
+    Answers "is this the KIND of artifact a PR body would ever embed?" — a
+    different question from "can these bytes be embedded here and now"
+    (core/pr.py::_is_embeddable_image), which additionally needs a base URL and
+    verification. An encrypted image is still an image; it just cannot be
+    published in readable form, which is precisely what finish must warn about.
+    Only this module can tell, because only it knows the `.enc` suffix hides the
+    logical extension.
+    """
+    return is_stored_ref(ref) and Path(_logical_ref(ref)).suffix.lower() in IMAGE_EXTS
+
+
+def is_encrypted_ref(ref: str) -> bool:
+    """True when the stored bytes behind `ref` are ciphertext. Independent of the
+    CURRENT evidence mode: a ref records how those bytes were written, which a
+    later change of `evidence_storage` does not rewrite."""
+    return ref.endswith(ENC_SUFFIX)
 
 
 class BadEvidenceRef(Exception):
@@ -221,8 +249,7 @@ def resolve_ref(workspace_root: Path, spec_id: str, ref: str) -> Path:
     # A full-length hash with an extension we do not serve (`deadbeefcafe.exe`)
     # is refused here, not by the regex. An encrypted ref carries a trailing
     # `.enc`, so the extension we care about is the one beneath that.
-    logical = ref[: -len(ENC_SUFFIX)] if ref.endswith(ENC_SUFFIX) else ref
-    if Path(logical).suffix.lower() not in CONTENT_TYPES:
+    if Path(_logical_ref(ref)).suffix.lower() not in CONTENT_TYPES:
         raise BadEvidenceRef(f"unsupported evidence extension in {ref!r}")
 
     store_root = Path(os.path.realpath(evidence_root(workspace_root)))

--- a/src/mship/core/evidence_url.py
+++ b/src/mship/core/evidence_url.py
@@ -46,6 +46,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 from mship.core.evidence_store import evidence_dir
+from mship.core.gh_auth import git_cred_args
 from mship.core.pr import _parse_github_slug
 
 RAW_HOST = "https://raw.githubusercontent.com"
@@ -69,11 +70,30 @@ _TREE_MODE = "100644"
 PUSH_TIMEOUT_SECONDS = 120
 
 
-def _remote_env() -> dict[str, str]:
+def _remote_env(token: str | None = None) -> dict[str, str]:
     env = {"GIT_TERMINAL_PROMPT": "0"}
     if not os.environ.get("GIT_SSH_COMMAND"):
         env["GIT_SSH_COMMAND"] = "ssh -oBatchMode=yes"
+    if token:
+        _, cred_env = git_cred_args(token)
+        env.update(cred_env)
     return env
+
+
+def _cred_prefix(token: str | None) -> str:
+    """The `-c credential....helper=...` global git option, pre-quoted and ready
+    to splice in front of a subcommand — empty when there is no token, so the
+    no-token path emits the exact command it always has.
+
+    `-c` is a global option, so it MUST precede the subcommand (`git -c ... push
+    ...`, never `git push -c ...`); every remote-facing call below builds its
+    command string with this prefix immediately after `git `. Mirrors
+    `PRManager.push_branch` (core/pr.py), the precedent for this pattern.
+    """
+    if not token:
+        return ""
+    args, _ = git_cred_args(token)
+    return " ".join(shlex.quote(a) for a in args) + " "
 
 
 class EvidencePublication(NamedTuple):
@@ -108,14 +128,14 @@ def _reason(result) -> str:
     return lines[-1] if lines else "no error output"
 
 
-def _remote_tip(shell, repo: Path) -> tuple[str | None, str | None]:
+def _remote_tip(shell, repo: Path, token: str | None = None) -> tuple[str | None, str | None]:
     """`(sha, reason)` for the orphan branch on origin. `(None, None)` means the
     branch does not exist yet — the first-publication case, which is normal and
     not a failure; `(None, reason)` means origin could not be asked."""
     ls = shell.run(
-        f"git ls-remote origin {shlex.quote(ORPHAN_REF)}",
+        f"git {_cred_prefix(token)}ls-remote origin {shlex.quote(ORPHAN_REF)}",
         cwd=repo,
-        env=_remote_env(),
+        env=_remote_env(token),
     )
     if ls.returncode != 0:
         return None, f"origin is unreachable ({_reason(ls)})"
@@ -126,7 +146,7 @@ def _remote_tip(shell, repo: Path) -> tuple[str | None, str | None]:
     return None, None
 
 
-def _fetch_tip(shell, repo: Path, sha: str) -> str | None:
+def _fetch_tip(shell, repo: Path, sha: str, token: str | None = None) -> str | None:
     """Make `sha`'s objects available locally so a new commit can PARENT on it.
 
     Published artifacts accumulate: the new commit extends the existing orphan
@@ -141,9 +161,9 @@ def _fetch_tip(shell, repo: Path, sha: str) -> str | None:
         return None
     try:
         fetched = shell.run(
-            f"git fetch --no-tags --quiet origin {shlex.quote(ORPHAN_REF)}",
+            f"git {_cred_prefix(token)}fetch --no-tags --quiet origin {shlex.quote(ORPHAN_REF)}",
             cwd=repo,
-            env=_remote_env(),
+            env=_remote_env(token),
             timeout=PUSH_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired:
@@ -238,7 +258,7 @@ def _publish_commit(
     return sha, None
 
 
-def _push_commit(shell, repo: Path, sha: str) -> str | None:
+def _push_commit(shell, repo: Path, sha: str, token: str | None = None) -> str | None:
     """Push `sha` to the orphan branch. None on success, else a reason.
 
     Pushes the COMMIT OBJECT (`<sha>:refs/heads/<branch>`) rather than a local
@@ -253,9 +273,9 @@ def _push_commit(shell, repo: Path, sha: str) -> str | None:
     """
     try:
         result = shell.run(
-            f"git push origin {shlex.quote(sha)}:{shlex.quote(ORPHAN_REF)}",
+            f"git {_cred_prefix(token)}push origin {shlex.quote(sha)}:{shlex.quote(ORPHAN_REF)}",
             cwd=repo,
-            env=_remote_env(),
+            env=_remote_env(token),
             timeout=PUSH_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired:
@@ -265,7 +285,7 @@ def _push_commit(shell, repo: Path, sha: str) -> str | None:
     return None
 
 
-def _is_on_origin(shell, repo: Path, sha: str) -> bool:
+def _is_on_origin(shell, repo: Path, sha: str, token: str | None = None) -> bool:
     """True when `sha` is reachable from origin's copy of the orphan branch.
 
     Asks the REMOTE rather than trusting a local ref, because claiming "pushed"
@@ -275,7 +295,7 @@ def _is_on_origin(shell, repo: Path, sha: str) -> bool:
     cannot judge ancestry and we report not-pushed, so the artifact is named even
     though it may well be on the remote.
     """
-    tip, _ = _remote_tip(shell, repo)
+    tip, _ = _remote_tip(shell, repo, token)
     if tip is None:
         return False
     if tip == sha:
@@ -299,7 +319,8 @@ def is_present_at(shell, repo: Path, sha: str, tree_path: str) -> bool:
 
 
 def publish_evidence(
-    workspace_root: Path, repo_path: Path, spec_id: str, refs: list[str], shell
+    workspace_root: Path, repo_path: Path, spec_id: str, refs: list[str], shell,
+    token: str | None = None,
 ) -> EvidencePublication:
     """Publish `spec_id`'s referenced artifacts to `repo_path`'s orphan evidence
     branch, then report which of them are provably fetchable.
@@ -309,6 +330,14 @@ def publish_evidence(
     and only under `published` evidence storage (see the module docstring).
     `refs` are bare stored refs; anything not proven present in the pinned commit
     is left out of `verified` so the caller names it instead.
+
+    `token`, when given, is spliced onto every git call that reaches the network
+    (`ls-remote`, `fetch`, `push`) as the same github.com-scoped credential
+    helper `push_branch` uses for the branch push (core/pr.py), so a token-only
+    environment (cloud agent, CI, an unattended overnight routine) with no
+    cached git credentials can publish evidence exactly as a local operator
+    with cached credentials already does. `None` reproduces today's behaviour
+    unchanged — the operator's cached credentials, if any, apply as before.
     """
     repo = Path(repo_path)
     store = evidence_dir(workspace_root, spec_id)
@@ -325,14 +354,14 @@ def publish_evidence(
         )
     owner, name = slug
 
-    tip, tip_note = _remote_tip(shell, repo)
+    tip, tip_note = _remote_tip(shell, repo, token)
     if tip_note is not None:
         return EvidencePublication(
             None, frozenset(), _warning([tip_note], spec_id, repo)
         )
     parent = tip
     if parent is not None:
-        note = _fetch_tip(shell, repo, parent)
+        note = _fetch_tip(shell, repo, parent, token)
         if note is not None:
             # Without the parent's objects we could only build a commit that
             # REPLACES the branch, discarding earlier publications, and the push
@@ -357,10 +386,10 @@ def publish_evidence(
         return EvidencePublication(None, frozenset(), _warning(notes, spec_id, repo))
 
     if pinned != tip:
-        note = _push_commit(shell, repo, pinned)
+        note = _push_commit(shell, repo, pinned, token)
         if note is not None:
             notes.append(note)
-    if not _is_on_origin(shell, repo, pinned):
+    if not _is_on_origin(shell, repo, pinned, token):
         notes.append(
             f"the evidence commit is not on origin's {ORPHAN_BRANCH} branch"
         )

--- a/src/mship/core/evidence_url.py
+++ b/src/mship/core/evidence_url.py
@@ -1,27 +1,73 @@
-"""The raw base URL under which this workspace's committed evidence is fetchable.
+"""Getting a spec's committed evidence onto raw.githubusercontent.com — and
+proving it arrived before anyone links to it.
 
-Returns None whenever an embed would break: non-committed storage, a non-GitHub
-remote, or an evidence commit that has not been pushed. Callers name the artifact
-instead of emitting an image that 404s.
+`mship capture --evidence` writes an artifact into the workspace repo's working
+tree; the PR body wants to embed it as a sha-pinned raw URL. Between those two
+sits a git commit and a push that, until this module owned them, nobody made:
+the ordinary sequence (capture, then finish without touching `specs/`) emitted a
+URL to an untracked path, which 404s silently. `publish_evidence` is that owner.
 
-The storage-mode half of that condition is the CALLER's: this module answers only
+It writes to the workspace repo, which nothing else in mship does — `mship sync`
+deliberately leaves that repo alone because it holds the operator's config and
+prose. The licence here is narrow and stays narrow: only files under
+`specs/evidence/<spec-id>/` that a criterion actually references, staged by
+explicit pathspec and committed by explicit pathspec, so a partial commit is
+made even if the operator has unrelated work staged. Never `commit -a`, never
+`add -A`, never `push --force`, never `add -f` past a .gitignore.
+
+Every failure degrades and none of them block: a PR that names its artifact is
+worth far more than no PR at all. So each step returns a reason rather than
+raising, and the caller turns the reasons into one operator warning.
+
+The storage-mode half of the condition is the CALLER's: this module answers only
 the git question ("are these bytes reachable at raw.githubusercontent.com?"), and
 `evidence_store.resolve_evidence_mode` already owns the config question. Callers
-must not call this under `local` (gitignored, so never on the remote) or
-`encrypted` (on the remote, but as ciphertext).
+must not call into here under `local` (gitignored, so never on the remote — and
+staging it would be actively wrong) or `encrypted` (on the remote, but as
+ciphertext).
 
 The URL pins a commit sha, never a branch: a content-hashed filename at a fixed
 sha stays valid forever, whereas a branch link breaks the moment files move.
 """
 from __future__ import annotations
 
+import os
 import shlex
+import subprocess
 from pathlib import Path
+from typing import NamedTuple
 
 from mship.core.evidence_store import EVIDENCE_DIRNAME, SPECS_DIRNAME
 from mship.core.pr import _parse_github_slug
 
 RAW_HOST = "https://raw.githubusercontent.com"
+
+# `mship finish` must never become interactive. A workspace repo whose
+# credentials are not cached would otherwise stop mid-finish on a password
+# prompt with a PR half-opened, which is worse than a named artifact. Both
+# settings make git fail fast instead of asking, and the timeout bounds a push
+# that hangs on an unresponsive host. GIT_SSH_COMMAND is left alone when the
+# operator already set one — theirs may select a key we know nothing about.
+PUSH_TIMEOUT_SECONDS = 120
+
+
+def _push_env() -> dict[str, str]:
+    env = {"GIT_TERMINAL_PROMPT": "0"}
+    if not os.environ.get("GIT_SSH_COMMAND"):
+        env["GIT_SSH_COMMAND"] = "ssh -oBatchMode=yes"
+    return env
+
+
+class EvidencePublication(NamedTuple):
+    """What came out fetchable, and what the operator should be told.
+
+    `verified` holds only refs proven present in the pinned commit's tree, so a
+    caller embeds per-ref and falls back to naming for the rest.
+    """
+
+    base_url: str | None
+    verified: frozenset[str]
+    warning: str | None
 
 
 def _stdout(shell, command: str, cwd: Path) -> str | None:
@@ -30,6 +76,12 @@ def _stdout(shell, command: str, cwd: Path) -> str | None:
     if result.returncode != 0:
         return None
     return result.stdout.strip()
+
+
+def _reason(result) -> str:
+    """The last line of stderr — git puts the actionable part there."""
+    lines = [ln.strip() for ln in (result.stderr or "").splitlines() if ln.strip()]
+    return lines[-1] if lines else "no error output"
 
 
 def _head_is_on_origin(shell, repo: Path, sha: str) -> bool:
@@ -71,9 +123,13 @@ def _head_is_on_origin(shell, repo: Path, sha: str) -> bool:
     return ancestry.returncode == 0
 
 
-def workspace_raw_base(workspace_root: Path, shell) -> str | None:
-    """`https://raw.githubusercontent.com/<owner>/<repo>/<sha>/specs/evidence`,
-    or None when the workspace's evidence is not fetchable from there."""
+def _raw_base_and_sha(workspace_root: Path, shell) -> tuple[str, str] | None:
+    """The raw base URL and the sha it pins, or None when not fetchable.
+
+    Resolved together in one call so the sha the URL advertises is the exact sha
+    the tracked-at check interrogates — re-deriving it would leave a window in
+    which the two could disagree.
+    """
     root = Path(workspace_root)
     remote_url = _stdout(shell, "git remote get-url origin", root)
     slug = _parse_github_slug(remote_url) if remote_url else None
@@ -85,4 +141,210 @@ def workspace_raw_base(workspace_root: Path, shell) -> str | None:
     if not _head_is_on_origin(shell, root, sha):
         return None
     owner, repo = slug
-    return f"{RAW_HOST}/{owner}/{repo}/{sha}/{SPECS_DIRNAME}/{EVIDENCE_DIRNAME}"
+    base = f"{RAW_HOST}/{owner}/{repo}/{sha}/{SPECS_DIRNAME}/{EVIDENCE_DIRNAME}"
+    return base, sha
+
+
+def workspace_raw_base(workspace_root: Path, shell) -> str | None:
+    """`https://raw.githubusercontent.com/<owner>/<repo>/<sha>/specs/evidence`,
+    or None when the workspace's evidence is not fetchable from there.
+
+    Says nothing about whether any particular artifact is IN that commit — see
+    `is_tracked_at`, and prefer `publish_evidence` which does both.
+    """
+    resolved = _raw_base_and_sha(workspace_root, shell)
+    return resolved[0] if resolved else None
+
+
+def is_tracked_at(shell, workspace_root: Path, sha: str, relpath: str) -> bool:
+    """True when `relpath` exists in `sha`'s tree.
+
+    The precondition of every embed, checked by the module that emits the URL
+    rather than assumed from the module that wrote the file. Working-tree
+    presence is deliberately not consulted: an artifact committed and later
+    deleted locally is still fetchable at the pinned sha, and one sitting
+    untracked on disk is not.
+    """
+    result = shell.run(
+        f"git cat-file -e {shlex.quote(f'{sha}:{relpath}')}", cwd=Path(workspace_root)
+    )
+    return result.returncode == 0
+
+
+def evidence_relpath(spec_id: str, ref: str) -> str:
+    """The artifact's path relative to the workspace repo root, in git's own
+    forward-slash form (a git pathspec, never an OS path)."""
+    return f"{SPECS_DIRNAME}/{EVIDENCE_DIRNAME}/{spec_id}/{ref}"
+
+
+def _commit_message(spec_id: str, count: int) -> str:
+    plural = "artifact" if count == 1 else "artifacts"
+    return (
+        f"chore(evidence): publish {count} {plural} for {spec_id}\n\n"
+        f"Written by `mship capture --evidence` and committed by `mship finish` "
+        f"so the PR body can embed them from raw.githubusercontent.com.\n\n"
+        f"Scoped to {SPECS_DIRNAME}/{EVIDENCE_DIRNAME}/{spec_id}/ — no other "
+        f"path in this repo is staged or committed."
+    )
+
+
+def _commit_artifacts(shell, root: Path, spec_id: str, relpaths: list[str]) -> str | None:
+    """Stage and commit exactly `relpaths`. None on success (including nothing
+    to do), else a reason.
+
+    Both halves are pathspec-scoped, and the commit is deliberately a PARTIAL
+    commit (`git commit -- <paths>`): it takes those paths' working-tree content
+    and ignores the rest of the index, so unrelated work the operator had already
+    staged is neither committed nor unstaged by us. No `-f`, so an evidence
+    directory the operator has gitignored refuses to stage rather than being
+    forced past their wishes.
+    """
+    pathspec = " ".join(shlex.quote(p) for p in relpaths)
+    add = shell.run(f"git add -- {pathspec}", cwd=root)
+    if add.returncode != 0:
+        return f"could not stage the artifacts ({_reason(add)})"
+    # Names rather than `--quiet`, so the commit message can say how many
+    # artifacts it really carries. Only the COUNT is taken from git's output —
+    # the commit still uses the pathspec we built ourselves, so no path ever
+    # makes a round trip through git's quoting rules.
+    staged = shell.run(f"git diff --cached --name-only -- {pathspec}", cwd=root)
+    if staged.returncode != 0:
+        return f"could not inspect the staged artifacts ({_reason(staged)})"
+    changed = len([line for line in staged.stdout.splitlines() if line.strip()])
+    if not changed:
+        return None
+    message = _commit_message(spec_id, changed)
+    commit = shell.run(
+        f"git commit -m {shlex.quote(message)} -- {pathspec}", cwd=root
+    )
+    if commit.returncode != 0:
+        return f"could not commit the artifacts ({_reason(commit)})"
+    return None
+
+
+def _push_current_branch(shell, root: Path) -> str | None:
+    """Push the workspace repo's current branch to origin. None on success, else
+    a reason.
+
+    Only ever updates a branch origin already has: creating one would publish a
+    workspace the operator has chosen not to push, which is far beyond the
+    licence to commit an artifact. Never `--force`, so a diverged branch is
+    reported rather than overwritten, and never `-u`, so the operator's tracking
+    config is left as they set it.
+    """
+    branch = _stdout(shell, "git rev-parse --abbrev-ref HEAD", root)
+    if not branch:
+        return "the workspace repo has no resolvable HEAD"
+    if branch == "HEAD":
+        return "the workspace repo is on a detached HEAD"
+    ls = shell.run(f"git ls-remote --heads origin {shlex.quote(branch)}", cwd=root)
+    if ls.returncode != 0:
+        return f"origin is unreachable ({_reason(ls)})"
+    if not ls.stdout.strip():
+        return f"origin has no {branch!r} branch to update"
+    try:
+        result = shell.run(
+            f"git push origin {shlex.quote(branch)}",
+            cwd=root,
+            env=_push_env(),
+            timeout=PUSH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return f"the push timed out after {PUSH_TIMEOUT_SECONDS}s"
+    if result.returncode != 0:
+        return f"the push failed ({_reason(result)})"
+    return None
+
+
+def publish_evidence(
+    workspace_root: Path, spec_id: str, refs: list[str], shell
+) -> EvidencePublication:
+    """Commit and push `spec_id`'s referenced artifacts, then report which of
+    them are provably fetchable.
+
+    Call only under `committed` evidence storage (see the module docstring).
+    `refs` are bare stored refs; anything not proven present in the pinned
+    commit is left out of `verified` so the caller names it instead.
+    """
+    root = Path(workspace_root)
+    relpaths = {ref: evidence_relpath(spec_id, ref) for ref in refs}
+
+    # The licence to write to the operator's workspace repo is "so the PR body
+    # can embed this" — so when no embed is possible at all, write nothing. A
+    # non-GitHub origin has no raw host to serve from, and committing anyway
+    # would be a change to their repo that buys them nothing.
+    remote_url = _stdout(shell, "git remote get-url origin", root)
+    if (_parse_github_slug(remote_url) if remote_url else None) is None:
+        return EvidencePublication(
+            None,
+            frozenset(),
+            _warning(["the workspace repo has no GitHub origin"], spec_id, root),
+        )
+
+    # A commit on a detached HEAD would be worse than useless: it is unreachable
+    # from any branch, and the next `git checkout` would DELETE the artifact from
+    # the working tree (tracked in the commit being left, absent from the one
+    # being entered). Nothing is fetchable from a detached HEAD anyway, so refuse
+    # before writing rather than after.
+    branch = _stdout(shell, "git rev-parse --abbrev-ref HEAD", root)
+    if not branch or branch == "HEAD":
+        return EvidencePublication(
+            None,
+            frozenset(),
+            _warning(
+                ["the workspace repo is on a detached HEAD, so nothing was "
+                 "committed or pushed"],
+                spec_id,
+                root,
+            ),
+        )
+
+    # Nothing to publish for a ref whose bytes are gone from the working tree;
+    # it may still be tracked at HEAD from an earlier finish, which the
+    # verification pass below settles.
+    to_commit = sorted(p for p in relpaths.values() if (root / p).exists())
+    notes: list[str] = []
+    if to_commit:
+        note = _commit_artifacts(shell, root, spec_id, to_commit)
+        if note is not None:
+            notes.append(note)
+
+    resolved = _raw_base_and_sha(root, shell)
+    if resolved is None:
+        # Not on the remote yet (or at all). Try to put it there, then ASK the
+        # remote again rather than assuming a zero exit means what we hoped.
+        note = _push_current_branch(shell, root)
+        if note is not None:
+            notes.append(note)
+        resolved = _raw_base_and_sha(root, shell)
+
+    if resolved is None:
+        notes.append(
+            "the workspace evidence is not reachable at raw.githubusercontent.com"
+        )
+        return EvidencePublication(None, frozenset(), _warning(notes, spec_id, root))
+
+    base_url, sha = resolved
+    verified = frozenset(
+        ref for ref, p in relpaths.items() if is_tracked_at(shell, root, sha, p)
+    )
+    missing = len(relpaths) - len(verified)
+    if missing:
+        notes.append(
+            f"{missing} of {len(relpaths)} image artifacts are not tracked at "
+            f"workspace commit {sha[:12]}"
+        )
+    return EvidencePublication(
+        base_url, verified, _warning(notes, spec_id, root) if notes else None
+    )
+
+
+def _warning(notes: list[str], spec_id: str, root: Path) -> str:
+    """One operator-facing message: what went wrong, what it costs, what to do."""
+    return (
+        f"Image evidence for {spec_id} is not embeddable ({'; '.join(notes)}), so "
+        f"the PR body will name the artifacts instead of emitting images that "
+        f"404. Opening the PR is unaffected. Once "
+        f"`{SPECS_DIRNAME}/{EVIDENCE_DIRNAME}/{spec_id}/` is committed and pushed "
+        f"in {root}, re-run finish to embed them."
+    )

--- a/src/mship/core/evidence_url.py
+++ b/src/mship/core/evidence_url.py
@@ -382,10 +382,18 @@ def publish_evidence(
 
 
 def _warning(notes: list[str], spec_id: str, repo: Path) -> str:
-    """One operator-facing message: what went wrong, what it costs, what to do."""
+    """One operator-facing message: what went wrong, what it costs, what to do.
+
+    The remedy deliberately does NOT say "re-run finish": the acceptance block is
+    rendered only while a PR is being CREATED, so a second finish over an
+    existing PR finds it and leaves its body exactly as it stands (cli/worktree
+    .py). Fix the push before the PR opens, or edit the body afterwards.
+    """
     return (
         f"Image evidence for {spec_id} is not embeddable ({'; '.join(notes)}), so "
         f"the PR body will name the artifacts instead of emitting images that "
-        f"404. Opening the PR is unaffected. Once the `{ORPHAN_BRANCH}` branch in "
-        f"{repo} can be pushed to origin, re-run finish to embed them."
+        f"404. Opening the PR is unaffected. Re-running finish will not re-render "
+        f"an existing PR's body: make the `{ORPHAN_BRANCH}` branch in {repo} "
+        f"pushable to origin BEFORE the PR is opened, or add the images to the "
+        f"body by hand afterwards."
     )

--- a/src/mship/core/evidence_url.py
+++ b/src/mship/core/evidence_url.py
@@ -1,0 +1,88 @@
+"""The raw base URL under which this workspace's committed evidence is fetchable.
+
+Returns None whenever an embed would break: non-committed storage, a non-GitHub
+remote, or an evidence commit that has not been pushed. Callers name the artifact
+instead of emitting an image that 404s.
+
+The storage-mode half of that condition is the CALLER's: this module answers only
+the git question ("are these bytes reachable at raw.githubusercontent.com?"), and
+`evidence_store.resolve_evidence_mode` already owns the config question. Callers
+must not call this under `local` (gitignored, so never on the remote) or
+`encrypted` (on the remote, but as ciphertext).
+
+The URL pins a commit sha, never a branch: a content-hashed filename at a fixed
+sha stays valid forever, whereas a branch link breaks the moment files move.
+"""
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+from mship.core.evidence_store import EVIDENCE_DIRNAME, SPECS_DIRNAME
+from mship.core.pr import _parse_github_slug
+
+RAW_HOST = "https://raw.githubusercontent.com"
+
+
+def _stdout(shell, command: str, cwd: Path) -> str | None:
+    """Trimmed stdout, or None on any non-zero exit."""
+    result = shell.run(command, cwd=cwd)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _head_is_on_origin(shell, repo: Path, sha: str) -> bool:
+    """True when `sha` is reachable from origin's copy of the current branch.
+
+    Asks the REMOTE (`git ls-remote`) for the tip rather than trusting
+    `origin/<branch>`, because a remote-tracking ref can be arbitrarily stale and
+    a stale one would let us claim "pushed" for a commit that only exists locally
+    — the one wrong answer here, since it puts a 404 image in a PR body.
+
+    The residual failure mode is the opposite, safe one: if the remote tip is a
+    commit this clone has never fetched, `merge-base` cannot judge ancestry and
+    we report not-pushed, so the artifact is named even though it may well be on
+    the remote. Same for an unreachable remote and for a detached HEAD (no branch
+    to ask about).
+    """
+    branch = _stdout(shell, "git rev-parse --abbrev-ref HEAD", repo)
+    if not branch or branch == "HEAD":
+        return False
+    ls = shell.run(
+        f"git ls-remote origin {shlex.quote('refs/heads/' + branch)}", cwd=repo
+    )
+    if ls.returncode != 0:
+        return False
+    remote_sha = ""
+    for line in ls.stdout.splitlines():
+        parts = line.split("\t", 1)
+        if len(parts) == 2:
+            remote_sha = parts[0].strip()
+            break
+    if not remote_sha:
+        return False
+    if remote_sha == sha:
+        return True
+    ancestry = shell.run(
+        f"git merge-base --is-ancestor {shlex.quote(sha)} {shlex.quote(remote_sha)}",
+        cwd=repo,
+    )
+    return ancestry.returncode == 0
+
+
+def workspace_raw_base(workspace_root: Path, shell) -> str | None:
+    """`https://raw.githubusercontent.com/<owner>/<repo>/<sha>/specs/evidence`,
+    or None when the workspace's evidence is not fetchable from there."""
+    root = Path(workspace_root)
+    remote_url = _stdout(shell, "git remote get-url origin", root)
+    slug = _parse_github_slug(remote_url) if remote_url else None
+    if slug is None:
+        return None
+    sha = _stdout(shell, "git rev-parse HEAD", root)
+    if not sha:
+        return None
+    if not _head_is_on_origin(shell, root, sha):
+        return None
+    owner, repo = slug
+    return f"{RAW_HOST}/{owner}/{repo}/{sha}/{SPECS_DIRNAME}/{EVIDENCE_DIRNAME}"

--- a/src/mship/core/evidence_url.py
+++ b/src/mship/core/evidence_url.py
@@ -1,19 +1,27 @@
-"""Getting a spec's committed evidence onto raw.githubusercontent.com — and
-proving it arrived before anyone links to it.
+"""Getting a spec's evidence artifacts onto raw.githubusercontent.com — and
+proving they arrived before anyone links to them.
 
-`mship capture --evidence` writes an artifact into the workspace repo's working
-tree; the PR body wants to embed it as a sha-pinned raw URL. Between those two
-sits a git commit and a push that, until this module owned them, nobody made:
-the ordinary sequence (capture, then finish without touching `specs/`) emitted a
-URL to an untracked path, which 404s silently. `publish_evidence` is that owner.
+`mship capture --evidence` writes an artifact into the machine-local store
+(`.mothership/evidence/<spec-id>/`, see evidence_store.py); the PR body wants to
+embed it as a sha-pinned raw URL. Between those two sits a publication step that
+nobody else makes, and that this module owns.
 
-It writes to the workspace repo, which nothing else in mship does — `mship sync`
-deliberately leaves that repo alone because it holds the operator's config and
-prose. The licence here is narrow and stays narrow: only files under
-`specs/evidence/<spec-id>/` that a criterion actually references, staged by
-explicit pathspec and committed by explicit pathspec, so a partial commit is
-made even if the operator has unrelated work staged. Never `commit -a`, never
-`add -A`, never `push --force`, never `add -f` past a .gitignore.
+WHERE it publishes is the whole design. GitHub has no public API for uploading an
+image attachment, so an embed must already live at a ref GitHub serves. The bytes
+therefore go to an **orphan branch (`mship-evidence`) in the member repo the pull
+request targets** — the repo the reviewer already has open:
+
+  * an orphan branch shares no history with the default branch, so binaries never
+    enter `main`'s tree and a clone of the product is unaffected;
+  * `raw.githubusercontent.com` serves any ref, so no special hosting is needed;
+  * every workspace shape (multi-repo, monorepo, single repo) has a member repo
+    with a remote, so this assumes no metarepo — the earlier design published to
+    the workspace repo, which in a monorepo or single repo IS the product repo,
+    and pushed its `main` as a side effect of opening a PR.
+
+That branch, and only that branch, is pushed. Nothing here ever touches `main`,
+any other branch, the index, HEAD, or the working tree — see `_publish_commit`
+for how the commit is built with plumbing instead of a checkout.
 
 Every failure degrades and none of them block: a PR that names its artifact is
 worth far more than no PR at all. So each step returns a reason rather than
@@ -22,36 +30,46 @@ raising, and the caller turns the reasons into one operator warning.
 The storage-mode half of the condition is the CALLER's: this module answers only
 the git question ("are these bytes reachable at raw.githubusercontent.com?"), and
 `evidence_store.resolve_evidence_mode` already owns the config question. Callers
-must not call into here under `local` (gitignored, so never on the remote — and
-staging it would be actively wrong) or `encrypted` (on the remote, but as
-ciphertext).
+must not call into here under `local` (nothing may leave the machine) or
+`encrypted` (the bytes are ciphertext, so an embed would render broken).
 
 The URL pins a commit sha, never a branch: a content-hashed filename at a fixed
-sha stays valid forever, whereas a branch link breaks the moment files move.
+sha stays valid forever, whereas a branch link breaks the moment the branch moves.
 """
 from __future__ import annotations
 
 import os
 import shlex
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import NamedTuple
 
-from mship.core.evidence_store import EVIDENCE_DIRNAME, SPECS_DIRNAME
+from mship.core.evidence_store import evidence_dir
 from mship.core.pr import _parse_github_slug
 
 RAW_HOST = "https://raw.githubusercontent.com"
 
-# `mship finish` must never become interactive. A workspace repo whose
-# credentials are not cached would otherwise stop mid-finish on a password
-# prompt with a PR half-opened, which is worse than a named artifact. Both
-# settings make git fail fast instead of asking, and the timeout bounds a push
-# that hangs on an unresponsive host. GIT_SSH_COMMAND is left alone when the
-# operator already set one — theirs may select a key we know nothing about.
+# One branch name for every repo and every spec. Shared, append-only, and named
+# so an operator seeing it in the branch list knows what made it.
+ORPHAN_BRANCH = "mship-evidence"
+ORPHAN_REF = f"refs/heads/{ORPHAN_BRANCH}"
+
+# Files are stored in the tree as `<spec-id>/<ref>`: `ref` is already a content
+# hash, so the spec id is the only grouping needed, and it keeps one spec's
+# publications legible in a branch shared by all of them.
+_TREE_MODE = "100644"
+
+# `mship finish` must never become interactive. A repo whose credentials are not
+# cached would otherwise stop mid-finish on a password prompt with a PR
+# half-opened, which is worse than a named artifact. Both settings make git fail
+# fast instead of asking, and the timeout bounds a transfer that hangs on an
+# unresponsive host. GIT_SSH_COMMAND is left alone when the operator already set
+# one — theirs may select a key we know nothing about.
 PUSH_TIMEOUT_SECONDS = 120
 
 
-def _push_env() -> dict[str, str]:
+def _remote_env() -> dict[str, str]:
     env = {"GIT_TERMINAL_PROMPT": "0"}
     if not os.environ.get("GIT_SSH_COMMAND"):
         env["GIT_SSH_COMMAND"] = "ssh -oBatchMode=yes"
@@ -70,9 +88,15 @@ class EvidencePublication(NamedTuple):
     warning: str | None
 
 
-def _stdout(shell, command: str, cwd: Path) -> str | None:
+def evidence_tree_path(spec_id: str, ref: str) -> str:
+    """The artifact's path inside the orphan branch's tree, in git's own
+    forward-slash form (a git path, never an OS path)."""
+    return f"{spec_id}/{ref}"
+
+
+def _stdout(shell, command: str, cwd: Path, env=None) -> str | None:
     """Trimmed stdout, or None on any non-zero exit."""
-    result = shell.run(command, cwd=cwd)
+    result = shell.run(command, cwd=cwd, env=env)
     if result.returncode != 0:
         return None
     return result.stdout.strip()
@@ -84,169 +108,154 @@ def _reason(result) -> str:
     return lines[-1] if lines else "no error output"
 
 
-def _head_is_on_origin(shell, repo: Path, sha: str) -> bool:
-    """True when `sha` is reachable from origin's copy of the current branch.
-
-    Asks the REMOTE (`git ls-remote`) for the tip rather than trusting
-    `origin/<branch>`, because a remote-tracking ref can be arbitrarily stale and
-    a stale one would let us claim "pushed" for a commit that only exists locally
-    — the one wrong answer here, since it puts a 404 image in a PR body.
-
-    The residual failure mode is the opposite, safe one: if the remote tip is a
-    commit this clone has never fetched, `merge-base` cannot judge ancestry and
-    we report not-pushed, so the artifact is named even though it may well be on
-    the remote. Same for an unreachable remote and for a detached HEAD (no branch
-    to ask about).
-    """
-    branch = _stdout(shell, "git rev-parse --abbrev-ref HEAD", repo)
-    if not branch or branch == "HEAD":
-        return False
+def _remote_tip(shell, repo: Path) -> tuple[str | None, str | None]:
+    """`(sha, reason)` for the orphan branch on origin. `(None, None)` means the
+    branch does not exist yet — the first-publication case, which is normal and
+    not a failure; `(None, reason)` means origin could not be asked."""
     ls = shell.run(
-        f"git ls-remote origin {shlex.quote('refs/heads/' + branch)}", cwd=repo
+        f"git ls-remote origin {shlex.quote(ORPHAN_REF)}",
+        cwd=repo,
+        env=_remote_env(),
     )
     if ls.returncode != 0:
-        return False
-    remote_sha = ""
+        return None, f"origin is unreachable ({_reason(ls)})"
     for line in ls.stdout.splitlines():
         parts = line.split("\t", 1)
-        if len(parts) == 2:
-            remote_sha = parts[0].strip()
-            break
-    if not remote_sha:
-        return False
-    if remote_sha == sha:
-        return True
-    ancestry = shell.run(
-        f"git merge-base --is-ancestor {shlex.quote(sha)} {shlex.quote(remote_sha)}",
-        cwd=repo,
-    )
-    return ancestry.returncode == 0
+        if len(parts) == 2 and parts[0].strip():
+            return parts[0].strip(), None
+    return None, None
 
 
-def _raw_base_and_sha(workspace_root: Path, shell) -> tuple[str, str] | None:
-    """The raw base URL and the sha it pins, or None when not fetchable.
+def _fetch_tip(shell, repo: Path, sha: str) -> str | None:
+    """Make `sha`'s objects available locally so a new commit can PARENT on it.
 
-    Resolved together in one call so the sha the URL advertises is the exact sha
-    the tracked-at check interrogates — re-deriving it would leave a window in
-    which the two could disagree.
+    Published artifacts accumulate: the new commit extends the existing orphan
+    branch rather than replacing it, which needs the old tree readable here. A
+    clone that has never fetched the branch (or a tip pushed from another
+    machine) has to fetch first. None on success, else a reason.
+
+    `--no-tags` and no refspec destination: the objects land in the object store
+    and nothing local is renamed, moved, or created.
     """
-    root = Path(workspace_root)
-    remote_url = _stdout(shell, "git remote get-url origin", root)
-    slug = _parse_github_slug(remote_url) if remote_url else None
-    if slug is None:
+    if _stdout(shell, f"git cat-file -e {shlex.quote(sha + '^{commit}')}", repo) is not None:
         return None
-    sha = _stdout(shell, "git rev-parse HEAD", root)
-    if not sha:
-        return None
-    if not _head_is_on_origin(shell, root, sha):
-        return None
-    owner, repo = slug
-    base = f"{RAW_HOST}/{owner}/{repo}/{sha}/{SPECS_DIRNAME}/{EVIDENCE_DIRNAME}"
-    return base, sha
-
-
-def workspace_raw_base(workspace_root: Path, shell) -> str | None:
-    """`https://raw.githubusercontent.com/<owner>/<repo>/<sha>/specs/evidence`,
-    or None when the workspace's evidence is not fetchable from there.
-
-    Says nothing about whether any particular artifact is IN that commit — see
-    `is_tracked_at`, and prefer `publish_evidence` which does both.
-    """
-    resolved = _raw_base_and_sha(workspace_root, shell)
-    return resolved[0] if resolved else None
-
-
-def is_tracked_at(shell, workspace_root: Path, sha: str, relpath: str) -> bool:
-    """True when `relpath` exists in `sha`'s tree.
-
-    The precondition of every embed, checked by the module that emits the URL
-    rather than assumed from the module that wrote the file. Working-tree
-    presence is deliberately not consulted: an artifact committed and later
-    deleted locally is still fetchable at the pinned sha, and one sitting
-    untracked on disk is not.
-    """
-    result = shell.run(
-        f"git cat-file -e {shlex.quote(f'{sha}:{relpath}')}", cwd=Path(workspace_root)
-    )
-    return result.returncode == 0
-
-
-def evidence_relpath(spec_id: str, ref: str) -> str:
-    """The artifact's path relative to the workspace repo root, in git's own
-    forward-slash form (a git pathspec, never an OS path)."""
-    return f"{SPECS_DIRNAME}/{EVIDENCE_DIRNAME}/{spec_id}/{ref}"
+    try:
+        fetched = shell.run(
+            f"git fetch --no-tags --quiet origin {shlex.quote(ORPHAN_REF)}",
+            cwd=repo,
+            env=_remote_env(),
+            timeout=PUSH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return f"fetching {ORPHAN_BRANCH} timed out after {PUSH_TIMEOUT_SECONDS}s"
+    if fetched.returncode != 0:
+        return f"could not fetch the existing {ORPHAN_BRANCH} branch ({_reason(fetched)})"
+    if _stdout(shell, f"git cat-file -e {shlex.quote(sha + '^{commit}')}", repo) is None:
+        return f"the fetched {ORPHAN_BRANCH} tip {sha[:12]} is still not readable here"
+    return None
 
 
 def _commit_message(spec_id: str, count: int) -> str:
     plural = "artifact" if count == 1 else "artifacts"
     return (
         f"chore(evidence): publish {count} {plural} for {spec_id}\n\n"
-        f"Written by `mship capture --evidence` and committed by `mship finish` "
+        f"Captured by `mship capture --evidence` and published by `mship finish` "
         f"so the PR body can embed them from raw.githubusercontent.com.\n\n"
-        f"Scoped to {SPECS_DIRNAME}/{EVIDENCE_DIRNAME}/{spec_id}/ — no other "
-        f"path in this repo is staged or committed."
+        f"This is the `{ORPHAN_BRANCH}` orphan branch: it shares no history with "
+        f"the default branch and holds nothing but evidence artifacts under "
+        f"<spec-id>/."
     )
 
 
-def _commit_artifacts(shell, root: Path, spec_id: str, relpaths: list[str]) -> str | None:
-    """Stage and commit exactly `relpaths`. None on success (including nothing
-    to do), else a reason.
+def _publish_commit(
+    shell, repo: Path, spec_id: str, sources: dict[str, Path], parent: str | None
+) -> tuple[str | None, str | None]:
+    """Build a commit carrying `sources` on top of `parent`. `(sha, reason)`.
 
-    Both halves are pathspec-scoped, and the commit is deliberately a PARTIAL
-    commit (`git commit -- <paths>`): it takes those paths' working-tree content
-    and ignores the rest of the index, so unrelated work the operator had already
-    staged is neither committed nor unstaged by us. No `-f`, so an evidence
-    directory the operator has gitignored refuses to stage rather than being
-    forced past their wishes.
+    Built entirely with plumbing, because the bytes being published do NOT live
+    in this repo's working tree — they sit in the workspace's local evidence
+    store, outside the repo entirely. The obvious alternative (check the orphan
+    branch out, copy files in, commit) is unavailable: `mship finish` runs while
+    an agent is working in this very worktree, and checking out another branch
+    would rewrite the files under it.
+
+    So: `hash-object -w` writes each artifact into the object store from an
+    arbitrary path on disk; a THROWAWAY index (`GIT_INDEX_FILE`) is seeded from
+    the parent commit's tree and added to, so earlier publications survive and
+    the repo's real index is never opened; `write-tree` + `commit-tree` produce
+    the commit. Nothing here writes a ref, moves HEAD, or touches a file in the
+    working tree — the only lasting effect is a few unreferenced objects if the
+    push later fails, which git gc collects.
+
+    `--no-filters` on hash-object: these are binaries, and a repo whose
+    `.gitattributes` declares CRLF or a clean filter must not be allowed to
+    rewrite them into a blob that no longer matches the ref's content hash.
     """
-    pathspec = " ".join(shlex.quote(p) for p in relpaths)
-    add = shell.run(f"git add -- {pathspec}", cwd=root)
-    if add.returncode != 0:
-        return f"could not stage the artifacts ({_reason(add)})"
-    # Names rather than `--quiet`, so the commit message can say how many
-    # artifacts it really carries. Only the COUNT is taken from git's output —
-    # the commit still uses the pathspec we built ourselves, so no path ever
-    # makes a round trip through git's quoting rules.
-    staged = shell.run(f"git diff --cached --name-only -- {pathspec}", cwd=root)
-    if staged.returncode != 0:
-        return f"could not inspect the staged artifacts ({_reason(staged)})"
-    changed = len([line for line in staged.stdout.splitlines() if line.strip()])
-    if not changed:
-        return None
-    message = _commit_message(spec_id, changed)
+    with tempfile.TemporaryDirectory(prefix="mship-evidence-") as tmp:
+        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
+        if parent is not None:
+            seeded = shell.run(f"git read-tree {shlex.quote(parent)}", cwd=repo, env=env)
+            if seeded.returncode != 0:
+                return None, f"could not read the existing {ORPHAN_BRANCH} tree ({_reason(seeded)})"
+        for ref, src in sorted(sources.items()):
+            blob = _stdout(
+                shell,
+                f"git hash-object -w --no-filters {shlex.quote(str(src))}",
+                repo,
+            )
+            if not blob:
+                return None, f"could not store {ref} as a git object"
+            added = shell.run(
+                f"git update-index --add --cacheinfo "
+                f"{_TREE_MODE},{blob},{shlex.quote(evidence_tree_path(spec_id, ref))}",
+                cwd=repo,
+                env=env,
+            )
+            if added.returncode != 0:
+                return None, f"could not add {ref} to the evidence tree ({_reason(added)})"
+        tree = _stdout(shell, "git write-tree", repo, env=env)
+    if not tree:
+        return None, "could not write the evidence tree"
+
+    # Identical content re-published (content-addressed refs make that the norm
+    # on a re-run of finish) produces the parent's own tree. Reuse the parent
+    # commit rather than stacking an empty one on the operator's branch.
+    if parent is not None and _stdout(
+        shell, f"git rev-parse {shlex.quote(parent + '^{tree}')}", repo
+    ) == tree:
+        return parent, None
+
+    message = _commit_message(spec_id, len(sources))
+    parent_arg = f"-p {shlex.quote(parent)} " if parent else ""
     commit = shell.run(
-        f"git commit -m {shlex.quote(message)} -- {pathspec}", cwd=root
+        f"git commit-tree {tree} {parent_arg}-m {shlex.quote(message)}", cwd=repo
     )
     if commit.returncode != 0:
-        return f"could not commit the artifacts ({_reason(commit)})"
-    return None
+        return None, f"could not create the evidence commit ({_reason(commit)})"
+    sha = commit.stdout.strip()
+    if not sha:
+        return None, "could not create the evidence commit"
+    return sha, None
 
 
-def _push_current_branch(shell, root: Path) -> str | None:
-    """Push the workspace repo's current branch to origin. None on success, else
-    a reason.
+def _push_commit(shell, repo: Path, sha: str) -> str | None:
+    """Push `sha` to the orphan branch. None on success, else a reason.
 
-    Only ever updates a branch origin already has: creating one would publish a
-    workspace the operator has chosen not to push, which is far beyond the
-    licence to commit an artifact. Never `--force`, so a diverged branch is
-    reported rather than overwritten, and never `-u`, so the operator's tracking
-    config is left as they set it.
+    Pushes the COMMIT OBJECT (`<sha>:refs/heads/<branch>`) rather than a local
+    branch, so publication creates no local ref at all: nothing appears in the
+    operator's `git branch`, and a stale local copy can never diverge from the
+    remote and start rejecting pushes.
+
+    Never `--force`: the new commit descends from the tip we read, so an ordinary
+    fast-forward is all it needs, and a concurrent publication from elsewhere is
+    reported rather than overwritten. `refs/heads/<branch>` is spelled in full so
+    the refspec can only ever name this one branch.
     """
-    branch = _stdout(shell, "git rev-parse --abbrev-ref HEAD", root)
-    if not branch:
-        return "the workspace repo has no resolvable HEAD"
-    if branch == "HEAD":
-        return "the workspace repo is on a detached HEAD"
-    ls = shell.run(f"git ls-remote --heads origin {shlex.quote(branch)}", cwd=root)
-    if ls.returncode != 0:
-        return f"origin is unreachable ({_reason(ls)})"
-    if not ls.stdout.strip():
-        return f"origin has no {branch!r} branch to update"
     try:
         result = shell.run(
-            f"git push origin {shlex.quote(branch)}",
-            cwd=root,
-            env=_push_env(),
+            f"git push origin {shlex.quote(sha)}:{shlex.quote(ORPHAN_REF)}",
+            cwd=repo,
+            env=_remote_env(),
             timeout=PUSH_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired:
@@ -256,95 +265,127 @@ def _push_current_branch(shell, root: Path) -> str | None:
     return None
 
 
-def publish_evidence(
-    workspace_root: Path, spec_id: str, refs: list[str], shell
-) -> EvidencePublication:
-    """Commit and push `spec_id`'s referenced artifacts, then report which of
-    them are provably fetchable.
+def _is_on_origin(shell, repo: Path, sha: str) -> bool:
+    """True when `sha` is reachable from origin's copy of the orphan branch.
 
-    Call only under `committed` evidence storage (see the module docstring).
-    `refs` are bare stored refs; anything not proven present in the pinned
-    commit is left out of `verified` so the caller names it instead.
+    Asks the REMOTE rather than trusting a local ref, because claiming "pushed"
+    for a commit that only exists locally is the one wrong answer here: it puts a
+    404 image in a PR body. The residual failure mode is the opposite, safe one —
+    if the remote tip is a commit this clone has never fetched, `merge-base`
+    cannot judge ancestry and we report not-pushed, so the artifact is named even
+    though it may well be on the remote.
     """
-    root = Path(workspace_root)
-    relpaths = {ref: evidence_relpath(spec_id, ref) for ref in refs}
-
-    # The licence to write to the operator's workspace repo is "so the PR body
-    # can embed this" — so when no embed is possible at all, write nothing. A
-    # non-GitHub origin has no raw host to serve from, and committing anyway
-    # would be a change to their repo that buys them nothing.
-    remote_url = _stdout(shell, "git remote get-url origin", root)
-    if (_parse_github_slug(remote_url) if remote_url else None) is None:
-        return EvidencePublication(
-            None,
-            frozenset(),
-            _warning(["the workspace repo has no GitHub origin"], spec_id, root),
-        )
-
-    # A commit on a detached HEAD would be worse than useless: it is unreachable
-    # from any branch, and the next `git checkout` would DELETE the artifact from
-    # the working tree (tracked in the commit being left, absent from the one
-    # being entered). Nothing is fetchable from a detached HEAD anyway, so refuse
-    # before writing rather than after.
-    branch = _stdout(shell, "git rev-parse --abbrev-ref HEAD", root)
-    if not branch or branch == "HEAD":
-        return EvidencePublication(
-            None,
-            frozenset(),
-            _warning(
-                ["the workspace repo is on a detached HEAD, so nothing was "
-                 "committed or pushed"],
-                spec_id,
-                root,
-            ),
-        )
-
-    # Nothing to publish for a ref whose bytes are gone from the working tree;
-    # it may still be tracked at HEAD from an earlier finish, which the
-    # verification pass below settles.
-    to_commit = sorted(p for p in relpaths.values() if (root / p).exists())
-    notes: list[str] = []
-    if to_commit:
-        note = _commit_artifacts(shell, root, spec_id, to_commit)
-        if note is not None:
-            notes.append(note)
-
-    resolved = _raw_base_and_sha(root, shell)
-    if resolved is None:
-        # Not on the remote yet (or at all). Try to put it there, then ASK the
-        # remote again rather than assuming a zero exit means what we hoped.
-        note = _push_current_branch(shell, root)
-        if note is not None:
-            notes.append(note)
-        resolved = _raw_base_and_sha(root, shell)
-
-    if resolved is None:
-        notes.append(
-            "the workspace evidence is not reachable at raw.githubusercontent.com"
-        )
-        return EvidencePublication(None, frozenset(), _warning(notes, spec_id, root))
-
-    base_url, sha = resolved
-    verified = frozenset(
-        ref for ref, p in relpaths.items() if is_tracked_at(shell, root, sha, p)
+    tip, _ = _remote_tip(shell, repo)
+    if tip is None:
+        return False
+    if tip == sha:
+        return True
+    ancestry = shell.run(
+        f"git merge-base --is-ancestor {shlex.quote(sha)} {shlex.quote(tip)}", cwd=repo
     )
-    missing = len(relpaths) - len(verified)
+    return ancestry.returncode == 0
+
+
+def is_present_at(shell, repo: Path, sha: str, tree_path: str) -> bool:
+    """True when `tree_path` exists in `sha`'s tree.
+
+    The precondition of every embed, checked by the module that emits the URL
+    rather than assumed from the module that wrote the file.
+    """
+    result = shell.run(
+        f"git cat-file -e {shlex.quote(f'{sha}:{tree_path}')}", cwd=Path(repo)
+    )
+    return result.returncode == 0
+
+
+def publish_evidence(
+    workspace_root: Path, repo_path: Path, spec_id: str, refs: list[str], shell
+) -> EvidencePublication:
+    """Publish `spec_id`'s referenced artifacts to `repo_path`'s orphan evidence
+    branch, then report which of them are provably fetchable.
+
+    Call once per repo receiving a pull request (see ac7: every PR is
+    self-contained, so a reviewer of one repo's PR needs no access to a sibling),
+    and only under `published` evidence storage (see the module docstring).
+    `refs` are bare stored refs; anything not proven present in the pinned commit
+    is left out of `verified` so the caller names it instead.
+    """
+    repo = Path(repo_path)
+    store = evidence_dir(workspace_root, spec_id)
+    tree_paths = {ref: evidence_tree_path(spec_id, ref) for ref in refs}
+    notes: list[str] = []
+
+    # No raw host to serve from means no embed is possible at all, so do no git
+    # work: the licence to write anything here is "so the PR body can embed it".
+    remote_url = _stdout(shell, "git remote get-url origin", repo)
+    slug = _parse_github_slug(remote_url) if remote_url else None
+    if slug is None:
+        return EvidencePublication(
+            None, frozenset(), _warning(["the repo has no GitHub origin"], spec_id, repo)
+        )
+    owner, name = slug
+
+    tip, tip_note = _remote_tip(shell, repo)
+    if tip_note is not None:
+        return EvidencePublication(
+            None, frozenset(), _warning([tip_note], spec_id, repo)
+        )
+    parent = tip
+    if parent is not None:
+        note = _fetch_tip(shell, repo, parent)
+        if note is not None:
+            # Without the parent's objects we could only build a commit that
+            # REPLACES the branch, discarding earlier publications, and the push
+            # would be rejected as a non-fast-forward anyway.
+            return EvidencePublication(
+                None, frozenset(), _warning([note], spec_id, repo)
+            )
+
+    # Bytes gone from the local store are not republishable, but may already be
+    # on the branch from an earlier finish — the verification pass settles that.
+    sources = {ref: store / ref for ref in refs if (store / ref).is_file()}
+
+    pinned = parent
+    if sources:
+        pinned, note = _publish_commit(shell, repo, spec_id, sources, parent)
+        if note is not None:
+            notes.append(note)
+            pinned = parent
+
+    if pinned is None:
+        notes.append(f"nothing could be published to {ORPHAN_BRANCH}")
+        return EvidencePublication(None, frozenset(), _warning(notes, spec_id, repo))
+
+    if pinned != tip:
+        note = _push_commit(shell, repo, pinned)
+        if note is not None:
+            notes.append(note)
+    if not _is_on_origin(shell, repo, pinned):
+        notes.append(
+            f"the evidence commit is not on origin's {ORPHAN_BRANCH} branch"
+        )
+        return EvidencePublication(None, frozenset(), _warning(notes, spec_id, repo))
+
+    base_url = f"{RAW_HOST}/{owner}/{name}/{pinned}"
+    verified = frozenset(
+        ref for ref, p in tree_paths.items() if is_present_at(shell, repo, pinned, p)
+    )
+    missing = len(tree_paths) - len(verified)
     if missing:
         notes.append(
-            f"{missing} of {len(relpaths)} image artifacts are not tracked at "
-            f"workspace commit {sha[:12]}"
+            f"{missing} of {len(tree_paths)} image artifacts are not present at "
+            f"evidence commit {pinned[:12]}"
         )
     return EvidencePublication(
-        base_url, verified, _warning(notes, spec_id, root) if notes else None
+        base_url, verified, _warning(notes, spec_id, repo) if notes else None
     )
 
 
-def _warning(notes: list[str], spec_id: str, root: Path) -> str:
+def _warning(notes: list[str], spec_id: str, repo: Path) -> str:
     """One operator-facing message: what went wrong, what it costs, what to do."""
     return (
         f"Image evidence for {spec_id} is not embeddable ({'; '.join(notes)}), so "
         f"the PR body will name the artifacts instead of emitting images that "
-        f"404. Opening the PR is unaffected. Once "
-        f"`{SPECS_DIRNAME}/{EVIDENCE_DIRNAME}/{spec_id}/` is committed and pushed "
-        f"in {root}, re-run finish to embed them."
+        f"404. Opening the PR is unaffected. Once the `{ORPHAN_BRANCH}` branch in "
+        f"{repo} can be pushed to origin, re-run finish to embed them."
     )

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -311,13 +311,44 @@ class PhaseManager:
             return []
         if spec is None:
             return []
-        missing = [c.id for c in spec.acceptance_criteria if not c.evidence]
-        if not missing:
+        msg = unevidenced_warning(spec, self._capture_repos())
+        return [msg] if msg else []
+
+    def _capture_repos(self) -> list[str]:
+        """Names of configured repos that actually define a capture target
+        (`RepoConfig.capture` is set). `cli/capture.py` resolves the underlying
+        task name via `tasks.get("capture", "capture")`, which silently falls
+        back to a "capture" task even for repos that never declared one — so
+        that dict can't tell us whether the command would work. The `capture:`
+        block is the one place a repo opts in, so its presence is the actual
+        signal."""
+        if self._config is None:
             return []
-        return [
-            f"Acceptance criteria without evidence: {', '.join(missing)} "
-            f"— attach with `mship spec evidence {spec.id} <ac> <ref>`"
-        ]
+        return [name for name, repo in self._config.repos.items() if repo.capture is not None]
 
     def _gate_run(self, task) -> list[str]:
         return []
+
+
+def unevidenced_warning(spec, capture_repos: list[str]) -> str:
+    """Warning text for a spec's acceptance criteria that carry no evidence.
+    Keeps the original `mship spec evidence` remedy verbatim and, only when at
+    least one repo in the workspace actually defines a capture target, appends
+    `mship capture --evidence` as a second, pull-based remedy — reusing a
+    mechanism that already exists rather than inventing one. Suggesting a
+    command that cannot run would be worse than saying nothing, so the hint is
+    omitted entirely when no repo defines one. Returns "" when every criterion
+    already has evidence — nothing to say."""
+    missing = [c.id for c in (spec.acceptance_criteria or []) if not c.evidence]
+    if not missing:
+        return ""
+    msg = (
+        f"Acceptance criteria without evidence: {', '.join(missing)} "
+        f"— attach with `mship spec evidence {spec.id} <ac> <ref>`"
+    )
+    if capture_repos:
+        msg += (
+            f", or `mship capture --evidence {spec.id}:<ac>` "
+            f"(capture targets: {', '.join(capture_repos)})"
+        )
+    return msg

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -311,20 +311,25 @@ class PhaseManager:
             return []
         if spec is None:
             return []
-        msg = unevidenced_warning(spec, self._capture_repos())
+        msg = unevidenced_warning(spec, self._capture_repos(task.affected_repos))
         return [msg] if msg else []
 
-    def _capture_repos(self) -> list[str]:
-        """Names of configured repos that actually define a capture target
+    def _capture_repos(self, affected: list[str]) -> list[str]:
+        """Names of `affected` repos that actually define a capture target
         (`RepoConfig.capture` is set). `cli/capture.py` resolves the underlying
         task name via `tasks.get("capture", "capture")`, which silently falls
         back to a "capture" task even for repos that never declared one — so
         that dict can't tell us whether the command would work. The `capture:`
         block is the one place a repo opts in, so its presence is the actual
-        signal."""
+        signal. Scoped to `affected` (the task's `affected_repos`) — naming an
+        unrelated repo's capture target would look actionable but be wrong."""
         if self._config is None:
             return []
-        return [name for name, repo in self._config.repos.items() if repo.capture is not None]
+        affected_set = set(affected)
+        return [
+            name for name, repo in self._config.repos.items()
+            if repo.capture is not None and name in affected_set
+        ]
 
     def _gate_run(self, task) -> list[str]:
         return []

--- a/src/mship/core/pr.py
+++ b/src/mship/core/pr.py
@@ -483,11 +483,12 @@ def build_acceptance_block(
     (no criteria), else a leading-separator markdown block ready to append to a
     PR body.
 
-    `evidence_base_url`, when given, is the raw base under which this workspace's
-    committed evidence is fetchable; image artifacts are then embedded rather than
-    named. It is None whenever the bytes are not fetchable by GitHub (local or
-    encrypted storage, or an evidence commit that has not been pushed), in which
-    case the artifact is named — never emitted as a broken image.
+    `evidence_base_url`, when given, is the raw base under which this spec's
+    published evidence is fetchable — a commit on the target repo's evidence
+    branch; image artifacts are then embedded rather than named. It is None
+    whenever the bytes are not fetchable by GitHub (local or encrypted storage, or
+    a publication that did not land), in which case the artifact is named — never
+    emitted as a broken image.
 
     `verified_refs` narrows that further to refs proven present in the pinned
     commit, so one unpublished artifact degrades to a name without dragging its
@@ -525,27 +526,29 @@ def build_acceptance_block(
     return "\n".join(lines)
 
 
-def acceptance_block_for_finish(spec, workspace_root, shell, config) -> tuple[str, str | None]:
-    """The acceptance block plus an optional operator warning.
+def acceptance_block_for_finish(
+    spec, workspace_root, repo_path, shell, config
+) -> tuple[str, str | None]:
+    """The acceptance block plus an optional operator warning, for the PR about to
+    be opened in `repo_path`.
 
     Split from build_acceptance_block so the pure renderer stays testable without
-    a git repo or a config. Embedding requires `committed` storage AND the artifact
-    actually present in a pushed workspace commit: under `local` the evidence
-    directory is gitignored, so a raw URL would 404, and under `encrypted` the
-    bytes are ciphertext.
+    a git repo or a config. Embedding requires `published` storage AND the artifact
+    actually present in a pushed commit: under `local` the bytes never leave the
+    machine, and under `encrypted` they are ciphertext.
 
-    Under `committed`, finish OWNS getting it there — `publish_evidence` commits
-    the referenced artifacts and pushes the workspace repo, because otherwise the
-    ordinary sequence (`capture --evidence`, then finish) emits a URL to a file
-    nobody ever committed. It reports back only the refs it could prove are in the
-    pinned commit; the rest are named.
+    Under `published`, finish OWNS getting them there — `publish_evidence` puts the
+    referenced artifacts on `repo_path`'s `mship-evidence` orphan branch, because
+    the store is machine-local and nothing else would. Called PER REPO, since each
+    PR embeds from its own repo's branch (ac7). It reports back only the refs it
+    could prove are in the pinned commit; the rest are named.
 
     The mode gate is checked FIRST and short-circuits before any shell call:
-    `publish_evidence` only answers the git question and would happily stage
-    gitignored bytes under `local` if asked, so it must never be asked under
-    `local`/`encrypted` (see evidence_url.py). The "has image evidence" scan
-    likewise runs first — an operator with no screenshots gets no message, no
-    commit, and no push.
+    `publish_evidence` only answers the git question and would happily publish
+    bytes that must never leave the machine if asked, so it must never be asked
+    under `local`/`encrypted` (see evidence_url.py). The "has image evidence" scan
+    likewise runs first — an operator with no screenshots gets no message and no
+    git work.
 
     `resolve_evidence_mode` can raise `EvidenceModeError` (evidence_storage more
     exposed than spec_storage). By the time `finish` runs, config load has already
@@ -569,7 +572,7 @@ def acceptance_block_for_finish(spec, workspace_root, shell, config) -> tuple[st
         from mship.core.evidence_url import publish_evidence
 
         base_url, verified, publish_warning = publish_evidence(
-            workspace_root, spec.id, image_refs, shell,
+            workspace_root, repo_path, spec.id, image_refs, shell,
         )
 
     block = build_acceptance_block(
@@ -582,6 +585,6 @@ def acceptance_block_for_finish(spec, workspace_root, shell, config) -> tuple[st
         return block, publish_warning
     return block, (
         f"Image evidence exists but evidence_storage={mode!r} keeps it off "
-        "the public workspace repo, so it will be named rather than "
-        "embedded in the PR body."
+        "GitHub in readable form, so it will be named rather than embedded in "
+        "the PR body."
     )

--- a/src/mship/core/pr.py
+++ b/src/mship/core/pr.py
@@ -568,7 +568,7 @@ def acceptance_block_for_finish(
     ))
 
     base_url, verified, publish_warning = None, None, None
-    if mode == "committed" and image_refs:
+    if mode == "published" and image_refs:
         from mship.core.evidence_url import publish_evidence
 
         base_url, verified, publish_warning = publish_evidence(
@@ -581,7 +581,7 @@ def acceptance_block_for_finish(
 
     if not image_refs:
         return block, None
-    if mode == "committed":
+    if mode == "published":
         return block, publish_warning
     return block, (
         f"Image evidence exists but evidence_storage={mode!r} keeps it off "

--- a/src/mship/core/pr.py
+++ b/src/mship/core/pr.py
@@ -4,7 +4,13 @@ import shlex
 from pathlib import Path
 from typing import NamedTuple
 
-from mship.core.evidence_store import IMAGE_EXTS, is_stored_ref, resolve_evidence_mode
+from mship.core.evidence_store import (
+    IMAGE_EXTS,
+    is_encrypted_ref,
+    is_image_ref,
+    is_stored_ref,
+    resolve_evidence_mode,
+)
 from mship.core.gh_auth import git_cred_args, create_pr_via_httpx, get_default_branch_via_httpx
 from mship.util.shell import ShellRunner
 
@@ -454,16 +460,18 @@ def _is_embeddable_image(
 ) -> bool:
     """True when GitHub's renderer can fetch these bytes AND they are an image.
 
+    Strictly the here-and-now question; "is this the KIND of artifact we would
+    embed?" is `evidence_store.is_image_ref`, which sees an encrypted image as
+    an image. This one must not: an `.enc` ref holds ciphertext, so it is not
+    embeddable even when a base URL exists.
+
     Only refs the evidence store produced can resolve under the base URL, so a
     hand-written ref (`docs/shot.png`, from before `capture --evidence`) is
-    named rather than embedded as a URL that would 404. An encrypted ref falls
-    out here for free: its extension is `.enc`, not an image one — and its bytes
-    are ciphertext, so an embed would render broken.
+    named rather than embedded as a URL that would 404.
 
     `verified_refs`, when given, additionally restricts embedding to refs proven
     to exist in the commit the base URL pins. None means "not checked" — the
-    pure renderer's default, and the shape callers use to ask the weaker
-    question "is this the KIND of thing we would embed?".
+    pure renderer's default.
     """
     if not evidence_base_url or evidence.kind != "artifact":
         return False
@@ -498,6 +506,11 @@ def build_acceptance_block(
     acs = getattr(spec, "acceptance_criteria", None) or []
     if not acs:
         return ""
+    # Deferred: evidence_url imports this module for `_parse_github_slug`. The
+    # embedded URL must use the same `<spec-id>/<ref>` layout the publisher
+    # writes into the orphan tree, so it comes from the module that owns it.
+    from mship.core.evidence_url import evidence_tree_path
+
     lines = [
         "",
         "---",
@@ -522,7 +535,9 @@ def build_acceptance_block(
         # both a hash filename and the picture of it is noise.
         for e in embeds:
             lines.append("")
-            lines.append(f"  ![{c.id}]({evidence_base_url}/{spec.id}/{e.ref})")
+            lines.append(
+                f"  ![{c.id}]({evidence_base_url}/{evidence_tree_path(spec.id, e.ref)})"
+            )
     return "\n".join(lines)
 
 
@@ -564,15 +579,22 @@ def acceptance_block_for_finish(
         e.ref
         for c in acs
         for e in (c.evidence or [])
-        if _is_embeddable_image(e, "placeholder")
+        if e.kind == "artifact" and is_image_ref(e.ref)
     ))
 
+    # A ref records how its bytes were written, which a later change of
+    # `evidence_storage` does not rewrite. So ciphertext can turn up while the
+    # mode reads `published`: it is still an image artifact (it must be warned
+    # about), but it is not publishable — pushing it would put blobs on the
+    # evidence branch that no renderer could ever use.
+    publishable = [r for r in image_refs if not is_encrypted_ref(r)]
+
     base_url, verified, publish_warning = None, None, None
-    if mode == "published" and image_refs:
+    if mode == "published" and publishable:
         from mship.core.evidence_url import publish_evidence
 
         base_url, verified, publish_warning = publish_evidence(
-            workspace_root, repo_path, spec.id, image_refs, shell,
+            workspace_root, repo_path, spec.id, publishable, shell,
         )
 
     block = build_acceptance_block(
@@ -581,10 +603,18 @@ def acceptance_block_for_finish(
 
     if not image_refs:
         return block, None
-    if mode == "published":
-        return block, publish_warning
-    return block, (
-        f"Image evidence exists but evidence_storage={mode!r} keeps it off "
-        "GitHub in readable form, so it will be named rather than embedded in "
-        "the PR body."
-    )
+    if mode != "published":
+        return block, (
+            f"Image evidence exists but evidence_storage={mode!r} keeps it off "
+            "GitHub in readable form, so it will be named rather than embedded in "
+            "the PR body."
+        )
+    encrypted = len(image_refs) - len(publishable)
+    if encrypted:
+        note = (
+            f"{encrypted} of {len(image_refs)} image artifacts were stored "
+            f"encrypted, under an earlier evidence_storage setting, so their "
+            f"bytes are ciphertext and they will be named rather than embedded."
+        )
+        return block, f"{publish_warning} {note}" if publish_warning else note
+    return block, publish_warning

--- a/src/mship/core/pr.py
+++ b/src/mship/core/pr.py
@@ -4,7 +4,7 @@ import shlex
 from pathlib import Path
 from typing import NamedTuple
 
-from mship.core.evidence_store import IMAGE_EXTS, _REF_RE
+from mship.core.evidence_store import IMAGE_EXTS, _REF_RE, resolve_evidence_mode
 from mship.core.gh_auth import git_cred_args, create_pr_via_httpx, get_default_branch_via_httpx
 from mship.util.shell import ShellRunner
 
@@ -507,3 +507,60 @@ def build_acceptance_block(spec, evidence_base_url: str | None = None) -> str:
             lines.append("")
             lines.append(f"  ![{c.id}]({evidence_base_url}/{spec.id}/{e.ref})")
     return "\n".join(lines)
+
+
+def acceptance_block_for_finish(spec, workspace_root, shell, config) -> tuple[str, str | None]:
+    """The acceptance block plus an optional operator warning.
+
+    Split from build_acceptance_block so the pure renderer stays testable without
+    a git repo or a config. Embedding requires `committed` storage AND the evidence
+    commit actually pushed: under `local` the evidence directory is gitignored, so
+    a raw URL would 404, and under `encrypted` the bytes are ciphertext.
+
+    The mode gate is checked FIRST and short-circuits before any shell call:
+    `workspace_raw_base` only answers the git question ("is this sha on origin?")
+    and would happily return a URL for gitignored bytes under `local` if asked, so
+    it must never be asked under `local`/`encrypted` (see evidence_url.py). The
+    "has image evidence" scan is what decides whether to warn — an operator with
+    no screenshots needs no message, so it is checked before doing any git work too.
+
+    `resolve_evidence_mode` can raise `EvidenceModeError` (evidence_storage more
+    exposed than spec_storage). By the time `finish` runs, config load has already
+    enforced that invariant, so a raise here means the config changed underneath
+    mid-session — a real inconsistency, not a normal path. Left to propagate
+    uncaught rather than downgraded to a warning: swallowing it would let finish
+    continue past a broken config silently, the opposite of surfacing the problem.
+    """
+    mode = resolve_evidence_mode(config)
+    acs = getattr(spec, "acceptance_criteria", None) or []
+    has_image_evidence = any(
+        _is_embeddable_image(e, "placeholder")
+        for c in acs
+        for e in (c.evidence or [])
+    )
+
+    base_url = None
+    if mode == "committed" and has_image_evidence:
+        from mship.core.evidence_url import workspace_raw_base
+
+        base_url = workspace_raw_base(workspace_root, shell)
+
+    block = build_acceptance_block(spec, evidence_base_url=base_url)
+
+    if not has_image_evidence or base_url is not None:
+        return block, None
+
+    if mode == "committed":
+        warning = (
+            "Image evidence exists but the workspace evidence commit has not "
+            "been pushed, so it will be named rather than embedded in the PR "
+            "body. Commit and push `specs/` (including `specs/evidence/`), "
+            "then re-run finish to embed it."
+        )
+    else:
+        warning = (
+            f"Image evidence exists but evidence_storage={mode!r} keeps it off "
+            "the public workspace repo, so it will be named rather than "
+            "embedded in the PR body."
+        )
+    return block, warning

--- a/src/mship/core/pr.py
+++ b/src/mship/core/pr.py
@@ -4,6 +4,7 @@ import shlex
 from pathlib import Path
 from typing import NamedTuple
 
+from mship.core.evidence_store import IMAGE_EXTS, _REF_RE
 from mship.core.gh_auth import git_cred_args, create_pr_via_httpx, get_default_branch_via_httpx
 from mship.util.shell import ShellRunner
 
@@ -448,12 +449,35 @@ class PRManager:
         return "\n".join(lines)
 
 
-def build_acceptance_block(spec) -> str:
+def _is_embeddable_image(evidence, evidence_base_url: str | None) -> bool:
+    """True when GitHub's renderer can fetch these bytes AND they are an image.
+
+    Only refs the evidence store produced can resolve under the base URL, so a
+    hand-written ref (`docs/shot.png`, from before `capture --evidence`) is
+    named rather than embedded as a URL that would 404. An encrypted ref falls
+    out here for free: its extension is `.enc`, not an image one — and its bytes
+    are ciphertext, so an embed would render broken.
+    """
+    if not evidence_base_url or evidence.kind != "artifact":
+        return False
+    if not _REF_RE.fullmatch(evidence.ref):
+        return False
+    return Path(evidence.ref).suffix.lower() in IMAGE_EXTS
+
+
+def build_acceptance_block(spec, evidence_base_url: str | None = None) -> str:
     """Render an 'Acceptance criteria' PR-body section listing each AC as verified
     (with its evidence refs) or unverified. Pure analogue of
     PRManager.build_coordination_block: returns '' when there is nothing to render
     (no criteria), else a leading-separator markdown block ready to append to a
-    PR body."""
+    PR body.
+
+    `evidence_base_url`, when given, is the raw base under which this workspace's
+    committed evidence is fetchable; image artifacts are then embedded rather than
+    named. It is None whenever the bytes are not fetchable by GitHub (local or
+    encrypted storage, or an evidence commit that has not been pushed), in which
+    case the artifact is named — never emitted as a broken image.
+    """
     acs = getattr(spec, "acceptance_criteria", None) or []
     if not acs:
         return ""
@@ -465,9 +489,21 @@ def build_acceptance_block(spec) -> str:
         "",
     ]
     for c in acs:
-        if c.evidence:
-            refs = ", ".join(f"{e.kind}:{e.ref}" for e in c.evidence)
-            lines.append(f"- [x] `{c.id}` {c.text} — {refs}")
-        else:
+        if not c.evidence:
             lines.append(f"- [ ] `{c.id}` {c.text} — _no evidence_")
+            continue
+        embeds, named = [], []
+        for e in c.evidence:
+            target = embeds if _is_embeddable_image(e, evidence_base_url) else named
+            target.append(e)
+        head = f"- [x] `{c.id}` {c.text}"
+        if named:
+            head += " — " + ", ".join(f"{e.kind}:{e.ref}" for e in named)
+        lines.append(head)
+        # Embedded on its own indented line beneath the criterion, so the
+        # checklist stays scannable. The image replaces the ref text: showing
+        # both a hash filename and the picture of it is noise.
+        for e in embeds:
+            lines.append("")
+            lines.append(f"  ![{c.id}]({evidence_base_url}/{spec.id}/{e.ref})")
     return "\n".join(lines)

--- a/src/mship/core/pr.py
+++ b/src/mship/core/pr.py
@@ -542,7 +542,7 @@ def build_acceptance_block(
 
 
 def acceptance_block_for_finish(
-    spec, workspace_root, repo_path, shell, config
+    spec, workspace_root, repo_path, shell, config, token: str | None = None,
 ) -> tuple[str, str | None]:
     """The acceptance block plus an optional operator warning, for the PR about to
     be opened in `repo_path`.
@@ -571,6 +571,12 @@ def acceptance_block_for_finish(
     mid-session — a real inconsistency, not a normal path. Left to propagate
     uncaught rather than downgraded to a warning: swallowing it would let finish
     continue past a broken config silently, the opposite of surfacing the problem.
+
+    `token`, when the caller has one (the same `gh_token` resolved for
+    `push_branch`), is passed straight through to `publish_evidence` so the
+    evidence push authenticates the same way the branch push already does —
+    otherwise a token-only environment with no cached git credentials pushes the
+    branch fine and silently fails to publish evidence.
     """
     mode = resolve_evidence_mode(config)
     acs = getattr(spec, "acceptance_criteria", None) or []
@@ -594,7 +600,7 @@ def acceptance_block_for_finish(
         from mship.core.evidence_url import publish_evidence
 
         base_url, verified, publish_warning = publish_evidence(
-            workspace_root, repo_path, spec.id, publishable, shell,
+            workspace_root, repo_path, spec.id, publishable, shell, token,
         )
 
     block = build_acceptance_block(

--- a/src/mship/core/pr.py
+++ b/src/mship/core/pr.py
@@ -4,7 +4,7 @@ import shlex
 from pathlib import Path
 from typing import NamedTuple
 
-from mship.core.evidence_store import IMAGE_EXTS, _REF_RE, resolve_evidence_mode
+from mship.core.evidence_store import IMAGE_EXTS, is_stored_ref, resolve_evidence_mode
 from mship.core.gh_auth import git_cred_args, create_pr_via_httpx, get_default_branch_via_httpx
 from mship.util.shell import ShellRunner
 
@@ -460,7 +460,7 @@ def _is_embeddable_image(evidence, evidence_base_url: str | None) -> bool:
     """
     if not evidence_base_url or evidence.kind != "artifact":
         return False
-    if not _REF_RE.fullmatch(evidence.ref):
+    if not is_stored_ref(evidence.ref):
         return False
     return Path(evidence.ref).suffix.lower() in IMAGE_EXTS
 

--- a/src/mship/core/pr.py
+++ b/src/mship/core/pr.py
@@ -449,7 +449,9 @@ class PRManager:
         return "\n".join(lines)
 
 
-def _is_embeddable_image(evidence, evidence_base_url: str | None) -> bool:
+def _is_embeddable_image(
+    evidence, evidence_base_url: str | None, verified_refs=None
+) -> bool:
     """True when GitHub's renderer can fetch these bytes AND they are an image.
 
     Only refs the evidence store produced can resolve under the base URL, so a
@@ -457,15 +459,24 @@ def _is_embeddable_image(evidence, evidence_base_url: str | None) -> bool:
     named rather than embedded as a URL that would 404. An encrypted ref falls
     out here for free: its extension is `.enc`, not an image one — and its bytes
     are ciphertext, so an embed would render broken.
+
+    `verified_refs`, when given, additionally restricts embedding to refs proven
+    to exist in the commit the base URL pins. None means "not checked" — the
+    pure renderer's default, and the shape callers use to ask the weaker
+    question "is this the KIND of thing we would embed?".
     """
     if not evidence_base_url or evidence.kind != "artifact":
         return False
     if not is_stored_ref(evidence.ref):
         return False
-    return Path(evidence.ref).suffix.lower() in IMAGE_EXTS
+    if Path(evidence.ref).suffix.lower() not in IMAGE_EXTS:
+        return False
+    return verified_refs is None or evidence.ref in verified_refs
 
 
-def build_acceptance_block(spec, evidence_base_url: str | None = None) -> str:
+def build_acceptance_block(
+    spec, evidence_base_url: str | None = None, verified_refs=None
+) -> str:
     """Render an 'Acceptance criteria' PR-body section listing each AC as verified
     (with its evidence refs) or unverified. Pure analogue of
     PRManager.build_coordination_block: returns '' when there is nothing to render
@@ -477,6 +488,11 @@ def build_acceptance_block(spec, evidence_base_url: str | None = None) -> str:
     named. It is None whenever the bytes are not fetchable by GitHub (local or
     encrypted storage, or an evidence commit that has not been pushed), in which
     case the artifact is named — never emitted as a broken image.
+
+    `verified_refs` narrows that further to refs proven present in the pinned
+    commit, so one unpublished artifact degrades to a name without dragging its
+    published siblings down with it. None (the default) embeds every image ref
+    the base URL covers.
     """
     acs = getattr(spec, "acceptance_criteria", None) or []
     if not acs:
@@ -494,8 +510,8 @@ def build_acceptance_block(spec, evidence_base_url: str | None = None) -> str:
             continue
         embeds, named = [], []
         for e in c.evidence:
-            target = embeds if _is_embeddable_image(e, evidence_base_url) else named
-            target.append(e)
+            embeddable = _is_embeddable_image(e, evidence_base_url, verified_refs)
+            (embeds if embeddable else named).append(e)
         head = f"- [x] `{c.id}` {c.text}"
         if named:
             head += " — " + ", ".join(f"{e.kind}:{e.ref}" for e in named)
@@ -513,16 +529,23 @@ def acceptance_block_for_finish(spec, workspace_root, shell, config) -> tuple[st
     """The acceptance block plus an optional operator warning.
 
     Split from build_acceptance_block so the pure renderer stays testable without
-    a git repo or a config. Embedding requires `committed` storage AND the evidence
-    commit actually pushed: under `local` the evidence directory is gitignored, so
-    a raw URL would 404, and under `encrypted` the bytes are ciphertext.
+    a git repo or a config. Embedding requires `committed` storage AND the artifact
+    actually present in a pushed workspace commit: under `local` the evidence
+    directory is gitignored, so a raw URL would 404, and under `encrypted` the
+    bytes are ciphertext.
+
+    Under `committed`, finish OWNS getting it there — `publish_evidence` commits
+    the referenced artifacts and pushes the workspace repo, because otherwise the
+    ordinary sequence (`capture --evidence`, then finish) emits a URL to a file
+    nobody ever committed. It reports back only the refs it could prove are in the
+    pinned commit; the rest are named.
 
     The mode gate is checked FIRST and short-circuits before any shell call:
-    `workspace_raw_base` only answers the git question ("is this sha on origin?")
-    and would happily return a URL for gitignored bytes under `local` if asked, so
-    it must never be asked under `local`/`encrypted` (see evidence_url.py). The
-    "has image evidence" scan is what decides whether to warn — an operator with
-    no screenshots needs no message, so it is checked before doing any git work too.
+    `publish_evidence` only answers the git question and would happily stage
+    gitignored bytes under `local` if asked, so it must never be asked under
+    `local`/`encrypted` (see evidence_url.py). The "has image evidence" scan
+    likewise runs first — an operator with no screenshots gets no message, no
+    commit, and no push.
 
     `resolve_evidence_mode` can raise `EvidenceModeError` (evidence_storage more
     exposed than spec_storage). By the time `finish` runs, config load has already
@@ -533,34 +556,32 @@ def acceptance_block_for_finish(spec, workspace_root, shell, config) -> tuple[st
     """
     mode = resolve_evidence_mode(config)
     acs = getattr(spec, "acceptance_criteria", None) or []
-    has_image_evidence = any(
-        _is_embeddable_image(e, "placeholder")
+    # Ordered-unique: one artifact attached to several criteria is one file.
+    image_refs = list(dict.fromkeys(
+        e.ref
         for c in acs
         for e in (c.evidence or [])
+        if _is_embeddable_image(e, "placeholder")
+    ))
+
+    base_url, verified, publish_warning = None, None, None
+    if mode == "committed" and image_refs:
+        from mship.core.evidence_url import publish_evidence
+
+        base_url, verified, publish_warning = publish_evidence(
+            workspace_root, spec.id, image_refs, shell,
+        )
+
+    block = build_acceptance_block(
+        spec, evidence_base_url=base_url, verified_refs=verified,
     )
 
-    base_url = None
-    if mode == "committed" and has_image_evidence:
-        from mship.core.evidence_url import workspace_raw_base
-
-        base_url = workspace_raw_base(workspace_root, shell)
-
-    block = build_acceptance_block(spec, evidence_base_url=base_url)
-
-    if not has_image_evidence or base_url is not None:
+    if not image_refs:
         return block, None
-
     if mode == "committed":
-        warning = (
-            "Image evidence exists but the workspace evidence commit has not "
-            "been pushed, so it will be named rather than embedded in the PR "
-            "body. Commit and push `specs/` (including `specs/evidence/`), "
-            "then re-run finish to embed it."
-        )
-    else:
-        warning = (
-            f"Image evidence exists but evidence_storage={mode!r} keeps it off "
-            "the public workspace repo, so it will be named rather than "
-            "embedded in the PR body."
-        )
-    return block, warning
+        return block, publish_warning
+    return block, (
+        f"Image evidence exists but evidence_storage={mode!r} keeps it off "
+        "the public workspace repo, so it will be named rather than "
+        "embedded in the PR body."
+    )

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -574,6 +574,7 @@ def create_app(
             ENC_SUFFIX,
             BadEvidenceRef,
             resolve_ref,
+            stored_size_cap,
         )
 
         # `resolve_ref` is the ONLY spec resolution on this path, deliberately.
@@ -586,6 +587,15 @@ def create_app(
             path = resolve_ref(workspace_root, spec_id, name)
         except BadEvidenceRef:
             raise HTTPException(status_code=404, detail="no such evidence")
+
+        # The size cap that actually bounds a response: `store_artifact` refuses
+        # oversized artifacts up front, but bytes can reach the store without it
+        # (a hand-placed file, a restore), and this is the one place a phone on a
+        # relay is on the other end of them.
+        if path.stat().st_size > stored_size_cap(name):
+            raise HTTPException(
+                status_code=413, detail="evidence artifact is too large to serve"
+            )
 
         if name.endswith(ENC_SUFFIX):
             from cryptography.fernet import InvalidToken

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -597,6 +597,11 @@ def create_app(
                 status_code=413, detail="evidence artifact is too large to serve"
             )
 
+        # Layout dumps carry app-under-test content, so nothing here is served as
+        # a type a browser executes (see evidence_store.CONTENT_TYPES); nosniff
+        # stops it being re-guessed into one.
+        headers = {"X-Content-Type-Options": "nosniff"}
+
         if name.endswith(ENC_SUFFIX):
             from cryptography.fernet import InvalidToken
 
@@ -625,10 +630,10 @@ def create_app(
                     status_code=409,
                     detail="evidence is locked: this host's key cannot decrypt it",
                 )
-            return Response(content=plain, media_type=media)
+            return Response(content=plain, media_type=media, headers=headers)
 
         media = CONTENT_TYPES.get(path.suffix.lower(), "application/octet-stream")
-        return FileResponse(path, media_type=media)
+        return FileResponse(path, media_type=media, headers=headers)
 
     from fastapi.encoders import jsonable_encoder
     from mship.core.view.task_index import build_task_index

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -576,10 +576,12 @@ def create_app(
             resolve_ref,
         )
 
-        # Cheap "no such spec" first (a pure id comparison over parsed specs — it
-        # never joins the id onto a path, so a traversing id simply matches
-        # nothing and 404s). Same status as an unresolvable ref either way.
-        _load_or_404(spec_id)
+        # `resolve_ref` is the ONLY spec resolution on this path, deliberately.
+        # It validates `spec_id` as a direct child of the evidence store, so an
+        # unknown spec has no directory and 404s here anyway — while the spec
+        # store's own lookup SKIPS locked specs, which would have turned the
+        # ordinary encrypted-workspace case into "no such spec" instead of the
+        # locked answer below.
         try:
             path = resolve_ref(workspace_root, spec_id, name)
         except BadEvidenceRef:

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -549,6 +549,75 @@ def create_app(
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
         return build_review(spec)
 
+    @app.get("/specs/{spec_id}/evidence/{name}/blob")
+    def get_evidence_blob(spec_id: str, name: str):
+        """Read-only artifact bytes for a criterion's evidence.
+
+        Inherits the app-wide bearer like every other route. Everything
+        unresolvable is a 404 rather than a 403 so the route never confirms what
+        exists. Both path parameters are attacker-controlled, and ALL of their
+        validation — including `spec_id` containment — is owned by
+        `core/evidence_store.py::resolve_ref`; a second copy here could drift out
+        of step with the real one, so there isn't one.
+
+        Note that Starlette percent-decodes the path before routing, so a
+        multi-segment `spec_id` (`..%2Fother`) fails to match `{spec_id}` and
+        404s in the router, while a bare `%2E%2E` does reach here — which is why
+        the resolver validates the spec id and not just the ref.
+        """
+        from pathlib import Path as _Path
+
+        from fastapi.responses import FileResponse, Response
+
+        from mship.core.evidence_store import (
+            CONTENT_TYPES,
+            ENC_SUFFIX,
+            BadEvidenceRef,
+            resolve_ref,
+        )
+
+        # Cheap "no such spec" first (a pure id comparison over parsed specs — it
+        # never joins the id onto a path, so a traversing id simply matches
+        # nothing and 404s). Same status as an unresolvable ref either way.
+        _load_or_404(spec_id)
+        try:
+            path = resolve_ref(workspace_root, spec_id, name)
+        except BadEvidenceRef:
+            raise HTTPException(status_code=404, detail="no such evidence")
+
+        if name.endswith(ENC_SUFFIX):
+            from cryptography.fernet import InvalidToken
+
+            from mship.core import spec_key
+
+            key = spec_key.load_key(workspace_root)
+            # The spec routes express "encrypted, no key on this host" as a
+            # `locked` marker; a byte stream has nowhere to put a marker, so the
+            # same condition is a 409 (serve's status for "the store can't
+            # satisfy this right now") whose detail names it locked. Never
+            # plaintext, never ciphertext, never a 500.
+            if key is None:
+                raise HTTPException(
+                    status_code=409,
+                    detail="evidence is locked: encrypted, and no key is available on this host",
+                )
+            logical = name[: -len(ENC_SUFFIX)]
+            media = CONTENT_TYPES.get(_Path(logical).suffix.lower(), "application/octet-stream")
+            try:
+                plain = spec_key.decrypt_bytes(key, path.read_bytes())
+            except InvalidToken:
+                # This host has A key, but not the one this artifact was sealed
+                # with (regenerated after a loss, or restored from elsewhere).
+                # Indistinguishable from locked to the caller, and equally not a 500.
+                raise HTTPException(
+                    status_code=409,
+                    detail="evidence is locked: this host's key cannot decrypt it",
+                )
+            return Response(content=plain, media_type=media)
+
+        media = CONTENT_TYPES.get(path.suffix.lower(), "application/octet-stream")
+        return FileResponse(path, media_type=media)
+
     from fastapi.encoders import jsonable_encoder
     from mship.core.view.task_index import build_task_index
 

--- a/src/mship/core/spec_key.py
+++ b/src/mship/core/spec_key.py
@@ -98,9 +98,17 @@ def _ensure_gitignored(workspace_root: Path, git: GitRunner) -> None:
         git.add_to_gitignore(workspace_root, pattern)
 
 
+def encrypt_bytes(key: bytes, data: bytes) -> bytes:
+    return Fernet(key).encrypt(data)
+
+
+def decrypt_bytes(key: bytes, data: bytes) -> bytes:
+    return Fernet(key).decrypt(data)
+
+
 def encrypt(key: bytes, text: str) -> bytes:
-    return Fernet(key).encrypt(text.encode("utf-8"))
+    return encrypt_bytes(key, text.encode("utf-8"))
 
 
 def decrypt(key: bytes, blob: bytes) -> str:
-    return Fernet(key).decrypt(blob).decode("utf-8")
+    return decrypt_bytes(key, blob).decode("utf-8")

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -543,10 +543,19 @@ class WorktreeManager:
         hub = workspace_root / ".worktrees" / slug
         hub.mkdir(parents=True, exist_ok=True)
 
-        # Workspace-root .gitignore gets .worktrees if root is a git repo.
+        # Workspace-root .gitignore gets mship's runtime directories if the root
+        # is a git repo. `.mothership` holds machine-local state — task state,
+        # captures, the spec key, the evidence store — none of which may ever be
+        # committed, and in a monorepo or single-repo workspace the root IS the
+        # product repo, so leaving it merely untracked would put screenshots and
+        # state files in every `git status`. Written without a trailing slash,
+        # like `.worktrees`: the `foo/` form does not match a SYMLINK named
+        # `foo`, which is how these directories get shared into a worktree (see
+        # _symlink_gitignore_footgun).
         if (workspace_root / ".git").exists():
-            if not self._git.is_ignored(workspace_root, ".worktrees"):
-                self._git.add_to_gitignore(workspace_root, ".worktrees")
+            for runtime_dir in (".worktrees", ".mothership"):
+                if not self._git.is_ignored(workspace_root, runtime_dir):
+                    self._git.add_to_gitignore(workspace_root, runtime_dir)
 
         for repo_name in all_repos:
             repo_config = self._config.repos[repo_name]

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -261,7 +261,7 @@ mship phase plan|dev|review|run [-f]  # `-f` overrides blocked or finished-task 
 mship block "reason" | mship unblock
 mship test [--all] [--repos|--tag] [--no-diff]
 mship build [--all] [--repos|--tag]   # runs `task build` across repos in dep order
-mship capture [--repo R] [--platform P] [--kind image|layout|all] [--out DIR]
+mship capture [--repo R] [--platform P] [--kind image|layout|all] [--out DIR] [--evidence SPEC:AC]
 mship journal "msg" [--action X] [--open Y] [--repo R] [--test-state pass|fail|mixed]
 mship journal --show-open                 # what am I blocked on across this task?
 mship finish [--base B] [--base-map ...] [--push-only] [--handoff] [--force-audit] [--body-file F | --body TEXT] [--force] [--require-tests] [--title T] [--body-map ...]
@@ -296,6 +296,20 @@ It's task-aware but **not** task-required: with an active task it runs in that
 task's worktree and files captures under the task; with no task it runs an
 ad-hoc capture against the repo's main checkout (pass `--repo` if the workspace
 has more than one). Capture observes a *running app*, not worktree source.
+
+**`--evidence SPEC:AC` promotes a capture into proof.** Bare `capture` is
+ephemeral — files you look at and overwrite on the next iteration. Adding
+`--evidence my-spec:ac3` also copies the artifact into the durable evidence
+store (`.mothership/evidence/<spec-id>/`, gitignored, content-hashed) and
+attaches it to that acceptance criterion as `kind=artifact` evidence, with a
+provenance note. From there it travels on its own: the operator sees the image
+on the spec's detail screen in Ground Control, and `mship finish` embeds it in
+the PR body — publishing the bytes to an `mship-evidence` orphan branch in the
+repo the PR targets so GitHub can render them. Under `local`/`encrypted`
+evidence storage, or if that publish fails, the PR **names** the artifact
+instead and finish warns; the PR still opens. So for UI work, capture with
+`--evidence` once the screen is right: it is the visual equivalent of a passing
+test, and the reviewer sees it without asking you for a screenshot.
 
 **`spawn` order:** slugify → worktree per repo → symlink `symlink_dirs` → `task setup` (unless `--skip-setup`) → save state → enter `plan`. If a repo's setup fails, the task still spawns; fix and re-run setup manually.
 

--- a/tests/cli/test_capture_evidence.py
+++ b/tests/cli/test_capture_evidence.py
@@ -58,6 +58,8 @@ class _FakeShell:
             return _FakeResult(stdout="abc1234\n")
         if command.startswith("git status"):
             return _FakeResult(stdout=" M src/app.kt\n" if self._dirty else "")
+        if command.startswith("git branch"):
+            return _FakeResult(stdout="* main\n")  # on a real branch, by default
         return _FakeResult()
 
 

--- a/tests/cli/test_capture_evidence.py
+++ b/tests/cli/test_capture_evidence.py
@@ -1,0 +1,185 @@
+"""`mship capture --evidence <spec>:<ac>` — promoting a capture into
+acceptance-criterion evidence in ONE command.
+
+The manual "capture, then attach" second step in practice never happens, so the
+behaviour worth pinning is: with the flag the artifact lands in the durable
+store AND on the criterion; without it nothing is stored (bare capture must not
+even create the store); and a storage failure warns without turning a good
+capture into a bad exit code.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.spec import AcceptanceCriterion, Spec
+from mship.core.spec_store import SpecStore
+from mship.core.state import StateManager, Task, WorkspaceState
+
+runner = CliRunner()
+
+_NOW = datetime(2026, 7, 25, tzinfo=timezone.utc)
+
+
+class _FakeResult:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class _FakeShell:
+    """Stands in for util/shell.py::ShellRunner.
+
+    `run_task` plays the repo's `capture` target (writes
+    `$MSHIP_CAPTURE_DIR/screen.png`); `run` plays the two git commands
+    `provenance_note` shells out for — note its command is a STRING, not argv.
+    """
+
+    def __init__(self, *, dirty: bool = False):
+        self._dirty = dirty
+        self.commands: list[str] = []
+
+    def run_task(self, task_name, actual_task_name, cwd, env_runner=None, env=None):
+        out = Path(env["MSHIP_CAPTURE_DIR"])
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "screen.png").write_bytes(b"PNGDATA")
+        return _FakeResult()
+
+    def run(self, command, cwd=None, **kwargs):
+        assert isinstance(command, str), "ShellRunner.run takes a command string"
+        self.commands.append(command)
+        if command.startswith("git rev-parse"):
+            return _FakeResult(stdout="abc1234\n")
+        if command.startswith("git status"):
+            return _FakeResult(stdout=" M src/app.kt\n" if self._dirty else "")
+        return _FakeResult()
+
+
+@pytest.fixture
+def workspace_with_spec(tmp_path: Path):
+    """Workspace with one capture-able repo, an active task, and spec `dq`
+    carrying criterion `ac1` (modelled on test_log.py::configured_app_with_task)."""
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    app_dir = tmp_path / "app"
+    app_dir.mkdir()
+    (app_dir / "Taskfile.yml").write_text(
+        "version: '3'\n"
+        "tasks:\n"
+        "  capture:\n"
+        "    cmds:\n"
+        "      - touch $MSHIP_CAPTURE_DIR/screen.png\n"
+    )
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\n"
+        "repos:\n"
+        "  app:\n"
+        "    path: ./app\n"
+        "    type: service\n"
+        "    capture:\n"
+        "      platforms: [android]\n"
+    )
+    StateManager(state_dir).save(WorkspaceState(tasks={
+        "t": Task(
+            slug="t", description="d", phase="dev", created_at=_NOW,
+            affected_repos=["app"], worktrees={"app": str(wt)},
+            branch="feat/t", base_branch="main", active_repo="app",
+        )
+    }))
+    SpecStore(tmp_path / "specs").save(Spec(
+        id="dq", title="Dequeue", status="approved",
+        created_at=_NOW, updated_at=_NOW, affected_repos=["app"],
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="The card clears.")],
+        body="## Problem\n\nCards linger.\n",
+    ))
+
+    shell = _FakeShell()
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    container.shell.override(shell)
+    try:
+        yield tmp_path
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset_override()
+        container.config.reset()
+        container.state_manager.reset_override()
+        container.state_manager.reset()
+        container.shell.reset_override()
+
+
+def _criterion(workspace: Path):
+    spec = SpecStore(workspace / "specs").find_by_id("dq")
+    assert spec is not None
+    return spec.acceptance_criteria[0]
+
+
+def test_evidence_attaches_to_the_named_criterion(workspace_with_spec: Path):
+    result = runner.invoke(
+        app, ["capture", "--task", "t", "--repo", "app", "--evidence", "dq:ac1"]
+    )
+    assert result.exit_code == 0, result.output
+    # --evidence must not add a line to STDOUT: that stream is the capture
+    # payload, and an agent runs `mship capture --evidence ... | jq`.
+    assert json.loads(result.stdout)["artifacts"][0]["kind"] == "image"
+
+    crit = _criterion(workspace_with_spec)
+    assert len(crit.evidence) == 1
+    ev = crit.evidence[0]
+    assert ev.kind == "artifact"
+    assert ev.ref.endswith(".png")
+    # The provenance marker: a reviewer can see WHICH tree the shot came from.
+    assert "at " in (ev.note or "")
+    # The bytes actually landed in the durable, spec-scoped store.
+    stored = workspace_with_spec / "specs" / "evidence" / "dq" / ev.ref
+    assert stored.read_bytes() == b"PNGDATA"
+
+
+def test_bare_capture_attaches_nothing(workspace_with_spec: Path):
+    result = runner.invoke(app, ["capture", "--task", "t", "--repo", "app"])
+    assert result.exit_code == 0, result.output
+
+    assert _criterion(workspace_with_spec).evidence == []
+    # Not merely empty — bare capture must not create the store at all.
+    assert not (workspace_with_spec / "specs" / "evidence").exists()
+
+
+def test_store_failure_warns_but_capture_succeeds(workspace_with_spec: Path, monkeypatch):
+    def _boom(*a, **kw):
+        raise OSError("disk went away")
+
+    # Patched where `_attach_evidence` LOOKS the name up (it imports inside the
+    # function body), not where the caller re-exports it.
+    monkeypatch.setattr("mship.core.evidence_store.store_artifact", _boom)
+
+    result = runner.invoke(
+        app, ["capture", "--task", "t", "--repo", "app", "--evidence", "dq:ac1"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "could not attach evidence" in result.output
+    assert "disk went away" in result.output
+    assert "Traceback" not in (result.output or "")
+    assert _criterion(workspace_with_spec).evidence == []
+
+
+def test_malformed_evidence_target_is_actionable(workspace_with_spec: Path):
+    """A typo'd --evidence must say what the shape is, not fail obscurely."""
+    result = runner.invoke(
+        app, ["capture", "--task", "t", "--repo", "app", "--evidence", "dq"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "could not attach evidence" in result.output
+    assert "<spec-id>:<criterion-id>" in result.output
+    assert _criterion(workspace_with_spec).evidence == []

--- a/tests/cli/test_capture_evidence.py
+++ b/tests/cli/test_capture_evidence.py
@@ -145,7 +145,7 @@ def test_evidence_attaches_to_the_named_criterion(workspace_with_spec: Path):
     # The provenance marker: a reviewer can see WHICH tree the shot came from.
     assert "at " in (ev.note or "")
     # The bytes actually landed in the durable, spec-scoped store.
-    stored = workspace_with_spec / "specs" / "evidence" / "dq" / ev.ref
+    stored = workspace_with_spec / ".mothership" / "evidence" / "dq" / ev.ref
     assert stored.read_bytes() == b"PNGDATA"
 
 
@@ -155,7 +155,7 @@ def test_bare_capture_attaches_nothing(workspace_with_spec: Path):
 
     assert _criterion(workspace_with_spec).evidence == []
     # Not merely empty — bare capture must not create the store at all.
-    assert not (workspace_with_spec / "specs" / "evidence").exists()
+    assert not (workspace_with_spec / ".mothership" / "evidence").exists()
 
 
 def test_store_failure_warns_but_capture_succeeds(workspace_with_spec: Path, monkeypatch):

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -35,6 +35,8 @@ from mship.cli import app, container
 from mship.core import remote_client
 from mship.core.remote_exec import ARTIFACT_MARKER, EXIT_MARKER
 from mship.core.run_host import RunHostConnection, RunHostError, RunHostStore
+from mship.core.spec import AcceptanceCriterion, Spec
+from mship.core.spec_store import SpecStore
 from mship.core.state import StateManager, Task, WorkspaceState
 from mship.util.shell import ShellResult, ShellRunner
 
@@ -634,6 +636,76 @@ def test_cli_capture_remote_extracts_artifacts_into_exact_local_captures_path(tm
 
         # The local capture target never ran.
         mock_shell.run_task.assert_not_called()
+    finally:
+        _reset()
+
+
+def test_cli_capture_remote_with_evidence_attaches_artifact_indistinguishably_from_local(
+    tmp_path, monkeypatch,
+):
+    """ac13 (specs/2026-07-12-ac-evidence-loop.md): `mship capture --remote
+    --evidence` must attach evidence from artifacts produced on the mapped run
+    host indistinguishably from a local capture. `_attach_evidence`
+    (cli/capture.py) is wired into the `--remote` branch AFTER `exec_remote`
+    returns, once the extracted artifacts are re-discovered locally as
+    `landed` — this proves that wiring actually runs and produces the same
+    criterion.evidence shape (kind=artifact, content-hashed `.png` ref, a
+    provenance note) that
+    test_capture_evidence.py::test_evidence_attaches_to_the_named_criterion
+    asserts for the LOCAL path."""
+    wt = _write_capture_workspace(tmp_path, run_hosts=["role-x"], platforms=["android"])
+    _seed_task(tmp_path, slug="t1", repos=["app"], worktrees={"app": str(wt)})
+    mock_shell = _configure(tmp_path)
+
+    # provenance_note() shells out through the same container.shell() the
+    # remote path already uses — always against the LOCAL, task-bound
+    # worktree `wt` (the remote only supplies the artifact bytes).
+    def _fake_run(command, cwd=None, **kwargs):
+        assert isinstance(command, str), "ShellRunner.run takes a command string"
+        if command.startswith("git rev-parse"):
+            return ShellResult(returncode=0, stdout="abc1234\n", stderr="")
+        if command.startswith("git branch"):
+            return ShellResult(returncode=0, stdout="* main\n", stderr="")
+        return ShellResult(returncode=0, stdout="", stderr="")  # git status: clean
+
+    mock_shell.run.side_effect = _fake_run
+
+    now = datetime(2026, 7, 25, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(
+        id="dq", title="Dequeue", status="approved",
+        created_at=now, updated_at=now, affected_repos=["app"],
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="The card clears.")],
+    ))
+
+    RunHostStore(tmp_path / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+    tar_bytes = _make_tar({"screen.png": b"PNGDATA"})
+    body = _frame(["captured\n"], exit_code=0, artifact_tar=tar_bytes)
+
+    try:
+        with _ClientPatch(monkeypatch, _recording_handler({}, body)):
+            result = runner.invoke(
+                app, [
+                    "capture", "--task", "t1", "--repo", "app", "--remote=role-x",
+                    "--evidence", "dq:ac1",
+                ]
+            )
+        assert result.exit_code == 0, result.output
+
+        spec = SpecStore(tmp_path / "specs").find_by_id("dq")
+        crit = spec.acceptance_criteria[0]
+        assert len(crit.evidence) == 1
+        ev = crit.evidence[0]
+        # Same shape a LOCAL --evidence capture produces.
+        assert ev.kind == "artifact"
+        assert ev.ref.endswith(".png")
+        assert "at " in (ev.note or "")
+
+        stored = tmp_path / "specs" / "evidence" / "dq" / ev.ref
+        assert stored.read_bytes() == b"PNGDATA"
+
+        mock_shell.run_task.assert_not_called()  # the local capture target never ran
     finally:
         _reset()
 

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -643,7 +643,7 @@ def test_cli_capture_remote_extracts_artifacts_into_exact_local_captures_path(tm
 def test_cli_capture_remote_with_evidence_attaches_artifact_indistinguishably_from_local(
     tmp_path, monkeypatch,
 ):
-    """ac13 (specs/2026-07-12-ac-evidence-loop.md): `mship capture --remote
+    """ac15 (specs/2026-07-26-artifact-evidence-on-phone.md): `mship capture --remote
     --evidence` must attach evidence from artifacts produced on the mapped run
     host indistinguishably from a local capture. `_attach_evidence`
     (cli/capture.py) is wired into the `--remote` branch AFTER `exec_remote`

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -702,7 +702,7 @@ def test_cli_capture_remote_with_evidence_attaches_artifact_indistinguishably_fr
         assert ev.ref.endswith(".png")
         assert "at " in (ev.note or "")
 
-        stored = tmp_path / "specs" / "evidence" / "dq" / ev.ref
+        stored = tmp_path / ".mothership" / "evidence" / "dq" / ev.ref
         assert stored.read_bytes() == b"PNGDATA"
 
         mock_shell.run_task.assert_not_called()  # the local capture target never ran

--- a/tests/core/test_config_evidence_storage.py
+++ b/tests/core/test_config_evidence_storage.py
@@ -18,7 +18,7 @@ def test_evidence_storage_defaults_to_none():
 
 
 def test_evidence_storage_accepts_each_mode():
-    for mode in ("committed", "local", "encrypted"):
+    for mode in ("published", "local", "encrypted"):
         assert (
             WorkspaceConfig(workspace="demo", evidence_storage=mode).evidence_storage
             == mode
@@ -28,6 +28,13 @@ def test_evidence_storage_accepts_each_mode():
 def test_invalid_evidence_storage_value_rejected_by_model():
     with pytest.raises(ValidationError):
         WorkspaceConfig(workspace="demo", evidence_storage="public")
+
+
+def test_spec_storages_own_word_is_not_an_evidence_mode():
+    """`committed` belongs to spec_storage; evidence calls the same exposure
+    `published`. Accepting both spellings would mean two names for one mode."""
+    with pytest.raises(ValidationError):
+        WorkspaceConfig(workspace="demo", evidence_storage="committed")
 
 
 def test_invalid_evidence_storage_fails_at_config_load(tmp_path: Path):
@@ -41,7 +48,7 @@ def test_invalid_evidence_storage_fails_at_config_load(tmp_path: Path):
 def test_evidence_more_exposed_than_spec_fails_at_config_load(tmp_path: Path):
     p = _write(tmp_path, (
         "workspace: w\nrepos: {}\n"
-        "spec_storage: encrypted\nevidence_storage: committed\n"
+        "spec_storage: encrypted\nevidence_storage: published\n"
     ))
     with pytest.raises(Exception) as e:
         ConfigLoader.load(p, require_paths=False)
@@ -49,10 +56,10 @@ def test_evidence_more_exposed_than_spec_fails_at_config_load(tmp_path: Path):
     assert "evidence_storage" in msg and "spec_storage" in msg
 
 
-def test_local_spec_with_committed_evidence_fails_at_config_load(tmp_path: Path):
+def test_local_spec_with_published_evidence_fails_at_config_load(tmp_path: Path):
     p = _write(tmp_path, (
         "workspace: w\nrepos: {}\n"
-        "spec_storage: local\nevidence_storage: committed\n"
+        "spec_storage: local\nevidence_storage: published\n"
     ))
     with pytest.raises(Exception):
         ConfigLoader.load(p, require_paths=False)
@@ -63,7 +70,8 @@ def test_equal_or_less_exposed_evidence_loads_fine(tmp_path: Path):
         ("committed", "local"),
         ("encrypted", "local"),
         ("encrypted", "encrypted"),
-        ("committed", "committed"),
+        # The mapped-equal case: `committed` specs, `published` evidence.
+        ("committed", "published"),
     ):
         p = _write(tmp_path, (
             f"workspace: w\nrepos: {{}}\n"

--- a/tests/core/test_config_evidence_storage.py
+++ b/tests/core/test_config_evidence_storage.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from mship.core.config import ConfigLoader, WorkspaceConfig
+
+
+def test_evidence_storage_defaults_to_none():
+    cfg = WorkspaceConfig(workspace="demo")
+    assert cfg.evidence_storage is None
+
+
+def test_evidence_storage_accepts_each_mode():
+    for mode in ("committed", "local", "encrypted"):
+        assert (
+            WorkspaceConfig(workspace="demo", evidence_storage=mode).evidence_storage
+            == mode
+        )
+
+
+def test_invalid_evidence_storage_value_rejected_by_model():
+    with pytest.raises(ValidationError):
+        WorkspaceConfig(workspace="demo", evidence_storage="public")
+
+
+def test_invalid_evidence_storage_fails_at_config_load(tmp_path: Path):
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: demo\nevidence_storage: public\n"
+    )
+    with pytest.raises(ValidationError):
+        ConfigLoader.load(tmp_path / "mothership.yaml", require_paths=False)

--- a/tests/core/test_config_evidence_storage.py
+++ b/tests/core/test_config_evidence_storage.py
@@ -6,6 +6,12 @@ from pydantic import ValidationError
 from mship.core.config import ConfigLoader, WorkspaceConfig
 
 
+def _write(tmp_path: Path, contents: str) -> Path:
+    p = tmp_path / "mothership.yaml"
+    p.write_text(contents)
+    return p
+
+
 def test_evidence_storage_defaults_to_none():
     cfg = WorkspaceConfig(workspace="demo")
     assert cfg.evidence_storage is None
@@ -30,3 +36,37 @@ def test_invalid_evidence_storage_fails_at_config_load(tmp_path: Path):
     )
     with pytest.raises(ValidationError):
         ConfigLoader.load(tmp_path / "mothership.yaml", require_paths=False)
+
+
+def test_evidence_more_exposed_than_spec_fails_at_config_load(tmp_path: Path):
+    p = _write(tmp_path, (
+        "workspace: w\nrepos: {}\n"
+        "spec_storage: encrypted\nevidence_storage: committed\n"
+    ))
+    with pytest.raises(Exception) as e:
+        ConfigLoader.load(p, require_paths=False)
+    msg = str(e.value)
+    assert "evidence_storage" in msg and "spec_storage" in msg
+
+
+def test_local_spec_with_committed_evidence_fails_at_config_load(tmp_path: Path):
+    p = _write(tmp_path, (
+        "workspace: w\nrepos: {}\n"
+        "spec_storage: local\nevidence_storage: committed\n"
+    ))
+    with pytest.raises(Exception):
+        ConfigLoader.load(p, require_paths=False)
+
+
+def test_equal_or_less_exposed_evidence_loads_fine(tmp_path: Path):
+    for spec_mode, ev_mode in (
+        ("committed", "local"),
+        ("encrypted", "local"),
+        ("encrypted", "encrypted"),
+        ("committed", "committed"),
+    ):
+        p = _write(tmp_path, (
+            f"workspace: w\nrepos: {{}}\n"
+            f"spec_storage: {spec_mode}\nevidence_storage: {ev_mode}\n"
+        ))
+        ConfigLoader.load(p, require_paths=False)

--- a/tests/core/test_evidence_attach.py
+++ b/tests/core/test_evidence_attach.py
@@ -1,0 +1,48 @@
+import pytest
+
+from mship.core.evidence_attach import EvidenceTarget, parse_evidence_target
+
+
+def test_parses_spec_and_criterion():
+    t = parse_evidence_target("my-spec:ac3")
+    assert t == EvidenceTarget(spec_id="my-spec", criterion_id="ac3")
+
+
+@pytest.mark.parametrize("bad", ["nocolon", ":ac1", "spec:", "a:b:c", ""])
+def test_rejects_malformed_targets(bad):
+    with pytest.raises(ValueError):
+        parse_evidence_target(bad)
+
+
+class _FakeShell:
+    """Stands in for util/shell.py::Shell. Its `run` takes a command STRING."""
+
+    def __init__(self, sha_out: str, status_out: str):
+        self._sha_out = sha_out
+        self._status_out = status_out
+        self.commands: list[str] = []
+
+    def run(self, command, cwd, env=None, timeout=None):
+        self.commands.append(command)
+        out = self._sha_out if "rev-parse" in command else self._status_out
+        return type("R", (), {"stdout": out, "stderr": "", "returncode": 0})()
+
+
+def test_provenance_note_names_the_revision(tmp_path):
+    from mship.core.evidence_attach import provenance_note
+
+    note = provenance_note(tmp_path, _FakeShell("abc1234\n", ""))
+    assert note == "at abc1234"
+
+
+def test_provenance_note_marks_an_uncommitted_tree(tmp_path):
+    from mship.core.evidence_attach import provenance_note
+
+    note = provenance_note(tmp_path, _FakeShell("abc1234\n", " M src/foo.py\n"))
+    assert "abc1234" in note and "uncommitted" in note
+
+
+def test_provenance_note_survives_an_unknown_revision(tmp_path):
+    from mship.core.evidence_attach import provenance_note
+
+    assert "unknown" in provenance_note(tmp_path, _FakeShell("", ""))

--- a/tests/core/test_evidence_attach.py
+++ b/tests/core/test_evidence_attach.py
@@ -15,16 +15,27 @@ def test_rejects_malformed_targets(bad):
 
 
 class _FakeShell:
-    """Stands in for util/shell.py::Shell. Its `run` takes a command STRING."""
+    """Stands in for util/shell.py::Shell. Its `run` takes a command STRING.
 
-    def __init__(self, sha_out: str, status_out: str):
+    `branch_out` defaults to a real branch name — "on a branch" is the common
+    case, so tests that don't care about branch-containment don't have to
+    supply it.
+    """
+
+    def __init__(self, sha_out: str, status_out: str, branch_out: str = "* main\n"):
         self._sha_out = sha_out
         self._status_out = status_out
+        self._branch_out = branch_out
         self.commands: list[str] = []
 
     def run(self, command, cwd, env=None, timeout=None):
         self.commands.append(command)
-        out = self._sha_out if "rev-parse" in command else self._status_out
+        if "rev-parse" in command:
+            out = self._sha_out
+        elif "branch" in command:
+            out = self._branch_out
+        else:
+            out = self._status_out
         return type("R", (), {"stdout": out, "stderr": "", "returncode": 0})()
 
 
@@ -46,3 +57,57 @@ def test_provenance_note_survives_an_unknown_revision(tmp_path):
     from mship.core.evidence_attach import provenance_note
 
     assert "unknown" in provenance_note(tmp_path, _FakeShell("", ""))
+
+
+def test_provenance_note_marks_a_detached_commit_not_on_any_branch(tmp_path):
+    """`git branch --all --contains <sha>` still emits a synthetic
+    `* (HEAD detached ...)` line even when no real branch contains the
+    commit — that line must NOT be mistaken for "on a branch"."""
+    from mship.core.evidence_attach import provenance_note
+
+    note = provenance_note(
+        tmp_path,
+        _FakeShell("abc1234\n", "", branch_out="* (HEAD detached from 1234abc)\n"),
+    )
+    assert "abc1234" in note
+    assert "not on any branch" in note
+    assert "uncommitted" not in note  # clean tree — only the branch marker fires
+
+
+def test_provenance_note_on_a_remote_only_branch_is_not_marked(tmp_path):
+    """A detached checkout of a commit that IS a remote branch's tip is still
+    "on a branch" — `--all` must see remote-tracking branches, not just local
+    ones."""
+    from mship.core.evidence_attach import provenance_note
+
+    note = provenance_note(
+        tmp_path,
+        _FakeShell(
+            "abc1234\n", "",
+            branch_out="* (HEAD detached from 1234abc)\n  remotes/origin/main\n",
+        ),
+    )
+    assert note == "at abc1234"
+
+
+def test_provenance_note_marks_both_dirty_and_detached(tmp_path):
+    from mship.core.evidence_attach import provenance_note
+
+    note = provenance_note(
+        tmp_path,
+        _FakeShell("abc1234\n", " M src/foo.py\n", branch_out="* (HEAD detached from x)\n"),
+    )
+    assert "uncommitted working tree" in note
+    assert "not on any branch" in note
+
+
+def test_provenance_note_unknown_revision_skips_branch_check(tmp_path):
+    """No SHA to check containment for — `git branch --contains` isn't even
+    called, so it can't spuriously add "not on any branch" to an already
+    unresolvable revision."""
+    from mship.core.evidence_attach import provenance_note
+
+    shell = _FakeShell("", "")
+    note = provenance_note(tmp_path, shell)
+    assert note == "at unknown"
+    assert not any("branch" in c for c in shell.commands)

--- a/tests/core/test_evidence_mode.py
+++ b/tests/core/test_evidence_mode.py
@@ -1,3 +1,12 @@
+"""Resolving the effective evidence mode.
+
+The two fields speak slightly different vocabularies on purpose: a spec is
+`committed` into the workspace repo's tracked tree, while an artifact is
+`published` onto an orphan branch in the repo whose PR embeds it. Inheritance
+therefore MAPS rather than copies, and the exposure comparison has to happen in
+the evidence vocabulary — a `spec_storage: committed` workspace must accept
+`evidence_storage: published`, not reject it as "more exposed".
+"""
 import pytest
 from mship.core.evidence_store import EvidenceModeError, resolve_evidence_mode
 
@@ -8,9 +17,10 @@ class _Cfg:
         self.evidence_storage = evidence_storage
 
 
-def test_unset_inherits_spec_storage():
-    for mode in ("committed", "local", "encrypted"):
-        assert resolve_evidence_mode(_Cfg(mode)) == mode
+def test_unset_inherits_spec_storage_mapping_committed_to_published():
+    assert resolve_evidence_mode(_Cfg("committed")) == "published"
+    assert resolve_evidence_mode(_Cfg("local")) == "local"
+    assert resolve_evidence_mode(_Cfg("encrypted")) == "encrypted"
 
 
 def test_explicit_mode_wins_when_not_more_exposed():
@@ -19,13 +29,18 @@ def test_explicit_mode_wins_when_not_more_exposed():
     assert resolve_evidence_mode(_Cfg("encrypted", "encrypted")) == "encrypted"
 
 
+def test_published_evidence_under_a_committed_spec_is_the_equal_case():
+    """The one the mapping exists for: same exposure, different word."""
+    assert resolve_evidence_mode(_Cfg("committed", "published")) == "published"
+
+
 def test_evidence_more_exposed_than_spec_is_refused():
     with pytest.raises(EvidenceModeError) as e:
-        resolve_evidence_mode(_Cfg("encrypted", "committed"))
+        resolve_evidence_mode(_Cfg("encrypted", "published"))
     msg = str(e.value)
     assert "evidence_storage" in msg and "spec_storage" in msg
 
 
-def test_local_spec_with_committed_evidence_is_refused():
+def test_local_spec_with_published_evidence_is_refused():
     with pytest.raises(EvidenceModeError):
-        resolve_evidence_mode(_Cfg("local", "committed"))
+        resolve_evidence_mode(_Cfg("local", "published"))

--- a/tests/core/test_evidence_mode.py
+++ b/tests/core/test_evidence_mode.py
@@ -1,0 +1,31 @@
+import pytest
+from mship.core.evidence_store import EvidenceModeError, resolve_evidence_mode
+
+
+class _Cfg:
+    def __init__(self, spec_storage, evidence_storage=None):
+        self.spec_storage = spec_storage
+        self.evidence_storage = evidence_storage
+
+
+def test_unset_inherits_spec_storage():
+    for mode in ("committed", "local", "encrypted"):
+        assert resolve_evidence_mode(_Cfg(mode)) == mode
+
+
+def test_explicit_mode_wins_when_not_more_exposed():
+    assert resolve_evidence_mode(_Cfg("committed", "local")) == "local"
+    assert resolve_evidence_mode(_Cfg("encrypted", "local")) == "local"
+    assert resolve_evidence_mode(_Cfg("encrypted", "encrypted")) == "encrypted"
+
+
+def test_evidence_more_exposed_than_spec_is_refused():
+    with pytest.raises(EvidenceModeError) as e:
+        resolve_evidence_mode(_Cfg("encrypted", "committed"))
+    msg = str(e.value)
+    assert "evidence_storage" in msg and "spec_storage" in msg
+
+
+def test_local_spec_with_committed_evidence_is_refused():
+    with pytest.raises(EvidenceModeError):
+        resolve_evidence_mode(_Cfg("local", "committed"))

--- a/tests/core/test_evidence_modes_on_disk.py
+++ b/tests/core/test_evidence_modes_on_disk.py
@@ -26,6 +26,13 @@ def test_encrypted_mode_writes_ciphertext_with_enc_suffix(tmp_path):
     assert ref.endswith(ENC_SUFFIX)
     raw = (evidence_dir(tmp_path, "s") / ref).read_bytes()
     assert b"marker" not in raw
+    # A regression where `store_artifact` copies the plaintext IN ADDITION TO
+    # encrypting it would leave a plaintext sibling in the same directory —
+    # checking only the `.enc` file's own bytes wouldn't catch that. Walk
+    # every file under the evidence dir, not just the one named `ref`.
+    for f in evidence_dir(tmp_path, "s").rglob("*"):
+        if f.is_file():
+            assert b"marker" not in f.read_bytes(), f"plaintext leaked into {f}"
 
 
 def test_encrypted_ref_round_trips_through_resolve_ref(tmp_path):

--- a/tests/core/test_evidence_modes_on_disk.py
+++ b/tests/core/test_evidence_modes_on_disk.py
@@ -11,8 +11,8 @@ def _png(tmp_path):
     return p
 
 
-def test_committed_mode_writes_plaintext(tmp_path):
-    ref = store_artifact(tmp_path, "s", _png(tmp_path), mode="committed")
+def test_published_mode_writes_plaintext(tmp_path):
+    ref = store_artifact(tmp_path, "s", _png(tmp_path), mode="published")
     assert (evidence_dir(tmp_path, "s") / ref).read_bytes().endswith(b"marker")
 
 

--- a/tests/core/test_evidence_modes_on_disk.py
+++ b/tests/core/test_evidence_modes_on_disk.py
@@ -1,0 +1,35 @@
+from mship.core.evidence_store import (
+    ENC_SUFFIX,
+    evidence_dir,
+    resolve_ref,
+    store_artifact,
+)
+
+
+def _png(tmp_path):
+    p = tmp_path / "screen.png"; p.write_bytes(b"\x89PNG plaintext marker")
+    return p
+
+
+def test_committed_mode_writes_plaintext(tmp_path):
+    ref = store_artifact(tmp_path, "s", _png(tmp_path), mode="committed")
+    assert (evidence_dir(tmp_path, "s") / ref).read_bytes().endswith(b"marker")
+
+
+def test_local_mode_gitignores_the_evidence_dir(tmp_path):
+    store_artifact(tmp_path, "s", _png(tmp_path), mode="local")
+    assert "specs/evidence/" in (tmp_path / ".gitignore").read_text()
+
+
+def test_encrypted_mode_writes_ciphertext_with_enc_suffix(tmp_path):
+    ref = store_artifact(tmp_path, "s", _png(tmp_path), mode="encrypted")
+    assert ref.endswith(ENC_SUFFIX)
+    raw = (evidence_dir(tmp_path, "s") / ref).read_bytes()
+    assert b"marker" not in raw
+
+
+def test_encrypted_ref_round_trips_through_resolve_ref(tmp_path):
+    """An encrypted ref must remain resolvable, or encrypted-mode evidence is
+    unservable — and that would not surface until someone set the mode."""
+    ref = store_artifact(tmp_path, "s", _png(tmp_path), mode="encrypted")
+    assert resolve_ref(tmp_path, "s", ref).is_file()

--- a/tests/core/test_evidence_modes_on_disk.py
+++ b/tests/core/test_evidence_modes_on_disk.py
@@ -16,9 +16,13 @@ def test_committed_mode_writes_plaintext(tmp_path):
     assert (evidence_dir(tmp_path, "s") / ref).read_bytes().endswith(b"marker")
 
 
-def test_local_mode_gitignores_the_evidence_dir(tmp_path):
-    store_artifact(tmp_path, "s", _png(tmp_path), mode="local")
-    assert "specs/evidence/" in (tmp_path / ".gitignore").read_text()
+def test_local_mode_writes_plaintext_and_no_gitignore_of_its_own(tmp_path):
+    """The whole store lives under the gitignored `.mothership/`, so `local`
+    needs no ignore entry of its own — writing one would only add a stray line
+    to the operator's .gitignore for no gain."""
+    ref = store_artifact(tmp_path, "s", _png(tmp_path), mode="local")
+    assert (evidence_dir(tmp_path, "s") / ref).read_bytes().endswith(b"marker")
+    assert not (tmp_path / ".gitignore").exists()
 
 
 def test_encrypted_mode_writes_ciphertext_with_enc_suffix(tmp_path):

--- a/tests/core/test_evidence_resolve.py
+++ b/tests/core/test_evidence_resolve.py
@@ -12,7 +12,7 @@ from mship.core.evidence_store import (
 
 def _stored(tmp_path):
     src = tmp_path / "screen.png"; src.write_bytes(b"bytes")
-    return store_artifact(tmp_path, "s", src, mode="committed")
+    return store_artifact(tmp_path, "s", src, mode="published")
 
 
 def test_resolves_a_stored_ref(tmp_path):

--- a/tests/core/test_evidence_resolve.py
+++ b/tests/core/test_evidence_resolve.py
@@ -1,0 +1,98 @@
+import os
+
+import pytest
+
+from mship.core.evidence_store import (
+    BadEvidenceRef,
+    evidence_dir,
+    resolve_ref,
+    store_artifact,
+)
+
+
+def _stored(tmp_path):
+    src = tmp_path / "screen.png"; src.write_bytes(b"bytes")
+    return store_artifact(tmp_path, "s", src, mode="committed")
+
+
+def test_resolves_a_stored_ref(tmp_path):
+    ref = _stored(tmp_path)
+    assert resolve_ref(tmp_path, "s", ref).read_bytes() == b"bytes"
+
+
+@pytest.mark.parametrize("bad", [
+    "../../etc/passwd",
+    "/etc/passwd",
+    "..%2Fescape.png",
+    "sub/dir.png",
+    "no-extension",
+    "deadbeef.exe",
+    "",
+])
+def test_refuses_malformed_or_escaping_refs(tmp_path, bad):
+    _stored(tmp_path)
+    with pytest.raises(BadEvidenceRef):
+        resolve_ref(tmp_path, "s", bad)
+
+
+def test_refuses_a_well_formed_hash_with_an_unserved_extension(tmp_path):
+    """`deadbeef.exe` is refused for its hash length; a full-length hash with a
+    bad extension must still be refused, by the extension check."""
+    _stored(tmp_path)
+    with pytest.raises(BadEvidenceRef):
+        resolve_ref(tmp_path, "s", "deadbeefcafe.exe")
+
+
+def test_refuses_a_ref_with_a_trailing_newline(tmp_path):
+    """A regex anchored with `$` would accept this; the ref must be exact."""
+    ref = _stored(tmp_path)
+    with pytest.raises(BadEvidenceRef):
+        resolve_ref(tmp_path, "s", ref + "\n")
+
+
+def test_refuses_a_symlink_pointing_out_of_the_store(tmp_path):
+    _stored(tmp_path)
+    secret = tmp_path / "secret.png"; secret.write_bytes(b"nope")
+    link = evidence_dir(tmp_path, "s") / "aaaaaaaaaaaa.png"
+    os.symlink(secret, link)
+    with pytest.raises(BadEvidenceRef):
+        resolve_ref(tmp_path, "s", "aaaaaaaaaaaa.png")
+
+
+def test_refuses_a_symlink_pointing_inside_the_store(tmp_path):
+    """Nothing in the store is legitimately a symlink: the ref attests the
+    content hash of a regular file. Refuse links regardless of target so
+    containment never depends on where one happens to point."""
+    ref = _stored(tmp_path)
+    link = evidence_dir(tmp_path, "s") / "bbbbbbbbbbbb.png"
+    os.symlink(evidence_dir(tmp_path, "s") / ref, link)
+    with pytest.raises(BadEvidenceRef):
+        resolve_ref(tmp_path, "s", "bbbbbbbbbbbb.png")
+
+
+def test_resolves_when_the_workspace_root_is_reached_through_a_symlink(tmp_path):
+    """`root` is realpath'd, so a symlinked ancestor (macOS /tmp) must not make
+    a legitimately stored ref look like an escape."""
+    real = tmp_path / "real"; real.mkdir()
+    ref = _stored(real)
+    alias = tmp_path / "alias"
+    os.symlink(real, alias)
+    assert resolve_ref(alias, "s", ref).read_bytes() == b"bytes"
+
+
+@pytest.mark.parametrize("bad_spec", ["../other-spec", "../../..", "a/b", ""])
+def test_refuses_a_spec_id_that_escapes_the_evidence_store(tmp_path, bad_spec):
+    """`spec_id` also arrives from the request path, so one spec's ref must not
+    be readable under another spec's id."""
+    ref = _stored(tmp_path)
+    other = tmp_path / "specs" / "evidence" / "other-spec"
+    other.mkdir(parents=True)
+    (other / ref).write_bytes(b"someone else's evidence")
+    with pytest.raises(BadEvidenceRef):
+        resolve_ref(tmp_path, bad_spec, ref)
+
+
+def test_missing_ref_raises(tmp_path):
+    _stored(tmp_path)
+    with pytest.raises(BadEvidenceRef):
+        resolve_ref(tmp_path, "s", "ffffffffffff.png")

--- a/tests/core/test_evidence_resolve.py
+++ b/tests/core/test_evidence_resolve.py
@@ -85,7 +85,7 @@ def test_refuses_a_spec_id_that_escapes_the_evidence_store(tmp_path, bad_spec):
     """`spec_id` also arrives from the request path, so one spec's ref must not
     be readable under another spec's id."""
     ref = _stored(tmp_path)
-    other = tmp_path / "specs" / "evidence" / "other-spec"
+    other = evidence_dir(tmp_path, "other-spec")
     other.mkdir(parents=True)
     (other / ref).write_bytes(b"someone else's evidence")
     with pytest.raises(BadEvidenceRef):

--- a/tests/core/test_evidence_store.py
+++ b/tests/core/test_evidence_store.py
@@ -30,7 +30,7 @@ def test_different_content_yields_different_ref(tmp_path):
 def test_store_lands_under_specs_evidence_spec_id(tmp_path):
     src = tmp_path / "layout.xml"; src.write_text("<hierarchy/>")
     store_artifact(tmp_path, "my-spec", src, mode="committed")
-    assert (tmp_path / "specs" / "evidence" / "my-spec").is_dir()
+    assert (tmp_path / ".mothership" / "evidence" / "my-spec").is_dir()
 
 
 def test_unsupported_extension_is_refused(tmp_path):

--- a/tests/core/test_evidence_store.py
+++ b/tests/core/test_evidence_store.py
@@ -40,3 +40,18 @@ def test_unsupported_extension_is_refused(tmp_path):
     src = tmp_path / "payload.exe"; src.write_bytes(b"MZ")
     with pytest.raises(EvidenceStoreError):
         store_artifact(tmp_path, "s", src, mode="committed")
+
+
+def test_oversized_artifact_is_refused_at_store_time(tmp_path, monkeypatch):
+    """The operator hears about an over-cap artifact when it is captured, not
+    later when a phone fails to fetch it. The cap VALUE is a judgement call, so
+    the test moves it rather than materialising megabytes."""
+    import pytest
+    from mship.core import evidence_store
+    from mship.core.evidence_store import EvidenceStoreError
+
+    monkeypatch.setattr(evidence_store, "MAX_EVIDENCE_BYTES", 8)
+    src = tmp_path / "screen.png"; src.write_bytes(b"\x89PNG far too many bytes")
+    with pytest.raises(EvidenceStoreError, match="limit"):
+        store_artifact(tmp_path, "s", src, mode="committed")
+    assert not (evidence_dir(tmp_path, "s")).exists()

--- a/tests/core/test_evidence_store.py
+++ b/tests/core/test_evidence_store.py
@@ -27,7 +27,7 @@ def test_different_content_yields_different_ref(tmp_path):
            store_artifact(tmp_path, "s", b, mode="published")
 
 
-def test_store_lands_under_specs_evidence_spec_id(tmp_path):
+def test_store_lands_under_mothership_evidence_spec_id(tmp_path):
     src = tmp_path / "layout.xml"; src.write_text("<hierarchy/>")
     store_artifact(tmp_path, "my-spec", src, mode="published")
     assert (tmp_path / ".mothership" / "evidence" / "my-spec").is_dir()

--- a/tests/core/test_evidence_store.py
+++ b/tests/core/test_evidence_store.py
@@ -1,0 +1,42 @@
+from mship.core.evidence_store import evidence_dir, store_artifact
+
+
+def test_store_returns_bare_filename_and_writes_bytes(tmp_path):
+    src = tmp_path / "screen.png"
+    src.write_bytes(b"\x89PNG fake bytes")
+
+    ref = store_artifact(tmp_path, "my-spec", src, mode="committed")
+
+    assert "/" not in ref and "\\" not in ref
+    assert ref.endswith(".png")
+    landed = evidence_dir(tmp_path, "my-spec") / ref
+    assert landed.read_bytes() == b"\x89PNG fake bytes"
+
+
+def test_identical_content_yields_identical_ref(tmp_path):
+    a = tmp_path / "a.png"; a.write_bytes(b"same")
+    b = tmp_path / "b.png"; b.write_bytes(b"same")
+    assert store_artifact(tmp_path, "s", a, mode="committed") == \
+           store_artifact(tmp_path, "s", b, mode="committed")
+
+
+def test_different_content_yields_different_ref(tmp_path):
+    a = tmp_path / "a.png"; a.write_bytes(b"one")
+    b = tmp_path / "b.png"; b.write_bytes(b"two")
+    assert store_artifact(tmp_path, "s", a, mode="committed") != \
+           store_artifact(tmp_path, "s", b, mode="committed")
+
+
+def test_store_lands_under_specs_evidence_spec_id(tmp_path):
+    src = tmp_path / "layout.xml"; src.write_text("<hierarchy/>")
+    store_artifact(tmp_path, "my-spec", src, mode="committed")
+    assert (tmp_path / "specs" / "evidence" / "my-spec").is_dir()
+
+
+def test_unsupported_extension_is_refused(tmp_path):
+    import pytest
+    from mship.core.evidence_store import EvidenceStoreError
+
+    src = tmp_path / "payload.exe"; src.write_bytes(b"MZ")
+    with pytest.raises(EvidenceStoreError):
+        store_artifact(tmp_path, "s", src, mode="committed")

--- a/tests/core/test_evidence_store.py
+++ b/tests/core/test_evidence_store.py
@@ -5,7 +5,7 @@ def test_store_returns_bare_filename_and_writes_bytes(tmp_path):
     src = tmp_path / "screen.png"
     src.write_bytes(b"\x89PNG fake bytes")
 
-    ref = store_artifact(tmp_path, "my-spec", src, mode="committed")
+    ref = store_artifact(tmp_path, "my-spec", src, mode="published")
 
     assert "/" not in ref and "\\" not in ref
     assert ref.endswith(".png")
@@ -16,20 +16,20 @@ def test_store_returns_bare_filename_and_writes_bytes(tmp_path):
 def test_identical_content_yields_identical_ref(tmp_path):
     a = tmp_path / "a.png"; a.write_bytes(b"same")
     b = tmp_path / "b.png"; b.write_bytes(b"same")
-    assert store_artifact(tmp_path, "s", a, mode="committed") == \
-           store_artifact(tmp_path, "s", b, mode="committed")
+    assert store_artifact(tmp_path, "s", a, mode="published") == \
+           store_artifact(tmp_path, "s", b, mode="published")
 
 
 def test_different_content_yields_different_ref(tmp_path):
     a = tmp_path / "a.png"; a.write_bytes(b"one")
     b = tmp_path / "b.png"; b.write_bytes(b"two")
-    assert store_artifact(tmp_path, "s", a, mode="committed") != \
-           store_artifact(tmp_path, "s", b, mode="committed")
+    assert store_artifact(tmp_path, "s", a, mode="published") != \
+           store_artifact(tmp_path, "s", b, mode="published")
 
 
 def test_store_lands_under_specs_evidence_spec_id(tmp_path):
     src = tmp_path / "layout.xml"; src.write_text("<hierarchy/>")
-    store_artifact(tmp_path, "my-spec", src, mode="committed")
+    store_artifact(tmp_path, "my-spec", src, mode="published")
     assert (tmp_path / ".mothership" / "evidence" / "my-spec").is_dir()
 
 
@@ -39,7 +39,7 @@ def test_unsupported_extension_is_refused(tmp_path):
 
     src = tmp_path / "payload.exe"; src.write_bytes(b"MZ")
     with pytest.raises(EvidenceStoreError):
-        store_artifact(tmp_path, "s", src, mode="committed")
+        store_artifact(tmp_path, "s", src, mode="published")
 
 
 def test_oversized_artifact_is_refused_at_store_time(tmp_path, monkeypatch):
@@ -53,5 +53,5 @@ def test_oversized_artifact_is_refused_at_store_time(tmp_path, monkeypatch):
     monkeypatch.setattr(evidence_store, "MAX_EVIDENCE_BYTES", 8)
     src = tmp_path / "screen.png"; src.write_bytes(b"\x89PNG far too many bytes")
     with pytest.raises(EvidenceStoreError, match="limit"):
-        store_artifact(tmp_path, "s", src, mode="committed")
+        store_artifact(tmp_path, "s", src, mode="published")
     assert not (evidence_dir(tmp_path, "s")).exists()

--- a/tests/core/test_finish_evidence_publish.py
+++ b/tests/core/test_finish_evidence_publish.py
@@ -321,6 +321,28 @@ def test_unrelated_uncommitted_work_is_never_swept_in(workspace, member, origin)
     assert "A  staged-by-operator.md" in status, "the operator's staged work moved"
 
 
+def test_the_store_stays_invisible_to_git_in_a_single_repo_workspace(tmp_path, origin):
+    """The shape the old design got wrong: the workspace root IS the product
+    repo, so the store sits inside it. It must never reach git — not as an
+    untracked file, not as a commit — and publishing must not change that."""
+    repo = _init_member(tmp_path, origin, "single")
+    # As `mship spawn` writes it (core/worktree.py); asserted there too.
+    (repo / ".gitignore").write_text(".worktrees\n.mothership\n")
+    _git(repo, "add", "--", ".gitignore")
+    _git(repo, "commit", "-qm", "ignore mship runtime dirs")
+    _git(repo, "push", "-q", "origin", "main")
+    _store(repo)
+    before = _main_shas(repo, origin)
+
+    block, warning = _finish(repo, repo)
+
+    assert warning is None, warning
+    _assert_url_resolves(origin, _embedded_url(block))
+    assert _status(repo) == "", "the evidence store showed up in git status"
+    assert _main_shas(repo, origin) == before
+    assert _git(origin, "ls-tree", "-r", "--name-only", "main") == ".gitignore\nproduct.py"
+
+
 def test_local_mode_touches_neither_the_shell_nor_the_repo(workspace, member, origin):
     """Under `local` nothing may leave the machine, so the mode gate must
     short-circuit before any git call at all."""

--- a/tests/core/test_finish_evidence_publish.py
+++ b/tests/core/test_finish_evidence_publish.py
@@ -1,17 +1,22 @@
 """The seam between writing an evidence artifact and linking to it, exercised
-end to end against a real git repo.
+end to end against real git repos.
 
 The bug this covers was not in either half. `capture --evidence` correctly wrote
-a file; `workspace_raw_base` correctly answered "is HEAD on origin?". Nobody
-committed the file, and nobody checked that the sha in the URL contained it — so
-the ordinary sequence emitted an image URL that 404ed, silently. Unit tests on
-each half would have stayed green throughout. So everything here drives
-`acceptance_block_for_finish` (what `mship finish` actually calls) against a real
-working clone with a real origin, and asserts on the repo's state afterwards as
-well as on the rendered block.
+a file; the URL builder correctly answered "is this sha on origin?". Nobody put
+the bytes anywhere GitHub could serve them, and nobody checked that the sha in
+the URL contained them — so the ordinary sequence emitted an image URL that
+404ed, silently. Unit tests on each half would have stayed green throughout.
 
-The origin is a local bare repo living at a path that happens to parse as a
-GitHub slug: real git plumbing, real push semantics, no network.
+So everything here drives `acceptance_block_for_finish` (what `mship finish`
+actually calls) against a real working clone with a real bare origin, and asserts
+on both repos' state afterwards as well as on the rendered block. The origin is a
+local bare repo living at a path that happens to parse as a GitHub slug: real git
+plumbing, real push semantics, no network.
+
+The target is the MEMBER REPO the pull request goes to, on an orphan
+`mship-evidence` branch — never the default branch, never the workspace repo (the
+store is machine-local and lives outside any repo's tree). `main` being untouched
+is the load-bearing property, so it is asserted explicitly and not just implied.
 """
 import subprocess
 from datetime import datetime, timezone
@@ -20,13 +25,15 @@ from types import SimpleNamespace
 
 import pytest
 
+from mship.core.evidence_store import evidence_dir
+from mship.core.evidence_url import ORPHAN_BRANCH
 from mship.core.pr import acceptance_block_for_finish
 from mship.core.spec import AcceptanceCriterion, AcceptanceEvidence, Spec
 from mship.util.shell import ShellRunner
 
 SPEC_ID = "my-spec"
 IMAGE_REF = "a1b2c3d4e5f6.png"
-RELPATH = f"specs/evidence/{SPEC_ID}/{IMAGE_REF}"
+TREE_PATH = f"{SPEC_ID}/{IMAGE_REF}"
 PNG_BYTES = b"\x89PNG\r\n\x1a\n-not-really-a-png-but-git-does-not-care"
 
 
@@ -36,25 +43,30 @@ def _git(repo: Path, *args: str) -> str:
     ).stdout.strip()
 
 
+def _git_ok(repo: Path, *args: str) -> bool:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True).returncode == 0
+
+
 def _status(repo: Path) -> str:
     """`git status --porcelain -uall`, UNstripped — the leading column is the
-    staged/unstaged distinction these tests are entirely about."""
+    staged/unstaged distinction several of these tests are about."""
     return subprocess.run(
         ["git", "status", "--porcelain", "-uall"],
         cwd=repo, capture_output=True, text=True, check=True,
     ).stdout
 
 
-def _spec() -> Spec:
+def _spec(*refs: str) -> Spec:
     now = datetime(2026, 7, 26, tzinfo=timezone.utc)
     return Spec(
         id=SPEC_ID, title="My spec", status="approved",
         created_at=now, updated_at=now,
         acceptance_criteria=[
             AcceptanceCriterion(
-                id="ac1", text="the screen renders", verdict="approved",
-                evidence=[AcceptanceEvidence(kind="artifact", ref=IMAGE_REF)],
+                id=f"ac{i}", text="the screen renders", verdict="approved",
+                evidence=[AcceptanceEvidence(kind="artifact", ref=ref)],
             )
+            for i, ref in enumerate(refs or (IMAGE_REF,), start=1)
         ],
     )
 
@@ -64,8 +76,8 @@ def _config(evidence_storage=None, spec_storage="committed"):
 
 
 class _SpyShell(ShellRunner):
-    """A real ShellRunner that remembers every command, so a test can assert the
-    workspace repo was never touched at all."""
+    """A real ShellRunner that remembers every command, so a test can assert no
+    git work happened at all."""
 
     def __init__(self) -> None:
         self.commands: list[str] = []
@@ -75,41 +87,61 @@ class _SpyShell(ShellRunner):
         return super().run(command, cwd, env=env, timeout=timeout)
 
 
-@pytest.fixture
-def origin(tmp_path: Path) -> Path:
-    bare = tmp_path / "github.com" / "o" / "r.git"
-    bare.parent.mkdir(parents=True)
+def _init_origin(tmp_path: Path, name: str = "r") -> Path:
+    bare = tmp_path / "github.com" / "o" / f"{name}.git"
+    bare.parent.mkdir(parents=True, exist_ok=True)
     subprocess.run(["git", "init", "--bare", "-q", str(bare)], check=True)
     return bare
 
 
-@pytest.fixture
-def workspace(tmp_path: Path, origin: Path) -> Path:
-    """A workspace clone with one pushed commit, an evidence artifact sitting
-    UNTRACKED on disk exactly as `capture --evidence` leaves it, and the
-    operator's own prose already committed."""
-    repo = tmp_path / "workspace"
+def _init_member(tmp_path: Path, origin: Path, name: str = "member") -> Path:
+    """A member repo with one pushed commit on `main` — the repo a PR targets."""
+    repo = tmp_path / name
     repo.mkdir()
     _git(repo, "init", "-q", "-b", "main")
     _git(repo, "config", "user.email", "t@example.com")
     _git(repo, "config", "user.name", "t")
     _git(repo, "config", "commit.gpgsign", "false")
     _git(repo, "remote", "add", "origin", str(origin))
-    (repo / "specs").mkdir()
-    (repo / "specs" / f"{SPEC_ID}.md").write_text("the operator's prose\n")
+    (repo / "product.py").write_text("the product's own code\n")
     _git(repo, "add", ".")
-    _git(repo, "commit", "-qm", "spec")
+    _git(repo, "commit", "-qm", "product")
     _git(repo, "push", "-q", "-u", "origin", "main")
-
-    artifact = repo / RELPATH
-    artifact.parent.mkdir(parents=True)
-    artifact.write_bytes(PNG_BYTES)
     return repo
 
 
-def _finish(repo: Path, config=None, shell=None) -> tuple[str, str | None]:
+def _store(workspace: Path, ref: str = IMAGE_REF, body: bytes = PNG_BYTES) -> Path:
+    """Seed the machine-local evidence store exactly as `capture --evidence`
+    leaves it. Located via evidence_store so this says WHAT, not where."""
+    path = evidence_dir(workspace, SPEC_ID) / ref
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(body)
+    return path
+
+
+@pytest.fixture
+def origin(tmp_path: Path) -> Path:
+    return _init_origin(tmp_path)
+
+
+@pytest.fixture
+def member(tmp_path: Path, origin: Path) -> Path:
+    return _init_member(tmp_path, origin)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """The workspace root holding the local evidence store. Deliberately NOT a
+    git repo: nothing in publication may depend on it being one."""
+    root = tmp_path / "workspace"
+    root.mkdir()
+    _store(root)
+    return root
+
+
+def _finish(workspace: Path, repo: Path, spec=None, config=None, shell=None):
     return acceptance_block_for_finish(
-        _spec(), repo, shell or ShellRunner(), config or _config(),
+        spec or _spec(), workspace, repo, shell or ShellRunner(), config or _config(),
     )
 
 
@@ -122,266 +154,277 @@ def _embedded_url(block: str) -> str | None:
 
 
 def _sha_from(url: str) -> str:
-    # .../<owner>/<repo>/<sha>/specs/evidence/<spec>/<ref>
-    return url.split("/")[-5]
+    # .../<owner>/<repo>/<sha>/<spec-id>/<ref>
+    return url.split("/")[-3]
 
 
-def _assert_url_resolves(repo: Path, origin: Path, url: str) -> None:
-    """The URL is not merely well-formed: its sha contains the artifact, and
-    that sha is on the remote. Together that is exactly what
-    raw.githubusercontent.com needs to return bytes instead of a 404."""
+def _blob_at(repo: Path, sha: str, tree_path: str) -> bytes:
+    return subprocess.run(
+        ["git", "cat-file", "-p", f"{sha}:{tree_path}"],
+        cwd=repo, capture_output=True, check=True,
+    ).stdout
+
+
+def _assert_url_resolves(origin: Path, url: str, tree_path: str = TREE_PATH) -> str:
+    """The URL is not merely well-formed: the sha it pins is on the REMOTE and
+    carries the artifact's bytes. Together that is exactly what
+    raw.githubusercontent.com needs to return an image instead of a 404.
+
+    Asserted against the bare origin, not the local clone — a local-only commit
+    is the one wrong answer here.
+    """
     sha = _sha_from(url)
-    assert url.endswith(f"/{sha}/{RELPATH}")
-    assert (
-        subprocess.run(
-            ["git", "cat-file", "-e", f"{sha}:{RELPATH}"], cwd=repo
-        ).returncode == 0
-    ), "the pinned sha does not contain the artifact"
-    # Ask the remote, not the local clone: the bytes must be fetchable by GitHub.
-    assert subprocess.run(
-        ["git", "cat-file", "-e", f"{sha}:{RELPATH}"], cwd=origin
-    ).returncode == 0, "the pinned sha is not on the remote"
+    assert url.endswith(f"/{sha}/{tree_path}"), url
+    assert _blob_at(origin, sha, tree_path) == PNG_BYTES, "the remote's bytes differ"
+    return sha
 
 
-# --- the three states an artifact can be in when finish runs ---------------
+def _main_shas(repo: Path, origin: Path) -> tuple[str, str]:
+    return _git(repo, "rev-parse", "main"), _git(origin, "rev-parse", "main")
 
 
-def test_never_committed_artifact_is_published_and_embedded(workspace, origin):
-    """The ordinary sequence: `capture --evidence`, then `finish` without ever
-    touching `specs/`. This is the case that used to emit a 404."""
-    block, warning = _finish(workspace)
+# --- the ordinary path -------------------------------------------------------
+
+
+def test_first_publication_creates_the_orphan_branch_and_embeds(workspace, member, origin):
+    """The ordinary sequence: `capture --evidence`, then `finish`. No evidence
+    branch exists yet, so this is also the branch-creation case."""
+    block, warning = _finish(workspace, member)
 
     assert warning is None
     url = _embedded_url(block)
     assert url is not None, f"expected an embed, got:\n{block}"
-    _assert_url_resolves(workspace, origin, url)
+    assert url.startswith("https://raw.githubusercontent.com/o/r/")
+    _assert_url_resolves(origin, url)
+    assert _git(origin, "rev-parse", ORPHAN_BRANCH)
 
 
-def test_committed_but_unpushed_artifact_is_pushed_and_embedded(workspace, origin):
-    _git(workspace, "add", "--", RELPATH)
-    _git(workspace, "commit", "-qm", "evidence, by hand")
+def test_main_is_never_touched_locally_or_on_the_origin(workspace, member, origin):
+    """ac6, and the whole point of the rework. Publishing must not create a
+    commit on the default branch, move it, or push it — in either repo."""
+    before = _main_shas(member, origin)
+    head_before = _git(member, "rev-parse", "HEAD")
+    branch_before = _git(member, "rev-parse", "--abbrev-ref", "HEAD")
+    status_before = _status(member)
 
-    block, warning = _finish(workspace)
+    block, warning = _finish(workspace, member)
+
+    assert _embedded_url(block) is not None and warning is None
+    assert _main_shas(member, origin) == before, "the default branch moved"
+    assert _git(member, "rev-parse", "HEAD") == head_before
+    assert _git(member, "rev-parse", "--abbrev-ref", "HEAD") == branch_before
+    assert _status(member) == status_before, "the working tree or index changed"
+    # And no local branch was created either: the commit is pushed by sha.
+    assert ORPHAN_BRANCH not in _git(member, "branch", "--list")
+
+
+def test_the_orphan_branch_shares_no_history_with_main(workspace, member, origin):
+    block, _ = _finish(workspace, member)
+    sha = _sha_from(_embedded_url(block))
+
+    assert not _git_ok(member, "merge-base", "--is-ancestor", sha, "main")
+    assert not _git_ok(member, "merge-base", "--is-ancestor", "main", sha)
+    assert not _git_ok(origin, "merge-base", "--is-ancestor", ORPHAN_BRANCH, "main")
+    # Nothing of the product is in that tree, and nothing of the evidence is in main's.
+    assert _git(origin, "ls-tree", "-r", "--name-only", ORPHAN_BRANCH) == TREE_PATH
+    assert TREE_PATH not in _git(origin, "ls-tree", "-r", "--name-only", "main")
+
+
+def test_a_second_publication_accumulates_rather_than_replacing(workspace, member, origin):
+    """Published artifacts pile up on the branch: a later PR's screenshots must
+    not silently drop an earlier one's."""
+    _finish(workspace, member)
+    first = _git(origin, "rev-parse", ORPHAN_BRANCH)
+
+    second_ref = "b1b2c3d4e5f6.png"
+    _store(workspace, second_ref)
+    block, warning = _finish(workspace, member, spec=_spec(IMAGE_REF, second_ref))
 
     assert warning is None
-    url = _embedded_url(block)
-    assert url is not None, f"expected an embed, got:\n{block}"
-    _assert_url_resolves(workspace, origin, url)
+    tip = _git(origin, "rev-parse", ORPHAN_BRANCH)
+    assert tip != first
+    assert _git(origin, "rev-parse", f"{tip}^") == first, "the new commit lost its parent"
+    listed = _git(origin, "ls-tree", "-r", "--name-only", tip).split()
+    assert listed == [TREE_PATH, f"{SPEC_ID}/{second_ref}"]
 
 
-def test_already_tracked_and_pushed_embeds_without_a_new_commit(workspace, origin):
-    _git(workspace, "add", "--", RELPATH)
-    _git(workspace, "commit", "-qm", "evidence, by hand")
-    _git(workspace, "push", "-q", "origin", "main")
-    before = _git(workspace, "rev-parse", "HEAD")
+def test_republishing_identical_bytes_makes_no_new_commit(workspace, member, origin):
+    """Refs are content hashes, so a re-run of finish publishes the same tree.
+    Stacking an empty commit each time would be noise on a shared branch."""
+    _finish(workspace, member)
+    first = _git(origin, "rev-parse", ORPHAN_BRANCH)
 
-    block, warning = _finish(workspace)
+    block, warning = _finish(workspace, member)
 
     assert warning is None
-    assert _git(workspace, "rev-parse", "HEAD") == before, "made a pointless commit"
-    url = _embedded_url(block)
-    assert url is not None
-    _assert_url_resolves(workspace, origin, url)
+    assert _git(origin, "rev-parse", ORPHAN_BRANCH) == first
+    assert _sha_from(_embedded_url(block)) == first
 
 
-# --- the narrowness guarantee ----------------------------------------------
+def test_bytes_deleted_from_the_store_still_embed_once_published(workspace, member, origin):
+    """The store is machine-local and nothing stops an operator clearing it. What
+    is already on the branch stays embeddable."""
+    _finish(workspace, member)
+    (evidence_dir(workspace, SPEC_ID) / IMAGE_REF).unlink()
+
+    block, warning = _finish(workspace, member)
+
+    assert warning is None
+    _assert_url_resolves(origin, _embedded_url(block))
 
 
-def test_unrelated_uncommitted_work_is_never_swept_in(workspace):
-    """The one that protects the licence. finish writes to the operator's own
-    workspace repo, so it must commit the artifact and NOTHING else — not their
-    untracked notes, not their edits in flight, not even work they had already
-    staged themselves."""
-    (workspace / "untracked-notes.md").write_text("private thinking\n")
-    (workspace / "specs" / f"{SPEC_ID}.md").write_text("the operator's EDITED prose\n")
-    (workspace / "staged-by-operator.md").write_text("half-done\n")
-    _git(workspace, "add", "--", "staged-by-operator.md")
+def test_the_evidence_commit_is_self_explanatory(workspace, member, origin):
+    """This commit lands in the operator's own repo, so it has to say what it is
+    and who made it without them having to go digging."""
+    _finish(workspace, member)
 
-    _finish(workspace)
+    subject = _git(origin, "log", "-1", "--format=%s", ORPHAN_BRANCH)
+    body = _git(origin, "log", "-1", "--format=%b", ORPHAN_BRANCH)
+    assert subject == f"chore(evidence): publish 1 artifact for {SPEC_ID}"
+    assert "mship finish" in body
+    assert ORPHAN_BRANCH in body
+    # The operator's own identity, as `mship commit` also uses — no impostor author.
+    assert _git(origin, "log", "-1", "--format=%an <%ae>", ORPHAN_BRANCH) == "t <t@example.com>"
 
-    committed = _git(workspace, "show", "--name-only", "--format=", "HEAD").split()
-    assert committed == [RELPATH]
 
-    status = _status(workspace)
+def test_a_detached_head_repo_publishes_anyway(workspace, member, origin):
+    """Publication never consults HEAD — it builds the commit with plumbing — so
+    a worktree parked on a detached HEAD is not a reason to degrade."""
+    _git(member, "checkout", "-q", "--detach")
+    before = _git(member, "rev-parse", "HEAD")
+
+    block, warning = _finish(workspace, member)
+
+    assert warning is None
+    _assert_url_resolves(origin, _embedded_url(block))
+    assert _git(member, "rev-parse", "HEAD") == before
+
+
+# --- the narrowness guarantee ------------------------------------------------
+
+
+def test_unrelated_uncommitted_work_is_never_swept_in(workspace, member, origin):
+    """The one that protects the licence. finish publishes the referenced
+    artifacts and NOTHING else — not the operator's untracked notes, not their
+    edits in flight, not even work they had already staged themselves."""
+    (member / "untracked-notes.md").write_text("private thinking\n")
+    (member / "product.py").write_text("edited in flight\n")
+    (member / "staged-by-operator.md").write_text("half-done\n")
+    _git(member, "add", "--", "staged-by-operator.md")
+
+    _finish(workspace, member)
+
+    assert _git(origin, "ls-tree", "-r", "--name-only", ORPHAN_BRANCH) == TREE_PATH
+    status = _status(member)
     assert "?? untracked-notes.md" in status, "the operator's untracked file moved"
-    assert f" M specs/{SPEC_ID}.md" in status, "the operator's edit was committed"
+    assert " M product.py" in status, "the operator's edit was committed"
     assert "A  staged-by-operator.md" in status, "the operator's staged work moved"
 
 
-def test_the_evidence_commit_is_scoped_and_self_explanatory(workspace):
-    """This commit lands in the operator's own history, so it has to say what it
-    is and who made it without them having to go digging."""
-    _finish(workspace)
-
-    subject = _git(workspace, "log", "-1", "--format=%s")
-    body = _git(workspace, "log", "-1", "--format=%b")
-    assert subject == f"chore(evidence): publish 1 artifact for {SPEC_ID}"
-    assert "mship finish" in body
-    assert f"specs/evidence/{SPEC_ID}/" in body
-    # The operator's own identity, as `mship commit` also uses — no impostor author.
-    assert _git(workspace, "log", "-1", "--format=%an <%ae>") == "t <t@example.com>"
-
-
-# --- local storage: nothing at all ------------------------------------------
-
-
-def test_local_mode_touches_neither_the_shell_nor_the_repo(workspace):
-    """Under `local` the evidence dir is gitignored, so staging it would be
-    actively wrong — and the mode gate must short-circuit before any git call."""
-    before = _git(workspace, "rev-parse", "HEAD")
+def test_local_mode_touches_neither_the_shell_nor_the_repo(workspace, member, origin):
+    """Under `local` nothing may leave the machine, so the mode gate must
+    short-circuit before any git call at all."""
+    before = _main_shas(member, origin)
     shell = _SpyShell()
 
-    block, warning = _finish(workspace, _config(evidence_storage="local"), shell)
+    block, warning = _finish(
+        workspace, member, config=_config(evidence_storage="local"), shell=shell,
+    )
 
     assert shell.commands == []
-    assert _git(workspace, "rev-parse", "HEAD") == before
-    assert RELPATH in _status(workspace)
+    assert _main_shas(member, origin) == before
+    assert _git(origin, "branch", "--list") == "* main"
     assert "![" not in block
     assert IMAGE_REF in block
     assert warning is not None
 
 
-# --- everything that can go wrong with the push -----------------------------
+# --- everything that can go wrong -------------------------------------------
 
 
 def test_a_rejected_push_warns_names_the_artifact_and_still_returns_a_block(
-    workspace, origin, tmp_path,
+    workspace, member, origin,
 ):
-    """Origin moved on underneath us, so the push is rejected. finish must not
-    force it, must not raise, and must not put a URL in the body."""
-    other = tmp_path / "other"
-    subprocess.run(["git", "clone", "-q", str(origin), str(other)], check=True)
-    _git(other, "config", "user.email", "o@example.com")
-    _git(other, "config", "user.name", "o")
-    _git(other, "config", "commit.gpgsign", "false")
-    (other / "elsewhere.md").write_text("someone else's commit\n")
-    _git(other, "add", ".")
-    _git(other, "commit", "-qm", "diverge")
-    _git(other, "push", "-q", "origin", "main")
+    """The remote refuses the push. finish must not force it, must not raise, and
+    must not put a URL in the body."""
+    hook = origin / "hooks" / "pre-receive"
+    hook.write_text("#!/bin/sh\nexit 1\n")
+    hook.chmod(0o755)
+    before = _main_shas(member, origin)
 
-    block, warning = _finish(workspace)
+    block, warning = _finish(workspace, member)
 
     assert "![" not in block
     assert IMAGE_REF in block, "the artifact must still be NAMED"
     assert warning is not None
     assert "push" in warning.lower()
-    # Not forced: origin still points at the other clone's commit.
-    assert _git(origin, "rev-parse", "main") == _git(other, "rev-parse", "HEAD")
+    assert _git(origin, "branch", "--list") == "* main"
+    assert _main_shas(member, origin) == before
 
 
-def test_an_unreachable_origin_warns_and_never_blocks(workspace, origin):
+def test_an_unreachable_origin_warns_and_never_blocks(workspace, member, origin):
     subprocess.run(["rm", "-rf", str(origin)], check=True)
 
-    block, warning = _finish(workspace)
+    block, warning = _finish(workspace, member)
 
     assert "![" not in block
     assert IMAGE_REF in block
     assert warning is not None
 
 
-def test_an_origin_without_our_branch_is_never_created_by_finish(tmp_path, origin):
-    """A workspace whose branch has never been pushed stays unpushed: publishing
-    the operator's whole specs/config repo is far beyond the licence to commit
-    one screenshot."""
-    repo = tmp_path / "never-pushed"
+def test_a_repo_without_a_github_origin_does_no_git_writing(workspace, tmp_path):
+    """No raw host to serve from means no embed is possible, so nothing is
+    published — writing to someone's repo has to buy them something."""
+    repo = tmp_path / "no-remote"
     repo.mkdir()
     _git(repo, "init", "-q", "-b", "main")
     _git(repo, "config", "user.email", "t@example.com")
     _git(repo, "config", "user.name", "t")
-    _git(repo, "config", "commit.gpgsign", "false")
-    _git(repo, "remote", "add", "origin", str(origin))
-    (repo / "seed.md").write_text("x")
+    (repo / "x.py").write_text("x\n")
     _git(repo, "add", ".")
     _git(repo, "commit", "-qm", "seed")
-    artifact = repo / RELPATH
-    artifact.parent.mkdir(parents=True)
-    artifact.write_bytes(PNG_BYTES)
+    before = _git(repo, "rev-parse", "HEAD")
 
-    block, warning = _finish(repo)
+    block, warning = _finish(workspace, repo)
 
-    assert _git(origin, "branch", "--list") == "", "finish created a branch on origin"
+    assert _git(repo, "rev-parse", "HEAD") == before
+    assert _git(repo, "branch", "--list") == "* main"
     assert "![" not in block
     assert warning is not None
 
 
-def test_a_detached_head_workspace_commits_nothing(workspace):
-    """A commit here would be unreachable from any branch, and the operator's
-    next checkout would delete the artifact along with it."""
-    _git(workspace, "checkout", "-q", "--detach")
-    before = _git(workspace, "rev-parse", "HEAD")
-
-    block, warning = _finish(workspace)
-
-    assert _git(workspace, "rev-parse", "HEAD") == before
-    assert RELPATH in _status(workspace)
-    assert "![" not in block
-    assert IMAGE_REF in block
-    assert warning is not None
-    assert "detached" in warning
-
-
-def test_a_gitignored_evidence_dir_is_never_forced_past(workspace):
-    """Left over from a spell under `local` storage. `git add` without `-f`
-    refuses, and we take the refusal rather than overriding the operator."""
-    (workspace / ".gitignore").write_text("specs/evidence/\n")
-    _git(workspace, "add", "--", ".gitignore")
-    _git(workspace, "commit", "-qm", "ignore evidence")
-    _git(workspace, "push", "-q", "origin", "main")
-
-    block, warning = _finish(workspace)
-
-    assert RELPATH not in _status(workspace)
-    assert "![" not in block
-    assert warning is not None
-
-
-def test_one_unpublished_artifact_does_not_drag_its_siblings_down(workspace, origin):
+def test_one_unpublished_artifact_does_not_drag_its_siblings_down(
+    workspace, member, origin,
+):
     """Verification is per-ref, so a criterion whose artifact never made it is
     named while the criterion next to it still shows its screenshot."""
     ghost = "0f0f0f0f0f0f.png"
-    now = datetime(2026, 7, 26, tzinfo=timezone.utc)
-    spec = Spec(
-        id=SPEC_ID, title="My spec", status="approved",
-        created_at=now, updated_at=now,
-        acceptance_criteria=[
-            AcceptanceCriterion(
-                id="ac1", text="the screen renders", verdict="approved",
-                evidence=[AcceptanceEvidence(kind="artifact", ref=IMAGE_REF)],
-            ),
-            AcceptanceCriterion(
-                id="ac2", text="the other screen renders", verdict="approved",
-                evidence=[AcceptanceEvidence(kind="artifact", ref=ghost)],
-            ),
-        ],
-    )
 
-    block, warning = acceptance_block_for_finish(
-        spec, workspace, ShellRunner(), _config(),
-    )
+    block, warning = _finish(workspace, member, spec=_spec(IMAGE_REF, ghost))
 
-    assert f"![ac1](" in block
+    assert "![ac1](" in block
     assert "![ac2](" not in block
     assert f"artifact:{ghost}" in block
     assert warning is not None
     assert "1 of 2" in warning
-    _assert_url_resolves(workspace, origin, _embedded_url(block))
+    _assert_url_resolves(origin, _embedded_url(block))
 
 
-def test_a_missing_artifact_file_is_named_not_embedded(workspace):
-    """The spec references a ref whose bytes are not on disk and never were."""
-    (workspace / RELPATH).unlink()
+def test_a_missing_artifact_file_is_named_not_embedded(workspace, member):
+    """The spec references a ref whose bytes are not in the store and never were,
+    and nothing is on the branch to fall back to."""
+    (evidence_dir(workspace, SPEC_ID) / IMAGE_REF).unlink()
 
-    block, warning = _finish(workspace)
+    block, warning = _finish(workspace, member)
 
     assert "![" not in block
     assert IMAGE_REF in block
     assert warning is not None
-    assert "not tracked at workspace commit" in warning
 
 
-def test_the_push_cannot_prompt_for_credentials(monkeypatch, workspace):
-    """finish must never go interactive: a workspace repo whose credentials are
-    not cached has to fail fast, not stop mid-finish waiting on a password."""
+def test_the_push_cannot_prompt_for_credentials(monkeypatch, workspace, member):
+    """finish must never go interactive: a repo whose credentials are not cached
+    has to fail fast, not stop mid-finish waiting on a password."""
     seen: dict[str, dict] = {}
     real = ShellRunner.run
 
@@ -392,8 +435,28 @@ def test_the_push_cannot_prompt_for_credentials(monkeypatch, workspace):
         return real(self, command, cwd, env=env, timeout=timeout)
 
     monkeypatch.setattr(ShellRunner, "run", spy)
-    _finish(workspace)
+    _finish(workspace, member)
 
     assert seen["env"]["GIT_TERMINAL_PROMPT"] == "0"
     assert "BatchMode=yes" in seen["env"]["GIT_SSH_COMMAND"]
     assert seen["timeout"] is not None
+
+
+# --- multi-repo (ac7) --------------------------------------------------------
+
+
+def test_each_repo_receiving_a_pr_publishes_to_its_own_branch(workspace, tmp_path):
+    """A spec spanning two repos gives each PR its own copy, so a reviewer of one
+    repo's PR needs no read access to the sibling."""
+    origin_a = _init_origin(tmp_path, "a")
+    origin_b = _init_origin(tmp_path, "b")
+    repo_a = _init_member(tmp_path, origin_a, "member-a")
+    repo_b = _init_member(tmp_path, origin_b, "member-b")
+
+    url_a = _embedded_url(_finish(workspace, repo_a)[0])
+    url_b = _embedded_url(_finish(workspace, repo_b)[0])
+
+    assert url_a.startswith("https://raw.githubusercontent.com/o/a/")
+    assert url_b.startswith("https://raw.githubusercontent.com/o/b/")
+    _assert_url_resolves(origin_a, url_a)
+    _assert_url_resolves(origin_b, url_b)

--- a/tests/core/test_finish_evidence_publish.py
+++ b/tests/core/test_finish_evidence_publish.py
@@ -1,0 +1,399 @@
+"""The seam between writing an evidence artifact and linking to it, exercised
+end to end against a real git repo.
+
+The bug this covers was not in either half. `capture --evidence` correctly wrote
+a file; `workspace_raw_base` correctly answered "is HEAD on origin?". Nobody
+committed the file, and nobody checked that the sha in the URL contained it — so
+the ordinary sequence emitted an image URL that 404ed, silently. Unit tests on
+each half would have stayed green throughout. So everything here drives
+`acceptance_block_for_finish` (what `mship finish` actually calls) against a real
+working clone with a real origin, and asserts on the repo's state afterwards as
+well as on the rendered block.
+
+The origin is a local bare repo living at a path that happens to parse as a
+GitHub slug: real git plumbing, real push semantics, no network.
+"""
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from mship.core.pr import acceptance_block_for_finish
+from mship.core.spec import AcceptanceCriterion, AcceptanceEvidence, Spec
+from mship.util.shell import ShellRunner
+
+SPEC_ID = "my-spec"
+IMAGE_REF = "a1b2c3d4e5f6.png"
+RELPATH = f"specs/evidence/{SPEC_ID}/{IMAGE_REF}"
+PNG_BYTES = b"\x89PNG\r\n\x1a\n-not-really-a-png-but-git-does-not-care"
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def _status(repo: Path) -> str:
+    """`git status --porcelain -uall`, UNstripped — the leading column is the
+    staged/unstaged distinction these tests are entirely about."""
+    return subprocess.run(
+        ["git", "status", "--porcelain", "-uall"],
+        cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout
+
+
+def _spec() -> Spec:
+    now = datetime(2026, 7, 26, tzinfo=timezone.utc)
+    return Spec(
+        id=SPEC_ID, title="My spec", status="approved",
+        created_at=now, updated_at=now,
+        acceptance_criteria=[
+            AcceptanceCriterion(
+                id="ac1", text="the screen renders", verdict="approved",
+                evidence=[AcceptanceEvidence(kind="artifact", ref=IMAGE_REF)],
+            )
+        ],
+    )
+
+
+def _config(evidence_storage=None, spec_storage="committed"):
+    return SimpleNamespace(spec_storage=spec_storage, evidence_storage=evidence_storage)
+
+
+class _SpyShell(ShellRunner):
+    """A real ShellRunner that remembers every command, so a test can assert the
+    workspace repo was never touched at all."""
+
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+
+    def run(self, command, cwd, env=None, timeout=None):
+        self.commands.append(command)
+        return super().run(command, cwd, env=env, timeout=timeout)
+
+
+@pytest.fixture
+def origin(tmp_path: Path) -> Path:
+    bare = tmp_path / "github.com" / "o" / "r.git"
+    bare.parent.mkdir(parents=True)
+    subprocess.run(["git", "init", "--bare", "-q", str(bare)], check=True)
+    return bare
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, origin: Path) -> Path:
+    """A workspace clone with one pushed commit, an evidence artifact sitting
+    UNTRACKED on disk exactly as `capture --evidence` leaves it, and the
+    operator's own prose already committed."""
+    repo = tmp_path / "workspace"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    _git(repo, "config", "commit.gpgsign", "false")
+    _git(repo, "remote", "add", "origin", str(origin))
+    (repo / "specs").mkdir()
+    (repo / "specs" / f"{SPEC_ID}.md").write_text("the operator's prose\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "spec")
+    _git(repo, "push", "-q", "-u", "origin", "main")
+
+    artifact = repo / RELPATH
+    artifact.parent.mkdir(parents=True)
+    artifact.write_bytes(PNG_BYTES)
+    return repo
+
+
+def _finish(repo: Path, config=None, shell=None) -> tuple[str, str | None]:
+    return acceptance_block_for_finish(
+        _spec(), repo, shell or ShellRunner(), config or _config(),
+    )
+
+
+def _embedded_url(block: str) -> str | None:
+    for line in block.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("!["):
+            return stripped[stripped.index("(") + 1: -1]
+    return None
+
+
+def _sha_from(url: str) -> str:
+    # .../<owner>/<repo>/<sha>/specs/evidence/<spec>/<ref>
+    return url.split("/")[-5]
+
+
+def _assert_url_resolves(repo: Path, origin: Path, url: str) -> None:
+    """The URL is not merely well-formed: its sha contains the artifact, and
+    that sha is on the remote. Together that is exactly what
+    raw.githubusercontent.com needs to return bytes instead of a 404."""
+    sha = _sha_from(url)
+    assert url.endswith(f"/{sha}/{RELPATH}")
+    assert (
+        subprocess.run(
+            ["git", "cat-file", "-e", f"{sha}:{RELPATH}"], cwd=repo
+        ).returncode == 0
+    ), "the pinned sha does not contain the artifact"
+    # Ask the remote, not the local clone: the bytes must be fetchable by GitHub.
+    assert subprocess.run(
+        ["git", "cat-file", "-e", f"{sha}:{RELPATH}"], cwd=origin
+    ).returncode == 0, "the pinned sha is not on the remote"
+
+
+# --- the three states an artifact can be in when finish runs ---------------
+
+
+def test_never_committed_artifact_is_published_and_embedded(workspace, origin):
+    """The ordinary sequence: `capture --evidence`, then `finish` without ever
+    touching `specs/`. This is the case that used to emit a 404."""
+    block, warning = _finish(workspace)
+
+    assert warning is None
+    url = _embedded_url(block)
+    assert url is not None, f"expected an embed, got:\n{block}"
+    _assert_url_resolves(workspace, origin, url)
+
+
+def test_committed_but_unpushed_artifact_is_pushed_and_embedded(workspace, origin):
+    _git(workspace, "add", "--", RELPATH)
+    _git(workspace, "commit", "-qm", "evidence, by hand")
+
+    block, warning = _finish(workspace)
+
+    assert warning is None
+    url = _embedded_url(block)
+    assert url is not None, f"expected an embed, got:\n{block}"
+    _assert_url_resolves(workspace, origin, url)
+
+
+def test_already_tracked_and_pushed_embeds_without_a_new_commit(workspace, origin):
+    _git(workspace, "add", "--", RELPATH)
+    _git(workspace, "commit", "-qm", "evidence, by hand")
+    _git(workspace, "push", "-q", "origin", "main")
+    before = _git(workspace, "rev-parse", "HEAD")
+
+    block, warning = _finish(workspace)
+
+    assert warning is None
+    assert _git(workspace, "rev-parse", "HEAD") == before, "made a pointless commit"
+    url = _embedded_url(block)
+    assert url is not None
+    _assert_url_resolves(workspace, origin, url)
+
+
+# --- the narrowness guarantee ----------------------------------------------
+
+
+def test_unrelated_uncommitted_work_is_never_swept_in(workspace):
+    """The one that protects the licence. finish writes to the operator's own
+    workspace repo, so it must commit the artifact and NOTHING else — not their
+    untracked notes, not their edits in flight, not even work they had already
+    staged themselves."""
+    (workspace / "untracked-notes.md").write_text("private thinking\n")
+    (workspace / "specs" / f"{SPEC_ID}.md").write_text("the operator's EDITED prose\n")
+    (workspace / "staged-by-operator.md").write_text("half-done\n")
+    _git(workspace, "add", "--", "staged-by-operator.md")
+
+    _finish(workspace)
+
+    committed = _git(workspace, "show", "--name-only", "--format=", "HEAD").split()
+    assert committed == [RELPATH]
+
+    status = _status(workspace)
+    assert "?? untracked-notes.md" in status, "the operator's untracked file moved"
+    assert f" M specs/{SPEC_ID}.md" in status, "the operator's edit was committed"
+    assert "A  staged-by-operator.md" in status, "the operator's staged work moved"
+
+
+def test_the_evidence_commit_is_scoped_and_self_explanatory(workspace):
+    """This commit lands in the operator's own history, so it has to say what it
+    is and who made it without them having to go digging."""
+    _finish(workspace)
+
+    subject = _git(workspace, "log", "-1", "--format=%s")
+    body = _git(workspace, "log", "-1", "--format=%b")
+    assert subject == f"chore(evidence): publish 1 artifact for {SPEC_ID}"
+    assert "mship finish" in body
+    assert f"specs/evidence/{SPEC_ID}/" in body
+    # The operator's own identity, as `mship commit` also uses — no impostor author.
+    assert _git(workspace, "log", "-1", "--format=%an <%ae>") == "t <t@example.com>"
+
+
+# --- local storage: nothing at all ------------------------------------------
+
+
+def test_local_mode_touches_neither_the_shell_nor_the_repo(workspace):
+    """Under `local` the evidence dir is gitignored, so staging it would be
+    actively wrong — and the mode gate must short-circuit before any git call."""
+    before = _git(workspace, "rev-parse", "HEAD")
+    shell = _SpyShell()
+
+    block, warning = _finish(workspace, _config(evidence_storage="local"), shell)
+
+    assert shell.commands == []
+    assert _git(workspace, "rev-parse", "HEAD") == before
+    assert RELPATH in _status(workspace)
+    assert "![" not in block
+    assert IMAGE_REF in block
+    assert warning is not None
+
+
+# --- everything that can go wrong with the push -----------------------------
+
+
+def test_a_rejected_push_warns_names_the_artifact_and_still_returns_a_block(
+    workspace, origin, tmp_path,
+):
+    """Origin moved on underneath us, so the push is rejected. finish must not
+    force it, must not raise, and must not put a URL in the body."""
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "-q", str(origin), str(other)], check=True)
+    _git(other, "config", "user.email", "o@example.com")
+    _git(other, "config", "user.name", "o")
+    _git(other, "config", "commit.gpgsign", "false")
+    (other / "elsewhere.md").write_text("someone else's commit\n")
+    _git(other, "add", ".")
+    _git(other, "commit", "-qm", "diverge")
+    _git(other, "push", "-q", "origin", "main")
+
+    block, warning = _finish(workspace)
+
+    assert "![" not in block
+    assert IMAGE_REF in block, "the artifact must still be NAMED"
+    assert warning is not None
+    assert "push" in warning.lower()
+    # Not forced: origin still points at the other clone's commit.
+    assert _git(origin, "rev-parse", "main") == _git(other, "rev-parse", "HEAD")
+
+
+def test_an_unreachable_origin_warns_and_never_blocks(workspace, origin):
+    subprocess.run(["rm", "-rf", str(origin)], check=True)
+
+    block, warning = _finish(workspace)
+
+    assert "![" not in block
+    assert IMAGE_REF in block
+    assert warning is not None
+
+
+def test_an_origin_without_our_branch_is_never_created_by_finish(tmp_path, origin):
+    """A workspace whose branch has never been pushed stays unpushed: publishing
+    the operator's whole specs/config repo is far beyond the licence to commit
+    one screenshot."""
+    repo = tmp_path / "never-pushed"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    _git(repo, "config", "commit.gpgsign", "false")
+    _git(repo, "remote", "add", "origin", str(origin))
+    (repo / "seed.md").write_text("x")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "seed")
+    artifact = repo / RELPATH
+    artifact.parent.mkdir(parents=True)
+    artifact.write_bytes(PNG_BYTES)
+
+    block, warning = _finish(repo)
+
+    assert _git(origin, "branch", "--list") == "", "finish created a branch on origin"
+    assert "![" not in block
+    assert warning is not None
+
+
+def test_a_detached_head_workspace_commits_nothing(workspace):
+    """A commit here would be unreachable from any branch, and the operator's
+    next checkout would delete the artifact along with it."""
+    _git(workspace, "checkout", "-q", "--detach")
+    before = _git(workspace, "rev-parse", "HEAD")
+
+    block, warning = _finish(workspace)
+
+    assert _git(workspace, "rev-parse", "HEAD") == before
+    assert RELPATH in _status(workspace)
+    assert "![" not in block
+    assert IMAGE_REF in block
+    assert warning is not None
+    assert "detached" in warning
+
+
+def test_a_gitignored_evidence_dir_is_never_forced_past(workspace):
+    """Left over from a spell under `local` storage. `git add` without `-f`
+    refuses, and we take the refusal rather than overriding the operator."""
+    (workspace / ".gitignore").write_text("specs/evidence/\n")
+    _git(workspace, "add", "--", ".gitignore")
+    _git(workspace, "commit", "-qm", "ignore evidence")
+    _git(workspace, "push", "-q", "origin", "main")
+
+    block, warning = _finish(workspace)
+
+    assert RELPATH not in _status(workspace)
+    assert "![" not in block
+    assert warning is not None
+
+
+def test_one_unpublished_artifact_does_not_drag_its_siblings_down(workspace, origin):
+    """Verification is per-ref, so a criterion whose artifact never made it is
+    named while the criterion next to it still shows its screenshot."""
+    ghost = "0f0f0f0f0f0f.png"
+    now = datetime(2026, 7, 26, tzinfo=timezone.utc)
+    spec = Spec(
+        id=SPEC_ID, title="My spec", status="approved",
+        created_at=now, updated_at=now,
+        acceptance_criteria=[
+            AcceptanceCriterion(
+                id="ac1", text="the screen renders", verdict="approved",
+                evidence=[AcceptanceEvidence(kind="artifact", ref=IMAGE_REF)],
+            ),
+            AcceptanceCriterion(
+                id="ac2", text="the other screen renders", verdict="approved",
+                evidence=[AcceptanceEvidence(kind="artifact", ref=ghost)],
+            ),
+        ],
+    )
+
+    block, warning = acceptance_block_for_finish(
+        spec, workspace, ShellRunner(), _config(),
+    )
+
+    assert f"![ac1](" in block
+    assert "![ac2](" not in block
+    assert f"artifact:{ghost}" in block
+    assert warning is not None
+    assert "1 of 2" in warning
+    _assert_url_resolves(workspace, origin, _embedded_url(block))
+
+
+def test_a_missing_artifact_file_is_named_not_embedded(workspace):
+    """The spec references a ref whose bytes are not on disk and never were."""
+    (workspace / RELPATH).unlink()
+
+    block, warning = _finish(workspace)
+
+    assert "![" not in block
+    assert IMAGE_REF in block
+    assert warning is not None
+    assert "not tracked at workspace commit" in warning
+
+
+def test_the_push_cannot_prompt_for_credentials(monkeypatch, workspace):
+    """finish must never go interactive: a workspace repo whose credentials are
+    not cached has to fail fast, not stop mid-finish waiting on a password."""
+    seen: dict[str, dict] = {}
+    real = ShellRunner.run
+
+    def spy(self, command, cwd, env=None, timeout=None):
+        if command.startswith("git push"):
+            seen["env"] = env or {}
+            seen["timeout"] = timeout
+        return real(self, command, cwd, env=env, timeout=timeout)
+
+    monkeypatch.setattr(ShellRunner, "run", spy)
+    _finish(workspace)
+
+    assert seen["env"]["GIT_TERMINAL_PROMPT"] == "0"
+    assert "BatchMode=yes" in seen["env"]["GIT_SSH_COMMAND"]
+    assert seen["timeout"] is not None

--- a/tests/core/test_finish_evidence_publish.py
+++ b/tests/core/test_finish_evidence_publish.py
@@ -72,6 +72,8 @@ def _spec(*refs: str) -> Spec:
 
 
 def _config(evidence_storage=None, spec_storage="committed"):
+    """`spec_storage: committed` with evidence unset — the default workspace,
+    which inherits as evidence mode `published`."""
     return SimpleNamespace(spec_storage=spec_storage, evidence_storage=evidence_storage)
 
 

--- a/tests/core/test_finish_evidence_publish.py
+++ b/tests/core/test_finish_evidence_publish.py
@@ -112,6 +112,30 @@ def _init_member(tmp_path: Path, origin: Path, name: str = "member") -> Path:
     return repo
 
 
+def _single_branch_clone(tmp_path: Path, origin: Path, name: str = "clone") -> Path:
+    """A clone that has `main` and NOTHING else — deliberately without the
+    evidence branch's objects, unlike an ordinary `_init_member` repo that
+    published from (which already has them in its own object store). This is
+    what makes `_fetch_tip` actually reach the network instead of finding the
+    objects already present locally, mirroring "a tip pushed from another
+    machine" (evidence_url.py's own docstring for that function).
+    """
+    repo = tmp_path / name
+    subprocess.run(
+        # `--no-local`: a local-path origin otherwise takes git's local-clone
+        # shortcut (hardlink/copy the WHOLE object database), which would
+        # smuggle in the evidence branch's objects regardless of
+        # `--single-branch` and defeat the point of this helper.
+        ["git", "clone", "-q", "--no-local", "--no-tags", "--single-branch",
+         "--branch", "main", str(origin), str(repo)],
+        check=True,
+    )
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    _git(repo, "config", "commit.gpgsign", "false")
+    return repo
+
+
 def _store(workspace: Path, ref: str = IMAGE_REF, body: bytes = PNG_BYTES) -> Path:
     """Seed the machine-local evidence store exactly as `capture --evidence`
     leaves it. Located via evidence_store so this says WHAT, not where."""
@@ -141,9 +165,10 @@ def workspace(tmp_path: Path) -> Path:
     return root
 
 
-def _finish(workspace: Path, repo: Path, spec=None, config=None, shell=None):
+def _finish(workspace: Path, repo: Path, spec=None, config=None, shell=None, token=None):
     return acceptance_block_for_finish(
         spec or _spec(), workspace, repo, shell or ShellRunner(), config or _config(),
+        token=token,
     )
 
 
@@ -464,6 +489,110 @@ def test_the_push_cannot_prompt_for_credentials(monkeypatch, workspace, member):
     assert seen["env"]["GIT_TERMINAL_PROMPT"] == "0"
     assert "BatchMode=yes" in seen["env"]["GIT_SSH_COMMAND"]
     assert seen["timeout"] is not None
+
+
+# --- token-backed credential helper (Greptile P1 on #421) -------------------
+#
+# `finish` in a token-only environment (cloud agent, CI, an unattended
+# overnight routine) has no cached git credentials. Before this, the evidence
+# push used none of the credential machinery the branch push already uses
+# (`push_branch`, core/pr.py) — it degraded to a named artifact instead of an
+# embed every time, silently. These pin the fix: the same github.com-scoped
+# helper reaches every git call that talks to the remote, the token itself
+# never appears in a command string (only in the env, like `git_cred_args`
+# promises — tests/core/test_gh_auth.py:188), and the no-token path is
+# byte-for-byte what it always was.
+
+
+def test_network_calls_use_the_credential_helper_when_a_token_is_given(
+    monkeypatch, workspace, member, origin,
+):
+    """ls-remote, fetch, and push are the only calls that reach the network —
+    hash-object/read-tree/write-tree/commit-tree/cat-file are local plumbing on
+    objects already on disk. Each network call must carry the same credential
+    helper `push_branch` splices onto the branch push, with the token landing
+    only in the env it carries, never in the command string itself.
+
+    Seeded with a first publish from `member` (no token) so the branch exists
+    on origin; the SECOND publish below runs from a fresh single-branch clone
+    (`_single_branch_clone`) that has never fetched it, so `_fetch_tip` has to
+    reach the network instead of finding the objects already in its own object
+    store — otherwise this test would never exercise the fetch call at all.
+    """
+    token = "ghp_secrettoken123"
+    _finish(workspace, member)
+    clone = _single_branch_clone(member.parent, origin)
+    second_ref = "b1b2c3d4e5f6.png"
+    _store(workspace, second_ref)
+
+    seen: list[tuple[str, dict]] = []
+    real = ShellRunner.run
+
+    def spy(self, command, cwd, env=None, timeout=None):
+        seen.append((command, env or {}))
+        return real(self, command, cwd, env=env, timeout=timeout)
+
+    monkeypatch.setattr(ShellRunner, "run", spy)
+
+    block, warning = _finish(
+        workspace, clone, spec=_spec(IMAGE_REF, second_ref), token=token,
+    )
+
+    assert warning is None
+    assert _embedded_url(block) is not None
+
+    def _kind(cmd: str) -> str | None:
+        for sub in ("ls-remote", "fetch", "push"):
+            if f" {sub} " in cmd:
+                return sub
+        return None
+
+    network = [(c, e, _kind(c)) for c, e in seen if _kind(c) is not None]
+    kinds = {k for _, _, k in network}
+    assert kinds == {"ls-remote", "fetch", "push"}, (
+        f"expected ls-remote, fetch, and push all exercised, got: {kinds}"
+    )
+    for cmd, env, _ in network:
+        assert "credential.https://github.com.helper" in cmd
+        assert token not in cmd
+        assert env.get("MSHIP_GH_TOKEN") == token
+
+    local = [
+        c for c, _ in seen
+        if any(
+            f" {sub} " in c or c.rstrip().endswith(sub)
+            for sub in ("hash-object", "read-tree", "write-tree", "commit-tree", "cat-file")
+        )
+    ]
+    assert local, "expected at least one local plumbing call"
+    for cmd in local:
+        assert "credential.https://github.com.helper" not in cmd, (
+            f"local plumbing call should never carry remote credentials: {cmd}"
+        )
+
+
+def test_no_token_path_is_unchanged(workspace, member, origin):
+    """A local operator with cached credentials passes no token at all, and
+    must keep working exactly as before: no credential helper spliced onto
+    any command, and the same commands this module has always run — including
+    the fetch path, exercised the same way as the token test above (a fresh
+    single-branch clone that has to fetch the existing tip's objects)."""
+    _finish(workspace, member)
+    clone = _single_branch_clone(member.parent, origin)
+    second_ref = "c1b2c3d4e5f6.png"
+    _store(workspace, second_ref)
+    shell = _SpyShell()
+
+    block, warning = _finish(
+        workspace, clone, spec=_spec(IMAGE_REF, second_ref), shell=shell,
+    )
+
+    assert warning is None
+    assert _embedded_url(block) is not None
+    assert all("credential.https://github.com.helper" not in c for c in shell.commands)
+    assert any(c.startswith("git ls-remote origin ") for c in shell.commands)
+    assert any(c.startswith("git fetch --no-tags --quiet origin ") for c in shell.commands)
+    assert any(c.startswith("git push origin ") for c in shell.commands)
 
 
 # --- multi-repo (ac7) --------------------------------------------------------

--- a/tests/core/test_finish_evidence_warning.py
+++ b/tests/core/test_finish_evidence_warning.py
@@ -1,16 +1,16 @@
 """finish's acceptance-block wrapper: embeds image evidence when the artifact is
-provably in a pushed workspace commit, and warns the operator (once, actionably)
+provably present at a published commit, and warns the operator (once, actionably)
 when it is not.
 
 Because `publish_evidence` answers only the git question and does not know the
 storage mode, the wrapper must gate on `committed` mode before ever calling it
-(see evidence_url.py's module docstring): under `local` the evidence dir is
-gitignored, so a URL would 404 for bytes never on the remote — and staging it
+(see evidence_url.py's module docstring): under `local` nothing may leave the
+machine and under `encrypted` the bytes are ciphertext, so publishing either
 would be actively wrong. The gate is asserted here as "the shell was never
 invoked at all".
 
-These are the wrapper's decisions with a scripted shell. The commit/push seam
-itself is covered end-to-end against a real git repo in
+These are the wrapper's decisions with a scripted shell. The publication seam
+itself is covered end-to-end against real git repos in
 test_finish_evidence_publish.py.
 """
 from datetime import datetime, timezone
@@ -60,41 +60,46 @@ class _FakeShell:
         return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
 
 
-def _pushed_shell() -> _FakeShell:
+TIP = "abc123def456"
+
+
+def _published_shell() -> _FakeShell:
+    """An evidence branch already carrying this artifact: the store holds no file
+    (tmp_path is empty), so nothing new is built and the existing tip is pinned.
+
+    Fragment order matters — the commit-readable probe is matched before the
+    generic `cat-file` reply so a test can flip one without the other.
+    """
     return _FakeShell({
         "remote get-url": (0, "git@github.com:o/r.git\n"),
-        "--abbrev-ref": (0, "main\n"),
-        "rev-parse HEAD": (0, "abc123def456\n"),
-        "ls-remote": (0, "abc123def456\trefs/heads/main\n"),
-        "cat-file": (0, ""),  # the artifact IS in the pinned commit's tree
+        "ls-remote": (0, f"{TIP}\trefs/heads/mship-evidence\n"),
+        "^{commit}": (0, ""),  # the tip's objects are readable here
+        "cat-file": (0, ""),   # the artifact IS in the pinned commit's tree
     })
 
 
-def _unpushed_shell() -> _FakeShell:
+def _unpublished_shell() -> _FakeShell:
     return _FakeShell({
         "remote get-url": (0, "git@github.com:o/r.git\n"),
-        "--abbrev-ref": (0, "main\n"),
-        "rev-parse HEAD": (0, "abc123def456\n"),
-        "ls-remote": (0, ""),  # no matching line for the branch => not on origin
+        "ls-remote": (0, ""),  # the evidence branch does not exist yet
     })
 
 
-def test_committed_and_not_pushed_names_the_artifact_and_warns(tmp_path):
+def test_nothing_published_names_the_artifact_and_warns(tmp_path):
     spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF))
     block, warning = acceptance_block_for_finish(
-        spec, tmp_path, _unpushed_shell(), _config(),
+        spec, tmp_path, tmp_path, _unpublished_shell(), _config(),
     )
     assert "![" not in block
     assert IMAGE_REF in block
     assert warning is not None
-    assert "pushed" in warning.lower()
-    assert "specs/" in warning
+    assert "mship-evidence" in warning
 
 
-def test_committed_and_pushed_embeds_with_no_warning(tmp_path):
+def test_published_and_present_embeds_with_no_warning(tmp_path):
     spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF))
     block, warning = acceptance_block_for_finish(
-        spec, tmp_path, _pushed_shell(), _config(),
+        spec, tmp_path, tmp_path, _published_shell(), _config(),
     )
     assert f"![ac1](" in block
     assert IMAGE_REF in block
@@ -102,24 +107,26 @@ def test_committed_and_pushed_embeds_with_no_warning(tmp_path):
 
 
 def test_pushed_but_not_tracked_at_the_pinned_sha_is_named_not_embedded(tmp_path):
-    """The seatbelt: HEAD is on origin, but the artifact is not in that tree, so
-    the URL would 404. The module emitting the URL checks its own precondition
-    instead of trusting whoever was supposed to have committed the file."""
-    shell = _pushed_shell()
+    """The seatbelt: the pinned commit is on origin, but the artifact is not in
+    its tree, so the URL would 404. The module emitting the URL checks its own
+    precondition instead of trusting whoever was supposed to publish the file."""
+    shell = _published_shell()
     shell._replies["cat-file"] = (128, "")
     spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF))
-    block, warning = acceptance_block_for_finish(spec, tmp_path, shell, _config())
+    block, warning = acceptance_block_for_finish(
+        spec, tmp_path, tmp_path, shell, _config(),
+    )
     assert "![" not in block
     assert IMAGE_REF in block
     assert warning is not None
-    assert "not tracked at workspace commit" in warning
+    assert "not present at evidence commit" in warning
 
 
 def test_local_mode_never_calls_the_shell_and_warns(tmp_path):
     spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF))
-    shell = _pushed_shell()  # would happily answer "pushed" if ever asked
+    shell = _published_shell()  # would happily answer "published" if ever asked
     block, warning = acceptance_block_for_finish(
-        spec, tmp_path, shell, _config(evidence_storage="local"),
+        spec, tmp_path, tmp_path, shell, _config(evidence_storage="local"),
     )
     assert shell.commands == []
     assert "![" not in block
@@ -129,9 +136,9 @@ def test_local_mode_never_calls_the_shell_and_warns(tmp_path):
 
 def test_encrypted_mode_names_the_artifact_and_warns(tmp_path):
     spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF))
-    shell = _pushed_shell()
+    shell = _published_shell()
     block, warning = acceptance_block_for_finish(
-        spec, tmp_path, shell, _config(evidence_storage="encrypted"),
+        spec, tmp_path, tmp_path, shell, _config(evidence_storage="encrypted"),
     )
     assert shell.commands == []
     assert "![" not in block
@@ -144,10 +151,12 @@ def test_no_image_evidence_produces_no_warning(tmp_path):
         AcceptanceEvidence(kind="test", ref="test-runs/7"),
         AcceptanceEvidence(kind="commit", ref="deadbee"),
     )
-    shell = _unpushed_shell()
-    block, warning = acceptance_block_for_finish(spec, tmp_path, shell, _config())
+    shell = _unpublished_shell()
+    block, warning = acceptance_block_for_finish(
+        spec, tmp_path, tmp_path, shell, _config(),
+    )
     assert warning is None
-    # Nothing embeddable => no reason to touch the operator's workspace repo.
+    # Nothing embeddable => no reason to touch any repo.
     assert shell.commands == []
 
 
@@ -159,6 +168,6 @@ def test_no_evidence_at_all_produces_no_warning(tmp_path):
         acceptance_criteria=[AcceptanceCriterion(id="ac1", text="does X")],
     )
     block, warning = acceptance_block_for_finish(
-        spec, tmp_path, _FakeShell(), _config(),
+        spec, tmp_path, tmp_path, _FakeShell(), _config(),
     )
     assert warning is None

--- a/tests/core/test_finish_evidence_warning.py
+++ b/tests/core/test_finish_evidence_warning.py
@@ -3,7 +3,7 @@ provably present at a published commit, and warns the operator (once, actionably
 when it is not.
 
 Because `publish_evidence` answers only the git question and does not know the
-storage mode, the wrapper must gate on `committed` mode before ever calling it
+storage mode, the wrapper must gate on `published` mode before ever calling it
 (see evidence_url.py's module docstring): under `local` nothing may leave the
 machine and under `encrypted` the bytes are ciphertext, so publishing either
 would be actively wrong. The gate is asserted here as "the shell was never
@@ -37,6 +37,8 @@ def _spec_with(*evidence: AcceptanceEvidence) -> Spec:
 
 
 def _config(evidence_storage=None, spec_storage="committed"):
+    """`spec_storage: committed` with evidence unset — the default workspace,
+    which inherits as evidence mode `published`."""
     return SimpleNamespace(spec_storage=spec_storage, evidence_storage=evidence_storage)
 
 

--- a/tests/core/test_finish_evidence_warning.py
+++ b/tests/core/test_finish_evidence_warning.py
@@ -1,0 +1,140 @@
+"""finish's acceptance-block wrapper: embeds image evidence when the workspace's
+evidence commit is fetchable, and warns the operator (once, actionably) when it
+exists but is not — because `workspace_raw_base` answers only the git question
+and does not know the storage mode, the wrapper must gate on `committed` mode
+before ever calling it (see evidence_url.py's module docstring): under `local`
+the evidence dir is gitignored, so a URL would 404 for bytes never on the remote.
+"""
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from mship.core.pr import acceptance_block_for_finish
+from mship.core.spec import AcceptanceCriterion, AcceptanceEvidence, Spec
+
+IMAGE_REF = "a1b2c3d4e5f6.png"
+
+
+def _spec_with(*evidence: AcceptanceEvidence) -> Spec:
+    now = datetime(2026, 7, 25, tzinfo=timezone.utc)
+    return Spec(
+        id="my-spec", title="My spec", status="approved",
+        created_at=now, updated_at=now,
+        acceptance_criteria=[
+            AcceptanceCriterion(
+                id="ac1", text="the screen renders", verdict="approved",
+                evidence=list(evidence),
+            )
+        ],
+    )
+
+
+def _config(evidence_storage=None, spec_storage="committed"):
+    return SimpleNamespace(spec_storage=spec_storage, evidence_storage=evidence_storage)
+
+
+class _FakeShell:
+    """Stands in for util/shell.py::ShellRunner. `run` takes a command STRING.
+
+    `replies` maps a command fragment to (returncode, stdout); first match wins,
+    anything unmatched fails. Every invocation is recorded in `commands` so a
+    test can assert the shell was NEVER called at all (the local/encrypted gate).
+    """
+
+    def __init__(self, replies: dict[str, tuple[int, str]] | None = None):
+        self._replies = replies or {}
+        self.commands: list[str] = []
+
+    def run(self, command, cwd, env=None, timeout=None):
+        self.commands.append(command)
+        for fragment, (rc, out) in self._replies.items():
+            if fragment in command:
+                return type("R", (), {"returncode": rc, "stdout": out, "stderr": ""})()
+        return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+
+
+def _pushed_shell() -> _FakeShell:
+    return _FakeShell({
+        "remote get-url": (0, "git@github.com:o/r.git\n"),
+        "--abbrev-ref": (0, "main\n"),
+        "rev-parse HEAD": (0, "abc123def456\n"),
+        "ls-remote": (0, "abc123def456\trefs/heads/main\n"),
+    })
+
+
+def _unpushed_shell() -> _FakeShell:
+    return _FakeShell({
+        "remote get-url": (0, "git@github.com:o/r.git\n"),
+        "--abbrev-ref": (0, "main\n"),
+        "rev-parse HEAD": (0, "abc123def456\n"),
+        "ls-remote": (0, ""),  # no matching line for the branch => not on origin
+    })
+
+
+def test_committed_and_not_pushed_names_the_artifact_and_warns(tmp_path):
+    spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF))
+    block, warning = acceptance_block_for_finish(
+        spec, tmp_path, _unpushed_shell(), _config(),
+    )
+    assert "![" not in block
+    assert IMAGE_REF in block
+    assert warning is not None
+    assert "pushed" in warning.lower()
+    assert "specs/" in warning
+
+
+def test_committed_and_pushed_embeds_with_no_warning(tmp_path):
+    spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF))
+    block, warning = acceptance_block_for_finish(
+        spec, tmp_path, _pushed_shell(), _config(),
+    )
+    assert f"![ac1](" in block
+    assert IMAGE_REF in block
+    assert warning is None
+
+
+def test_local_mode_never_calls_the_shell_and_warns(tmp_path):
+    spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF))
+    shell = _pushed_shell()  # would happily answer "pushed" if ever asked
+    block, warning = acceptance_block_for_finish(
+        spec, tmp_path, shell, _config(evidence_storage="local"),
+    )
+    assert shell.commands == []
+    assert "![" not in block
+    assert IMAGE_REF in block
+    assert warning is not None
+
+
+def test_encrypted_mode_names_the_artifact_and_warns(tmp_path):
+    spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF))
+    shell = _pushed_shell()
+    block, warning = acceptance_block_for_finish(
+        spec, tmp_path, shell, _config(evidence_storage="encrypted"),
+    )
+    assert shell.commands == []
+    assert "![" not in block
+    assert warning is not None
+
+
+def test_no_image_evidence_produces_no_warning(tmp_path):
+    """test/commit refs only — nothing embeddable, so nothing to nag about."""
+    spec = _spec_with(
+        AcceptanceEvidence(kind="test", ref="test-runs/7"),
+        AcceptanceEvidence(kind="commit", ref="deadbee"),
+    )
+    block, warning = acceptance_block_for_finish(
+        spec, tmp_path, _unpushed_shell(), _config(),
+    )
+    assert warning is None
+
+
+def test_no_evidence_at_all_produces_no_warning(tmp_path):
+    now = datetime(2026, 7, 25, tzinfo=timezone.utc)
+    spec = Spec(
+        id="my-spec", title="My spec", status="approved",
+        created_at=now, updated_at=now,
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="does X")],
+    )
+    block, warning = acceptance_block_for_finish(
+        spec, tmp_path, _FakeShell(), _config(),
+    )
+    assert warning is None

--- a/tests/core/test_finish_evidence_warning.py
+++ b/tests/core/test_finish_evidence_warning.py
@@ -1,9 +1,17 @@
-"""finish's acceptance-block wrapper: embeds image evidence when the workspace's
-evidence commit is fetchable, and warns the operator (once, actionably) when it
-exists but is not — because `workspace_raw_base` answers only the git question
-and does not know the storage mode, the wrapper must gate on `committed` mode
-before ever calling it (see evidence_url.py's module docstring): under `local`
-the evidence dir is gitignored, so a URL would 404 for bytes never on the remote.
+"""finish's acceptance-block wrapper: embeds image evidence when the artifact is
+provably in a pushed workspace commit, and warns the operator (once, actionably)
+when it is not.
+
+Because `publish_evidence` answers only the git question and does not know the
+storage mode, the wrapper must gate on `committed` mode before ever calling it
+(see evidence_url.py's module docstring): under `local` the evidence dir is
+gitignored, so a URL would 404 for bytes never on the remote — and staging it
+would be actively wrong. The gate is asserted here as "the shell was never
+invoked at all".
+
+These are the wrapper's decisions with a scripted shell. The commit/push seam
+itself is covered end-to-end against a real git repo in
+test_finish_evidence_publish.py.
 """
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -58,6 +66,7 @@ def _pushed_shell() -> _FakeShell:
         "--abbrev-ref": (0, "main\n"),
         "rev-parse HEAD": (0, "abc123def456\n"),
         "ls-remote": (0, "abc123def456\trefs/heads/main\n"),
+        "cat-file": (0, ""),  # the artifact IS in the pinned commit's tree
     })
 
 
@@ -92,6 +101,20 @@ def test_committed_and_pushed_embeds_with_no_warning(tmp_path):
     assert warning is None
 
 
+def test_pushed_but_not_tracked_at_the_pinned_sha_is_named_not_embedded(tmp_path):
+    """The seatbelt: HEAD is on origin, but the artifact is not in that tree, so
+    the URL would 404. The module emitting the URL checks its own precondition
+    instead of trusting whoever was supposed to have committed the file."""
+    shell = _pushed_shell()
+    shell._replies["cat-file"] = (128, "")
+    spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF))
+    block, warning = acceptance_block_for_finish(spec, tmp_path, shell, _config())
+    assert "![" not in block
+    assert IMAGE_REF in block
+    assert warning is not None
+    assert "not tracked at workspace commit" in warning
+
+
 def test_local_mode_never_calls_the_shell_and_warns(tmp_path):
     spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF))
     shell = _pushed_shell()  # would happily answer "pushed" if ever asked
@@ -121,10 +144,11 @@ def test_no_image_evidence_produces_no_warning(tmp_path):
         AcceptanceEvidence(kind="test", ref="test-runs/7"),
         AcceptanceEvidence(kind="commit", ref="deadbee"),
     )
-    block, warning = acceptance_block_for_finish(
-        spec, tmp_path, _unpushed_shell(), _config(),
-    )
+    shell = _unpushed_shell()
+    block, warning = acceptance_block_for_finish(spec, tmp_path, shell, _config())
     assert warning is None
+    # Nothing embeddable => no reason to touch the operator's workspace repo.
+    assert shell.commands == []
 
 
 def test_no_evidence_at_all_produces_no_warning(tmp_path):

--- a/tests/core/test_finish_evidence_warning.py
+++ b/tests/core/test_finish_evidence_warning.py
@@ -16,10 +16,30 @@ test_finish_evidence_publish.py.
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
+from mship.core.evidence_store import store_artifact
 from mship.core.pr import acceptance_block_for_finish
 from mship.core.spec import AcceptanceCriterion, AcceptanceEvidence, Spec
 
+# The published-mode cases want an EMPTY store (see `_published_shell`), so they
+# use a literal of the shape `published` storage produces. Shape drift there
+# cannot go unnoticed: the embed assertions fail the moment a literal stops
+# looking like a stored ref. The local/encrypted cases go through the store
+# itself — see `_real_ref`.
 IMAGE_REF = "a1b2c3d4e5f6.png"
+
+
+def _real_ref(tmp_path, mode) -> str:
+    """A ref produced by the store itself, in `mode`.
+
+    The refs differ in SHAPE by mode (`encrypted` appends `.enc`), and a
+    hand-written literal cannot track that: this test file once asserted the
+    encrypted warning using a plaintext `.png` ref, which no encrypted store ever
+    produces, and passed while the warning did not fire at all. Going through
+    `store_artifact` makes that drift impossible.
+    """
+    src = tmp_path / "shot.png"
+    src.write_bytes(b"\x89PNG\r\n\x1a\n" + mode.encode())
+    return store_artifact(tmp_path, "my-spec", src, mode=mode)
 
 
 def _spec_with(*evidence: AcceptanceEvidence) -> Spec:
@@ -125,26 +145,54 @@ def test_pushed_but_not_tracked_at_the_pinned_sha_is_named_not_embedded(tmp_path
 
 
 def test_local_mode_never_calls_the_shell_and_warns(tmp_path):
-    spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF))
+    ref = _real_ref(tmp_path, "local")
+    spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=ref))
     shell = _published_shell()  # would happily answer "published" if ever asked
     block, warning = acceptance_block_for_finish(
         spec, tmp_path, tmp_path, shell, _config(evidence_storage="local"),
     )
     assert shell.commands == []
     assert "![" not in block
-    assert IMAGE_REF in block
+    assert ref in block
     assert warning is not None
+    assert "'local'" in warning
 
 
 def test_encrypted_mode_names_the_artifact_and_warns(tmp_path):
-    spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF))
+    """ac19: the ref an encrypted store really produces is `<hash>.png.enc`, so
+    the scan deciding whether this spec HAS image evidence has to see through the
+    suffix — otherwise the whole warning path is skipped for exactly the mode
+    that most needs it."""
+    ref = _real_ref(tmp_path, "encrypted")
+    assert ref.endswith(".png.enc")  # the shape under test, not an assumption
+    spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=ref))
     shell = _published_shell()
     block, warning = acceptance_block_for_finish(
         spec, tmp_path, tmp_path, shell, _config(evidence_storage="encrypted"),
     )
     assert shell.commands == []
     assert "![" not in block
+    assert ref in block
     assert warning is not None
+    assert "'encrypted'" in warning
+
+
+def test_ciphertext_left_over_from_an_earlier_mode_is_named_not_published(tmp_path):
+    """A ref records how its bytes were written; switching `evidence_storage` to
+    `published` later does not decrypt them. Such an artifact must still be named
+    and warned about, and must NOT be pushed to the evidence branch — ciphertext
+    on a public branch is bytes no renderer can ever use."""
+    ref = _real_ref(tmp_path, "encrypted")
+    spec = _spec_with(AcceptanceEvidence(kind="artifact", ref=ref))
+    shell = _published_shell()
+    block, warning = acceptance_block_for_finish(
+        spec, tmp_path, tmp_path, shell, _config(),  # mode: published
+    )
+    assert shell.commands == []
+    assert "![" not in block
+    assert ref in block
+    assert warning is not None
+    assert "encrypted" in warning
 
 
 def test_no_image_evidence_produces_no_warning(tmp_path):

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -848,3 +848,76 @@ def test_transition_to_review_no_ac_warning_without_bound_spec(state_with_task, 
     result = pm.transition("add-labels", "review")
     assert not any("evidence" in w.lower() and "acceptance" in w.lower()
                    for w in result.warnings)
+
+
+def _bind_spec_for_capture_hint(state_with_task, tmp_path):
+    """Shared setup for the two capture-hint-scoping tests below: bind an
+    approved spec with one unevidenced criterion to `add-labels`
+    (affected_repos=["shared", "auth-service"])."""
+    from mship.core.spec import AcceptanceCriterion, Spec
+    from mship.core.spec_store import SpecStore
+    from mship.core.workitem_store import WorkItemStore
+    now = datetime(2026, 4, 10, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(
+        id="add-labels-spec", title="S", status="approved",
+        created_at=now, updated_at=now,
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
+    ))
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi_id = state_with_task.load().tasks["add-labels"].work_item_id
+    items.link_spec(wi_id, "add-labels-spec", now=now)
+
+
+def test_transition_to_review_ac_capture_hint_only_names_affected_repos(state_with_task, tmp_path):
+    """C2: the `mship capture --evidence` hint must name only repos the TASK
+    affects (here "shared"/"auth-service"), even when the workspace also has
+    an unrelated repo ("notes") with its own capture target."""
+    from mship.core.config import CaptureConfig, RepoConfig, WorkspaceConfig
+    _bind_spec_for_capture_hint(state_with_task, tmp_path)
+
+    config = WorkspaceConfig(
+        workspace="test",
+        repos={
+            "shared": RepoConfig(path=Path("./shared"), type="library"),
+            "auth-service": RepoConfig(
+                path=Path("./auth-service"), type="service",
+                capture=CaptureConfig(platforms=["android"]),
+            ),
+            "notes": RepoConfig(
+                path=Path("./notes"), type="service",
+                capture=CaptureConfig(platforms=["ios"]),
+            ),
+        },
+    )
+    pm = PhaseManager(state_with_task, MagicMock(spec=LogManager), config=config, workspace_root=tmp_path)
+    pm.transition("add-labels", "dev")
+    result = pm.transition("add-labels", "review")
+    hint = next(w for w in result.warnings if "evidence" in w.lower() and "ac1" in w)
+    assert "auth-service" in hint
+    assert "notes" not in hint
+
+
+def test_transition_to_review_ac_capture_hint_omitted_when_intersection_empty(state_with_task, tmp_path):
+    """C2: when NONE of the task's affected repos define a capture target
+    (only an unrelated repo does), the `mship capture --evidence` suggestion
+    is omitted entirely — only the `mship spec evidence` remedy fires."""
+    from mship.core.config import CaptureConfig, RepoConfig, WorkspaceConfig
+    _bind_spec_for_capture_hint(state_with_task, tmp_path)
+
+    config = WorkspaceConfig(
+        workspace="test",
+        repos={
+            "shared": RepoConfig(path=Path("./shared"), type="library"),
+            "auth-service": RepoConfig(path=Path("./auth-service"), type="service"),
+            "notes": RepoConfig(
+                path=Path("./notes"), type="service",
+                capture=CaptureConfig(platforms=["ios"]),
+            ),
+        },
+    )
+    pm = PhaseManager(state_with_task, MagicMock(spec=LogManager), config=config, workspace_root=tmp_path)
+    pm.transition("add-labels", "dev")
+    result = pm.transition("add-labels", "review")
+    hint = next(w for w in result.warnings if "evidence" in w.lower() and "ac1" in w)
+    assert "mship capture --evidence" not in hint
+    assert "mship spec evidence" in hint

--- a/tests/core/test_phase_evidence_hint.py
+++ b/tests/core/test_phase_evidence_hint.py
@@ -1,0 +1,44 @@
+"""`unevidenced_warning`: the phase-transition hint for acceptance criteria
+carrying no evidence. Extends the existing `mship spec evidence` remedy with
+`mship capture --evidence` — but only for repos that actually define a capture
+target, since suggesting a command that cannot run is worse than saying
+nothing.
+"""
+from datetime import datetime, timezone
+
+from mship.core.phase import unevidenced_warning
+from mship.core.spec import AcceptanceCriterion, AcceptanceEvidence, Spec
+
+
+def _spec_with(*criteria: AcceptanceCriterion) -> Spec:
+    now = datetime(2026, 7, 25, tzinfo=timezone.utc)
+    return Spec(
+        id="my-spec", title="My spec", status="approved",
+        created_at=now, updated_at=now,
+        acceptance_criteria=list(criteria),
+    )
+
+
+def test_hint_names_capture_when_a_repo_has_a_capture_target():
+    spec = _spec_with(AcceptanceCriterion(id="ac1", text="renders"))
+    msg = unevidenced_warning(spec, capture_repos=["ground-control"])
+    assert "mship capture --evidence" in msg
+    assert "ground-control" in msg
+
+
+def test_hint_omits_capture_when_no_repo_defines_one():
+    spec = _spec_with(AcceptanceCriterion(id="ac1", text="renders"))
+    msg = unevidenced_warning(spec, capture_repos=[])
+    assert "mship capture" not in msg
+    # The original remedy still fires.
+    assert "mship spec evidence" in msg
+
+
+def test_no_warning_when_every_criterion_has_evidence():
+    spec = _spec_with(
+        AcceptanceCriterion(
+            id="ac1", text="renders",
+            evidence=[AcceptanceEvidence(kind="artifact", ref="abc123.png")],
+        )
+    )
+    assert unevidenced_warning(spec, capture_repos=["ground-control"]) == ""

--- a/tests/core/test_pr_evidence_embed.py
+++ b/tests/core/test_pr_evidence_embed.py
@@ -1,0 +1,297 @@
+"""Image evidence in the PR body: embedded when GitHub can fetch the bytes,
+named when it cannot.
+
+There is no public API for uploading an image attachment to a PR, so an embed
+only works when the artifact already lives somewhere GitHub's renderer can
+reach — i.e. committed to the public workspace repo and pushed. Everything here
+is about the two halves of that: rendering (`build_acceptance_block`, pure) and
+deciding whether a fetchable base URL exists at all (`workspace_raw_base`).
+"""
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from mship.core.pr import build_acceptance_block
+from mship.core.spec import AcceptanceCriterion, AcceptanceEvidence, Spec
+
+BASE = "https://raw.githubusercontent.com/o/r/abc123/specs/evidence"
+IMAGE_REF = "a1b2c3d4e5f6.png"
+
+
+def _spec_with(*evidence: AcceptanceEvidence) -> Spec:
+    now = datetime(2026, 7, 25, tzinfo=timezone.utc)
+    return Spec(
+        id="my-spec", title="My spec", status="approved",
+        created_at=now, updated_at=now,
+        acceptance_criteria=[
+            AcceptanceCriterion(
+                id="ac1", text="the screen renders", verdict="approved",
+                evidence=list(evidence),
+            )
+        ],
+    )
+
+
+# --- rendering -------------------------------------------------------------
+
+
+def test_image_artifact_is_embedded_when_a_base_url_is_available():
+    body = build_acceptance_block(
+        _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF)),
+        evidence_base_url=BASE,
+    )
+    assert f"![ac1]({BASE}/my-spec/{IMAGE_REF})" in body
+
+
+def test_without_a_base_url_the_artifact_is_named_not_embedded():
+    body = build_acceptance_block(
+        _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF)),
+        evidence_base_url=None,
+    )
+    assert "![" not in body
+    assert IMAGE_REF in body
+
+
+def test_non_image_artifact_is_never_embedded():
+    ref = "a1b2c3d4e5f6.xml"
+    body = build_acceptance_block(
+        _spec_with(AcceptanceEvidence(kind="artifact", ref=ref)),
+        evidence_base_url=BASE,
+    )
+    assert "![" not in body
+    assert f"artifact:{ref}" in body
+
+
+def test_encrypted_artifact_is_never_embedded():
+    """The bytes on GitHub are ciphertext, so an embed would render broken."""
+    ref = f"{IMAGE_REF}.enc"
+    body = build_acceptance_block(
+        _spec_with(AcceptanceEvidence(kind="artifact", ref=ref)),
+        evidence_base_url=BASE,
+    )
+    assert "![" not in body
+    assert f"artifact:{ref}" in body
+
+
+def test_artifact_ref_that_is_not_a_stored_ref_is_never_embedded():
+    """Only refs the evidence store produced resolve under the base URL; a
+    hand-written path would embed a URL that 404s."""
+    body = build_acceptance_block(
+        _spec_with(AcceptanceEvidence(kind="artifact", ref="docs/shot.png")),
+        evidence_base_url=BASE,
+    )
+    assert "![" not in body
+    assert "artifact:docs/shot.png" in body
+
+
+def test_test_and_commit_refs_render_as_before():
+    body = build_acceptance_block(
+        _spec_with(
+            AcceptanceEvidence(kind="test", ref="test-runs/7"),
+            AcceptanceEvidence(kind="commit", ref="deadbee"),
+        ),
+        evidence_base_url=BASE,
+    )
+    assert "- [x] `ac1` the screen renders — test:test-runs/7, commit:deadbee" in body
+    assert "![" not in body
+
+
+def test_embedded_image_sits_on_its_own_line_beneath_the_criterion():
+    body = build_acceptance_block(
+        _spec_with(
+            AcceptanceEvidence(kind="test", ref="test-runs/7"),
+            AcceptanceEvidence(kind="artifact", ref=IMAGE_REF),
+        ),
+        evidence_base_url=BASE,
+    )
+    lines = body.splitlines()
+    i = lines.index("- [x] `ac1` the screen renders — test:test-runs/7")
+    assert lines[i + 1] == ""
+    assert lines[i + 2] == f"  ![ac1]({BASE}/my-spec/{IMAGE_REF})"
+
+
+def test_criterion_with_no_evidence_is_unchanged():
+    now = datetime(2026, 7, 25, tzinfo=timezone.utc)
+    spec = Spec(
+        id="my-spec", title="My spec", status="approved",
+        created_at=now, updated_at=now,
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="does X")],
+    )
+    assert "- [ ] `ac1` does X — _no evidence_" in build_acceptance_block(
+        spec, evidence_base_url=BASE
+    )
+
+
+def test_default_call_still_names_artifacts():
+    """Existing callers pass no base URL and must be unaffected."""
+    body = build_acceptance_block(
+        _spec_with(AcceptanceEvidence(kind="artifact", ref=IMAGE_REF))
+    )
+    assert "![" not in body
+    assert f"artifact:{IMAGE_REF}" in body
+
+
+# --- base-URL resolution ---------------------------------------------------
+
+
+class _FakeShell:
+    """Stands in for util/shell.py::ShellRunner. `run` takes a command STRING.
+
+    `replies` maps a command fragment to (returncode, stdout); first match wins,
+    anything unmatched fails.
+    """
+
+    def __init__(self, replies: dict[str, tuple[int, str]] | None = None):
+        self._replies = replies or {}
+        self.commands: list[str] = []
+
+    def run(self, command, cwd, env=None, timeout=None):
+        self.commands.append(command)
+        for fragment, (rc, out) in self._replies.items():
+            if fragment in command:
+                return type("R", (), {"returncode": rc, "stdout": out, "stderr": ""})()
+        return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+
+
+def _pushed_shell(remote_url: str) -> _FakeShell:
+    return _FakeShell({
+        "remote get-url": (0, remote_url),
+        "--abbrev-ref": (0, "main\n"),
+        "rev-parse HEAD": (0, "abc123def456\n"),
+        "ls-remote": (0, "abc123def456\trefs/heads/main\n"),
+    })
+
+
+def test_ssh_remote_yields_a_sha_pinned_raw_base(tmp_path):
+    from mship.core.evidence_url import workspace_raw_base
+
+    assert workspace_raw_base(
+        tmp_path, _pushed_shell("git@github.com:o/r.git\n")
+    ) == "https://raw.githubusercontent.com/o/r/abc123def456/specs/evidence"
+
+
+def test_https_remote_yields_the_same_base(tmp_path):
+    from mship.core.evidence_url import workspace_raw_base
+
+    assert workspace_raw_base(
+        tmp_path, _pushed_shell("https://github.com/o/r.git\n")
+    ) == "https://raw.githubusercontent.com/o/r/abc123def456/specs/evidence"
+
+
+def test_non_github_remote_has_no_base(tmp_path):
+    from mship.core.evidence_url import workspace_raw_base
+
+    assert workspace_raw_base(
+        tmp_path, _pushed_shell("git@gitlab.com:o/r.git\n")
+    ) is None
+
+
+def test_missing_remote_has_no_base(tmp_path):
+    from mship.core.evidence_url import workspace_raw_base
+
+    assert workspace_raw_base(tmp_path, _FakeShell()) is None
+
+
+def test_detached_head_has_no_base(tmp_path):
+    from mship.core.evidence_url import workspace_raw_base
+
+    shell = _FakeShell({
+        "remote get-url": (0, "git@github.com:o/r.git\n"),
+        "--abbrev-ref": (0, "HEAD\n"),
+        "rev-parse HEAD": (0, "abc123def456\n"),
+    })
+    assert workspace_raw_base(tmp_path, shell) is None
+
+
+def test_unreachable_remote_has_no_base(tmp_path):
+    from mship.core.evidence_url import workspace_raw_base
+
+    shell = _FakeShell({
+        "remote get-url": (0, "git@github.com:o/r.git\n"),
+        "--abbrev-ref": (0, "main\n"),
+        "rev-parse HEAD": (0, "abc123def456\n"),
+        "ls-remote": (128, ""),
+    })
+    assert workspace_raw_base(tmp_path, shell) is None
+
+
+# --- the pushed/unpushed call, against real git ----------------------------
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def _real_repo(tmp_path: Path) -> Path:
+    """A working clone whose origin is a local bare repo living at a path that
+    parses as a GitHub slug — so the slug is real, the git plumbing is real, and
+    no network is touched."""
+    origin = tmp_path / "github.com" / "o" / "r.git"
+    origin.parent.mkdir(parents=True)
+    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True)
+    repo = tmp_path / "wc"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    _git(repo, "remote", "add", "origin", str(origin))
+    (repo / "specs").mkdir()
+    (repo / "specs" / "f.md").write_text("x")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "evidence")
+    return repo
+
+
+def test_real_repo_unpushed_head_has_no_base(tmp_path):
+    from mship.core.evidence_url import workspace_raw_base
+    from mship.util.shell import ShellRunner
+
+    repo = _real_repo(tmp_path)
+    assert workspace_raw_base(repo, ShellRunner()) is None
+
+
+def test_real_repo_pushed_head_pins_the_sha(tmp_path):
+    from mship.core.evidence_url import workspace_raw_base
+    from mship.util.shell import ShellRunner
+
+    repo = _real_repo(tmp_path)
+    _git(repo, "push", "-q", "-u", "origin", "main")
+    sha = _git(repo, "rev-parse", "HEAD")
+
+    assert workspace_raw_base(repo, ShellRunner()) == (
+        f"https://raw.githubusercontent.com/o/r/{sha}/specs/evidence"
+    )
+
+
+def test_real_repo_head_behind_a_pushed_tip_is_still_fetchable(tmp_path):
+    """HEAD reachable from the remote tip is on the remote — the evidence blob
+    at that sha is fetchable even though the branch has moved on."""
+    from mship.core.evidence_url import workspace_raw_base
+    from mship.util.shell import ShellRunner
+
+    repo = _real_repo(tmp_path)
+    (repo / "specs" / "g.md").write_text("y")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "more")
+    _git(repo, "push", "-q", "-u", "origin", "main")
+    _git(repo, "checkout", "-q", "-B", "main", "HEAD~1")
+    sha = _git(repo, "rev-parse", "HEAD")
+
+    assert workspace_raw_base(repo, ShellRunner()) == (
+        f"https://raw.githubusercontent.com/o/r/{sha}/specs/evidence"
+    )
+
+
+def test_real_repo_new_local_commit_after_a_push_has_no_base(tmp_path):
+    from mship.core.evidence_url import workspace_raw_base
+    from mship.util.shell import ShellRunner
+
+    repo = _real_repo(tmp_path)
+    _git(repo, "push", "-q", "-u", "origin", "main")
+    (repo / "specs" / "h.md").write_text("z")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "unpushed evidence")
+
+    assert workspace_raw_base(repo, ShellRunner()) is None

--- a/tests/core/test_pr_evidence_embed.py
+++ b/tests/core/test_pr_evidence_embed.py
@@ -3,18 +3,19 @@ named when it cannot.
 
 There is no public API for uploading an image attachment to a PR, so an embed
 only works when the artifact already lives somewhere GitHub's renderer can
-reach — i.e. committed to the public workspace repo and pushed. Everything here
-is about the two halves of that: rendering (`build_acceptance_block`, pure) and
-deciding whether a fetchable base URL exists at all (`workspace_raw_base`).
+reach — i.e. published to the target repo's evidence branch. This is the pure
+half: `build_acceptance_block` deciding what to embed and what to name, given a
+base URL. Whether such a URL exists at all is the publication question, covered
+against real git in test_finish_evidence_publish.py.
 """
-import subprocess
 from datetime import datetime, timezone
-from pathlib import Path
 
 from mship.core.pr import build_acceptance_block
 from mship.core.spec import AcceptanceCriterion, AcceptanceEvidence, Spec
 
-BASE = "https://raw.githubusercontent.com/o/r/abc123/specs/evidence"
+# A published-commit base: `<owner>/<repo>/<orphan-commit-sha>`, under which
+# an artifact lives at `<spec-id>/<ref>`.
+BASE = "https://raw.githubusercontent.com/o/r/abc123"
 IMAGE_REF = "a1b2c3d4e5f6.png"
 
 
@@ -129,169 +130,3 @@ def test_default_call_still_names_artifacts():
     )
     assert "![" not in body
     assert f"artifact:{IMAGE_REF}" in body
-
-
-# --- base-URL resolution ---------------------------------------------------
-
-
-class _FakeShell:
-    """Stands in for util/shell.py::ShellRunner. `run` takes a command STRING.
-
-    `replies` maps a command fragment to (returncode, stdout); first match wins,
-    anything unmatched fails.
-    """
-
-    def __init__(self, replies: dict[str, tuple[int, str]] | None = None):
-        self._replies = replies or {}
-        self.commands: list[str] = []
-
-    def run(self, command, cwd, env=None, timeout=None):
-        self.commands.append(command)
-        for fragment, (rc, out) in self._replies.items():
-            if fragment in command:
-                return type("R", (), {"returncode": rc, "stdout": out, "stderr": ""})()
-        return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
-
-
-def _pushed_shell(remote_url: str) -> _FakeShell:
-    return _FakeShell({
-        "remote get-url": (0, remote_url),
-        "--abbrev-ref": (0, "main\n"),
-        "rev-parse HEAD": (0, "abc123def456\n"),
-        "ls-remote": (0, "abc123def456\trefs/heads/main\n"),
-    })
-
-
-def test_ssh_remote_yields_a_sha_pinned_raw_base(tmp_path):
-    from mship.core.evidence_url import workspace_raw_base
-
-    assert workspace_raw_base(
-        tmp_path, _pushed_shell("git@github.com:o/r.git\n")
-    ) == "https://raw.githubusercontent.com/o/r/abc123def456/specs/evidence"
-
-
-def test_https_remote_yields_the_same_base(tmp_path):
-    from mship.core.evidence_url import workspace_raw_base
-
-    assert workspace_raw_base(
-        tmp_path, _pushed_shell("https://github.com/o/r.git\n")
-    ) == "https://raw.githubusercontent.com/o/r/abc123def456/specs/evidence"
-
-
-def test_non_github_remote_has_no_base(tmp_path):
-    from mship.core.evidence_url import workspace_raw_base
-
-    assert workspace_raw_base(
-        tmp_path, _pushed_shell("git@gitlab.com:o/r.git\n")
-    ) is None
-
-
-def test_missing_remote_has_no_base(tmp_path):
-    from mship.core.evidence_url import workspace_raw_base
-
-    assert workspace_raw_base(tmp_path, _FakeShell()) is None
-
-
-def test_detached_head_has_no_base(tmp_path):
-    from mship.core.evidence_url import workspace_raw_base
-
-    shell = _FakeShell({
-        "remote get-url": (0, "git@github.com:o/r.git\n"),
-        "--abbrev-ref": (0, "HEAD\n"),
-        "rev-parse HEAD": (0, "abc123def456\n"),
-    })
-    assert workspace_raw_base(tmp_path, shell) is None
-
-
-def test_unreachable_remote_has_no_base(tmp_path):
-    from mship.core.evidence_url import workspace_raw_base
-
-    shell = _FakeShell({
-        "remote get-url": (0, "git@github.com:o/r.git\n"),
-        "--abbrev-ref": (0, "main\n"),
-        "rev-parse HEAD": (0, "abc123def456\n"),
-        "ls-remote": (128, ""),
-    })
-    assert workspace_raw_base(tmp_path, shell) is None
-
-
-# --- the pushed/unpushed call, against real git ----------------------------
-
-
-def _git(repo: Path, *args: str) -> str:
-    return subprocess.run(
-        ["git", *args], cwd=repo, capture_output=True, text=True, check=True,
-    ).stdout.strip()
-
-
-def _real_repo(tmp_path: Path) -> Path:
-    """A working clone whose origin is a local bare repo living at a path that
-    parses as a GitHub slug — so the slug is real, the git plumbing is real, and
-    no network is touched."""
-    origin = tmp_path / "github.com" / "o" / "r.git"
-    origin.parent.mkdir(parents=True)
-    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True)
-    repo = tmp_path / "wc"
-    repo.mkdir()
-    _git(repo, "init", "-q", "-b", "main")
-    _git(repo, "config", "user.email", "t@example.com")
-    _git(repo, "config", "user.name", "t")
-    _git(repo, "remote", "add", "origin", str(origin))
-    (repo / "specs").mkdir()
-    (repo / "specs" / "f.md").write_text("x")
-    _git(repo, "add", ".")
-    _git(repo, "commit", "-qm", "evidence")
-    return repo
-
-
-def test_real_repo_unpushed_head_has_no_base(tmp_path):
-    from mship.core.evidence_url import workspace_raw_base
-    from mship.util.shell import ShellRunner
-
-    repo = _real_repo(tmp_path)
-    assert workspace_raw_base(repo, ShellRunner()) is None
-
-
-def test_real_repo_pushed_head_pins_the_sha(tmp_path):
-    from mship.core.evidence_url import workspace_raw_base
-    from mship.util.shell import ShellRunner
-
-    repo = _real_repo(tmp_path)
-    _git(repo, "push", "-q", "-u", "origin", "main")
-    sha = _git(repo, "rev-parse", "HEAD")
-
-    assert workspace_raw_base(repo, ShellRunner()) == (
-        f"https://raw.githubusercontent.com/o/r/{sha}/specs/evidence"
-    )
-
-
-def test_real_repo_head_behind_a_pushed_tip_is_still_fetchable(tmp_path):
-    """HEAD reachable from the remote tip is on the remote — the evidence blob
-    at that sha is fetchable even though the branch has moved on."""
-    from mship.core.evidence_url import workspace_raw_base
-    from mship.util.shell import ShellRunner
-
-    repo = _real_repo(tmp_path)
-    (repo / "specs" / "g.md").write_text("y")
-    _git(repo, "add", ".")
-    _git(repo, "commit", "-qm", "more")
-    _git(repo, "push", "-q", "-u", "origin", "main")
-    _git(repo, "checkout", "-q", "-B", "main", "HEAD~1")
-    sha = _git(repo, "rev-parse", "HEAD")
-
-    assert workspace_raw_base(repo, ShellRunner()) == (
-        f"https://raw.githubusercontent.com/o/r/{sha}/specs/evidence"
-    )
-
-
-def test_real_repo_new_local_commit_after_a_push_has_no_base(tmp_path):
-    from mship.core.evidence_url import workspace_raw_base
-    from mship.util.shell import ShellRunner
-
-    repo = _real_repo(tmp_path)
-    _git(repo, "push", "-q", "-u", "origin", "main")
-    (repo / "specs" / "h.md").write_text("z")
-    _git(repo, "add", ".")
-    _git(repo, "commit", "-qm", "unpushed evidence")
-
-    assert workspace_raw_base(repo, ShellRunner()) is None

--- a/tests/core/test_serve_evidence_blob.py
+++ b/tests/core/test_serve_evidence_blob.py
@@ -180,6 +180,21 @@ def test_encrypted_blob_with_key_returns_decrypted_bytes(tmp_path: Path):
     assert r.headers["content-type"].startswith("image/png")
 
 
+def test_layout_html_is_never_served_as_html(tmp_path: Path):
+    """A layout dump is app-under-test content, so serving it as text/html would
+    make the API's own origin a stored-XSS sink. Type and nosniff, together."""
+    _seed_spec(tmp_path)
+    from mship.core.evidence_store import store_artifact
+    src = tmp_path / "layout.html"
+    src.write_text("<script>alert(1)</script>")
+    ref = store_artifact(tmp_path, "dq", src, mode="committed")
+
+    r = _client(tmp_path).get(f"/specs/dq/evidence/{ref}/blob", headers=AUTH)
+    assert r.status_code == 200, r.text
+    assert r.headers["content-type"].startswith("text/plain")
+    assert r.headers["x-content-type-options"] == "nosniff"
+
+
 def test_oversized_blob_is_refused(tmp_path: Path, monkeypatch):
     """Serve-time is where the cap actually protects the caller: bytes can reach
     the store without passing store_artifact. The cap VALUE is a judgement call,

--- a/tests/core/test_serve_evidence_blob.py
+++ b/tests/core/test_serve_evidence_blob.py
@@ -64,7 +64,7 @@ def _seed_encrypted_spec(tmp_path: Path) -> None:
     )
 
 
-def _seed_evidence(tmp_path: Path, mode: str = "committed") -> str:
+def _seed_evidence(tmp_path: Path, mode: str = "published") -> str:
     """Store an artifact the way the CLI does, so the ref under test is the real
     content-hashed name rather than one this test invented."""
     from mship.core.evidence_store import store_artifact
@@ -188,7 +188,7 @@ def test_layout_html_is_never_served_as_html(tmp_path: Path):
     from mship.core.evidence_store import store_artifact
     src = tmp_path / "layout.html"
     src.write_text("<script>alert(1)</script>")
-    ref = store_artifact(tmp_path, "dq", src, mode="committed")
+    ref = store_artifact(tmp_path, "dq", src, mode="published")
 
     r = _client(tmp_path).get(f"/specs/dq/evidence/{ref}/blob", headers=AUTH)
     assert r.status_code == 200, r.text

--- a/tests/core/test_serve_evidence_blob.py
+++ b/tests/core/test_serve_evidence_blob.py
@@ -180,6 +180,20 @@ def test_encrypted_blob_with_key_returns_decrypted_bytes(tmp_path: Path):
     assert r.headers["content-type"].startswith("image/png")
 
 
+def test_oversized_blob_is_refused(tmp_path: Path, monkeypatch):
+    """Serve-time is where the cap actually protects the caller: bytes can reach
+    the store without passing store_artifact. The cap VALUE is a judgement call,
+    so the test moves it rather than materialising megabytes."""
+    from mship.core import evidence_store
+
+    _seed_spec(tmp_path)
+    ref = _seed_evidence(tmp_path)
+    monkeypatch.setattr(evidence_store, "MAX_EVIDENCE_BYTES", 1)
+    r = _client(tmp_path).get(f"/specs/dq/evidence/{ref}/blob", headers=AUTH)
+    assert r.status_code == 413, r.text
+    assert PNG_BYTES not in r.content
+
+
 def test_undecryptable_encrypted_blob_is_not_a_500(tmp_path: Path):
     """A `.enc` artifact the current key cannot open (key regenerated after a
     loss, or a restore from another host) is a locked-shaped 409, not a

--- a/tests/core/test_serve_evidence_blob.py
+++ b/tests/core/test_serve_evidence_blob.py
@@ -23,7 +23,7 @@ AUTH = {"Authorization": f"Bearer {TOKEN}"}
 PNG_BYTES = b"\x89PNG fake bytes"
 
 
-def _app(tmp_path: Path, auth_token: str | None = None):
+def _app(tmp_path: Path, auth_token: str | None = None, config=None):
     return create_app(
         specs_dir=tmp_path / "specs",
         state_manager=StateManager(tmp_path / ".mothership"),
@@ -31,21 +31,37 @@ def _app(tmp_path: Path, auth_token: str | None = None):
         workspace_root=tmp_path,
         workspace_name="test-ws",
         auth_token=auth_token,
+        config=config,
     )
 
 
-def _client(tmp_path: Path) -> TestClient:
-    return TestClient(_app(tmp_path, auth_token=TOKEN))
+def _client(tmp_path: Path, config=None) -> TestClient:
+    return TestClient(_app(tmp_path, auth_token=TOKEN, config=config))
 
 
-def _seed_spec(tmp_path: Path) -> None:
-    now = datetime(2026, 7, 26, tzinfo=timezone.utc)
-    SpecStore(tmp_path / "specs").save(Spec(
+def _spec(now) -> Spec:
+    return Spec(
         id="dq", title="Decision queue", status="needs_review",
         created_at=now, updated_at=now, task_slug="dq",
         body=render_body("the problem", "as a user", "the approach"),
         acceptance_criteria=[AcceptanceCriterion(id="ac1", text="view questions")],
-    ))
+    )
+
+
+def _seed_spec(tmp_path: Path) -> None:
+    SpecStore(tmp_path / "specs").save(_spec(datetime(2026, 7, 26, tzinfo=timezone.utc)))
+
+
+def _seed_encrypted_spec(tmp_path: Path) -> None:
+    """A genuinely encrypted workspace: the SPEC FILE itself is ciphertext, not
+    just the artifact. This is what `spec_storage: encrypted` produces, and the
+    only shape in which a missing key locks the spec as well as its evidence."""
+    from mship.core.spec_storage import SpecStorage
+
+    storage = SpecStorage(tmp_path / "specs", mode="encrypted", workspace_root=tmp_path)
+    SpecStore(tmp_path / "specs", storage=storage).save(
+        _spec(datetime(2026, 7, 26, tzinfo=timezone.utc))
+    )
 
 
 def _seed_evidence(tmp_path: Path, mode: str = "committed") -> str:
@@ -112,7 +128,36 @@ def test_traversing_spec_id_is_404(tmp_path: Path):
     assert b"secret screenshot" not in r.content
 
 
+def test_locked_spec_reports_locked_rather_than_missing(tmp_path: Path):
+    """The primary shape of "no key on this host": `spec_storage: encrypted`,
+    so the spec file is ciphertext too and evidence inherits the mode.
+
+    The blob route must report the SAME key-unavailable condition the spec read
+    path reports. It used to 404 "no spec" instead, because its pre-check went
+    through the spec store's list, which silently skips locked specs.
+    """
+    from mship.core.config import WorkspaceConfig
+
+    _seed_encrypted_spec(tmp_path)
+    ref = _seed_evidence(tmp_path, mode="encrypted")
+    spec_key.keyfile_path(tmp_path).unlink()
+
+    client = _client(tmp_path, config=WorkspaceConfig(
+        workspace="test-ws", spec_storage="encrypted",
+    ))
+    # What the spec read path says about this spec, for comparison.
+    detail = client.get("/specs/dq", headers=AUTH)
+    assert detail.status_code == 200 and detail.json()["locked"] is True
+
+    r = client.get(f"/specs/dq/evidence/{ref}/blob", headers=AUTH)
+    assert r.status_code == 409, r.text
+    assert "locked" in r.text
+    assert PNG_BYTES not in r.content and b"gAAAA" not in r.content
+
+
 def test_encrypted_blob_without_key_is_locked_not_plaintext(tmp_path: Path):
+    # The legal-but-narrower config: plaintext spec, encrypted evidence
+    # (`spec_storage: committed` + `evidence_storage: encrypted`).
     _seed_spec(tmp_path)
     ref = _seed_evidence(tmp_path, mode="encrypted")
     spec_key.keyfile_path(tmp_path).unlink()

--- a/tests/core/test_serve_evidence_blob.py
+++ b/tests/core/test_serve_evidence_blob.py
@@ -1,0 +1,150 @@
+"""GET /specs/{spec_id}/evidence/{name}/blob — the read-only artifact bytes.
+
+Both path parameters arrive from the network, so the interesting cases here are
+the ones that must NOT resolve. All of that validation lives in
+`core/evidence_store.py::resolve_ref`; these tests pin the route's contract
+(status codes, content-type, never ciphertext), not a second copy of the rules.
+"""
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mship.core import spec_key
+from mship.core.serve import create_app
+from mship.core.spec import AcceptanceCriterion, Spec
+from mship.core.spec_body import render_body
+from mship.core.spec_store import SpecStore
+from mship.core.state import StateManager
+
+TOKEN = "sekrit"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+PNG_BYTES = b"\x89PNG fake bytes"
+
+
+def _app(tmp_path: Path, auth_token: str | None = None):
+    return create_app(
+        specs_dir=tmp_path / "specs",
+        state_manager=StateManager(tmp_path / ".mothership"),
+        log_manager=None,
+        workspace_root=tmp_path,
+        workspace_name="test-ws",
+        auth_token=auth_token,
+    )
+
+
+def _client(tmp_path: Path) -> TestClient:
+    return TestClient(_app(tmp_path, auth_token=TOKEN))
+
+
+def _seed_spec(tmp_path: Path) -> None:
+    now = datetime(2026, 7, 26, tzinfo=timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(
+        id="dq", title="Decision queue", status="needs_review",
+        created_at=now, updated_at=now, task_slug="dq",
+        body=render_body("the problem", "as a user", "the approach"),
+        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="view questions")],
+    ))
+
+
+def _seed_evidence(tmp_path: Path, mode: str = "committed") -> str:
+    """Store an artifact the way the CLI does, so the ref under test is the real
+    content-hashed name rather than one this test invented."""
+    from mship.core.evidence_store import store_artifact
+
+    src = tmp_path / "screen.png"
+    src.write_bytes(PNG_BYTES)
+    return store_artifact(tmp_path, "dq", src, mode=mode)
+
+
+def test_blob_returns_stored_bytes_and_content_type(tmp_path: Path):
+    _seed_spec(tmp_path)
+    ref = _seed_evidence(tmp_path)
+    r = _client(tmp_path).get(f"/specs/dq/evidence/{ref}/blob", headers=AUTH)
+    assert r.status_code == 200
+    assert r.content == PNG_BYTES
+    assert r.headers["content-type"].startswith("image/png")
+
+
+def test_blob_requires_the_bearer(tmp_path: Path):
+    _seed_spec(tmp_path)
+    ref = _seed_evidence(tmp_path)
+    # The app-wide dependency covers this route like every other one.
+    assert _client(tmp_path).get(f"/specs/dq/evidence/{ref}/blob").status_code == 401
+
+
+@pytest.mark.parametrize("bad", [
+    "../../etc/passwd",       # traversal, encoded by the client into %2F segments
+    "sub%2Fdir.png",          # an encoded separator, decoded before routing
+    "ffffffffffff.png",       # well-formed but absent
+    "x",                      # not a ref at all
+    "deadbeefcafe.exe",       # full-length hash, extension we never serve
+    "deadbeefcafe.png%0A",    # trailing newline (why resolve_ref uses fullmatch)
+])
+def test_unresolvable_ref_is_404_not_403(tmp_path: Path, bad: str):
+    # 404 for everything: the route must never confirm what exists on disk.
+    _seed_spec(tmp_path)
+    _seed_evidence(tmp_path)
+    r = _client(tmp_path).get(f"/specs/dq/evidence/{bad}/blob", headers=AUTH)
+    assert r.status_code == 404, r.text
+
+
+def test_traversing_spec_id_is_404(tmp_path: Path):
+    """Two distinct shapes, both 404 — the second is the one that reaches us.
+
+    Starlette percent-decodes the request path BEFORE routing, so `..%2Fother`
+    becomes two segments and no longer matches the single-segment `{spec_id}`
+    path parameter: the router 404s before the handler runs. But `%2E%2E`
+    decodes to a bare `..`, which is a legal single segment and DOES arrive in
+    the handler — so the handler itself has to refuse it.
+    """
+    _seed_spec(tmp_path)
+    ref = _seed_evidence(tmp_path)
+    other = tmp_path / "specs" / "evidence" / "other"
+    other.mkdir(parents=True)
+    (other / ref).write_bytes(b"another spec's secret screenshot")
+
+    client = _client(tmp_path)
+    assert client.get(f"/specs/..%2Fother/evidence/{ref}/blob", headers=AUTH).status_code == 404
+    r = client.get(f"/specs/%2E%2E/evidence/{ref}/blob", headers=AUTH)
+    assert r.status_code == 404, r.text
+    assert b"secret screenshot" not in r.content
+
+
+def test_encrypted_blob_without_key_is_locked_not_plaintext(tmp_path: Path):
+    _seed_spec(tmp_path)
+    ref = _seed_evidence(tmp_path, mode="encrypted")
+    spec_key.keyfile_path(tmp_path).unlink()
+    r = _client(tmp_path).get(f"/specs/dq/evidence/{ref}/blob", headers=AUTH)
+    assert r.status_code == 409, r.text
+    assert "locked" in r.text
+    # Neither plaintext nor ciphertext leaves the host.
+    assert PNG_BYTES not in r.content
+    assert b"gAAAA" not in r.content
+
+
+def test_encrypted_blob_with_key_returns_decrypted_bytes(tmp_path: Path):
+    _seed_spec(tmp_path)
+    ref = _seed_evidence(tmp_path, mode="encrypted")
+    assert ref.endswith(".png.enc")
+    r = _client(tmp_path).get(f"/specs/dq/evidence/{ref}/blob", headers=AUTH)
+    assert r.status_code == 200, r.text
+    assert r.content == PNG_BYTES
+    # The content-type is the LOGICAL extension's, not `.enc`'s.
+    assert r.headers["content-type"].startswith("image/png")
+
+
+def test_undecryptable_encrypted_blob_is_not_a_500(tmp_path: Path):
+    """A `.enc` artifact the current key cannot open (key regenerated after a
+    loss, or a restore from another host) is a locked-shaped 409, not a
+    traceback."""
+    _seed_spec(tmp_path)
+    ref = _seed_evidence(tmp_path, mode="encrypted")
+    keyfile = spec_key.keyfile_path(tmp_path)
+    keyfile.unlink()
+    from cryptography.fernet import Fernet
+    keyfile.write_bytes(Fernet.generate_key())
+    r = _client(tmp_path).get(f"/specs/dq/evidence/{ref}/blob", headers=AUTH)
+    assert r.status_code == 409, r.text
+    assert PNG_BYTES not in r.content

--- a/tests/core/test_serve_evidence_blob.py
+++ b/tests/core/test_serve_evidence_blob.py
@@ -117,7 +117,8 @@ def test_traversing_spec_id_is_404(tmp_path: Path):
     """
     _seed_spec(tmp_path)
     ref = _seed_evidence(tmp_path)
-    other = tmp_path / "specs" / "evidence" / "other"
+    from mship.core.evidence_store import evidence_dir
+    other = evidence_dir(tmp_path, "other")
     other.mkdir(parents=True)
     (other / ref).write_bytes(b"another spec's secret screenshot")
 

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -85,6 +85,24 @@ def test_spawn_all_repos(worktree_deps):
 
 
 
+def test_spawn_gitignores_mships_runtime_directories(worktree_deps):
+    """In a monorepo or single-repo workspace the root IS a product repo, so
+    mship's machine-local state — task state, captures, the spec key, the
+    evidence store — has to be invisible to git rather than merely untracked."""
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    # The interesting shape: the workspace ROOT is itself a git repo.
+    subprocess.run(["git", "init", "-q", str(workspace)], check=True, capture_output=True)
+    mgr = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    mgr.spawn("ignore runtime dirs", repos=["shared"], workspace_root=workspace)
+
+    ignored = (workspace / ".gitignore").read_text().splitlines()
+    assert ".worktrees" in ignored
+    assert ".mothership" in ignored
+    # The entry actually covers what lives under it — a stored evidence artifact
+    # in the workspace repo's own tree must never show up in `git status`.
+    assert git.is_ignored(workspace, ".mothership/evidence/s/a1b2c3d4e5f6.png")
+
+
 def test_spawn_custom_branch_pattern(workspace_with_git: Path):
     workspace = workspace_with_git
     cfg = workspace / "mothership.yaml"


### PR DESCRIPTION
## Summary

Closes the artifact half of the acceptance-criterion evidence loop. A capture becomes evidence in one command, the phone can fetch it, and the pull request embeds it — so a criterion about visible behaviour is reviewed by looking at the screen rather than by trusting a claim.

`mship capture --evidence <spec-id>:<ac-id>` hashes each captured artifact, stores it, and attaches it to the criterion with the revision it was taken from. `mship serve` grows a read-only blob route the phone fetches over the relay. Ground Control renders images full-width on the spec-detail row with tap-to-zoom. `mship finish` publishes referenced artifacts and embeds them in the PR body.

Bare `mship capture` is unchanged — it stays an ephemeral develop-verify-iterate artifact. Only `--evidence` promotes.

## Two decisions worth the reasoning

**Bytes live in `.mothership/evidence/`, not in a repo.** The first design stored them in the workspace repo under `specs/`, which silently assumed the workspace is a separate metarepo from the product code. mship also supports a monorepo and a single repo, where the workspace root *is* the product repo — that design would have committed screenshots into the product's own history and pushed its `main` as a side effect of opening a PR. The local store works identically in all three shapes.

**Publication is an `mship-evidence` orphan branch in the member repo the PR targets.** It shares no history with `main`, so binaries never enter the default branch's tree; `raw.githubusercontent.com` serves any ref; and every workspace shape has a member repo with a remote. The commit is built with plumbing (`hash-object`, a throwaway index seeded from the previous tip, `commit-tree`) and pushed as a bare object — no checkout, no local ref, and `main` is provably untouched both locally and on the origin.

## Security boundaries

The evidence ref is a bare filename, so a path outside the store is unrepresentable rather than merely rejected. `resolve_ref` owns all validation for both the CLI and the route, including `spec_id` containment — both arrive from an HTTP path. Symlinks in the store are refused outright. Responses are size-capped before decryption, non-image artifacts are served as `text/plain` with `nosniff`, and everything unresolvable is a 404 rather than a 403 so the route never confirms what exists.

`evidence_storage` may never be more exposed than `spec_storage` — a plaintext screenshot beside an encrypted spec discloses exactly what the encryption protects. That is enforced at config load, not at use.

## Test plan

- [x] `mship test` green across both repos, no regressions (iteration 5)
- [x] mothership 3499 passing; ground-control JVM suite passing, `assembleDebug` clean
- [x] Publication tested end-to-end against a real working clone and a real bare origin: `main` unmoved on both sides, orphan branch shares no history, publications accumulate, unrelated uncommitted work never swept in, push failure degrades to a named artifact
- [x] Traversal, symlink-escape, encoded-path and locked-workspace cases pinned on the blob route
- [ ] Ground Control rendering verified on a device — not possible in this environment (no emulator); the decision logic is unit-tested, the Compose slots rest on review

## Known limitations

- Remote provenance is computed against the local worktree, so a `--remote` capture's revision marker is directionally honest but imprecise.
- Evidence renders on spec detail only. The Queue shows specs awaiting approval — before implementation — so no evidence exists at that point.
- No garbage collection of the orphan branch; published artifacts accumulate.

Closes #412
---

## Acceptance criteria

All 20 from spec `artifact-evidence-on-phone`. **ac11 and ac12 are Ground Control's** and are implemented on atomikpanda/ground-control#63, not here.

On the evidence refs below: every criterion carries the same `test-runs/5` reference because that is the passing cross-repo suite, not because each criterion has an individually attached artifact. Per-criterion evidence is what this feature adds; it could not be used on its own PR, since capturing a screenshot needs a device and none is attached in this environment.

- [x] `ac1` Running mship capture --evidence <spec-id>:<ac-id> in a repo with a capture target attaches artifact evidence to that criterion in a single command, with no separate mship spec evidence call. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac2` Artifact bytes are stored under .mothership/evidence/<spec-id>/ named by a content hash plus the original extension, and the ref persisted on the criterion is the bare filename rather than a path. The store is machine-local and gitignored, so it works identically in a multi-repo workspace, a monorepo, and a single repo. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac3` mothership.yaml accepts an evidence_storage key of published, local, or encrypted, and when the key is absent evidence inherits the workspace's spec_storage mode, mapping committed to published. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac4` Config load fails with an error naming both keys when evidence_storage is more exposed than spec_storage, where exposure orders as committed above encrypted above local. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac5` Under published mode a referenced artifact is committed to an mship-evidence orphan branch in the member repo the pull request targets, and only that branch is pushed; under local mode nothing is ever published; under encrypted mode the artifact is written as ciphertext with an .enc suffix and no plaintext bytes are emitted or published. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac6` Publishing never touches a repo's default branch: the orphan branch shares no history with it, mship finish pushes that branch alone, and no commit is created on main in any repo. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac7` A spec whose task spans several repos publishes to each repo that receives a pull request, so every PR is self-contained and no reviewer needs read access to a sibling repo. — test:test-runs/5.ground-control, test:test-runs/5.mothership, commit:0c10432bffd72d1090a4036445322e27484a05d0
- [x] `ac8` GET /specs/{spec_id}/evidence/{name}/blob returns the artifact bytes with a content-type derived from the extension when called with a valid filename and the existing bearer token. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac9` The blob route returns 404 for any name that resolves outside the spec's evidence directory, including relative traversal, an absolute path, and a symlink pointing out of the store. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac10` When an encrypted artifact cannot be decrypted on the responding host, the blob route reports the same key-unavailable condition the spec read path already reports rather than a generic failure. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac11` In Ground Control an image artifact renders full-width on the spec detail criterion row, and tapping it opens a zoomed view. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac12` Non-image artifact evidence continues to render as the existing text label, and an image artifact whose bytes cannot be fetched renders as that same text label rather than a broken image. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac13` A capture whose evidence attach fails still reports the artifacts it produced and exits successfully, emitting a warning rather than an error. — test:test-runs/5.ground-control, test:test-runs/5.mothership, commit:7a4c603bd1629f002d3222f3bec63b36a9fdb31b, commit:a974e109090080dac880e68aea990ac04f652eda
- [x] `ac14` The un-evidenced-criteria warning emitted at a phase transition names mship capture --evidence as the remedy for affected repos that define a capture target. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac15` mship capture --remote --evidence attaches evidence from artifacts produced on a mapped run host, indistinguishably from a locally produced capture. — test:test-runs/5.ground-control, test:test-runs/5.mothership, commit:7a4c603bd1629f002d3222f3bec63b36a9fdb31b
- [x] `ac16` A capture run without --evidence writes only to the existing ephemeral captures location, copies nothing into the evidence store, and attaches no evidence to any spec. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac17` Attached evidence records the revision the capture was taken from, and marks it when that revision is not a commit on a branch — an uncommitted working tree or a throwaway run ref — with Ground Control showing that marker alongside the image. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac18` Under published storage, the PR body renders an image artifact as an embedded image using an absolute raw URL pinned to the orphan-branch commit that contains it, verified present at that commit before the URL is emitted, so a reviewer on GitHub sees the screenshot rather than a filename. — test:test-runs/5.ground-control, test:test-runs/5.mothership
- [x] `ac19` When the artifact cannot be embedded — local or encrypted storage, a push that failed, or a byte not verifiably present at the pinned commit — the PR body names the artifact instead of emitting a broken image, and finish warns with the reason. — test:test-runs/5.ground-control, test:test-runs/5.mothership, commit:a9e5d73ce6de4ae0a61a707c8eca25a12ce94d1f
- [x] `ac20` Non-image artifact evidence and the existing test and commit evidence refs render in the PR body exactly as they do today. — test:test-runs/5.ground-control, test:test-runs/5.mothership
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `artifact-evidence`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/63 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/421 | this PR |

⚠ Merge in order: ground-control → mothership
