### PR TITLE
fix(skills): hyphenate the Ultrathink trigger keyword in systematic-debugging

### DIFF
--- a/src/mship/skills/systematic-debugging/SKILL.md
+++ b/src/mship/skills/systematic-debugging/SKILL.md
@@ -269,7 +269,7 @@ If you catch yourself thinking:
 - "Is that not happening?" - You assumed without verifying
 - "Will it show us...?" - You should have added evidence gathering
 - "Stop guessing" - You're proposing fixes without understanding
-- "Ultrathink this" - Question fundamentals, not just symptoms
+- "Ultra-think this" - Question fundamentals, not just symptoms
 - "We're stuck?" (frustrated) - Your approach isn't working
 
 **When you see these:** STOP. Return to Phase 1.


### PR DESCRIPTION
## Summary

- `systematic-debugging/SKILL.md:272` contained the literal keyword `"Ultrathink this"` — the exact string Claude Code scans for, which silently forced **every session that loads the skill** into extended thinking. Hyphenated to `"Ultra-think this"`, the same fix upstream superpowers shipped in 6.0.0 (their line 239). The text still reads correctly.
- Extracted from #437 (the 5.0.7 → 6.2.0 re-vendor) because the cost is live on every dispatch today; the full re-vendor lands separately.

## Test plan

- [x] `grep -rn "Ultrathink" src/mship/skills/` → no matches anywhere in the vendored tree (the hyphenated form doesn't trigger the scanner)
- [x] One-line prose change in a vendored skill file; no code paths touched

Refs #437
