### PR TITLE
fix(relay): restore sish idle-connection reaping to stop the dead-tunnel goroutine leak

### DIFF
--- a/docker/relay/docker-compose.yml
+++ b/docker/relay/docker-compose.yml
@@ -29,7 +29,14 @@ services:
       - --private-keys-directory=/keys
       - --bind-random-subdomains=false      # honor the requested subdomain
       - --bind-random-ports=false
-      - --idle-connection=false
+      # Leave idle-connection at sish's default (true): it is the only thing that
+      # wraps a proxied stream in IdleTimeoutConn, so disabling it means a tunnel
+      # peer that vanishes without a clean close (cell handoff, NAT eviction,
+      # suspend) is never reaped — its route stays registered and its goroutines
+      # leak. 120s sits above the client's keepalive budget
+      # (ServerAliveInterval=30 x ServerAliveCountMax=3, see relay/tunnel.py), so a
+      # live-but-quiet tunnel refreshes the deadline long before it expires.
+      - --idle-connection-timeout=120s
 
   caddy:
     image: caddy:2

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -98,6 +98,33 @@ The compose file (`docker/relay/docker-compose.yml`) starts two services:
 - **sish** — `--https=false`, HTTP on internal `127.0.0.1:8080`, SSH on `:2222`. Mounts `./pubkeys` (read-only key allowlist) and `./keys` (sish host key).
 - **caddy** — `network_mode: host` so it can bind `:80`/`:443` directly and reach the sish and enroll-server loopback addresses. Mounts `./Caddyfile`, `./caddy-data`, and `./caddy-config`.
 
+### Idle-connection reaping
+
+sish's `--idle-connection` (default `true`) is the only switch that wraps a proxied
+stream in `IdleTimeoutConn`, which re-arms a deadline on every read and write. With it
+disabled, a stream between an inbound HTTP connection and its SSH channel has **no
+deadline in either direction** — so a tunnel peer that disappears without a clean close
+(cell handoff, NAT eviction, laptop suspend, i.e. the normal life of a phone tunnel) is
+never detected. The connection is never torn down, its subdomain route stays registered,
+and sish keeps queueing failed-channel messages onto an unbuffered channel nothing
+drains: goroutines accumulate in `chan send` until the relay degrades. Stale routes from
+tunnels that "should" be gone are the visible symptom — a new tunnel for the same
+subdomain collides with a dead one.
+
+So leave the reaper on and tune the timeout instead:
+
+```yaml
+- --idle-connection-timeout=120s
+```
+
+**The timeout must stay above the client's keepalive budget.** `mship` opens its tunnel
+with `ServerAliveInterval=30` and `ServerAliveCountMax=3` (see
+`src/mship/core/relay/tunnel.py`), so a live-but-quiet tunnel produces traffic every 30s
+and refreshes the deadline long before 120s elapses. Drop the timeout near or below 30s
+and you will start disconnecting healthy idle tunnels; raise the client's interval
+without raising this timeout and you get the same. A third-party client that sends no
+keepalives at all needs either its own keepalive or a longer timeout here.
+
 The `Caddyfile` (`docker/relay/Caddyfile`) wires:
 
 - `enroll.{$RELAY_DOMAIN}` → `127.0.0.1:47180` (enroll-server; only `POST /enroll` and `GET /status/*` are forwarded — everything else returns 404).
@@ -274,6 +301,8 @@ Data directories (`keys/`, `pubkeys/`, `caddy-data/`, `caddy-config/`) are mount
 ## Troubleshooting
 
 **Tunnel connection refused** — confirm port 2222 is open (`nc -zv relay.example.com 2222`) and the client public key is in `docker/relay/pubkeys/`.
+
+**A subdomain stops receiving after a reconnect, or the relay slows down over weeks of uptime** — a dead tunnel was never reaped, so its route is still registered and a new tunnel for the same subdomain collides with it. Check that sish is running with idle-connection reaping on (`docker compose -f docker/relay/docker-compose.yml exec sish ps` or inspect the container's command line); see [Idle-connection reaping](#idle-connection-reaping). A relay left with `--idle-connection=false` leaks a goroutine per inbound request to every dead tunnel.
 
 **Certificate errors** — verify the wildcard DNS record resolves to the relay IP, and that ports 80 and 443 are open. Caddy writes ACME state to `docker/relay/caddy-data/`; check `docker compose logs caddy` for ACME errors.
 


### PR DESCRIPTION
## Summary

The relay has run with `--idle-connection=false` since #187, carried from the original plan doc with no recorded rationale. The flag name reads like "don't disconnect idle tunnels," but that isn't what it guards: in sish it is the sole gate on wrapping a proxied stream in `IdleTimeoutConn` (`utils/conn.go:229`), which re-arms a deadline on every read and write. Disabled, the stream between an inbound HTTP connection and its SSH channel has **no deadline in either direction**, so a tunnel peer that vanishes without a clean close — cell handoff, NAT eviction, laptop suspend, i.e. the normal life of a phone tunnel — is never detected, never cleaned up, and its subdomain route stays registered.

The cost is an unbounded goroutine leak. A dump from a relay up 28 days:

- 137 goroutines, **60 parked in `chan send`**, top frames `handleRemoteForward.func7.1` (61) → `SSHConnection.SendMessage` (59)
- goroutine ID 14,791,699 — heavy churn over the uptime
- the one `running` goroutine was the keepalive (`handleConn.func4` → `mux.SendRequest` → `selectnbrecv`) spinning against the same dead mux

Each inbound request for a stale route fails `OpenChannel("forwarded-tcpip")` and calls `sshConn.SendMessage(err.Error(), true)` (`sshmuxer/requests.go:439`). `Messages` is unbuffered (`make(chan string)`, `sshmuxer/sshmuxer.go:282`) and the blocking form is a naked `s.Messages <- message` with no select, no `Close` case, no timeout (`utils/conn.go:46-50`) — so every one parks forever. This is also the likely source of the recurring orphaned-tunnel / duplicated-subdomain symptom: routes whose cleanup never runs.

**The change:** take sish's `true` default back and set `--idle-connection-timeout=120s`. That's safe because the client already sends keepalives — `ServerAliveInterval=30` × `ServerAliveCountMax=3` in `src/mship/core/relay/tunnel.py` — so a live-but-quiet tunnel refreshes the deadline every 30s and never trips a 120s timer, while a dead one is reaped in ~2 minutes. The docs now state that coupling explicitly, because the timeout is only correct *relative to* the client's keepalive budget.

## Test plan

This is a compose-flag and docs change; there is no Python in the diff and the repo has no test for the relay compose file (asserting on a YAML literal would test the file against itself). Verification is operational:

- [x] `docker/relay/docker-compose.yml` parses and yields the expected sish argv, confirmed with `yaml.safe_load` — `--idle-connection=false` gone, `--idle-connection-timeout=120s` present
- [ ] **Deploy pending** — recreate the sish container on the relay host and confirm the new flags on the *running* container. Merging this does not redeploy anything.
- [ ] **Post-deploy** — establish a tunnel, fetch the subdomain URL, kill the peer uncleanly, and confirm the goroutine count returns to baseline within ~3 min instead of retaining a `chan send` pileup

## Notes

- The unguarded blocking send is an upstream sish bug, filed separately. The deadline makes the wedge rare, not impossible: as long as `SendMessage(_, true)` can park forever on an unbuffered channel with no `Close` case, any stalled consumer reproduces it.
- **Not addressed:** why the `ping-client` goroutine never reaped the connection. `--ping-client` defaults true and sets its own deadline *independent* of `--idle-connection` (`sshmuxer/sshmuxer.go:340-363`), so "nothing could reap this" is too strong. Why it re-arms faster than the dead peer trips it needs per-connection goroutines, not the aggregate dump. If the leak survives deploy, that's the next thread.

Spec: `specs/2026-07-28-relay.md`

---

## Acceptance criteria

- [ ] `ac1` `docker/relay/docker-compose.yml` no longer passes `--idle-connection=false`, passes `--idle-connection-timeout=120s`, and carries a comment stating that 120s is chosen to sit above the client's ServerAliveInterval=30 x ServerAliveCountMax=3. — _no evidence_
- [ ] `ac2` `docs/relay-hosting.md` documents the idle-connection timeout, why it must stay above the client's keepalive budget, and the symptom it prevents (leaked goroutines and stale subdomain routes from tunnels that die without a clean close). — _no evidence_
- [ ] `ac3` The live relay has been recreated with the new flags, verified by inspecting the running container's command line to confirm the new flags are actually in effect. — _no evidence_
- [ ] `ac4` After deploy, a phone tunnel is established, the relay subdomain URL is fetched successfully, and the tunnel is then killed uncleanly (peer disappears without a clean close); within ~3 minutes the relay's goroutine count returns to its pre-tunnel baseline rather than retaining a `chan send` pileup. — _no evidence_
- [ ] `ac5` An upstream sish issue is filed describing the unbounded blocking send on the unbuffered `Messages` channel at sshmuxer/requests.go:439, with the goroutine evidence, and its URL is linked on the WorkItem. — _no evidence_