### PR TITLE
exact-copy remote runs via a scratch ref

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,6 +235,7 @@ Additional keys on each entry under `repos:` (alongside `path`, `type`, `depends
 | `allow_extra_worktrees` | Allow extra worktrees on the repo without failing the drift audit. Default: `false`. |
 | `capture` | UI-capture config — a `platforms:` list `mship capture` can target (`--platform` required when more than one). |
 | `run_host` | Logical run-host role this repo uses for `--remote` execution (`mship build`/`capture`). Must name an entry in the workspace `run_hosts:` list. |
+| `setup_inputs` | Manifests/lockfiles whose content decides whether a **remote** run re-runs `task setup` on the run host (glob patterns, matched inside the materialized worktree). Undeclared means setup runs on first materialization only — declaring them is what enables re-run-on-change. See [`remote-run.md`](remote-run.md). |
 
 ```yaml
 repos:
@@ -255,6 +256,7 @@ repos:
     path: ground-control
     type: service
     run_host: android-emu-host     # `mship build/capture --remote` targets this role
+    setup_inputs: [build.gradle, gradle/libs.versions.toml]   # remote runs re-run `task setup` when these change
     capture:
       platforms: [android, ios]    # `mship capture --platform android|ios`
 ```

--- a/docs/remote-run.md
+++ b/docs/remote-run.md
@@ -96,70 +96,116 @@ so `discover_artifacts` and anything reading captures locally (including an agen
 
 These are deliberately out of scope for the first cut. Know them before you lean on `--remote` for a repo with heavier setup needs.
 
-- **The remote worktree is a bare `git fetch` + `git worktree add`.** It does **not** replicate the local `WorktreeManager.spawn` machinery — `symlink_dirs` / `bind_files` and any `task setup` step are not run on the remote. So remote `capture` (which observes a running app) works, but remote `run`/`build` for a repo that depends on symlinked gitignored deps (a shared `.venv`, `node_modules`, etc.) may fail because those deps aren't present in the freshly-added remote worktree. If your `run`/`build` needs them, run it locally for now.
+- **`symlink_dirs` / `bind_files` are not replicated on the remote worktree.** `task setup` now runs there (see "Dependencies are derived there, not copied"), so a repo whose deps come from tracked manifests works. A repo that depends on symlinked gitignored material from your source checkout still does not.
 - **Remote task stdout is streamed to your terminal verbatim.** There is no ANSI / control-sequence sanitization — the remote host is trusted. Don't point `--remote` at a host you don't control.
 - **A `run_host:` set under a `capture:` block in `mothership.yaml` is silently ignored.** `CaptureConfig` has no `run_host` field; only the **repo-level** `run_host` (documented above under "Declaring roles") is honored. Put `run_host:` directly on the repo, not inside its `capture:` block.
 
-## Before it dispatches
+## What travels to the run host
 
-`--remote` runs the code that is on **origin**, because the run host materializes
-the task's branch by fetching it and hard-resetting to `origin/<branch>`. So before
-dispatching, mship asks origin itself (one `git ls-remote` per repo — a local
-`origin/<branch>` ref is a cache, and it goes stale in the dangerous direction) and
-compares against your HEAD:
+`--remote` runs the code you are looking at, **including work you have not
+committed**. Before dispatching, mship reads every repo the task touches and
+takes one of three paths per repo:
 
-- **Clean, and origin is missing the branch or behind your HEAD** → it pushes for
-  you. Nothing is lost, and it is unambiguously what you meant.
-- **Origin has a commit you don't** — someone else pushed the branch, or you
-  haven't pulled — → it **refuses**. The run would execute that commit instead of
-  what you have checked out, and pushing cannot fix it: you can't fast-forward from
-  behind. It prints a `git pull --ff-only` for each affected repo (or reset to
-  origin deliberately), then re-run.
-- **Tracked changes present** → it refuses, and names the commands that unblock
-  you. Committing your work in progress is not a decision mship makes for you, and
-  running the previous revision while you are mid-edit is worse than stopping.
-- **Untracked files only** → it warns. They cannot change what the push carries,
-  but they will not exist on the run host either.
-- **The worktree isn't on the task's branch** — detached, or some other branch
-  checked out → it refuses, and prints the `git checkout <branch>` that fixes it.
-  Every check above reads the worktree's HEAD while the run host materializes the
-  *task's* branch, so the commit that was verified and the commit that would run
-  are two different things. (Nothing is quietly resolved for you: publishing that
-  HEAD would move the task's branch on origin to a commit you never named.)
-- **The repo can't be inspected at all** — `git status` fails, the worktree is
-  gone, origin won't answer → it refuses, naming which. Nothing about what the run
-  host would execute was established, and that is the one case that must never pass
-  silently.
-- **`--repos`/`--tag` names a repo that isn't one of the task's repos at all** — no
-  worktree, no branch, nothing to compare against origin → it refuses with the
-  same "missing worktree" message as a worktree that existed and vanished. The run
-  host would still materialize that repo's branch from origin regardless, so a
-  selection outside the task's own repos is never silently dropped from the check.
+- **Working tree differs from HEAD** — tracked edits, untracked files, or both →
+  mship builds a commit from your working tree and pushes it **straight to the
+  run host**, onto a throwaway ref (`refs/mship/run/<task>/<repo>`). The host
+  resets a worktree to that ref and runs it. **Nothing is pushed to origin on
+  this path**, and nothing on your machine changes: your HEAD, your branch, your
+  index and `git status` are exactly as you left them, and the synthesized commit
+  belongs to no branch. mship names it as a throwaway run ref in the output for
+  that reason — do not build on it.
+- **Clean, but origin is missing the branch or is behind it** → mship pushes the
+  branch to origin for you, then dispatches. There is nothing extra to send, so
+  this is the old, fast path. If origin has a commit you do not, mship **refuses**
+  — a push cannot fast-forward from behind, and the run would execute a commit
+  you have never seen. It prints the `git pull --ff-only` that fixes it.
+- **Mid-merge, mid-rebase, or with unmerged paths** → mship **refuses**, and
+  names the command that unblocks you. Files in that state hold conflict markers,
+  and a remote failure over a conflict marker tells you nothing about the edit
+  you were making.
 
-When it does push for you, it pushes the exact sha it resolved HEAD to during
-inspection — `<sha>:refs/heads/<branch>` — rather than letting git resolve `HEAD`
-(or the branch) a second time when the push itself runs moments later. That
-closes the gap between inspecting and pushing: if something else commits in the
-worktree in between — a subagent, a background job, anything — the push still
-names the commit every check above actually cleared, not whatever HEAD has
-become by the time the push runs.
-
-That guarantee ends at origin, and this is a real limit, not a hypothetical one:
-**the commit *pushed* is the commit *inspected*; that is not the same claim as
-"the commit *executed* is the commit inspected."** Once the push lands, the
-branch on origin is a mutable ref, and mutable refs are exactly what this module
-cannot make safe — anyone with push access can advance the branch before the run
-host's own `git fetch` picks it up, and nothing here can see that happen or stop
-it: the write lands after mship has finished checking, on a different machine's
-clock, outside this process entirely. Closing that second gap would need the run
-host to materialize a specific, immutable revision — a commit, not a branch —
-instead of resolving the branch itself at fetch time; it does not do that today,
-and no amount of extra checking on the dispatching side substitutes for it.
+It also still refuses a worktree that is not on the task's branch, a repo whose
+git state it cannot read, and a worktree that is missing — in each case naming
+which, because the remedies differ.
 
 Every repo **the run will actually touch** is checked, not just the one you are
 standing in: a task has a branch per repo and the run host materializes each
 separately. `--repos` / `--tag` narrow the check as well as the run, so work in
-progress in a repo you excluded neither blocks the run nor gets pushed.
+progress in a repo you excluded neither blocks the run nor gets sent.
+
+### Why the run host and not origin
+
+Routing uncommitted work through origin would publish it. `git add -A` sweeps in
+untracked files, so a debug dump, a data sample or a throwaway script with a
+token in it would land on GitHub. Refs under `refs/mship/` are outside the
+default fetch refspec but they are not private — `git ls-remote` enumerates them
+and anyone with read access can fetch them, which on a public repo means anyone —
+and deleting the ref afterwards does not retract the objects, because they stay
+reachable by sha. The destination is your own machine, so there is no reason for
+a third party to be in the path. **Real history goes to origin; throwaway state
+goes host to host.**
+
+The run host accepts these pushes on a purpose-built endpoint (`/git/<repo>`)
+that is bearer-authenticated with the same run-host token, accepts only repos
+that workspace declares, and accepts writes only onto the `refs/mship/run/*`
+namespace. It is not a mirror, not a remote you add by hand, and not a path for
+real history. Each run force-updates its own ref, and `mship close` deletes the
+task's scratch refs from the host.
+
+Nothing here changes what `mship finish` requires. The scratch namespace is not
+a branch, is not PR-able, and no code path merges or branches from it — so
+nothing reaches a PR unreviewed.
+
+### The guarantee, and where it stops
+
+On the clean path mship pushes the **exact sha it resolved HEAD to** during
+inspection — `<sha>:refs/heads/<branch>` — rather than letting git resolve `HEAD`
+(or the branch) a second time when the push runs moments later. On the dirty path
+the same sha becomes the synthesized snapshot's parent. Either way, if something
+else commits in the worktree in between — a subagent, a background job — the run
+still carries the commit every check actually cleared.
+
+That guarantee ends at origin, and this is a real limit, not a hypothetical one:
+**the commit *pushed* is the commit *inspected*; that is not the same claim as
+"the commit *executed* is the commit inspected."** Once a push to origin lands,
+the branch there is a mutable ref, and anyone with push access can advance it
+before the run host fetches it — after mship has finished checking, on a
+different machine's clock, outside this process entirely. Closing that gap would
+need the run host to materialize an immutable revision instead of resolving a
+branch at fetch time. The **dirty path already does exactly that**: it
+materializes a specific commit from a ref nothing else writes, with no fetch at
+all. The clean path does not.
+
+### Dependencies are derived there, not copied
+
+Git carries source, not `node_modules`. So after materializing, the run host runs
+**`task setup`** in that worktree, rebuilding dependencies from the manifests the
+push just delivered.
+
+That is keyed, or it would defeat the fast loop this exists to enable:
+
+- setup runs the **first time** a worktree is materialized for a task on that
+  host — so the first remote run on a fresh host is the slowest it will ever be,
+  a one-time cost rather than a regression;
+- and again whenever the repo's declared **`setup_inputs`** (its manifests and
+  lockfiles — `package.json`, `uv.lock`, `build.gradle`) differ from what that
+  host last set up at.
+
+A source-only edit, the common case, pays nothing. A dependency change pays once.
+**A repo that declares no `setup_inputs` gets setup on first materialization
+only**, because there is nothing to invalidate against — declaring them is what
+buys re-run-on-change. A repo that defines no `setup` target at all is skipped
+rather than failed. If setup fails, the run stops and you see setup's own output.
+
+### What does not travel
+
+- **Gitignored files.** `.env` and other secrets, build output, virtualenvs,
+  `node_modules`. Where they can be rebuilt from tracked manifests that is now
+  setup's job; where they cannot — secrets, platform state — they simply are not
+  there, and you put them on the run host yourself.
+- **`symlink_dirs` / `bind_files`.** Still not replicated on the run host.
+- **Your machine.** The source is exact and the dependency environment is derived
+  from it, but the run host is not a clone of your box.
 
 ## Troubleshooting
 

--- a/src/mship/cli/exec.py
+++ b/src/mship/cli/exec.py
@@ -129,11 +129,12 @@ def _run_remote(
     `--remote=<role>`.
 
     Remote execution always operates on a task's branch — the remote
-    materializes `.worktrees/<task>/<repo>` from origin — so there's no
-    "ad-hoc" remote run. Local `run`/`build` gracefully fall back to "the
-    whole workspace" when no task is active, but that fallback has no branch
-    for the remote to check out, so `--remote` without a resolvable task is a
-    clean, actionable CLI error rather than a confusing remote-side failure.
+    materializes `.worktrees/<task>/<repo>`, either from origin or from a
+    scratch ref this command pushes it — so there's no "ad-hoc" remote run.
+    Local `run`/`build` gracefully fall back to "the whole workspace" when no
+    task is active, but that fallback has no branch for the remote to check out,
+    so `--remote` without a resolvable task is a clean, actionable CLI error
+    rather than a confusing remote-side failure.
 
     A `RunHostError` (unknown/ambiguous/unmapped role) or `RemoteExecError`
     (remote unreachable) surfaces as `output.error(...)` + `typer.Exit(1)` —
@@ -160,27 +161,59 @@ def _run_remote(
         output.error(str(e))
         raise typer.Exit(code=1)
 
-    # The run host materializes the task's branch FROM ORIGIN, and nothing pushes
-    # during development (`git push -u` happens at `mship finish`). Without this
-    # check a remote run either fails with a confusing remote-side materialize
+    # A CLEAN repo is still materialized on the run host FROM ORIGIN, and nothing
+    # pushes during development (`git push -u` happens at `mship finish`). Without
+    # this check a remote run either fails with a confusing remote-side materialize
     # error, or — worse — silently executes the last pushed revision and reports it
     # as a result for code the operator is currently editing.
-    #
-    # Scoped to `target_repos` — the same `--repos`/`--tag`-filtered set that is
-    # dispatched below. Preflighting the task's other repos would refuse a run over
-    # work in progress it never touches, and push repos the operator did not name.
-    from mship.core import remote_preflight
+    from mship.core import remote_preflight, run_transfer
+    from mship.core.run_ref import RunRefNameError
 
-    pre = remote_preflight.inspect(task_obj, container.shell(), repos=target_repos)
+    shell = container.shell()
+    # `repos=target_repos` is load-bearing and stays: preflighting the task's
+    # other repos would both refuse a run over work in progress it never touches
+    # and transfer repos the operator never named. `config` is what lets a
+    # `git_root` child and its parent collapse to one transfer.
+    pre = remote_preflight.inspect(
+        task_obj, shell, repos=target_repos, config=config,
+    )
     if not pre.ok:
         output.error(remote_preflight.blocked_message(pre))
         raise typer.Exit(code=1)
-    for state in pre.untracked:
-        output.warning(
-            f"{state.repo}: untracked files will not exist on the run host "
-            f"(they are not part of the push)"
+
+    # A working tree that differs from HEAD is no longer a refusal, it is a
+    # TRANSFER: synthesize a commit from that tree and push it STRAIGHT to the
+    # run host, onto the throwaway namespace `core/run_ref.py` owns. Origin is
+    # never in this path — routing uncommitted work through it would publish
+    # untracked scratch files to a third party, and deleting the ref afterwards
+    # would not retract the objects.
+    #
+    # `state.head_sha` is the sha the preflight certified HEAD to be at, not a
+    # re-read of HEAD: it is the same guarantee `remote_preflight.push` makes
+    # for the origin path, applied to the snapshot's parent.
+    run_ref_repos: list[str] = []
+    for state in pre.dirty:
+        try:
+            sha = run_transfer.synthesize_commit(
+                shell, state.path, base_sha=state.head_sha,
+            )
+            ref = run_transfer.push_run_ref(
+                shell, state.path, conn=conn, repo=state.git_repo,
+                task=task_obj.slug, sha=sha,
+            )
+        except (run_transfer.RunTransferError, RunRefNameError) as e:
+            output.error(str(e))
+            raise typer.Exit(code=1)
+        run_ref_repos.append(state.git_repo)
+        # Name it as throwaway (spec ac13): an operator who sees a bare sha will
+        # reasonably try to `git show` it and find it attached to nothing.
+        output.breadcrumb(
+            f"{state.git_repo}: sent your working tree to the run host as "
+            f"{ref} ({sha[:12]}) — a throwaway run ref, not a commit on "
+            f"{state.branch}"
         )
-    pushed, push_error = remote_preflight.push(pre, container.shell())
+
+    pushed, push_error = remote_preflight.push(pre, shell)
     if push_error is not None:
         output.error(push_error)
         raise typer.Exit(code=1)
@@ -198,6 +231,7 @@ def _run_remote(
     try:
         return exec_remote(
             verb=verb, conn=conn, task=task_obj.slug, repos=target_repos,
+            run_ref_repos=run_ref_repos,
         )
     except RemoteExecError as e:
         output.error(str(e))

--- a/src/mship/cli/exec.py
+++ b/src/mship/cli/exec.py
@@ -35,33 +35,6 @@ def _relpath(path_str: str) -> str:
         return path_str
 
 
-def _taskfile_has_target(repo_path, target: str) -> bool:
-    """True if `<repo_path>/Taskfile.yml` (or .yaml) defines `target`.
-
-    Reads the local Taskfile only; `includes:` are not recursed into. That
-    covers the common case — `mship logs` looks for a target defined
-    locally in the repo's Taskfile. False on missing file or parse error,
-    which is the correct, fail-loud signal for the caller.
-    """
-    from pathlib import Path
-    import yaml
-    p = Path(repo_path)
-    candidates = [p / "Taskfile.yml", p / "Taskfile.yaml"]
-    taskfile = next((c for c in candidates if c.exists()), None)
-    if taskfile is None:
-        return False
-    try:
-        data = yaml.safe_load(taskfile.read_text())
-    except Exception:
-        return False
-    if not isinstance(data, dict):
-        return False
-    tasks = data.get("tasks", {})
-    if not isinstance(tasks, dict):
-        return False
-    return target in tasks
-
-
 def _file_nonempty(path_str: str) -> bool:
     """True if the path exists and has non-zero size. False on OSError."""
     from pathlib import Path
@@ -788,7 +761,8 @@ def register(app: typer.Typer, get_container):
             # `logs:` target lets go-task print its general help text
             # instead of an actionable error. Reads the local Taskfile
             # only — `includes:` aren't recursed into.
-            if not _taskfile_has_target(cwd, actual_task):
+            from mship.util.taskfile import taskfile_has_target
+            if not taskfile_has_target(cwd, actual_task):
                 output.error(
                     f"'{name}' has no '{actual_task}' task in its Taskfile.\n"
                     f"  Add a `{actual_task}:` task to {cwd}/Taskfile.yml, "

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -929,6 +929,21 @@ def register(app: typer.Typer, get_container):
             if not hr.ok:
                 output.warning(f"lifecycle hook '{hr.hook_name}' for task.closed failed: {hr.error}")
 
+        # Scratch refs left on run hosts by `--remote` (spec remote-exact-copy).
+        # Fail-open like the spec/WorkItem advances above: a run host that is
+        # off, unreachable, or was never mapped must not stop a close. The refs
+        # are on the operator's own machine, so a missed one is disk, not
+        # disclosure.
+        try:
+            from mship.core.run_host import RunHostStore
+            from mship.core.run_transfer import cleanup_run_refs
+            cleanup_run_refs(
+                task, config=config, store=RunHostStore(container.state_dir()),
+                shell=container.shell(), warn=output.warning,
+            )
+        except Exception:
+            pass
+
         wt_mgr = container.worktree_manager()
         from mship.core.worktree import WorktreeDirtyError
         try:

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -203,6 +203,17 @@ class RepoConfig(BaseModel):
     # role lives in the gitignored `.mothership/run-hosts.yaml` store, never
     # here. See mship.core.run_host.resolve_run_host.
     run_host: str | None = None
+    # Files whose CONTENT decides whether a remote run re-runs `task setup` on
+    # the run host — this repo's manifests and lockfiles (e.g. package.json,
+    # uv.lock, build.gradle). Glob patterns, matched inside the materialized
+    # worktree. See mship.core.remote_setup.
+    #
+    # Empty (the default) is NOT "never run setup": it means there is nothing to
+    # invalidate against, so setup runs the first time a worktree is
+    # materialized on a host and not again. DECLARING inputs is what buys
+    # re-run-on-change. Deliberately explicit rather than inferred — an operator
+    # can see and widen a declared key; they cannot inspect a heuristic.
+    setup_inputs: list[str] = []
 
     @field_validator("url", mode="after")
     @classmethod

--- a/src/mship/core/git_receive.py
+++ b/src/mship/core/git_receive.py
@@ -48,6 +48,15 @@ RESULT_CONTENT_TYPE = "application/x-git-receive-pack-result"
 # and is refused rather than read past.
 _OID_RE = re.compile(rb"[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?$")
 
+# A `shallow <oid>` line, which a push from a shallow clone sends BEFORE its
+# commands. Reachable rather than theoretical: `git worktree add` from a
+# `--depth 1` clone succeeds and the worktree is shallow too, so an operator who
+# shallow-cloned a workspace repo gets shallow task worktrees. Exactly as strict
+# as git's own reader (`read_head_info`, receive-pack.c): the literal prefix then
+# a whole, valid oid and nothing else — git dies on anything laxer, and a laxer
+# skip here would be a way to hide a command from the scope check.
+_SHALLOW_RE = re.compile(rb"shallow (?:[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?)\Z")
+
 
 class PktLineError(ValueError):
     """The request body is not parseable pkt-line framing. Refused rather than
@@ -77,7 +86,7 @@ def service_advertisement(refs_output: bytes) -> bytes:
     return pkt_line(f"# service={RECEIVE_SERVICE}\n".encode("utf-8")) + b"0000" + refs_output
 
 
-def _command_ref(payload: bytes) -> str:
+def _command_ref(payload: bytes) -> str | None:
     """The ref name in one receive-pack command packet, read exactly as git
     reads it (`read_head_info` in receive-pack.c):
 
@@ -85,6 +94,9 @@ def _command_ref(payload: bytes) -> str:
       - the payload is a C string, so it ends at the first NUL — which is why
         capabilities are stripped on EVERY line, not only the first one that
         carries them;
+      - a `shallow <oid>` line is not a command at all; git records it and moves
+        on, and so do we (None). Failing the whole push on one would refuse a
+        legitimate push from a shallow worktree;
       - two object ids and a space each must lead, and the ref name is then the
         WHOLE remainder, spaces included. Stopping at the next space would
         report a shorter, in-scope name for a command git reads as a different
@@ -93,6 +105,8 @@ def _command_ref(payload: bytes) -> str:
     if payload.endswith(b"\n"):
         payload = payload[:-1]
     line = payload.split(b"\x00", 1)[0]
+    if _SHALLOW_RE.match(line):
+        return None
     fields = line.split(b" ", 2)
     if len(fields) < 3 or not fields[2]:
         raise PktLineError(f"malformed ref command: {payload!r}")
@@ -106,7 +120,9 @@ def ref_commands(body: bytes) -> list[str]:
 
     The request is `pkt_line("<old-oid> <new-oid> <ref>[\\0<capabilities>]")`
     repeated, then a `0000` flush, then push options and (for anything but a
-    delete) the packfile. Parsing stops at the flush, so neither is touched.
+    delete) the packfile. Parsing stops at the flush, so neither is touched. A
+    shallow client leads with `shallow <oid>` lines, which are not commands and
+    contribute no names.
 
     Only the flush ends the list. A body truncated instead is parsed to its end
     anyway (real receive-pack dies on one, but the check must never see fewer
@@ -128,7 +144,9 @@ def ref_commands(body: bytes) -> list[str]:
             )
         payload = body[i + 4:i + length]
         i += length
-        names.append(_command_ref(payload))
+        name = _command_ref(payload)
+        if name is not None:
+            names.append(name)
     return names
 
 

--- a/src/mship/core/git_receive.py
+++ b/src/mship/core/git_receive.py
@@ -54,10 +54,19 @@ _OID_RE = re.compile(rb"[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?\Z")
 # A `shallow <oid>` line, which a push from a shallow clone sends BEFORE its
 # commands. Reachable rather than theoretical: `git worktree add` from a
 # `--depth 1` clone succeeds and the worktree is shallow too, so an operator who
-# shallow-cloned a workspace repo gets shallow task worktrees. Exactly as strict
-# as git's own reader (`read_head_info`, receive-pack.c): the literal prefix then
-# a whole, valid oid and nothing else — git dies on anything laxer, and a laxer
-# skip here would be a way to hide a command from the scope check.
+# shallow-cloned a workspace repo gets shallow task worktrees.
+#
+# STRICTER than git's own reader, not equal to it: `read_head_info`
+# (receive-pack.c) parses the oid with `get_oid_hex`, which consumes exactly
+# hexsz hex characters and does NOT require the string to end there — so git
+# also skips `shallow <oid> junk` and `shallow <oid>deadbeef`, then accepts the
+# command after them and creates its ref (verified, git 2.43).
+#
+# The invariant is one-directional, and this pattern being a strict SUBSET of
+# what git skips is what gives it: OUR shallow skip implies GIT's, so a line
+# skipped here is never a line git would have read as a command. Refusing the
+# laxer shapes costs a real push nothing — git never sends them — so do not
+# relax this to "match git".
 _SHALLOW_RE = re.compile(rb"shallow (?:[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?)\Z")
 
 

--- a/src/mship/core/git_receive.py
+++ b/src/mship/core/git_receive.py
@@ -45,8 +45,11 @@ RESULT_CONTENT_TYPE = "application/x-git-receive-pack-result"
 
 # An object id as receive-pack's own `parse_oid_hex` accepts it: hex, either
 # hash algorithm's width, case-insensitive. Anything else is not a ref command
-# and is refused rather than read past.
-_OID_RE = re.compile(rb"[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?$")
+# and is refused rather than read past. `\Z`, not `$`: Python's `$` also matches
+# BEFORE a trailing newline, and `<40 hex>\n` is not an oid to git — its reader
+# wants a space immediately after the last hex character and dies otherwise
+# ("protocol error: expected old/new/ref", verified).
+_OID_RE = re.compile(rb"[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?\Z")
 
 # A `shallow <oid>` line, which a push from a shallow clone sends BEFORE its
 # commands. Reachable rather than theoretical: `git worktree add` from a

--- a/src/mship/core/git_receive.py
+++ b/src/mship/core/git_receive.py
@@ -1,0 +1,199 @@
+"""A deliberately narrow git smart-HTTP RECEIVE path for `mship serve`.
+
+`mship run --remote` hands the operator's working tree to the run host by
+pushing a synthesized commit straight to it (see `core/run_transfer.py`), so
+serve needs somewhere for that push to land. This module is that somewhere, and
+nothing more: it is not a mirror, not a remote an operator adds by hand, and not
+a path for real history.
+
+Two controls, both security controls rather than tidiness:
+
+  - the REPO ALLOWLIST (`receive_repo_path`) — only repos this workspace's
+    config declares, and only top-level ones;
+  - the REF-NAME constraint (`check_ref_scope`) — only the run scratch
+    namespace owned by `core/run_ref.py`.
+
+Without the second this is an arbitrary-ref-write primitive against the run
+host: a plain receive-pack pass-through was verified to accept
+`<sha>:refs/heads/attacker` and create that branch. The body is therefore parsed
+for its ref commands BEFORE any git process sees it.
+
+Wire shape (verified end to end against real `git push`, git 2.43):
+
+    GET  <base>/info/refs?service=git-receive-pack
+      -> pkt_line(b"# service=git-receive-pack\\n") + b"0000"
+         + `git receive-pack --http-backend-info-refs <repo>` stdout
+    POST <base>/git-receive-pack
+      -> raw body piped to `git receive-pack --stateless-rpc <repo>` stdin,
+         its stdout returned verbatim
+
+The HTTP layer (auth, status codes, threadpool) lives in `core/serve.py`; this
+module is pure logic plus two subprocess calls so it can be tested without a
+server.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+from mship.core.run_ref import RUN_REF_PREFIX, is_run_ref
+
+RECEIVE_SERVICE = "git-receive-pack"
+ADVERTISEMENT_CONTENT_TYPE = "application/x-git-receive-pack-advertisement"
+RESULT_CONTENT_TYPE = "application/x-git-receive-pack-result"
+
+# An object id as receive-pack's own `parse_oid_hex` accepts it: hex, either
+# hash algorithm's width, case-insensitive. Anything else is not a ref command
+# and is refused rather than read past.
+_OID_RE = re.compile(rb"[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?$")
+
+
+class PktLineError(ValueError):
+    """The request body is not parseable pkt-line framing. Refused rather than
+    guessed at: a body we cannot read is a body whose refs we cannot check."""
+
+
+class RefScopeError(ValueError):
+    """The push asks to write a ref outside the run scratch namespace."""
+
+
+class UnknownReceiveRepoError(ValueError):
+    """No git repository this endpoint will accept a push for."""
+
+
+class ReceivePackError(RuntimeError):
+    """`git receive-pack` itself failed on this host."""
+
+
+def pkt_line(payload: bytes) -> bytes:
+    """`<4-hex-length><payload>`, where the length counts its own 4 bytes."""
+    return f"{len(payload) + 4:04x}".encode("ascii") + payload
+
+
+def service_advertisement(refs_output: bytes) -> bytes:
+    """The `info/refs` body: the service pkt-line, a flush, then receive-pack's
+    own advertisement."""
+    return pkt_line(f"# service={RECEIVE_SERVICE}\n".encode("utf-8")) + b"0000" + refs_output
+
+
+def _command_ref(payload: bytes) -> str:
+    """The ref name in one receive-pack command packet, read exactly as git
+    reads it (`read_head_info` in receive-pack.c):
+
+      - one trailing newline is chomped from the packet;
+      - the payload is a C string, so it ends at the first NUL — which is why
+        capabilities are stripped on EVERY line, not only the first one that
+        carries them;
+      - two object ids and a space each must lead, and the ref name is then the
+        WHOLE remainder, spaces included. Stopping at the next space would
+        report a shorter, in-scope name for a command git reads as a different
+        ref.
+    """
+    if payload.endswith(b"\n"):
+        payload = payload[:-1]
+    line = payload.split(b"\x00", 1)[0]
+    fields = line.split(b" ", 2)
+    if len(fields) < 3 or not fields[2]:
+        raise PktLineError(f"malformed ref command: {payload!r}")
+    if not (_OID_RE.match(fields[0]) and _OID_RE.match(fields[1])):
+        raise PktLineError(f"ref command does not begin with two object ids: {payload!r}")
+    return fields[2].decode("utf-8", errors="replace")
+
+
+def ref_commands(body: bytes) -> list[str]:
+    """The ref names a receive-pack request asks to update, in order.
+
+    The request is `pkt_line("<old-oid> <new-oid> <ref>[\\0<capabilities>]")`
+    repeated, then a `0000` flush, then push options and (for anything but a
+    delete) the packfile. Parsing stops at the flush, so neither is touched.
+
+    Only the flush ends the list. A body truncated instead is parsed to its end
+    anyway (real receive-pack dies on one, but the check must never see fewer
+    refs than git might act on).
+    """
+    names: list[str] = []
+    i = 0
+    while i + 4 <= len(body):
+        header = body[i:i + 4]
+        try:
+            length = int(header, 16)
+        except ValueError:
+            raise PktLineError(f"not a pkt-line length: {header!r}")
+        if length == 0:
+            break
+        if length < 4 or i + length > len(body):
+            raise PktLineError(
+                f"pkt-line length {length} runs past the end of the request body"
+            )
+        payload = body[i + 4:i + length]
+        i += length
+        names.append(_command_ref(payload))
+    return names
+
+
+def check_ref_scope(body: bytes) -> None:
+    """Raise unless every ref the push writes is in the run scratch namespace."""
+    names = ref_commands(body)
+    if not names:
+        raise PktLineError("push request contains no ref command")
+    outside = [n for n in names if not is_run_ref(n)]
+    if outside:
+        raise RefScopeError(
+            f"refusing to write {', '.join(outside)}: this endpoint accepts "
+            f"pushes only onto {RUN_REF_PREFIX}<task>/<repo>"
+        )
+
+
+def receive_repo_path(config, repo: str) -> Path:
+    """The git directory a push for `repo` may land in — the ALLOWLIST.
+
+    Only repos declared in this workspace's config are accepted (spec ac5). A
+    `git_root` child has no git directory of its own (its tree IS its parent's),
+    so a push named for a child is refused and names the parent instead (ac7).
+
+    `ConfigLoader.load` resolves top-level repo paths to absolute, so the value
+    returned here is directly usable as a git argument.
+    """
+    repo_config = getattr(config, "repos", {}).get(repo)
+    if repo_config is None:
+        known = ", ".join(sorted(getattr(config, "repos", {}))) or "(none)"
+        raise UnknownReceiveRepoError(
+            f"unknown repo {repo!r}; this workspace knows: {known}"
+        )
+    if repo_config.git_root is not None:
+        raise UnknownReceiveRepoError(
+            f"{repo!r} is a git_root child of {repo_config.git_root!r} and has "
+            f"no git directory of its own; push to {repo_config.git_root!r}"
+        )
+    return Path(repo_config.path)
+
+
+def advertise_refs(repo_path: Path) -> bytes:
+    """The `info/refs?service=git-receive-pack` body for `repo_path`."""
+    result = subprocess.run(
+        ["git", "receive-pack", "--http-backend-info-refs", str(repo_path)],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise ReceivePackError(
+            f"git receive-pack advertisement failed for {repo_path}: "
+            f"{result.stderr.decode('utf-8', errors='replace').strip()}"
+        )
+    return service_advertisement(result.stdout)
+
+
+def receive_pack(repo_path: Path, body: bytes) -> bytes:
+    """Run the push. Ref scope is checked BEFORE git is invoked, so an
+    out-of-scope push never reaches the repository at all."""
+    check_ref_scope(body)
+    result = subprocess.run(
+        ["git", "receive-pack", "--stateless-rpc", str(repo_path)],
+        input=body, capture_output=True,
+    )
+    if result.returncode != 0:
+        raise ReceivePackError(
+            f"git receive-pack failed for {repo_path}: "
+            f"{result.stderr.decode('utf-8', errors='replace').strip()}"
+        )
+    return result.stdout

--- a/src/mship/core/git_receive.py
+++ b/src/mship/core/git_receive.py
@@ -126,10 +126,16 @@ def ref_commands(body: bytes) -> list[str]:
 
     Only the flush ends the list. A body truncated instead is parsed to its end
     anyway (real receive-pack dies on one, but the check must never see fewer
-    refs than git might act on).
+    refs than git might act on) — EXCEPT when it also yielded no commands, which
+    is not a receive-pack request at all rather than one that asks for nothing.
+    That is the line between "no commands" and "unreadable": `0000` is a
+    well-formed request for nothing and is returned as `[]`, while a body that
+    runs out before either a flush or a command is refused, as it must be — git
+    answers one with `fatal: the remote end hung up unexpectedly` (verified).
     """
     names: list[str] = []
     i = 0
+    flushed = False
     while i + 4 <= len(body):
         header = body[i:i + 4]
         try:
@@ -137,6 +143,7 @@ def ref_commands(body: bytes) -> list[str]:
         except ValueError:
             raise PktLineError(f"not a pkt-line length: {header!r}")
         if length == 0:
+            flushed = True
             break
         if length < 4 or i + length > len(body):
             raise PktLineError(
@@ -147,14 +154,25 @@ def ref_commands(body: bytes) -> list[str]:
         name = _command_ref(payload)
         if name is not None:
             names.append(name)
+    if not flushed and not names:
+        raise PktLineError(
+            f"not a receive-pack request: no pkt-line command and no flush in "
+            f"{body[:16]!r}"
+        )
     return names
 
 
 def check_ref_scope(body: bytes) -> None:
-    """Raise unless every ref the push writes is in the run scratch namespace."""
+    """Raise unless every ref the push writes is in the run scratch namespace.
+
+    A body with NO commands passes. It is not an oversight and not a hole: git's
+    remote-curl sends exactly that — a `0000` probe, `Content-Length: 4` — ahead
+    of any request bigger than `http.postBuffer` (1 MiB by default), and aborts
+    the push on anything but a clean answer, so refusing it broke every push
+    over that size. Nothing is waved through: a body with no commands names no
+    refs, and one that cannot be read still raises out of `ref_commands` above.
+    """
     names = ref_commands(body)
-    if not names:
-        raise PktLineError("push request contains no ref command")
     outside = [n for n in names if not is_run_ref(n)]
     if outside:
         raise RefScopeError(

--- a/src/mship/core/remote_client.py
+++ b/src/mship/core/remote_client.py
@@ -236,6 +236,7 @@ def exec_remote(
     platform: str | None = None,
     kind: str = "all",
     captures_dir_for: Path | None = None,
+    run_ref_repos: list[str] | None = None,
     print_fn: Callable[[str], None] = print,
     transport: httpx.BaseTransport | None = None,
 ) -> int:
@@ -250,6 +251,13 @@ def exec_remote(
     indistinguishable on disk from a local one. `captures_dir_for` is ignored
     (nothing to extract) for `run`/`build`, which never emit an artifact
     block.
+
+    `run_ref_repos` (optional) names the repos this host should materialize
+    from its own local scratch ref for this task rather than from origin —
+    the operator's working tree was pushed straight to it (see
+    `mship.core.run_transfer`). Repo NAMES, not refs: the host builds the ref
+    itself from values it has already validated. Omitted from the request
+    body entirely when empty, so a clean run's wire format is unchanged.
 
     Returns the remote task's exit code, parsed from the trailing
     `__MSHIP_EXIT__ <code>` line — conveyed as DATA, not an HTTP error, so a
@@ -267,6 +275,8 @@ def exec_remote(
     body: dict = {"task": task, "repos": repos, "kind": kind}
     if platform is not None:
         body["platform"] = platform
+    if run_ref_repos:
+        body["run_ref_repos"] = list(run_ref_repos)
 
     headers = {"Authorization": f"Bearer {conn.token}"}
     url = f"{conn.url}/exec/{verb}"

--- a/src/mship/core/remote_exec.py
+++ b/src/mship/core/remote_exec.py
@@ -61,9 +61,11 @@ from pathlib import Path
 from typing import Iterator, Protocol
 
 from mship.core import capture as _cap
+from mship.core import remote_setup
 from mship.core.config import WorkspaceConfig
 from mship.core.run_ref import RunRefNameError
 from mship.core.run_ref import run_ref as build_run_ref
+from mship.util.taskfile import taskfile_has_target
 
 VERBS: tuple[str, ...] = ("run", "capture", "build")
 
@@ -504,6 +506,64 @@ def run_verb_stream(
         materialized[top_repo] = worktree_path
         return True
 
+    def _ensure_setup(repo_name: str, repo_config, worktree_path: Path) -> Iterator[bytes]:
+        """Run `task setup` in a freshly-materialized worktree when it is
+        needed, streaming its output live exactly like the verb itself.
+
+        Git carries source, not dependencies. Without this, an exact-source run
+        against stale dependencies fails with a module-not-found that has no
+        visible relationship to the edit — the same confusing-staleness class
+        the rest of this feature exists to eliminate. So the host DERIVES them.
+
+        Keyed (see `core/remote_setup.py`): the first materialization on this
+        host, then only when the repo's declared `setup_inputs` change. Skipped
+        entirely for a repo that declares `setup` not applicable or whose
+        Taskfile has no such target — `task setup` in a repo that never defined
+        one exits non-zero, and that must not fail every remote run.
+
+        PEP 380 value: True to continue, False when setup FAILED — in which case
+        the error line and the exit sentinel have ALREADY been emitted and the
+        caller MUST return, exactly like `_ensure_materialized`.
+        """
+        if "setup" in repo_config.not_applicable:
+            return True
+        actual_setup = repo_config.tasks.get("setup", "setup")
+        if not taskfile_has_target(worktree_path, actual_setup):
+            return True
+
+        key = remote_setup.setup_key(worktree_path, repo_config.setup_inputs)
+        key_path = remote_setup.key_file(deps.workspace_root, task, repo_name)
+        if not remote_setup.needs_setup(key_path, key):
+            return True
+
+        yield f"setup: {repo_name} (task {actual_setup})\n".encode("utf-8")
+        env_runner = repo_config.env_runner or config.env_runner
+        command = shell.build_command(f"task {actual_setup}", env_runner)
+        proc = None
+        try:
+            proc = shell.run_streaming(command, cwd=worktree_path, env=None)
+            yield from _stream_proc_lines(proc)
+            setup_code = proc.wait()
+        finally:
+            _terminate_proc(proc)
+
+        if setup_code != 0:
+            # Surface setup's OWN failure rather than letting the verb run
+            # against half-built dependencies and report something that does not
+            # name the real cause (spec ac18).
+            yield (
+                f"error: `task {actual_setup}` failed on the run host for repo "
+                f"{repo_name!r} (exit {setup_code}); the output above is setup's "
+                f"own. The {verb} was not started.\n"
+            ).encode("utf-8")
+            yield f"{EXIT_MARKER}:{nonce} {setup_code}\n".encode("utf-8")
+            return False
+
+        # Recorded only after a SUCCESSFUL setup: caching a failure would skip
+        # the retry that fixes it.
+        remote_setup.record_setup(key_path, key)
+        return True
+
     for repo_name in repos:
         repo_config = config.repos[repo_name]
 
@@ -524,6 +584,9 @@ def run_verb_stream(
             if not (yield from _ensure_materialized(repo_name)):
                 return
             worktree_path = materialized[repo_name]
+
+        if not (yield from _ensure_setup(repo_name, repo_config, worktree_path)):
+            return
 
         actual_task_name = repo_config.tasks.get(verb, verb)
         env_runner = repo_config.env_runner or config.env_runner

--- a/src/mship/core/remote_exec.py
+++ b/src/mship/core/remote_exec.py
@@ -180,25 +180,59 @@ def _run_checked(shell: ShellLike, command: str, cwd: Path, *, repo_name: str) -
 
 
 def materialize_worktree(
-    shell: ShellLike, repo_path: Path, worktree_path: Path, branch: str, *, repo_name: str
+    shell: ShellLike,
+    repo_path: Path,
+    worktree_path: Path,
+    branch: str,
+    *,
+    repo_name: str,
+    run_ref: str | None = None,
 ) -> None:
-    """Ensure `worktree_path` is a git worktree of `repo_path` sitting on
-    `branch`, fresh from origin.
+    """Ensure `worktree_path` is a git worktree of `repo_path` holding the
+    revision this run is supposed to execute.
 
-    `branch` already exists on origin (created by `mship spawn`/dispatch on
-    the operator's machine and pushed there) — this NEVER creates a new
-    branch here, it only fetches + tracks the existing one. Idempotent: a
-    worktree that already exists is fetched + hard-reset to the new tip
-    rather than re-added (the remote branch may have moved since the last
-    remote run); a first-time run creates it with `git worktree add -B`,
-    which is safe to re-run even if a stale local branch ref of the same
-    name exists (e.g. left over from a removed worktree).
+    Two modes.
 
-    Every git command runs through `_run_checked` (`repo_name` is only used
-    for that error message): a failure here (e.g. the branch not yet pushed,
-    a dirty/locked worktree) raises `MaterializeError` instead of silently
-    letting execution continue against a missing/stale checkout.
+    `run_ref` GIVEN (spec remote-exact-copy): the operator pushed a commit
+    synthesized from their working tree straight to this host, so the revision is
+    ALREADY in this repository. Materialization is a reset to a LOCAL ref with NO
+    FETCH — origin is not consulted at all, which is also why the caller skips
+    the base-freshness probe for these repos. HEAD is left DETACHED on purpose:
+    the scratch commit is throwaway state, and pointing a branch at it would
+    dress it up as history. `git clean -fd` removes leftovers from a previous
+    run so the result is an exact copy; it does not remove gitignored files, so
+    dependencies derived by `task setup` survive between runs.
+
+    `run_ref` NONE (unchanged from before): `branch` already exists on origin
+    (created by `mship spawn`/dispatch on the operator's machine and pushed
+    there) — this NEVER creates a new branch here, it only fetches + tracks the
+    existing one. Idempotent: an existing worktree is fetched + hard-reset to the
+    new tip; a first-time run creates it with `git worktree add -B`, which is
+    safe to re-run even if a stale local branch ref of the same name exists.
+
+    Every git command runs through `_run_checked` (`repo_name` is only used for
+    that error message): a failure here raises `MaterializeError` instead of
+    silently letting execution continue against a missing/stale checkout.
     """
+    if run_ref is not None:
+        if (worktree_path / ".git").exists():
+            # `checkout --detach` with NO ref keeps the current commit, so it
+            # succeeds even when the worktree is dirty from the last run
+            # (verified); the reset then moves detached HEAD without ever moving
+            # a branch.
+            _run_checked(shell, "git checkout --detach", worktree_path, repo_name=repo_name)
+            _run_checked(shell, f"git reset --hard {run_ref}", worktree_path, repo_name=repo_name)
+            _run_checked(shell, "git clean -fd", worktree_path, repo_name=repo_name)
+        else:
+            worktree_path.parent.mkdir(parents=True, exist_ok=True)
+            _run_checked(
+                shell,
+                f"git worktree add --detach {worktree_path} {run_ref}",
+                repo_path,
+                repo_name=repo_name,
+            )
+        return
+
     _run_checked(shell, f"git fetch origin {branch}", repo_path, repo_name=repo_name)
     if (worktree_path / ".git").exists():
         _run_checked(shell, f"git fetch origin {branch}", worktree_path, repo_name=repo_name)

--- a/src/mship/core/remote_exec.py
+++ b/src/mship/core/remote_exec.py
@@ -62,6 +62,8 @@ from typing import Iterator, Protocol
 
 from mship.core import capture as _cap
 from mship.core.config import WorkspaceConfig
+from mship.core.run_ref import RunRefNameError
+from mship.core.run_ref import run_ref as build_run_ref
 
 VERBS: tuple[str, ...] = ("run", "capture", "build")
 
@@ -359,6 +361,7 @@ def run_verb_stream(
     deps: RemoteExecDeps,
     kind: str = "all",
     nonce: str,
+    run_ref_repos: list[str] | None = None,
 ) -> Iterator[bytes]:
     """The serve-side body of `POST /exec/{verb}`.
 
@@ -373,6 +376,13 @@ def run_verb_stream(
          subdirectory) repos skip their own fetch/worktree-add and resolve
          to a path under their parent's worktree instead, mirroring
          `WorktreeManager.spawn`'s treatment of subdirectory services.
+      2b. A repo named in `run_ref_repos` is materialized from THIS host's own
+          scratch ref for the task instead — the operator pushed a commit
+          synthesized from their working tree straight here, so the revision is
+          already local and NO fetch (not even the base-freshness probe, which
+          exists only to refresh this host's view of origin) is issued for it.
+          Names are TOP-LEVEL git repo names, so a `git_root` child is covered
+          by its parent's entry.
       3. Resolve the repo's go-task target for `verb` + its env_runner;
          for `verb == "capture"` build the same env-var contract as local
          capture (`MSHIP_CAPTURE_DIR` a fresh remote temp dir,
@@ -435,6 +445,20 @@ def run_verb_stream(
         yield f"{EXIT_MARKER}:{nonce} 2\n".encode("utf-8")
         return
 
+    scratch_repos = sorted(set(run_ref_repos or []))
+    run_refs: dict[str, str] = {}
+    for scratch_repo in scratch_repos:
+        try:
+            run_refs[scratch_repo] = build_run_ref(task, scratch_repo)
+        except RunRefNameError as exc:
+            # The ref is interpolated into git commands run with shell=True, so
+            # a name that cannot form one is refused before anything runs — as
+            # stream DATA, never a raised exception mid-generator, matching the
+            # unknown-repo guard above.
+            yield f"error: cannot build a run ref for this request: {exc}\n".encode("utf-8")
+            yield f"{EXIT_MARKER}:{nonce} 2\n".encode("utf-8")
+            return
+
     materialized: dict[str, Path] = {}
     exit_code = 0
 
@@ -456,13 +480,22 @@ def run_verb_stream(
         rc = config.repos[top_repo]
         repo_path = rc.path
         worktree_path = hub / top_repo
+        ref = run_refs.get(top_repo)
 
-        warning = check_base_freshness(shell, repo_path, rc.base_branch)
-        if warning is not None:
-            yield f"{warning}\n".encode("utf-8")
+        if ref is None:
+            # Origin is the source of truth for this repo, so make sure this
+            # host's view of its base is current first (MOS-203). Skipped
+            # entirely on the scratch-ref path: nothing there comes from origin,
+            # and a fetch would be pure latency.
+            warning = check_base_freshness(shell, repo_path, rc.base_branch)
+            if warning is not None:
+                yield f"{warning}\n".encode("utf-8")
 
         try:
-            materialize_worktree(shell, repo_path, worktree_path, branch, repo_name=top_repo)
+            materialize_worktree(
+                shell, repo_path, worktree_path, branch,
+                repo_name=top_repo, run_ref=ref,
+            )
         except MaterializeError as exc:
             yield f"error: {exc}\n".encode("utf-8")
             yield f"{EXIT_MARKER}:{nonce} 1\n".encode("utf-8")

--- a/src/mship/core/remote_preflight.py
+++ b/src/mship/core/remote_preflight.py
@@ -1,10 +1,9 @@
 """Make sure a remote run executes the code you are actually looking at.
 
-`--remote` works by having the run host materialize the task's branch **from
-origin** (see `remote_exec.materialize_worktree`, which ends in `git reset --hard
-origin/<branch>`). Nothing on the caller side ever checked that origin matched the
-local worktree, and nothing pushes during development — `git push -u` happens at
-`mship finish`. So two things could happen silently:
+`--remote` used to run whatever was on origin, because the run host materialized
+the task's branch by fetching it. Nothing on the caller side checked that origin
+matched the local worktree, and nothing pushes during development — `git push -u`
+happens at `mship finish`. So two things could happen silently:
 
   * the branch was never pushed at all, and the remote failed with a materialize
     error that pointed at the remote rather than at the real cause; or
@@ -12,14 +11,34 @@ local worktree, and nothing pushes during development — `git push -u` happens 
     The output looked like a real result for code the operator was not editing.
 
 The second is the dangerous one, and it is what this module exists to prevent. It
-is deliberately conservative, and every verdict is reached by ASKING ORIGIN rather
-than by reading a local remote-tracking ref: `@{u}` is a cached copy that another
-machine's push makes stale, and it goes stale in the unsafe direction — it reports
-"up to date" for a branch origin has since moved ahead on. One
-`git ls-remote origin refs/heads/<branch>` per dispatched repo settles it (the same
-pattern, for the same reason, as `evidence_url._remote_tip`).
+sorts the task's repos into three outcomes:
 
-Against origin's real tip:
+  * **REFUSE** — the repo cannot be sent, or sending it would be a lie about what
+    the operator meant. See the reason constants below.
+  * **TRANSFER** (`Preflight.dirty`) — the working tree differs from HEAD, in any
+    way at all. `cli/exec.py` synthesizes a commit from that tree
+    (`core/run_transfer.py`) and pushes it STRAIGHT TO THE RUN HOST, onto a ref
+    under the throwaway namespace `core/run_ref.py` owns. Origin is never in this
+    path: routing uncommitted work through it would publish untracked scratch
+    files to a third party, and deleting the ref afterwards would not retract the
+    objects. Nothing local is mutated — see `synthesize_commit`.
+  * **PUSH** (`Preflight.to_push`) — the tree is clean but origin is missing the
+    branch or is behind it. Push the branch to origin exactly as before. There is
+    nothing extra to send, so nothing extra happens.
+
+Real history goes to origin; throwaway state goes host to host.
+
+ANY `git status --porcelain` output makes a repo dirty, untracked entries
+included. That is not laxity: untracked files are part of what the operator sees,
+they now travel only between the operator's own two machines, and a rule that
+excluded them would mean they never travel at all.
+
+For a CLEAN repo, and only for a clean repo, the verdict is reached by ASKING
+ORIGIN rather than by reading a local remote-tracking ref: `@{u}` is a cached copy
+that another machine's push makes stale, and it goes stale in the unsafe direction
+— it reports "up to date" for a branch origin has since moved ahead on. One
+`git ls-remote origin refs/heads/<branch>` settles it (the same pattern, for the
+same reason, as `evidence_url._remote_tip`). Against origin's real tip:
 
   * the branch is **missing from origin, or origin's tip is an ancestor of HEAD** →
     **push**. That is unambiguously what the operator meant, and nothing is lost.
@@ -27,11 +46,21 @@ Against origin's real tip:
     execute a commit the operator does not have, and no push can fix it: a
     fast-forward from behind is impossible, so attempting one would only produce a
     confusing git error in place of the real remedy (sync, or reset deliberately).
-  * a repo with **tracked** modifications → **refuse**, because inventing a commit
-    out of someone's work in progress is not a decision this tool should make
-    silently;
-  * untracked files only → **warn**. They cannot change what the push contains, but
-    they also will not exist on the run host, which is worth saying out loud.
+
+A DIRTY repo never asks origin at all. The run host materializes the scratch ref
+this machine pushed, with no fetch (`remote_exec.materialize_worktree(run_ref=…)`),
+so origin's tip cannot change what executes — and a network round trip that cannot
+change the outcome is one not worth taking. BEHIND_ORIGIN and ORIGIN_UNREACHABLE
+therefore keep their full force on the path where they describe a real hazard, and
+are simply unreachable on the path where they would not.
+
+A repo mid-merge, mid-rebase, mid-cherry-pick or with unmerged paths is refused
+outright (IN_PROGRESS). The working tree is what gets sent, and in that state it
+holds conflict markers and half-applied changes; shipping them produces a remote
+failure with no visible relationship to the edit the operator was making. That
+check runs BEFORE the branch check on purpose: `git rebase` detaches HEAD, so
+checking the branch first would refuse a rebase as WRONG_BRANCH and print a
+`git checkout` that abandons it.
 
 Every one of those verdicts is reached by reading the worktree's **HEAD**, and
 `push` publishes what they cleared — so HEAD has to *be* the task's branch for the
@@ -94,7 +123,7 @@ _NO_PROMPT = {"GIT_TERMINAL_PROMPT": "0"}
 
 # Why a repo must not be dispatched. Distinct rather than one "dirty" bucket
 # because each has a different remedy, and the message has to name the right one.
-DIRTY = "uncommitted changes"
+IN_PROGRESS = "merge or rebase in progress"
 UNREADABLE = "unreadable git state"
 BEHIND_ORIGIN = "unpulled commits on origin"
 MISSING_WORKTREE = "missing worktree"
@@ -102,9 +131,9 @@ ORIGIN_UNREACHABLE = "unverified origin"
 WRONG_BRANCH = "worktree is not on the task's branch"
 
 _WHY = {
-    DIRTY:
-        "the run host materializes the task's branch from origin, so it would "
-        "run the last PUSHED revision, not what you are editing.",
+    IN_PROGRESS:
+        "the working tree is what gets sent, and mid-operation it holds conflict "
+        "markers and half-applied changes rather than code you meant to run.",
     WRONG_BRANCH:
         "every check here reads the worktree's HEAD, but the run host "
         "materializes the TASK's branch — so what was verified and what would "
@@ -129,10 +158,10 @@ _WHY = {
 # other line is printed as written. That keeps the remedy for a five-repo task from
 # collapsing into a command the operator has to rewrite five times by hand.
 _FIX = {
-    DIRTY: [
-        "Commit and push first:",
-        '  mship commit "<what changed>"        # commits across every task repo',
-        '  git -C "{path}" push -u origin HEAD',
+    IN_PROGRESS: [
+        "Finish it or abandon it, then re-run:",
+        '  git -C "{path}" status                 # what git is in the middle of',
+        '  git -C "{path}" rebase --abort         # ...or merge/cherry-pick/revert --abort',
     ],
     WRONG_BRANCH: [
         "Check the task's branch back out, then re-run:",
@@ -167,10 +196,15 @@ class RepoState:
     branch: str
     blocked_reason: str | None   # one of the reason constants, else None
     detail: str | None           # git's own words, for this repo
-    untracked_only: bool
+    dirty: bool                  # working tree differs from HEAD -> TRANSFER
     needs_push: bool
     push_reason: str | None      # "not on origin" | "ahead of origin" | None
     head_sha: str | None = None  # HEAD as resolved during inspect; see `push`
+    # The TOP-LEVEL git repo this worktree belongs to. Equal to `repo` except
+    # for a `git_root` child, whose tree IS its parent's — so both name the
+    # parent and dedupe to one transfer (spec ac7). Resolved in `inspect` from
+    # the workspace config; `repo` itself when no config was supplied.
+    git_repo: str | None = None
 
 
 @dataclass(frozen=True)
@@ -179,7 +213,7 @@ class Preflight:
     states: list[RepoState]
     blocked: list[RepoState]
     to_push: list[RepoState]
-    untracked: list[RepoState]
+    dirty: list[RepoState]       # one entry per GIT repo, not per repo name
 
     @property
     def ok(self) -> bool:
@@ -191,6 +225,32 @@ def _tail(result) -> str:
     text = (result.stderr or "").strip() or (result.stdout or "")
     lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
     return lines[-1] if lines else f"exit {result.returncode}"
+
+
+# `git status --porcelain` spells an unmerged path with these two-letter codes
+# (verified: a real conflict reports `UU`). They are the only porcelain codes
+# that mean "git has not finished", which is why they are singled out rather
+# than lumped in with the dirty check below.
+_UNMERGED_CODES = ("DD", "AU", "UD", "UA", "DU", "AA", "UU")
+
+# Marker files git leaves in the per-worktree git dir while an operation is
+# suspended. A `--no-commit` merge leaves MERGE_HEAD with NOTHING unmerged, so
+# the porcelain alone cannot see it — hence the extra look.
+_OPERATIONS = (
+    ("rebase-merge", "a rebase is in progress"),
+    ("rebase-apply", "a rebase or `git am` is in progress"),
+    ("MERGE_HEAD", "a merge is in progress"),
+    ("CHERRY_PICK_HEAD", "a cherry-pick is in progress"),
+    ("REVERT_HEAD", "a revert is in progress"),
+)
+
+
+def _operation_in_progress(git_dir: Path) -> str | None:
+    """Which suspended git operation this worktree is in, if any."""
+    for marker, description in _OPERATIONS:
+        if (git_dir / marker).exists():
+            return description
+    return None
 
 
 def _origin_tip(shell, path: Path, branch: str) -> tuple[str | None, str | None]:
@@ -216,15 +276,18 @@ def _origin_tip(shell, path: Path, branch: str) -> tuple[str | None, str | None]
     return None, None
 
 
-def _inspect_repo(shell, repo: str, path: Path, branch: str) -> RepoState:
+def _inspect_repo(
+    shell, repo: str, path: Path, branch: str, *, git_repo: str | None = None,
+) -> RepoState:
     """One repo's verdict. Every path out of here is either a decision or a
     refusal — there is no "could not tell, carry on"."""
-    def state(*, blocked=None, detail=None, untracked_only=False,
+    def state(*, blocked=None, detail=None, dirty=False,
               needs_push=False, push_reason=None, head_sha=None) -> RepoState:
         return RepoState(
             repo=repo, path=path, branch=branch, blocked_reason=blocked,
-            detail=detail, untracked_only=untracked_only,
+            detail=detail, dirty=dirty,
             needs_push=needs_push, push_reason=push_reason, head_sha=head_sha,
+            git_repo=git_repo or repo,
         )
 
     if not path.exists():
@@ -232,14 +295,40 @@ def _inspect_repo(shell, repo: str, path: Path, branch: str) -> RepoState:
 
     # `git status --porcelain` lists untracked entries as `??` and never lists
     # gitignored files, so an ignored `.venv` does not make a repo look dirty.
-    # Untracked files are reported separately because they cannot alter what a
-    # push carries — refusing on them would block a run over a stray scratch file.
+    # (It DOES list a tracked-and-gitignored file that changed, as ` M` —
+    # verified — which is right: that file is part of what gets sent.)
     status = shell.run("git status --porcelain", cwd=path)
     if status.returncode != 0:
         # Empty stdout from a FAILED status is indistinguishable from a clean
         # tree, so the return code is the only thing separating "nothing to
         # report" from "could not look".
         return state(blocked=UNREADABLE, detail=_tail(status))
+
+    lines = [ln for ln in (status.stdout or "").splitlines() if ln.strip()]
+
+    # An interrupted operation is refused BEFORE the branch is checked, because
+    # `git rebase` detaches HEAD: checking the branch first would refuse a
+    # rebase as WRONG_BRANCH and hand the operator a `git checkout` that
+    # abandons it. Still AFTER `git status`, so a path that is not a git
+    # worktree at all stays UNREADABLE rather than becoming "finish your merge".
+    unmerged = [ln[3:].strip() for ln in lines if ln[:2] in _UNMERGED_CODES]
+    git_dir_result = shell.run("git rev-parse --git-dir", cwd=path)
+    git_dir_raw = (git_dir_result.stdout or "").strip()
+    if git_dir_result.returncode != 0 or not git_dir_raw:
+        # Same rule as the status guard above: a repo whose state could not be
+        # established is refused, never assumed clean — and never shipped.
+        return state(blocked=UNREADABLE, detail=_tail(git_dir_result))
+    git_dir = Path(git_dir_raw)
+    if not git_dir.is_absolute():
+        # `git rev-parse --git-dir` answers a bare `.git` at a repo root and an
+        # absolute path in a linked worktree (verified) — resolve either.
+        git_dir = path / git_dir
+    operation = _operation_in_progress(git_dir)
+    if operation is not None or unmerged:
+        detail = operation or "unmerged paths"
+        if unmerged:
+            detail = f"{detail}; unresolved: {', '.join(sorted(unmerged)[:5])}"
+        return state(blocked=IN_PROGRESS, detail=detail)
 
     # WHAT is being inspected, before WHAT STATE it is in: every verdict below
     # reads HEAD and `push` publishes what they cleared, so a worktree that is
@@ -291,10 +380,13 @@ def _inspect_repo(shell, repo: str, path: Path, branch: str) -> RepoState:
             detail=f"HEAD is {checked_out or 'detached'}, not {branch}",
         )
 
-    lines = [ln for ln in (status.stdout or "").splitlines() if ln.strip()]
-    if any(not ln.startswith("??") for ln in lines):
-        return state(blocked=DIRTY)
-    untracked_only = bool(lines)
+    # ANY porcelain output at all — tracked edits, untracked files, or both —
+    # means the working tree is not HEAD, and the working tree is what gets
+    # sent. Returning HERE is also what keeps origin out of the dirty path: the
+    # `ls-remote` below is never reached, because origin's tip cannot change
+    # what the run host executes once it is materializing a scratch ref.
+    if lines:
+        return state(dirty=True, head_sha=head_sha)
 
     # `head_sha`, resolved above, is carried on every state this repo can
     # still reach rather than re-read at push time. `push` names this exact
@@ -305,13 +397,12 @@ def _inspect_repo(shell, repo: str, path: Path, branch: str) -> RepoState:
 
     tip, error = _origin_tip(shell, path, branch)
     if error is not None:
-        return state(blocked=ORIGIN_UNREACHABLE, detail=error,
-                     untracked_only=untracked_only, head_sha=head_sha)
+        return state(blocked=ORIGIN_UNREACHABLE, detail=error, head_sha=head_sha)
     if tip is None:
-        return state(untracked_only=untracked_only, head_sha=head_sha,
-                     needs_push=True, push_reason="not on origin")
+        return state(head_sha=head_sha, needs_push=True,
+                     push_reason="not on origin")
     if head_sha == tip:
-        return state(untracked_only=untracked_only, head_sha=head_sha)
+        return state(head_sha=head_sha)
 
     # A tip that is an ancestor of HEAD is one a push fast-forwards past. A tip
     # that is not — because origin moved on, or because the branches diverged, or
@@ -322,15 +413,15 @@ def _inspect_repo(shell, repo: str, path: Path, branch: str) -> RepoState:
         cwd=path,
     )
     if ancestor.returncode == 0:
-        return state(untracked_only=untracked_only, head_sha=head_sha,
-                     needs_push=True, push_reason="ahead of origin")
+        return state(head_sha=head_sha, needs_push=True,
+                     push_reason="ahead of origin")
     return state(
-        blocked=BEHIND_ORIGIN, untracked_only=untracked_only, head_sha=head_sha,
+        blocked=BEHIND_ORIGIN, head_sha=head_sha,
         detail=f"origin/{branch} is at {tip[:12]}, which is not in your history",
     )
 
 
-def inspect(task, shell, *, repos: list[str] | None = None) -> Preflight:
+def inspect(task, shell, *, repos: list[str] | None = None, config=None) -> Preflight:
     """Read the task's worktrees for the repos being dispatched. No mutation.
 
     `repos` is the caller's `--repos`/`--tag`-filtered set — the repos the run
@@ -345,11 +436,24 @@ def inspect(task, shell, *, repos: list[str] | None = None) -> Preflight:
     ref, immediately before a network dispatch that makes the run host fetch that
     same branch, so the round trip buys the one guarantee the whole feature rests
     on.
+
+    `config` (the workspace's `WorkspaceConfig`, optional) is used for one thing:
+    resolving each repo to its TOP-LEVEL git repo, so a `git_root` child and its
+    parent — one git repository, one tree — dedupe to a single entry in `dirty`
+    (spec ac7). Without it every repo is its own git repo, which is correct for
+    every workspace that has no `git_root` children.
     """
     selected = None if repos is None else set(repos)
     worktrees = task.worktrees or {}
+    repo_configs = getattr(config, "repos", {}) if config is not None else {}
+
+    def _git_repo_of(repo: str) -> str:
+        rc = repo_configs.get(repo)
+        return rc.git_root if rc is not None and rc.git_root else repo
+
     states = [
-        _inspect_repo(shell, repo, Path(raw_path), task.branch)
+        _inspect_repo(shell, repo, Path(raw_path), task.branch,
+                      git_repo=_git_repo_of(repo))
         for repo, raw_path in sorted(worktrees.items())
         if selected is None or repo in selected
     ]
@@ -367,25 +471,40 @@ def inspect(task, shell, *, repos: list[str] | None = None) -> Preflight:
                 repo=repo, path=Path(f"<no worktree for {repo!r} on this task>"),
                 branch=task.branch, blocked_reason=MISSING_WORKTREE,
                 detail=f"{repo!r} is not one of this task's repos (no worktree entry)",
-                untracked_only=False, needs_push=False, push_reason=None,
+                dirty=False, needs_push=False, push_reason=None,
+                git_repo=_git_repo_of(repo),
             )
             for repo in sorted(selected - worktrees.keys())
         ]
+
+    # One transfer per GIT repository: a `git_root` child and its parent share
+    # one tree, so pushing both would send the same objects twice under two
+    # names, and the run host materializes the parent either way (spec ac7).
+    # The parent's own state is preferred as the survivor when it is in scope,
+    # because the parent is the name the run host resolves the child under.
+    dirty_states = [s for s in states if s.dirty]
+    dirty: list[RepoState] = []
+    seen_git_repos: set[str] = set()
+    for s in [d for d in dirty_states if d.repo == d.git_repo] + dirty_states:
+        if s.git_repo in seen_git_repos:
+            continue
+        seen_git_repos.add(s.git_repo)
+        dirty.append(s)
 
     return Preflight(
         states=states,
         blocked=[s for s in states if s.blocked_reason is not None],
         to_push=[s for s in states if s.needs_push],
-        untracked=[s for s in states if s.untracked_only],
+        dirty=dirty,
     )
 
 
 def blocked_message(pre: Preflight) -> str:
     """Why the run was refused, and the commands that unblock it — one section
-    per reason, because a task with a dirty repo AND a stale one needs both
+    per reason, because a task with a conflicted repo AND a stale one needs both
     remedies, not whichever happened to be found first."""
     sections = []
-    for reason in (DIRTY, WRONG_BRANCH, BEHIND_ORIGIN, MISSING_WORKTREE,
+    for reason in (IN_PROGRESS, WRONG_BRANCH, BEHIND_ORIGIN, MISSING_WORKTREE,
                    UNREADABLE, ORIGIN_UNREACHABLE):
         group = [s for s in pre.blocked if s.blocked_reason == reason]
         if not group:

--- a/src/mship/core/remote_setup.py
+++ b/src/mship/core/remote_setup.py
@@ -36,6 +36,15 @@ FIRST_MATERIALIZATION_KEY = "first-materialization"
 
 _UNSAFE = re.compile(r"[^A-Za-z0-9_-]")
 
+# How much of each name the filename carries for a human to read. `_TASK_NAME_RE`
+# bounds the charset of a task arriving over the wire but NOT its length, and a
+# name can be short enough for `.worktrees/<task>` yet overflow NAME_MAX (255)
+# once the repo and digest land beside it. Two of these plus the separators and
+# the digest come to 224 bytes, and `_safe` leaves only single-byte characters,
+# so the count is the byte count. Truncating costs nothing but legibility
+# because identity lives in the digest, taken over the UNtruncated pair.
+_READABLE_MAX = 100
+
 
 def _safe(name: str) -> str:
     """A filename component that cannot escape its directory.
@@ -44,7 +53,7 @@ def _safe(name: str) -> str:
     permits `.` and `/` — so `../..` would otherwise be a legal path component
     here.
     """
-    return _UNSAFE.sub("-", name) or "unnamed"
+    return (_UNSAFE.sub("-", name) or "unnamed")[:_READABLE_MAX]
 
 
 def key_file(workspace_root: Path, task: str, repo: str) -> Path:

--- a/src/mship/core/remote_setup.py
+++ b/src/mship/core/remote_setup.py
@@ -48,10 +48,24 @@ def _safe(name: str) -> str:
 
 
 def key_file(workspace_root: Path, task: str, repo: str) -> Path:
-    """Where this host records the key it last set `task`/`repo` up at."""
+    """Where this host records the key it last set `task`/`repo` up at.
+
+    The readable part is sanitized and therefore LOSSY — `_safe` maps every
+    unsafe character to `-`, so `api.v2` and `api-v2` both read `api-v2`, and
+    `_` survives intact, so a bare `__` join lets the boundary move (`a__b`/`c`
+    vs `a`/`b__c`). Either collision would be a correctness bug, not just a
+    spurious re-run: two repos sharing a file whose digests happen to agree —
+    which they do whenever both declare the same patterns and neither has the
+    files yet — let the second read the first's record, match, and skip the
+    setup that installs ITS dependencies.
+
+    So identity comes from a digest of the exact pair, and the sanitized names
+    are kept only so an operator can tell at a glance whose state a file holds.
+    """
+    ident = hashlib.sha256(f"{task}\0{repo}".encode("utf-8")).hexdigest()[:16]
     return (
         Path(workspace_root) / ".mothership" / SETUP_STATE_DIRNAME
-        / f"{_safe(task)}__{_safe(repo)}.key"
+        / f"{_safe(task)}__{_safe(repo)}__{ident}.key"
     )
 
 

--- a/src/mship/core/remote_setup.py
+++ b/src/mship/core/remote_setup.py
@@ -1,0 +1,96 @@
+"""When a run host needs to re-run `task setup`.
+
+Exact source with stale dependencies is its own trap: change a manifest, run
+remotely, and the failure is a module-not-found with no visible relationship to
+the edit. So the run host DERIVES what git cannot carry — it runs `task setup`
+against the source the push just delivered, rather than copying `node_modules`
+over the wire.
+
+Running setup on every invocation would defeat the fast loop this exists to
+enable, so it is keyed:
+
+  - setup runs the first time a worktree is materialized for a task on a host;
+  - and again whenever the repo's declared `setup_inputs` differ from what that
+    host last set up at.
+
+A source-only edit — the common case — pays nothing. A dependency change pays
+once. A repo declaring no `setup_inputs` gets setup on first materialization
+only, because there is nothing to invalidate against.
+
+This is a cache key of exactly the shape any build cache uses, and it has the
+same failure mode: a repo whose setup depends on something undeclared will skip
+a re-run it needed. The mitigation is that the key is explicit config an
+operator can see and widen, not an inferred heuristic they cannot inspect.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+SETUP_STATE_DIRNAME = "remote-setup"
+
+# The key recorded for a repo that declares no inputs: constant, so it matches
+# on every run after the first and setup never repeats.
+FIRST_MATERIALIZATION_KEY = "first-materialization"
+
+_UNSAFE = re.compile(r"[^A-Za-z0-9_-]")
+
+
+def _safe(name: str) -> str:
+    """A filename component that cannot escape its directory.
+
+    The task name arrives over the wire, where `core/serve.py`'s `_TASK_NAME_RE`
+    permits `.` and `/` — so `../..` would otherwise be a legal path component
+    here.
+    """
+    return _UNSAFE.sub("-", name) or "unnamed"
+
+
+def key_file(workspace_root: Path, task: str, repo: str) -> Path:
+    """Where this host records the key it last set `task`/`repo` up at."""
+    return (
+        Path(workspace_root) / ".mothership" / SETUP_STATE_DIRNAME
+        / f"{_safe(task)}__{_safe(repo)}.key"
+    )
+
+
+def setup_key(worktree_path: Path, patterns: list[str]) -> str:
+    """A digest of the declared setup inputs as they exist in this worktree.
+
+    Every match of every pattern contributes its worktree-relative path AND its
+    bytes, so a rename, an edit, an addition or a deletion all move the key. A
+    pattern that matches nothing contributes nothing but is still folded in as a
+    declaration, so WIDENING `setup_inputs` moves the key by itself rather than
+    silently reusing a narrower run's result.
+    """
+    if not patterns:
+        return FIRST_MATERIALIZATION_KEY
+
+    digest = hashlib.sha256()
+    root = Path(worktree_path)
+    for pattern in patterns:
+        digest.update(f"\0pattern:{pattern}\0".encode("utf-8"))
+        for match in sorted(root.glob(pattern)):
+            if not match.is_file():
+                continue
+            digest.update(str(match.relative_to(root)).encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(match.read_bytes())
+            digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def needs_setup(path: Path, key: str) -> bool:
+    """True when this host has not recorded a successful setup at `key`."""
+    try:
+        return path.read_text().strip() != key
+    except OSError:
+        return True
+
+
+def record_setup(path: Path, key: str) -> None:
+    """Record `key` as set up. Called ONLY after setup exits zero — recording a
+    failed setup would cache the failure and skip the retry."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{key}\n")

--- a/src/mship/core/run_ref.py
+++ b/src/mship/core/run_ref.py
@@ -33,7 +33,11 @@ RUN_REF_PREFIX = "refs/mship/run/"
 # run through a shell, and `core/remote_setup.py` derives a filename from the
 # same values. `.` and `..` are excluded outright so no traversal segment can
 # exist.
-_SEGMENT_RE = re.compile(r"^(?!\.{1,2}$)[A-Za-z0-9._-]+$")
+#
+# Anchored `\Z`, not `$`: Python's `$` also matches BEFORE a trailing newline,
+# so `$` accepts `api\n` — and a trailing newline TERMINATES a shell command,
+# which is the one character this charset exists to keep out.
+_SEGMENT_RE = re.compile(r"\A(?!\.{1,2}\Z)[A-Za-z0-9._-]+\Z")
 
 
 class RunRefNameError(ValueError):

--- a/src/mship/core/run_ref.py
+++ b/src/mship/core/run_ref.py
@@ -1,0 +1,64 @@
+"""The scratch-ref namespace used to hand a working tree to a run host.
+
+ONE owner for the ref name, imported by every side that touches it: the client
+that pushes (`core/run_transfer.py`), the endpoint that decides which pushes to
+accept (`core/git_receive.py`), the run host that materializes from it
+(`core/remote_exec.py`), and `mship close`, which deletes it. If the shape ever
+changes, it changes here.
+
+`refs/mship/run/<task>/<repo>` is deliberately NOT under `refs/heads/`:
+
+  - `receive.denyCurrentBranch` never applies, so a push lands cleanly in a
+    non-bare repo whose branch is checked out (verified against real git);
+  - nothing else writes this namespace, which is what makes the force-push per
+    run safe;
+  - it is not real history and must never become any — no code path branches
+    from it, merges it, or opens a PR from it (spec ac14, guarded by
+    `tests/core/test_remote_exact_copy_invariants.py`).
+
+The `<repo>` segment is the TOP-LEVEL git repo's name. A `git_root` child has no
+git directory of its own — its tree IS its parent's — so parent and child dedupe
+to one ref (spec ac7). That collapsing happens in `core/remote_preflight.py`;
+this module only refuses to build a name it cannot make safe.
+"""
+from __future__ import annotations
+
+import re
+
+RUN_REF_PREFIX = "refs/mship/run/"
+
+# One path segment of the ref. Deliberately NARROWER than the task-name charset
+# `core/serve.py` accepts for `/exec` (`^[A-Za-z0-9._/-]+$`, which allows `/` and
+# a bare `.`): this string is interpolated into `git push` / `git reset --hard`
+# run through a shell, and `core/remote_setup.py` derives a filename from the
+# same values. `.` and `..` are excluded outright so no traversal segment can
+# exist.
+_SEGMENT_RE = re.compile(r"^(?!\.{1,2}$)[A-Za-z0-9._-]+$")
+
+
+class RunRefNameError(ValueError):
+    """A task or repo name that cannot appear in a run ref."""
+
+
+def run_ref(task: str, repo: str) -> str:
+    """`refs/mship/run/<task>/<repo>` — per task AND per git repo, so two tasks
+    or two repos running remotely at once cannot overwrite each other's refs."""
+    for label, value in (("task", task), ("repo", repo)):
+        if not _SEGMENT_RE.match(value or ""):
+            raise RunRefNameError(
+                f"{label} name {value!r} cannot be used in a run ref; it must "
+                f"match [A-Za-z0-9._-]+ and not be '.' or '..'"
+            )
+    return f"{RUN_REF_PREFIX}{task}/{repo}"
+
+
+def is_run_ref(name: str) -> bool:
+    """True iff `name` is a ref this feature is allowed to write.
+
+    The receive endpoint's ref-scope control (spec ac5). Strict on purpose:
+    exactly the prefix, then exactly two well-formed segments.
+    """
+    if not name.startswith(RUN_REF_PREFIX):
+        return False
+    segments = name[len(RUN_REF_PREFIX):].split("/")
+    return len(segments) == 2 and all(_SEGMENT_RE.match(s) for s in segments)

--- a/src/mship/core/run_transfer.py
+++ b/src/mship/core/run_transfer.py
@@ -12,7 +12,7 @@ import shlex
 import tempfile
 from pathlib import Path
 
-from mship.core.run_ref import run_ref
+from mship.core.run_ref import RunRefNameError, run_ref
 
 # Pinned identity for synthesized commits. Deliberately NOT the operator's: this
 # is machinery, not a commit they made (spec ac13), and pinning it also means
@@ -216,3 +216,48 @@ def delete_run_ref(shell, repo_root: Path, *, conn, repo: str, task: str) -> Non
         shell, repo_root, conn=conn, url=url, refspec=f":{ref}",
         failure=f"could not delete {ref} from the run host at {url}",
     )
+
+
+def cleanup_run_refs(task, *, config, store, shell, warn) -> list[str]:
+    """Delete this task's scratch refs from the run hosts that hold them.
+
+    Called by `mship close`. Without it the refs are a slow leak of objects
+    nothing deletes — on the operator's own machine, so a missed one costs disk
+    rather than disclosure, which is exactly why every failure here WARNS and
+    the close continues.
+
+    One delete per GIT repository: a `git_root` child shares its parent's ref
+    (spec ac7). Issued from the repo's MAIN CHECKOUT rather than a task worktree,
+    which is about to be torn down. A repo with no mapped run host is silently
+    skipped — a task that never ran remotely must not warn on every close.
+    """
+    from mship.core.run_host import RunHostError, resolve_run_host
+
+    deleted: list[str] = []
+    seen: set[str] = set()
+    repos = getattr(config, "repos", {})
+    for repo in sorted(getattr(task, "affected_repos", None) or []):
+        repo_config = repos.get(repo)
+        if repo_config is None:
+            continue
+        git_repo = repo_config.git_root or repo
+        if git_repo in seen:
+            continue
+        seen.add(git_repo)
+        root_config = repos.get(git_repo)
+        if root_config is None:
+            continue
+        try:
+            conn = resolve_run_host(None, repo=root_config, config=config, store=store)
+        except RunHostError:
+            continue
+        try:
+            delete_run_ref(
+                shell, Path(root_config.path), conn=conn,
+                repo=git_repo, task=task.slug,
+            )
+        except (RunTransferError, RunRefNameError) as exc:
+            warn(f"could not delete {git_repo}'s run ref from the run host: {exc}")
+            continue
+        deleted.append(git_repo)
+    return deleted

--- a/src/mship/core/run_transfer.py
+++ b/src/mship/core/run_transfer.py
@@ -1,0 +1,98 @@
+"""Client side of an exact-copy remote run: turn a working tree into a commit,
+and hand that commit to the run host.
+
+Real history goes to origin; throwaway state goes host to host and never touches
+origin. This module owns the second half of that rule. `core/remote_preflight.py`
+decides which repos take which path; this one carries them.
+"""
+from __future__ import annotations
+
+import shlex
+import tempfile
+from pathlib import Path
+
+# Pinned identity for synthesized commits. Deliberately NOT the operator's: this
+# is machinery, not a commit they made (spec ac13), and pinning it also means
+# synthesis works in a repo with no `user.email` configured.
+_IDENTITY_NAME = "mship run"
+_IDENTITY_EMAIL = "mship-run@localhost"
+
+_MESSAGE = "mship --remote: working-tree snapshot (throwaway, not real history)"
+
+
+class RunTransferError(Exception):
+    """A git command needed to synthesize or deliver the working tree failed.
+
+    Always names the command and git's own stderr: using git's transport rather
+    than a hand-rolled one is partly FOR those diagnostics, so they are passed
+    through rather than replaced.
+    """
+
+
+def _checked(shell, command: str, cwd: Path, env: dict[str, str]) -> str:
+    result = shell.run(command, cwd=cwd, env=env)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise RunTransferError(
+            f"`{command}` failed in {cwd}: {detail or f'exit {result.returncode}'}"
+        )
+    return result.stdout or ""
+
+
+def synthesize_commit(shell, repo_root: Path, *, base_sha: str) -> str:
+    """A real commit object whose tree is byte-identical to the working tree at
+    `repo_root`, created without touching the repository's own state.
+
+    The TEMPORARY INDEX is load-bearing, not an implementation detail. `git add
+    -A` against the DEFAULT index would stage the operator's work in progress —
+    a destructive surprise on their real repository — so every command here runs
+    with `GIT_INDEX_FILE` pointed at a scratch file that is deleted afterwards.
+    HEAD, the current branch, the real index and `git status` output are all
+    unchanged when this returns (verified against real git), and the commit
+    belongs to no branch.
+
+    `git read-tree <base_sha>` seeds the scratch index BEFORE `git add -A`.
+    Without that seed a file that is both tracked and gitignored is silently
+    dropped from the tree — git will not add an ignored path that is not already
+    in the index — which is exactly the "the remote ran something subtly
+    different" failure this feature exists to remove. Verified against real git.
+
+    `base_sha` is the sha `remote_preflight.inspect` certified HEAD to be at, not
+    the string `HEAD`. Re-resolving HEAD here would let anything that commits in
+    this worktree between inspection and synthesis (a subagent, a background job)
+    re-root the snapshot on a commit nothing verified — the same bypass
+    `remote_preflight.push` closes for the origin path.
+
+    `git commit-tree` rather than `git commit`: it writes an object and moves no
+    ref, and (verified) it does not honour `commit.gpgsign`, so an operator with
+    commit signing configured cannot be blocked on a passphrase prompt a
+    captured-output subprocess would never show them.
+
+    Untracked files are included — they are part of what the operator sees, and
+    they now travel only between the operator's own two machines. Gitignored
+    files are not; `git add -A` never picks them up.
+
+    Safe to call from a SUBDIRECTORY of the repository (a `git_root` child):
+    `git add -A` with no pathspec is whole-tree since git 2.0 and `git
+    write-tree` writes the full index, so the result is the same tree either
+    way. Verified.
+    """
+    with tempfile.TemporaryDirectory(prefix="mship-run-index-") as tmp:
+        env = {
+            "GIT_INDEX_FILE": str(Path(tmp) / "index"),
+            "GIT_AUTHOR_NAME": _IDENTITY_NAME,
+            "GIT_AUTHOR_EMAIL": _IDENTITY_EMAIL,
+            "GIT_COMMITTER_NAME": _IDENTITY_NAME,
+            "GIT_COMMITTER_EMAIL": _IDENTITY_EMAIL,
+        }
+        base = shlex.quote(base_sha)
+        _checked(shell, f"git read-tree {base}", repo_root, env)
+        _checked(shell, "git add -A", repo_root, env)
+        tree = _checked(shell, "git write-tree", repo_root, env).strip()
+        sha = _checked(
+            shell,
+            f"git commit-tree {shlex.quote(tree)} -p {base} "
+            f"-m {shlex.quote(_MESSAGE)}",
+            repo_root, env,
+        ).strip()
+    return sha

--- a/src/mship/core/run_transfer.py
+++ b/src/mship/core/run_transfer.py
@@ -7,9 +7,12 @@ decides which repos take which path; this one carries them.
 """
 from __future__ import annotations
 
+import os
 import shlex
 import tempfile
 from pathlib import Path
+
+from mship.core.run_ref import run_ref
 
 # Pinned identity for synthesized commits. Deliberately NOT the operator's: this
 # is machinery, not a commit they made (spec ac13), and pinning it also means
@@ -96,3 +99,120 @@ def synthesize_commit(shell, repo_root: Path, *, base_sha: str) -> str:
             repo_root, env,
         ).strip()
     return sha
+
+
+def extra_header_env(token: str, url: str) -> dict[str, str]:
+    """Env that makes git send `Authorization: Bearer <token>` on BOTH legs of a
+    push to `url` (the `info/refs` GET and the `git-receive-pack` POST), and
+    nowhere else.
+
+    Carried as git's ENV-based config (`GIT_CONFIG_COUNT` / `_KEY_n` /
+    `_VALUE_n`, git >= 2.31) rather than `git -c http.extraHeader=…`: argv is
+    world-readable through `/proc/<pid>/cmdline`, a process's environment is
+    not. Nothing is written to any git config file, and the token never appears
+    in the remote URL (spec ac4).
+
+    APPENDS at the next free index instead of claiming index 0 — the caller's
+    environment may already carry GIT_CONFIG entries (the test suite disables
+    commit signing that way, tests/conftest.py), and overwriting them would
+    silently drop them. The index comes from `os.environ` because `ShellRunner.
+    run` layers this dict OVER `os.environ`; the two have to be read from the
+    same place or the count will not match the keys git actually receives.
+
+    Two settings, both load-bearing:
+
+    - `http.<url>.extraHeader` is SCOPED to the run host, so the bearer cannot
+      ride a request this git process makes to anything else.
+    - `http.followRedirects=false` because that scoping is not enough on its
+      own. git binds the header to the request before it is sent and does not
+      re-match config per hop, so a redirect to another path on the SAME origin
+      carries the bearer verbatim (verified against real git; curl only strips a
+      custom Authorization header when the redirect crosses origins). git's
+      default, `initial`, follows exactly the redirect that matters here — the
+      one on `info/refs`. Refusing it fails the push loudly instead.
+
+    `GIT_TERMINAL_PROMPT=0` makes a rejected push FAIL rather than block on an
+    interactive credential prompt that a captured-output subprocess would never
+    show anyone.
+    """
+    settings = {
+        f"http.{url}.extraHeader": f"Authorization: Bearer {token}",
+        "http.followRedirects": "false",
+    }
+    try:
+        index = max(int(os.environ.get("GIT_CONFIG_COUNT", "0")), 0)
+    except ValueError:
+        index = 0
+    env = {"GIT_TERMINAL_PROMPT": "0", "GIT_CONFIG_COUNT": str(index + len(settings))}
+    for offset, (key, value) in enumerate(settings.items()):
+        env[f"GIT_CONFIG_KEY_{index + offset}"] = key
+        env[f"GIT_CONFIG_VALUE_{index + offset}"] = value
+    return env
+
+
+def _receive_url(conn, repo: str) -> str:
+    """The run host's scoped receive endpoint for `repo`. git appends
+    `/info/refs?service=git-receive-pack` and `/git-receive-pack` itself.
+
+    The trailing slash is stripped because this string is both the remote git is
+    given AND the URL the auth header is scoped to; a `//` in the middle would
+    make the two disagree.
+    """
+    return f"{conn.url.rstrip('/')}/git/{repo}"
+
+
+def _push(shell, repo_root: Path, *, conn, refspec: str, url: str, failure: str) -> None:
+    result = shell.run(
+        f"git push --force {shlex.quote(url)} {refspec}",
+        cwd=repo_root, env=extra_header_env(conn.token, url),
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise RunTransferError(f"{failure}: {detail or f'exit {result.returncode}'}")
+
+
+def push_run_ref(shell, repo_root: Path, *, conn, repo: str, task: str, sha: str) -> str:
+    """Push `sha` straight to the run host's scratch ref, and return that ref.
+
+    Origin is not in this path: uncommitted work — including untracked scratch
+    files — goes only between the operator's own two machines.
+
+    `git push` performs the have/want negotiation itself, so only objects the
+    run host is missing cross the wire, with no need to compute what it already
+    has. `--force` is required because each run replaces the last, and is safe
+    precisely because nothing else writes this namespace.
+
+    `repo` is the TOP-LEVEL git repo's name — the receive endpoint refuses a
+    `git_root` child, which has no git directory of its own.
+    """
+    ref = run_ref(task, repo)
+    url = _receive_url(conn, repo)
+    _push(
+        shell, repo_root, conn=conn, url=url,
+        refspec=f"{shlex.quote(sha)}:{ref}",
+        failure=f"could not send {repo}'s working tree to the run host at {url}",
+    )
+    return ref
+
+
+def delete_run_ref(shell, repo_root: Path, *, conn, repo: str, task: str) -> None:
+    """Delete this task's scratch ref from the run host.
+
+    Deleting a ref that is not there exits 0 with `remote: warning: deleting a
+    non-existent ref`, so `mship close` needs no "does it exist" probe. What
+    buys that is the ref being FULLY QUALIFIED, which `run_ref` guarantees: an
+    unqualified name has to be resolved against the remote's advertisement and
+    fails with `unable to delete 'api': remote ref does not exist` — in the
+    `:<ref>` form exactly as in `--delete <ref>` (git 2.43, verified in both
+    forms and both transports; the two forms are NOT the distinction, the
+    earlier note in this feature's tests notwithstanding).
+
+    The plain `:<ref>` refspec is used anyway so delete and push are the same
+    command shape through `_push`, with no option parsing after the URL.
+    """
+    ref = run_ref(task, repo)
+    url = _receive_url(conn, repo)
+    _push(
+        shell, repo_root, conn=conn, url=url, refspec=f":{ref}",
+        failure=f"could not delete {ref} from the run host at {url}",
+    )

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1453,6 +1453,7 @@ def create_app(
         gen = remote_exec.run_verb_stream(
             verb, body.task, body.repos, body.platform,
             kind=body.kind, deps=deps, nonce=nonce,
+            run_ref_repos=body.run_ref_repos,
         )
         return StreamingResponse(
             iterate_in_threadpool(gen),

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -130,6 +130,11 @@ class ExecBody(BaseModel):
     # Only meaningful for verb == "capture"; mirrors `cli/capture.py`'s
     # `--kind` default. Optional so run/build callers can omit it.
     kind: str = "all"
+    # Repos whose working tree the caller pushed to this host's own scratch ref
+    # for this task (spec remote-exact-copy). Materialized from that LOCAL ref
+    # instead of from origin — no fetch. Absent or empty means today's behaviour
+    # for every repo in the request, so an older client is unaffected.
+    run_ref_repos: list[str] = []
 
 
 def _make_auth_dependency(token: str):

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -13,6 +13,16 @@ from typing import Any, Optional
 
 from pydantic import BaseModel
 
+# The only fastapi names imported at MODULE scope, and they have to be: this
+# module is `from __future__ import annotations`, so a handler's annotations are
+# strings that FastAPI resolves against the function's __globals__. A `Request`
+# imported inside `create_app` is a closure local, invisible there — FastAPI
+# then reads `request: Request` as an ordinary query parameter and every push
+# 422s before the body is ever read (observed, not theorised). Same reason
+# `core/relay/egress/proxy.py` imports it at module scope. Everything else stays
+# a deferred import inside `create_app`.
+from fastapi import Request, Response
+
 from mship.core.gh_app import GhAppError, mint_installation_token, resolve_installation
 from mship.core.pr import PRManager
 from mship.core.pr_watcher import PrWatcher
@@ -1444,5 +1454,92 @@ def create_app(
             media_type="application/octet-stream",
             headers={"X-Mship-Exec-Nonce": nonce},
         )
+
+    # --- scoped git receive (spec remote-exact-copy) -------------------------
+    # Where `mship run --remote` lands the operator's working tree: a commit
+    # synthesized from it and pushed straight here, so uncommitted work never
+    # travels through origin. Narrow by construction — `core/git_receive.py`
+    # owns both controls (the repo allowlist and the run-scratch ref-name
+    # constraint) and explains why an unscoped version would be an
+    # arbitrary-ref-write primitive against this host. Auth is the app-wide
+    # bearer dependency every other route already inherits.
+    from starlette.concurrency import run_in_threadpool
+
+    from mship.core import git_receive
+
+    def _receive_repo(repo: str) -> Path:
+        if config is None:
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "remote workspace not bootstrapped: this serve host has no "
+                    "workspace config wired in, so there is no repo to receive "
+                    "a push for — bootstrap this machine as an mship workspace "
+                    "(mothership.yaml present) and restart `mship serve`"
+                ),
+            )
+        try:
+            return git_receive.receive_repo_path(config, repo)
+        except git_receive.UnknownReceiveRepoError as exc:
+            raise HTTPException(status_code=404, detail=str(exc))
+
+    @app.get("/git/{repo}/info/refs")
+    async def get_git_info_refs(repo: str, service: str = ""):
+        if service != git_receive.RECEIVE_SERVICE:
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    f"only service={git_receive.RECEIVE_SERVICE} is served here; "
+                    f"this is a receive path for `mship run --remote`, not a git host"
+                ),
+            )
+        repo_path = _receive_repo(repo)
+        # `advertise_refs` and `receive_pack` both block on a git subprocess, so
+        # they run in the threadpool: an `async def` handler runs ON the event
+        # loop, and a blocking call there would stall every other request this
+        # serve is handling — including the phone's. (The exec route reaches for
+        # `iterate_in_threadpool` for the same reason; sync `def` handlers
+        # elsewhere get the threadpool from Starlette automatically.)
+        try:
+            body = await run_in_threadpool(git_receive.advertise_refs, repo_path)
+        except git_receive.ReceivePackError as exc:
+            raise HTTPException(status_code=500, detail=str(exc))
+        return Response(
+            content=body,
+            media_type=git_receive.ADVERTISEMENT_CONTENT_TYPE,
+            headers={"Cache-Control": "no-cache"},
+        )
+
+    @app.post("/git/{repo}/git-receive-pack")
+    async def post_git_receive_pack(repo: str, request: Request):
+        encoding = (request.headers.get("content-encoding") or "").strip().lower()
+        if encoding not in ("", "identity"):
+            # git does not compress a receive-pack request (verified). A body we
+            # cannot read is a body whose refs we cannot check, so refuse it
+            # rather than hand it to receive-pack unexamined.
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"unsupported Content-Encoding {encoding!r}; send the body "
+                    f"uncompressed"
+                ),
+            )
+        repo_path = _receive_repo(repo)
+        # The RAW body, deliberately: `await request.body()` is the bytes off the
+        # wire with nothing between (this app installs no middleware, and no
+        # content-type-driven parsing happens because the handler declares no
+        # body model). Verified byte-identical for a binary packfile, chunked and
+        # unchunked. It matters — the bytes handed to receive-pack MUST be the
+        # bytes whose refs were scope-checked.
+        body = await request.body()
+        try:
+            result = await run_in_threadpool(git_receive.receive_pack, repo_path, body)
+        except git_receive.RefScopeError as exc:
+            raise HTTPException(status_code=403, detail=str(exc))
+        except git_receive.PktLineError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        except git_receive.ReceivePackError as exc:
+            raise HTTPException(status_code=500, detail=str(exc))
+        return Response(content=result, media_type=git_receive.RESULT_CONTENT_TYPE)
 
     return app

--- a/src/mship/util/taskfile.py
+++ b/src/mship/util/taskfile.py
@@ -1,0 +1,34 @@
+"""Read a repo's go-task file without running go-task.
+
+Moved verbatim out of `cli/exec.py` (where `mship logs` used it to turn a
+missing target into an actionable error instead of go-task's general help text,
+issue #125) so `core/remote_exec.py` can ask the same question on a run host —
+`core` must not import from `cli`.
+"""
+from pathlib import Path
+
+import yaml
+
+
+def taskfile_has_target(repo_path, target: str) -> bool:
+    """True if `<repo_path>/Taskfile.yml` (or .yaml) defines `target`.
+
+    Reads the local Taskfile only; `includes:` are not recursed into. That
+    covers the common case. False on a missing file or a parse error, which is
+    the correct, fail-loud signal for the caller.
+    """
+    p = Path(repo_path)
+    candidates = [p / "Taskfile.yml", p / "Taskfile.yaml"]
+    taskfile = next((c for c in candidates if c.exists()), None)
+    if taskfile is None:
+        return False
+    try:
+        data = yaml.safe_load(taskfile.read_text())
+    except Exception:
+        return False
+    if not isinstance(data, dict):
+        return False
+    tasks = data.get("tasks", {})
+    if not isinstance(tasks, dict):
+        return False
+    return target in tasks

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -1021,15 +1021,20 @@ def _git_shell(spec: dict | dict[str, dict], *, push_rc: int = 0):
         spec = {"api": spec}
     shell = MagicMock(spec=ShellRunner)
     pushes: list[str] = []
+    push_envs: list[dict] = []
     touched: set[str] = set()
 
-    def _run(cmd, cwd=None, **kw):
+    def _run(cmd, cwd=None, env=None, **kw):
         touched.add(Path(cwd).name)
         s = spec[Path(cwd).name]
         if "status --porcelain" in cmd:
             return ShellResult(
                 returncode=s["status_rc"], stdout=s["status"], stderr=s["status_err"],
             )
+        if "rev-parse --git-dir" in cmd:
+            # `_inspect_repo` looks here for MERGE_HEAD / rebase-merge — a test
+            # that wants the in-progress refusal creates the marker itself.
+            return ShellResult(returncode=0, stdout=str(Path(cwd) / ".git"), stderr="")
         if "symbolic-ref" in cmd:
             return ShellResult(
                 returncode=0 if s["head_ref"] else 1, stdout=s["head_ref"], stderr="",
@@ -1054,25 +1059,161 @@ def _git_shell(spec: dict | dict[str, dict], *, push_rc: int = 0):
             tip = cmd.split()[-2].strip("'")
             return ShellResult(returncode=0 if tip in s["contains"] else 1,
                                stdout="", stderr="")
+        # --- commit synthesis (core/run_transfer.py) -------------------------
+        if "write-tree" in cmd:
+            return ShellResult(returncode=0, stdout="tree1111\n", stderr="")
+        if "commit-tree" in cmd:
+            return ShellResult(returncode=0, stdout="synth2222\n", stderr="")
         if cmd.startswith("git push"):
             pushes.append(cmd)
+            push_envs.append(dict(env or {}))
             return ShellResult(returncode=push_rc, stdout="", stderr="denied\n")
         return ShellResult(returncode=0, stdout="", stderr="")
 
     shell.run.side_effect = _run
     shell.run_task.return_value = ShellResult(returncode=0, stdout="ok\n", stderr="")
     shell.pushes = pushes
+    shell.push_envs = push_envs
     shell.touched = touched
     return shell
 
 
-def test_remote_run_is_refused_when_the_worktree_is_dirty(tmp_path, monkeypatch):
-    """The dangerous case: the run host would materialize the last PUSHED commit
-    and report a result for code the operator is still editing."""
+def test_a_dirty_worktree_is_sent_to_the_run_host_not_to_origin(tmp_path, monkeypatch):
+    """ac1 + ac3 + ac7 through the CLI: the operator's uncommitted content is
+    synthesized into a commit and pushed straight to the run host, and origin
+    sees nothing at all. Under PR #419 this exact repo shape was a refusal."""
+    _write_run_workspace(tmp_path, run_hosts=["role-x"])
+    _seed_task_with_worktree(tmp_path, "t1", "api")
+    _configure(tmp_path)
+    shell = _git_shell(_repo_git(" M src/app.py\n?? scratch.txt\n"))
+    container.shell.override(shell)
+    RunHostStore(tmp_path / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+    recorder: dict = {}
+    try:
+        with _ClientPatch(monkeypatch, _recording_handler(recorder, _frame(["ok\n"], exit_code=0))):
+            result = runner.invoke(app, ["run", "--task", "t1", "--remote=role-x"])
+        assert result.exit_code == 0, result.output
+
+        assert len(shell.pushes) == 1
+        assert "synth2222:refs/mship/run/t1/api" in shell.pushes[0]
+        assert "http://remote.example/git/api" in shell.pushes[0]
+        assert "origin" not in shell.pushes[0]              # ac3
+        assert recorder["json"]["run_ref_repos"] == ["api"]
+        # The snapshot is rooted on the sha the preflight CERTIFIED HEAD to be
+        # at, not on a re-resolved `HEAD`: a subagent committing in this
+        # worktree between inspection and synthesis would otherwise re-parent it
+        # on a commit nothing verified — the same bypass `remote_preflight.push`
+        # closes for the origin path. Passing the literal "HEAD" here reads
+        # identically in every other assertion, so it is asserted directly.
+        commands = [c.args[0] for c in shell.run.call_args_list]
+        assert any(c.startswith("git commit-tree tree1111 -p headsha ")
+                   for c in commands), commands
+    finally:
+        container.shell.reset_override()
+        _reset()
+
+
+def test_a_git_root_child_is_transferred_under_its_parents_name(tmp_path, monkeypatch):
+    """ac7 through the CLI: a `git_root` child has no git directory of its own —
+    its tree IS the parent's — so the ref, the receive URL and `run_ref_repos`
+    all name the PARENT, which is what the run host materializes and the only
+    name the receive endpoint accepts. This is the one thing the `config=`
+    argument on the preflight buys: without it every repo is its own git repo
+    and this run would push `pkg` to an endpoint that has no such repository."""
+    (tmp_path / "mono" / "pkg").mkdir(parents=True)
+    taskfile = "version: '3'\ntasks:\n  run:\n    cmds:\n      - echo run\n"
+    (tmp_path / "mono" / "Taskfile.yml").write_text(taskfile)
+    (tmp_path / "mono" / "pkg" / "Taskfile.yml").write_text(taskfile)
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\n"
+        "run_hosts: [role-x]\n"
+        "repos:\n"
+        "  mono:\n    path: ./mono\n    type: service\n"
+        "  pkg:\n    path: pkg\n    type: service\n    git_root: mono\n"
+    )
+    wt_mono = tmp_path / ".worktrees" / "t1" / "mono"
+    wt_pkg = wt_mono / "pkg"
+    wt_pkg.mkdir(parents=True)
+    _seed_task(tmp_path, slug="t1", repos=["mono", "pkg"],
+               worktrees={"mono": str(wt_mono), "pkg": str(wt_pkg)})
+    _configure(tmp_path)
+    shell = _git_shell({"mono": _repo_git(), "pkg": _repo_git(" M pkg/a.py\n")})
+    container.shell.override(shell)
+    RunHostStore(tmp_path / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+    recorder: dict = {}
+    try:
+        with _ClientPatch(monkeypatch, _recording_handler(recorder, _frame(["ok\n"], exit_code=0))):
+            result = runner.invoke(
+                app, ["run", "--task", "t1", "--repos", "pkg", "--remote=role-x"]
+            )
+        assert result.exit_code == 0, result.output
+        assert len(shell.pushes) == 1
+        assert "synth2222:refs/mship/run/t1/mono" in shell.pushes[0]
+        assert "http://remote.example/git/mono" in shell.pushes[0]
+        assert recorder["json"]["run_ref_repos"] == ["mono"]
+        assert recorder["json"]["repos"] == ["pkg"]   # the RUN's scope is unchanged
+    finally:
+        container.shell.reset_override()
+        _reset()
+
+
+def test_the_bearer_never_reaches_the_push_command_line(tmp_path, monkeypatch):
+    """ac4, end to end through the CLI: argv is world-readable via /proc."""
+    _write_run_workspace(tmp_path, run_hosts=["role-x"])
+    _seed_task_with_worktree(tmp_path, "t1", "api")
+    _configure(tmp_path)
+    shell = _git_shell(_repo_git(" M src/app.py\n"))
+    container.shell.override(shell)
+    RunHostStore(tmp_path / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+    try:
+        with _ClientPatch(monkeypatch, _recording_handler({}, _frame(["ok\n"], exit_code=0))):
+            runner.invoke(app, ["run", "--task", "t1", "--remote=role-x"])
+        assert "tok-abc" not in shell.pushes[0]
+        assert "Authorization: Bearer tok-abc" in shell.push_envs[0].values()
+    finally:
+        container.shell.reset_override()
+        _reset()
+
+
+def test_the_output_names_the_revision_as_a_throwaway_run_ref(tmp_path, monkeypatch):
+    """ac13: nobody should `git show` it and try to build on it.
+
+    `MSHIP_JSON=0` is required, not decorative: `Output.breadcrumb` is gated on
+    `human_mode`, and `json_mode` defaults to `not is_tty` — so under CliRunner
+    breadcrumbs are suppressed and `result.output` would never contain the line.
+    """
+    monkeypatch.setenv("MSHIP_JSON", "0")
     _write_run_workspace(tmp_path, run_hosts=["role-x"])
     _seed_task_with_worktree(tmp_path, "t1", "api")
     _configure(tmp_path)
     container.shell.override(_git_shell(_repo_git(" M src/app.py\n")))
+    RunHostStore(tmp_path / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+    try:
+        with _ClientPatch(monkeypatch, _recording_handler({}, _frame(["ok\n"], exit_code=0))):
+            result = runner.invoke(app, ["run", "--task", "t1", "--remote=role-x"])
+        assert "throwaway" in result.output
+        assert "refs/mship/run/t1/api" in result.output
+        assert "synth2222"[:12] in result.output
+    finally:
+        container.shell.reset_override()
+        _reset()
+
+
+def test_a_failed_transfer_aborts_before_dispatch(tmp_path, monkeypatch):
+    """Dispatching after a failed transfer would run the previous ref's tree —
+    the same silent-stale-code failure, one layer along."""
+    _write_run_workspace(tmp_path, run_hosts=["role-x"])
+    _seed_task_with_worktree(tmp_path, "t1", "api")
+    _configure(tmp_path)
+    container.shell.override(_git_shell(_repo_git(" M src/app.py\n"), push_rc=1))
     RunHostStore(tmp_path / ".mothership").set(
         "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
     )
@@ -1081,9 +1222,32 @@ def test_remote_run_is_refused_when_the_worktree_is_dirty(tmp_path, monkeypatch)
         with _ClientPatch(monkeypatch, _recording_handler(recorder, _frame([], exit_code=0))):
             result = runner.invoke(app, ["run", "--task", "t1", "--remote=role-x"])
         assert result.exit_code == 1, result.output
-        assert "uncommitted changes in api" in result.output
-        assert "last PUSHED revision" in result.output
-        # the decisive assertion: the remote was never contacted
+        assert "run host" in result.output and "denied" in result.output
+        assert recorder == {}                       # never contacted
+    finally:
+        container.shell.reset_override()
+        _reset()
+
+
+def test_a_mid_rebase_repo_is_refused_before_anything_is_sent(tmp_path, monkeypatch):
+    """ac12 through the CLI."""
+    _write_run_workspace(tmp_path, run_hosts=["role-x"])
+    wts = _seed_task_with_worktree(tmp_path, "t1", "api")
+    (wts["api"] / ".git" / "rebase-merge").mkdir(parents=True)
+    _configure(tmp_path)
+    shell = _git_shell(_repo_git("UU src/app.py\n"))
+    container.shell.override(shell)
+    RunHostStore(tmp_path / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+    recorder: dict = {}
+    try:
+        with _ClientPatch(monkeypatch, _recording_handler(recorder, _frame([], exit_code=0))):
+            result = runner.invoke(app, ["run", "--task", "t1", "--remote=role-x"])
+        assert result.exit_code == 1, result.output
+        assert "merge or rebase in progress in api" in result.output
+        assert "--abort" in result.output
+        assert shell.pushes == []
         assert recorder == {}
     finally:
         container.shell.reset_override()
@@ -1284,13 +1448,16 @@ def test_a_task_missing_from_a_later_state_read_does_not_skip_the_preflight(
 ):
     """The preflight is mandatory. Looking the resolved slug up in a SECOND
     state read made it conditional on that read succeeding: a task gone by then
-    dispatched with no check at all, over a repo (here, dirty) that the first
-    read had every fact needed to refuse. The remedy is not to report the race
-    but to remove it — the caller already holds the resolved task."""
+    dispatched with no check at all, over a repo (here, one whose git state
+    cannot be read at all) that the first read had every fact needed to refuse.
+    The remedy is not to report the race but to remove it — the caller already
+    holds the resolved task."""
     _write_run_workspace(tmp_path, run_hosts=["role-x"])
     _seed_task_with_worktree(tmp_path, "t1", "api")
     _configure(tmp_path)
-    container.shell.override(_git_shell(_repo_git(" M src/app.py\n")))
+    container.shell.override(_git_shell(_repo_git(
+        "", status_rc=128, status_err="fatal: not a git repository\n",
+    )))
     container.state_manager.override(
         _TaskVanishesAfterFirstRead(StateManager(tmp_path / ".mothership"))
     )
@@ -1302,7 +1469,7 @@ def test_a_task_missing_from_a_later_state_read_does_not_skip_the_preflight(
         with _ClientPatch(monkeypatch, _recording_handler(recorder, _frame([], exit_code=0))):
             result = runner.invoke(app, ["run", "--task", "t1", "--remote=role-x"])
         assert result.exit_code == 1, result.output
-        assert "uncommitted changes in api" in result.output
+        assert "unreadable git state in api" in result.output
         assert recorder == {}                    # the remote was never contacted
     finally:
         container.shell.reset_override()
@@ -1328,6 +1495,7 @@ def test_repos_scope_keeps_an_unrelated_dirty_repo_from_blocking(tmp_path, monke
             )
         assert result.exit_code == 0, result.output
         assert recorder["json"]["repos"] == ["api"]
+        assert "run_ref_repos" not in recorder["json"]   # web was never transferred
     finally:
         container.shell.reset_override()
         _reset()

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -1387,3 +1387,34 @@ def test_repos_scope_does_not_push_a_repo_the_operator_did_not_name(tmp_path, mo
     finally:
         container.shell.reset_override()
         _reset()
+
+
+# --- exact copy: which repos come from a scratch ref -------------------------
+
+def test_exec_remote_sends_run_ref_repos_when_there_are_any():
+    recorder: dict = {}
+    conn = RunHostConnection(url="http://remote.example", token="tok")
+
+    remote_client.exec_remote(
+        verb="run", conn=conn, task="t1", repos=["api", "web"],
+        run_ref_repos=["api"], print_fn=lambda _l: None,
+        transport=_mock_transport(_recording_handler(recorder, _frame(["ok\n"], exit_code=0))),
+    )
+
+    assert recorder["json"] == {
+        "task": "t1", "repos": ["api", "web"], "kind": "all", "run_ref_repos": ["api"],
+    }
+
+
+def test_exec_remote_omits_the_key_entirely_when_nothing_was_transferred():
+    """ac9: a clean run must be byte-identical on the wire to today's, so a run
+    host on an older mship keeps working."""
+    recorder: dict = {}
+    conn = RunHostConnection(url="http://remote.example", token="tok")
+
+    remote_client.exec_remote(
+        verb="run", conn=conn, task="t1", repos=["api"], print_fn=lambda _l: None,
+        transport=_mock_transport(_recording_handler(recorder, _frame(["ok\n"], exit_code=0))),
+    )
+
+    assert recorder["json"] == {"task": "t1", "repos": ["api"], "kind": "all"}

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -2348,3 +2348,85 @@ def test_finish_body_unchanged_when_no_linked_issues(configured_git_app: Path):
         assert "Closes acme" not in captured.get("create_cmd", "")
     finally:
         cli_container.shell.reset_override()
+
+
+def test_close_deletes_scratch_refs_from_the_run_host(configured_git_app):
+    """ac8, wired: closing a task removes what `--remote` left on the host."""
+    from datetime import datetime, timezone
+
+    from mship.core.run_host import RunHostConnection, RunHostStore
+
+    config_path = configured_git_app / "mothership.yaml"
+    config_path.write_text(
+        config_path.read_text().replace(
+            "workspace: test-platform",
+            "workspace: test-platform\nrun_hosts: [role-x]",
+        ).replace(
+            "  shared:\n    path: ./shared\n    type: library\n",
+            "  shared:\n    path: ./shared\n    type: library\n    run_host: role-x\n",
+        )
+    )
+    container.config.reset()
+    RunHostStore(configured_git_app / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+
+    sm = StateManager(configured_git_app / ".mothership")
+    sm.save(WorkspaceState(tasks={"t": Task(
+        slug="t", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["shared"], branch="feat/t",
+    )}))
+
+    result = runner.invoke(app, ["close", "--yes", "--abandon", "--task", "t"])
+
+    assert result.exit_code == 0, result.output
+    shell = container.shell()
+    assert any(
+        ":refs/mship/run/t/shared" in call.args[0]
+        for call in shell.run.call_args_list
+    )
+
+
+def test_close_still_succeeds_when_the_run_host_is_unreachable(configured_git_app):
+    """Fail-open: a run host that is off must never stop a close."""
+    from datetime import datetime, timezone
+
+    from mship.core.run_host import RunHostConnection, RunHostStore
+
+    config_path = configured_git_app / "mothership.yaml"
+    config_path.write_text(
+        config_path.read_text().replace(
+            "workspace: test-platform",
+            "workspace: test-platform\nrun_hosts: [role-x]",
+        ).replace(
+            "  shared:\n    path: ./shared\n    type: library\n",
+            "  shared:\n    path: ./shared\n    type: library\n    run_host: role-x\n",
+        )
+    )
+    container.config.reset()
+    RunHostStore(configured_git_app / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+
+    shell = container.shell()
+    original = shell.run.side_effect
+
+    def _fail_pushes(cmd, cwd=None, env=None, **kw):
+        if cmd.startswith("git push"):
+            return ShellResult(returncode=1, stdout="", stderr="host unreachable\n")
+        return original(cmd, cwd, env)
+
+    shell.run.side_effect = _fail_pushes
+
+    sm = StateManager(configured_git_app / ".mothership")
+    sm.save(WorkspaceState(tasks={"t": Task(
+        slug="t", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["shared"], branch="feat/t",
+    )}))
+
+    result = runner.invoke(app, ["close", "--yes", "--abandon", "--task", "t"])
+
+    assert result.exit_code == 0, result.output
+    assert "t" not in sm.load().tasks

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from mship.core.config import WorkspaceConfig, ConfigLoader, Dependency, Healthcheck
+from mship.core.config import WorkspaceConfig, ConfigLoader, Dependency, Healthcheck, RepoConfig
 
 
 def test_load_minimal_config(workspace: Path):
@@ -1260,4 +1260,35 @@ def test_git_root_child_depends_on_parent_still_loads(tmp_path: Path):
         "  web:\n    path: web\n    type: service\n    git_root: mono\n    depends_on: [mono]\n"
     )
     assert ConfigLoader.load(cfg).repos["web"].git_root == "mono"
+
+
+def test_setup_inputs_defaults_to_nothing_declared():
+    """ac17: no declaration is the honest default — there is nothing to
+    invalidate against, so setup runs on first materialization only."""
+    repo = RepoConfig(path=Path("./api"), type="service")
+    assert repo.setup_inputs == []
+
+
+def test_setup_inputs_accepts_manifests_and_globs():
+    repo = RepoConfig(
+        path=Path("./api"), type="service",
+        setup_inputs=["package.json", "uv.lock", "**/build.gradle"],
+    )
+    assert repo.setup_inputs == ["package.json", "uv.lock", "**/build.gradle"]
+
+
+def test_setup_inputs_parses_from_yaml(tmp_path):
+    config_path = tmp_path / "mothership.yaml"
+    (tmp_path / "api").mkdir()
+    (tmp_path / "api" / "Taskfile.yml").write_text("version: '3'\ntasks:\n  run:\n    cmds: [echo]\n")
+    config_path.write_text(
+        "workspace: t\n"
+        "repos:\n"
+        "  api:\n"
+        "    path: ./api\n"
+        "    type: service\n"
+        "    setup_inputs: [pyproject.toml, uv.lock]\n"
+    )
+    config = ConfigLoader.load(config_path)
+    assert config.repos["api"].setup_inputs == ["pyproject.toml", "uv.lock"]
 

--- a/tests/core/test_git_receive.py
+++ b/tests/core/test_git_receive.py
@@ -365,9 +365,22 @@ def test_a_shallow_push_still_has_its_refs_checked():
     b"shallow " + SHA.encode() + b" more",   # trailing junk after the oid
     b"shallowness is a virtue",              # only the exact prefix is a shallow line
 ])
-def test_a_line_git_would_not_read_as_shallow_is_still_refused(line):
-    """git's own reader dies on `shallow <not-an-oid>` rather than skipping it;
-    a laxer skip here would be a way to hide a command from the scope check."""
+def test_a_line_that_is_not_exactly_a_shallow_line_is_refused(line):
+    """Fail-closed, and STRICTER than git rather than equal to it.
+
+    git skips more than this. `read_head_info` parses the oid with
+    `get_oid_hex`, which consumes hexsz hex characters and does not require the
+    string to end there, so `shallow <oid> junk` and `shallow <oid>deadbeef` are
+    both skipped by git, which then accepts the following command and creates
+    its ref (verified, git 2.43). Of the three cases here only the first and
+    third actually die in git.
+
+    That direction is the safe one, and it is the invariant to hold: OUR shallow
+    skip must IMPLY GIT's, so that a line skipped here is never one git reads as
+    a command. This pattern is a strict subset of git's, which gives exactly
+    that. Refusing the laxer shapes costs a legitimate push nothing — git never
+    sends them.
+    """
     with pytest.raises(PktLineError):
         ref_commands(_body(line))
 

--- a/tests/core/test_git_receive.py
+++ b/tests/core/test_git_receive.py
@@ -1,0 +1,123 @@
+"""The scoped git receive path.
+
+Layered on purpose: pure pkt-line framing first (no git, no HTTP), then the
+allowlist and receive-pack against REAL repositories, then the FastAPI routes,
+then a real `git push` over a real socket. The framing is the security boundary,
+so it is tested where nothing can hide behind a mock.
+"""
+import pytest
+
+from mship.core.git_receive import (
+    PktLineError,
+    RefScopeError,
+    check_ref_scope,
+    pkt_line,
+    ref_commands,
+    service_advertisement,
+)
+
+ZERO = "0" * 40
+SHA = "9647986511a9eb8e9260ca70fc90406674ece7a9"
+
+
+def _body(*commands: bytes, pack: bytes = b"") -> bytes:
+    return b"".join(pkt_line(c) for c in commands) + b"0000" + pack
+
+
+def test_pkt_line_prefixes_a_four_hex_length_including_itself():
+    assert pkt_line(b"abc") == b"0007abc"
+
+
+def test_service_advertisement_matches_the_wire_prefix_git_expects():
+    """Verified against a real `git push`: this exact prefix, then the
+    `git receive-pack --http-backend-info-refs` output verbatim."""
+    assert service_advertisement(b"REFS").startswith(b"001f# service=git-receive-pack\n0000")
+    assert service_advertisement(b"REFS").endswith(b"REFS")
+
+
+def test_first_command_capabilities_are_stripped():
+    body = _body(f"{ZERO} {SHA} refs/mship/run/t1/api\x00report-status side-band-64k".encode())
+    assert ref_commands(body) == ["refs/mship/run/t1/api"]
+
+
+def test_every_command_is_reported_not_just_the_first():
+    body = _body(
+        f"{ZERO} {SHA} refs/mship/run/t1/api\x00report-status".encode(),
+        f"{ZERO} {SHA} refs/heads/sneaky".encode(),
+    )
+    assert ref_commands(body) == ["refs/mship/run/t1/api", "refs/heads/sneaky"]
+
+
+def test_a_delete_command_is_parsed():
+    """Deleting a scratch ref is old=<sha>, new=<zeros> — the same ref-name
+    control governs it."""
+    body = _body(f"{SHA} {ZERO} refs/mship/run/t1/api".encode())
+    assert ref_commands(body) == ["refs/mship/run/t1/api"]
+
+
+def test_trailing_pack_data_is_ignored():
+    body = _body(f"{ZERO} {SHA} refs/mship/run/t1/api".encode(), pack=b"PACK\x00\x01binary")
+    assert ref_commands(body) == ["refs/mship/run/t1/api"]
+
+
+@pytest.mark.parametrize("body", [
+    b"zzzz0000",                    # length is not hex
+    b"0003ab",                      # length below the 4-byte header
+    b"00ff" + b"short",             # length runs past the body
+    b"0010" + b"only two fields",   # not a ref command
+])
+def test_unparseable_bodies_raise_rather_than_being_guessed_at(body):
+    """A body whose refs cannot be read is a body whose refs cannot be checked."""
+    with pytest.raises(PktLineError):
+        ref_commands(body)
+
+
+def test_the_whole_remainder_of_a_command_is_the_ref_name():
+    """git takes the ref name as everything after the two oids up to a NUL —
+    spaces included: fed this command, real receive-pack answers
+    `ng refs/heads/a b funny refname`. A parser that stopped at the next space
+    would report the shorter, IN-SCOPE `refs/mship/run/t1/api` for a command git
+    reads as a different ref. Read it git's way and the scope check refuses it."""
+    command = f"{ZERO} {SHA} refs/mship/run/t1/api refs/heads/evil".encode()
+    assert ref_commands(_body(command)) == ["refs/mship/run/t1/api refs/heads/evil"]
+    with pytest.raises(RefScopeError):
+        check_ref_scope(_body(command))
+
+
+def test_commands_are_reported_when_the_body_ends_without_a_flush():
+    """Only a flush ends the command list. Truncating the body instead makes
+    real receive-pack die without touching a ref, so this is belt and braces —
+    but the check must never see FEWER refs than git might act on, and a parser
+    that treated end-of-body as end-of-list would silently drop the last one."""
+    body = (
+        pkt_line(f"{ZERO} {SHA} refs/mship/run/t1/api\x00report-status".encode())
+        + pkt_line(f"{ZERO} {SHA} refs/heads/sneaky".encode())
+    )
+    assert ref_commands(body) == ["refs/mship/run/t1/api", "refs/heads/sneaky"]
+    with pytest.raises(RefScopeError):
+        check_ref_scope(body)
+
+
+def test_check_ref_scope_accepts_the_run_namespace():
+    check_ref_scope(_body(f"{ZERO} {SHA} refs/mship/run/t1/api".encode()))
+
+
+def test_check_ref_scope_refuses_a_branch_write():
+    """ac5. An unscoped receive path really does create refs/heads/<anything> —
+    verified against a live prototype. This is the control that stops it."""
+    with pytest.raises(RefScopeError) as exc:
+        check_ref_scope(_body(f"{ZERO} {SHA} refs/heads/attacker".encode()))
+    assert "refs/heads/attacker" in str(exc.value)
+
+
+def test_one_out_of_scope_ref_refuses_the_whole_push():
+    with pytest.raises(RefScopeError):
+        check_ref_scope(_body(
+            f"{ZERO} {SHA} refs/mship/run/t1/api".encode(),
+            f"{ZERO} {SHA} refs/tags/v1".encode(),
+        ))
+
+
+def test_a_body_with_no_commands_is_refused():
+    with pytest.raises(PktLineError):
+        check_ref_scope(b"0000")

--- a/tests/core/test_git_receive.py
+++ b/tests/core/test_git_receive.py
@@ -764,3 +764,106 @@ def test_a_real_push_onto_a_branch_is_rejected(tmp_path):
     assert result.returncode != 0
     assert "403" in result.stderr        # the endpoint's refusal, not a git error
     assert "refs/heads/attacker" not in _refnames(host_repo)
+
+
+# --- the whole path ----------------------------------------------------------
+
+from mship.core import remote_exec
+from mship.core.run_host import RunHostConnection
+from mship.core.run_transfer import push_run_ref, synthesize_commit
+from mship.util.shell import ShellRunner
+
+
+def test_the_run_host_materializes_the_operators_uncommitted_bytes(tmp_path, monkeypatch):
+    """ac1 end to end: synthesize -> real HTTP push -> materialize -> read the
+    file. The operator edits files and never commits them; the run host's
+    worktree ends up holding exactly those bytes.
+
+    Every layer below this one is tested against a fixture of the layer beneath
+    it. This one has no fixtures: real git on both sides, a real socket in the
+    middle, and the ASSERTION IS THE FILE'S CONTENT ON THE RUN HOST — not that
+    the commands were issued. That is the only shape that catches a seam, and
+    seams are what this feature has produced: a push that exited 0 against the
+    wrong repository looked identical to every layer test until the ref was
+    read back server-side.
+
+    Unlike the `_git` helper, the code under test runs through `ShellRunner`,
+    which layers its env over `os.environ` — so it inherits whoever's
+    `~/.gitconfig` the suite runs under. A global `core.excludesFile` alone
+    would change which of the files below travel. Point git's global and system
+    config at /dev/null for the duration, exactly as `_GIT_ENV` already does for
+    the helper, so both halves of the test see the same git.
+    """
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+
+    host_repo = _repo(tmp_path / "api")
+    # `tracked.env` is TRACKED AND GITIGNORED — the one shape that distinguishes
+    # `synthesize_commit`'s `read-tree` seed from a bare `git add -A`. Without
+    # the seed the scratch index starts empty, the file reads as untracked and
+    # ignored, and `add -A` drops it: every other assertion here still passes.
+    # `-f` because the ignore rule lands in the same commit that first tracks it.
+    (host_repo / "tracked.env").write_text("committed\n")
+    (host_repo / ".gitignore").write_text("tracked.env\n")
+    _git("add", "-A", "-f", cwd=host_repo)
+    _git("commit", "-qm", "a tracked file the ignore rules also match", cwd=host_repo)
+
+    operator = _clone(host_repo, tmp_path / "operator")
+    _git("checkout", "-q", "-b", "feat/t1", cwd=operator)
+
+    # Uncommitted work of every shape that matters.
+    (operator / "a.txt").write_text("what I am editing right now\n")
+    (operator / "scratch.py").write_text("print('debug')\n")
+    (operator / "tracked.env").write_text("edited, never committed\n")
+    (operator / ".gitignore").write_text("tracked.env\nsecret.env\nbuilt.log\n")
+    (operator / "secret.env").write_text("TOKEN=hunter2\n")
+    (operator / "built.log").write_text("derived\n")
+
+    shell = ShellRunner()
+    base = _git("rev-parse", "HEAD", cwd=operator)
+    sha = synthesize_commit(shell, operator, base_sha=base)
+
+    with live_serve(_app(tmp_path, auth_token="tok-abc")) as base_url:
+        push_run_ref(
+            shell, operator,
+            conn=RunHostConnection(url=base_url, token="tok-abc"),
+            repo="api", task="t1", sha=sha,
+        )
+
+    worktree = tmp_path / "host-wt" / "api"
+    remote_exec.materialize_worktree(
+        shell, host_repo, worktree, "feat/t1",
+        repo_name="api", run_ref="refs/mship/run/t1/api",
+    )
+
+    # ac1: the tracked edit arrived, uncommitted.
+    assert (worktree / "a.txt").read_text() == "what I am editing right now\n"
+    # ac11: untracked travels, gitignored does not.
+    assert (worktree / "scratch.py").read_text() == "print('debug')\n"
+    assert not (worktree / "secret.env").exists()
+    assert not (worktree / "built.log").exists()
+    # ac1 again, at the shape that needs the `read-tree` seed: already tracked,
+    # and matched by an ignore rule.
+    assert (worktree / "tracked.env").read_text() == "edited, never committed\n"
+    # It is the synthesized commit that is checked out, and HEAD is detached:
+    # throwaway state is not dressed up as a branch on the run host.
+    assert _git("rev-parse", "HEAD", cwd=worktree) == sha
+    assert _git("rev-parse", "--abbrev-ref", "HEAD", cwd=worktree) == "HEAD"
+
+    # ac2: the operator's own repo is untouched — still dirty, still on the
+    # branch, HEAD unmoved, nothing staged, no new branch.
+    assert _git("status", "--porcelain", cwd=operator) != ""
+    assert _git("rev-parse", "--abbrev-ref", "HEAD", cwd=operator) == "feat/t1"
+    assert _git("rev-parse", "HEAD", cwd=operator) == base
+    assert _git("diff", "--cached", "--name-only", cwd=operator) == ""
+
+    # ac3: the branch never reached the host as a branch — only the scratch ref
+    # did. (`host_repo` is the operator's origin here, which makes this the
+    # strongest available form of "origin saw nothing but the scratch ref".)
+    refs = _refnames(host_repo)
+    assert "refs/heads/feat/t1" not in refs
+    assert "refs/mship/run/t1/api" in refs
+    # And the host's own checkout is where it was: materialization happens in a
+    # separate worktree, never on the branch the host has out.
+    assert _git("rev-parse", "--abbrev-ref", "HEAD", cwd=host_repo) == "main"
+    assert _git("status", "--porcelain", cwd=host_repo) == ""

--- a/tests/core/test_git_receive.py
+++ b/tests/core/test_git_receive.py
@@ -5,13 +5,22 @@ allowlist and receive-pack against REAL repositories, then the FastAPI routes,
 then a real `git push` over a real socket. The framing is the security boundary,
 so it is tested where nothing can hide behind a mock.
 """
+import os
+import subprocess
+from pathlib import Path
+
 import pytest
 
+from mship.core.config import RepoConfig, WorkspaceConfig
 from mship.core.git_receive import (
     PktLineError,
     RefScopeError,
+    UnknownReceiveRepoError,
+    advertise_refs,
     check_ref_scope,
     pkt_line,
+    receive_pack,
+    receive_repo_path,
     ref_commands,
     service_advertisement,
 )
@@ -121,3 +130,180 @@ def test_one_out_of_scope_ref_refuses_the_whole_push():
 def test_a_body_with_no_commands_is_refused():
     with pytest.raises(PktLineError):
         check_ref_scope(b"0000")
+
+
+# --- real repositories -------------------------------------------------------
+
+# The operator's own git config must not reach these repos: a global
+# `commit.gpgsign`, `insteadOf`, or `hooksPath` would make the outcome depend on
+# whose machine the suite runs on. Same reasoning (and same shape) as
+# `_GIT_ENV` in tests/core/test_remote_preflight.py:581.
+_GIT_ENV = {
+    **os.environ,
+    "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull,
+    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+def _git(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True,
+        env=_GIT_ENV,
+    ).stdout.strip()
+
+
+def _repo(path: Path) -> Path:
+    """A real, NON-BARE git repository with one commit — the shape a run host's
+    checkout actually has."""
+    path.mkdir(parents=True, exist_ok=True)
+    _git("init", "-q", "-b", "main", ".", cwd=path)
+    (path / "a.txt").write_text("one\n")
+    _git("add", "-A", cwd=path)
+    _git("commit", "-qm", "init", cwd=path)
+    return path
+
+
+def _empty_pack(repo: Path) -> bytes:
+    """A valid packfile carrying zero objects.
+
+    Not a detail: real receive-pack REFUSES a non-delete command that arrives
+    without a pack ("unpack eof before pack header was fully read") and creates
+    nothing, so a body that stops at the flush proves nothing about ordering.
+    With this appended — and the pushed oid already in the repo, so no object is
+    actually needed — git answers `unpack ok` / `ok refs/heads/attacker` and
+    really does create the ref. That is what makes the "no ref exists" assertion
+    below evidence that git was never run.
+    """
+    return subprocess.run(
+        ["git", "pack-objects", "--stdout"], cwd=repo, input=b"",
+        capture_output=True, check=True, env=_GIT_ENV,
+    ).stdout
+
+
+def _config(tmp_path: Path) -> WorkspaceConfig:
+    """One top-level repo plus a `git_root` child of it. Top-level paths are
+    absolute because `ConfigLoader.load` resolves them that way in production
+    (config.py:577) and `receive_repo_path` hands the value straight to git."""
+    return WorkspaceConfig(
+        workspace="t",
+        repos={
+            "api": RepoConfig(path=tmp_path / "api", type="service"),
+            "server": RepoConfig(path=Path("server"), type="service", git_root="api"),
+        },
+    )
+
+
+def test_allowlist_resolves_a_declared_repo(tmp_path):
+    assert receive_repo_path(_config(tmp_path), "api") == tmp_path / "api"
+
+
+def test_allowlist_refuses_a_repo_this_workspace_does_not_declare(tmp_path):
+    """ac5: not a general-purpose git host — an undeclared repo is refused."""
+    with pytest.raises(UnknownReceiveRepoError) as exc:
+        receive_repo_path(_config(tmp_path), "somebody-elses-repo")
+    assert "api" in str(exc.value)          # names what IS known
+
+
+def test_allowlist_refuses_a_git_root_child_and_names_its_parent(tmp_path):
+    """ac7: a child has no git directory of its own, so the push belongs to the
+    parent — and the refusal has to say which parent."""
+    with pytest.raises(UnknownReceiveRepoError) as exc:
+        receive_repo_path(_config(tmp_path), "server")
+    assert "api" in str(exc.value)
+
+
+def test_advertisement_is_the_prefix_plus_real_receive_pack_output(tmp_path):
+    repo = _repo(tmp_path / "api")
+    head = _git("rev-parse", "HEAD", cwd=repo)
+    body = advertise_refs(repo)
+    assert body.startswith(b"001f# service=git-receive-pack\n0000")
+    assert head.encode() in body
+
+
+def test_receive_pack_refuses_an_out_of_scope_push_without_touching_the_repo(tmp_path):
+    """The decisive assertion: no ref is created, because git was never run.
+
+    The body is one real receive-pack would ACCEPT (verified: fed to
+    `git receive-pack --stateless-rpc` it answers `ok refs/heads/attacker` and
+    the branch appears), so the absent ref can only mean the scope check ran
+    first.
+    """
+    repo = _repo(tmp_path / "api")
+    zero, sha = "0" * 40, _git("rev-parse", "HEAD", cwd=repo)
+    body = (
+        pkt_line(f"{zero} {sha} refs/heads/attacker\x00report-status".encode())
+        + b"0000" + _empty_pack(repo)
+    )
+
+    with pytest.raises(RefScopeError):
+        receive_pack(repo, body)
+
+    refs = _git("for-each-ref", "--format=%(refname)", cwd=repo)
+    assert "refs/heads/attacker" not in refs
+
+
+# --- pushes from a shallow clone ---------------------------------------------
+#
+# Reachable, not theoretical: `git worktree add` from a `--depth 1` clone
+# succeeds and the worktree is shallow too (`rev-parse
+# --is-shallow-repository` -> true), so an operator who shallow-cloned a
+# workspace repo gets shallow task worktrees — and every push from one leads
+# with `shallow <oid>` lines. Left unparsed those refuse the whole push with
+# "malformed ref command", which is safe but wrong.
+
+
+def test_a_shallow_line_is_not_a_ref_command(tmp_path):
+    """The real thing, from a real shallow worktree: capture the bytes git
+    actually sends by pushing through a `git receive-pack` that tees its stdin
+    (the command section is identical over HTTP — verified against a live
+    `mship serve`-shaped endpoint)."""
+    origin = _repo(tmp_path / "origin")
+    (origin / "a.txt").write_text("two\n")
+    _git("commit", "-qam", "second", cwd=origin)
+    # The run host holds a full clone. It has to: git refuses a push whose
+    # history is truncated ("shallow update not allowed") unless the receiving
+    # end already has the missing objects, so a shallow client only works
+    # against a host that does — which is exactly the run-host case.
+    host = tmp_path / "host"
+    _git("clone", "-q", str(origin), str(host), cwd=tmp_path)
+    _git("clone", "-q", "--depth", "1", f"file://{origin}", str(tmp_path / "shallow"),
+         cwd=tmp_path)
+    shallow = tmp_path / "shallow"
+    _git("worktree", "add", "-q", str(tmp_path / "wt"), "-b", "wt", cwd=shallow)
+    worktree = tmp_path / "wt"
+    assert _git("rev-parse", "--is-shallow-repository", cwd=worktree) == "true"
+
+    captured = tmp_path / "body.bin"
+    tee = tmp_path / "tee-receive-pack"
+    tee.write_text(f'#!/bin/sh\ntee "{captured}" | git receive-pack "$@"\n')
+    tee.chmod(0o755)
+    _git("push", f"--receive-pack={tee}", str(host),
+         "HEAD:refs/mship/run/t1/api", cwd=worktree)
+
+    body = captured.read_bytes()
+    assert b"shallow " in body[:64]
+    assert ref_commands(body) == ["refs/mship/run/t1/api"]
+    check_ref_scope(body)
+
+
+def test_a_shallow_push_still_has_its_refs_checked():
+    """Skipping the line must not skip the control it precedes."""
+    body = _body(
+        f"shallow {SHA}".encode(),
+        f"{ZERO} {SHA} refs/heads/attacker".encode(),
+    )
+    with pytest.raises(RefScopeError):
+        check_ref_scope(body)
+
+
+@pytest.mark.parametrize("line", [
+    b"shallow refs/heads/evil",              # not an oid where git demands one
+    b"shallow " + SHA.encode() + b" more",   # trailing junk after the oid
+    b"shallowness is a virtue",              # only the exact prefix is a shallow line
+])
+def test_a_line_git_would_not_read_as_shallow_is_still_refused(line):
+    """git's own reader dies on `shallow <not-an-oid>` rather than skipping it;
+    a laxer skip here would be a way to hide a command from the scope check."""
+    with pytest.raises(PktLineError):
+        ref_commands(_body(line))

--- a/tests/core/test_git_receive.py
+++ b/tests/core/test_git_receive.py
@@ -429,3 +429,193 @@ def test_receive_is_unavailable_without_a_workspace_config(tmp_path):
     assert client.post(
         "/git/api/git-receive-pack", content=b"0000"
     ).status_code == 503
+
+
+# --- real git over a real socket ---------------------------------------------
+
+import contextlib
+import socket
+import threading
+import time
+
+import uvicorn
+
+
+@contextlib.contextmanager
+def live_serve(app):
+    """Run `app` under uvicorn on a loopback port for the duration of the block.
+
+    Real git speaks real HTTP; TestClient does not. Anything asserting the smart-
+    HTTP framing, the auth header git actually sends, or a push's effect on refs
+    has to go through a socket.
+
+    The listening socket is bound HERE and handed to uvicorn, rather than probing
+    for a free port and letting uvicorn bind it: the port is never unbound
+    between the two, so nothing else on the machine can take it in between. The
+    block is only entered once `server.started` is set, which uvicorn does after
+    `create_server` — so the port is accepting before the first `git push`, and
+    the test cannot race the startup. `thread.is_alive()` is part of the wait
+    condition so a server that dies during startup fails immediately with its
+    reason rather than after the full timeout.
+    """
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    server = uvicorn.Server(
+        uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    )
+    thread = threading.Thread(target=server.run, kwargs={"sockets": [sock]}, daemon=True)
+    thread.start()
+    deadline = time.time() + 10
+    while not server.started and thread.is_alive() and time.time() < deadline:
+        time.sleep(0.02)
+    if not server.started:
+        server.should_exit = True
+        thread.join(timeout=10)
+        sock.close()       # uvicorn only closes it as part of its own shutdown
+        raise RuntimeError(
+            f"uvicorn did not start within 10s (thread alive: {thread.is_alive()})"
+        )
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=10)
+
+
+def _push_env(token: str | None) -> dict[str, str]:
+    """The env `core/run_transfer.extra_header_env` will build in Task 8: the
+    bearer as an HTTP header through git's ENV config, and no interactive
+    credential prompt (a rejected push must fail the command, not hang).
+
+    The index is taken from `_GIT_ENV` — the dict actually being handed to git —
+    and NOT from `os.environ`. They differ: tests/conftest.py:41 sets
+    GIT_CONFIG_COUNT=2 in `os.environ` from a session fixture, which runs AFTER
+    this module is imported, so the `_GIT_ENV` snapshot above does not carry the
+    count or its keys. Reading the count from `os.environ` (=2) while passing an
+    env with no GIT_CONFIG_KEY_0 makes every push die with `error: missing
+    config key GIT_CONFIG_KEY_0` / `fatal: unable to parse command-line config`
+    — verified. Nothing is lost by starting at 0 here: those two keys only
+    disable commit signing, and `_GIT_ENV` already points GIT_CONFIG_GLOBAL and
+    GIT_CONFIG_SYSTEM at /dev/null, so no signing config reaches these repos at
+    all.
+    """
+    env = {**_GIT_ENV, "GIT_TERMINAL_PROMPT": "0"}
+    if token is not None:
+        n = int(env.get("GIT_CONFIG_COUNT", "0"))
+        env["GIT_CONFIG_COUNT"] = str(n + 1)
+        env[f"GIT_CONFIG_KEY_{n}"] = "http.extraHeader"
+        env[f"GIT_CONFIG_VALUE_{n}"] = f"Authorization: Bearer {token}"
+    return env
+
+
+def _push(cwd: Path, url: str, refspec: str, token: str | None):
+    return subprocess.run(
+        ["git", "push", "--force", url, refspec],
+        cwd=cwd, capture_output=True, text=True, env=_push_env(token),
+    )
+
+
+def _clone(host_repo: Path, dest: Path) -> Path:
+    subprocess.run(
+        ["git", "clone", "-q", str(host_repo), str(dest)],
+        check=True, capture_output=True, env=_GIT_ENV,
+    )
+    return dest
+
+
+def _refnames(repo: Path) -> str:
+    return _git("for-each-ref", "--format=%(refname)", cwd=repo)
+
+
+def test_a_real_git_push_lands_on_the_scratch_ref(tmp_path):
+    """ac5/ac6/ac8/ac20 end to end: real git, real socket, real refs.
+
+    `returncode == 0` is not the assertion that matters — a push can exit 0
+    against the wrong repository. The ref on the HOST, at the sha the operator
+    pushed, is: pointed at a second repo, `receive_repo_path` still answers and
+    git still exits 0, and only the rev-parse below notices (verified).
+    """
+    host_repo = _repo(tmp_path / "api")
+    operator = _clone(host_repo, tmp_path / "operator")
+    (operator / "b.txt").write_text("two\n")
+    _git("add", "-A", cwd=operator)
+    _git("commit", "-qm", "second", cwd=operator)
+    sha = _git("rev-parse", "HEAD", cwd=operator)
+
+    with live_serve(_app(tmp_path, auth_token="tok-abc")) as base:
+        result = _push(
+            operator, f"{base}/git/api", f"{sha}:refs/mship/run/t1/api", "tok-abc"
+        )
+        assert result.returncode == 0, result.stderr
+        assert _git("rev-parse", "refs/mship/run/t1/api", cwd=host_repo) == sha
+
+        # ac8: the same ref force-updates on the next run.
+        (operator / "b.txt").write_text("three\n")
+        _git("commit", "-qam", "third", cwd=operator)
+        sha2 = _git("rev-parse", "HEAD", cwd=operator)
+        assert sha2 != sha
+        assert _push(
+            operator, f"{base}/git/api", f"{sha2}:refs/mship/run/t1/api", "tok-abc"
+        ).returncode == 0
+
+        # Deleting an absent ref is a no-op success (verified against real git:
+        # `remote: warning: deleting a non-existent ref`, exit 0), so
+        # `mship close` needs no "does it exist" probe.
+        delete_absent = _push(
+            operator, f"{base}/git/api", ":refs/mship/run/never/api", "tok-abc"
+        )
+        assert delete_absent.returncode == 0, delete_absent.stderr
+
+    assert _git("rev-parse", "refs/mship/run/t1/api", cwd=host_repo) == sha2
+    # The push never touched the host's checkout: `receive.denyCurrentBranch`
+    # cannot apply outside refs/heads/.
+    assert _git("rev-parse", "--abbrev-ref", "HEAD", cwd=host_repo) == "main"
+    assert _git("status", "--porcelain", cwd=host_repo) == ""
+
+
+def test_a_real_push_without_the_bearer_is_rejected(tmp_path):
+    """ac6: an unauthenticated push fails — and fails rather than prompting.
+
+    git turns the 401 into a credential request, which `GIT_TERMINAL_PROMPT=0`
+    then refuses; the observed stderr is `fatal: could not read Username for
+    'http://127.0.0.1:<port>': terminal prompts disabled` (exit 128), NOT the
+    string "401". Assert the outcome — non-zero exit, no ref created, and an
+    intelligible one-line reason rather than a hang or a traceback — not git's
+    exact wording.
+    """
+    host_repo = _repo(tmp_path / "api")
+    operator = _clone(host_repo, tmp_path / "operator")
+    sha = _git("rev-parse", "HEAD", cwd=operator)
+    before = _refnames(host_repo)
+
+    with live_serve(_app(tmp_path, auth_token="tok-abc")) as base:
+        result = _push(operator, f"{base}/git/api", f"{sha}:refs/mship/run/t1/api", None)
+
+    assert result.returncode != 0
+    assert "refs/mship/run/t1/api" not in _refnames(host_repo)
+    assert _refnames(host_repo) == before
+    # The failure is legible to whoever ran the push: one fatal line, no prompt
+    # left hanging and no server traceback echoed back.
+    assert "terminal prompts disabled" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_a_real_push_onto_a_branch_is_rejected(tmp_path):
+    """ac5, with real git driving: the endpoint is not an arbitrary-ref writer.
+
+    The ref assertion is the one that bites. Move `check_ref_scope` AFTER the
+    `git receive-pack` call in `receive_pack` and this push still fails with
+    HTTP 403 — the branch is simply created first (verified). Only the absent
+    ref distinguishes "refused" from "done, then complained".
+    """
+    host_repo = _repo(tmp_path / "api")
+    operator = _clone(host_repo, tmp_path / "operator")
+    sha = _git("rev-parse", "HEAD", cwd=operator)
+
+    with live_serve(_app(tmp_path, auth_token="tok-abc")) as base:
+        result = _push(operator, f"{base}/git/api", f"{sha}:refs/heads/attacker", "tok-abc")
+
+    assert result.returncode != 0
+    assert "403" in result.stderr        # the endpoint's refusal, not a git error
+    assert "refs/heads/attacker" not in _refnames(host_repo)

--- a/tests/core/test_git_receive.py
+++ b/tests/core/test_git_receive.py
@@ -81,6 +81,31 @@ def test_unparseable_bodies_raise_rather_than_being_guessed_at(body):
         ref_commands(body)
 
 
+def test_a_ref_name_with_a_trailing_newline_is_out_of_scope():
+    """The command git genuinely reads as a newline-suffixed ref: the NUL that
+    starts the capabilities comes AFTER the newline, so the packet-level chomp
+    never reaches it. Fed exactly this, real receive-pack answers
+    `ng refs/mship/run/t1/api\\n funny refname` and creates nothing (verified) —
+    but that is GIT's validation saving the run host. This check advertises
+    itself as the one that decides, so it has to refuse the name itself."""
+    command = f"{ZERO} {SHA} refs/mship/run/t1/api\n".encode() + b"\x00report-status"
+    assert ref_commands(_body(command)) == ["refs/mship/run/t1/api\n"]
+    with pytest.raises(RefScopeError):
+        check_ref_scope(_body(command))
+
+
+def test_an_object_id_with_a_trailing_newline_is_not_an_object_id():
+    """Python's `$` also matches BEFORE a trailing newline, so an oid pattern
+    anchored with `$` reads `<40 hex>\\n` as a whole, valid oid and hands the
+    command on as in-scope. git's reader does not: it wants a space immediately
+    after the 40th hex character and dies otherwise (`protocol error: expected
+    old/new/ref, got ...` — verified). Refuse it where the parse IS the security
+    boundary rather than count on git to."""
+    command = f"{ZERO} {SHA}\n refs/mship/run/t1/api".encode()
+    with pytest.raises(PktLineError):
+        ref_commands(_body(command))
+
+
 def test_the_whole_remainder_of_a_command_is_the_ref_name():
     """git takes the ref name as everything after the two oids up to a NUL —
     spaces included: fed this command, real receive-pack answers

--- a/tests/core/test_git_receive.py
+++ b/tests/core/test_git_receive.py
@@ -127,9 +127,36 @@ def test_one_out_of_scope_ref_refuses_the_whole_push():
         ))
 
 
-def test_a_body_with_no_commands_is_refused():
+def test_a_zero_command_body_is_forwarded_rather_than_refused():
+    """git's own probe, and therefore the feature's ordinary path.
+
+    Before streaming a body larger than `http.postBuffer` (1 MiB by default),
+    remote-curl POSTs a zero-command probe first: the body is exactly `0000`,
+    `Content-Length: 4`. Refusing it as "contains no ref command" aborted every
+    push over 1 MiB with `error: RPC failed; HTTP 400` and then a misleading
+    `Everything up-to-date` (reproduced three ways) — and Task 8 pushes a
+    synthesized working tree, routinely over 1 MiB.
+
+    Safe to forward, and safe for the scope check to pass: a body with no
+    commands names no refs, so there is nothing to check; real `git receive-pack
+    --stateless-rpc <repo>` fed `0000` exits 0 with empty stdout (verified,
+    git 2.43).
+    """
+    assert ref_commands(b"0000") == []
+    check_ref_scope(b"0000")
+
+
+@pytest.mark.parametrize("body", [b"", b"00", b"000"])
+def test_a_body_that_is_not_a_pkt_line_stream_at_all_is_still_refused(body):
+    """"No commands" and "unreadable" have to stay distinct.
+
+    `0000` is a well-formed request that asks for nothing. A body that ends
+    without either a flush or a command is not a receive-pack request at all:
+    forwarded, it gets `fatal: the remote end hung up unexpectedly` out of git
+    (verified) — a 500 for what is really a bad request.
+    """
     with pytest.raises(PktLineError):
-        check_ref_scope(b"0000")
+        ref_commands(body)
 
 
 # --- real repositories -------------------------------------------------------
@@ -241,6 +268,17 @@ def test_receive_pack_refuses_an_out_of_scope_push_without_touching_the_repo(tmp
 
     refs = _git("for-each-ref", "--format=%(refname)", cwd=repo)
     assert "refs/heads/attacker" not in refs
+
+
+def test_a_zero_command_probe_is_answered_by_real_receive_pack(tmp_path):
+    """The unit twin above says the probe is not refused; this says git is happy
+    to be handed it — exit 0, empty stdout, no ref touched. Both halves matter:
+    forwarding a body git chokes on would only move the failure from a 400 to a
+    500."""
+    repo = _repo(tmp_path / "api")
+    before = _git("for-each-ref", "--format=%(refname)", cwd=repo)
+    assert receive_pack(repo, b"0000") == b""
+    assert _git("for-each-ref", "--format=%(refname)", cwd=repo) == before
 
 
 # --- pushes from a shallow clone ---------------------------------------------
@@ -483,10 +521,11 @@ def live_serve(app):
         thread.join(timeout=10)
 
 
-def _push_env(token: str | None) -> dict[str, str]:
+def _push_env(token: str | None, config: dict[str, str] | None = None) -> dict[str, str]:
     """The env `core/run_transfer.extra_header_env` will build in Task 8: the
     bearer as an HTTP header through git's ENV config, and no interactive
     credential prompt (a rejected push must fail the command, not hang).
+    `config` adds further git settings through the same mechanism.
 
     The index is taken from `_GIT_ENV` — the dict actually being handed to git —
     and NOT from `os.environ`. They differ: tests/conftest.py:41 sets
@@ -501,18 +540,23 @@ def _push_env(token: str | None) -> dict[str, str]:
     all.
     """
     env = {**_GIT_ENV, "GIT_TERMINAL_PROMPT": "0"}
+    settings = dict(config or {})
     if token is not None:
-        n = int(env.get("GIT_CONFIG_COUNT", "0"))
-        env["GIT_CONFIG_COUNT"] = str(n + 1)
-        env[f"GIT_CONFIG_KEY_{n}"] = "http.extraHeader"
-        env[f"GIT_CONFIG_VALUE_{n}"] = f"Authorization: Bearer {token}"
+        settings["http.extraHeader"] = f"Authorization: Bearer {token}"
+    n = int(env.get("GIT_CONFIG_COUNT", "0"))
+    for key, value in settings.items():
+        env[f"GIT_CONFIG_KEY_{n}"] = key
+        env[f"GIT_CONFIG_VALUE_{n}"] = value
+        n += 1
+    env["GIT_CONFIG_COUNT"] = str(n)
     return env
 
 
-def _push(cwd: Path, url: str, refspec: str, token: str | None):
+def _push(cwd: Path, url: str, refspec: str, token: str | None,
+          config: dict[str, str] | None = None):
     return subprocess.run(
         ["git", "push", "--force", url, refspec],
-        cwd=cwd, capture_output=True, text=True, env=_push_env(token),
+        cwd=cwd, capture_output=True, text=True, env=_push_env(token, config),
     )
 
 
@@ -572,6 +616,69 @@ def test_a_real_git_push_lands_on_the_scratch_ref(tmp_path):
     # cannot apply outside refs/heads/.
     assert _git("rev-parse", "--abbrev-ref", "HEAD", cwd=host_repo) == "main"
     assert _git("status", "--porcelain", cwd=host_repo) == ""
+
+
+def _commit_incompressible(operator: Path, size: int) -> str:
+    """Commit `size` bytes of random data and return the sha.
+
+    Random on purpose: git zlib-deflates a blob before it goes on the wire, so a
+    file of zeros would be a few hundred bytes by the time `http.postBuffer` is
+    consulted and would not exercise this path at all. The existing end-to-end
+    push above misses the whole probe path for exactly that reason — its payload
+    is a few hundred bytes.
+    """
+    (operator / "big.bin").write_bytes(os.urandom(size))
+    _git("add", "-A", cwd=operator)
+    _git("commit", "-qm", "big", cwd=operator)
+    return _git("rev-parse", "HEAD", cwd=operator)
+
+
+def test_a_push_over_the_post_buffer_takes_the_probe_path_and_lands(tmp_path):
+    """The path EVERY push bigger than `http.postBuffer` takes.
+
+    remote-curl will not buffer a request that large, so it cannot retry one; it
+    POSTs a zero-command probe (`0000`, `Content-Length: 4`) first and only
+    streams the real body once that is answered. Refusing the probe aborted the
+    push with `error: RPC failed; HTTP 400` and then a misleading `Everything
+    up-to-date`.
+
+    `http.postBuffer=1024` forces the probe for a few hundred KB rather than
+    several MB, so this stays cheap; the sibling below runs at the real default
+    so the shipped configuration is exercised too.
+    """
+    host_repo = _repo(tmp_path / "api")
+    operator = _clone(host_repo, tmp_path / "operator")
+    sha = _commit_incompressible(operator, 200 * 1024)
+
+    with live_serve(_app(tmp_path, auth_token="tok-abc")) as base:
+        result = _push(
+            operator, f"{base}/git/api", f"{sha}:refs/mship/run/t1/api", "tok-abc",
+            config={"http.postBuffer": "1024"},
+        )
+
+    assert result.returncode == 0, result.stderr
+    assert _git("rev-parse", "refs/mship/run/t1/api", cwd=host_repo) == sha
+
+
+def test_a_multi_megabyte_push_lands_at_the_default_post_buffer(tmp_path):
+    """The same path with nothing configured — 4 MiB against the 1 MiB default.
+
+    Task 8 pushes a synthesized working tree, which is routinely this size, so
+    the default is the configuration that actually ships. Kept alongside the
+    cheap one above so a change to git's buffering default cannot quietly stop
+    the probe from being covered.
+    """
+    host_repo = _repo(tmp_path / "api")
+    operator = _clone(host_repo, tmp_path / "operator")
+    sha = _commit_incompressible(operator, 4 * 1024 * 1024)
+
+    with live_serve(_app(tmp_path, auth_token="tok-abc")) as base:
+        result = _push(
+            operator, f"{base}/git/api", f"{sha}:refs/mship/run/t1/api", "tok-abc"
+        )
+
+    assert result.returncode == 0, result.stderr
+    assert _git("rev-parse", "refs/mship/run/t1/api", cwd=host_repo) == sha
 
 
 def test_a_real_push_without_the_bearer_is_rejected(tmp_path):

--- a/tests/core/test_git_receive.py
+++ b/tests/core/test_git_receive.py
@@ -307,3 +307,125 @@ def test_a_line_git_would_not_read_as_shallow_is_still_refused(line):
     a laxer skip here would be a way to hide a command from the scope check."""
     with pytest.raises(PktLineError):
         ref_commands(_body(line))
+
+
+# --- the HTTP routes ---------------------------------------------------------
+
+from fastapi.testclient import TestClient
+
+from mship.core.serve import create_app
+from mship.core.state import StateManager
+
+
+def _app(tmp_path: Path, *, auth_token: str | None = None, with_config: bool = True):
+    """Mirrors `tests/core/test_serve_exec.py::_app` (line 141) so the receive
+    routes are exercised through exactly the app the exec routes are."""
+    return create_app(
+        specs_dir=tmp_path / "specs",
+        state_manager=StateManager(tmp_path / ".mothership"),
+        log_manager=None,
+        workspace_root=tmp_path,
+        workspace_name="test-ws",
+        auth_token=auth_token,
+        config=_config(tmp_path) if with_config else None,
+    )
+
+
+def test_receive_endpoints_require_the_bearer(tmp_path):
+    """ac6: the run-host bearer gates the push, on both legs of it."""
+    client = TestClient(_app(tmp_path, auth_token="secret"))
+    assert client.get(
+        "/git/api/info/refs", params={"service": "git-receive-pack"}
+    ).status_code == 401
+    assert client.post("/git/api/git-receive-pack", content=b"0000").status_code == 401
+
+
+def test_advertisement_is_served_with_the_bearer(tmp_path):
+    _repo(tmp_path / "api")
+    client = TestClient(_app(tmp_path, auth_token="secret"))
+    r = client.get(
+        "/git/api/info/refs",
+        params={"service": "git-receive-pack"},
+        headers={"Authorization": "Bearer secret"},
+    )
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "application/x-git-receive-pack-advertisement"
+    assert r.content.startswith(b"001f# service=git-receive-pack\n0000")
+
+
+def test_upload_pack_service_is_not_served_here(tmp_path):
+    """Narrow on purpose: this is a receive path, not a git host."""
+    _repo(tmp_path / "api")
+    client = TestClient(_app(tmp_path))
+    r = client.get("/git/api/info/refs", params={"service": "git-upload-pack"})
+    assert r.status_code == 403
+
+
+def test_a_repo_the_workspace_does_not_declare_is_404(tmp_path):
+    """The detail is asserted, not just the status: an unrouted path 404s too,
+    so status alone would pass against an app with no receive routes at all."""
+    client = TestClient(_app(tmp_path))
+    for r in (
+        client.get("/git/nope/info/refs", params={"service": "git-receive-pack"}),
+        client.post("/git/nope/git-receive-pack", content=b"0000"),
+    ):
+        assert r.status_code == 404
+        assert "unknown repo 'nope'" in r.json()["detail"]
+
+
+def test_a_git_root_child_is_404_and_names_its_parent(tmp_path):
+    """ac7 at the HTTP boundary."""
+    r = TestClient(_app(tmp_path)).post("/git/server/git-receive-pack", content=b"0000")
+    assert r.status_code == 404
+    assert "api" in r.json()["detail"]
+
+
+def test_a_push_outside_the_run_namespace_is_403_and_creates_nothing(tmp_path):
+    """ac5 at the HTTP boundary.
+
+    Carries a real (empty) packfile for the same reason the unit twin above
+    does: without one, receive-pack refuses the push itself and the "no ref
+    exists" assertion would hold even with the scope check moved AFTER git.
+    With it, git would happily answer `ok refs/heads/attacker` — so the absent
+    ref, and the 403 rather than a 500, are evidence the check ran first.
+    """
+    repo = _repo(tmp_path / "api")
+    sha = _git("rev-parse", "HEAD", cwd=repo)
+    body = (
+        pkt_line(f"{'0' * 40} {sha} refs/heads/attacker\x00report-status".encode())
+        + b"0000" + _empty_pack(repo)
+    )
+    r = TestClient(_app(tmp_path)).post("/git/api/git-receive-pack", content=body)
+    assert r.status_code == 403
+    assert "refs/mship/run" in r.json()["detail"]
+    assert "attacker" not in _git("for-each-ref", "--format=%(refname)", cwd=repo)
+
+
+def test_an_unparseable_body_is_400(tmp_path):
+    _repo(tmp_path / "api")
+    r = TestClient(_app(tmp_path)).post("/git/api/git-receive-pack", content=b"zzzz0000")
+    assert r.status_code == 400
+
+
+def test_a_compressed_body_is_refused_rather_than_mis_parsed(tmp_path):
+    """git does not compress a receive-pack request body (verified against a
+    real push), so a non-identity encoding means bytes whose refs cannot be
+    checked. Refuse rather than hand them to receive-pack unexamined."""
+    _repo(tmp_path / "api")
+    r = TestClient(_app(tmp_path)).post(
+        "/git/api/git-receive-pack", content=b"0000",
+        headers={"Content-Encoding": "gzip"},
+    )
+    assert r.status_code == 400
+    # The detail, not just the status: an unreadable body 400s from the pkt-line
+    # parser anyway, so status alone would pass with no encoding check at all.
+    assert "Content-Encoding" in r.json()["detail"]
+
+
+def test_receive_is_unavailable_without_a_workspace_config(tmp_path):
+    """Mirrors `POST /exec/{verb}` (serve.py:1411): 503 with an actionable
+    message, never a bare 404."""
+    client = TestClient(_app(tmp_path, with_config=False))
+    assert client.post(
+        "/git/api/git-receive-pack", content=b"0000"
+    ).status_code == 503

--- a/tests/core/test_remote_exact_copy_invariants.py
+++ b/tests/core/test_remote_exact_copy_invariants.py
@@ -19,6 +19,21 @@ cannot prove a run ref is never merged — only that nothing in the tree spells
 out a merge, a branch, or a PR while naming the namespace. It is a tripwire for
 the next person, not a proof. `_test_the_detector_fires` below is what keeps it
 from being a tripwire that has quietly stopped working.
+
+Two escapes it used to have, both found by mutating the source and watching the
+whole suite stay green, and both closed here rather than left as folklore:
+
+  * **it saw only the modules that spell the namespace out.** `\\brun_ref\\(`
+    cannot see `build_run_ref(...)`, `push_run_ref(...)` or
+    `cleanup_run_refs(...)` — the names the namespace actually crosses module
+    boundaries under — so `core/remote_exec.py` (which resets the run host's
+    worktree to the ref), `cli/exec.py` (which pushes it) and `cli/worktree.py`
+    (which deletes it) were never parsed at all.
+  * **it saw only single-expression call sites.**
+    `shell.run(f"git merge {run_ref(t, r)}")` was caught; the same merge split
+    over two statements — `cmd = f"git merge {run_ref(t, r)}"` then
+    `shell.run(cmd)` — was not, because neither expression contains both halves.
+    Simple local bindings are therefore followed (see `_run_ref_bindings`).
 """
 import ast
 import re
@@ -28,11 +43,21 @@ import pytest
 
 SRC = Path(__file__).resolve().parents[2] / "src" / "mship"
 
-# Naming the run scratch namespace, in any of the three forms the tree uses it:
-# the literal ref, the constant, or an import of the module that owns it.
+# Naming the run scratch namespace — the literal ref, the constant, the module
+# that owns it, or any of the helpers the namespace travels under between
+# modules. The helper names are what make the scan REACH `core/remote_exec.py`,
+# `cli/exec.py` and `cli/worktree.py`, none of which ever spell `refs/mship/run`
+# themselves.
+#
 # `refs/mship-probe/` (cli/workitem.py) is a DIFFERENT namespace and must not
 # match; nor must `test_run_refs`, which is about test runs, not run refs.
-_NAMES_RUN_NAMESPACE = re.compile(r"refs/mship/run|RUN_REF_PREFIX|\brun_ref\(|is_run_ref\(")
+_NAMES_RUN_NAMESPACE = re.compile(
+    r"refs/mship/run|RUN_REF_PREFIX|\brun_refs?\b|\bis_run_ref\b|\bbuild_run_ref\b"
+    r"|\bpush_run_ref\b|\bdelete_run_ref\b|\bcleanup_run_refs\b|\bRunRefNameError\b"
+    # The import itself, so a helper named something nobody thought to list here
+    # still cannot be reached from the finish gate below without showing up.
+    r"|mship\.core\.run_(ref|transfer)"
+)
 
 # Forming a branch, a merge, or a pull request. Matched as git/gh command
 # shapes rather than bare words so that a `"branch"` dict key or a `.branch`
@@ -42,35 +67,128 @@ _FORMS_HISTORY = {
     "git checkout -b / switch -c": re.compile(
         r"""["'](checkout|switch)["'].{0,80}?["'](-b|-c)["']""", re.S
     ),
-    "shell git branch/merge": re.compile(r"\bgit\s+(branch|merge|rebase|cherry-pick)\b"),
+    # `(?![\w-])`, not `\b`: `\b` matches between `merge` and the `-` of
+    # `git merge-base`, which `core/remote_preflight.py` runs legitimately and
+    # which forms no history at all. Now that this scan reaches that module, a
+    # bare `\b` would cry wolf there.
+    "shell git branch/merge": re.compile(
+        r"\bgit\s+(branch|merge|rebase|cherry-pick)(?![\w-])"
+    ),
     "gh pr create": re.compile(r"""gh\s+pr\s+create|["']pr["']\s*,\s*["']create["']"""),
 }
+
+_IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 
 def _source_files() -> list[Path]:
     return sorted(SRC.rglob("*.py"))
 
 
+def _scopes(tree: ast.AST):
+    """Each function body, plus the module's own top level.
+
+    Per FUNCTION rather than per module so that one function's `cmd` cannot
+    stand in for another's — the same local name is reused all over this tree,
+    and merging them would fire on unrelated code.
+    """
+    yield tree
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node
+
+
+def _own_nodes(scope: ast.AST):
+    """The nodes `scope` owns — its subtree, not descending into a function
+    nested inside it, which `_scopes` yields separately as its own scope."""
+    stack = list(ast.iter_child_nodes(scope))
+    while stack:
+        node = stack.pop()
+        yield node
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            stack.extend(ast.iter_child_nodes(node))
+
+
+def _run_ref_bindings(source: str, scope: ast.AST) -> dict[str, frozenset[str]]:
+    """Local names in `scope` holding a run-ref-derived value, mapped to every
+    source fragment that went into them.
+
+    ONLY namespace-carrying assignments are recorded, so the map stays tiny,
+    and it is iterated to a fixed point so a chain lands WHOLE:
+    `ref = run_ref(t, r)` then `cmd = "git branch x " + ref` leaves `cmd`
+    carrying both fragments — the `git branch` that names the offence and the
+    `run_ref(...)` that makes it this namespace's offence. Carrying only the
+    nearest one would find the command and lose the ref, or the reverse.
+
+    Fragments are a SET, so a chain that revisits a name converges instead of
+    concatenating the same text on every pass.
+    """
+    assigns: list[tuple[str, str]] = []
+    for node in _own_nodes(scope):
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+            targets, value = [node.target], node.value
+        else:
+            continue
+        if value is None:
+            continue
+        text = ast.get_source_segment(source, value) or ""
+        assigns.extend((t.id, text) for t in targets if isinstance(t, ast.Name))
+
+    bound: dict[str, frozenset[str]] = {}
+    for _ in range(len(assigns) + 1):
+        grew = False
+        for name, text in assigns:
+            referenced = [bound[i] for i in _IDENT.findall(text) if i in bound]
+            if not (_NAMES_RUN_NAMESPACE.search(text) or referenced):
+                continue
+            merged = bound.get(name, frozenset()) | {text} | frozenset().union(*referenced or [frozenset()])
+            if merged != bound.get(name):
+                bound[name] = merged
+                grew = True
+        if not grew:
+            break
+    return bound
+
+
+def _with_bindings(segment: str, bound: dict[str, frozenset[str]]) -> str:
+    extra = [
+        fragment
+        for name in dict.fromkeys(_IDENT.findall(segment)) if name in bound
+        for fragment in sorted(bound[name])
+    ]
+    return " ".join([segment, *extra])
+
+
 def _calls_naming_the_namespace(path: Path) -> list[tuple[int, str]]:
-    """Every call expression in `path` whose source names the run namespace.
+    """Every call expression in `path` whose source names the run namespace,
+    with the text of any run-ref-derived local it references appended.
 
     A call is the tightest scope that still holds a whole git invocation
     together, whatever shape it takes in this tree — an argv list
     (`subprocess.run(["git", ...])`), a varargs helper (`self._git("rebase",
     ...)`), or an f-string command line (`f"gh pr create ..."`). Nested calls
     yield the same text more than once, which costs nothing.
+
+    The appended binding text is what closes the two-statement escape: fed
+    `shell.run(cmd)` where `cmd` was built from a run ref, the call reads as if
+    the command line had been written inline.
     """
     source = path.read_text(encoding="utf-8")
     if not _NAMES_RUN_NAMESPACE.search(source):
         return []                      # nothing to parse: most of the tree
     tree = ast.parse(source)
     found = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        segment = ast.get_source_segment(source, node) or ""
-        if _NAMES_RUN_NAMESPACE.search(segment):
-            found.append((node.lineno, segment))
+    for scope in _scopes(tree):
+        bound = _run_ref_bindings(source, scope)
+        for node in _own_nodes(scope):
+            if not isinstance(node, ast.Call):
+                continue
+            segment = _with_bindings(
+                ast.get_source_segment(source, node) or "", bound
+            )
+            if _NAMES_RUN_NAMESPACE.search(segment):
+                found.append((node.lineno, segment))
     return found
 
 
@@ -89,14 +207,37 @@ def test_no_code_path_branches_from_merges_or_opens_a_pr_from_the_run_namespace(
     )
 
 
-def test_the_scan_actually_reaches_the_modules_that_own_the_namespace():
+# Every module that HANDLES the run namespace, per `core/run_ref.py`'s own
+# docstring: the one that owns the name, the endpoint that accepts pushes onto
+# it, the client that pushes, the run host that materializes from it, the CLI
+# that dispatches, and `mship close`, which deletes it. A scan that does not
+# reach one of these cannot say anything about it.
+NAMESPACE_MODULES = (
+    "core/run_ref.py",
+    "core/git_receive.py",
+    "core/run_transfer.py",
+    "core/remote_exec.py",
+    "cli/exec.py",
+    "cli/worktree.py",
+)
+
+
+def test_the_scan_actually_reaches_every_module_that_handles_the_namespace():
     """Guards the guard: a scan that matched nothing would pass the test above
-    for free. The two modules that own the namespace today must be seen."""
+    for free, and one that matched only SOME modules would pass it for the
+    modules it never opened.
+
+    That was the real hole. `core/remote_exec.py` resets the run host's
+    worktree to the ref, `cli/exec.py` pushes it and `cli/worktree.py` deletes
+    it — and none of the three ever writes `refs/mship/run` or calls
+    `run_ref(...)` directly, so the original `\\brun_ref\\(` pattern opened none
+    of them. A merge added in any of them was invisible.
+    """
     seen = {
-        path.name for path in _source_files()
-        if _NAMES_RUN_NAMESPACE.search(path.read_text(encoding="utf-8"))
+        module for module in NAMESPACE_MODULES
+        if _NAMES_RUN_NAMESPACE.search((SRC / module).read_text(encoding="utf-8"))
     }
-    assert {"run_ref.py", "git_receive.py"} <= seen, seen
+    assert set(NAMESPACE_MODULES) == seen, sorted(set(NAMESPACE_MODULES) - seen)
 
 
 def test_a_different_mship_namespace_is_not_mistaken_for_the_run_namespace():
@@ -123,42 +264,112 @@ def test_the_detector_fires_on_the_shapes_it_claims_to_catch(sample):
     assert any(p.search(sample) for p in _FORMS_HISTORY.values()), sample
 
 
+def _scan_module(tmp_path: Path, body: str) -> list[str]:
+    """Run the WHOLE scanner — parser, bindings and patterns — over `body`,
+    exactly as `test_no_code_path_branches_...` runs it over `src/mship`."""
+    path = tmp_path / "sample.py"
+    path.write_text(body, encoding="utf-8")
+    return [
+        label
+        for _lineno, segment in _calls_naming_the_namespace(path)
+        for label, pattern in _FORMS_HISTORY.items()
+        if pattern.search(segment)
+    ]
+
+
+@pytest.mark.parametrize("body", [
+    # The escape that mattered: split over two statements, neither expression
+    # holding both the command and the ref. Confirmed to survive the previous
+    # scanner with the whole suite green.
+    'def go(shell, task, repo, root):\n'
+    '    cmd = f"git merge {run_ref(task, repo)}"\n'
+    '    return shell.run(cmd, cwd=root)\n',
+    # And a chain, so one hop is not the limit.
+    'def go(shell, task, repo, root):\n'
+    '    ref = run_ref(task, repo)\n'
+    '    cmd = "git branch keepme " + ref\n'
+    '    return shell.run(cmd, cwd=root)\n',
+    # Reached through an imported helper rather than the literal name — the
+    # only way `cli/exec.py` and `cli/worktree.py` ever touch the namespace.
+    'def go(shell, root, **kw):\n'
+    '    ref = push_run_ref(shell, root, **kw)\n'
+    '    return shell.run(f"git merge {ref}", cwd=root)\n',
+])
+def test_the_detector_fires_when_the_command_is_built_across_statements(tmp_path, body):
+    assert _scan_module(tmp_path, body), body
+
+
+@pytest.mark.parametrize("body", [
+    # `git merge-base` forms no history, and `core/remote_preflight.py` — now
+    # in scope for this scan — runs one on every clean repo.
+    'def go(shell, root, task, repo):\n'
+    '    ref = run_ref(task, repo)\n'
+    '    return shell.run(f"git merge-base --is-ancestor {ref} HEAD", cwd=root)\n',
+    # One function's `cmd` must not stand in for another's.
+    'def a(shell, root):\n'
+    '    cmd = "git merge origin/main"\n'
+    '    return shell.run(cmd, cwd=root)\n'
+    'def b(shell, root, task, repo):\n'
+    '    cmd = run_ref(task, repo)\n'
+    '    return shell.run(cmd, cwd=root)\n',
+])
+def test_the_detector_does_not_cry_wolf(tmp_path, body):
+    """A tripwire that fires on legitimate work gets disabled, which is a
+    slower way of having no tripwire at all."""
+    assert _scan_module(tmp_path, body) == [], body
+
+
 # The gate that decides whether `finish` pushes a branch and opens a PR for a
 # repo at all: `PRManager.count_commits_ahead` (`core/pr.py`) counts real
 # commits between base and the task's own branch, purely from that branch's
-# own git history; `finish` (`cli/worktree.py`) is the CLI command that acts
-# on the result. Neither module can start treating scratch state as a
-# substitute for a real commit if neither one can even name the scratch
-# namespace — that is the property this pins.
-FINISH_GATE_MODULES = (
-    "core/pr.py",
-    "cli/worktree.py",
+# own git history; `finish` (`cli/worktree.py`) is the CLI command that acts on
+# the result. Neither can treat scratch state as a substitute for a real commit
+# if neither can name the scratch namespace — that is the property this pins.
+#
+# Pinned per FUNCTION, not per module. `cli/worktree.py` as a whole DOES know
+# the namespace exists: `close` calls `cleanup_run_refs` to delete the task's
+# scratch refs from the run host (spec ac8). Deleting them is the opposite of
+# treating them as history, so a module-wide assertion would be false as
+# written — and would have to be deleted rather than tightened the first time
+# anyone read it.
+FINISH_GATE_FUNCTIONS = (
+    ("core/pr.py", "count_commits_ahead"),
+    ("cli/worktree.py", "finish"),
 )
 
 
-def test_the_real_commits_gate_and_finish_do_not_know_the_run_namespace_exists():
+def _function_source(path: Path, name: str) -> str:
+    source = path.read_text(encoding="utf-8")
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return ast.get_source_segment(source, node) or ""
+    raise AssertionError(f"{path.name} has no function {name!r}; update FINISH_GATE_FUNCTIONS")
+
+
+def test_the_real_commits_gate_and_finish_do_not_consult_the_run_namespace():
     """ac14's third clause: `finish` still requires real commits.
 
     The scratch ref never reaches the operator's own branch (ac2, pinned in
     `test_run_transfer.py::test_local_state_is_identical_before_and_after` and
     `::test_the_commit_is_on_no_branch`), so today `count_commits_ahead` has
-    nothing to see. The risk this guards is a FUTURE one: `core/pr.py` or
-    `cli/worktree.py`'s `finish` growing a special case keyed on `is_run_ref`
-    or `RUN_REF_PREFIX` — e.g. "a run ref exists for this repo, treat it as
-    ready to finish" — which would let scratch state stand in for a commit
-    the operator never made. If neither module can name the namespace at all,
-    neither can special-case it.
+    nothing to see. The risk this guards is a FUTURE one: either function
+    growing a special case keyed on the run namespace — e.g. "a run ref exists
+    for this repo, treat it as ready to finish" — which would let scratch state
+    stand in for a commit the operator never made.
+
+    Matched with the same broadened pattern the scan above uses, so the case
+    that actually reaches these two — an imported helper like
+    `push_run_ref` / `cleanup_run_refs`, never the literal ref string — is
+    caught rather than read straight past.
     """
-    for module in FINISH_GATE_MODULES:
+    for module, function in FINISH_GATE_FUNCTIONS:
         path = SRC / module
-        assert path.exists(), f"{module} moved; update FINISH_GATE_MODULES"
-        source = path.read_text(encoding="utf-8")
-        assert not _NAMES_RUN_NAMESPACE.search(source), (
-            f"{module} now names the run scratch namespace. `finish` must "
-            f"keep deciding whether to push/open a PR from real branch "
-            f"history alone (spec ac14) — if {module} genuinely needs to "
-            f"consult run refs, that is a spec-level decision, not a silent "
-            f"one."
+        assert path.exists(), f"{module} moved; update FINISH_GATE_FUNCTIONS"
+        assert not _NAMES_RUN_NAMESPACE.search(_function_source(path, function)), (
+            f"{module}:{function} now names the run scratch namespace. `finish` "
+            f"must keep deciding whether to push/open a PR from real branch "
+            f"history alone (spec ac14) — if it genuinely needs to consult run "
+            f"refs, that is a spec-level decision, not a silent one."
         )
 
 

--- a/tests/core/test_remote_exact_copy_invariants.py
+++ b/tests/core/test_remote_exact_copy_invariants.py
@@ -4,12 +4,15 @@ Everything else about this feature is tested where it lives. What lands here is
 the class of claim that is about what the REST of the tree does not do, and so
 can only be checked by looking at all of it.
 
-ac14, the one guarded now: the run scratch namespace is throwaway, so no code
-path may branch from it, merge it, or open a pull request from it. That is a
+ac14 has three clauses. Two are guarded below already: no code path may
+branch from, merge, or open a pull request from the run namespace (the scan
+this file started with), and the namespace exists only on run hosts (ac3,
+pinned at the unit level in `tests/core/test_run_transfer.py::
+test_the_push_goes_to_the_run_host_not_origin` — nothing here duplicates
+it). Task 15 adds the third: `finish` still requires real commits. That is a
 property of every file in `src/mship`, not of `core/run_ref.py` — whose
 docstring cites this file, which is why it exists ahead of the task that fills
-it out. Task 15 extends it with the rest of the feature's cross-cutting
-invariants.
+it out.
 
 The scan is deliberately blunt: it reads source text, not behaviour, so it
 cannot prove a run ref is never merged — only that nothing in the tree spells
@@ -118,3 +121,42 @@ def test_the_detector_fires_on_the_shapes_it_claims_to_catch(sample):
     regexes the scan runs."""
     assert _NAMES_RUN_NAMESPACE.search(sample)
     assert any(p.search(sample) for p in _FORMS_HISTORY.values()), sample
+
+
+# The gate that decides whether `finish` pushes a branch and opens a PR for a
+# repo at all: `PRManager.count_commits_ahead` (`core/pr.py`) counts real
+# commits between base and the task's own branch, purely from that branch's
+# own git history; `finish` (`cli/worktree.py`) is the CLI command that acts
+# on the result. Neither module can start treating scratch state as a
+# substitute for a real commit if neither one can even name the scratch
+# namespace — that is the property this pins.
+FINISH_GATE_MODULES = (
+    "core/pr.py",
+    "cli/worktree.py",
+)
+
+
+def test_the_real_commits_gate_and_finish_do_not_know_the_run_namespace_exists():
+    """ac14's third clause: `finish` still requires real commits.
+
+    The scratch ref never reaches the operator's own branch (ac2, pinned in
+    `test_run_transfer.py::test_local_state_is_identical_before_and_after` and
+    `::test_the_commit_is_on_no_branch`), so today `count_commits_ahead` has
+    nothing to see. The risk this guards is a FUTURE one: `core/pr.py` or
+    `cli/worktree.py`'s `finish` growing a special case keyed on `is_run_ref`
+    or `RUN_REF_PREFIX` — e.g. "a run ref exists for this repo, treat it as
+    ready to finish" — which would let scratch state stand in for a commit
+    the operator never made. If neither module can name the namespace at all,
+    neither can special-case it.
+    """
+    for module in FINISH_GATE_MODULES:
+        path = SRC / module
+        assert path.exists(), f"{module} moved; update FINISH_GATE_MODULES"
+        source = path.read_text(encoding="utf-8")
+        assert not _NAMES_RUN_NAMESPACE.search(source), (
+            f"{module} now names the run scratch namespace. `finish` must "
+            f"keep deciding whether to push/open a PR from real branch "
+            f"history alone (spec ac14) — if {module} genuinely needs to "
+            f"consult run refs, that is a spec-level decision, not a silent "
+            f"one."
+        )

--- a/tests/core/test_remote_exact_copy_invariants.py
+++ b/tests/core/test_remote_exact_copy_invariants.py
@@ -1,0 +1,120 @@
+"""Invariants of the remote-exact-copy feature that no single module can hold.
+
+Everything else about this feature is tested where it lives. What lands here is
+the class of claim that is about what the REST of the tree does not do, and so
+can only be checked by looking at all of it.
+
+ac14, the one guarded now: the run scratch namespace is throwaway, so no code
+path may branch from it, merge it, or open a pull request from it. That is a
+property of every file in `src/mship`, not of `core/run_ref.py` — whose
+docstring cites this file, which is why it exists ahead of the task that fills
+it out. Task 15 extends it with the rest of the feature's cross-cutting
+invariants.
+
+The scan is deliberately blunt: it reads source text, not behaviour, so it
+cannot prove a run ref is never merged — only that nothing in the tree spells
+out a merge, a branch, or a PR while naming the namespace. It is a tripwire for
+the next person, not a proof. `_test_the_detector_fires` below is what keeps it
+from being a tripwire that has quietly stopped working.
+"""
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "mship"
+
+# Naming the run scratch namespace, in any of the three forms the tree uses it:
+# the literal ref, the constant, or an import of the module that owns it.
+# `refs/mship-probe/` (cli/workitem.py) is a DIFFERENT namespace and must not
+# match; nor must `test_run_refs`, which is about test runs, not run refs.
+_NAMES_RUN_NAMESPACE = re.compile(r"refs/mship/run|RUN_REF_PREFIX|\brun_ref\(|is_run_ref\(")
+
+# Forming a branch, a merge, or a pull request. Matched as git/gh command
+# shapes rather than bare words so that a `"branch"` dict key or a `.branch`
+# attribute is not mistaken for one.
+_FORMS_HISTORY = {
+    "git branch": re.compile(r"""["'](branch|merge|rebase|cherry-pick|revert)["']"""),
+    "git checkout -b / switch -c": re.compile(
+        r"""["'](checkout|switch)["'].{0,80}?["'](-b|-c)["']""", re.S
+    ),
+    "shell git branch/merge": re.compile(r"\bgit\s+(branch|merge|rebase|cherry-pick)\b"),
+    "gh pr create": re.compile(r"""gh\s+pr\s+create|["']pr["']\s*,\s*["']create["']"""),
+}
+
+
+def _source_files() -> list[Path]:
+    return sorted(SRC.rglob("*.py"))
+
+
+def _calls_naming_the_namespace(path: Path) -> list[tuple[int, str]]:
+    """Every call expression in `path` whose source names the run namespace.
+
+    A call is the tightest scope that still holds a whole git invocation
+    together, whatever shape it takes in this tree — an argv list
+    (`subprocess.run(["git", ...])`), a varargs helper (`self._git("rebase",
+    ...)`), or an f-string command line (`f"gh pr create ..."`). Nested calls
+    yield the same text more than once, which costs nothing.
+    """
+    source = path.read_text(encoding="utf-8")
+    if not _NAMES_RUN_NAMESPACE.search(source):
+        return []                      # nothing to parse: most of the tree
+    tree = ast.parse(source)
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        segment = ast.get_source_segment(source, node) or ""
+        if _NAMES_RUN_NAMESPACE.search(segment):
+            found.append((node.lineno, segment))
+    return found
+
+
+def test_no_code_path_branches_from_merges_or_opens_a_pr_from_the_run_namespace():
+    """ac14. The scratch ref is not history and must never become any."""
+    offences = []
+    for path in _source_files():
+        for lineno, segment in _calls_naming_the_namespace(path):
+            for label, pattern in _FORMS_HISTORY.items():
+                if pattern.search(segment):
+                    offences.append(f"{path.relative_to(SRC.parent.parent)}:{lineno} ({label})")
+    assert not offences, (
+        "these call sites name refs/mship/run AND form a branch, merge or pull "
+        "request, which spec ac14 forbids — the run namespace is a throwaway "
+        f"hand-off, not history: {offences}"
+    )
+
+
+def test_the_scan_actually_reaches_the_modules_that_own_the_namespace():
+    """Guards the guard: a scan that matched nothing would pass the test above
+    for free. The two modules that own the namespace today must be seen."""
+    seen = {
+        path.name for path in _source_files()
+        if _NAMES_RUN_NAMESPACE.search(path.read_text(encoding="utf-8"))
+    }
+    assert {"run_ref.py", "git_receive.py"} <= seen, seen
+
+
+def test_a_different_mship_namespace_is_not_mistaken_for_the_run_namespace():
+    """`cli/workitem.py` writes `refs/mship-probe/<ns>/branch` — throwaway refs
+    for a commits-ahead probe, and nothing to do with ac14. A pattern loose
+    enough to catch it would make the scan above cry wolf on unrelated work."""
+    assert not _NAMES_RUN_NAMESPACE.search('"refs/mship-probe/x/branch"')
+    assert not _NAMES_RUN_NAMESPACE.search("for ref in test_run_refs:")
+
+
+@pytest.mark.parametrize("sample", [
+    'subprocess.run(["git", "merge", run_ref(task, repo)])',
+    'subprocess.run(["git", "checkout", "-b", "x", run_ref(task, repo)])',
+    'self._git("branch", "x", f"{RUN_REF_PREFIX}t1/api")',
+    'shell(f"gh pr create --head refs/mship/run/t1/api")',
+    'run(["gh", "pr", "create", "--head", run_ref(task, repo)])',
+])
+def test_the_detector_fires_on_the_shapes_it_claims_to_catch(sample):
+    """The scan above is green because the tree is clean. This is what says it
+    is green for that reason and not because the patterns stopped matching —
+    every command shape the tree actually uses, fed through the same two
+    regexes the scan runs."""
+    assert _NAMES_RUN_NAMESPACE.search(sample)
+    assert any(p.search(sample) for p in _FORMS_HISTORY.values()), sample

--- a/tests/core/test_remote_exact_copy_invariants.py
+++ b/tests/core/test_remote_exact_copy_invariants.py
@@ -160,3 +160,56 @@ def test_the_real_commits_gate_and_finish_do_not_know_the_run_namespace_exists()
             f"consult run refs, that is a spec-level decision, not a silent "
             f"one."
         )
+
+
+# --- ac19: the docs say what travels ----------------------------------------
+
+DOCS = Path(__file__).resolve().parents[2] / "docs"
+
+
+def _remote_run_doc() -> str:
+    return (DOCS / "remote-run.md").read_text().lower()
+
+
+def test_docs_state_that_uncommitted_work_travels_and_never_reaches_origin():
+    t = _remote_run_doc()
+    assert "uncommitted" in t
+    assert "untracked" in t
+    assert "never" in t and "origin" in t
+
+
+def test_docs_state_what_does_not_travel():
+    """ac19: secrets, platform state, symlink_dirs/bind_files."""
+    t = _remote_run_doc()
+    assert ".env" in t or "secret" in t
+    assert "symlink_dirs" in t and "bind_files" in t
+    assert "gitignore" in t
+
+
+def test_docs_state_that_dependencies_are_derived_by_setup():
+    """ac19 + ac17, including that the first run on a fresh host is a one-time
+    cost rather than a regression."""
+    t = _remote_run_doc()
+    assert "task setup" in t
+    assert "setup_inputs" in t
+    assert "first" in t
+
+
+def test_docs_name_the_scratch_ref_as_throwaway():
+    """ac13: an operator reading the output must not think it is their commit."""
+    t = _remote_run_doc()
+    assert "refs/mship/run" in t
+    assert "throwaway" in t
+
+
+def test_docs_no_longer_claim_a_dirty_tree_is_refused():
+    """The #419 wording is now false; leaving it would be worse than silence."""
+    t = _remote_run_doc()
+    assert "tracked changes present" not in t
+
+
+def test_configuration_documents_setup_inputs():
+    """ac17: declaring them is what enables re-run-on-change."""
+    t = (DOCS / "configuration.md").read_text().lower()
+    assert "setup_inputs" in t
+    assert "re-run" in t or "rerun" in t

--- a/tests/core/test_remote_preflight.py
+++ b/tests/core/test_remote_preflight.py
@@ -13,9 +13,10 @@ import os
 import subprocess
 from pathlib import Path
 
+from mship.core.config import RepoConfig, WorkspaceConfig
 from mship.core.remote_preflight import (
     BEHIND_ORIGIN,
-    DIRTY,
+    IN_PROGRESS,
     MISSING_WORKTREE,
     ORIGIN_UNREACHABLE,
     UNREADABLE,
@@ -59,9 +60,13 @@ class FakeShell:
         self.pushes: list[tuple[str, Path]] = []
         self.touched: set[str] = set()
         self.pair_calls: dict[str, int] = {}
+        # Every command issued, in order — the only way to assert that a query
+        # was NOT made (e.g. that a dirty repo never asks origin).
+        self.commands: list[str] = []
 
     def run(self, cmd, cwd=None, **kw):
         key = Path(cwd).name
+        self.commands.append(cmd)
         spec = self._answers[key]
         self.touched.add(key)
         err = ""
@@ -78,6 +83,13 @@ class FakeShell:
                 out, rc = "", 0
             else:
                 out, rc = f"{spec['origin']}\trefs/heads/feat/x\n", 0
+        elif "rev-parse --git-dir" in cmd:
+            # `_inspect_repo` asks for the per-worktree git dir to look for an
+            # interrupted merge/rebase (MERGE_HEAD, rebase-merge/, ...). Real
+            # git returns an absolute path in a linked worktree and may return a
+            # bare `.git` at a repo root; either is fine here because the
+            # production code resolves a relative answer against `cwd`.
+            out, rc = spec.get("git_dir", str(Path(cwd) / ".git")), 0
         elif "rev-parse HEAD" in cmd and "refs/heads/" in cmd:
             # The atomic branch-identity + sha read `_inspect_repo` makes:
             # one call answering both "which branch is HEAD on" and "what sha
@@ -129,44 +141,69 @@ def _clean(**over):
     return {"status": "", "origin": "headsha", "head": "headsha", **over}
 
 
-# --- what must be refused ---------------------------------------------------
+# --- what must be TRANSFERRED, not refused ----------------------------------
+#
+# These five were refusals under PR #419, for a reason that no longer holds:
+# inventing a commit out of someone's work in progress was not a decision the
+# tool could make, because that commit would have gone to ORIGIN. It now goes
+# only to the operator's own run host, on a ref nothing else writes, leaving
+# their repository untouched — so the same repo shapes route instead of stopping.
 
-def test_tracked_changes_block_the_run(tmp_path):
-    """The dangerous case: the remote would run the last pushed revision."""
+def test_tracked_changes_are_transferred_not_refused(tmp_path):
+    """The whole point of the spec: run what the operator is editing."""
     api = _repo(tmp_path, "api")
-    task = FakeTask({"api": api})
     shell = FakeShell({"api": _clean(status=" M src/app.py\n")})
 
-    pre = inspect(task, shell)
-    assert not pre.ok
-    assert [s.repo for s in pre.blocked] == ["api"]
-    assert shell.pushes == []                       # nothing pushed while blocked
+    pre = inspect(FakeTask({"api": api}), shell)
 
-    msg = blocked_message(pre)
-    assert "uncommitted changes in api" in msg
-    assert "last PUSHED revision" in msg
-    assert "mship commit" in msg                    # multi-repo commit named first
-    assert str(api) in msg                          # exact per-repo push command
+    assert pre.ok
+    assert [s.repo for s in pre.dirty] == ["api"]
+    assert pre.to_push == []            # ac3: origin is not in this path
+    assert shell.pushes == []
 
 
-def test_staged_but_uncommitted_also_blocks(tmp_path):
+def test_staged_but_uncommitted_is_also_transferred(tmp_path):
     api = _repo(tmp_path, "api")
     shell = FakeShell({"api": _clean(status="M  src/app.py\n")})
-    assert not inspect(FakeTask({"api": api}), shell).ok
+    pre = inspect(FakeTask({"api": api}), shell)
+    assert pre.ok and [s.repo for s in pre.dirty] == ["api"]
 
 
-def test_every_dirty_repo_is_named_not_just_the_first(tmp_path):
-    """A multi-repo task must not report one repo and leave the others to
-    surface one at a time."""
+def test_every_dirty_repo_is_transferred_not_just_the_first(tmp_path):
+    """A multi-repo task must send every repo's tree; sending one and leaving
+    the others on origin's revision is the stale-code failure again."""
     api, web = _repo(tmp_path, "api"), _repo(tmp_path, "web")
     shell = FakeShell({
         "api": _clean(status=" M a.py\n"),
         "web": _clean(status=" M b.ts\n"),
     })
     pre = inspect(FakeTask({"api": api, "web": web}), shell)
-    assert sorted(s.repo for s in pre.blocked) == ["api", "web"]
-    assert "api, web" in blocked_message(pre)
+    assert sorted(s.repo for s in pre.dirty) == ["api", "web"]
+    assert pre.ok and shell.pushes == []
 
+
+def test_untracked_only_counts_as_dirty_and_travels(tmp_path):
+    """ac9/ac11. Under #419 this only warned, because untracked files could not
+    change what a push to origin carried. They are part of what the operator
+    sees, and they now travel only between the operator's own two machines — so
+    ANY porcelain output at all is dirty, or untracked files would never travel
+    and ac11 would be unsatisfiable."""
+    api = _repo(tmp_path, "api")
+    shell = FakeShell({"api": _clean(status="?? scratch.txt\n")})
+    pre = inspect(FakeTask({"api": api}), shell)
+    assert pre.ok
+    assert [s.repo for s in pre.dirty] == ["api"]
+    assert pre.to_push == []
+
+
+def test_untracked_alongside_tracked_is_transferred_once(tmp_path):
+    api = _repo(tmp_path, "api")
+    shell = FakeShell({"api": _clean(status="?? new.py\n M old.py\n")})
+    pre = inspect(FakeTask({"api": api}), shell)
+    assert pre.ok and [s.repo for s in pre.dirty] == ["api"]
+
+
+# --- what must be refused ---------------------------------------------------
 
 def test_a_failed_git_status_blocks_rather_than_reading_as_clean(tmp_path):
     """A broken repo's `git status` exits non-zero with EMPTY stdout, which is
@@ -406,13 +443,15 @@ def test_a_detached_worktree_is_refused_and_says_so(tmp_path):
 
 
 def test_the_branch_is_checked_before_the_tree_is_judged_dirty(tmp_path):
-    """A wrong-branch worktree that is also dirty must report the branch: telling
-    the operator to `mship commit` would commit their work onto the wrong
-    branch, which is worse than the state they are already in."""
+    """A wrong-branch worktree that is also dirty must report the branch. Under
+    #419 the alternative was telling the operator to `mship commit` onto the
+    wrong branch; now it is silently SENDING that branch's tree as if it were
+    the task's, which is worse still. So WRONG_BRANCH keeps winning."""
     api = _repo(tmp_path, "api")
     shell = FakeShell({"api": _clean(status=" M a.py\n", head_ref="refs/heads/main")})
-    assert [s.blocked_reason for s in inspect(FakeTask({"api": api}), shell).blocked] \
-        == [WRONG_BRANCH]
+    pre = inspect(FakeTask({"api": api}), shell)
+    assert [s.blocked_reason for s in pre.blocked] == [WRONG_BRANCH]
+    assert pre.dirty == []
 
 
 def test_a_path_that_is_not_a_git_repo_is_unreadable_not_wrong_branch(tmp_path):
@@ -442,17 +481,84 @@ def test_an_unreachable_origin_blocks(tmp_path):
 
 
 def test_each_blocked_reason_gets_its_own_section(tmp_path):
-    """A dirty repo and a stale one need BOTH remedies, not whichever was found
-    first — the fix for one is actively wrong for the other."""
+    """A conflicted repo and a stale one need BOTH remedies, not whichever was
+    found first — the fix for one is actively wrong for the other."""
     api, web = _repo(tmp_path, "api"), _repo(tmp_path, "web")
+    (api / ".git").mkdir(parents=True, exist_ok=True)
+    (api / ".git" / "MERGE_HEAD").write_text("abc\n")
     shell = FakeShell({
-        "api": _clean(status=" M a.py\n"),
+        "api": _clean(status="UU a.py\n"),
         "web": _clean(origin="beefbeefbeef", head="oldsha", contains=[]),
     })
     msg = blocked_message(inspect(FakeTask({"api": api, "web": web}), shell))
-    assert "uncommitted changes in api" in msg
+    assert "merge or rebase in progress in api" in msg
     assert "unpulled commits on origin in web" in msg
-    assert "mship commit" in msg and "pull --ff-only" in msg
+    assert "--abort" in msg and "pull --ff-only" in msg
+
+
+def test_a_conflicted_repo_is_refused(tmp_path):
+    """ac12: the working tree IS what gets sent, and mid-conflict it holds
+    conflict markers rather than code anyone meant to run."""
+    api = _repo(tmp_path, "api")
+    shell = FakeShell({"api": _clean(status="UU src/app.py\n")})
+
+    pre = inspect(FakeTask({"api": api}), shell)
+
+    assert not pre.ok
+    assert [s.blocked_reason for s in pre.blocked] == [IN_PROGRESS]
+    assert pre.dirty == [] and shell.pushes == []
+
+    msg = blocked_message(pre)
+    assert "merge or rebase in progress in api" in msg
+    assert "src/app.py" in msg          # which file, exactly
+    assert "--abort" in msg             # the way out
+
+
+def test_a_mid_rebase_repo_is_refused_ahead_of_the_branch_check(tmp_path):
+    """Ordering matters, and it is not cosmetic: `git rebase` DETACHES HEAD, so
+    checking the branch first would refuse this as WRONG_BRANCH and print
+    `git checkout <branch>` — a command that abandons the rebase. The
+    in-progress check is deliberately ordered ahead of it."""
+    api = _repo(tmp_path, "api")
+    (api / ".git" / "rebase-merge").mkdir(parents=True)
+    shell = FakeShell({"api": _clean(status="", head_ref="")})   # detached
+
+    pre = inspect(FakeTask({"api": api}), shell)
+
+    assert [s.blocked_reason for s in pre.blocked] == [IN_PROGRESS]
+    msg = blocked_message(pre)
+    assert "rebase" in msg
+    assert "checkout" not in msg        # NOT the wrong-branch remedy
+
+
+def test_a_mid_merge_repo_is_refused_even_with_a_clean_tree(tmp_path):
+    """`git merge --no-commit` leaves MERGE_HEAD with nothing unmerged: the
+    porcelain alone cannot see it, which is why the git dir is consulted."""
+    api = _repo(tmp_path, "api")
+    (api / ".git").mkdir(parents=True, exist_ok=True)
+    (api / ".git" / "MERGE_HEAD").write_text("abc\n")
+    shell = FakeShell({"api": _clean(status="")})
+    assert [s.blocked_reason for s in inspect(FakeTask({"api": api}), shell).blocked] \
+        == [IN_PROGRESS]
+
+
+def test_a_cherry_pick_in_progress_is_refused(tmp_path):
+    api = _repo(tmp_path, "api")
+    (api / ".git").mkdir(parents=True, exist_ok=True)
+    (api / ".git" / "CHERRY_PICK_HEAD").write_text("abc\n")
+    shell = FakeShell({"api": _clean(status="")})
+    assert [s.blocked_reason for s in inspect(FakeTask({"api": api}), shell).blocked] \
+        == [IN_PROGRESS]
+
+
+def test_an_unanswerable_git_dir_is_unreadable_not_transferred(tmp_path):
+    """Same rule as fix 1's `git status` guard: a repo whose state could not be
+    established is refused, never assumed clean — and never shipped."""
+    api = _repo(tmp_path, "api")
+    shell = FakeShell({"api": _clean(status=" M a.py\n", git_dir="")})
+    pre = inspect(FakeTask({"api": api}), shell)
+    assert [s.blocked_reason for s in pre.blocked] == [UNREADABLE]
+    assert pre.dirty == []
 
 
 # --- what must be pushed ----------------------------------------------------
@@ -520,30 +626,11 @@ def test_a_failed_push_stops_the_run(tmp_path):
     assert "could not push api" in err and "permission denied" in err
 
 
-# --- what must only warn ----------------------------------------------------
-
-def test_untracked_files_warn_rather_than_block(tmp_path):
-    """They cannot change what a push carries, so blocking over a stray scratch
-    file would be obstruction — but they will not exist on the run host."""
-    api = _repo(tmp_path, "api")
-    shell = FakeShell({"api": _clean(status="?? scratch.txt\n")})
-    pre = inspect(FakeTask({"api": api}), shell)
-    assert pre.ok
-    assert [s.repo for s in pre.untracked] == ["api"]
-
-
-def test_untracked_alongside_tracked_still_blocks(tmp_path):
-    api = _repo(tmp_path, "api")
-    shell = FakeShell({"api": _clean(status="?? new.py\n M old.py\n")})
-    pre = inspect(FakeTask({"api": api}), shell)
-    assert not pre.ok
-
-
 # --- scoping to the repos actually dispatched -------------------------------
 
 def test_repos_scoping_ignores_a_dirty_repo_the_run_never_touches(tmp_path):
-    """`--repos api` dispatches only api; work in progress in web cannot make
-    api's run execute stale code, so refusing over it is pure obstruction."""
+    """`--repos api` dispatches only api; work in progress in web is neither a
+    reason to stop nor a tree to ship."""
     api, web = _repo(tmp_path, "api"), _repo(tmp_path, "web")
     shell = FakeShell({
         "api": _clean(),
@@ -552,6 +639,7 @@ def test_repos_scoping_ignores_a_dirty_repo_the_run_never_touches(tmp_path):
     pre = inspect(FakeTask({"api": api, "web": web}), shell, repos=["api"])
     assert pre.ok
     assert [s.repo for s in pre.states] == ["api"]
+    assert pre.dirty == []
 
 
 def test_repos_scoping_does_not_push_an_unselected_repo(tmp_path):
@@ -571,6 +659,71 @@ def test_no_scope_means_every_repo_the_task_touches(tmp_path):
     shell = FakeShell({"api": _clean(), "web": _clean()})
     pre = inspect(FakeTask({"api": api, "web": web}), shell)
     assert [s.repo for s in pre.states] == ["api", "web"]
+
+
+# --- how a dirty repo is routed ---------------------------------------------
+
+def test_a_dirty_repo_never_asks_origin(tmp_path):
+    """BEHIND_ORIGIN and ORIGIN_UNREACHABLE exist because the run host
+    materializes a BRANCH from origin. On this path it materializes a scratch
+    ref this machine pushes, with no fetch at all, so origin's answer cannot
+    change what executes — and a round trip that cannot change the outcome is a
+    round trip not worth taking. Both refusals keep their full force on the
+    clean path (see the tests above)."""
+    api = _repo(tmp_path, "api")
+    shell = FakeShell({"api": _clean(
+        status=" M a.py\n",
+        origin="0123456789abcdef", head="oldsha", contains=[],   # would be BEHIND_ORIGIN
+    )})
+
+    pre = inspect(FakeTask({"api": api}), shell)
+
+    assert pre.ok
+    assert [s.repo for s in pre.dirty] == ["api"]
+    assert pre.blocked == []                                # not BEHIND_ORIGIN
+    assert not any("ls-remote" in c for c in shell.commands)
+    assert not any("merge-base" in c for c in shell.commands)
+
+
+def test_a_dirty_repo_carries_the_sha_inspect_certified(tmp_path):
+    """Fix 9, carried onto the new path: `synthesize_commit` parents the
+    snapshot on THIS sha rather than re-resolving HEAD moments later."""
+    api = _repo(tmp_path, "api")
+    shell = FakeShell({"api": _clean(status=" M a.py\n", head="certified")})
+    pre = inspect(FakeTask({"api": api}), shell)
+    assert [s.head_sha for s in pre.dirty] == ["certified"]
+
+
+def test_a_git_root_child_and_its_parent_dedupe_to_one_transfer(tmp_path):
+    """ac7: one git repository, one scratch ref. The child's tree IS the
+    parent's, so pushing both would send the same objects twice under two names
+    — and the run host resolves the child under the materialized parent anyway.
+    The parent is the survivor because that is the name the host materializes."""
+    mono = _repo(tmp_path, "mono")
+    child = _repo(tmp_path / "mono", "pkg")
+    shell = FakeShell({
+        "mono": _clean(status=" M a.py\n"),
+        "pkg": _clean(status=" M a.py\n"),
+    })
+    config = WorkspaceConfig(workspace="t", repos={
+        "mono": RepoConfig(path=mono, type="service"),
+        "pkg": RepoConfig(path=Path("pkg"), type="service", git_root="mono"),
+    })
+
+    pre = inspect(FakeTask({"mono": mono, "pkg": child}), shell, config=config)
+
+    assert [s.git_repo for s in pre.dirty] == ["mono"]
+    assert [s.repo for s in pre.dirty] == ["mono"]
+    assert [s.repo for s in pre.states] == ["mono", "pkg"]   # both still inspected
+
+
+def test_without_a_config_every_repo_is_its_own_git_repo(tmp_path):
+    """`config` is optional so the 25 untouched tests in this file keep calling
+    `inspect(task, shell)`. Absent it there is nothing to collapse against."""
+    api = _repo(tmp_path, "api")
+    shell = FakeShell({"api": _clean(status=" M a.py\n")})
+    pre = inspect(FakeTask({"api": api}), shell)
+    assert [s.git_repo for s in pre.dirty] == ["api"]
 
 
 # --- against real git, where staleness is real ------------------------------
@@ -814,3 +967,39 @@ def test_real_repo_that_is_not_a_git_worktree_blocks(tmp_path):
     plain.mkdir()
     pre = inspect(FakeTask({"api": plain}), RealShell())
     assert [s.blocked_reason for s in pre.blocked] == [UNREADABLE]
+
+
+def test_a_real_dirty_repo_is_transferred_and_origin_is_untouched(tmp_path):
+    """ac3 against real git: the whole point is that origin sees nothing."""
+    origin, work = _real_repo(tmp_path)
+    before = _git(origin, "rev-parse", "refs/heads/feat/x")
+    (work / "f.txt").write_text("uncommitted\n")
+    (work / "scratch.txt").write_text("untracked\n")
+
+    shell = RealShell()
+    pre = inspect(FakeTask({"api": work}), shell)
+
+    assert pre.ok
+    assert [s.repo for s in pre.dirty] == ["api"]
+    assert pre.to_push == []
+    assert push(pre, shell) == ([], None)
+    assert _git(origin, "rev-parse", "refs/heads/feat/x") == before
+
+
+def test_a_real_conflicted_repo_is_refused(tmp_path):
+    """ac12 against real git: a real merge conflict, real MERGE_HEAD, real
+    `UU` porcelain — the exact state a mock can only assert about."""
+    _, work = _real_repo(tmp_path)
+    _git(work, "checkout", "-b", "side")
+    (work / "f.txt").write_text("side\n")
+    _git(work, "commit", "-am", "side")
+    _git(work, "checkout", "feat/x")
+    (work / "f.txt").write_text("mine\n")
+    _git(work, "commit", "-am", "mine")
+    subprocess.run(["git", "merge", "side"], cwd=work, capture_output=True, env=_GIT_ENV)
+
+    pre = inspect(FakeTask({"api": work}), RealShell())
+
+    assert [s.blocked_reason for s in pre.blocked] == [IN_PROGRESS]
+    assert pre.dirty == []
+    assert "--abort" in blocked_message(pre)

--- a/tests/core/test_remote_setup.py
+++ b/tests/core/test_remote_setup.py
@@ -145,6 +145,30 @@ def test_the_key_file_path_is_per_task_and_per_repo(tmp_path):
     assert key_file(tmp_path, "t1", "api") != key_file(tmp_path, "t1", "web")
 
 
+def test_names_that_sanitize_alike_still_get_their_own_file(tmp_path):
+    """`_safe` maps every unsafe character to `-`, so `api.v2` and `api-v2` both
+    read `api-v2`. Sharing a file is not merely a spurious re-run: two repos that
+    declare the same patterns hash the SAME key while those patterns match no
+    files yet, so the second would read the first's record, match, and skip the
+    setup that installs its dependencies."""
+    assert key_file(tmp_path, "t1", "api.v2") != key_file(tmp_path, "t1", "api-v2")
+    assert key_file(tmp_path, "a.b", "api") != key_file(tmp_path, "a-b", "api")
+
+
+def test_the_separator_cannot_be_forged_from_a_name(tmp_path):
+    """`_` survives sanitizing, so a bare `__` join lets the boundary move: task
+    `a__b` + repo `c` and task `a` + repo `b__c` would name one file."""
+    assert key_file(tmp_path, "a__b", "c") != key_file(tmp_path, "a", "b__c")
+
+
+def test_the_pair_cannot_be_confused_across_its_boundary(tmp_path):
+    """Both halves of the name have to agree to collide, so the case that bites
+    is one where the readable prefix AND the digest move together: `a` + `__b`
+    and `a__` + `b` sanitize to one prefix and concatenate to one string. Only
+    separating the pair inside the digest keeps them apart."""
+    assert key_file(tmp_path, "a", "__b") != key_file(tmp_path, "a__", "b")
+
+
 def test_a_task_name_cannot_escape_the_state_directory(tmp_path):
     """The task name arrives over the wire, where `core/serve.py` permits `/`
     and `.`, so `../..` would otherwise be a legal path component here."""

--- a/tests/core/test_remote_setup.py
+++ b/tests/core/test_remote_setup.py
@@ -169,6 +169,25 @@ def test_the_pair_cannot_be_confused_across_its_boundary(tmp_path):
     assert key_file(tmp_path, "a", "__b") != key_file(tmp_path, "a__", "b")
 
 
+def test_a_long_name_still_produces_a_writable_file(tmp_path):
+    """`_TASK_NAME_RE` bounds the charset of a task arriving over the wire but
+    not its length, and a name can be short enough for `.worktrees/<task>` yet
+    overflow NAME_MAX once the suffix lands. Recording happens AFTER setup
+    succeeded, so an unwritable path throws away work already done."""
+    path = key_file(tmp_path, "t" * 300, "r" * 300)
+    assert len(path.name.encode("utf-8")) <= 255
+    record_setup(path, "abc")
+    assert not needs_setup(path, "abc")
+
+
+def test_long_names_sharing_a_truncated_prefix_stay_distinct(tmp_path):
+    """Truncation is only free because identity lives in the digest, which is
+    taken over the untruncated pair."""
+    a = key_file(tmp_path, "t" * 300 + "one", "api")
+    b = key_file(tmp_path, "t" * 300 + "two", "api")
+    assert a != b
+
+
 def test_a_task_name_cannot_escape_the_state_directory(tmp_path):
     """The task name arrives over the wire, where `core/serve.py` permits `/`
     and `.`, so `../..` would otherwise be a legal path component here."""

--- a/tests/core/test_remote_setup.py
+++ b/tests/core/test_remote_setup.py
@@ -1,0 +1,153 @@
+"""The `task setup` cache key on a run host.
+
+A cache key of exactly the shape any build cache uses — and with the same
+failure mode, which is precisely why the inputs are DECLARED rather than
+guessed: an operator can see and widen a declared key, and cannot inspect a
+heuristic.
+"""
+from pathlib import Path
+
+from mship.core.remote_setup import (
+    FIRST_MATERIALIZATION_KEY,
+    key_file,
+    needs_setup,
+    record_setup,
+    setup_key,
+)
+
+
+def _worktree(tmp_path: Path) -> Path:
+    wt = tmp_path / "wt"
+    (wt / "src").mkdir(parents=True)
+    (wt / "package.json").write_text('{"deps": 1}\n')
+    (wt / "src" / "app.js").write_text("console.log(1)\n")
+    return wt
+
+
+def test_no_declared_inputs_gives_the_first_materialization_key(tmp_path):
+    """ac17: nothing to invalidate against, so the key never changes."""
+    assert setup_key(_worktree(tmp_path), []) == FIRST_MATERIALIZATION_KEY
+
+
+def test_the_key_changes_when_a_declared_input_changes(tmp_path):
+    """ac16: a dependency change pays once."""
+    wt = _worktree(tmp_path)
+    before = setup_key(wt, ["package.json"])
+    (wt / "package.json").write_text('{"deps": 2}\n')
+    assert setup_key(wt, ["package.json"]) != before
+
+
+def test_the_key_is_unchanged_by_a_source_only_edit(tmp_path):
+    """ac16, the case the whole feature exists for: the common iteration pays
+    nothing."""
+    wt = _worktree(tmp_path)
+    before = setup_key(wt, ["package.json"])
+    (wt / "src" / "app.js").write_text("console.log(2)\n")
+    assert setup_key(wt, ["package.json"]) == before
+
+
+def test_globs_are_matched_inside_the_worktree(tmp_path):
+    wt = _worktree(tmp_path)
+    (wt / "src" / "package.json").write_text('{"nested": 1}\n')
+    before = setup_key(wt, ["**/package.json"])
+    (wt / "src" / "package.json").write_text('{"nested": 2}\n')
+    assert setup_key(wt, ["**/package.json"]) != before
+
+
+def test_a_declared_input_that_does_not_exist_is_not_an_error(tmp_path):
+    """A repo that declares `uv.lock` before it has one must still run."""
+    assert setup_key(_worktree(tmp_path), ["uv.lock"])
+
+
+def test_adding_a_file_a_pattern_matches_moves_the_key(tmp_path):
+    wt = _worktree(tmp_path)
+    before = setup_key(wt, ["*.lock"])
+    (wt / "uv.lock").write_text("locked\n")
+    assert setup_key(wt, ["*.lock"]) != before
+
+
+def test_widening_the_declaration_moves_the_key_by_itself(tmp_path):
+    """The declaration is part of the key, so an operator who widens
+    `setup_inputs` gets a re-run rather than a stale skip."""
+    wt = _worktree(tmp_path)
+    assert setup_key(wt, ["package.json"]) != setup_key(wt, ["package.json", "*.lock"])
+
+
+def test_deleting_a_declared_input_moves_the_key(tmp_path):
+    """The too-lazy failure named in the task: a dependency file the operator
+    deleted between runs must not be silently treated as unchanged just
+    because the glob no longer sees it — its absence IS the change."""
+    wt = _worktree(tmp_path)
+    before = setup_key(wt, ["package.json"])
+    (wt / "package.json").unlink()
+    assert setup_key(wt, ["package.json"]) != before
+
+
+def test_a_content_identical_rename_still_moves_the_key(tmp_path):
+    """Hashing only file bytes (and not the path) would miss a rename: same
+    bytes, different location, key must still move — a setup script that
+    reads a manifest by its old name would otherwise run against a target
+    that silently vanished."""
+    wt = _worktree(tmp_path)
+    (wt / "package.json").write_text("fixed-content\n")
+    before = setup_key(wt, ["package*.json"])
+    (wt / "package.json").rename(wt / "package2.json")
+    assert setup_key(wt, ["package*.json"]) != before
+
+
+def test_path_and_content_cannot_be_confused_across_a_boundary(tmp_path):
+    """Concatenating `path + content` with no separator would make file `a`
+    with content `b` indistinguishable from file `ab` with empty content —
+    two genuinely different worktree states collapsing onto the same key is
+    exactly the too-lazy failure this key exists to rule out."""
+    wt1 = tmp_path / "wt1"
+    wt1.mkdir()
+    (wt1 / "a").write_text("b")
+    wt2 = tmp_path / "wt2"
+    wt2.mkdir()
+    (wt2 / "ab").write_text("")
+    assert setup_key(wt1, ["*"]) != setup_key(wt2, ["*"])
+
+
+def test_every_declared_pattern_contributes_not_just_the_last(tmp_path):
+    """A change matched by an earlier pattern in the list must move the key
+    even though a later pattern in the same declaration matches nothing — a
+    bug that only tracked the final pattern would mask it."""
+    wt = _worktree(tmp_path)
+    before = setup_key(wt, ["package.json", "*.lock"])
+    (wt / "package.json").write_text('{"deps": 2}\n')
+    assert setup_key(wt, ["package.json", "*.lock"]) != before
+
+
+def test_setup_key_is_deterministic_for_an_unchanged_worktree(tmp_path):
+    """Same declared inputs, same on-disk state, called twice: the key must
+    not depend on filesystem iteration order happening to differ between
+    calls."""
+    wt = _worktree(tmp_path)
+    assert setup_key(wt, ["package.json", "**/*.js"]) == setup_key(
+        wt, ["package.json", "**/*.js"]
+    )
+
+
+def test_needs_setup_is_true_when_nothing_was_recorded(tmp_path):
+    assert needs_setup(tmp_path / "absent.key", "abc")
+
+
+def test_recording_then_asking_again_says_no(tmp_path):
+    path = key_file(tmp_path, "t1", "api")
+    record_setup(path, "abc")
+    assert not needs_setup(path, "abc")
+    assert needs_setup(path, "different")
+
+
+def test_the_key_file_path_is_per_task_and_per_repo(tmp_path):
+    assert key_file(tmp_path, "t1", "api") != key_file(tmp_path, "t2", "api")
+    assert key_file(tmp_path, "t1", "api") != key_file(tmp_path, "t1", "web")
+
+
+def test_a_task_name_cannot_escape_the_state_directory(tmp_path):
+    """The task name arrives over the wire, where `core/serve.py` permits `/`
+    and `.`, so `../..` would otherwise be a legal path component here."""
+    path = key_file(tmp_path, "../../etc", "api")
+    root = (tmp_path / ".mothership").resolve()
+    assert root in path.resolve().parents

--- a/tests/core/test_run_ref.py
+++ b/tests/core/test_run_ref.py
@@ -19,10 +19,17 @@ def test_ref_is_outside_refs_heads():
     assert not run_ref("t1", "api").startswith("refs/heads/")
 
 
-@pytest.mark.parametrize("bad", ["..", ".", "a/b", "", "with space", "semi;colon", "dollar$"])
+@pytest.mark.parametrize("bad", [
+    "..", ".", "a/b", "", "with space", "semi;colon", "dollar$", "api\n",
+])
 def test_traversal_and_shell_metachars_are_refused(bad):
     """The ref reaches `git push` / `git reset --hard` through a shell and names
-    a file on disk, so anything outside the segment charset is refused up front."""
+    a file on disk, so anything outside the segment charset is refused up front.
+
+    `api\\n` is in the list because Python's `$` also matches BEFORE a trailing
+    newline, so an anchor written `$` accepts one — and a trailing newline
+    terminates a shell command. Harmless while nothing follows the ref on those
+    command lines; Task 8 onward appends flags after it."""
     with pytest.raises(RunRefNameError):
         run_ref(bad, "api")
     with pytest.raises(RunRefNameError):
@@ -42,6 +49,11 @@ def test_is_run_ref_accepts_exactly_two_segments():
     "refs/mship/run/../../heads/main",
     "HEAD",
     "",
+    "refs/mship/run/t1/api\n",
 ])
 def test_is_run_ref_refuses_everything_else(bad):
+    """The trailing-newline case is the scope control's own business, not git's.
+    Real receive-pack does refuse `refs/mship/run/t1/api\\n` ("refusing to update
+    funny ref"), so nothing was ever written — but this check advertises itself
+    as the last line of defence, and being saved by git downstream is not that."""
     assert not is_run_ref(bad)

--- a/tests/core/test_run_ref.py
+++ b/tests/core/test_run_ref.py
@@ -1,0 +1,47 @@
+"""`refs/mship/run/<task>/<repo>` — the throwaway namespace, and the only place
+its shape is decided."""
+import pytest
+
+from mship.core.run_ref import RUN_REF_PREFIX, RunRefNameError, is_run_ref, run_ref
+
+
+def test_ref_is_per_task_and_per_repo():
+    """ac7: two tasks, or two repos, must never collide on one ref."""
+    assert run_ref("t1", "api") == "refs/mship/run/t1/api"
+    assert run_ref("t1", "api") != run_ref("t2", "api")
+    assert run_ref("t1", "api") != run_ref("t1", "web")
+
+
+def test_ref_is_outside_refs_heads():
+    """Not a branch: `receive.denyCurrentBranch` never applies (verified against
+    a real non-bare repo), and it is nothing a human would branch from (ac14)."""
+    assert RUN_REF_PREFIX.startswith("refs/mship/")
+    assert not run_ref("t1", "api").startswith("refs/heads/")
+
+
+@pytest.mark.parametrize("bad", ["..", ".", "a/b", "", "with space", "semi;colon", "dollar$"])
+def test_traversal_and_shell_metachars_are_refused(bad):
+    """The ref reaches `git push` / `git reset --hard` through a shell and names
+    a file on disk, so anything outside the segment charset is refused up front."""
+    with pytest.raises(RunRefNameError):
+        run_ref(bad, "api")
+    with pytest.raises(RunRefNameError):
+        run_ref("t1", bad)
+
+
+def test_is_run_ref_accepts_exactly_two_segments():
+    assert is_run_ref("refs/mship/run/t1/api")
+    assert not is_run_ref("refs/mship/run/t1")
+    assert not is_run_ref("refs/mship/run/t1/api/extra")
+
+
+@pytest.mark.parametrize("bad", [
+    "refs/heads/main",
+    "refs/heads/../mship/run/t1/api",
+    "refs/mship/runaway/t1/api",
+    "refs/mship/run/../../heads/main",
+    "HEAD",
+    "",
+])
+def test_is_run_ref_refuses_everything_else(bad):
+    assert not is_run_ref(bad)

--- a/tests/core/test_run_transfer.py
+++ b/tests/core/test_run_transfer.py
@@ -557,3 +557,107 @@ def test_a_real_push_lands_the_ref_and_writes_the_token_to_no_config_file(tmp_pa
     )
     assert "tok-abc" not in on_disk
     assert "tok-abc" not in (operator / ".git" / "config").read_text()
+
+
+# --- cleanup on close --------------------------------------------------------
+
+from mship.core.config import RepoConfig, WorkspaceConfig
+from mship.core.run_host import RunHostStore
+from mship.core.run_transfer import cleanup_run_refs
+
+
+class FakeTask:
+    def __init__(self, slug, affected_repos):
+        self.slug = slug
+        self.affected_repos = affected_repos
+
+
+def _run_host_config(tmp_path, **extra_repos) -> WorkspaceConfig:
+    repos = {"api": RepoConfig(path=tmp_path / "api", type="service", run_host="role-x")}
+    repos.update(extra_repos)
+    return WorkspaceConfig(workspace="t", run_hosts=["role-x"], repos=repos)
+
+
+def _store(tmp_path) -> RunHostStore:
+    store = RunHostStore(tmp_path / ".mothership")
+    store.set("role-x", RunHostConnection(url="http://remote.example", token="tok-abc"))
+    return store
+
+
+def test_close_deletes_the_tasks_scratch_ref(tmp_path):
+    """ac8: they do not accumulate."""
+    shell = RecordingShell()
+    warnings: list[str] = []
+
+    deleted = cleanup_run_refs(
+        FakeTask("t1", ["api"]),
+        config=_run_host_config(tmp_path), store=_store(tmp_path),
+        shell=shell, warn=warnings.append,
+    )
+
+    assert deleted == ["api"]
+    assert ":refs/mship/run/t1/api" in shell.calls[0][0]
+    assert warnings == []
+
+
+def test_a_git_root_child_is_cleaned_once_via_its_parent(tmp_path):
+    """ac7 again: one git repository, one ref, one delete."""
+    shell = RecordingShell()
+    config = _run_host_config(
+        tmp_path,
+        server=RepoConfig(path=Path("server"), type="service", git_root="api"),
+    )
+
+    deleted = cleanup_run_refs(
+        FakeTask("t1", ["api", "server"]), config=config, store=_store(tmp_path),
+        shell=shell, warn=lambda _m: None,
+    )
+
+    assert deleted == ["api"]
+    assert len(shell.calls) == 1
+
+
+def test_no_mapped_run_host_means_nothing_to_clean(tmp_path):
+    """A task that never ran remotely must not warn on every close."""
+    shell = RecordingShell()
+    warnings: list[str] = []
+
+    deleted = cleanup_run_refs(
+        FakeTask("t1", ["api"]),
+        config=WorkspaceConfig(
+            workspace="t",
+            repos={"api": RepoConfig(path=tmp_path / "api", type="service")},
+        ),
+        store=RunHostStore(tmp_path / ".mothership"),
+        shell=shell, warn=warnings.append,
+    )
+
+    assert deleted == [] and shell.calls == [] and warnings == []
+
+
+def test_a_failed_delete_warns_and_keeps_going(tmp_path):
+    """Cleanup must never block a close: a missed ref is disk, not disclosure."""
+    shell = RecordingShell(returncode=1, stderr="host unreachable\n")
+    warnings: list[str] = []
+
+    deleted = cleanup_run_refs(
+        FakeTask("t1", ["api"]), config=_run_host_config(tmp_path),
+        store=_store(tmp_path), shell=shell, warn=warnings.append,
+    )
+
+    assert deleted == []
+    assert warnings and "api" in warnings[0]
+
+
+def test_a_task_slug_that_cannot_form_a_ref_warns_rather_than_raising(tmp_path):
+    """`run_ref` refuses `/` in a slug; a close must not die on it."""
+    shell = RecordingShell()
+    warnings: list[str] = []
+
+    deleted = cleanup_run_refs(
+        FakeTask("a/b", ["api"]), config=_run_host_config(tmp_path),
+        store=_store(tmp_path), shell=shell, warn=warnings.append,
+    )
+
+    assert deleted == [] and shell.calls == []
+    assert warnings

--- a/tests/core/test_run_transfer.py
+++ b/tests/core/test_run_transfer.py
@@ -260,3 +260,300 @@ def test_a_git_failure_raises_a_named_error(tmp_path):
     with pytest.raises(RunTransferError) as exc:
         synthesize_commit(ShellRunner(), not_a_repo, base_sha="HEAD")
     assert "read-tree" in str(exc.value)
+
+
+# --- delivery: where the commit goes, and where the token does NOT -----------
+
+import contextlib
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from mship.core.run_host import RunHostConnection
+from mship.core.run_transfer import delete_run_ref, extra_header_env, push_run_ref
+from mship.util.shell import ShellResult, ShellRunner
+
+
+class RecordingShell:
+    """Records every command with the env it was given — the only way to assert
+    where the bearer did and did not go. `ShellRunner.run` takes a command
+    STRING (shell=True), so `calls[i][0]` is the whole command line."""
+
+    def __init__(self, returncode: int = 0, stderr: str = ""):
+        self.calls: list[tuple[str, Path, dict]] = []
+        self._returncode = returncode
+        self._stderr = stderr
+
+    def run(self, command, cwd=None, env=None, **kw):
+        self.calls.append((command, Path(cwd), dict(env or {})))
+        return ShellResult(returncode=self._returncode, stdout="", stderr=self._stderr)
+
+
+CONN = RunHostConnection(url="https://mac-abc.relay.example", token="tok-secret")
+RECEIVE_URL = "https://mac-abc.relay.example/git/api"
+
+
+def test_the_push_targets_the_per_task_per_repo_scratch_ref(repo):
+    """ac7: two tasks or two repos cannot overwrite each other."""
+    shell = RecordingShell()
+    ref = push_run_ref(shell, repo, conn=CONN, repo="api", task="t1", sha="abc123")
+
+    assert ref == "refs/mship/run/t1/api"
+    command, cwd, _env = shell.calls[0]
+    assert "abc123:refs/mship/run/t1/api" in command
+    assert cwd == repo
+
+
+def test_each_run_force_updates_its_own_ref(repo):
+    """ac8: the ref is replaced per run — safe only because nothing else writes
+    this namespace, which is why it must never be a branch."""
+    shell = RecordingShell()
+    push_run_ref(shell, repo, conn=CONN, repo="api", task="t1", sha="abc123")
+    assert shell.calls[0][0].startswith("git push --force ")
+
+
+def test_the_push_goes_to_the_run_host_not_origin(repo):
+    """ac3: origin is not in this path at all."""
+    shell = RecordingShell()
+    push_run_ref(shell, repo, conn=CONN, repo="api", task="t1", sha="abc123")
+    command = shell.calls[0][0]
+    assert RECEIVE_URL in command
+    assert "origin" not in command
+
+
+def test_the_bearer_is_supplied_out_of_band_only(repo):
+    """ac4, all three prohibitions at once: not in the remote URL, not written
+    to any git config file, and above all not in argv — `/proc/<pid>/cmdline` is
+    world-readable, `/proc/<pid>/environ` is not."""
+    shell = RecordingShell()
+    push_run_ref(shell, repo, conn=CONN, repo="api", task="t1", sha="abc123")
+    command, _cwd, env = shell.calls[0]
+
+    assert "tok-secret" not in command
+    assert "-c" not in command.split()                    # no `git -c http.extraHeader=`
+    assert not any(c[0].startswith("git config") for c in shell.calls)
+    assert "Authorization: Bearer tok-secret" in env.values()
+    assert f"http.{RECEIVE_URL}.extraHeader" in env.values()
+    # The token rides in a VALUE, never in a key: keys are the half of this that
+    # a `git config --list`-style dump would show without values.
+    assert not any("tok-secret" in key for key in env)
+
+
+def test_the_push_never_prompts_for_credentials(repo):
+    """A stale token must fail the command, not hang the CLI on a prompt that a
+    captured-output subprocess never shows anyone."""
+    shell = RecordingShell()
+    push_run_ref(shell, repo, conn=CONN, repo="api", task="t1", sha="abc123")
+    assert shell.calls[0][2]["GIT_TERMINAL_PROMPT"] == "0"
+
+
+def test_redirects_are_turned_off_for_the_push(repo):
+    """The header is bound to the curl handle at request time, NOT re-matched
+    per hop, so a same-origin redirect carries it to wherever it points even
+    with the key scoped to the run host (verified against real git; see the
+    end-to-end test below). Refusing redirects is what actually closes that."""
+    shell = RecordingShell()
+    push_run_ref(shell, repo, conn=CONN, repo="api", task="t1", sha="abc123")
+    env = shell.calls[0][2]
+    keys = {env[k]: env[k.replace("KEY", "VALUE")] for k in env if "GIT_CONFIG_KEY" in k}
+    assert keys["http.followRedirects"] == "false"
+
+
+def test_the_header_config_appends_to_inherited_git_config_entries(monkeypatch):
+    """tests/conftest.py:41 sets GIT_CONFIG_COUNT=2 suite-wide to disable commit
+    signing. Claiming index 0 would silently re-enable signing everywhere."""
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "2")
+    env = extra_header_env("tok", RECEIVE_URL)
+    assert env["GIT_CONFIG_COUNT"] == "4"
+    assert env["GIT_CONFIG_KEY_2"] == f"http.{RECEIVE_URL}.extraHeader"
+    assert env["GIT_CONFIG_KEY_3"] == "http.followRedirects"
+    assert "GIT_CONFIG_KEY_0" not in env          # the inherited pair is untouched
+    assert "GIT_CONFIG_KEY_1" not in env
+
+
+def test_a_missing_count_starts_at_zero(monkeypatch):
+    monkeypatch.delenv("GIT_CONFIG_COUNT", raising=False)
+    env = extra_header_env("tok", RECEIVE_URL)
+    assert env["GIT_CONFIG_COUNT"] == "2"
+    assert env["GIT_CONFIG_KEY_0"] == f"http.{RECEIVE_URL}.extraHeader"
+
+
+@pytest.mark.parametrize("count", ["not-a-number", "-1", ""])
+def test_a_nonsense_count_does_not_crash_the_push(monkeypatch, count):
+    monkeypatch.setenv("GIT_CONFIG_COUNT", count)
+    env = extra_header_env("tok", RECEIVE_URL)
+    assert env["GIT_CONFIG_COUNT"] == "2"
+    assert env["GIT_CONFIG_KEY_0"] == f"http.{RECEIVE_URL}.extraHeader"
+
+
+def test_a_failed_push_raises_with_gits_own_message(repo):
+    shell = RecordingShell(returncode=1, stderr="fatal: unable to access\n")
+    with pytest.raises(RunTransferError) as exc:
+        push_run_ref(shell, repo, conn=CONN, repo="api", task="t1", sha="abc123")
+    assert "unable to access" in str(exc.value)
+    assert "api" in str(exc.value)
+
+
+def test_delete_uses_the_colon_refspec_form(repo):
+    """ac8: cleanup is one plain refspec through the same `_push` as the push —
+    no option parsing after the URL.
+
+    NOT because `--delete <ref>` errors on an absent ref: with a fully qualified
+    ref (which `run_ref` always builds) both forms are a no-op success, and with
+    an unqualified one both fail (git 2.43, verified locally and over HTTP). The
+    no-op success cleanup relies on is pinned end to end below."""
+    shell = RecordingShell()
+    delete_run_ref(shell, repo, conn=CONN, repo="api", task="t1")
+    command = shell.calls[0][0]
+    assert ":refs/mship/run/t1/api" in command
+    assert "--delete" not in command
+
+
+def test_a_failed_delete_raises(repo):
+    shell = RecordingShell(returncode=1, stderr="fatal: unable to access\n")
+    with pytest.raises(RunTransferError) as exc:
+        delete_run_ref(shell, repo, conn=CONN, repo="api", task="t1")
+    assert "unable to access" in str(exc.value)
+    assert "refs/mship/run/t1/api" in str(exc.value)
+
+
+# --- the same guarantees against real git ------------------------------------
+
+
+def _urlmatch(env: dict[str, str], url: str) -> str:
+    """What real git resolves `http.*` to for `url`, given our env config.
+
+    Asserting the key string is not the same as asserting git AGREES the key
+    applies: a URL-scoped key that matches nothing would still look right in a
+    dict and would silently push unauthenticated."""
+    return subprocess.run(
+        ["git", "config", "--get-urlmatch", "http", url],
+        capture_output=True, text=True, env={**_git_env(), **env},
+    ).stdout
+
+
+def test_real_git_applies_the_header_to_the_run_host_and_nowhere_else(repo):
+    """The scoping is only worth having if git reads it the way we mean it."""
+    shell = RecordingShell()
+    push_run_ref(shell, repo, conn=CONN, repo="api", task="t1", sha="abc123")
+    env = shell.calls[0][2]
+
+    # Both legs git will request live under the receive URL.
+    for leg in ("/info/refs?service=git-receive-pack", "/git-receive-pack"):
+        assert "Bearer tok-secret" in _urlmatch(env, RECEIVE_URL + leg)
+    assert "tok-secret" not in _urlmatch(env, "https://elsewhere.example/git/api")
+    assert "tok-secret" not in _urlmatch(env, "https://mac-abc.relay.example/git/other")
+
+
+@contextlib.contextmanager
+def _recording_host(redirect: bool = False):
+    """A loopback HTTP server that records the Authorization header of every
+    request, optionally 302-ing the smart-HTTP entry point somewhere else on the
+    SAME origin — the case URL scoping cannot save, because curl only strips a
+    custom Authorization header when the redirect crosses origins."""
+    seen: list[tuple[str, str | None]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            seen.append((self.path, self.headers.get("Authorization")))
+            if redirect and self.path.startswith("/git/api/"):
+                self.send_response(302)
+                self.send_header(
+                    "Location", self.path.replace("/git/api/", "/elsewhere/", 1)
+                )
+            else:
+                self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}", seen
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=10)
+
+
+def test_a_redirect_does_not_carry_the_bearer(repo, monkeypatch):
+    """The leak the URL scoping does NOT close. With redirects followed, real
+    git sends `Authorization: Bearer …` to the redirect target verbatim
+    (verified); `http.followRedirects=false` makes the push fail instead."""
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+    with _recording_host(redirect=True) as (base, seen):
+        conn = RunHostConnection(url=base, token="tok-live")
+        with pytest.raises(RunTransferError) as exc:
+            push_run_ref(
+                ShellRunner(), repo, conn=conn, repo="api", task="t1",
+                sha=_head(repo),
+            )
+
+    assert "302" in str(exc.value)
+    assert [path for path, _auth in seen] == [
+        "/git/api/info/refs?service=git-receive-pack"
+    ], "git followed the redirect"
+    assert all("elsewhere" not in path for path, _ in seen)
+
+
+def test_the_bearer_reaches_the_run_host_over_a_real_socket(repo, monkeypatch):
+    """The other half: refusing redirects must not have broken the auth."""
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+    with _recording_host() as (base, seen):
+        conn = RunHostConnection(url=base, token="tok-live")
+        with pytest.raises(RunTransferError):     # the recorder 404s every path
+            push_run_ref(
+                ShellRunner(), repo, conn=conn, repo="api", task="t1",
+                sha=_head(repo),
+            )
+
+    assert seen == [
+        ("/git/api/info/refs?service=git-receive-pack", "Bearer tok-live")
+    ]
+
+
+def test_a_real_push_lands_the_ref_and_writes_the_token_to_no_config_file(tmp_path):
+    """End to end through the run host's own receive endpoint: the ref lands,
+    the bearer only ever travelled in the environment, and — the assertion the
+    mocks above cannot make — nothing on disk holds it afterwards.
+
+    Also the live proof that the GIT_CONFIG append is right: tests/conftest.py
+    has GIT_CONFIG_COUNT=2 set in `os.environ` for the whole session and
+    `ShellRunner` merges `os.environ` under our env, so a push that claimed
+    index 0 or miscounted would fail here against real git.
+    """
+    from tests.core.test_git_receive import _app, _repo, live_serve
+
+    host_repo = _repo(tmp_path / "api")
+    operator = tmp_path / "operator"
+    subprocess.run(
+        ["git", "clone", "-q", str(host_repo), str(operator)],
+        check=True, capture_output=True, env=_git_env(),
+    )
+    (operator / "scratch.txt").write_text("uncommitted\n")
+    sha = synthesize_commit(ShellRunner(), operator, base_sha=_head(operator))
+
+    with live_serve(_app(tmp_path, auth_token="tok-abc")) as base:
+        conn = RunHostConnection(url=base, token="tok-abc")
+        ref = push_run_ref(
+            ShellRunner(), operator, conn=conn, repo="api", task="t1", sha=sha
+        )
+        assert _git("rev-parse", ref, cwd=host_repo) == sha
+        assert _git("show", f"{ref}:scratch.txt", cwd=host_repo) == "uncommitted"
+
+        delete_run_ref(ShellRunner(), operator, conn=conn, repo="api", task="t1")
+        assert ref not in _git("for-each-ref", "--format=%(refname)", cwd=host_repo)
+        # Deleting what is no longer there is a no-op success, so `mship close`
+        # never has to ask first.
+        delete_run_ref(ShellRunner(), operator, conn=conn, repo="api", task="t1")
+
+    on_disk = "\n".join(
+        p.read_text(errors="ignore")
+        for p in operator.rglob("*") if p.is_file() and ".git" in p.parts
+    )
+    assert "tok-abc" not in on_disk
+    assert "tok-abc" not in (operator / ".git" / "config").read_text()

--- a/tests/core/test_run_transfer.py
+++ b/tests/core/test_run_transfer.py
@@ -1,0 +1,262 @@
+"""Commit synthesis: a real commit object whose tree is the working tree, built
+without touching the operator's repository.
+
+Real git, real repositories, real ShellRunner throughout. The spec's own risk
+list says the failure here is SILENT — an empty temporary index drops
+tracked-and-gitignored files with no error — so nothing in this file is allowed
+to be asserted against a mock.
+"""
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mship.core.run_transfer import RunTransferError, synthesize_commit
+from mship.util.shell import ShellRunner
+
+
+def _git_env() -> dict[str, str]:
+    """Keep the operator's global git config out of these repos, exactly as
+    tests/core/test_git_receive.py:195 does and for the same reason.
+
+    Built per call, not snapshotted at import: `tests/conftest.py` installs its
+    GIT_CONFIG_* signing overrides in a session fixture that runs AFTER this
+    module is imported, and two tests below monkeypatch os.environ. A snapshot
+    would silently hand git a different environment than the one under test.
+    The identity is pinned unconditionally so the helper keeps working in the
+    test that strips identity from os.environ.
+    """
+    return {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+    }
+
+
+def _git(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True,
+        env=_git_env(),
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo on a feature branch with one commit, a .gitignore, and a
+    deliberately ignored file."""
+    path = tmp_path / "api"
+    path.mkdir()
+    _git("init", "-q", "-b", "main", ".", cwd=path)
+    (path / "a.txt").write_text("one\n")
+    (path / ".gitignore").write_text("ignored.txt\n")
+    _git("add", "-A", cwd=path)
+    _git("commit", "-qm", "init", cwd=path)
+    _git("checkout", "-q", "-b", "feat/x", cwd=path)
+    return path
+
+
+def _head(repo: Path) -> str:
+    return _git("rev-parse", "HEAD", cwd=repo)
+
+
+def _dirty(repo: Path) -> None:
+    (repo / "a.txt").write_text("one\nedited\n")
+    (repo / "untracked.txt").write_text("scratch\n")
+    (repo / "ignored.txt").write_text("secret\n")
+
+
+def _tree_files(repo: Path, sha: str) -> list[str]:
+    return _git("ls-tree", "-r", "--name-only", sha, cwd=repo).splitlines()
+
+
+def test_the_synthesized_tree_is_the_working_tree(repo):
+    """ac1: what the run host is asked to materialize contains the modified file
+    exactly as it is on disk."""
+    _dirty(repo)
+    sha = synthesize_commit(ShellRunner(), repo, base_sha=_head(repo))
+
+    blob = _git("show", f"{sha}:a.txt", cwd=repo)
+    assert blob == "one\nedited"
+    assert (repo / "a.txt").read_text() == blob + "\n"
+
+
+def test_untracked_files_travel_and_gitignored_ones_do_not(repo):
+    """ac11, pinned in both directions."""
+    _dirty(repo)
+    files = _tree_files(repo, synthesize_commit(ShellRunner(), repo, base_sha=_head(repo)))
+    assert "untracked.txt" in files
+    assert "ignored.txt" not in files
+
+
+def test_a_tracked_file_that_is_also_gitignored_survives(repo):
+    """ac1's second half, and the spec's top risk. Verified failure mode: with
+    an EMPTY temporary index `git add -A` silently skips this file, because git
+    will not add an ignored path that is not already in the index — the run host
+    would then execute a tree missing a file the operator can plainly see.
+    Seeding the scratch index from the base commit is what keeps it."""
+    (repo / ".gitignore").write_text("ignored.txt\na.txt\n")
+    files = _tree_files(repo, synthesize_commit(ShellRunner(), repo, base_sha=_head(repo)))
+    assert "a.txt" in files
+
+
+def test_a_modified_tracked_and_gitignored_file_carries_its_WORKING_content(repo):
+    """Seeding from the base commit must not mean shipping the base commit's
+    version: it seeds, then `git add -A` overwrites from the working tree."""
+    (repo / ".gitignore").write_text("a.txt\n")
+    (repo / "a.txt").write_text("edited while ignored\n")
+    sha = synthesize_commit(ShellRunner(), repo, base_sha=_head(repo))
+    assert _git("show", f"{sha}:a.txt", cwd=repo) == "edited while ignored"
+
+
+def test_a_deleted_tracked_file_is_absent_from_the_tree(repo):
+    (repo / "a.txt").unlink()
+    sha = synthesize_commit(ShellRunner(), repo, base_sha=_head(repo))
+    assert "a.txt" not in _tree_files(repo, sha)
+
+
+def test_local_state_is_identical_before_and_after(repo):
+    """ac2, the destructive-surprise guard: `git add -A` against the DEFAULT
+    index would stage the operator's work in progress."""
+    _dirty(repo)
+
+    def snapshot():
+        return {
+            "head": _git("rev-parse", "HEAD", cwd=repo),
+            "branch": _git("rev-parse", "--abbrev-ref", "HEAD", cwd=repo),
+            "status": _git("status", "--porcelain", cwd=repo),
+            "index": _git("diff", "--cached", "--name-only", cwd=repo),
+            "branches": _git("branch", "--list", cwd=repo),
+        }
+
+    before = snapshot()
+    sha = synthesize_commit(ShellRunner(), repo, base_sha=before["head"])
+    after = snapshot()
+
+    assert after == before
+    assert before["index"] == ""                     # nothing was staged
+    assert sha != before["head"]
+
+
+def test_the_commit_is_on_no_branch(repo):
+    """ac2/ac14: it is not history anyone can build on."""
+    _dirty(repo)
+    base = _head(repo)
+    sha = synthesize_commit(ShellRunner(), repo, base_sha=base)
+    assert _git("branch", "--contains", sha, "--all", cwd=repo) == ""
+    assert _git("rev-parse", f"{sha}^", cwd=repo) == base
+
+
+def test_the_parent_is_the_sha_it_was_given_not_a_re_resolved_head(repo):
+    """Fix 9 carried onto this path. `inspect` certifies a sha; something else
+    committing in this worktree in the meantime (a subagent, a background job —
+    this workspace's normal pattern) must not silently re-root the snapshot."""
+    _dirty(repo)
+    certified = _head(repo)
+
+    (repo / "raced.txt").write_text("raced\n")
+    _git("add", "raced.txt", cwd=repo)
+    _git("commit", "-qm", "raced after inspection", cwd=repo)
+    assert _head(repo) != certified
+
+    sha = synthesize_commit(ShellRunner(), repo, base_sha=certified)
+    assert _git("rev-parse", f"{sha}^", cwd=repo) == certified
+
+
+def test_it_works_in_a_repo_with_no_configured_identity(tmp_path, monkeypatch):
+    """`git commit-tree` needs an author; taking it from git config would make
+    synthesis fail on a machine that has none. It is pinned to mship instead."""
+    for var in ("GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL",
+                "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+
+    path = tmp_path / "no-identity"
+    path.mkdir()
+    _git("init", "-q", "-b", "main", ".", cwd=path)
+    (path / "a.txt").write_text("one\n")
+    _git("add", "-A", cwd=path)
+    _git("commit", "-qm", "init", cwd=path)
+    (path / "a.txt").write_text("edited\n")
+
+    # The identity can only have come from synthesize_commit: nothing in this
+    # repo's config supplies one.
+    assert subprocess.run(
+        ["git", "config", "user.email"], cwd=path, capture_output=True,
+        text=True, env={k: v for k, v in _git_env().items()
+                        if not k.startswith("GIT_AUTHOR")
+                        and not k.startswith("GIT_COMMITTER")},
+    ).returncode != 0
+
+    sha = synthesize_commit(ShellRunner(), path, base_sha=_head(path))
+    assert "mship" in _git("show", "-s", "--format=%an <%ae>", sha, cwd=path)
+
+
+def test_commit_signing_cannot_block_synthesis(repo, monkeypatch):
+    """`git commit-tree` does not honour `commit.gpgsign` (verified with
+    `-c commit.gpgsign=true -c gpg.program=/bin/false`), so an operator with
+    signing configured cannot be left waiting on a passphrase prompt that a
+    captured-output subprocess never shows anyone."""
+    # tests/conftest.py's session fixture force-disables commit.gpgsign for the
+    # whole suite via GIT_CONFIG_* env vars, which outrank repo config. Left in
+    # place, this test would assert nothing at all.
+    for var in ("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0",
+                "GIT_CONFIG_KEY_1", "GIT_CONFIG_VALUE_1"):
+        monkeypatch.delenv(var, raising=False)
+
+    _git("config", "commit.gpgsign", "true", cwd=repo)
+    _git("config", "gpg.program", "/bin/false", cwd=repo)
+    _dirty(repo)
+
+    # Control: the signing config really is live on this repo — `git commit`
+    # under it cannot produce a commit object.
+    control = subprocess.run(
+        ["git", "commit", "-am", "would sign"], cwd=repo, capture_output=True,
+        text=True, env=_git_env(),
+    )
+    assert control.returncode != 0 and "sign" in control.stderr
+
+    assert synthesize_commit(ShellRunner(), repo, base_sha=_head(repo))
+
+
+def test_synthesis_from_a_subdirectory_still_captures_the_whole_repo(tmp_path):
+    """A `git_root` child's path is a subdirectory of its parent's worktree, so
+    synthesis may be invoked there. Verified: `git add -A` with no pathspec is
+    whole-tree since git 2.0, and `git write-tree` writes the full index."""
+    mono = tmp_path / "mono"
+    (mono / "pkg").mkdir(parents=True)
+    _git("init", "-q", "-b", "main", ".", cwd=mono)
+    (mono / "root.txt").write_text("root\n")
+    (mono / "pkg" / "c.txt").write_text("child\n")
+    _git("add", "-A", cwd=mono)
+    _git("commit", "-qm", "init", cwd=mono)
+    (mono / "root.txt").write_text("ROOT-EDIT\n")
+    (mono / "pkg" / "c.txt").write_text("CHILD-EDIT\n")
+
+    sha = synthesize_commit(ShellRunner(), mono / "pkg", base_sha=_head(mono))
+
+    # Listed from the repo ROOT: `git ls-tree` filters and strips by the cwd
+    # prefix, so running it inside `pkg/` would show a single `c.txt` and hide
+    # the very regression this test exists for.
+    assert sorted(_tree_files(mono, sha)) == ["pkg/c.txt", "root.txt"]
+    assert _git("show", f"{sha}:root.txt", cwd=mono) == "ROOT-EDIT"
+
+
+def test_a_clean_tree_still_synthesizes_the_same_content(repo):
+    """Not a path the CLI takes (clean repos go to origin), but the function
+    must not depend on there being changes."""
+    base = _head(repo)
+    sha = synthesize_commit(ShellRunner(), repo, base_sha=base)
+    assert _git("rev-parse", f"{sha}^{{tree}}", cwd=repo) == _git(
+        "rev-parse", f"{base}^{{tree}}", cwd=repo
+    )
+
+
+def test_a_git_failure_raises_a_named_error(tmp_path):
+    not_a_repo = tmp_path / "plain"
+    not_a_repo.mkdir()
+    with pytest.raises(RunTransferError) as exc:
+        synthesize_commit(ShellRunner(), not_a_repo, base_sha="HEAD")
+    assert "read-tree" in str(exc.value)

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -1173,6 +1173,14 @@ def test_setup_runs_the_first_time_a_worktree_is_materialized(tmp_path):
     _stream_run(deps)
 
     assert [c["command"] for c in fake.streaming_calls] == ["task setup", "task start"]
+    # WHERE setup ran, not just that it ran: "from the delivered source" is the
+    # whole of ac15. Run in the repo's own checkout instead of the materialized
+    # worktree, setup would derive dependencies for the run host's stale tree
+    # while the operator's exact source executes against them — the
+    # exact-source-with-stale-deps trap this feature exists to close. Every
+    # other setup test here asserts only the command, which cannot see that.
+    worktree = tmp_path / ".worktrees" / "t1" / "api"
+    assert [c["cwd"] for c in fake.streaming_calls] == [worktree, worktree]
 
 
 def test_setup_is_skipped_on_the_next_run(tmp_path):

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -22,7 +22,7 @@ from fastapi.testclient import TestClient
 
 from mship.core import remote_exec
 from mship.core.config import RepoConfig, WorkspaceConfig
-from mship.core.serve import create_app
+from mship.core.serve import ExecBody, create_app
 from mship.core.state import StateManager
 from mship.util.shell import ShellResult
 
@@ -743,3 +743,26 @@ def test_exec_run_and_build_never_emit_artifact_block(tmp_path, monkeypatch):
         r = client.post(f"/exec/{verb}", json={"task": "t1", "repos": ["api"]})
         assert r.status_code == 200
         assert b"__MSHIP_ARTIFACTS__" not in r.content
+
+
+def test_exec_body_accepts_run_ref_repos(tmp_path, monkeypatch):
+    fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    _patch_shell(monkeypatch, fake)
+    client = TestClient(_app(tmp_path))
+    r = client.post(
+        "/exec/run", json={"task": "t1", "repos": ["api"], "run_ref_repos": ["api"]},
+    )
+    assert r.status_code == 200
+    # A 200 alone doesn't prove the field was captured — pydantic silently
+    # drops unrecognized keys by default, so a body without the field would
+    # also 200. Assert directly on the model to catch that.
+    assert ExecBody(task="t1", repos=["api"], run_ref_repos=["api"]).run_ref_repos == ["api"]
+
+
+def test_exec_body_defaults_run_ref_repos_to_empty(tmp_path, monkeypatch):
+    """An older client omits the key; the host must behave exactly as before."""
+    fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    _patch_shell(monkeypatch, fake)
+    r = TestClient(_app(tmp_path)).post("/exec/run", json={"task": "t1", "repos": ["api"]})
+    assert r.status_code == 200
+    assert any("fetch origin feat/t1" in cmd for cmd, _cwd in fake.run_calls)

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -766,3 +766,198 @@ def test_exec_body_defaults_run_ref_repos_to_empty(tmp_path, monkeypatch):
     r = TestClient(_app(tmp_path)).post("/exec/run", json={"task": "t1", "repos": ["api"]})
     assert r.status_code == 200
     assert any("fetch origin feat/t1" in cmd for cmd, _cwd in fake.run_calls)
+
+
+# --- exact copy: materializing from a pushed scratch ref ---------------------
+
+import os
+import subprocess
+
+from mship.util.shell import ShellRunner
+
+_REAL_GIT_ENV = {
+    **os.environ,
+    "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull,
+    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+def _real_git(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True,
+        env=_REAL_GIT_ENV,
+    ).stdout.strip()
+
+
+def _host_repo_with_run_ref(tmp_path: Path) -> tuple[Path, str, str]:
+    """A run-host-shaped repo: a branch tip, plus a scratch ref holding
+    DIFFERENT content, as a push from the operator would have left it.
+
+    Deliberately has NO `origin` remote. That is load-bearing, not incidental:
+    every git command on the run-ref path runs through `_run_checked`, so if a
+    fetch is ever reintroduced there it cannot fail silently — it raises
+    `MaterializeError` and every test using this fixture goes red.
+    """
+    repo = tmp_path / "hostrepo"
+    repo.mkdir()
+    _real_git("init", "-q", "-b", "main", ".", cwd=repo)
+    (repo / "a.txt").write_text("branch tip\n")
+    _real_git("add", "-A", cwd=repo)
+    _real_git("commit", "-qm", "tip", cwd=repo)
+    _real_git("branch", "-f", "feat/t1", "HEAD", cwd=repo)
+    tip = _real_git("rev-parse", "HEAD", cwd=repo)
+
+    (repo / "a.txt").write_text("what the operator is editing\n")
+    (repo / "untracked.txt").write_text("scratch\n")
+    _real_git("add", "-A", cwd=repo)
+    _real_git("commit", "-qm", "synthesized", cwd=repo)
+    scratch = _real_git("rev-parse", "HEAD", cwd=repo)
+    _real_git("update-ref", "refs/mship/run/t1/api", scratch, cwd=repo)
+
+    _real_git("reset", "-q", "--hard", tip, cwd=repo)
+    assert _real_git("remote", cwd=repo) == ""      # nothing to fetch from
+    return repo, tip, scratch
+
+
+def test_materialize_from_a_run_ref_creates_a_detached_worktree(tmp_path):
+    """ac10, first materialization: no fetch at all, and HEAD is left detached
+    because the scratch commit is throwaway state, not a branch."""
+    repo, _tip, scratch = _host_repo_with_run_ref(tmp_path)
+    worktree = tmp_path / "wt" / "api"
+
+    remote_exec.materialize_worktree(
+        ShellRunner(), repo, worktree, "feat/t1",
+        repo_name="api", run_ref="refs/mship/run/t1/api",
+    )
+
+    assert _real_git("rev-parse", "HEAD", cwd=worktree) == scratch
+    assert (worktree / "a.txt").read_text() == "what the operator is editing\n"
+    assert (worktree / "untracked.txt").exists()
+
+
+def test_the_run_ref_worktree_is_detached_not_a_branch(tmp_path):
+    """ac14 on the run host: a branch pointing at a synthesized commit would
+    dress throwaway state up as history."""
+    repo, _tip, _scratch = _host_repo_with_run_ref(tmp_path)
+    worktree = tmp_path / "wt" / "api"
+    remote_exec.materialize_worktree(
+        ShellRunner(), repo, worktree, "feat/t1",
+        repo_name="api", run_ref="refs/mship/run/t1/api",
+    )
+    head_ref = subprocess.run(
+        ["git", "symbolic-ref", "--quiet", "HEAD"], cwd=worktree,
+        capture_output=True, text=True, env=_REAL_GIT_ENV,
+    )
+    assert head_ref.returncode != 0          # detached: no symbolic HEAD
+
+
+def test_a_stale_worktree_lands_on_the_pushed_tree_not_the_branch_tip(tmp_path):
+    """ac10, the decisive case: an existing worktree sitting on the branch, with
+    leftovers from a previous run, ends up at the pushed ref's tree."""
+    repo, tip, scratch = _host_repo_with_run_ref(tmp_path)
+    worktree = tmp_path / "wt" / "api"
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "worktree", "add", "-q", str(worktree), "feat/t1"],
+        cwd=repo, capture_output=True, check=True, env=_REAL_GIT_ENV,
+    )
+    (worktree / "a.txt").write_text("stale local edit\n")
+    (worktree / "leftover.txt").write_text("from the last run\n")
+
+    remote_exec.materialize_worktree(
+        ShellRunner(), repo, worktree, "feat/t1",
+        repo_name="api", run_ref="refs/mship/run/t1/api",
+    )
+
+    assert _real_git("rev-parse", "HEAD", cwd=worktree) == scratch != tip
+    assert (worktree / "a.txt").read_text() == "what the operator is editing\n"
+    assert not (worktree / "leftover.txt").exists()   # cleaned, so the copy is exact
+    assert _real_git("status", "--porcelain", cwd=worktree) == ""
+
+
+def test_re_materializing_never_moves_the_task_branch(tmp_path):
+    """ac14 on the re-materialize path, which is where it is easiest to lose:
+    checking the BRANCH out before the reset would drag `feat/t1` — a real ref,
+    shared with the run host — onto the synthesized commit."""
+    repo, tip, scratch = _host_repo_with_run_ref(tmp_path)
+    worktree = tmp_path / "wt" / "api"
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "worktree", "add", "-q", str(worktree), "feat/t1"],
+        cwd=repo, capture_output=True, check=True, env=_REAL_GIT_ENV,
+    )
+
+    remote_exec.materialize_worktree(
+        ShellRunner(), repo, worktree, "feat/t1",
+        repo_name="api", run_ref="refs/mship/run/t1/api",
+    )
+
+    assert _real_git("rev-parse", "feat/t1", cwd=repo) == tip != scratch
+    assert _real_git("rev-parse", "HEAD", cwd=repo) == tip
+    head_ref = subprocess.run(
+        ["git", "symbolic-ref", "--quiet", "HEAD"], cwd=worktree,
+        capture_output=True, text=True, env=_REAL_GIT_ENV,
+    )
+    assert head_ref.returncode != 0          # detached, so nothing to drag
+
+
+def test_materializing_leaves_the_run_hosts_own_checkout_alone(tmp_path):
+    """The run host's repository is not a scratch pad: materializing must not
+    move its HEAD, its branches, or the scratch ref, nor dirty its work tree."""
+    repo, tip, scratch = _host_repo_with_run_ref(tmp_path)
+    branches_before = _real_git("branch", "--format=%(refname) %(objectname)", cwd=repo)
+
+    remote_exec.materialize_worktree(
+        ShellRunner(), repo, tmp_path / "wt" / "api", "feat/t1",
+        repo_name="api", run_ref="refs/mship/run/t1/api",
+    )
+
+    assert _real_git("rev-parse", "HEAD", cwd=repo) == tip
+    assert _real_git("rev-parse", "feat/t1", cwd=repo) == tip
+    assert _real_git("rev-parse", "refs/mship/run/t1/api", cwd=repo) == scratch
+    assert _real_git("status", "--porcelain", cwd=repo) == ""
+    # ac14: no branch was created pointing at the synthesized commit.
+    assert _real_git("branch", "--format=%(refname) %(objectname)", cwd=repo) == branches_before
+
+
+def test_materializing_from_a_run_ref_issues_no_fetch(tmp_path):
+    """ac10 as a command-level invariant: origin is not consulted, at all."""
+    fake = _FakeShellRunner()
+    remote_exec.materialize_worktree(
+        fake, tmp_path / "api", tmp_path / "wt" / "api", "feat/t1",
+        repo_name="api", run_ref="refs/mship/run/t1/api",
+    )
+    assert not any("fetch" in cmd for cmd, _cwd in fake.run_calls)
+    assert not any("origin" in cmd for cmd, _cwd in fake.run_calls)
+
+
+def test_re_materializing_an_existing_worktree_issues_no_fetch(tmp_path):
+    """The same invariant on the OTHER branch of the function — the path a
+    second remote run takes, where a worktree is already there."""
+    fake = _FakeShellRunner()
+    worktree = tmp_path / "wt" / "api"
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text("gitdir: elsewhere\n")
+
+    remote_exec.materialize_worktree(
+        fake, tmp_path / "api", worktree, "feat/t1",
+        repo_name="api", run_ref="refs/mship/run/t1/api",
+    )
+
+    assert fake.run_calls                            # it did do something
+    assert not any("fetch" in cmd for cmd, _cwd in fake.run_calls)
+    assert not any("origin" in cmd for cmd, _cwd in fake.run_calls)
+
+
+def test_without_a_run_ref_the_branch_path_is_unchanged(tmp_path):
+    """ac9: nothing about today's behaviour moves."""
+    fake = _FakeShellRunner()
+    worktree = tmp_path / "wt" / "api"
+    remote_exec.materialize_worktree(
+        fake, tmp_path / "api", worktree, "feat/t1", repo_name="api",
+    )
+    assert [cmd for cmd, _cwd in fake.run_calls] == [
+        "git fetch origin feat/t1",
+        f"git worktree add -B feat/t1 {worktree} origin/feat/t1",
+    ]

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -1125,3 +1125,223 @@ def test_exec_endpoint_forwards_run_ref_repos_to_the_run(tmp_path, monkeypatch):
     assert any("refs/mship/run/t1/api" in c for c in commands)
     assert not any("fetch" in c for c in commands)
     assert not any("origin" in c for c in commands)
+
+
+# --- setup on the run host, keyed --------------------------------------------
+
+def _config_with_setup(tmp_path: Path, *, setup_inputs=None) -> WorkspaceConfig:
+    """A repo whose MATERIALIZED WORKTREE really has a Taskfile declaring
+    `setup`. The Taskfile has to exist on disk because `taskfile_has_target`
+    reads it — the fake shell cannot answer for it."""
+    repo_dir = tmp_path / "api"
+    repo_dir.mkdir(exist_ok=True)
+    worktree = tmp_path / ".worktrees" / "t1" / "api"
+    worktree.mkdir(parents=True, exist_ok=True)
+    (worktree / "Taskfile.yml").write_text(
+        "version: '3'\ntasks:\n  setup:\n    cmds: [echo setup]\n"
+        "  start:\n    cmds: [echo run]\n"
+    )
+    (worktree / "package.json").write_text('{"deps": 1}\n')
+    return WorkspaceConfig(
+        workspace="t",
+        repos={
+            "api": RepoConfig(
+                path=repo_dir, type="service",
+                tasks={"run": "start"},
+                setup_inputs=setup_inputs or [],
+            ),
+        },
+    )
+
+
+def _stream_run(deps, **kw) -> list[str]:
+    return [
+        l.decode() for l in remote_exec.run_verb_stream(
+            "run", "t1", ["api"], None, deps=deps, nonce=_TEST_NONCE, **kw
+        )
+    ]
+
+
+def test_setup_runs_the_first_time_a_worktree_is_materialized(tmp_path):
+    """ac15: a fresh host builds its dependencies from the delivered source
+    instead of failing on missing ones."""
+    fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    deps = remote_exec.RemoteExecDeps(
+        config=_config_with_setup(tmp_path), shell=fake, workspace_root=tmp_path,
+    )
+
+    _stream_run(deps)
+
+    assert [c["command"] for c in fake.streaming_calls] == ["task setup", "task start"]
+
+
+def test_setup_is_skipped_on_the_next_run(tmp_path):
+    """ac16: a source-only iteration pays no setup cost."""
+    config = _config_with_setup(tmp_path)
+    first = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    _stream_run(remote_exec.RemoteExecDeps(
+        config=config, shell=first, workspace_root=tmp_path))
+
+    second = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    _stream_run(remote_exec.RemoteExecDeps(
+        config=config, shell=second, workspace_root=tmp_path))
+
+    assert [c["command"] for c in second.streaming_calls] == ["task start"]
+
+
+def test_setup_re_runs_when_a_declared_input_changes(tmp_path):
+    """ac16: a dependency change pays once."""
+    config = _config_with_setup(tmp_path, setup_inputs=["package.json"])
+    first = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    _stream_run(remote_exec.RemoteExecDeps(
+        config=config, shell=first, workspace_root=tmp_path))
+
+    (tmp_path / ".worktrees" / "t1" / "api" / "package.json").write_text('{"deps": 2}\n')
+    second = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    _stream_run(remote_exec.RemoteExecDeps(
+        config=config, shell=second, workspace_root=tmp_path))
+
+    assert [c["command"] for c in second.streaming_calls] == ["task setup", "task start"]
+
+
+def test_declaring_no_inputs_means_setup_runs_once_only(tmp_path):
+    """ac17: nothing to invalidate against, even when a manifest changes."""
+    config = _config_with_setup(tmp_path)
+    first = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    _stream_run(remote_exec.RemoteExecDeps(
+        config=config, shell=first, workspace_root=tmp_path))
+
+    (tmp_path / ".worktrees" / "t1" / "api" / "package.json").write_text('{"deps": 9}\n')
+    second = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    _stream_run(remote_exec.RemoteExecDeps(
+        config=config, shell=second, workspace_root=tmp_path))
+
+    assert [c["command"] for c in second.streaming_calls] == ["task start"]
+
+
+def test_a_failing_setup_fails_the_run_with_its_own_output(tmp_path):
+    """ac18: not a downstream error that does not name the real cause."""
+    fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["npm ERR! ENOENT\n"], returncode=3),
+    )
+    deps = remote_exec.RemoteExecDeps(
+        config=_config_with_setup(tmp_path), shell=fake, workspace_root=tmp_path,
+    )
+
+    lines = _stream_run(deps)
+
+    assert "npm ERR! ENOENT\n" in lines                       # setup's own output
+    assert any(l.startswith("error:") and "setup" in l and "api" in l for l in lines)
+    assert lines[-1] == f"{remote_exec.EXIT_MARKER}:{_TEST_NONCE} 3\n"
+    assert [c["command"] for c in fake.streaming_calls] == ["task setup"]  # run never started
+
+
+def test_a_failed_setup_is_not_recorded_as_done(tmp_path):
+    """Caching a failure would skip the retry."""
+    config = _config_with_setup(tmp_path)
+    failing = _FakeShellRunner(streaming_proc=_FakeProc(returncode=1))
+    _stream_run(remote_exec.RemoteExecDeps(
+        config=config, shell=failing, workspace_root=tmp_path))
+
+    second = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    _stream_run(remote_exec.RemoteExecDeps(
+        config=config, shell=second, workspace_root=tmp_path))
+
+    assert [c["command"] for c in second.streaming_calls][0] == "task setup"
+
+
+def test_a_repo_with_no_setup_target_is_not_failed_over_it(tmp_path):
+    """ac15's second half: `task setup` in a repo that never declared one exits
+    non-zero, and that must not turn every remote run into a failure."""
+    config = _config_with_setup(tmp_path)
+    (tmp_path / ".worktrees" / "t1" / "api" / "Taskfile.yml").write_text(
+        "version: '3'\ntasks:\n  start:\n    cmds: [echo run]\n"
+    )
+    fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+
+    _stream_run(remote_exec.RemoteExecDeps(
+        config=config, shell=fake, workspace_root=tmp_path))
+
+    assert [c["command"] for c in fake.streaming_calls] == ["task start"]
+
+
+def test_a_repo_declaring_setup_not_applicable_skips_it(tmp_path):
+    config = _config_with_setup(tmp_path)
+    config.repos["api"].not_applicable = ["setup"]
+    fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+
+    _stream_run(remote_exec.RemoteExecDeps(
+        config=config, shell=fake, workspace_root=tmp_path))
+
+    assert [c["command"] for c in fake.streaming_calls] == ["task start"]
+
+
+def test_setup_honours_an_aliased_target_name(tmp_path):
+    """A repo may spell its setup target something else via `tasks:`."""
+    config = _config_with_setup(tmp_path)
+    config.repos["api"].tasks = {"run": "start", "setup": "bootstrap"}
+    (tmp_path / ".worktrees" / "t1" / "api" / "Taskfile.yml").write_text(
+        "version: '3'\ntasks:\n  bootstrap:\n    cmds: [echo boot]\n"
+        "  start:\n    cmds: [echo run]\n"
+    )
+    fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+
+    _stream_run(remote_exec.RemoteExecDeps(
+        config=config, shell=fake, workspace_root=tmp_path))
+
+    assert [c["command"] for c in fake.streaming_calls] == ["task bootstrap", "task start"]
+
+
+class _MaterializingShellRunner(_FakeShellRunner):
+    """Like `_FakeShellRunner`, but `.run()` actually creates the worktree
+    directory + a `setup`-declaring Taskfile as a side effect of the real
+    `git worktree add` command — standing in for what a real git checkout
+    does to disk.
+
+    `_config_with_setup`'s fixture pre-creates the Taskfile at the
+    destination path regardless of call order, so a test built on it can't
+    tell "setup ran before materialization" from "setup ran after" — the
+    file is there either way. This fake makes the file's existence
+    CONDITIONAL on materialization having actually run, which is the only
+    way to pin that ordering.
+    """
+
+    def run(self, command, cwd, env=None):
+        result = super().run(command, cwd, env=env)
+        if command.startswith("git worktree add"):
+            # `git worktree add -B <branch> <worktree_path> origin/<branch>`
+            worktree_path = Path(command.split()[5])
+            worktree_path.mkdir(parents=True, exist_ok=True)
+            (worktree_path / "Taskfile.yml").write_text(
+                "version: '3'\ntasks:\n  setup:\n    cmds: [echo setup]\n"
+                "  start:\n    cmds: [echo run]\n"
+            )
+        return result
+
+
+def test_setup_runs_only_after_materialization_creates_the_worktree(tmp_path):
+    """Pins the ordering the plan calls out explicitly: setup must run AFTER
+    the worktree is materialized (the files don't exist before that), never
+    before. A shell fake that only produces the Taskfile as a side effect of
+    the real `git worktree add` command proves it — unlike
+    `_config_with_setup`'s pre-created fixture, this one distinguishes "ran
+    before materialize" (no Taskfile yet, so setup is skipped as
+    not-applicable and only `task start` streams) from "ran after" (Taskfile
+    exists, `task setup` streams first)."""
+    repo_dir = tmp_path / "api"
+    repo_dir.mkdir(exist_ok=True)
+    config = WorkspaceConfig(
+        workspace="t",
+        repos={
+            "api": RepoConfig(
+                path=repo_dir, type="service",
+                tasks={"run": "start"},
+            ),
+        },
+    )
+    fake = _MaterializingShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    deps = remote_exec.RemoteExecDeps(config=config, shell=fake, workspace_root=tmp_path)
+
+    _stream_run(deps)
+
+    assert [c["command"] for c in fake.streaming_calls] == ["task setup", "task start"]

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -961,3 +961,167 @@ def test_without_a_run_ref_the_branch_path_is_unchanged(tmp_path):
         "git fetch origin feat/t1",
         f"git worktree add -B feat/t1 {worktree} origin/feat/t1",
     ]
+
+
+# --- exact copy: routing run_ref_repos through the streaming run -------------
+
+
+def test_run_verb_stream_uses_the_scratch_ref_for_named_repos(tmp_path):
+    fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path), shell=fake, workspace_root=tmp_path,
+    )
+
+    list(remote_exec.run_verb_stream(
+        "run", "t1", ["api"], None, deps=deps, nonce=_TEST_NONCE, run_ref_repos=["api"],
+    ))
+
+    commands = [cmd for cmd, _cwd in fake.run_calls]
+    assert any("refs/mship/run/t1/api" in c for c in commands)
+    # ac10: no fetch, not even the MOS-203 base-freshness probe, which exists
+    # only to keep this host's view of ORIGIN current.
+    assert not any("fetch" in c for c in commands)
+
+
+def test_a_repo_not_named_still_comes_from_origin(tmp_path):
+    """The mixed case: one repo transferred, another clean."""
+    fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    deps = remote_exec.RemoteExecDeps(
+        config=_config_with_child(tmp_path), shell=fake, workspace_root=tmp_path,
+    )
+
+    list(remote_exec.run_verb_stream(
+        "run", "t1", ["app"], None, deps=deps, nonce=_TEST_NONCE, run_ref_repos=[],
+    ))
+
+    commands = [cmd for cmd, _cwd in fake.run_calls]
+    assert any("fetch origin feat/t1" in c for c in commands)
+    assert not any("refs/mship/run" in c for c in commands)
+
+
+def test_a_git_root_child_is_materialized_from_its_parents_scratch_ref(tmp_path):
+    """ac7 on the run host: one git repository, one ref. The client sends the
+    PARENT's name even when only the child was requested."""
+    fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    deps = remote_exec.RemoteExecDeps(
+        config=_config_with_child(tmp_path), shell=fake, workspace_root=tmp_path,
+    )
+
+    list(remote_exec.run_verb_stream(
+        "run", "t1", ["server"], None, deps=deps, nonce=_TEST_NONCE, run_ref_repos=["app"],
+    ))
+
+    commands = [cmd for cmd, _cwd in fake.run_calls]
+    assert any("refs/mship/run/t1/app" in c for c in commands)
+
+
+def test_a_task_name_that_cannot_form_a_ref_fails_cleanly(tmp_path):
+    """The ref reaches a shell here, so a name that cannot form one is refused
+    BEFORE anything runs — as stream DATA (an error line + a non-zero exit
+    sentinel), never a raised exception mid-generator, matching how the
+    unknown-repo guard already behaves. `/exec` accepts `/` in a task name;
+    `run_ref` does not."""
+    fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path), shell=fake, workspace_root=tmp_path,
+    )
+
+    lines = [
+        l.decode() for l in remote_exec.run_verb_stream(
+            "run", "a/b", ["api"], None, deps=deps, nonce=_TEST_NONCE,
+            run_ref_repos=["api"],
+        )
+    ]
+
+    assert lines[-1].startswith(f"{remote_exec.EXIT_MARKER}:{_TEST_NONCE} ")
+    assert int(lines[-1].split(" ", 1)[1].strip()) != 0
+    assert any("run ref" in l for l in lines[:-1])
+    assert fake.streaming_calls == []       # the task never started
+    assert fake.run_calls == []             # nor did any git command
+
+
+def test_the_base_freshness_probe_is_skipped_for_a_run_ref_repo(tmp_path):
+    """The hole the plan's own no-fetch assertion cannot see: `_config()` has no
+    `base_branch`, so `check_base_freshness` short-circuits and issues no fetch
+    even when it IS called. With a base branch configured it fetches, and calling
+    it unconditionally reopens exactly what ac10 closes — Task 6 lets a dirty
+    repo skip the BEHIND_ORIGIN preflight check ONLY because this path never
+    consults origin. So: no fetch, and no origin probe either."""
+    fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path, base_branch="main"), shell=fake, workspace_root=tmp_path,
+    )
+
+    list(remote_exec.run_verb_stream(
+        "run", "t1", ["api"], None, deps=deps, nonce=_TEST_NONCE, run_ref_repos=["api"],
+    ))
+
+    commands = [cmd for cmd, _cwd in fake.run_calls]
+    assert any("refs/mship/run/t1/api" in c for c in commands)
+    assert not any("fetch" in c for c in commands)
+    assert not any("origin" in c for c in commands)
+
+
+def _config_two_repos(tmp_path: Path) -> WorkspaceConfig:
+    """Two independent top-level repos, both with a base branch — the mixed
+    request's shape: one repo the operator transferred, one still from origin."""
+    repos = {}
+    for name in ("api", "web"):
+        repo_dir = tmp_path / name
+        repo_dir.mkdir(exist_ok=True)
+        repos[name] = RepoConfig(
+            path=repo_dir, type="service", base_branch="main",
+            tasks={"run": "start", "capture": "capture", "build": "build"},
+        )
+    return WorkspaceConfig(workspace="t", repos=repos)
+
+
+def test_a_mixed_run_routes_each_repo_by_its_own_source(tmp_path):
+    """One request, both sources. Each repo's git commands are partitioned by
+    the repo they ran in, so neither repo's routing can be inferred from the
+    other's — the scratch repo must see no origin traffic at all, and the clean
+    repo must still get the full branch path including the MOS-203 probe."""
+    fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
+    deps = remote_exec.RemoteExecDeps(
+        config=_config_two_repos(tmp_path), shell=fake, workspace_root=tmp_path,
+    )
+
+    list(remote_exec.run_verb_stream(
+        "run", "t1", ["api", "web"], None, deps=deps, nonce=_TEST_NONCE,
+        run_ref_repos=["api"],
+    ))
+
+    in_api = [cmd for cmd, cwd in fake.run_calls if cwd == tmp_path / "api"]
+    in_web = [cmd for cmd, cwd in fake.run_calls if cwd == tmp_path / "web"]
+
+    assert any("refs/mship/run/t1/api" in c for c in in_api)
+    assert not any("fetch" in c for c in in_api)
+    assert not any("origin" in c for c in in_api)
+
+    assert "git fetch origin main" in in_web           # MOS-203 probe, still there
+    assert "git fetch origin feat/t1" in in_web        # branch path, unchanged
+    assert not any("refs/mship/run" in c for c in in_web)
+
+    # Both tasks ran, each in its own worktree.
+    assert [c["cwd"] for c in fake.streaming_calls] == [
+        tmp_path / ".worktrees" / "t1" / "api",
+        tmp_path / ".worktrees" / "t1" / "web",
+    ]
+
+
+def test_exec_endpoint_forwards_run_ref_repos_to_the_run(tmp_path, monkeypatch):
+    """End to end over HTTP: the field `ExecBody` already accepts has to reach
+    `run_verb_stream`, or the whole transfer is pushed and then ignored."""
+    fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"], returncode=0))
+    _patch_shell(monkeypatch, fake)
+    client = TestClient(_app(tmp_path, config=_config(tmp_path, base_branch="main")))
+
+    r = client.post(
+        "/exec/run", json={"task": "t1", "repos": ["api"], "run_ref_repos": ["api"]},
+    )
+
+    assert r.status_code == 200
+    commands = [c for c, _cwd in fake.run_calls]
+    assert any("refs/mship/run/t1/api" in c for c in commands)
+    assert not any("fetch" in c for c in commands)
+    assert not any("origin" in c for c in commands)

--- a/tests/util/test_taskfile.py
+++ b/tests/util/test_taskfile.py
@@ -1,0 +1,48 @@
+"""`taskfile_has_target` — moved out of cli/exec.py so core can use it too."""
+from mship.util.taskfile import taskfile_has_target
+
+_WITH_SETUP = "version: '3'\ntasks:\n  setup:\n    cmds: [echo hi]\n"
+
+
+def _taskfile(tmp_path, name="Taskfile.yml", body=_WITH_SETUP):
+    (tmp_path / name).write_text(body)
+    return tmp_path
+
+
+def test_finds_a_declared_target(tmp_path):
+    assert taskfile_has_target(_taskfile(tmp_path), "setup")
+
+
+def test_missing_target_is_false(tmp_path):
+    assert not taskfile_has_target(_taskfile(tmp_path), "lint")
+
+
+def test_the_yaml_spelling_is_honoured(tmp_path):
+    assert taskfile_has_target(_taskfile(tmp_path, name="Taskfile.yaml"), "setup")
+
+
+def test_no_taskfile_is_false(tmp_path):
+    assert not taskfile_has_target(tmp_path, "setup")
+
+
+def test_an_unparseable_taskfile_is_false(tmp_path):
+    assert not taskfile_has_target(_taskfile(tmp_path, body="{{{not yaml"), "setup")
+
+
+def test_a_taskfile_without_a_tasks_map_is_false(tmp_path):
+    assert not taskfile_has_target(_taskfile(tmp_path, body="version: '3'\n"), "setup")
+
+
+def test_a_taskfile_whose_tasks_key_is_not_a_map_is_false(tmp_path):
+    assert not taskfile_has_target(
+        _taskfile(tmp_path, body="version: '3'\ntasks: [setup]\n"), "setup"
+    )
+
+
+def test_a_taskfile_whose_top_level_is_not_a_map_is_false(tmp_path):
+    # Valid YAML (no parse error), but a bare list rather than a mapping —
+    # distinct from the "tasks key is not a map" case above, which still has
+    # a top-level dict.
+    assert not taskfile_has_target(
+        _taskfile(tmp_path, body="- setup\n- lint\n"), "setup"
+    )


### PR DESCRIPTION
exact-copy remote runs via a scratch ref
---

## Acceptance criteria

- [x] `ac1` With a dirty working tree, `mship run --remote` executes the operator's uncommitted content: a test asserts the tree the run host is asked to materialize contains the modified file exactly as it is on disk, and a second test asserts a file that is BOTH tracked and gitignored survives — `git add -A` into an empty index silently drops those, so the temporary index must be seeded from HEAD first. — test:test-runs/4.mothership
- [x] `ac2` Synthesizing the commit leaves local state untouched — HEAD, the current branch, the index, and `git status` output are identical before and after, and no commit appears in the branch's history or in `git branch` — verified against a real git repo rather than a mocked shell — test:test-runs/4.mothership
- [x] `ac3` On the dirty path nothing is pushed to origin: a test asserts the operator's origin remote receives no push, and the synthesized objects exist only locally and on the run host — test:test-runs/4.mothership
- [x] `ac4` The client pushes the synthesized commit to the run host's git receive endpoint with the run-host bearer supplied out of band — never in the remote URL, never written to git config, and never on the command line, since process arguments are world-readable via /proc. A test asserts the token appears in none of those three places. — test:test-runs/4.mothership
- [x] `ac5` The receive endpoint refuses a push onto any ref outside `refs/mship/run/*`, and refuses any repo not configured in the workspace, with both refusals covered by tests — test:test-runs/4.mothership
- [x] `ac6` The receive endpoint requires the run-host bearer and rejects an unauthenticated push — test:test-runs/4.mothership
- [x] `ac7` The scratch ref is per task AND per GIT repository (`refs/mship/run/<task>/<repo>`), keyed on the top-level repo when a monorepo child declares a `git_root` — such a child has no git directory of its own, so parent and child dedupe to one push, and the receive endpoint refuses a child name and names the parent instead. — test:test-runs/4.mothership
- [x] `ac8` Each run force-updates its own scratch ref, and `mship close` deletes the task's scratch refs from the run host so they do not accumulate — test:test-runs/4.mothership, commit:00d418b6770469d943230d013665a38505b04739
- [x] `ac9` A working tree with no `git status --porcelain` output takes the existing path: the branch is pushed to origin and no scratch ref is created. Any porcelain output at all counts as dirty, including untracked-only — otherwise untracked files would never travel, contradicting the criterion that they do. — test:test-runs/4.mothership
- [x] `ac10` The run host materializes the pushed ref by resetting to it without fetching from origin, with a test that a stale existing worktree ends up at the pushed ref's tree rather than the branch tip — test:test-runs/4.mothership
- [x] `ac11` Untracked files are included (they are part of what the operator sees, and they travel only to the operator's own run host), while gitignored files are not, and a test pins both — test:test-runs/4.mothership
- [x] `ac12` A repo in a conflicted or mid-rebase state is refused with an actionable message rather than shipping conflict markers to the run host — test:test-runs/4.mothership
- [x] `ac13` The CLI names the synthesized revision as a throwaway run ref rather than as a commit the operator made, so nobody tries to build on it. The synthesis is client-side, so this is local output, not something the run host reports. — test:test-runs/4.mothership
- [x] `ac14` Nothing reaches a PR unreviewed: `finish` still requires real commits, the scratch namespace exists only on run hosts, and no code path merges or branches from `refs/mship/` — test:test-runs/4.mothership, commit:00d418b6770469d943230d013665a38505b04739, commit:05cf141395f436cf0e257c0afb208fecee42abe6
- [x] `ac15` `task setup` runs on the run host the first time a worktree is materialized for a task, so a fresh host builds its dependencies from the delivered source instead of failing on missing ones — and a repo that defines no setup target is skipped rather than failed, since `task setup` exits non-zero when the target is undefined. — test:test-runs/4.mothership, commit:00d418b6770469d943230d013665a38505b04739
- [x] `ac16` Setup re-runs when the repo's declared `setup_inputs` differ from what that run host last set up at, and is skipped when they are unchanged, so a source-only iteration pays no setup cost — test:test-runs/4.mothership
- [x] `ac17` A repo that declares no `setup_inputs` runs setup on first materialization only, and the documentation states that declaring them is what enables re-run-on-change — test:test-runs/4.mothership
- [x] `ac18` A failing `task setup` on the run host fails the run with setup's own output surfaced, rather than permitting a downstream error that does not name the real cause — test:test-runs/4.mothership
- [x] `ac19` The docs state plainly what does and does not travel: the source is exact, uncommitted work goes only to the operator's own run host and never to origin, dependencies are derived there by setup, and secrets, platform state, and `symlink_dirs`/`bind_files` still do not travel — test:test-runs/4.mothership
- [x] `ac20` `mship test --repos mothership` passes; the git plumbing is exercised against real temporary repositories, not a mocked shell, because the whole risk here is in git's actual behaviour — test:test-runs/4.mothership
---

## Verification

Full suite green (`mship test` iteration 4: no new failures, no regressions). 21 tasks, each red-before-green with a mutation ledger.

**What is not verified:** there is no run-host configured in this workspace (`mship run-host list` → none), so the end-to-end path — synthesize on a laptop, push to a real second machine, materialize and run there — has **not** been exercised against real hardware. Every layer is covered by tests including real-git integration tests, but the assembled path across two machines is unproven. That is the first thing to try after merge.

## Review findings

A fresh-eyes review ran 55 source mutations against 506 tests. 51 killed, 2 genuine gaps, both fixed in `00d418b`:

- **ac15 was unpinned.** Moving `task setup`'s `cwd` off the materialized worktree left all 506 tests green — every setup test asserted the command string, never where it ran. This is the exact failure the feature exists to prevent: setup resolving dependencies for the run host's stale checkout while the operator's source runs against them.
- **The ac14 invariant scan was escapable two ways.** A `git merge <run ref>` split across two statements matched neither half, and the module regex only ever opened 3 of the 6 modules that touch the namespace — `remote_exec.py`, `cli/exec.py` and `cli/worktree.py` reach it through helpers and were never parsed.

## Known gaps, tracked separately

- `mship capture --remote` still bypasses preflight entirely (#422) — it calls `exec_remote` with no `run_ref_repos` wiring, so a remote capture runs origin's code, not yours.
- `_TASK_NAME_RE` in `serve.py` permits `.` and `/`, letting an authenticated caller's task name traverse out of `.worktrees` via `_hub_dir`. Pre-existing on `main`, unchanged here, filed separately.
## Greptile round

Both findings were in `remote_setup.py` and both were real; fixed in `abb9981` and `24b3ee6`.

1. **Colliding cache filenames.** `_safe` maps every unsafe character to `-`, so `api.v2` and `api-v2` shared a file; separately, `_` survives sanitizing, so the `__` join let the boundary move (`a__b`/`c` vs `a`/`b__c`). Greptile scored this as spurious re-runs. The reachable consequence is worse — two repos sharing a file whose digests agree, which they do whenever both declare the same patterns and neither has the files yet, let the second read the first's record, match, and **skip the setup that installs its dependencies**. Identity now comes from a digest of the exact pair, NUL-separated so the boundary cannot be forged.
2. **Unbounded filename length.** `_TASK_NAME_RE` bounds the charset of a task arriving over the wire but not its length, so a name could be short enough for `.worktrees/<task>` yet overflow `NAME_MAX` once the repo and digest landed beside it — and `record_setup` runs only *after* setup exits zero, so the `OSError` discarded work already done. The readable half is now capped; identity is unaffected because the digest is taken over the untruncated pair.

Its third point — concurrent `/exec` calls both passing the cache check and running setup in one worktree — is real but **pre-existing and broader**: nothing serializes the run-host exec path at all, and `3037a76` already races over `git reset --hard` in the same shared directory. Filed as #435 rather than widened into this PR.