### PR TITLE
feat(dispatch): model resolution, metadata-only briefs, and context-isolated subagent handoff (mship-dispatch-v2)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,6 +189,7 @@ Top-level keys on `mothership.yaml` (alongside `workspace`, `env_runner`, `branc
 | `redact` | Extra `mship export --redacted` regex patterns, unioned with the built-in set. (MOS-102) |
 | `lifecycle_hooks` | Declarative reactions to task / WorkItem / PR lifecycle transitions. Named `lifecycle_hooks` (not `hooks`) to disambiguate from the git commit/push hooks. (MOS-220) |
 | `lifecycle_hooks_default_timeout` | Fallback per-hook timeout in seconds when a `lifecycle_hooks:` entry omits `timeout`. Default: `30`. |
+| `dispatch_models` | Per-mode model map for `mship dispatch` (`implementer` / `reviewer` / `standalone`). Values pass through verbatim to the dispatching harness. Precedence: `--model` flag > this map > built-in defaults (reviewer defaults to a cheaper tier). |
 
 ```yaml
 workspace: my-platform

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -4,6 +4,7 @@ See docs/superpowers/specs/2026-04-17-mship-dispatch-design.md.
 """
 from __future__ import annotations
 
+import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -171,6 +172,12 @@ def register(app: typer.Typer, get_container):
                         f"controller runs `mship dispatch --mode reviewer` first."
                     )
                     raise typer.Exit(code=1)
+                except json.JSONDecodeError:
+                    output.error(
+                        "review package manifest is corrupt — re-run "
+                        "`mship dispatch --mode reviewer`."
+                    )
+                    raise typer.Exit(code=1)
                 try:
                     _instr, ac_ids, warnings = resolve_instruction_and_acs(
                         rec, workspace_root
@@ -238,6 +245,14 @@ def register(app: typer.Typer, get_container):
             except (OSError, ValueError) as e:
                 output.error(f"cannot build the review package: {e}")
                 raise typer.Exit(code=1)
+            for p in pkg.diff_paths:
+                if p.stat().st_size == 0:
+                    print(
+                        f"warning: review package diff is empty ({p.name}) — 0 "
+                        f"commits past {prior.base_sha}; dispatching a reviewer "
+                        f"now reviews nothing",
+                        file=sys.stderr,
+                    )
             # Same work-item key as the implementer record -> record.json is
             # overwritten in place and the review/ dir beside it survives
             # (SddStore.write only prunes dirs under OTHER keys).

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -5,6 +5,7 @@ See docs/superpowers/specs/2026-04-17-mship-dispatch-design.md.
 from __future__ import annotations
 
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -14,6 +15,9 @@ from mship.cli._resolve import resolve_for_command
 from mship.cli.output import Output
 from mship.core import dispatch as _d
 from mship.core.base_resolver import resolve_base
+from mship.core.dispatch_models import resolve_model
+from mship.core.dispatch_stub import build_stub
+from mship.core.sdd_store import DispatchRecord, SddStore
 from mship.core.plan import resolve_plan_path
 from mship.core.skill_install import pkg_skills_source
 from mship.core.workitem_store import WorkItemStore
@@ -61,6 +65,21 @@ def register(app: typer.Typer, get_container):
                 "orchestrator that owns finishing. 'standalone': finish the work and "
                 "open the PR via `mship finish`."
             ),
+        ),
+        model: Optional[str] = typer.Option(
+            None, "--model",
+            help="Model for the subagent. Default: dispatch_models map in "
+                 "mothership.yaml, else built-in per-mode default.",
+        ),
+        full: bool = typer.Option(
+            False, "--full",
+            help="Print the full subagent prompt inline (legacy). Default for "
+                 "--plan-task is a closed stub; the subagent emits its own "
+                 "prompt via --emit.",
+        ),
+        stub: bool = typer.Option(
+            False, "--stub",
+            help="Print the closed stub even for --instruction dispatches.",
         ),
     ):
         """Emit a self-contained markdown subagent prompt to stdout.
@@ -119,7 +138,7 @@ def register(app: typer.Typer, get_container):
                 output.error(f"cannot read plan {str(plan_path)!r}: {e}")
                 raise typer.Exit(code=2)
             try:
-                resolved_instruction = _d.extract_plan_task(plan_text, plan_task)
+                resolved_instruction, plan_meta = _d.extract_plan_task_meta(plan_text, plan_task)
             except ValueError as e:
                 output.error(str(e))
                 raise typer.Exit(code=2)
@@ -146,6 +165,35 @@ def register(app: typer.Typer, get_container):
             known_repos=config.repos.keys(), task_base=task_obj.base_override,
         ) or task_obj.base_branch or "main"
         base_sha_info = _d.collect_base_sha_info(worktree, effective_base)
+
+        resolved_model = resolve_model(
+            mode, flag=model, configured=config.dispatch_models
+        )
+
+        # Persist the record (pointer + metadata; never plan prose).
+        acs = plan_meta.get("acs", []) if plan_task is not None else []
+        rec = DispatchRecord(
+            task_slug=task_obj.slug,
+            work_item_id=getattr(task_obj, "work_item_id", None),
+            mode=mode,
+            model=resolved_model,
+            repo=resolved_repo,
+            worktree=str(worktree),
+            base_branch=effective_base,
+            base_sha=base_sha_info.base_sha,
+            head_sha=base_sha_info.head_sha,
+            plan_path=str(plan_path) if plan_task is not None else None,
+            plan_task_id=plan_task,
+            acs=acs,
+            instruction=None if plan_task is not None else resolved_instruction,
+            created_at=datetime.now(timezone.utc),
+        )
+        record_path = SddStore(Path(container.state_dir())).write(rec)
+
+        want_stub = (plan_task is not None and not full) or stub
+        if want_stub:
+            print(build_stub(rec, record_path=str(record_path)), end="")
+            return
 
         log_mgr = container.log_manager()
         journal_entries = log_mgr.read(task_obj.slug, last=10)

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -245,12 +245,17 @@ def register(app: typer.Typer, get_container):
             # resolves it (repo config / task override).
             config = container.config()
             targets: list[tuple[str, str, str | None]] = []
+            # Skips are first-class: warned here for the controller AND
+            # recorded in the manifest so the reviewer knows the package is
+            # partial (a silent omission reads as full coverage).
+            skipped: dict[str, str] = {}
             for repo_name in task_obj.affected_repos:
                 wt_path = task_obj.worktrees.get(repo_name)
                 if wt_path is None:
                     continue
                 wt = Path(wt_path)
                 if not wt.is_dir():
+                    skipped[repo_name] = f"worktree missing ({wt})"
                     print(
                         f"warning: worktree for repo {repo_name!r} is missing "
                         f"({wt}) — skipping it in the review package",
@@ -267,6 +272,7 @@ def register(app: typer.Typer, get_container):
                     ) or task_obj.base_branch or "main"
                     repo_base_sha = _d.collect_base_sha_info(wt, effective_base).base_sha
                 if repo_base_sha is None:
+                    skipped[repo_name] = "no resolvable local base"
                     print(
                         f"warning: no resolvable local base for repo "
                         f"{repo_name!r} — skipping it in the review package",
@@ -292,6 +298,7 @@ def register(app: typer.Typer, get_container):
                     git_runner=container.shell().run,
                     state_dir=Path(container.state_dir()),
                     excludes=excludes,
+                    skipped=skipped,
                 )
             except (OSError, ValueError) as e:
                 output.error(f"cannot build the review package: {e}")

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -237,12 +237,18 @@ def register(app: typer.Typer, get_container):
                 raise typer.Exit(code=1)
             # Diff EVERY affected repo, not just the dispatched one — a
             # single-repo package on a multi-repo task is an incomplete
-            # review presented as complete. The record's base_sha covers its
-            # own repo; the others get their base resolved the same way the
-            # dispatch path resolves it (repo config / task override).
+            # review presented as complete. Affected repos are the reviewable
+            # surface; passive repos (context checkouts, detached, possibly
+            # no local base ref) live only in task.worktrees and are never
+            # diffed. The record's base_sha covers its own repo; the others
+            # get their base resolved the same way the dispatch path
+            # resolves it (repo config / task override).
             config = container.config()
             targets: list[tuple[str, str, str | None]] = []
-            for repo_name, wt_path in sorted(task_obj.worktrees.items()):
+            for repo_name in task_obj.affected_repos:
+                wt_path = task_obj.worktrees.get(repo_name)
+                if wt_path is None:
+                    continue
                 wt = Path(wt_path)
                 if not wt.is_dir():
                     print(
@@ -260,13 +266,32 @@ def register(app: typer.Typer, get_container):
                         task_base=task_obj.base_override,
                     ) or task_obj.base_branch or "main"
                     repo_base_sha = _d.collect_base_sha_info(wt, effective_base).base_sha
+                if repo_base_sha is None:
+                    print(
+                        f"warning: no resolvable local base for repo "
+                        f"{repo_name!r} — skipping it in the review package",
+                        file=sys.stderr,
+                    )
+                    continue
                 targets.append((repo_name, str(wt), repo_base_sha))
+            # A git_root child's worktree is a subdirectory of its parent's
+            # checkout; when both are targeted, drop the child subtree from
+            # the parent's diff so no hunk lands in two files.
+            targeted = {t[0] for t in targets}
+            excludes: dict[str, list[str]] = {}
+            for repo_name in targeted:
+                repo_config = config.repos.get(repo_name)
+                if repo_config is not None and repo_config.git_root in targeted:
+                    excludes.setdefault(repo_config.git_root, []).append(
+                        str(repo_config.path)
+                    )
             try:
                 pkg = build_review_package(
                     prior,
                     targets=targets,
                     git_runner=container.shell().run,
                     state_dir=Path(container.state_dir()),
+                    excludes=excludes,
                 )
             except (OSError, ValueError) as e:
                 output.error(f"cannot build the review package: {e}")

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -15,9 +15,18 @@ from mship.cli._resolve import resolve_for_command
 from mship.cli.output import Output
 from mship.core import dispatch as _d
 from mship.core.base_resolver import resolve_base
-from mship.core.dispatch_emit import build_emitted_prompt
+from mship.core.dispatch_emit import (
+    build_emitted_prompt,
+    resolve_acceptance,
+    resolve_instruction_and_acs,
+)
 from mship.core.dispatch_models import resolve_model
 from mship.core.dispatch_stub import build_stub
+from mship.core.review_package import (
+    build_review_package,
+    build_reviewer_prompt,
+    load_review_package,
+)
 from mship.core.sdd_store import DispatchRecord, SddStore
 from mship.core.plan import resolve_plan_path
 from mship.core.skill_install import pkg_skills_source
@@ -51,6 +60,20 @@ def _journal_and_agents(container, slug: str) -> tuple[list, Optional[Path]]:
     return journal_entries, agents_md if agents_md.is_file() else None
 
 
+def _load_bound_spec(container, task_obj, rec):
+    """Load the task's bound spec when the record references ACs/a plan slice
+    (both emit sub-paths resolve acceptance text the same way)."""
+    if not (rec.acs or rec.plan_task_id is not None):
+        return None
+    spec_id = getattr(task_obj, "spec_id", None)
+    if not spec_id:
+        return None
+    from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+    return SpecStore(
+        Path(container.config_path()).parent / SPECS_DIRNAME
+    ).find_by_id(spec_id)
+
+
 def register(app: typer.Typer, get_container):
     @app.command(rich_help_panel="Inspection")
     def dispatch(
@@ -73,7 +96,8 @@ def register(app: typer.Typer, get_container):
                 "Closing framing. 'implementer' (default): scope to a single task, "
                 "report back, do not open a PR — for per-task execution under an "
                 "orchestrator that owns finishing. 'standalone': finish the work and "
-                "open the PR via `mship finish`."
+                "open the PR via `mship finish`. 'reviewer': read-only dual-verdict "
+                "review of the prior dispatch's diff (takes no instruction source)."
             ),
         ),
         model: Optional[str] = typer.Option(
@@ -133,15 +157,33 @@ def register(app: typer.Typer, get_container):
                     f"controller runs `mship dispatch --plan-task N` first."
                 )
                 raise typer.Exit(code=1)
-            spec = None
-            if rec.acs or rec.plan_task_id is not None:
-                spec_id = getattr(task_obj, "spec_id", None)
-                if spec_id:
-                    from mship.core.spec_store import SPECS_DIRNAME, SpecStore
-                    spec = SpecStore(
-                        Path(container.config_path()).parent / SPECS_DIRNAME
-                    ).find_by_id(spec_id)
+            spec = _load_bound_spec(container, task_obj, rec)
             workspace_root = Path(container.config_path()).parent
+            if rec.mode == "reviewer":
+                # The reviewer's content IS the prepared package: print its
+                # paths + live ACs + the read-only dual-verdict contract —
+                # never the diff content itself.
+                try:
+                    pkg = load_review_package(rec, Path(container.state_dir()))
+                except OSError:
+                    output.error(
+                        f"no review package for task {task_obj.slug!r} — the "
+                        f"controller runs `mship dispatch --mode reviewer` first."
+                    )
+                    raise typer.Exit(code=1)
+                try:
+                    _instr, ac_ids, warnings = resolve_instruction_and_acs(
+                        rec, workspace_root
+                    )
+                except (OSError, ValueError) as e:
+                    output.error(f"cannot resolve acceptance criteria: {e}")
+                    raise typer.Exit(code=1)
+                acceptance, ac_warnings = resolve_acceptance(ac_ids, spec)
+                warnings.extend(ac_warnings)
+                for w in warnings:
+                    print(f"warning: {w}", file=sys.stderr)
+                print(build_reviewer_prompt(rec, pkg, acceptance=acceptance or []))
+                return
             journal_entries, agents_md_path = _journal_and_agents(container, task_obj.slug)
             base_sha_info = _d.collect_base_sha_info(Path(rec.worktree), rec.base_branch)
             try:
@@ -163,6 +205,51 @@ def register(app: typer.Typer, get_container):
             for w in warnings:
                 print(f"warning: {w}", file=sys.stderr)
             print(prompt)
+            return
+
+        # --- controller-side reviewer dispatch: package the existing record ---
+        if mode == "reviewer":
+            if instruction is not None or plan is not None or plan_task is not None:
+                output.error(
+                    "--mode reviewer takes no instruction source (its content is "
+                    "the review package built from the prior dispatch record); "
+                    "drop --instruction/--plan/--plan-task."
+                )
+                raise typer.Exit(code=2)
+            container = get_container()
+            state = container.state_manager().load()
+            resolved = resolve_for_command("dispatch", state, task, output)
+            task_obj = resolved.task
+            store = SddStore(Path(container.state_dir()))
+            prior = store.find_for_slug(task_obj.slug)
+            if prior is None:
+                output.error(
+                    f"no dispatch record for task {task_obj.slug!r} — dispatch "
+                    f"the implementer first (`mship dispatch --plan-task N`); its "
+                    f"record supplies the plan pointer, ACs, and review range."
+                )
+                raise typer.Exit(code=1)
+            try:
+                pkg = build_review_package(
+                    prior,
+                    git_runner=container.shell().run,
+                    state_dir=Path(container.state_dir()),
+                )
+            except (OSError, ValueError) as e:
+                output.error(f"cannot build the review package: {e}")
+                raise typer.Exit(code=1)
+            # Same work-item key as the implementer record -> record.json is
+            # overwritten in place and the review/ dir beside it survives
+            # (SddStore.write only prunes dirs under OTHER keys).
+            rec = prior.model_copy(update={
+                "mode": "reviewer",
+                "model": resolve_model(
+                    "reviewer", flag=model, configured=container.config().dispatch_models
+                ),
+                "created_at": datetime.now(timezone.utc),
+            })
+            record_path = store.write(rec)
+            print(build_stub(rec, record_path=str(record_path)), end="")
             return
 
         # --- resolve the instruction source (exactly one of) ---

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -4,7 +4,6 @@ See docs/superpowers/specs/2026-04-17-mship-dispatch-design.md.
 """
 from __future__ import annotations
 
-import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -172,7 +171,7 @@ def register(app: typer.Typer, get_container):
                         f"controller runs `mship dispatch --mode reviewer` first."
                     )
                     raise typer.Exit(code=1)
-                except json.JSONDecodeError:
+                except ValueError:  # incl. json.JSONDecodeError (a subclass)
                     output.error(
                         "review package manifest is corrupt — re-run "
                         "`mship dispatch --mode reviewer`."
@@ -380,6 +379,7 @@ def register(app: typer.Typer, get_container):
             pkg_skills_source=pkg_skills_source(),
             state=state,
             mode=mode,
+            model=resolved_model,
         )
         # Print directly to stdout (NOT via Output.json — this is meant to be piped).
         print(prompt)

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -15,6 +15,7 @@ from mship.cli._resolve import resolve_for_command
 from mship.cli.output import Output
 from mship.core import dispatch as _d
 from mship.core.base_resolver import resolve_base
+from mship.core.dispatch_emit import build_emitted_prompt
 from mship.core.dispatch_models import resolve_model
 from mship.core.dispatch_stub import build_stub
 from mship.core.sdd_store import DispatchRecord, SddStore
@@ -39,6 +40,15 @@ def _resolve_task_plan(container, task_obj) -> Optional[Path]:
         if wi is not None:
             linked = wi.plan_path
     return resolve_plan_path(task_obj.slug, linked, workspace_root, docs_dir)
+
+
+def _journal_and_agents(container, slug: str) -> tuple[list, Optional[Path]]:
+    """Gather the journal tail and the workspace AGENTS.md (if present) —
+    shared by the full-prompt and --emit paths."""
+    journal_entries = container.log_manager().read(slug, last=10)
+    # AGENTS.md lives next to the config file (workspace root).
+    agents_md = Path(container.config_path()).parent / "AGENTS.md"
+    return journal_entries, agents_md if agents_md.is_file() else None
 
 
 def register(app: typer.Typer, get_container):
@@ -81,6 +91,12 @@ def register(app: typer.Typer, get_container):
             False, "--stub",
             help="Print the closed stub even for --instruction dispatches.",
         ),
+        emit: bool = typer.Option(
+            False, "--emit",
+            help="Subagent-side: derive and print MY full prompt from the "
+                 "dispatch record (cwd-resolved task). Prints drift warnings "
+                 "to stderr.",
+        ),
     ):
         """Emit a self-contained markdown subagent prompt to stdout.
 
@@ -97,6 +113,57 @@ def register(app: typer.Typer, get_container):
                 f"--mode must be one of: {', '.join(_d.DISPATCH_MODES)} (got {mode!r})."
             )
             raise typer.Exit(code=2)
+
+        # --- subagent-side emit: derive the prompt from the persisted record ---
+        if emit:
+            if instruction is not None or plan is not None or plan_task is not None:
+                output.error(
+                    "--emit derives everything from the dispatch record; drop "
+                    "--instruction/--plan/--plan-task."
+                )
+                raise typer.Exit(code=2)
+            container = get_container()
+            state = container.state_manager().load()
+            resolved = resolve_for_command("dispatch", state, task, output)
+            task_obj = resolved.task
+            rec = SddStore(Path(container.state_dir())).find_for_slug(task_obj.slug)
+            if rec is None:
+                output.error(
+                    f"no dispatch record for task {task_obj.slug!r} — the "
+                    f"controller runs `mship dispatch --plan-task N` first."
+                )
+                raise typer.Exit(code=1)
+            spec = None
+            if rec.acs or rec.plan_task_id is not None:
+                spec_id = getattr(task_obj, "spec_id", None)
+                if spec_id:
+                    from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+                    spec = SpecStore(
+                        Path(container.config_path()).parent / SPECS_DIRNAME
+                    ).find_by_id(spec_id)
+            workspace_root = Path(container.config_path()).parent
+            journal_entries, agents_md_path = _journal_and_agents(container, task_obj.slug)
+            base_sha_info = _d.collect_base_sha_info(Path(rec.worktree), rec.base_branch)
+            try:
+                prompt, warnings = build_emitted_prompt(
+                    rec,
+                    workspace_root=workspace_root,
+                    spec=spec,
+                    task=task_obj,
+                    journal_entries=journal_entries,
+                    base_sha_info=base_sha_info,
+                    base_branch=rec.base_branch,
+                    agents_md_path=agents_md_path,
+                    pkg_skills_source=pkg_skills_source(),
+                    state=state,
+                )
+            except (OSError, ValueError) as e:
+                output.error(f"cannot derive the prompt from the record: {e}")
+                raise typer.Exit(code=1)
+            for w in warnings:
+                print(f"warning: {w}", file=sys.stderr)
+            print(prompt)
+            return
 
         # --- resolve the instruction source (exactly one of) ---
         if (instruction is not None) == (plan_task is not None):
@@ -195,13 +262,7 @@ def register(app: typer.Typer, get_container):
             print(build_stub(rec, record_path=str(record_path)), end="")
             return
 
-        log_mgr = container.log_manager()
-        journal_entries = log_mgr.read(task_obj.slug, last=10)
-
-        # AGENTS.md lives next to the config file (workspace root).
-        config_path = Path(container.config_path())
-        agents_md = config_path.parent / "AGENTS.md"
-        agents_md_path = agents_md if agents_md.is_file() else None
+        journal_entries, agents_md_path = _journal_and_agents(container, task_obj.slug)
 
         prompt = _d.build_dispatch_prompt(
             task=task_obj,

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -249,7 +249,10 @@ def register(app: typer.Typer, get_container):
             base_branch=effective_base,
             base_sha=base_sha_info.base_sha,
             head_sha=base_sha_info.head_sha,
-            plan_path=str(plan_path) if plan_task is not None else None,
+            # Resolved (absolute) so emit reads exactly the file extracted from
+            # here — an explicit relative --plan recorded as-typed would depend
+            # on the emit-time cwd instead.
+            plan_path=str(plan_path.resolve()) if plan_task is not None else None,
             plan_task_id=plan_task,
             acs=acs,
             instruction=None if plan_task is not None else resolved_instruction,

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -235,9 +235,36 @@ def register(app: typer.Typer, get_container):
                     f"record supplies the plan pointer, ACs, and review range."
                 )
                 raise typer.Exit(code=1)
+            # Diff EVERY affected repo, not just the dispatched one — a
+            # single-repo package on a multi-repo task is an incomplete
+            # review presented as complete. The record's base_sha covers its
+            # own repo; the others get their base resolved the same way the
+            # dispatch path resolves it (repo config / task override).
+            config = container.config()
+            targets: list[tuple[str, str, str | None]] = []
+            for repo_name, wt_path in sorted(task_obj.worktrees.items()):
+                wt = Path(wt_path)
+                if not wt.is_dir():
+                    print(
+                        f"warning: worktree for repo {repo_name!r} is missing "
+                        f"({wt}) — skipping it in the review package",
+                        file=sys.stderr,
+                    )
+                    continue
+                if repo_name == prior.repo:
+                    repo_base_sha = prior.base_sha
+                else:
+                    effective_base = resolve_base(
+                        repo_name, config.repos.get(repo_name), cli_base=None,
+                        base_map={}, known_repos=config.repos.keys(),
+                        task_base=task_obj.base_override,
+                    ) or task_obj.base_branch or "main"
+                    repo_base_sha = _d.collect_base_sha_info(wt, effective_base).base_sha
+                targets.append((repo_name, str(wt), repo_base_sha))
             try:
                 pkg = build_review_package(
                     prior,
+                    targets=targets,
                     git_runner=container.shell().run,
                     state_dir=Path(container.state_dir()),
                 )
@@ -258,7 +285,7 @@ def register(app: typer.Typer, get_container):
             rec = prior.model_copy(update={
                 "mode": "reviewer",
                 "model": resolve_model(
-                    "reviewer", flag=model, configured=container.config().dispatch_models
+                    "reviewer", flag=model, configured=config.dispatch_models
                 ),
                 "created_at": datetime.now(timezone.utc),
             })

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -978,7 +978,11 @@ def register(app: typer.Typer, get_container):
         # (spec mship-dispatch-v2 ac6). Best-effort: cleanup never blocks close.
         try:
             from mship.core.sdd_store import SddStore
-            SddStore(container.state_dir()).remove_task(task_slug)
+            sdd_store = SddStore(container.state_dir())
+            sdd_store.remove_task(task_slug)
+            if downstream and cascade:
+                for d_slug in downstream:
+                    sdd_store.remove_task(d_slug)
         except Exception:
             pass
         output.success(f"{log_msg.capitalize()}: {task_slug}")

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -973,6 +973,14 @@ def register(app: typer.Typer, get_container):
             ReconcileCache(container.state_dir()).remove_ignore(task_slug)
         except Exception:
             pass
+
+        # sdd dispatch records are per-task scratch — remove with the worktree
+        # (spec mship-dispatch-v2 ac6). Best-effort: cleanup never blocks close.
+        try:
+            from mship.core.sdd_store import SddStore
+            SddStore(container.state_dir()).remove_task(task_slug)
+        except Exception:
+            pass
         output.success(f"{log_msg.capitalize()}: {task_slug}")
 
         # Post-op diagnostic: if any affected repo's main-checkout path is

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -370,6 +370,11 @@ class WorkspaceConfig(BaseModel):
     # which matches the bundled `brainstorming` / `writing-plans` skill
     # convention. See #113.
     spec_paths: list[str] | None = None
+    # Per-dispatch-mode model map for `mship dispatch` (spec mship-dispatch-v2).
+    # Keys: implementer | reviewer | standalone. Values are passed through
+    # verbatim (harness-specific). None = built-in defaults
+    # (core/dispatch_models.py). Precedence: --model flag > this map > builtin.
+    dispatch_models: dict[str, str] | None = None
     # When True, `mship phase dev` hard-blocks plan→dev unless a bound,
     # approved spec exists (status in approved/dispatched/implemented).
     # Default False so existing configs/tests are unaffected. See MOS-151.

--- a/src/mship/core/context.py
+++ b/src/mship/core/context.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Optional
 
 from mship.core.base_resolver import resolve_base
 from mship.core.config import WorkspaceConfig
+from mship.core.dispatch_models import BUILTIN_MODEL_DEFAULTS, resolve_model
 from mship.core.log import LogManager
 from mship.core.reconcile.cache import ReconcileCache
 from mship.core.state import Task, WorkspaceState
@@ -418,6 +419,10 @@ def build_context(
         "mship_binary_matches_editable_install": binary_check(),
         "last_workspace_fetch_at": last_sync.isoformat() if last_sync else None,
         "last_drift_check_at": _last_drift_check_at(cache),
+        "dispatch_models": {
+            mode: resolve_model(mode, flag=None, configured=config.dispatch_models)
+            for mode in BUILTIN_MODEL_DEFAULTS
+        },
     }
     if audience is not None:
         payload["audience"] = audience

--- a/src/mship/core/dispatch.py
+++ b/src/mship/core/dispatch.py
@@ -24,6 +24,7 @@ _CANONICAL_SKILL_NAMES: tuple[str, ...] = (
 )
 
 
+# Keep in sync with plan._TASK_ANCHOR_RE
 _TASK_OPEN_RE = re.compile(r"<!--\s*mship:task\s+id=([^\s>]+)((?:\s+[a-z_]+=[^\s>]+)*)\s*-->")
 _TASK_CLOSE_RE = re.compile(r"<!--\s*/mship:task\s*-->")
 _ATTR_RE = re.compile(r"([a-z_]+)=([^\s>]+)")
@@ -38,6 +39,15 @@ def extract_plan_task_meta(plan_text: str, task_id: str) -> tuple[str, dict]:
     """
     opens = [m for m in _TASK_OPEN_RE.finditer(plan_text) if m.group(1) == task_id]
     if not opens:
+        # A malformed attribute (uppercase key, space in a value, empty value)
+        # makes the whole anchor unmatchable — distinguish that near-miss from
+        # a genuinely absent id so the error points at the real problem.
+        if re.search(rf"mship:task\s+id={re.escape(task_id)}", plan_text):
+            raise ValueError(
+                f"anchor for task id {task_id!r} found but its attributes are "
+                f"malformed (keys are [a-z_]+, values may not contain spaces; "
+                f"e.g. write acs=ac1,ac2 with no space after the comma)"
+            )
         raise ValueError(
             f"no task with id {task_id!r} in plan "
             f"(expected an anchor mship:task id={task_id})"
@@ -54,7 +64,7 @@ def extract_plan_task_meta(plan_text: str, task_id: str) -> tuple[str, dict]:
         )
     meta: dict = {}
     for k, v in _ATTR_RE.findall(open_m.group(2) or ""):
-        meta[k] = v.split(",") if k == "acs" else v
+        meta[k] = [p for p in v.split(",") if p] if k == "acs" else v
     return plan_text[open_m.end():close_m.start()].strip(), meta
 
 

--- a/src/mship/core/dispatch.py
+++ b/src/mship/core/dispatch.py
@@ -325,6 +325,8 @@ def build_dispatch_prompt(
     pkg_skills_source: Path,
     state=None,
     mode: str = "implementer",
+    model: str | None = None,
+    acceptance: list | None = None,   # list of (ac_id, text) pairs
 ) -> str:
     """Return the full markdown dispatch prompt for a fresh subagent.
 
@@ -347,6 +349,14 @@ def build_dispatch_prompt(
     journal_block = _render_journal(journal_entries)
     base_block = _render_base_sha_block(base_sha_info, base_branch)
     dependencies_block = _format_dependencies_section(task, state=state)
+    model_line = f"- **Model:** {model}\n" if model else ""
+    acceptance_block = ""
+    if acceptance:
+        joined = "\n".join(f"- [{ac_id}] {text}" for ac_id, text in acceptance)
+        acceptance_block = (
+            "## Acceptance criteria this task serves (from the spec store — live text)\n\n"
+            f"{joined}\n\n"
+        )
     conventions_recap = _conventions_recap(mode)
     closing_heading, closing_body = _closing_section(mode)
     agents_line = f"\nFull doc: `{agents_md_path}`." if agents_md_path else ""
@@ -372,9 +382,9 @@ This is a git worktree checked out on branch `{task.branch}`. Every edit, test r
 - **branch:** {task.branch}
 - **base branch:** {base_branch}
 - **active repo:** {repo}
-
+{model_line}
 {dependencies_block}
-## Where the branch stands
+{acceptance_block}## Where the branch stands
 
 {base_block}
 

--- a/src/mship/core/dispatch.py
+++ b/src/mship/core/dispatch.py
@@ -24,8 +24,38 @@ _CANONICAL_SKILL_NAMES: tuple[str, ...] = (
 )
 
 
-_TASK_OPEN_RE = re.compile(r"<!--\s*mship:task\s+id=([^\s>]+)\s*-->")
+_TASK_OPEN_RE = re.compile(r"<!--\s*mship:task\s+id=([^\s>]+)((?:\s+[a-z_]+=[^\s>]+)*)\s*-->")
 _TASK_CLOSE_RE = re.compile(r"<!--\s*/mship:task\s*-->")
+_ATTR_RE = re.compile(r"([a-z_]+)=([^\s>]+)")
+
+
+def extract_plan_task_meta(plan_text: str, task_id: str) -> tuple[str, dict]:
+    """Like extract_plan_task, but also returns parsed anchor attributes.
+
+    Attributes are optional `key=value` pairs after the id (e.g. an anchor
+    of the form mship:task id=3 acs=ac2,ac5). `acs` is split on commas into
+    a list. Unknown keys pass through as raw strings (forward-compatible).
+    """
+    opens = [m for m in _TASK_OPEN_RE.finditer(plan_text) if m.group(1) == task_id]
+    if not opens:
+        raise ValueError(
+            f"no task with id {task_id!r} in plan "
+            f"(expected an anchor mship:task id={task_id})"
+        )
+    if len(opens) > 1:
+        raise ValueError(f"duplicate task id {task_id!r} in plan ({len(opens)} anchors)")
+    open_m = opens[0]
+    close_m = _TASK_CLOSE_RE.search(plan_text, open_m.end())
+    next_open = _TASK_OPEN_RE.search(plan_text, open_m.end())
+    if close_m is None or (next_open is not None and next_open.start() < close_m.start()):
+        raise ValueError(
+            f"unterminated task block for id {task_id!r} "
+            f"(missing the closing /mship:task anchor)"
+        )
+    meta: dict = {}
+    for k, v in _ATTR_RE.findall(open_m.group(2) or ""):
+        meta[k] = v.split(",") if k == "acs" else v
+    return plan_text[open_m.end():close_m.start()].strip(), meta
 
 
 def extract_plan_task(plan_text: str, task_id: str) -> str:
@@ -38,25 +68,8 @@ def extract_plan_task(plan_text: str, task_id: str) -> str:
     Raises ValueError when the id is missing, appears more than once, or the
     block is unterminated (no closing anchor before the next open anchor / EOF).
     """
-    opens = [m for m in _TASK_OPEN_RE.finditer(plan_text) if m.group(1) == task_id]
-    if not opens:
-        raise ValueError(
-            f"no task with id {task_id!r} in plan "
-            f"(expected an anchor `<!-- mship:task id={task_id} -->`)"
-        )
-    if len(opens) > 1:
-        raise ValueError(
-            f"duplicate task id {task_id!r} in plan ({len(opens)} anchors)"
-        )
-    open_m = opens[0]
-    close_m = _TASK_CLOSE_RE.search(plan_text, open_m.end())
-    next_open = _TASK_OPEN_RE.search(plan_text, open_m.end())
-    if close_m is None or (next_open is not None and next_open.start() < close_m.start()):
-        raise ValueError(
-            f"unterminated task block for id {task_id!r} "
-            f"(missing closing `<!-- /mship:task -->`)"
-        )
-    return plan_text[open_m.end():close_m.start()].strip()
+    text, _ = extract_plan_task_meta(plan_text, task_id)
+    return text
 
 
 @dataclass(frozen=True)

--- a/src/mship/core/dispatch.py
+++ b/src/mship/core/dispatch.py
@@ -204,7 +204,7 @@ def _summarize_base_sha(
     return "; ".join(parts) if parts else "unknown"
 
 
-DISPATCH_MODES: tuple[str, ...] = ("implementer", "standalone")
+DISPATCH_MODES: tuple[str, ...] = ("implementer", "standalone", "reviewer")
 
 
 _CONVENTIONS_INTRO = "These are strictly enforced in this workspace:"
@@ -254,8 +254,29 @@ If you get stuck or the task is wrong-shaped, stop and report what you tried and
 """
 
 
+# Reviewer: read-only over a prepared review package; one reviewer returns
+# both verdicts (upstream 6.2.0 task-reviewer contract).
+_REVIEW_CONTRACT = """\
+You are a READ-ONLY reviewer. Do not edit files, run git write commands, or
+check out branches — a reviewer mutating the worktree orphans commits.
+
+Read the diff files listed above (they are on disk — read them as files, do
+not ask for them to be pasted). Then return BOTH verdicts in one report:
+
+1. **Spec-compliance** — does the change satisfy each listed acceptance
+   criterion? Verdict per criterion: satisfied / not-satisfied / can't-tell,
+   with the evidence line (file:line) that convinced you.
+2. **Code quality** — correctness, tests, naming, duplication, style fit with
+   the surrounding code. Findings ranked by severity; state what you verified,
+   not just what you suspect.
+
+Report back as text. Do NOT open a PR, do not run `mship finish`."""
+
+
 def _closing_section(mode: str) -> tuple[str, str]:
     """Return the (heading, body) for the prompt's closing section."""
+    if mode == "reviewer":
+        return "Review contract (read-only; both verdicts)", _REVIEW_CONTRACT
     if mode == "standalone":
         return "How to finish", _FINISH_CONTRACT
     return "Report back (do not open a PR)", _REPORT_CONTRACT

--- a/src/mship/core/dispatch_emit.py
+++ b/src/mship/core/dispatch_emit.py
@@ -1,0 +1,153 @@
+"""Derive the full subagent prompt from a DispatchRecord (spec mship-dispatch-v2).
+
+Run by the SUBAGENT (not the controller): the plan slice is re-parsed from the
+canonical plan file and acceptance text is pulled live from the spec store, so
+neither is ever copied into the record and both reflect edits at emit time.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from mship.core.dispatch import (
+    BaseShaInfo,
+    build_dispatch_prompt,
+    extract_plan_task_meta,
+)
+from mship.core.log import LogEntry
+from mship.core.sdd_store import DispatchRecord
+from mship.core.state import Task
+
+
+@dataclass
+class PlanDriftWarning:
+    plan_path: str
+    record_created_at: str
+    plan_mtime: str
+
+    def __str__(self) -> str:
+        return (
+            f"plan {self.plan_path} modified after this dispatch was recorded "
+            f"({self.plan_mtime} > {self.record_created_at}); emitting the CURRENT "
+            f"plan text — re-dispatch if the task was re-scoped"
+        )
+
+
+def resolve_instruction_and_acs(
+    rec: DispatchRecord, workspace_root: Path
+) -> tuple[str, list[str], list]:
+    """Return (instruction_text, ac_ids, warnings) — plan-sliced or ad-hoc."""
+    warnings: list = []
+    if rec.plan_task_id is None:
+        return rec.instruction or "", list(rec.acs), warnings
+    plan_file = workspace_root / rec.plan_path
+    text, meta = extract_plan_task_meta(plan_file.read_text(), rec.plan_task_id)
+    mtime = datetime.fromtimestamp(plan_file.stat().st_mtime, tz=timezone.utc)
+    if mtime > rec.created_at:
+        warnings.append(PlanDriftWarning(
+            plan_path=str(plan_file),
+            record_created_at=rec.created_at.isoformat(),
+            plan_mtime=mtime.isoformat(),
+        ))
+    return text, meta.get("acs", list(rec.acs)), warnings
+
+
+def _minimal_task(rec: DispatchRecord) -> Task:
+    """Reconstruct just what build_dispatch_prompt reads from a Task.
+
+    Used only when the caller (a bare library user or test) doesn't pass the
+    real Task: slug/worktree/repo come from the record; the branch is probed
+    from the worktree's HEAD ("?" when the worktree is gone or detached probes
+    fail); depends_on is empty — the CLI passes the real Task, so dependency
+    context is only missing on this fallback path.
+    """
+    from mship.core.dispatch import _git_out
+
+    branch = _git_out(["rev-parse", "--abbrev-ref", "HEAD"], cwd=Path(rec.worktree)) or "?"
+    return Task(
+        slug=rec.task_slug, description="", phase="dev",
+        created_at=rec.created_at, affected_repos=[rec.repo],
+        worktrees={rec.repo: Path(rec.worktree)}, branch=branch,
+        active_repo=rec.repo,
+    )
+
+
+def _snapshot_base_sha_info(rec: DispatchRecord) -> BaseShaInfo:
+    """Dispatch-time snapshot fallback when the caller doesn't re-probe git."""
+    return BaseShaInfo(
+        base_sha=rec.base_sha, origin_base_sha=None,
+        head_sha=rec.head_sha or "?", ahead_of_base=None,
+        base_behind_origin=None, has_upstream=False,
+        summary="as recorded at dispatch time (not re-probed)",
+    )
+
+
+def build_emitted_prompt(
+    rec: DispatchRecord,
+    *,
+    workspace_root: Path,
+    spec,
+    task: Task | None = None,
+    journal_entries: list[LogEntry] | None = None,
+    base_sha_info: BaseShaInfo | None = None,
+    base_branch: str | None = None,
+    agents_md_path: Path | None = None,
+    pkg_skills_source: Path | None = None,
+    state=None,
+) -> tuple[str, list]:
+    """Return (prompt, warnings) — the full dispatch prompt derived live.
+
+    Contract: `rec`, `workspace_root`, and `spec` are the only required inputs;
+    the remaining keyword params mirror build_dispatch_prompt and default to
+    record-derived values so a bare record is enough to emit:
+
+    - task: the real Task when available (the CLI passes it); else a minimal
+      Task reconstructed from the record (_minimal_task) — no depends_on.
+    - journal_entries: default [] (no journal context).
+    - base_sha_info: default the record's dispatch-time snapshot; the CLI
+      passes a live collect_base_sha_info() probe instead.
+    - base_branch: default rec.base_branch.
+    - pkg_skills_source: default the installed package's skills dir.
+
+    `spec` supplies live acceptance text for the record's AC ids. An unknown
+    AC id, or acs with spec=None, appends a string warning (never an error).
+    """
+    instruction, ac_ids, warnings = resolve_instruction_and_acs(rec, workspace_root)
+
+    acceptance: list[tuple[str, str]] | None = None
+    if ac_ids:
+        if spec is None:
+            warnings.append(
+                f"acceptance criteria {', '.join(ac_ids)} referenced but no spec "
+                f"is bound to this task — emitting without AC text"
+            )
+        else:
+            by_id = {ac.id: ac.text for ac in spec.acceptance_criteria}
+            acceptance = [(i, by_id[i]) for i in ac_ids if i in by_id]
+            unknown = [i for i in ac_ids if i not in by_id]
+            if unknown:
+                warnings.append(
+                    f"AC id(s) {', '.join(unknown)} not found in spec {spec.id!r} "
+                    f"— emitting without them"
+                )
+
+    if pkg_skills_source is None:
+        from mship.core.skill_install import pkg_skills_source as _pkg_src
+        pkg_skills_source = _pkg_src()
+
+    prompt = build_dispatch_prompt(
+        task=task if task is not None else _minimal_task(rec),
+        repo=rec.repo,
+        instruction=instruction,
+        journal_entries=journal_entries if journal_entries is not None else [],
+        base_sha_info=base_sha_info if base_sha_info is not None else _snapshot_base_sha_info(rec),
+        base_branch=base_branch if base_branch is not None else rec.base_branch,
+        agents_md_path=agents_md_path,
+        pkg_skills_source=pkg_skills_source,
+        state=state,
+        mode=rec.mode,
+        model=rec.model,
+        acceptance=acceptance,
+    )
+    return prompt, warnings

--- a/src/mship/core/dispatch_emit.py
+++ b/src/mship/core/dispatch_emit.py
@@ -53,6 +53,29 @@ def resolve_instruction_and_acs(
     return text, meta.get("acs", list(rec.acs)), warnings
 
 
+def resolve_acceptance(ac_ids: list[str], spec) -> tuple[list[tuple[str, str]] | None, list]:
+    """Map AC ids to live (id, text) pairs from the spec. An unknown AC id,
+    or ids with spec=None, appends a string warning (never an error)."""
+    warnings: list = []
+    if not ac_ids:
+        return None, warnings
+    if spec is None:
+        warnings.append(
+            f"acceptance criteria {', '.join(ac_ids)} referenced but no spec "
+            f"is bound to this task — emitting without AC text"
+        )
+        return None, warnings
+    by_id = {ac.id: ac.text for ac in spec.acceptance_criteria}
+    acceptance = [(i, by_id[i]) for i in ac_ids if i in by_id]
+    unknown = [i for i in ac_ids if i not in by_id]
+    if unknown:
+        warnings.append(
+            f"AC id(s) {', '.join(unknown)} not found in spec {spec.id!r} "
+            f"— emitting without them"
+        )
+    return acceptance, warnings
+
+
 def _minimal_task(rec: DispatchRecord) -> Task:
     """Reconstruct just what build_dispatch_prompt reads from a Task.
 
@@ -114,23 +137,8 @@ def build_emitted_prompt(
     AC id, or acs with spec=None, appends a string warning (never an error).
     """
     instruction, ac_ids, warnings = resolve_instruction_and_acs(rec, workspace_root)
-
-    acceptance: list[tuple[str, str]] | None = None
-    if ac_ids:
-        if spec is None:
-            warnings.append(
-                f"acceptance criteria {', '.join(ac_ids)} referenced but no spec "
-                f"is bound to this task — emitting without AC text"
-            )
-        else:
-            by_id = {ac.id: ac.text for ac in spec.acceptance_criteria}
-            acceptance = [(i, by_id[i]) for i in ac_ids if i in by_id]
-            unknown = [i for i in ac_ids if i not in by_id]
-            if unknown:
-                warnings.append(
-                    f"AC id(s) {', '.join(unknown)} not found in spec {spec.id!r} "
-                    f"— emitting without them"
-                )
+    acceptance, ac_warnings = resolve_acceptance(ac_ids, spec)
+    warnings.extend(ac_warnings)
 
     if pkg_skills_source is None:
         from mship.core.skill_install import pkg_skills_source as _pkg_src

--- a/src/mship/core/dispatch_models.py
+++ b/src/mship/core/dispatch_models.py
@@ -1,0 +1,33 @@
+"""Resolve the model a dispatched subagent runs on (spec mship-dispatch-v2).
+
+The dispatcher — not the untrusted worker — owns the model choice. Precedence:
+CLI flag > `dispatch_models:` per-mode map in mothership.yaml > built-in
+per-mode default. Values are operator-chosen strings passed through verbatim
+(harness-specific tier names are not validated here).
+
+Upstream superpowers found that an unnamed model silently inherits the
+session's most expensive tier; resolving here makes the choice explicit,
+auditable, and configured in one place.
+"""
+from __future__ import annotations
+
+# Reviewer work is judgment over prepared files — a cheaper tier by default.
+# "inherit" means: no explicit model; the dispatching harness uses its session
+# model. Implementers default to inherit so a capable session stays capable.
+BUILTIN_MODEL_DEFAULTS: dict[str, str] = {
+    "implementer": "inherit",
+    "standalone": "inherit",
+    "reviewer": "sonnet",
+}
+
+
+def resolve_model(mode: str, *, flag: str | None, configured: dict[str, str] | None) -> str:
+    if mode not in BUILTIN_MODEL_DEFAULTS:
+        raise ValueError(
+            f"unknown dispatch mode {mode!r}; choose one of {', '.join(BUILTIN_MODEL_DEFAULTS)}"
+        )
+    if flag is not None:
+        return flag
+    if configured and mode in configured:
+        return configured[mode]
+    return BUILTIN_MODEL_DEFAULTS[mode]

--- a/src/mship/core/dispatch_stub.py
+++ b/src/mship/core/dispatch_stub.py
@@ -1,0 +1,24 @@
+"""Controller-facing dispatch stub (spec mship-dispatch-v2, ac3).
+
+A CLOSED set of fields. The controller's context carries orchestration facts
+only; every byte of prompt content (plan slice, template, acceptance text)
+reaches the subagent alone via `mship dispatch --emit`. Adding a field here
+means updating the closed-set test in tests/core/test_dispatch_stub.py — that
+friction is the point.
+"""
+from __future__ import annotations
+
+from mship.core.sdd_store import DispatchRecord
+
+STUB_FIELDS = ("record", "model", "mode", "worktree", "emit")
+
+
+def build_stub(rec: DispatchRecord, *, record_path: str) -> str:
+    return (
+        f"record: {record_path}\n"
+        f"model: {rec.model}\n"
+        f"mode: {rec.mode}\n"
+        f"worktree: {rec.worktree}\n"
+        f"emit: run subagent with cwd={rec.worktree}, model={rec.model}; "
+        f"its first command: `mship dispatch --emit`\n"
+    )

--- a/src/mship/core/plan.py
+++ b/src/mship/core/plan.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+# Keep in sync with dispatch._TASK_OPEN_RE
 _TASK_ANCHOR_RE = re.compile(r"<!--\s*mship:task\s+id=([^\s>]+)(?:\s+[a-z_]+=[^\s>]+)*\s*-->")
 
 

--- a/src/mship/core/plan.py
+++ b/src/mship/core/plan.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-_TASK_ANCHOR_RE = re.compile(r"<!--\s*mship:task\s+id=([^\s>]+)\s*-->")
+_TASK_ANCHOR_RE = re.compile(r"<!--\s*mship:task\s+id=([^\s>]+)(?:\s+[a-z_]+=[^\s>]+)*\s*-->")
 
 
 def _plan_stem_matches_slug(stem: str, task_slug: str) -> bool:

--- a/src/mship/core/pr_watcher.py
+++ b/src/mship/core/pr_watcher.py
@@ -287,6 +287,15 @@ class PrWatcher:
                     log.exception("pr_watcher: teardown-skip note failed (task=%s)", slug)
             else:
                 log.exception("pr_watcher: merge teardown failed (task=%s)", slug)
+            return
+
+        # sdd dispatch records are per-task scratch — remove with the worktree
+        # (spec mship-dispatch-v2 ac6). Best-effort: cleanup never blocks close.
+        try:
+            from mship.core.sdd_store import SddStore
+            SddStore(self.workspace_root / ".mothership").remove_task(slug)
+        except Exception:
+            log.exception("pr_watcher: sdd cleanup failed (task=%s)", slug)
 
     def _post_teardown_skipped_note(
         self, slug: str, task: Any, url: str, exc: Any,

--- a/src/mship/core/review_package.py
+++ b/src/mship/core/review_package.py
@@ -65,10 +65,15 @@ def build_review_package(rec: DispatchRecord, *, git_runner, state_dir: Path) ->
     diff_file = d / f"{rec.repo}.diff"
     diff_file.write_text(res.stdout)
     diff_paths.append(diff_file)
+    # The diff runs to LIVE HEAD (which may have moved past the dispatch-time
+    # rec.head_sha) — the manifest must describe the diff it sits beside, so
+    # record the resolved head, not the record's snapshot.
+    head = git_runner("git rev-parse HEAD", cwd=Path(rec.worktree))
     manifest = {
         "task_slug": rec.task_slug, "work_item_id": rec.work_item_id,
         "plan_path": rec.plan_path, "plan_task_id": rec.plan_task_id,
-        "acs": rec.acs, "base_sha": rec.base_sha, "head_sha": rec.head_sha,
+        "acs": rec.acs, "base_sha": rec.base_sha,
+        "head_sha": head.stdout.strip() if head.returncode == 0 else rec.head_sha,
         "diff_files": [str(p) for p in diff_paths],
     }
     manifest_path = d / "manifest.json"

--- a/src/mship/core/review_package.py
+++ b/src/mship/core/review_package.py
@@ -51,6 +51,7 @@ def build_review_package(
     targets: list[tuple[str, str, str | None]],
     git_runner,
     state_dir: Path,
+    excludes: dict[str, list[str]] | None = None,
 ) -> ReviewPackage:
     """Write `<record-dir>/review/{manifest.json, <repo>.diff per target}`.
 
@@ -62,6 +63,14 @@ def build_review_package(
     An empty diff is still written — the CLI warns per empty file.
     `git_runner(cmd, cwd=...)` is the injected shell (same contract as
     container.shell().run) so tests use fixture repos.
+
+    Every diff is pathspec-scoped with `-- .` relative to the target's
+    worktree: a git_root child (whose worktree is a subdirectory of its
+    parent's checkout) diffs only its own subtree instead of mislabeling the
+    parent's whole diff; a normal repo run from its root is unaffected.
+    `excludes` maps repo -> subtree paths to drop from that repo's diff
+    (the CLI passes a git_root parent's co-targeted children here so no
+    hunk appears in two files).
     """
     if not targets:
         raise ValueError(
@@ -78,7 +87,10 @@ def build_review_package(
                 f"no base_sha for repo {repo!r} — cannot compute its review "
                 f"diff range"
             )
-        res = git_runner(f"git diff {base_sha}..HEAD", cwd=Path(worktree))
+        pathspec = " ".join(
+            ["."] + [f"':(exclude){sub}'" for sub in (excludes or {}).get(repo, [])]
+        )
+        res = git_runner(f"git diff {base_sha}..HEAD -- {pathspec}", cwd=Path(worktree))
         if res.returncode != 0:
             raise ValueError(
                 f"git diff {base_sha}..HEAD failed in {worktree}: "

--- a/src/mship/core/review_package.py
+++ b/src/mship/core/review_package.py
@@ -29,10 +29,16 @@ def review_dir(rec: DispatchRecord, state_dir: Path) -> Path:
 def load_review_package(rec: DispatchRecord, state_dir: Path) -> ReviewPackage:
     """Reload a previously built package from its manifest (the emit path).
 
-    Raises OSError when no package was built for this record.
+    Raises OSError when no package was built for this record, ValueError
+    (incl. json.JSONDecodeError) when the manifest is corrupt.
     """
     manifest_path = review_dir(rec, state_dir) / "manifest.json"
     manifest = json.loads(manifest_path.read_text())
+    if not isinstance(manifest, dict) or "diff_files" not in manifest:
+        raise ValueError(
+            "review package manifest is corrupt — re-run "
+            "`mship dispatch --mode reviewer`"
+        )
     return ReviewPackage(
         manifest_path=manifest_path,
         diff_paths=[Path(p) for p in manifest["diff_files"]],

--- a/src/mship/core/review_package.py
+++ b/src/mship/core/review_package.py
@@ -8,7 +8,7 @@ measured token win (~2x faster, ~50% fewer review tokens in their evals).
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from mship.core.dispatch import _closing_section, _conventions_recap
@@ -19,6 +19,9 @@ from mship.core.sdd_store import DispatchRecord, SddStore
 class ReviewPackage:
     manifest_path: Path
     diff_paths: list[Path]
+    # Affected repos OMITTED from the package (repo -> reason). First-class in
+    # the artifact: a verdict over a partial package must disclose the gap.
+    skipped: dict[str, str] = field(default_factory=dict)
 
 
 def review_dir(rec: DispatchRecord, state_dir: Path) -> Path:
@@ -42,6 +45,7 @@ def load_review_package(rec: DispatchRecord, state_dir: Path) -> ReviewPackage:
     return ReviewPackage(
         manifest_path=manifest_path,
         diff_paths=[Path(p) for p in manifest["diff_files"]],
+        skipped=manifest.get("skipped", {}),  # tolerate pre-"skipped" manifests
     )
 
 
@@ -52,6 +56,7 @@ def build_review_package(
     git_runner,
     state_dir: Path,
     excludes: dict[str, list[str]] | None = None,
+    skipped: dict[str, str] | None = None,
 ) -> ReviewPackage:
     """Write `<record-dir>/review/{manifest.json, <repo>.diff per target}`.
 
@@ -71,6 +76,11 @@ def build_review_package(
     `excludes` maps repo -> subtree paths to drop from that repo's diff
     (the CLI passes a git_root parent's co-targeted children here so no
     hunk appears in two files).
+
+    `skipped` is repo -> reason for affected repos the caller OMITTED
+    (missing worktree, unresolvable base): recorded in the manifest and
+    disclosed to the reviewer, so a partial package never reads as full
+    coverage.
     """
     if not targets:
         raise ValueError(
@@ -114,10 +124,13 @@ def build_review_package(
         "head_sha": targets_meta.get(rec.repo, {}).get("head_sha") or rec.head_sha,
         "targets": targets_meta,
         "diff_files": [str(p) for p in diff_paths],
+        "skipped": skipped or {},
     }
     manifest_path = d / "manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
-    return ReviewPackage(manifest_path=manifest_path, diff_paths=diff_paths)
+    return ReviewPackage(
+        manifest_path=manifest_path, diff_paths=diff_paths, skipped=skipped or {}
+    )
 
 
 def build_reviewer_prompt(
@@ -128,6 +141,16 @@ def build_reviewer_prompt(
     the contract text lives once, in core.dispatch)."""
     ac_block = "\n".join(f"- [{ac_id}] {text}" for ac_id, text in acceptance) or "(none mapped)"
     files_block = "\n".join(f"- `{p}`" for p in pkg.diff_paths)
+    skipped_block = ""
+    if pkg.skipped:
+        skipped_lines = "\n".join(f"- `{repo}` — {reason}" for repo, reason in pkg.skipped.items())
+        skipped_block = f"""
+## Affected repos NOT included in this package
+
+{skipped_lines}
+
+Your verdict cannot cover these — mark any acceptance criterion touching them as can't-tell and state the omission in your report.
+"""
     closing_heading, closing_body = _closing_section("reviewer")
     return f"""\
 # Review: task {rec.task_slug} (plan task {rec.plan_task_id or 'ad-hoc'})
@@ -139,7 +162,7 @@ def build_reviewer_prompt(
 {files_block}
 
 Manifest: `{pkg.manifest_path}`
-
+{skipped_block}
 ## Acceptance criteria to check (live from the spec store)
 
 {ac_block}

--- a/src/mship/core/review_package.py
+++ b/src/mship/core/review_package.py
@@ -1,0 +1,109 @@
+"""Review-package builder (spec mship-dispatch-v2, ac4).
+
+The ONE stored content in the sdd store: raw `git diff` output written as
+files (generated artifacts, not duplicated prose) plus a metadata manifest.
+Reading diffs from disk instead of pasting them is upstream superpowers'
+measured token win (~2x faster, ~50% fewer review tokens in their evals).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from mship.core.dispatch import _closing_section, _conventions_recap
+from mship.core.sdd_store import DispatchRecord, SddStore
+
+
+@dataclass
+class ReviewPackage:
+    manifest_path: Path
+    diff_paths: list[Path]
+
+
+def review_dir(rec: DispatchRecord, state_dir: Path) -> Path:
+    """The review-package dir beside the record: `<record-dir>/review/`."""
+    return SddStore(state_dir)._dir(rec.work_item_id, rec.task_slug) / "review"
+
+
+def load_review_package(rec: DispatchRecord, state_dir: Path) -> ReviewPackage:
+    """Reload a previously built package from its manifest (the emit path).
+
+    Raises OSError when no package was built for this record.
+    """
+    manifest_path = review_dir(rec, state_dir) / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    return ReviewPackage(
+        manifest_path=manifest_path,
+        diff_paths=[Path(p) for p in manifest["diff_files"]],
+    )
+
+
+def build_review_package(rec: DispatchRecord, *, git_runner, state_dir: Path) -> ReviewPackage:
+    """Write `<record-dir>/review/{manifest.json, <repo>.diff}`.
+
+    Diff range: `<base_sha>..HEAD` of the worktree (the task's commits —
+    HEAD at dispatch time may have moved past the recorded head_sha; the
+    record's base_sha anchors the review range). `git_runner(cmd, cwd=...)`
+    is the injected shell (same contract as container.shell().run) so tests
+    use a fixture repo.
+    """
+    if not rec.base_sha:
+        raise ValueError(
+            f"dispatch record for {rec.task_slug!r} has no base_sha — "
+            f"cannot compute the review diff range"
+        )
+    d = review_dir(rec, state_dir)
+    d.mkdir(parents=True, exist_ok=True)
+    diff_paths: list[Path] = []
+    res = git_runner(f"git diff {rec.base_sha}..HEAD", cwd=Path(rec.worktree))
+    if res.returncode != 0:
+        raise ValueError(
+            f"git diff {rec.base_sha}..HEAD failed in {rec.worktree}: "
+            f"{res.stderr.strip() or 'unknown error'}"
+        )
+    diff_file = d / f"{rec.repo}.diff"
+    diff_file.write_text(res.stdout)
+    diff_paths.append(diff_file)
+    manifest = {
+        "task_slug": rec.task_slug, "work_item_id": rec.work_item_id,
+        "plan_path": rec.plan_path, "plan_task_id": rec.plan_task_id,
+        "acs": rec.acs, "base_sha": rec.base_sha, "head_sha": rec.head_sha,
+        "diff_files": [str(p) for p in diff_paths],
+    }
+    manifest_path = d / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    return ReviewPackage(manifest_path=manifest_path, diff_paths=diff_paths)
+
+
+def build_reviewer_prompt(
+    rec: DispatchRecord, pkg: ReviewPackage, *, acceptance: list
+) -> str:
+    """The full reviewer prompt: package paths + live ACs + the read-only
+    dual-verdict contract (composed from the shared closing-section flow —
+    the contract text lives once, in core.dispatch)."""
+    ac_block = "\n".join(f"- [{ac_id}] {text}" for ac_id, text in acceptance) or "(none mapped)"
+    files_block = "\n".join(f"- `{p}`" for p in pkg.diff_paths)
+    closing_heading, closing_body = _closing_section("reviewer")
+    return f"""\
+# Review: task {rec.task_slug} (plan task {rec.plan_task_id or 'ad-hoc'})
+
+**Model:** {rec.model}
+
+## Diff files to read (on disk — read, don't paste)
+
+{files_block}
+
+Manifest: `{pkg.manifest_path}`
+
+## Acceptance criteria to check (live from the spec store)
+
+{ac_block}
+
+## Conventions (recap)
+
+{_conventions_recap("reviewer")}
+
+## {closing_heading}
+
+{closing_body}"""

--- a/src/mship/core/review_package.py
+++ b/src/mship/core/review_package.py
@@ -45,41 +45,62 @@ def load_review_package(rec: DispatchRecord, state_dir: Path) -> ReviewPackage:
     )
 
 
-def build_review_package(rec: DispatchRecord, *, git_runner, state_dir: Path) -> ReviewPackage:
-    """Write `<record-dir>/review/{manifest.json, <repo>.diff}`.
+def build_review_package(
+    rec: DispatchRecord,
+    *,
+    targets: list[tuple[str, str, str | None]],
+    git_runner,
+    state_dir: Path,
+) -> ReviewPackage:
+    """Write `<record-dir>/review/{manifest.json, <repo>.diff per target}`.
 
-    Diff range: `<base_sha>..HEAD` of the worktree (the task's commits —
-    HEAD at dispatch time may have moved past the recorded head_sha; the
-    record's base_sha anchors the review range). `git_runner(cmd, cwd=...)`
-    is the injected shell (same contract as container.shell().run) so tests
-    use a fixture repo.
+    `targets` is (repo, worktree, base_sha) for EVERY affected repo — a
+    multi-repo task reviewed from only the dispatched repo's diff would
+    present an incomplete review as complete. Diff range per target:
+    `<base_sha>..HEAD` of that worktree (HEAD at dispatch time may have
+    moved past the recorded head_sha; base_sha anchors the review range).
+    An empty diff is still written — the CLI warns per empty file.
+    `git_runner(cmd, cwd=...)` is the injected shell (same contract as
+    container.shell().run) so tests use fixture repos.
     """
-    if not rec.base_sha:
+    if not targets:
         raise ValueError(
-            f"dispatch record for {rec.task_slug!r} has no base_sha — "
-            f"cannot compute the review diff range"
+            f"no reviewable targets for task {rec.task_slug!r} — "
+            f"cannot build a review package"
         )
     d = review_dir(rec, state_dir)
     d.mkdir(parents=True, exist_ok=True)
     diff_paths: list[Path] = []
-    res = git_runner(f"git diff {rec.base_sha}..HEAD", cwd=Path(rec.worktree))
-    if res.returncode != 0:
-        raise ValueError(
-            f"git diff {rec.base_sha}..HEAD failed in {rec.worktree}: "
-            f"{res.stderr.strip() or 'unknown error'}"
-        )
-    diff_file = d / f"{rec.repo}.diff"
-    diff_file.write_text(res.stdout)
-    diff_paths.append(diff_file)
-    # The diff runs to LIVE HEAD (which may have moved past the dispatch-time
-    # rec.head_sha) — the manifest must describe the diff it sits beside, so
-    # record the resolved head, not the record's snapshot.
-    head = git_runner("git rev-parse HEAD", cwd=Path(rec.worktree))
+    targets_meta: dict[str, dict] = {}
+    for repo, worktree, base_sha in targets:
+        if not base_sha:
+            raise ValueError(
+                f"no base_sha for repo {repo!r} — cannot compute its review "
+                f"diff range"
+            )
+        res = git_runner(f"git diff {base_sha}..HEAD", cwd=Path(worktree))
+        if res.returncode != 0:
+            raise ValueError(
+                f"git diff {base_sha}..HEAD failed in {worktree}: "
+                f"{res.stderr.strip() or 'unknown error'}"
+            )
+        diff_file = d / f"{repo}.diff"
+        diff_file.write_text(res.stdout)
+        diff_paths.append(diff_file)
+        # Each diff runs to that worktree's LIVE HEAD — the manifest must
+        # describe the diff it sits beside, not the record's snapshot.
+        head = git_runner("git rev-parse HEAD", cwd=Path(worktree))
+        targets_meta[repo] = {
+            "base_sha": base_sha,
+            "head_sha": head.stdout.strip() if head.returncode == 0 else None,
+        }
     manifest = {
         "task_slug": rec.task_slug, "work_item_id": rec.work_item_id,
         "plan_path": rec.plan_path, "plan_task_id": rec.plan_task_id,
         "acs": rec.acs, "base_sha": rec.base_sha,
-        "head_sha": head.stdout.strip() if head.returncode == 0 else rec.head_sha,
+        # Dispatched repo's live head (record snapshot when it wasn't diffed).
+        "head_sha": targets_meta.get(rec.repo, {}).get("head_sha") or rec.head_sha,
+        "targets": targets_meta,
         "diff_files": [str(p) for p in diff_paths],
     }
     manifest_path = d / "manifest.json"

--- a/src/mship/core/sdd_store.py
+++ b/src/mship/core/sdd_store.py
@@ -1,0 +1,74 @@
+"""Dispatch-record store under `<state_dir>/sdd/` (spec mship-dispatch-v2).
+
+A record is metadata + a POINTER to canonical content — plan path + anchor id
+(or an ad-hoc instruction for non-plan dispatches) — never a copy of plan
+prose. Prompts are derived at emit time from the plan and spec stores, so an
+edited plan is reflected on the next emit and no second copy can drift.
+Layout: `<state_dir>/sdd/<work-item-id | no-item>/<task-slug>/record.json`,
+with review-package artifacts (Task 6) beside it. Everything here is
+git-ignored with the rest of `.mothership/` and removed by `mship close`.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+from pydantic import BaseModel
+
+_NO_ITEM = "no-item"
+
+
+class DispatchRecord(BaseModel):
+    task_slug: str
+    work_item_id: str | None
+    mode: str
+    model: str
+    repo: str
+    worktree: str
+    base_branch: str
+    base_sha: str | None
+    head_sha: str | None
+    # Exactly one content pointer: (plan_path + plan_task_id) or instruction.
+    plan_path: str | None
+    plan_task_id: str | None
+    acs: list[str] = []
+    instruction: str | None
+    created_at: datetime
+
+
+class SddStore:
+    def __init__(self, state_dir: Path):
+        self.root = state_dir / "sdd"
+
+    def _dir(self, work_item_id: str | None, task_slug: str) -> Path:
+        return self.root / (work_item_id or _NO_ITEM) / task_slug
+
+    def write(self, rec: DispatchRecord) -> Path:
+        d = self._dir(rec.work_item_id, rec.task_slug)
+        d.mkdir(parents=True, exist_ok=True)
+        path = d / "record.json"
+        path.write_text(rec.model_dump_json(indent=2) + "\n")
+        return path
+
+    def read(self, *, work_item_id: str | None, task_slug: str) -> DispatchRecord:
+        path = self._dir(work_item_id, task_slug) / "record.json"
+        return DispatchRecord.model_validate(json.loads(path.read_text()))
+
+    def find_for_slug(self, task_slug: str) -> DispatchRecord | None:
+        """Locate a record by slug alone (the subagent's emit path — it knows
+        its task from cwd, not its WorkItem)."""
+        for p in sorted(self.root.glob(f"*/{task_slug}/record.json")):
+            return DispatchRecord.model_validate(json.loads(p.read_text()))
+        return None
+
+    def remove_task(self, task_slug: str) -> None:
+        """Remove every record dir for this slug (close-time teardown)."""
+        if not self.root.is_dir():
+            return
+        for d in self.root.glob(f"*/{task_slug}"):
+            shutil.rmtree(d, ignore_errors=True)
+        for item_dir in self.root.iterdir():
+            if item_dir.is_dir() and not any(item_dir.iterdir()):
+                item_dir.rmdir()

--- a/src/mship/core/sdd_store.py
+++ b/src/mship/core/sdd_store.py
@@ -47,6 +47,12 @@ class SddStore:
 
     def write(self, rec: DispatchRecord) -> Path:
         d = self._dir(rec.work_item_id, rec.task_slug)
+        # Supersede: a slug has at most one live record. A task that gains a
+        # WorkItem between dispatches would otherwise leave a stale record
+        # under the old key shadowing the new one in find_for_slug ("no-item"
+        # sorts before "wi-*"); dropping the whole dir also clears stale
+        # review/ artifacts beside it.
+        self._remove_dirs_for_slug(rec.task_slug, keep=d)
         d.mkdir(parents=True, exist_ok=True)
         path = d / "record.json"
         path.write_text(rec.model_dump_json(indent=2) + "\n")
@@ -65,10 +71,16 @@ class SddStore:
 
     def remove_task(self, task_slug: str) -> None:
         """Remove every record dir for this slug (close-time teardown)."""
+        self._remove_dirs_for_slug(task_slug, keep=None)
+
+    def _remove_dirs_for_slug(self, task_slug: str, *, keep: Path | None) -> None:
+        """Remove record dirs for `task_slug` (except `keep`), pruning
+        work-item dirs left empty."""
         if not self.root.is_dir():
             return
         for d in self.root.glob(f"*/{task_slug}"):
-            shutil.rmtree(d, ignore_errors=True)
+            if d != keep:
+                shutil.rmtree(d, ignore_errors=True)
         for item_dir in self.root.iterdir():
             if item_dir.is_dir() and not any(item_dir.iterdir()):
                 item_dir.rmdir()

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -195,6 +195,23 @@ Two mship-native primitives for handing work to subagents. Use them instead of h
 
   **Modes (`--mode`).** By default (`implementer`) the prompt scopes the subagent to the single task, tells it to ask clarifying questions, self-review, and report back — and explicitly **not** to open a PR, because the orchestrator owns integration and runs `mship finish` after review. This is what you want for per-task execution under an orchestrator. Pass `--mode standalone` for the alternative contract where the subagent finishes the work and opens its own PR (use it only for genuinely standalone, one-off dispatches).
 
+  **Model resolution:** dispatch resolves the subagent's model (`--model` >
+  `dispatch_models:` in mothership.yaml > built-in per-mode default) and stamps
+  it in the output — the worker never chooses its own model.
+
+  **Context isolation (SDD flow):** `mship dispatch --plan-task N` persists a
+  metadata-only record under `.mothership/sdd/` and prints a **closed stub**
+  (record path, model, mode, emit line). Do NOT expand it: launch the subagent
+  with cwd set to the worktree and let its first command be
+  `mship dispatch --emit`, which derives the full prompt (plan slice + live
+  spec AC text) in the subagent's own context, printing drift warnings to
+  stderr. Reviewer dispatches (`--mode reviewer`) build a review package
+  (raw per-repo diff files + manifest) the reviewer reads from disk; the
+  reviewer's `--emit` prints diff paths, never diff content. `--full` prints
+  the old inline prompt when you genuinely need it in-context; `--stub` opts
+  an `--instruction` dispatch into the stub. Plan task anchors may declare
+  `acs=ac1,ac2` to map a task to the spec acceptance criteria it serves.
+
 - **`mship context`** — emits structured JSON for programmatic consumers. Use when feeding state into a non-Claude-Code LLM, logging for audit, or scripting decisions. `jq`-friendly.
 
   ```bash

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -851,6 +851,102 @@ def test_reviewer_skips_missing_worktree_with_warning(tmp_path: Path):
         _reset()
 
 
+def test_reviewer_skips_passive_repos_without_warning(tmp_path: Path):
+    """Passive worktrees (in task.worktrees but not affected_repos) are
+    context checkouts, not reviewable surface — never diffed, nothing warns
+    or aborts even when they have no local base ref."""
+    wt_a = _git_worktree(tmp_path, "wt-a")
+    wt_p = tmp_path / "wt-p"; wt_p.mkdir()   # no local base ref at all
+    state_dir = tmp_path / ".mothership"; state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"; cfg.write_text("workspace: t\nrepos: {}\n")
+    task = Task(
+        slug="t", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["a"],                 # p is NOT affected
+        worktrees={"a": wt_a, "p": wt_p}, branch="feat/t",
+        base_branch="main", active_repo="a", passive_repos={"p"},
+    )
+    StateManager(state_dir).save(WorkspaceState(tasks={"t": task}))
+    _write_convention_plan(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "1"])
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "reviewer"])
+        assert result.exit_code == 0, result.output
+        assert "'p'" not in result.stderr and "warning" not in result.stderr
+        review_dir = state_dir / "sdd" / "no-item" / "t" / "review"
+        assert [p.name for p in review_dir.glob("*.diff")] == ["a.diff"]
+    finally:
+        _reset()
+
+
+def test_reviewer_git_root_child_diff_scoped_no_duplication(tmp_path: Path):
+    """A git_root child shares the parent's checkout: its .diff carries only
+    its subtree and the parent's .diff excludes it — no mislabeled parent
+    diff, no hunk in two files."""
+    import subprocess
+
+    # Source checkout (config-declared paths must exist with go-task files).
+    src = tmp_path / "parent-src"; (src / "sub").mkdir(parents=True)
+    (src / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    (src / "sub" / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+
+    # The shared task worktree: one git repo, child nested at sub/.
+    wt = tmp_path / "wt"; (wt / "sub").mkdir(parents=True)
+
+    def g(*args):
+        subprocess.run(["git", *args], cwd=wt, capture_output=True, text=True, check=True)
+
+    g("init", "-q"); g("config", "user.email", "t@t"); g("config", "user.name", "t")
+    (wt / "root.txt").write_text("base\n")
+    (wt / "sub" / "child.txt").write_text("base\n")
+    g("add", "-A"); g("commit", "-q", "-m", "base")
+    g("checkout", "-q", "-B", "main")
+    g("checkout", "-q", "-b", "feat/t")
+    (wt / "root.txt").write_text("changed\n")
+    (wt / "sub" / "child.txt").write_text("changed\n")
+    g("commit", "-q", "-am", "work")
+
+    state_dir = tmp_path / ".mothership"; state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\n"
+        "repos:\n"
+        "  parent:\n"
+        f"    path: {src}\n"
+        "    type: library\n"
+        "  child:\n"
+        "    git_root: parent\n"
+        "    path: sub\n"
+        "    type: library\n"
+    )
+    task = Task(
+        slug="t", description="d", phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["parent", "child"],
+        worktrees={"parent": wt, "child": wt / "sub"}, branch="feat/t",
+        base_branch="main", active_repo="parent",
+    )
+    StateManager(state_dir).save(WorkspaceState(tasks={"t": task}))
+    _write_convention_plan(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "1"])
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "reviewer"])
+        assert result.exit_code == 0, result.output
+        review_dir = state_dir / "sdd" / "no-item" / "t" / "review"
+        diffs = {p.name: p.read_text() for p in review_dir.glob("*.diff")}
+        assert sorted(diffs) == ["child.diff", "parent.diff"]
+        assert "sub/child.txt" in diffs["child.diff"]
+        assert "root.txt" not in diffs["child.diff"]
+        assert "root.txt" in diffs["parent.diff"]
+        assert "sub/child.txt" not in diffs["parent.diff"]
+    finally:
+        _reset()
+
+
 def test_reviewer_record_write_preserves_review_dir(tmp_path: Path):
     """The reviewer record supersedes the implementer record in the SAME keyed
     dir — the review/ package written just before must survive the write."""

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -607,6 +607,34 @@ def test_emit_after_plan_task_dispatch_prints_prompt(tmp_path: Path):
         assert "first thing" in result.output      # plan body, derived live
         assert "Model:" in result.output
         assert "Work from (mandatory)" in result.output
+        # Warnings (here: acs=ac2 with no bound spec) go ONLY to stderr — the
+        # stdout prompt must stay cleanly pipeable.
+        assert "warning:" in result.stderr
+        assert "warning:" not in result.stdout  # .output is the combined stream
+    finally:
+        _reset()
+
+
+def test_emit_uses_recorded_resolved_plan_path(tmp_path: Path, monkeypatch):
+    # An explicit relative --plan is resolved against the dispatch-time cwd
+    # when recorded, so a later --emit (any cwd) reads exactly that file.
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    sub = tmp_path / "sub"; sub.mkdir()
+    (sub / "plan.md").write_text(
+        "<!-- mship:task id=7 -->\n### Task 7\n\nsubdir plan body\n<!-- /mship:task -->\n"
+    )
+    _override(cfg, state_dir)
+    try:
+        monkeypatch.chdir(sub)
+        result = runner.invoke(
+            app, ["dispatch", "--task", "t", "--plan", "plan.md", "--plan-task", "7"]
+        )
+        assert result.exit_code == 0, result.output
+        monkeypatch.chdir(tmp_path)  # different cwd at emit time
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--emit"])
+        assert result.exit_code == 0, result.output
+        assert "subdir plan body" in result.output
     finally:
         _reset()
 

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -130,7 +130,7 @@ def test_dispatch_plan_task_uses_extracted_section(tmp_path: Path):
     _override(cfg, state_dir)
     try:
         result = runner.invoke(
-            app, ["dispatch", "--task", "t", "--plan", str(plan), "--plan-task", "7"]
+            app, ["dispatch", "--task", "t", "--plan", str(plan), "--plan-task", "7", "--full"]
         )
         assert result.exit_code == 0, result.output
         assert "wire the parser" in result.output
@@ -194,7 +194,7 @@ def test_dispatch_task_auto_resolves_convention_plan(tmp_path: Path):
     )
     _override(cfg, state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "2"])
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "2", "--full"])
         assert result.exit_code == 0, result.output
         assert "Task 2" in result.output
         assert "second thing" in result.output
@@ -225,7 +225,7 @@ def test_dispatch_task_auto_resolves_workitem_linked_plan(tmp_path: Path):
     StateManager(state_dir).save(WorkspaceState(tasks={"t": task}))
     _override(cfg, state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "3"])
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "3", "--full"])
         assert result.exit_code == 0, result.output
         assert "linked plan body" in result.output
     finally:
@@ -245,7 +245,7 @@ def test_dispatch_explicit_plan_overrides_linked(tmp_path: Path):
     _override(cfg, state_dir)
     try:
         result = runner.invoke(
-            app, ["dispatch", "--task", "t", "--plan", str(explicit), "--plan-task", "2"]
+            app, ["dispatch", "--task", "t", "--plan", str(explicit), "--plan-task", "2", "--full"]
         )
         assert result.exit_code == 0, result.output
         assert "explicit thing" in result.output
@@ -449,6 +449,117 @@ def test_dispatch_repo_missing_from_config_falls_back_to_main(tmp_path: Path):
         result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "x"])
         assert result.exit_code == 0, result.output
         assert "- **base branch:** main" in result.output
+    finally:
+        _reset()
+
+
+def _write_convention_plan(tmp_path: Path) -> None:
+    plans = tmp_path / "docs" / "plans"; plans.mkdir(parents=True)
+    (plans / "t.md").write_text(
+        "<!-- mship:task id=1 acs=ac2 -->\n### Task 1\n\nfirst thing\n<!-- /mship:task -->\n"
+    )
+
+
+def test_plan_task_dispatch_prints_stub_not_prompt(tmp_path: Path):
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _write_convention_plan(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "1"])
+        assert result.exit_code == 0, result.output
+        assert "record:" in result.output and "model:" in result.output
+        assert "Work from (mandatory)" not in result.output
+        assert "Your instruction" not in result.output
+        assert "first thing" not in result.output
+    finally:
+        _reset()
+
+
+def test_plan_task_dispatch_full_flag_prints_prompt(tmp_path: Path):
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _write_convention_plan(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(
+            app, ["dispatch", "--task", "t", "--plan-task", "1", "--full"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Work from (mandatory)" in result.output
+        assert "first thing" in result.output
+    finally:
+        _reset()
+
+
+def test_plan_task_dispatch_persists_record(tmp_path: Path):
+    from mship.core.sdd_store import SddStore
+
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _write_convention_plan(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "1"])
+        assert result.exit_code == 0, result.output
+        rec = SddStore(state_dir).find_for_slug("t")
+        assert rec is not None
+        assert rec.plan_task_id == "1"
+        assert rec.acs == ["ac2"]
+        assert rec.instruction is None
+        assert rec.plan_path is not None and rec.plan_path.endswith("t.md")
+    finally:
+        _reset()
+
+
+def test_instruction_dispatch_keeps_full_output_and_persists_record(tmp_path: Path):
+    from mship.core.sdd_store import SddStore
+
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing"])
+        assert result.exit_code == 0, result.output
+        assert "> do the thing" in result.output  # unchanged default output
+        rec = SddStore(state_dir).find_for_slug("t")
+        assert rec is not None
+        assert rec.instruction == "do the thing"
+        assert rec.plan_path is None and rec.plan_task_id is None
+    finally:
+        _reset()
+
+
+def test_instruction_dispatch_stub_flag_opts_into_stub(tmp_path: Path):
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(
+            app, ["dispatch", "--task", "t", "-i", "do the thing", "--stub"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "record:" in result.output
+        assert "do the thing" not in result.output
+    finally:
+        _reset()
+
+
+def test_dispatch_model_flag_recorded(tmp_path: Path):
+    from mship.core.sdd_store import SddStore
+
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _write_convention_plan(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(
+            app, ["dispatch", "--task", "t", "--plan-task", "1", "--model", "haiku"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "model: haiku" in result.output
+        rec = SddStore(state_dir).find_for_slug("t")
+        assert rec is not None and rec.model == "haiku"
     finally:
         _reset()
 

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -847,6 +847,17 @@ def test_reviewer_skips_missing_worktree_with_warning(tmp_path: Path):
         assert "'b'" in result.stderr and "skipping" in result.stderr
         review_dir = state_dir / "sdd" / "no-item" / "t" / "review"
         assert [p.name for p in review_dir.glob("*.diff")] == ["a.diff"]
+        # The omission is first-class in the artifact, not just controller
+        # stderr: manifest records it and the emitted prompt discloses it.
+        import json
+        manifest = json.loads((review_dir / "manifest.json").read_text())
+        assert "b" in manifest["skipped"]
+        assert "worktree missing" in manifest["skipped"]["b"]
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--emit"])
+        assert result.exit_code == 0, result.output
+        assert "NOT included" in result.stdout
+        assert "`b`" in result.stdout and "worktree missing" in result.stdout
+        assert "can't-tell" in result.stdout
     finally:
         _reset()
 

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -592,3 +592,44 @@ def test_dispatch_prompt_includes_dependencies_section(tmp_path: Path):
         assert "not ready" in result.output
     finally:
         _reset()
+
+
+def test_emit_after_plan_task_dispatch_prints_prompt(tmp_path: Path):
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _write_convention_plan(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "1"])
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--emit"])
+        assert result.exit_code == 0, result.output
+        assert "first thing" in result.output      # plan body, derived live
+        assert "Model:" in result.output
+        assert "Work from (mandatory)" in result.output
+    finally:
+        _reset()
+
+
+def test_emit_without_record_errors(tmp_path: Path):
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--emit"])
+        assert result.exit_code != 0
+        assert "no dispatch record" in result.output
+    finally:
+        _reset()
+
+
+def test_emit_rejects_instruction_sources(tmp_path: Path):
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--emit", "--plan-task", "1"])
+        assert result.exit_code == 2
+        assert "--emit" in result.output
+    finally:
+        _reset()

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -661,3 +661,114 @@ def test_emit_rejects_instruction_sources(tmp_path: Path):
         assert "--emit" in result.output
     finally:
         _reset()
+
+
+# --- reviewer mode (Task 6) ---
+
+def _git_worktree(tmp_path: Path) -> Path:
+    """A real git repo usable as the task worktree: base commit + one commit."""
+    import subprocess
+
+    wt = tmp_path / "wt"; wt.mkdir()
+
+    def g(*args):
+        subprocess.run(["git", *args], cwd=wt, capture_output=True, text=True, check=True)
+
+    g("init", "-q"); g("config", "user.email", "t@t"); g("config", "user.name", "t")
+    (wt / "f.txt").write_text("base\n")
+    g("add", "-A"); g("commit", "-q", "-m", "base")
+    g("checkout", "-q", "-B", "main")     # local base branch at the base commit
+    g("checkout", "-q", "-b", "feat/t")
+    (wt / "f.txt").write_text("changed\n")
+    g("commit", "-q", "-am", "work")
+    return wt
+
+
+def test_reviewer_dispatch_prints_stub_and_writes_package(tmp_path: Path):
+    wt = _git_worktree(tmp_path)
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _write_convention_plan(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "1"])
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "reviewer"])
+        assert result.exit_code == 0, result.output
+        assert "record:" in result.output and "mode: reviewer" in result.output
+        review_dir = state_dir / "sdd" / "no-item" / "t" / "review"
+        assert (review_dir / "manifest.json").is_file()
+        assert list(review_dir.glob("*.diff"))
+    finally:
+        _reset()
+
+
+def test_reviewer_emit_prints_paths_and_contract_not_diff(tmp_path: Path):
+    wt = _git_worktree(tmp_path)
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _write_convention_plan(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "1"])
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "reviewer"])
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--emit"])
+        assert result.exit_code == 0, result.output
+        review_dir = state_dir / "sdd" / "no-item" / "t" / "review"
+        assert str(next(review_dir.glob("*.diff"))) in result.stdout
+        assert "diff --git" not in result.stdout          # paths, never content
+        assert "spec-compliance" in result.stdout.lower()
+        assert "quality" in result.stdout.lower()
+        assert "READ-ONLY" in result.stdout
+    finally:
+        _reset()
+
+
+def test_reviewer_dispatch_without_prior_record_errors(tmp_path: Path):
+    wt = _git_worktree(tmp_path)
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "reviewer"])
+        assert result.exit_code != 0
+        assert "no dispatch record" in result.output
+    finally:
+        _reset()
+
+
+def test_reviewer_dispatch_rejects_instruction_sources(tmp_path: Path):
+    wt = _git_worktree(tmp_path)
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(
+            app, ["dispatch", "--task", "t", "--mode", "reviewer", "--plan-task", "1"]
+        )
+        assert result.exit_code == 2
+        assert "reviewer" in result.output
+    finally:
+        _reset()
+
+
+def test_reviewer_record_write_preserves_review_dir(tmp_path: Path):
+    """The reviewer record supersedes the implementer record in the SAME keyed
+    dir — the review/ package written just before must survive the write."""
+    from mship.core.sdd_store import SddStore
+
+    wt = _git_worktree(tmp_path)
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _write_convention_plan(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "1"])
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "reviewer"])
+        assert result.exit_code == 0, result.output
+        rec = SddStore(state_dir).find_for_slug("t")
+        assert rec is not None and rec.mode == "reviewer"
+        assert rec.model == "sonnet"                       # reviewer builtin default
+        assert rec.plan_task_id == "1" and rec.acs == ["ac2"]  # pointer fields kept
+        review_dir = state_dir / "sdd" / "no-item" / "t" / "review"
+        assert (review_dir / "manifest.json").is_file()    # survived the write
+    finally:
+        _reset()

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -750,6 +750,55 @@ def test_reviewer_dispatch_rejects_instruction_sources(tmp_path: Path):
         _reset()
 
 
+def test_reviewer_dispatch_warns_on_empty_diff(tmp_path: Path):
+    """base_sha == HEAD (no commits past base) -> a 0-byte .diff; the
+    controller must hear it's dispatching a reviewer at nothing."""
+    import subprocess
+
+    wt = tmp_path / "wt"; wt.mkdir()
+
+    def g(*args):
+        subprocess.run(["git", *args], cwd=wt, capture_output=True, text=True, check=True)
+
+    g("init", "-q"); g("config", "user.email", "t@t"); g("config", "user.name", "t")
+    (wt / "f.txt").write_text("base\n")
+    g("add", "-A"); g("commit", "-q", "-m", "base")
+    g("checkout", "-q", "-B", "main")     # base branch AT HEAD: nothing to diff
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _write_convention_plan(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "1"])
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "reviewer"])
+        assert result.exit_code == 0, result.output
+        assert "review package diff is empty" in result.stderr
+        assert "reviews nothing" in result.stderr
+        assert "review package diff is empty" not in result.stdout  # stub stays pipeable
+    finally:
+        _reset()
+
+
+def test_reviewer_emit_with_corrupt_manifest_errors_cleanly(tmp_path: Path):
+    wt = _git_worktree(tmp_path)
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _write_convention_plan(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "1"])
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "reviewer"])
+        assert result.exit_code == 0, result.output
+        manifest = state_dir / "sdd" / "no-item" / "t" / "review" / "manifest.json"
+        manifest.write_text("{not json")
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--emit"])
+        assert result.exit_code == 1
+        assert "manifest is corrupt" in result.output
+        assert "Traceback" not in result.output
+    finally:
+        _reset()
+
+
 def test_reviewer_record_write_preserves_review_dir(tmp_path: Path):
     """The reviewer record supersedes the implementer record in the SAME keyed
     dir — the review/ package written just before must survive the write."""

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -488,6 +488,7 @@ def test_plan_task_dispatch_full_flag_prints_prompt(tmp_path: Path):
         assert result.exit_code == 0, result.output
         assert "Work from (mandatory)" in result.output
         assert "first thing" in result.output
+        assert "**Model:**" in result.output  # inline path stamps the resolved model too
     finally:
         _reset()
 
@@ -508,6 +509,10 @@ def test_plan_task_dispatch_persists_record(tmp_path: Path):
         assert rec.acs == ["ac2"]
         assert rec.instruction is None
         assert rec.plan_path is not None and rec.plan_path.endswith("t.md")
+        # Content-absence, not just field-absence: the record raw text must not
+        # carry the plan task's body prose (it is a pointer, spec ac2).
+        raw = next((state_dir / "sdd").rglob("record.json")).read_text()
+        assert "first thing" not in raw
     finally:
         _reset()
 

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -670,11 +670,11 @@ def test_emit_rejects_instruction_sources(tmp_path: Path):
 
 # --- reviewer mode (Task 6) ---
 
-def _git_worktree(tmp_path: Path) -> Path:
+def _git_worktree(tmp_path: Path, name: str = "wt") -> Path:
     """A real git repo usable as the task worktree: base commit + one commit."""
     import subprocess
 
-    wt = tmp_path / "wt"; wt.mkdir()
+    wt = tmp_path / name; wt.mkdir()
 
     def g(*args):
         subprocess.run(["git", *args], cwd=wt, capture_output=True, text=True, check=True)
@@ -800,6 +800,53 @@ def test_reviewer_emit_with_corrupt_manifest_errors_cleanly(tmp_path: Path):
         assert result.exit_code == 1
         assert "manifest is corrupt" in result.output
         assert "Traceback" not in result.output
+    finally:
+        _reset()
+
+
+def test_reviewer_package_covers_all_affected_repos(tmp_path: Path):
+    """A multi-repo task's review package diffs EVERY affected repo, not just
+    the dispatched one, and --emit lists every diff file (PR #439 P1)."""
+    wt_a = _git_worktree(tmp_path, "wt-a")
+    wt_b = _git_worktree(tmp_path, "wt-b")
+    cfg, state_dir = _bootstrap(tmp_path, {"a": wt_a, "b": wt_b}, active_repo="a")
+    _write_convention_plan(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "1"])
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "reviewer"])
+        assert result.exit_code == 0, result.output
+        review_dir = state_dir / "sdd" / "no-item" / "t" / "review"
+        assert sorted(p.name for p in review_dir.glob("*.diff")) == ["a.diff", "b.diff"]
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--emit"])
+        assert result.exit_code == 0, result.output
+        assert str(review_dir / "a.diff") in result.stdout
+        assert str(review_dir / "b.diff") in result.stdout
+        assert "diff --git" not in result.stdout
+    finally:
+        _reset()
+
+
+def test_reviewer_skips_missing_worktree_with_warning(tmp_path: Path):
+    """A gone worktree is skipped (stderr warning naming the repo) rather than
+    failing the whole package."""
+    import shutil
+
+    wt_a = _git_worktree(tmp_path, "wt-a")
+    wt_b = _git_worktree(tmp_path, "wt-b")
+    cfg, state_dir = _bootstrap(tmp_path, {"a": wt_a, "b": wt_b}, active_repo="a")
+    _write_convention_plan(tmp_path)
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--plan-task", "1"])
+        assert result.exit_code == 0, result.output
+        shutil.rmtree(wt_b)
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "reviewer"])
+        assert result.exit_code == 0, result.output
+        assert "'b'" in result.stderr and "skipping" in result.stderr
+        review_dir = state_dir / "sdd" / "no-item" / "t" / "review"
+        assert [p.name for p in review_dir.glob("*.diff")] == ["a.diff"]
     finally:
         _reset()
 

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -317,6 +317,7 @@ def test_close_removes_sdd_records(configured_git_app):
         base_sha=None, head_sha=None, plan_path=None, plan_task_id=None,
         instruction="x", created_at=datetime.now(timezone.utc),
     ))
+    assert (state_dir / "sdd" / "wi-x" / "t" / "record.json").exists()
 
     from unittest.mock import MagicMock
     from mship.util.shell import ShellRunner, ShellResult
@@ -2110,6 +2111,28 @@ def test_close_cascade_removes_downstream(configured_git_app: Path):
     assert result.exit_code == 0, result.output
     state = sm.load()
     assert state.tasks == {}
+
+
+def test_close_cascade_removes_downstream_sdd_records(configured_git_app: Path):
+    """--cascade also removes the downstream task's sdd records, not just its state."""
+    from mship.core.sdd_store import SddStore, DispatchRecord
+    from datetime import datetime, timezone
+
+    sm = _seed_ab_tasks(configured_git_app)
+    state_dir = configured_git_app / ".mothership"
+    store = SddStore(state_dir)
+    store.write(DispatchRecord(
+        task_slug="b", work_item_id="wi-x", mode="implementer", model="m",
+        repo="shared", worktree=str(configured_git_app), base_branch="main",
+        base_sha=None, head_sha=None, plan_path=None, plan_task_id=None,
+        instruction="x", created_at=datetime.now(timezone.utc),
+    ))
+    assert (state_dir / "sdd" / "wi-x" / "b" / "record.json").exists()
+
+    result = runner.invoke(app, ["close", "a", "--yes", "--skip-pr-check", "--cascade"])
+    assert result.exit_code == 0, result.output
+    assert sm.load().tasks == {}
+    assert not list((state_dir / "sdd").rglob("*/b"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -291,6 +291,50 @@ def test_close_with_all_merged_prs(configured_git_app):
         container.shell.reset_override()
 
 
+def test_close_removes_sdd_records(configured_git_app):
+    from mship.cli import container
+    from mship.core.state import StateManager, Task, WorkspaceState
+    from mship.core.sdd_store import SddStore, DispatchRecord
+    from datetime import datetime, timezone
+
+    state_dir = configured_git_app / ".mothership"
+    sm = StateManager(state_dir)
+    state = WorkspaceState(
+        tasks={"t": Task(
+            slug="t", description="d", phase="review",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/t",
+            pr_urls={"shared": "https://github.com/o/r/pull/1"},
+            finished_at=datetime.now(timezone.utc),
+        )},
+    )
+    sm.save(state)
+
+    store = SddStore(state_dir)
+    store.write(DispatchRecord(
+        task_slug="t", work_item_id="wi-x", mode="implementer", model="m",
+        repo="shared", worktree=str(configured_git_app), base_branch="main",
+        base_sha=None, head_sha=None, plan_path=None, plan_task_id=None,
+        instruction="x", created_at=datetime.now(timezone.utc),
+    ))
+
+    from unittest.mock import MagicMock
+    from mship.util.shell import ShellRunner, ShellResult
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run.return_value = ShellResult(returncode=0, stdout="MERGED\n", stderr="")
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    container.shell.override(mock_shell)
+    try:
+        from typer.testing import CliRunner
+        from mship.cli import app as _app
+        r = CliRunner()
+        result = r.invoke(_app, ["close", "--yes", "--task", "t"])
+        assert result.exit_code == 0, result.output
+        assert not list((state_dir / "sdd").rglob("*/t"))
+    finally:
+        container.shell.reset_override()
+
+
 def test_close_with_open_pr_refuses_without_force(configured_git_app):
     from mship.cli import container
     from mship.core.state import StateManager, Task, WorkspaceState

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -609,3 +609,20 @@ def test_for_values_and_kind_values_are_the_documented_closed_set():
     --kind is spec/code-quality."""
     assert set(FOR_VALUES) == {"claude-code", "codex", "human", "reviewer"}
     assert set(KIND_VALUES) == {"spec", "code-quality"}
+
+
+def test_context_includes_dispatch_models(tmp_path: Path):
+    log_mgr = LogManager(tmp_path / "logs")
+    out = _build(WorkspaceState(), _config(tmp_path), log_mgr, tmp_path)
+    assert "dispatch_models" in out
+    assert out["dispatch_models"]["implementer"] == "inherit"
+    assert out["dispatch_models"]["reviewer"] == "sonnet"
+
+
+def test_context_dispatch_models_reflects_configured_override(tmp_path: Path):
+    log_mgr = LogManager(tmp_path / "logs")
+    cfg = _config(tmp_path)
+    cfg.dispatch_models = {"reviewer": "haiku"}
+    out = _build(WorkspaceState(), cfg, log_mgr, tmp_path)
+    assert out["dispatch_models"]["reviewer"] == "haiku"
+    assert out["dispatch_models"]["implementer"] == "inherit"

--- a/tests/core/test_dispatch.py
+++ b/tests/core/test_dispatch.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from mship.core.dispatch import BaseShaInfo, SkillRef, canonical_skills, collect_base_sha_info, resolve_repo, build_dispatch_prompt, extract_plan_task
+from mship.core.dispatch import BaseShaInfo, SkillRef, canonical_skills, collect_base_sha_info, resolve_repo, build_dispatch_prompt, extract_plan_task, extract_plan_task_meta
 from mship.core.log import LogEntry
 from mship.core.state import Task
 
@@ -67,6 +67,30 @@ def test_extract_unterminated_block_raises():
     bad = "<!-- mship:task id=1 -->\nno closing anchor here\n"
     with pytest.raises(ValueError, match="unterminated"):
         extract_plan_task(bad, "1")
+
+
+PLAN_WITH_ACS = (
+    "<!-- mship:" "task id=3 acs=ac2,ac5 -->\n"
+    "### Task 3: Thing\n"
+    "body here\n"
+    "<!-- /mship:" "task -->\n"
+)
+
+
+def test_extract_plan_task_ignores_attributes():
+    assert "body here" in extract_plan_task(PLAN_WITH_ACS, "3")
+
+
+def test_extract_plan_task_meta_returns_acs():
+    text, meta = extract_plan_task_meta(PLAN_WITH_ACS, "3")
+    assert "body here" in text
+    assert meta == {"acs": ["ac2", "ac5"]}
+
+
+def test_extract_plan_task_meta_no_attrs():
+    plan = "<!-- mship:" "task id=1 -->\nx\n<!-- /mship:" "task -->"
+    text, meta = extract_plan_task_meta(plan, "1")
+    assert meta == {}
 
 
 def test_extract_unterminated_when_next_open_precedes_close():

--- a/tests/core/test_dispatch.py
+++ b/tests/core/test_dispatch.py
@@ -85,6 +85,22 @@ def test_extract_plan_task_meta_returns_acs():
     text, meta = extract_plan_task_meta(PLAN_WITH_ACS, "3")
     assert "body here" in text
     assert meta == {"acs": ["ac2", "ac5"]}
+    # empty segments (trailing/doubled commas) are dropped, not kept as ''
+    trailing = PLAN_WITH_ACS.replace("acs=ac2,ac5", "acs=ac2,ac5,")
+    _, meta = extract_plan_task_meta(trailing, "3")
+    assert meta == {"acs": ["ac2", "ac5"]}
+
+
+def test_extract_plan_task_meta_malformed_attrs_diagnosed():
+    # space after the comma makes the anchor unmatchable — the error must say
+    # the attributes are malformed, not that the id is missing
+    plan = (
+        "<!-- mship:" "task id=3 acs=ac1, ac2 -->\n"
+        "body\n"
+        "<!-- /mship:" "task -->\n"
+    )
+    with pytest.raises(ValueError, match="attributes are malformed"):
+        extract_plan_task_meta(plan, "3")
 
 
 def test_extract_plan_task_meta_no_attrs():

--- a/tests/core/test_dispatch_emit.py
+++ b/tests/core/test_dispatch_emit.py
@@ -1,0 +1,110 @@
+"""Emit derives everything live: plan slice from the plan file, acceptance
+text from the spec store. Editing either changes the next emit; the record
+never contains them (spec ac2/ac3/ac8)."""
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from mship.core.dispatch_emit import PlanDriftWarning, build_emitted_prompt
+from mship.core.spec import AcceptanceCriterion, Spec
+from mship.core.spec_body import render_body
+from tests.core.test_sdd_store import _record
+
+PLAN = (
+    "# Plan\n\n"
+    "<!-- mship:" "task id=1 acs=ac1 -->\n"
+    "### Task 1\n\n"
+    "the anchored body\n"
+    "<!-- /mship:" "task -->\n"
+)
+
+
+def _spec() -> Spec:
+    now = datetime(2026, 7, 28, tzinfo=timezone.utc)
+    return Spec(
+        id="sp1", title="Emit spec", status="approved",
+        created_at=now, updated_at=now, affected_repos=["mothership"],
+        body=render_body("the problem", "as a user", "the approach"),
+        acceptance_criteria=[
+            AcceptanceCriterion(id="ac1", text="prompts render live plan text"),
+        ],
+    )
+
+
+@dataclass
+class _Ws:
+    root: Path
+    plan_path: Path
+    spec: Spec | None
+    record: object
+
+
+@pytest.fixture
+def ws(tmp_path: Path) -> _Ws:
+    plan_path = tmp_path / "docs" / "plans" / "plan.md"
+    plan_path.parent.mkdir(parents=True)
+    plan_path.write_text(PLAN)
+    record = _record(
+        plan_path="docs/plans/plan.md", plan_task_id="1", acs=["ac1"],
+        worktree=str(tmp_path / "wt"),
+        # Exactly the plan's mtime: no spurious drift (file timestamps come
+        # from the kernel's coarse clock, which lags datetime.now()).
+        created_at=datetime.fromtimestamp(plan_path.stat().st_mtime, tz=timezone.utc),
+    )
+    return _Ws(root=tmp_path, plan_path=plan_path, spec=_spec(), record=record)
+
+
+@pytest.fixture
+def ws_adhoc(tmp_path: Path) -> _Ws:
+    record = _record(
+        plan_path=None, plan_task_id=None, acs=[],
+        instruction="wire the ad-hoc thing",
+        worktree=str(tmp_path / "wt"),
+        created_at=datetime.now(timezone.utc),
+    )
+    return _Ws(root=tmp_path, plan_path=tmp_path / "unused.md", spec=None, record=record)
+
+
+def test_emit_contains_plan_body_and_ac_text(ws):
+    prompt, warnings = build_emitted_prompt(ws.record, workspace_root=ws.root, spec=ws.spec)
+    assert "the anchored body" in prompt          # from the plan file
+    assert "[ac1]" in prompt and ws.spec.acceptance_criteria[0].text in prompt
+    assert f"**Model:** {ws.record.model}" in prompt
+
+
+def test_emit_reflects_plan_edit_without_touching_store(ws):
+    ws.plan_path.write_text(ws.plan_path.read_text().replace("the anchored body", "EDITED BODY"))
+    prompt, _ = build_emitted_prompt(ws.record, workspace_root=ws.root, spec=ws.spec)
+    assert "EDITED BODY" in prompt
+
+
+def test_emit_warns_when_plan_newer_than_record(ws):
+    t = time.time() + 60  # deterministic mtime > record.created_at (touch()
+    os.utime(ws.plan_path, (t, t))  # can lag on the coarse kernel clock)
+    _, warnings = build_emitted_prompt(ws.record, workspace_root=ws.root, spec=ws.spec)
+    assert any(isinstance(w, PlanDriftWarning) for w in warnings)
+
+
+def test_emit_ad_hoc_instruction_record(ws_adhoc):
+    prompt, _ = build_emitted_prompt(ws_adhoc.record, workspace_root=ws_adhoc.root, spec=None)
+    assert ws_adhoc.record.instruction in prompt
+
+
+def test_emit_unknown_ac_id_warns_not_errors(ws):
+    # The plan anchor's acs= is authoritative at emit time; put the unknown
+    # id there, not on the record.
+    ws.plan_path.write_text(ws.plan_path.read_text().replace("acs=ac1", "acs=ac1,ac9"))
+    prompt, warnings = build_emitted_prompt(ws.record, workspace_root=ws.root, spec=ws.spec)
+    assert "[ac1]" in prompt
+    assert any("ac9" in str(w) for w in warnings)
+
+
+def test_emit_acs_without_spec_warns(ws):
+    _, warnings = build_emitted_prompt(ws.record, workspace_root=ws.root, spec=None)
+    assert any("ac1" in str(w) for w in warnings)

--- a/tests/core/test_dispatch_models.py
+++ b/tests/core/test_dispatch_models.py
@@ -1,0 +1,29 @@
+import pytest
+
+from mship.core.dispatch_models import resolve_model, BUILTIN_MODEL_DEFAULTS
+
+
+def test_flag_wins():
+    assert resolve_model("implementer", flag="opus", configured={"implementer": "sonnet"}) == "opus"
+
+
+def test_config_beats_builtin():
+    assert resolve_model("reviewer", flag=None, configured={"reviewer": "haiku"}) == "haiku"
+
+
+def test_builtin_default_per_mode():
+    assert resolve_model("implementer", flag=None, configured=None) == BUILTIN_MODEL_DEFAULTS["implementer"]
+    assert resolve_model("reviewer", flag=None, configured=None) == BUILTIN_MODEL_DEFAULTS["reviewer"]
+
+
+def test_unknown_mode_raises():
+    with pytest.raises(ValueError):
+        resolve_model("juggler", flag=None, configured=None)
+
+
+def test_config_field_roundtrip():
+    from mship.core.config import WorkspaceConfig
+
+    cfg = WorkspaceConfig(workspace="w", dispatch_models={"implementer": "sonnet"})
+    assert cfg.dispatch_models == {"implementer": "sonnet"}
+    assert WorkspaceConfig(workspace="w").dispatch_models is None

--- a/tests/core/test_dispatch_stub.py
+++ b/tests/core/test_dispatch_stub.py
@@ -5,8 +5,10 @@ from tests.core.test_sdd_store import _record  # reuse the fixture factory
 def test_stub_contains_exactly_the_closed_fields():
     rec = _record()
     stub = build_stub(rec, record_path="/ws/.mothership/sdd/wi-1/my-task/record.json")
-    for label in ("record:", "model:", "mode:", "emit:"):
-        assert label in stub
+    labels = tuple(line.split(":", 1)[0] for line in stub.splitlines())
+    # Every field present, in order, and NOTHING else — a new field must be
+    # added to STUB_FIELDS and consciously accepted here (that's the point).
+    assert labels == STUB_FIELDS
 
 
 def test_stub_carries_no_prompt_content():

--- a/tests/core/test_dispatch_stub.py
+++ b/tests/core/test_dispatch_stub.py
@@ -1,0 +1,30 @@
+from mship.core.dispatch_stub import STUB_FIELDS, build_stub
+from tests.core.test_sdd_store import _record  # reuse the fixture factory
+
+
+def test_stub_contains_exactly_the_closed_fields():
+    rec = _record()
+    stub = build_stub(rec, record_path="/ws/.mothership/sdd/wi-1/my-task/record.json")
+    for label in ("record:", "model:", "mode:", "emit:"):
+        assert label in stub
+
+
+def test_stub_carries_no_prompt_content():
+    """Spec ac3: controller stdout is a closed set — no task body, no template
+    boilerplate, no acceptance text, no subagent-only prompt content."""
+    rec = _record()
+    stub = build_stub(rec, record_path="/p/record.json")
+    assert len(stub.splitlines()) <= 8
+    for leaked in (
+        "Work from (mandatory)",     # template section headings
+        "Conventions (recap)",
+        "Report back",
+        "Your instruction",
+    ):
+        assert leaked not in stub
+
+
+def test_stub_emit_line_is_runnable_from_worktree():
+    rec = _record()
+    stub = build_stub(rec, record_path="/p/record.json")
+    assert "mship dispatch --emit" in stub

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -55,3 +55,7 @@ def test_resolve_plan_path_rejects_absolute_escape(tmp_path):
 def test_resolve_plan_path_rejects_dotdot_traversal(tmp_path):
     (tmp_path.parent / "esc-plan.md").write_text(_PLAN)
     assert resolve_plan_path("add-labels", "../esc-plan.md", tmp_path, "docs") is None
+
+
+def test_plan_has_tasks_with_attributes():
+    assert plan_has_tasks("<!-- mship:" "task id=1 acs=ac1 -->\nx\n<!-- /mship:" "task -->")

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -867,6 +867,39 @@ def test_merge_auto_advances_spec_and_workitem_then_tears_down(tmp_path):
     assert any(c["kind"] == "event" and "merged" in c["text"] for c in msgs.append_calls)
 
 
+def test_merge_auto_close_removes_sdd_records(tmp_path):
+    from mship.core.sdd_store import SddStore, DispatchRecord
+    from datetime import datetime, timezone
+
+    spec, wi, wstore = _seed_dispatched_spec_and_workitem(tmp_path)
+
+    store = SddStore(tmp_path / ".mothership")
+    store.write(DispatchRecord(
+        task_slug="task-m", work_item_id=wi.id, mode="implementer", model="m",
+        repo="repo1", worktree=str(tmp_path / "wt"), base_branch="main",
+        base_sha=None, head_sha=None, plan_path=None, plan_task_id=None,
+        instruction="x", created_at=datetime.now(timezone.utc),
+    ))
+
+    msgs = FakeMessageStore()
+    url = "https://github.com/org/repo1/pull/1"
+    task = SimpleNamespace(
+        slug="task-m", pr_urls={"repo1": url}, work_item_id=wi.id,
+        spec_id=spec.id, worktrees={"repo1": str(tmp_path / "wt")},
+    )
+    tasks = {"task-m": task}
+    state = FakeStateManager(tasks)
+    fwm = FakeWorktreeManager(tasks)
+
+    watcher = PrWatcher(
+        msgs, wstore, state, lambda u: "merged", now_fn,
+        worktree_manager=fwm, workspace_root=tmp_path,
+    )
+    watcher.check_once()
+
+    assert not list((tmp_path / ".mothership" / "sdd").rglob("*/task-m"))
+
+
 def test_merge_auto_close_noop_without_worktree_manager(tmp_path):
     spec, wi, wstore = _seed_dispatched_spec_and_workitem(tmp_path)
     from mship.core.spec_store import SpecStore

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -880,6 +880,7 @@ def test_merge_auto_close_removes_sdd_records(tmp_path):
         base_sha=None, head_sha=None, plan_path=None, plan_task_id=None,
         instruction="x", created_at=datetime.now(timezone.utc),
     ))
+    assert (tmp_path / ".mothership" / "sdd" / wi.id / "task-m" / "record.json").exists()
 
     msgs = FakeMessageStore()
     url = "https://github.com/org/repo1/pull/1"

--- a/tests/core/test_review_package.py
+++ b/tests/core/test_review_package.py
@@ -1,0 +1,78 @@
+"""Reviewer packages: manifest JSON + raw diff files. The reviewer READS the
+diff from disk; the prompt references paths and never embeds diff content
+(spec ac4). One reviewer returns both spec-compliance and quality verdicts
+(upstream 6.2.0 task-reviewer contract)."""
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from mship.core.review_package import build_review_package, build_reviewer_prompt
+from mship.core.sdd_store import DispatchRecord
+from mship.util.shell import ShellRunner
+from tests.core.test_sdd_store import _record
+
+
+def _git(repo: Path, *args: str) -> str:
+    r = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    )
+    return r.stdout.strip()
+
+
+@dataclass
+class _Ws:
+    record: DispatchRecord
+    shell: object  # callable(cmd, cwd=...) -> result with .stdout
+    state_dir: Path
+
+
+@pytest.fixture
+def ws(tmp_path: Path) -> _Ws:
+    """A real git repo (base commit + 2 commits past base), a DispatchRecord
+    pointing at it, and a shell runner with the container.shell().run
+    contract."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "a.txt").write_text("base\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+    base_sha = _git(repo, "rev-parse", "HEAD")
+    (repo / "a.txt").write_text("change one\n")
+    _git(repo, "commit", "-q", "-am", "one")
+    (repo / "b.txt").write_text("new file\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "two")
+    head_sha = _git(repo, "rev-parse", "HEAD")
+    record = _record(worktree=str(repo), base_sha=base_sha, head_sha=head_sha)
+    return _Ws(record=record, shell=ShellRunner().run, state_dir=tmp_path / ".mothership")
+
+
+def test_package_writes_manifest_and_diff_files(ws):
+    pkg = build_review_package(ws.record, git_runner=ws.shell, state_dir=ws.state_dir)
+    assert pkg.manifest_path.name == "manifest.json"
+    assert pkg.diff_paths and all(p.exists() for p in pkg.diff_paths)
+    assert "diff --git" in pkg.diff_paths[0].read_text()  # the raw diff landed
+    raw = pkg.manifest_path.read_text()
+    assert '"diff_files"' in raw and '"acs"' in raw
+    assert "diff --git" not in raw               # manifest is metadata, not content
+
+
+def test_reviewer_prompt_references_paths_not_content(ws):
+    pkg = build_review_package(ws.record, git_runner=ws.shell, state_dir=ws.state_dir)
+    prompt = build_reviewer_prompt(ws.record, pkg, acceptance=[("ac1", "does the thing")])
+    assert str(pkg.diff_paths[0]) in prompt
+    assert "diff --git" not in prompt             # never embedded
+    assert "spec-compliance" in prompt.lower() and "quality" in prompt.lower()
+    assert "[ac1] does the thing" in prompt
+
+
+def test_reviewer_mode_is_dispatchable():
+    from mship.core.dispatch import DISPATCH_MODES
+    assert "reviewer" in DISPATCH_MODES

--- a/tests/core/test_review_package.py
+++ b/tests/core/test_review_package.py
@@ -73,6 +73,18 @@ def test_reviewer_prompt_references_paths_not_content(ws):
     assert "[ac1] does the thing" in prompt
 
 
+def test_manifest_head_sha_matches_the_diffed_head(ws):
+    """The diff runs to live HEAD, which may have moved past the dispatch-time
+    rec.head_sha — the manifest must describe the diff it sits beside."""
+    import json
+
+    live_head = _git(Path(ws.record.worktree), "rev-parse", "HEAD")
+    stale = ws.record.model_copy(update={"head_sha": "deadbee"})
+    pkg = build_review_package(stale, git_runner=ws.shell, state_dir=ws.state_dir)
+    manifest = json.loads(pkg.manifest_path.read_text())
+    assert manifest["head_sha"] == live_head
+
+
 def test_reviewer_mode_is_dispatchable():
     from mship.core.dispatch import DISPATCH_MODES
     assert "reviewer" in DISPATCH_MODES

--- a/tests/core/test_review_package.py
+++ b/tests/core/test_review_package.py
@@ -71,6 +71,18 @@ def test_reviewer_prompt_references_paths_not_content(ws):
     assert "diff --git" not in prompt             # never embedded
     assert "spec-compliance" in prompt.lower() and "quality" in prompt.lower()
     assert "[ac1] does the thing" in prompt
+    # Content-absence: the manifest carries AC IDs, never the AC prose.
+    assert "does the thing" not in pkg.manifest_path.read_text()
+
+
+def test_load_package_rejects_manifest_missing_diff_files(ws):
+    from mship.core.review_package import load_review_package, review_dir
+
+    d = review_dir(ws.record, ws.state_dir)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "manifest.json").write_text('{"task_slug": "my-task"}\n')  # valid JSON, no diff_files
+    with pytest.raises(ValueError, match="manifest is corrupt"):
+        load_review_package(ws.record, ws.state_dir)
 
 
 def test_manifest_head_sha_matches_the_diffed_head(ws):

--- a/tests/core/test_review_package.py
+++ b/tests/core/test_review_package.py
@@ -23,6 +23,26 @@ def _git(repo: Path, *args: str) -> str:
     return r.stdout.strip()
 
 
+def _targets(rec: DispatchRecord) -> list[tuple[str, str, str | None]]:
+    """The single-repo target list for a record (repo, worktree, base_sha)."""
+    return [(rec.repo, rec.worktree, rec.base_sha)]
+
+
+def _make_repo(path: Path, marker: str) -> tuple[str, str]:
+    """Init a git repo with a base commit + one commit; return (base, head) SHAs."""
+    path.mkdir()
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "t@t")
+    _git(path, "config", "user.name", "t")
+    (path / "a.txt").write_text(f"{marker} base\n")
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", "base")
+    base = _git(path, "rev-parse", "HEAD")
+    (path / "a.txt").write_text(f"{marker} changed\n")
+    _git(path, "commit", "-q", "-am", "work")
+    return base, _git(path, "rev-parse", "HEAD")
+
+
 @dataclass
 class _Ws:
     record: DispatchRecord
@@ -55,7 +75,7 @@ def ws(tmp_path: Path) -> _Ws:
 
 
 def test_package_writes_manifest_and_diff_files(ws):
-    pkg = build_review_package(ws.record, git_runner=ws.shell, state_dir=ws.state_dir)
+    pkg = build_review_package(ws.record, targets=_targets(ws.record), git_runner=ws.shell, state_dir=ws.state_dir)
     assert pkg.manifest_path.name == "manifest.json"
     assert pkg.diff_paths and all(p.exists() for p in pkg.diff_paths)
     assert "diff --git" in pkg.diff_paths[0].read_text()  # the raw diff landed
@@ -65,7 +85,7 @@ def test_package_writes_manifest_and_diff_files(ws):
 
 
 def test_reviewer_prompt_references_paths_not_content(ws):
-    pkg = build_review_package(ws.record, git_runner=ws.shell, state_dir=ws.state_dir)
+    pkg = build_review_package(ws.record, targets=_targets(ws.record), git_runner=ws.shell, state_dir=ws.state_dir)
     prompt = build_reviewer_prompt(ws.record, pkg, acceptance=[("ac1", "does the thing")])
     assert str(pkg.diff_paths[0]) in prompt
     assert "diff --git" not in prompt             # never embedded
@@ -92,7 +112,7 @@ def test_manifest_head_sha_matches_the_diffed_head(ws):
 
     live_head = _git(Path(ws.record.worktree), "rev-parse", "HEAD")
     stale = ws.record.model_copy(update={"head_sha": "deadbee"})
-    pkg = build_review_package(stale, git_runner=ws.shell, state_dir=ws.state_dir)
+    pkg = build_review_package(stale, targets=_targets(stale), git_runner=ws.shell, state_dir=ws.state_dir)
     manifest = json.loads(pkg.manifest_path.read_text())
     assert manifest["head_sha"] == live_head
 
@@ -100,3 +120,35 @@ def test_manifest_head_sha_matches_the_diffed_head(ws):
 def test_reviewer_mode_is_dispatchable():
     from mship.core.dispatch import DISPATCH_MODES
     assert "reviewer" in DISPATCH_MODES
+
+
+def test_package_covers_every_target_repo(tmp_path: Path):
+    """A task spanning multiple repos gets one .diff per repo, all listed in
+    the manifest — a single-repo package would present an incomplete review
+    as complete (PR #439 P1)."""
+    import json
+
+    api_base, _ = _make_repo(tmp_path / "api", "api")
+    web_base, web_head = _make_repo(tmp_path / "web", "web")
+    rec = _record(worktree=str(tmp_path / "api"), base_sha=api_base)
+    pkg = build_review_package(
+        rec,
+        targets=[
+            ("api", str(tmp_path / "api"), api_base),
+            ("web", str(tmp_path / "web"), web_base),
+        ],
+        git_runner=ShellRunner().run,
+        state_dir=tmp_path / ".mothership",
+    )
+    assert sorted(p.name for p in pkg.diff_paths) == ["api.diff", "web.diff"]
+    assert all(p.exists() and "diff --git" in p.read_text() for p in pkg.diff_paths)
+    manifest = json.loads(pkg.manifest_path.read_text())
+    assert sorted(Path(f).name for f in manifest["diff_files"]) == ["api.diff", "web.diff"]
+    assert manifest["targets"]["web"] == {"base_sha": web_base, "head_sha": web_head}
+
+
+def test_package_requires_at_least_one_target(ws):
+    with pytest.raises(ValueError, match="target"):
+        build_review_package(
+            ws.record, targets=[], git_runner=ws.shell, state_dir=ws.state_dir
+        )

--- a/tests/core/test_review_package.py
+++ b/tests/core/test_review_package.py
@@ -147,6 +147,44 @@ def test_package_covers_every_target_repo(tmp_path: Path):
     assert manifest["targets"]["web"] == {"base_sha": web_base, "head_sha": web_head}
 
 
+def test_git_root_child_diff_is_scoped_and_never_duplicated(tmp_path: Path):
+    """A git_root child shares its parent's checkout — its diff must cover
+    only its subtree (not the parent's whole diff mislabeled), and the
+    parent's diff must exclude the co-targeted child so no hunk appears in
+    both files (PR #439 P1 follow-up)."""
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    (parent / "sub").mkdir(parents=True)
+    _git(parent, "init", "-q")
+    _git(parent, "config", "user.email", "t@t")
+    _git(parent, "config", "user.name", "t")
+    (parent / "root.txt").write_text("base\n")
+    (parent / "sub" / "child.txt").write_text("base\n")
+    _git(parent, "add", "-A")
+    _git(parent, "commit", "-q", "-m", "base")
+    base = _git(parent, "rev-parse", "HEAD")
+    (parent / "root.txt").write_text("changed\n")
+    (parent / "sub" / "child.txt").write_text("changed\n")
+    _git(parent, "commit", "-q", "-am", "work")
+
+    rec = _record(worktree=str(parent), base_sha=base, repo="parent")
+    pkg = build_review_package(
+        rec,
+        targets=[
+            ("parent", str(parent), base),
+            ("child", str(parent / "sub"), base),
+        ],
+        excludes={"parent": ["sub"]},
+        git_runner=ShellRunner().run,
+        state_dir=tmp_path / ".mothership",
+    )
+    diffs = {p.name: p.read_text() for p in pkg.diff_paths}
+    assert "sub/child.txt" in diffs["child.diff"]        # child subtree hunks
+    assert "root.txt" not in diffs["child.diff"]         # ...and nothing else
+    assert "root.txt" in diffs["parent.diff"]            # parent keeps the rest
+    assert "sub/child.txt" not in diffs["parent.diff"]   # no hunk in both files
+
+
 def test_package_requires_at_least_one_target(ws):
     with pytest.raises(ValueError, match="target"):
         build_review_package(

--- a/tests/core/test_review_package.py
+++ b/tests/core/test_review_package.py
@@ -91,6 +91,26 @@ def test_reviewer_prompt_references_paths_not_content(ws):
     assert "diff --git" not in prompt             # never embedded
     assert "spec-compliance" in prompt.lower() and "quality" in prompt.lower()
     assert "[ac1] does the thing" in prompt
+    assert "NOT included" not in prompt           # no skips -> no omission section
+
+
+def test_skipped_repos_are_disclosed_in_manifest_and_prompt(ws):
+    """An omitted affected repo must be first-class in the artifact — a
+    verdict over a partial package that doesn't say so implies full
+    coverage (PR #439, Greptile 3/5)."""
+    import json
+
+    pkg = build_review_package(
+        ws.record, targets=_targets(ws.record),
+        skipped={"web": "worktree missing (/gone/web)"},
+        git_runner=ws.shell, state_dir=ws.state_dir,
+    )
+    manifest = json.loads(pkg.manifest_path.read_text())
+    assert manifest["skipped"] == {"web": "worktree missing (/gone/web)"}
+    prompt = build_reviewer_prompt(ws.record, pkg, acceptance=[])
+    assert "NOT included" in prompt
+    assert "web" in prompt and "worktree missing" in prompt
+    assert "can't-tell" in prompt
     # Content-absence: the manifest carries AC IDs, never the AC prose.
     assert "does the thing" not in pkg.manifest_path.read_text()
 

--- a/tests/core/test_sdd_store.py
+++ b/tests/core/test_sdd_store.py
@@ -40,6 +40,19 @@ def test_record_never_contains_plan_body(tmp_path):
     for field in ("body", "task_text", "prompt", "template"):
         assert f'"{field}"' not in raw
 
+def test_write_supersedes_record_under_other_workitem_key(tmp_path):
+    """A slug has at most one live record: gaining a WorkItem after a no-item
+    dispatch must not leave a stale no-item record shadowing the new one
+    (find_for_slug returns the first sorted glob — "no-item" sorts before
+    "wi-*")."""
+    store = SddStore(tmp_path / ".mothership")
+    store.write(_record(work_item_id=None, plan_task_id="1"))
+    store.write(_record(work_item_id="wi-1", plan_task_id="2"))
+    rec = store.find_for_slug("my-task")
+    assert rec is not None and rec.work_item_id == "wi-1" and rec.plan_task_id == "2"
+    assert not (tmp_path / ".mothership" / "sdd" / "no-item" / "my-task").exists()
+
+
 def test_remove_task_removes_all_records_for_slug(tmp_path):
     store = SddStore(tmp_path / ".mothership")
     store.write(_record())

--- a/tests/core/test_sdd_store.py
+++ b/tests/core/test_sdd_store.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timezone
+from pathlib import Path
+from mship.core.sdd_store import DispatchRecord, SddStore
+
+NOW = datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+
+def _record(**over):
+    base = dict(
+        task_slug="my-task", work_item_id="wi-1", mode="implementer",
+        model="sonnet", repo="api", worktree="/ws/.worktrees/my-task/api",
+        base_branch="main", base_sha="a" * 7, head_sha="b" * 7,
+        plan_path="docs/plans/2026-07-28-my-task.md", plan_task_id="3",
+        acs=["ac2", "ac5"], instruction=None, created_at=NOW,
+    )
+    base.update(over)
+    return DispatchRecord(**base)
+
+def test_write_then_read_roundtrip(tmp_path):
+    store = SddStore(tmp_path / ".mothership")
+    store.write(_record())
+    rec = store.read(work_item_id="wi-1", task_slug="my-task")
+    assert rec.plan_task_id == "3" and rec.model == "sonnet" and rec.acs == ["ac2", "ac5"]
+
+def test_record_dir_is_keyed_by_workitem_and_slug(tmp_path):
+    store = SddStore(tmp_path / ".mothership")
+    p = store.write(_record())
+    assert p == tmp_path / ".mothership" / "sdd" / "wi-1" / "my-task" / "record.json"
+
+def test_no_workitem_uses_no_item_key(tmp_path):
+    store = SddStore(tmp_path / ".mothership")
+    p = store.write(_record(work_item_id=None))
+    assert p.parent.parent.name == "no-item"
+
+def test_record_never_contains_plan_body(tmp_path):
+    """The record is a pointer: plan prose must not be persisted (spec ac2)."""
+    store = SddStore(tmp_path / ".mothership")
+    p = store.write(_record())
+    raw = p.read_text()
+    assert "plan_path" in raw and "docs/plans" in raw
+    for field in ("body", "task_text", "prompt", "template"):
+        assert f'"{field}"' not in raw
+
+def test_remove_task_removes_all_records_for_slug(tmp_path):
+    store = SddStore(tmp_path / ".mothership")
+    store.write(_record())
+    store.write(_record(work_item_id=None))
+    store.remove_task("my-task")
+    assert not list((tmp_path / ".mothership" / "sdd").rglob("record.json"))

--- a/tests/skills/test_skill_dispatch_ergonomics.py
+++ b/tests/skills/test_skill_dispatch_ergonomics.py
@@ -1,7 +1,11 @@
 """Guard the bundled skills against drifting from the dispatch-ergonomics workflow."""
 from __future__ import annotations
 
+from pathlib import Path
+
 from mship.core.skill_install import pkg_skills_source
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _read(skill: str, fname: str = "SKILL.md") -> str:
@@ -32,3 +36,18 @@ def test_sdd_uses_mship_test_for_evidence():
 def test_implementer_prompt_uses_mship_test():
     text = _read("subagent-driven-development", "implementer-prompt.md")
     assert "mship test" in text
+
+
+def test_working_with_mothership_documents_stub_and_emit():
+    text = _read("working-with-mothership")
+    assert "--emit" in text          # subagent derives its own prompt
+    assert "stub" in text.lower()    # controller gets a pointer, not the prompt
+
+
+def test_working_with_mothership_documents_model_resolution():
+    text = _read("working-with-mothership")
+    assert "dispatch_models" in text
+
+
+def test_configuration_docs_cover_dispatch_models():
+    assert "dispatch_models" in (_REPO_ROOT / "docs" / "configuration.md").read_text()


### PR DESCRIPTION
## Summary

Implements spec `mship-dispatch-v2`: `mship dispatch` now owns the two subagent-orchestration mechanisms upstream superpowers 6.2.0 ships in skill prose (#437), reimplemented at the CLI layer under mship's trust model and single-source-of-truth discipline.

**Model resolution** — the dispatcher, not the untrusted worker, picks the subagent's model: `--model` flag > `dispatch_models:` per-mode map in `mothership.yaml` > built-in defaults (implementer/standalone `inherit`, reviewer a cheaper tier). Stamped in every stub and prompt; exposed per-mode in `mship context`.

**Context isolation** — each context pays only for what it owns:
- The controller gets a **closed stub** (record path, model, mode, worktree, emit line — a test fails if any other field appears). `--full`/`--stub` are the escape hatches.
- A **metadata-only record** persists under `.mothership/sdd/<work-item>/<slug>/record.json`: pointers (plan path + anchor id, or ad-hoc instruction) + SHAs + model — never plan prose (test-enforced). Superseding writes; removed by every close path (manual, `--cascade` downstream, serve merge auto-close).
- The subagent derives its own prompt via `mship dispatch --emit`: plan slice re-parsed live from the plan's `mship:task` anchor, acceptance text resolved live from the spec store via the new `acs=ac1,ac2` anchor attribute, drift warnings on stderr. Editing plan or spec changes the next emit; the store never holds a copy that can drift.
- **Reviewer mode** (`--mode reviewer`) builds a review package — `manifest.json` + raw `git diff` files — and the reviewer prompt references the file paths (upstream's measured ~2x/~50% review-token win), never embedding diff content, under a read-only dual-verdict contract.

Docs: `dispatch_models` in `configuration.md`; the SDD flow in `working-with-mothership`; `tests/skills/` guard extended to pin both.

## Test plan

- [x] TDD throughout: every module landed red-first (failure observed) → green; per-task spec-compliance + quality reviews with fix loops (supersede shadowing, malformed-anchor diagnosis, closed-set enforcement, resolved plan paths, stderr separation, empty-diff warning, corrupt-manifest handling, cascade orphans — all caught pre-merge and test-pinned)
- [x] `uv run mship test` — full suite green, 3804 passed, evidence recorded on the task
- [x] Whole-branch final review against all 8 spec ACs

Spec: `mship-dispatch-v2` · WorkItem: `wi-20260728124144-99a8b132` · Plan: `mship-workspace/docs/plans/2026-07-28-mship-dispatch-v2.md`

Refs #437 (unblocks the superpowers 6.2.0 re-vendor, which references these commands)

Closes issue #437
---

## Acceptance criteria

- [x] `ac1` `mship dispatch` resolves the subagent model with precedence flag > `dispatch_models:` per-mode map in `mothership.yaml` > built-in per-mode default, and the resolved model appears explicitly in the emitted stub and prompt; unit tests cover all three precedence levels. — test:test-runs/2.mothership
- [x] `ac2` A dispatch persists a metadata-only JSON record under `.mothership/sdd/<work-item-id>/<task-slug>/` containing a pointer to the canonical content (plan path + anchor id, or the ad-hoc instruction) and never a copy of plan task text — verified by a test asserting the record lacks the plan body while the emitted prompt contains it. — test:test-runs/2.mothership
- [x] `ac3` The full prompt is derived at emit time from the canonical plan slice wrapped in the shared template, by a command the downstream agent runs itself; the controller-facing stub is a closed set of fields (storage key, resolved model, mode, and the one-line emit instruction for the subagent) and a test fails if controller-facing stdout contains anything beyond them — no task body, no template boilerplate, no acceptance text, no subagent-only prompt content of any kind. Editing the plan changes the next emit without touching the store. — test:test-runs/2.mothership
- [x] `ac4` Review-package generation stores a JSON manifest plus raw `git diff` files for the task's commit range in the same keyed directory, and the emitted reviewer prompt references those file paths instead of embedding the diff. — test:test-runs/2.mothership
- [x] `ac5` No rendered markdown is persisted anywhere under `.mothership/sdd/` — the store is metadata JSON plus diff blobs, with markdown emitted to stdout on demand. — test:test-runs/2.mothership
- [x] `ac6` `mship close` removes the task's `.mothership/sdd/` records as part of worktree teardown, and a test proves a closed task leaves no orphan store directory. — test:test-runs/2.mothership
- [x] `ac7` A plan task anchor may declare `acs=<id,...>`; implementer and reviewer emits derive the referenced criteria's current text from the spec store (a spec-AC edit changes the next emit), and a test asserts the acceptance text appears in emitted prompts but in neither the plan body, the dispatch record, nor the review-package manifest. — test:test-runs/2.mothership
- [x] `ac8` `tests/skills/test_skill_dispatch_ergonomics.py` is extended to assert the new capabilities and passes alongside the existing suite. — test:test-runs/2.mothership