### PR TITLE
feat(dispatch): closed stub is the universal default; --full is the only inline escape

### DIFF
--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -107,13 +107,14 @@ def register(app: typer.Typer, get_container):
         ),
         full: bool = typer.Option(
             False, "--full",
-            help="Print the full subagent prompt inline (legacy). Default for "
-                 "--plan-task is a closed stub; the subagent emits its own "
-                 "prompt via --emit.",
+            help="Print the full subagent prompt inline instead of the closed "
+                 "stub (the default for every dispatch). The subagent normally "
+                 "derives its own prompt via --emit.",
         ),
         stub: bool = typer.Option(
-            False, "--stub",
-            help="Print the closed stub even for --instruction dispatches.",
+            False, "--stub", hidden=True,
+            help="Deprecated no-op: the closed stub is now the default for "
+                 "every dispatch.",
         ),
         emit: bool = typer.Option(
             False, "--emit",
@@ -420,8 +421,16 @@ def register(app: typer.Typer, get_container):
         )
         record_path = SddStore(Path(container.state_dir())).write(rec)
 
-        want_stub = (plan_task is not None and not full) or stub
-        if want_stub:
+        if stub:
+            print(
+                "warning: --stub is deprecated and a no-op — the closed stub "
+                "is the default for every dispatch (use --full for the inline prompt)",
+                file=sys.stderr,
+            )
+        # The closed stub is the universal default: every byte of prompt
+        # content reaches only the subagent (via --emit). --full is the sole
+        # inline escape hatch.
+        if not full:
             print(build_stub(rec, record_path=str(record_path)), end="")
             return
 

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -323,6 +323,24 @@ def register(app: typer.Typer, get_container):
                 "created_at": datetime.now(timezone.utc),
             })
             record_path = store.write(rec)
+            if full:
+                # Honor the universal inline escape: print the same reviewer
+                # prompt the subagent's --emit would derive (paths + live ACs
+                # + contract — never diff content).
+                try:
+                    _instr, ac_ids, warnings = resolve_instruction_and_acs(
+                        rec, Path(container.config_path()).parent
+                    )
+                except (OSError, ValueError) as e:
+                    output.error(f"cannot resolve acceptance criteria: {e}")
+                    raise typer.Exit(code=1)
+                spec = _load_bound_spec(container, task_obj, rec)
+                acceptance, ac_warnings = resolve_acceptance(ac_ids, spec)
+                warnings.extend(ac_warnings)
+                for w in warnings:
+                    print(f"warning: {w}", file=sys.stderr)
+                print(build_reviewer_prompt(rec, pkg, acceptance=acceptance or []))
+                return
             print(build_stub(rec, record_path=str(record_path)), end="")
             return
 

--- a/src/mship/skills/subagent-driven-development/SKILL.md
+++ b/src/mship/skills/subagent-driven-development/SKILL.md
@@ -251,7 +251,7 @@ dispatch record; this copy is for your bookkeeping.)
   first command is `mship dispatch --emit`, which derives its full prompt
   (plan-task slice + live spec AC text + worktree, phase, journal, bases) in
   its own context — the task text never transits yours. For an ad-hoc
-  instruction not in the plan, use `mship dispatch --stub -i "<text>"` (or
+  instruction not in the plan, use `mship dispatch -i "<text>"` (or
   `-i -` for stdin); exactly one instruction source is allowed.
 - The default mode is **implementer** — it scopes the subagent to the single
   task and tells it to report back, NOT open a PR. That's what you want:
@@ -376,7 +376,7 @@ scoped re-review. Five rounds maximum per task:
 **Rounds 1-3 — resume the original implementer.** Send it the open findings
 verbatim. Its context is intact: it knows the task, the code, and its own
 choices. If your harness cannot send another message to a live subagent,
-dispatch a fresh implementer via `mship dispatch --stub -i -` with the
+dispatch a fresh implementer via `mship dispatch -i -` with the
 findings, the report-file path, and the covering-test names as the
 instruction — the report file is the persistent memory either way.
 

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -199,17 +199,17 @@ Two mship-native primitives for handing work to subagents. Use them instead of h
   `dispatch_models:` in mothership.yaml > built-in per-mode default) and stamps
   it in the output — the worker never chooses its own model.
 
-  **Context isolation (SDD flow):** `mship dispatch --plan-task N` persists a
-  metadata-only record under `.mothership/sdd/` and prints a **closed stub**
+  **Context isolation (SDD flow):** every dispatch (plan-task or ad-hoc `-i`)
+  persists a metadata-only record under `.mothership/sdd/` and prints a **closed stub**
   (record path, model, mode, emit line). Do NOT expand it: launch the subagent
   with cwd set to the worktree and let its first command be
   `mship dispatch --emit`, which derives the full prompt (plan slice + live
   spec AC text) in the subagent's own context, printing drift warnings to
   stderr. Reviewer dispatches (`--mode reviewer`) build a review package
   (raw per-repo diff files + manifest) the reviewer reads from disk; the
-  reviewer's `--emit` prints diff paths, never diff content. `--full` prints
-  the old inline prompt when you genuinely need it in-context; `--stub` opts
-  an `--instruction` dispatch into the stub. Plan task anchors may declare
+  reviewer's `--emit` prints diff paths, never diff content. `--full` is the
+  ONLY inline escape — it prints the old full prompt when you genuinely need
+  it in your own context (`--stub` is a deprecated no-op). Plan task anchors may declare
   `acs=ac1,ac2` to map a task to the spec acceptance criteria it serves.
 
 - **`mship context`** — emits structured JSON for programmatic consumers. Use when feeding state into a non-Claude-Code LLM, logging for audit, or scripting decisions. `jq`-friendly.

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -190,7 +190,8 @@ Two mship-native primitives for handing work to subagents. Use them instead of h
 - **`mship dispatch`** — turns an instruction source (ad-hoc `-i/--instruction`, or a plan anchor via `--plan-task`) into a subagent dispatch. Default output is a **closed stub** (record path, resolved model, mode, worktree, emit line) — launch the subagent with cwd set to the worktree and let its first command be `mship dispatch --emit`, which derives the full self-contained prompt (instruction/plan slice, task slug, journal, per-repo bases, live spec AC text) in the subagent's own context. Pass `--full` only when you genuinely want the inline prompt in YOUR context (then pipe it as the `prompt` field of a Claude Code `Task` dispatch or the analogous mechanism elsewhere).
 
   ```bash
-  mship dispatch --task my-task -i "implement the parser changes"   # prints a ready-to-use prompt to stdout
+  mship dispatch --task my-task -i "implement the parser changes"          # prints the closed stub; the subagent runs `mship dispatch --emit`
+  mship dispatch --task my-task -i "implement the parser changes" --full   # inline prompt in YOUR context (explicit escape)
   ```
 
   **Modes (`--mode`).** By default (`implementer`) the prompt scopes the subagent to the single task, tells it to ask clarifying questions, self-review, and report back — and explicitly **not** to open a PR, because the orchestrator owns integration and runs `mship finish` after review. This is what you want for per-task execution under an orchestrator. Pass `--mode standalone` for the alternative contract where the subagent finishes the work and opens its own PR (use it only for genuinely standalone, one-off dispatches).

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -187,7 +187,7 @@ non-event message on the thread; serve does no drafting itself.
 
 Two mship-native primitives for handing work to subagents. Use them instead of hand-rolling task context:
 
-- **`mship dispatch`** — wraps your instruction (`-i/--instruction`, **required**) in a self-contained Markdown prompt for a subagent. Output includes your instruction plus the task slug, worktree path, phase, recent journal entries, affected repos, and per-repo bases. Pipe stdout directly as the `prompt` field of a Claude Code `Task` tool dispatch (or analogous mechanism in Codex / other agent platforms).
+- **`mship dispatch`** — turns an instruction source (ad-hoc `-i/--instruction`, or a plan anchor via `--plan-task`) into a subagent dispatch. Default output is a **closed stub** (record path, resolved model, mode, worktree, emit line) — launch the subagent with cwd set to the worktree and let its first command be `mship dispatch --emit`, which derives the full self-contained prompt (instruction/plan slice, task slug, journal, per-repo bases, live spec AC text) in the subagent's own context. Pass `--full` only when you genuinely want the inline prompt in YOUR context (then pipe it as the `prompt` field of a Claude Code `Task` dispatch or the analogous mechanism elsewhere).
 
   ```bash
   mship dispatch --task my-task -i "implement the parser changes"   # prints a ready-to-use prompt to stdout

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -1001,3 +1001,37 @@ def test_reviewer_record_write_preserves_review_dir(tmp_path: Path):
         assert (review_dir / "manifest.json").is_file()    # survived the write
     finally:
         _reset()
+
+
+def test_reviewer_dispatch_honors_full_flag(tmp_path: Path):
+    """--full is the universal inline escape: reviewer mode must honor it
+    (previously it silently printed the stub regardless)."""
+    import subprocess
+    wt = tmp_path / "wt"; wt.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=wt, check=True)
+    subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                    "commit", "-q", "--allow-empty", "-m", "base"], cwd=wt, check=True)
+    base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=wt,
+                          capture_output=True, text=True, check=True).stdout.strip()
+    (wt / "f.txt").write_text("x\n")
+    subprocess.run(["git", "add", "."], cwd=wt, check=True)
+    subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                    "commit", "-q", "-m", "change"], cwd=wt, check=True)
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _override(cfg, state_dir)
+    try:
+        r1 = runner.invoke(app, ["dispatch", "--task", "t", "-i", "impl work"])
+        assert r1.exit_code == 0, r1.output
+        # base_sha in the record comes from the bootstrap task's branch state;
+        # patch the record to the real base for a valid diff range
+        from mship.core.sdd_store import SddStore
+        store = SddStore(state_dir)
+        rec = store.find_for_slug("t")
+        store.write(rec.model_copy(update={"base_sha": base}))
+        r2 = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "reviewer", "--full"])
+        assert r2.exit_code == 0, r2.output
+        assert "record:" not in r2.stdout          # not the stub
+        assert "Diff files to read" in r2.stdout   # the reviewer prompt
+        assert "diff --git" not in r2.stdout       # never diff content
+    finally:
+        _reset()

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -46,7 +46,7 @@ def test_dispatch_single_repo_task_prints_prompt(tmp_path: Path):
     container.config_path.override(cfg)
     container.state_dir.override(state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing"])
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing", "--full"])
         assert result.exit_code == 0, result.output
         assert f"cd {wt}" in result.output
         assert "> do the thing" in result.output
@@ -63,7 +63,7 @@ def test_dispatch_multi_repo_no_active_errors(tmp_path: Path):
     container.config_path.override(cfg)
     container.state_dir.override(state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "x"])
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "x", "--full"])
         assert result.exit_code == 1
         assert "affects 2 repos" in result.output
     finally:
@@ -78,7 +78,7 @@ def test_dispatch_multi_repo_with_repo_flag_picks_that_one(tmp_path: Path):
     container.config_path.override(cfg)
     container.state_dir.override(state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "t", "--repo", "b", "-i", "x"])
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--repo", "b", "-i", "x", "--full"])
         assert result.exit_code == 0, result.output
         assert f"cd {b}" in result.output
         assert f"cd {a}" not in result.output
@@ -93,7 +93,7 @@ def test_dispatch_unknown_repo_errors(tmp_path: Path):
     container.config_path.override(cfg)
     container.state_dir.override(state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "t", "--repo", "nope", "-i", "x"])
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--repo", "nope", "-i", "x", "--full"])
         assert result.exit_code == 1
         assert "unknown repo" in result.output
     finally:
@@ -275,7 +275,9 @@ def test_dispatch_instruction_dash_reads_stdin(tmp_path: Path):
     cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
     _override(cfg, state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "-"], input="from stdin\n")
+        result = runner.invoke(
+            app, ["dispatch", "--task", "t", "-i", "-", "--full"], input="from stdin\n"
+        )
         assert result.exit_code == 0, result.output
         assert "> from stdin" in result.output
     finally:
@@ -287,7 +289,7 @@ def test_dispatch_default_mode_reports_back_no_pr(tmp_path: Path):
     cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
     _override(cfg, state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing"])
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing", "--full"])
         assert result.exit_code == 0, result.output
         assert "Report back" in result.output
         assert "status report" in result.output.lower()
@@ -302,7 +304,7 @@ def test_dispatch_standalone_mode_has_finish_contract(tmp_path: Path):
     cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
     _override(cfg, state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "standalone", "-i", "x"])
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "standalone", "-i", "x", "--full"])
         assert result.exit_code == 0, result.output
         assert "How to finish" in result.output
         assert "mship finish --body-file" in result.output
@@ -374,7 +376,7 @@ def test_dispatch_uses_repo_config_base_branch(tmp_path: Path):
     container.config_path.override(cfg)
     container.state_dir.override(state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing"])
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing", "--full"])
         assert result.exit_code == 0, result.output
         assert "- **base branch:** dev" in result.output
         assert "base (dev)" in result.output
@@ -392,7 +394,7 @@ def test_dispatch_base_override_wins_over_repo_config(tmp_path: Path):
     container.config_path.override(cfg)
     container.state_dir.override(state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing"])
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing", "--full"])
         assert result.exit_code == 0, result.output
         assert "- **base branch:** stacked" in result.output
     finally:
@@ -409,7 +411,7 @@ def test_dispatch_falls_back_to_main_when_repo_config_has_no_base_branch(tmp_pat
     container.config_path.override(cfg)
     container.state_dir.override(state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing"])
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing", "--full"])
         assert result.exit_code == 0, result.output
         assert "- **base branch:** main" in result.output
     finally:
@@ -429,7 +431,7 @@ def test_dispatch_falls_back_to_stored_task_base_before_main(tmp_path: Path):
     container.config_path.override(cfg)
     container.state_dir.override(state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing"])
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing", "--full"])
         assert result.exit_code == 0, result.output
         assert "- **base branch:** staging" in result.output
     finally:
@@ -446,7 +448,7 @@ def test_dispatch_repo_missing_from_config_falls_back_to_main(tmp_path: Path):
     container.config_path.override(cfg)
     container.state_dir.override(state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "x"])
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "x", "--full"])
         assert result.exit_code == 0, result.output
         assert "- **base branch:** main" in result.output
     finally:
@@ -517,7 +519,9 @@ def test_plan_task_dispatch_persists_record(tmp_path: Path):
         _reset()
 
 
-def test_instruction_dispatch_keeps_full_output_and_persists_record(tmp_path: Path):
+def test_instruction_dispatch_defaults_to_stub_and_persists_record(tmp_path: Path):
+    """The stub is the universal default: ad-hoc dispatches leak neither the
+    template nor the instruction back into the controller's stdout."""
     from mship.core.sdd_store import SddStore
 
     wt = tmp_path / "wt"; wt.mkdir()
@@ -526,7 +530,8 @@ def test_instruction_dispatch_keeps_full_output_and_persists_record(tmp_path: Pa
     try:
         result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "do the thing"])
         assert result.exit_code == 0, result.output
-        assert "> do the thing" in result.output  # unchanged default output
+        assert "record:" in result.output
+        assert "do the thing" not in result.output
         rec = SddStore(state_dir).find_for_slug("t")
         assert rec is not None
         assert rec.instruction == "do the thing"
@@ -535,7 +540,22 @@ def test_instruction_dispatch_keeps_full_output_and_persists_record(tmp_path: Pa
         _reset()
 
 
-def test_instruction_dispatch_stub_flag_opts_into_stub(tmp_path: Path):
+def test_instruction_dispatch_full_flag_prints_prompt(tmp_path: Path):
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(
+            app, ["dispatch", "--task", "t", "-i", "do the thing", "--full"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "> do the thing" in result.output
+        assert "Work from (mandatory)" in result.output
+    finally:
+        _reset()
+
+
+def test_stub_flag_is_a_deprecated_noop(tmp_path: Path):
     wt = tmp_path / "wt"; wt.mkdir()
     cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
     _override(cfg, state_dir)
@@ -545,7 +565,8 @@ def test_instruction_dispatch_stub_flag_opts_into_stub(tmp_path: Path):
         )
         assert result.exit_code == 0, result.output
         assert "record:" in result.output
-        assert "do the thing" not in result.output
+        assert "do the thing" not in result.stdout
+        assert "deprecated" in result.stderr
     finally:
         _reset()
 
@@ -590,7 +611,7 @@ def test_dispatch_prompt_includes_dependencies_section(tmp_path: Path):
     container.config_path.override(cfg)
     container.state_dir.override(state_dir)
     try:
-        result = runner.invoke(app, ["dispatch", "--task", "b", "-i", "go"])
+        result = runner.invoke(app, ["dispatch", "--task", "b", "-i", "go", "--full"])
         assert result.exit_code == 0, result.output
         assert "## Dependencies" in result.output
         assert "a" in result.output


### PR DESCRIPTION
## Summary

Closes the last gap in the dispatch context-isolation contract (operator-flagged): ad-hoc `--instruction` dispatches still printed the **full inline prompt** by default. The instruction is the controller's own words, but the ~150 lines of wrapper around it — journal, base SHAs, conventions recap, skills list, closing contract — are subagent-only content that leaked into the controller's context on every ad-hoc dispatch.

- **The closed stub is now the universal default** for every dispatch (plan-task and ad-hoc alike); the subagent derives its own prompt via `mship dispatch --emit`.
- **`--full` is the only inline escape** — explicit, for when the controller genuinely wants the prompt in its own context.
- **`--stub` is a hidden, deprecated no-op** (accepted for one release; warns on stderr).
- Docs/skills updated: `working-with-mothership`'s SDD-flow section and the two `--stub -i` invocations in `subagent-driven-development`.

## Test plan

- [x] TDD: new default-stub + `--full` + deprecated-noop tests written first and observed red
- [x] The 11 prompt-assembly tests keep their original intent via `--full` (same precedent as the `--plan-task` flip in #439)
- [x] `mship test` full suite green (evidence recorded); `tests/skills/` guards 16/16

WorkItem: `wi-20260728191656-895c71e2` (chore)
