### PR TITLE
product_assumptions.md: backtest gate + Wave 1/L3 (assumption coverage parser, validator, advisory CLI)

### DIFF
--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -131,6 +131,7 @@ from mship.cli import message as _message_mod
 from mship.cli import net as _net_mod
 from mship.cli import pair as _pair_mod
 from mship.cli import phase as _phase_mod
+from mship.cli import plan as _plan_mod
 from mship.cli import pr as _pr_mod
 from mship.cli import prune as _prune_mod
 from mship.cli import reconcile as _reconcile_mod
@@ -195,6 +196,7 @@ _log_mod.register(app, get_container)
 _message_mod.register(app, get_container)
 _pair_mod.register(app, get_container)
 _phase_mod.register(app, get_container)
+_plan_mod.register(app, get_container)
 _pr_mod.register(app, get_container)
 _prune_mod.register(app, get_container)
 _reconcile_mod.register(app, get_container)

--- a/src/mship/cli/plan.py
+++ b/src/mship/cli/plan.py
@@ -1,0 +1,73 @@
+"""`mship plan` sub-app: implementation-plan self-checks.
+
+Wave 1 (issue #444): the "Assumptions checked" coverage check is advisory
+only — it always exits 0. The hard plan-gate block lands in Wave 3 once the
+L1 assumption store exists; this command is the self-check a planner runs by
+hand (or wires into their own pre-dev habit) in the meantime.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from mship.cli.output import Output
+
+
+def register(parent: typer.Typer, get_container):
+    plan_app = typer.Typer(
+        name="plan",
+        help="Implementation-plan checks.",
+        no_args_is_help=True,
+    )
+
+    @plan_app.command("check-assumptions")
+    def check_assumptions(
+        task: Optional[str] = typer.Option(None, "--task", help="Task slug; resolves the plan via the docs/plans/<date>-<slug>.md convention."),
+        plan: Optional[str] = typer.Option(None, "--plan", help="Explicit plan path (workspace-relative)."),
+    ):
+        """Report which seed assumption axes the plan's 'Assumptions checked'
+        block leaves undispositioned. Advisory only — always exits 0."""
+        from mship.core.config import ConfigLoader
+        from mship.core.plan import SEED_AXES, missing_assumption_axes, resolve_plan_path
+
+        output = Output()
+        container = get_container()
+
+        if task is None and plan is None:
+            output.error("Provide --task or --plan.")
+            raise typer.Exit(1)
+
+        workspace_root = Path(container.config_path()).parent
+        try:
+            docs_dir = ConfigLoader.load(Path(container.config_path()), require_paths=False).docs_dir
+        except Exception:
+            docs_dir = "docs"
+
+        resolved = resolve_plan_path(task or "", plan, workspace_root, docs_dir)
+        if resolved is None:
+            where = f"for task {task!r}" if task else f"at {plan!r}"
+            output.error(f"No plan found {where}.")
+            raise typer.Exit(1)
+
+        missing = missing_assumption_axes(resolved.read_text(), SEED_AXES)
+        ok = not missing
+
+        if output.human_mode:
+            output.print(f"Plan: {resolved}")
+            if ok:
+                output.success("All seed assumption axes dispositioned.")
+            else:
+                output.print("[yellow]Missing assumption axes:[/yellow]")
+                for axis in missing:
+                    output.print(f"  - {axis}")
+        else:
+            output.json({
+                "plan": str(resolved),
+                "expected": list(SEED_AXES),
+                "missing": missing,
+                "ok": ok,
+            })
+
+    parent.add_typer(plan_app, rich_help_panel="Work items & specs")

--- a/src/mship/cli/plan.py
+++ b/src/mship/cli/plan.py
@@ -39,11 +39,16 @@ def register(parent: typer.Typer, get_container):
             output.error("Provide --task or --plan.")
             raise typer.Exit(1)
 
-        workspace_root = Path(container.config_path()).parent
-        try:
-            docs_dir = ConfigLoader.load(Path(container.config_path()), require_paths=False).docs_dir
-        except Exception:
-            docs_dir = "docs"
+        config_path = Path(container.config_path())
+        workspace_root = config_path.parent
+        # Fall back to "docs" only when there is no config file (e.g. invoked
+        # outside a materialized workspace); a present-but-malformed config must
+        # surface, not be swallowed behind a plausible default.
+        docs_dir = (
+            ConfigLoader.load(config_path, require_paths=False).docs_dir
+            if config_path.is_file()
+            else "docs"
+        )
 
         resolved = resolve_plan_path(task or "", plan, workspace_root, docs_dir)
         if resolved is None:

--- a/src/mship/core/plan.py
+++ b/src/mship/core/plan.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Iterable
 
 # Keep in sync with dispatch._TASK_OPEN_RE
 _TASK_ANCHOR_RE = re.compile(r"<!--\s*mship:task\s+id=([^\s>]+)(?:\s+[a-z_]+=[^\s>]+)*\s*-->")
@@ -50,6 +51,17 @@ def dispositioned_axes(plan_text: str) -> set[str]:
     next_heading = re.search(r"^#{1,6}\s+\S", rest, re.MULTILINE)
     block = rest[: next_heading.start()] if next_heading else rest
     return {_normalize_axis(row.group("axis")) for row in _ASSUMPTION_ROW_RE.finditer(block)}
+
+
+def missing_assumption_axes(plan_text: str, expected_axes: Iterable[str]) -> list[str]:
+    """Expected assumption axes the plan does NOT disposition, in expected order.
+
+    N/A counts as dispositioned (an explicit N/A IS a disposition — that is the
+    HAZOP discipline). Empty list ⇒ well-formed. `expected_axes` is injected so
+    the live source (Wave 1: SEED_AXES; Wave 2: the L1 store) is the caller's
+    choice, not baked in here."""
+    covered = dispositioned_axes(plan_text)
+    return [a for a in (_normalize_axis(x) for x in expected_axes) if a not in covered]
 
 
 def _plan_stem_matches_slug(stem: str, task_slug: str) -> bool:

--- a/src/mship/core/plan.py
+++ b/src/mship/core/plan.py
@@ -29,28 +29,47 @@ SEED_AXES: tuple[str, ...] = (
 
 # "## Assumptions checked" (any case), then consecutive "- <axis> <sep> <disposition>"
 # bullet lines. Separator is an em-dash or one/two hyphens. Axis = text before the
-# first separator, normalized (lowercased, internal whitespace collapsed).
+# first separator; disposition = the rest of the line.
 _ASSUMPTIONS_HEADING_RE = re.compile(r"^#{1,6}\s+assumptions\s+checked\s*$", re.IGNORECASE | re.MULTILINE)
-_ASSUMPTION_ROW_RE = re.compile(r"^\s*[-*]\s+(?P<axis>.+?)\s*(?:—|--|-)\s+\S", re.MULTILINE)
+_ASSUMPTION_ROW_RE = re.compile(r"^\s*[-*]\s+(?P<axis>.+?)\s*(?:—|--|-)\s+(?P<disposition>\S.*)$", re.MULTILINE)
 
 
 def _normalize_axis(raw: str) -> str:
     return " ".join(raw.strip().lower().split())
 
 
-def dispositioned_axes(plan_text: str) -> set[str]:
-    """Axis names dispositioned in the plan's 'Assumptions checked' block.
+def _is_real_disposition(disposition: str) -> bool:
+    """True unless the disposition is only an unfilled template placeholder.
 
-    Returns the normalized axis name of each bullet row under the first
-    '## Assumptions checked' heading, up to the next heading. Empty set when
-    there is no such block (an unchecked plan)."""
+    The writing-plans template seeds each row with a `[...]`/`<...>` placeholder
+    (e.g. `[covered/N/A: one line]`). A copied-but-unfilled template must NOT
+    count as dispositioned, or the checker greenlights a plan with no actual
+    assumption analysis (Greptile #448). Only a disposition that is ENTIRELY a
+    single bracketed token is rejected — a real disposition that merely contains
+    brackets (e.g. `covered [see #123]`) still counts."""
+    d = disposition.strip()
+    return not ((d.startswith("[") and d.endswith("]")) or (d.startswith("<") and d.endswith(">")))
+
+
+def dispositioned_axes(plan_text: str) -> set[str]:
+    """Axis names GENUINELY dispositioned in the plan's 'Assumptions checked'
+    block.
+
+    Returns the normalized axis name of each bullet row (under the first
+    '## Assumptions checked' heading, up to the next heading) whose disposition
+    is real — an unfilled `[...]`/`<...>` template placeholder does not count.
+    Empty set when there is no such block (an unchecked plan)."""
     m = _ASSUMPTIONS_HEADING_RE.search(plan_text)
     if m is None:
         return set()
     rest = plan_text[m.end():]
     next_heading = re.search(r"^#{1,6}\s+\S", rest, re.MULTILINE)
     block = rest[: next_heading.start()] if next_heading else rest
-    return {_normalize_axis(row.group("axis")) for row in _ASSUMPTION_ROW_RE.finditer(block)}
+    return {
+        _normalize_axis(row.group("axis"))
+        for row in _ASSUMPTION_ROW_RE.finditer(block)
+        if _is_real_disposition(row.group("disposition"))
+    }
 
 
 def missing_assumption_axes(plan_text: str, expected_axes: Iterable[str]) -> list[str]:

--- a/src/mship/core/plan.py
+++ b/src/mship/core/plan.py
@@ -14,6 +14,43 @@ from pathlib import Path
 # Keep in sync with dispatch._TASK_OPEN_RE
 _TASK_ANCHOR_RE = re.compile(r"<!--\s*mship:task\s+id=([^\s>]+)(?:\s+[a-z_]+=[^\s>]+)*\s*-->")
 
+# The 7 seed assumptions (issue #444). Canonical lowercase axis names.
+# SINGLE SOURCE for Wave 1; Wave 2's L1 store supersedes this constant.
+SEED_AXES: tuple[str, ...] = (
+    "repo topology",
+    "credential locus",
+    "execution locus",
+    "state durability",
+    "review surface",
+    "agent stream",
+    "dispatched model",
+)
+
+# "## Assumptions checked" (any case), then consecutive "- <axis> <sep> <disposition>"
+# bullet lines. Separator is an em-dash or one/two hyphens. Axis = text before the
+# first separator, normalized (lowercased, internal whitespace collapsed).
+_ASSUMPTIONS_HEADING_RE = re.compile(r"^#{1,6}\s+assumptions\s+checked\s*$", re.IGNORECASE | re.MULTILINE)
+_ASSUMPTION_ROW_RE = re.compile(r"^\s*[-*]\s+(?P<axis>.+?)\s*(?:—|--|-)\s+\S", re.MULTILINE)
+
+
+def _normalize_axis(raw: str) -> str:
+    return " ".join(raw.strip().lower().split())
+
+
+def dispositioned_axes(plan_text: str) -> set[str]:
+    """Axis names dispositioned in the plan's 'Assumptions checked' block.
+
+    Returns the normalized axis name of each bullet row under the first
+    '## Assumptions checked' heading, up to the next heading. Empty set when
+    there is no such block (an unchecked plan)."""
+    m = _ASSUMPTIONS_HEADING_RE.search(plan_text)
+    if m is None:
+        return set()
+    rest = plan_text[m.end():]
+    next_heading = re.search(r"^#{1,6}\s+\S", rest, re.MULTILINE)
+    block = rest[: next_heading.start()] if next_heading else rest
+    return {_normalize_axis(row.group("axis")) for row in _ASSUMPTION_ROW_RE.finditer(block)}
+
 
 def _plan_stem_matches_slug(stem: str, task_slug: str) -> bool:
     """Precise match, not substring: either the stem IS the slug, or it's the

--- a/src/mship/core/plan.py
+++ b/src/mship/core/plan.py
@@ -39,16 +39,18 @@ def _normalize_axis(raw: str) -> str:
 
 
 def _is_real_disposition(disposition: str) -> bool:
-    """True unless the disposition is only an unfilled template placeholder.
+    """True unless the disposition is still the unfilled template placeholder.
 
-    The writing-plans template seeds each row with a `[...]`/`<...>` placeholder
-    (e.g. `[covered/N/A: one line]`). A copied-but-unfilled template must NOT
-    count as dispositioned, or the checker greenlights a plan with no actual
-    assumption analysis (Greptile #448). Only a disposition that is ENTIRELY a
-    single bracketed token is rejected — a real disposition that merely contains
-    brackets (e.g. `covered [see #123]`) still counts."""
-    d = disposition.strip()
-    return not ((d.startswith("[") and d.endswith("]")) or (d.startswith("<") and d.endswith(">")))
+    The writing-plans template seeds each row with `[covered/N/A: one line]`. A
+    copied-but-unfilled template must NOT count as dispositioned, or the checker
+    greenlights a plan with no actual assumption analysis (Greptile #448). The
+    unmistakable unfilled marker is the literal `covered/N/A` choice — a real
+    disposition PICKS one ("covered" or "N/A") and never writes the slash-form.
+    Keying off that marker (rather than "is bracketed") means a filled
+    disposition that merely retains brackets — e.g.
+    `[covered: metarepo handles clones]` — still counts."""
+    compact = re.sub(r"\s+", "", disposition).lower()
+    return "covered/n/a" not in compact
 
 
 def dispositioned_axes(plan_text: str) -> set[str]:

--- a/src/mship/skills/writing-plans/SKILL.md
+++ b/src/mship/skills/writing-plans/SKILL.md
@@ -66,6 +66,23 @@ independently testable deliverable.
 
 **Goal:** [One sentence describing what this builds]
 
+## Assumptions checked
+
+[Before naming an approach, disposition every current assumption axis —
+`covered` (one line on how) or `N/A` (one line why). Wave 1's axis list is
+the seed set in `core/plan.SEED_AXES` (repo topology, credential locus,
+execution locus, state durability, review surface, agent stream, dispatched
+model); a later wave replaces this fixed list with a live store. Self-check
+with `mship plan check-assumptions --plan <path>`.]
+
+- repo topology — [covered/N/A: one line]
+- credential locus — [covered/N/A: one line]
+- execution locus — [covered/N/A: one line]
+- state durability — [covered/N/A: one line]
+- review surface — [covered/N/A: one line]
+- agent stream — [covered/N/A: one line]
+- dispatched model — [covered/N/A: one line]
+
 **Architecture:** [2-3 sentences about approach]
 
 **Tech Stack:** [Key technologies/libraries]

--- a/tests/cli/test_plan_check_assumptions.py
+++ b/tests/cli/test_plan_check_assumptions.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+import typer
+from typer.testing import CliRunner
+
+def _app(tmp_path):
+    from mship.cli.plan import register
+    class FakeContainer:
+        def config_path(self): return str(tmp_path / "mothership.yaml")
+    app = typer.Typer(); register(app, lambda: FakeContainer()); return app
+
+def test_check_assumptions_reports_missing(tmp_path):
+    plans = tmp_path / "docs" / "plans"; plans.mkdir(parents=True)
+    (plans / "2026-07-29-x.md").write_text(
+        "## Assumptions checked\n- repo topology — meta\n"
+    )
+    runner = CliRunner()
+    res = runner.invoke(_app(tmp_path), ["plan", "check-assumptions", "--plan", str(plans / "2026-07-29-x.md")])
+    assert res.exit_code == 0, res.output
+    data = json.loads(res.output)
+    assert data["ok"] is False
+    assert "credential locus" in data["missing"]
+    assert "repo topology" not in data["missing"]
+
+def test_check_assumptions_ok_when_all_covered(tmp_path):
+    from mship.core.plan import SEED_AXES
+    plans = tmp_path / "docs" / "plans"; plans.mkdir(parents=True)
+    body = "## Assumptions checked\n" + "".join(f"- {a} — ok\n" for a in SEED_AXES)
+    (plans / "2026-07-29-y.md").write_text(body)
+    runner = CliRunner()
+    res = runner.invoke(_app(tmp_path), ["plan", "check-assumptions", "--plan", str(plans / "2026-07-29-y.md")])
+    data = json.loads(res.output)
+    assert data["ok"] is True and data["missing"] == []

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -139,7 +139,14 @@ def test_unfilled_template_reports_all_axes_missing():
 
 
 def test_real_disposition_containing_brackets_still_counts():
-    """Only a disposition that is ENTIRELY a bracketed token is rejected; a real
-    disposition that merely contains brackets still counts."""
+    """A real disposition that merely contains brackets still counts."""
     plan = "## Assumptions checked\n- repo topology — covered [see #123], metarepo\n"
+    assert dispositioned_axes(plan) == {"repo topology"}
+
+
+def test_filled_but_bracketed_disposition_counts():
+    """A filled disposition that keeps the template's brackets but replaced the
+    `covered/N/A` choice with real content counts — only the unfilled slash-form
+    marker is rejected, not brackets per se (Greptile #448 follow-up)."""
+    plan = "## Assumptions checked\n- repo topology — [covered: metarepo handles clones across repos]\n"
     assert dispositioned_axes(plan) == {"repo topology"}

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from mship.core.plan import discover_plan_path, plan_has_tasks, resolve_plan_path
+from mship.core.plan import (
+    SEED_AXES,
+    discover_plan_path,
+    dispositioned_axes,
+    plan_has_tasks,
+    resolve_plan_path,
+)
 
 _PLAN = "# Plan\n\n<!-- mship:task id=1 -->\n### Task 1\n<!-- /mship:task -->\n"
 
@@ -59,3 +65,28 @@ def test_resolve_plan_path_rejects_dotdot_traversal(tmp_path):
 
 def test_plan_has_tasks_with_attributes():
     assert plan_has_tasks("<!-- mship:" "task id=1 acs=ac1 -->\nx\n<!-- /mship:" "task -->")
+
+
+def test_dispositioned_axes_parses_block_with_em_dash_and_hyphen():
+    plan = (
+        "## Assumptions checked\n"
+        "- repo topology — metarepo; covers clone across N repos\n"
+        "- credential locus - N/A, no credential handling\n"
+        "- execution locus -- cloud worker\n\n"
+        "## Approach\nsomething\n"
+    )
+    assert dispositioned_axes(plan) == {"repo topology", "credential locus", "execution locus"}
+
+
+def test_dispositioned_axes_no_block_returns_empty():
+    assert dispositioned_axes("## Approach\nno assumptions block here\n") == set()
+
+
+def test_dispositioned_axes_normalizes_case_and_whitespace():
+    plan = "## Assumptions Checked\n- Repo   Topology — meta\n"
+    assert dispositioned_axes(plan) == {"repo topology"}
+
+
+def test_seed_axes_has_seven_including_repo_topology():
+    assert len(SEED_AXES) == 7
+    assert "repo topology" in SEED_AXES

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -7,6 +7,7 @@ from mship.core.plan import (
     SEED_AXES,
     discover_plan_path,
     dispositioned_axes,
+    missing_assumption_axes,
     plan_has_tasks,
     resolve_plan_path,
 )
@@ -90,3 +91,28 @@ def test_dispositioned_axes_normalizes_case_and_whitespace():
 def test_seed_axes_has_seven_including_repo_topology():
     assert len(SEED_AXES) == 7
     assert "repo topology" in SEED_AXES
+
+
+_FULL_BLOCK = "## Assumptions checked\n" + "".join(
+    f"- {a} — disposition line\n" for a in SEED_AXES
+)
+
+
+def test_missing_none_when_all_dispositioned():
+    assert missing_assumption_axes(_FULL_BLOCK, SEED_AXES) == []
+
+
+def test_missing_lists_omitted_axis_in_expected_order():
+    partial = "## Assumptions checked\n- repo topology — meta\n- execution locus — cloud\n"
+    missing = missing_assumption_axes(partial, SEED_AXES)
+    assert "credential locus" in missing
+    assert missing == [a for a in SEED_AXES if a not in {"repo topology", "execution locus"}]
+
+
+def test_na_disposition_counts_as_covered():
+    block = "## Assumptions checked\n" + "".join(f"- {a} — N/A\n" for a in SEED_AXES)
+    assert missing_assumption_axes(block, SEED_AXES) == []
+
+
+def test_no_block_reports_all_expected_missing():
+    assert missing_assumption_axes("## Approach\nx\n", SEED_AXES) == list(SEED_AXES)

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -116,3 +116,30 @@ def test_na_disposition_counts_as_covered():
 
 def test_no_block_reports_all_expected_missing():
     assert missing_assumption_axes("## Approach\nx\n", SEED_AXES) == list(SEED_AXES)
+
+
+def test_unfilled_bracket_placeholder_does_not_count():
+    """A copied-but-unfilled template placeholder ([...]/<...>) must NOT parse as
+    a real disposition (Greptile #448) — else an untouched template greenlights."""
+    plan = (
+        "## Assumptions checked\n"
+        "- repo topology — [covered/N/A: one line]\n"
+        "- credential locus — <covered/N/A: one line>\n"
+    )
+    assert dispositioned_axes(plan) == set()
+
+
+def test_unfilled_template_reports_all_axes_missing():
+    """The writing-plans template, copied verbatim with every row left as a
+    placeholder, must report ALL seed axes missing (ok would be false)."""
+    block = "## Assumptions checked\n" + "".join(
+        f"- {a} — [covered/N/A: one line]\n" for a in SEED_AXES
+    )
+    assert missing_assumption_axes(block, SEED_AXES) == list(SEED_AXES)
+
+
+def test_real_disposition_containing_brackets_still_counts():
+    """Only a disposition that is ENTIRELY a bracketed token is rejected; a real
+    disposition that merely contains brackets still counts."""
+    plan = "## Assumptions checked\n- repo topology — covered [see #123], metarepo\n"
+    assert dispositioned_axes(plan) == {"repo topology"}


### PR DESCRIPTION
Implements the **validation gate + Wave 1 / L3** of `product_assumptions.md` (issue #444). The remaining layers (L1 store, L2 injection, L4 checker/gate, L5 ratchet, L0 fixtures) are deferred to follow-up PRs, each gated on this one — see the plan for the skeleton.

## What's in this PR

**AC-0 — Backtest (validation, ships no product code)**
Retrospective run of a cold assumption-coverage checker over our own plan corpus. Result: **GO**. The checker caught the motivating metarepo canary and false-flagged 0 of 12 accepted plans (both flags it raised were real divergences; ~8% worst-case attention). Header-vs-body consistency isn't yet measurable (no historical plan carries the block). Report committed under `docs/plans/backtest/` in the workspace repo. Headline finding: plan/spec rejections aren't first-class anywhere — filed as #447 (the substrate L5 will need).

**Wave 1 / L3 — the "Assumptions checked" mechanism (this repo)**
- `SEED_AXES` + `dispositioned_axes(plan_text)` — parse a plan's "Assumptions checked" markdown block (em-dash / hyphen tolerant, N/A-aware). Single source for the 7 seed axes.
- `missing_assumption_axes(plan_text, expected_axes)` — coverage validator; N/A counts as covered; ordering follows `expected_axes` (injected so Wave 2's store can supersede the constant).
- `mship plan check-assumptions [--task|--plan]` — **advisory only, always exits 0** (the hard plan→dev gate is L4/Wave 3; blocking now would reject every in-flight feature plan). Plus the disposition-all convention added to the writing-plans skill.

## Acceptance criteria delivered
- [x] `ac1` — AC-0 backtest run, three numbers reported, GO verdict (gates the rest).
- [x] `ac2` — Wave 1 / L3: "Assumptions checked" parser + coverage validator + advisory CLI + plan-template convention.

## Deferred to later waves (NOT in this PR)
- [ ] `ac3` / `ac4` — Wave 2: L1 assumptions store + L2 late injection.
- [ ] `ac5` / `ac6` — Wave 3: L4 agent-run checker record + deterministic cross-check + Ground Control flag + plan→dev gate.
- [ ] `ac7` — Wave 4: L5 rejection→row ratchet (needs #447).
- [ ] `ac8` / `ac9` — Wave 5: L0 metarepo fixtures + import-linter + health metrics.

## Testing
`mship test` green on the final commit — mothership + ground-control, no regressions. 19 focused tests for the L3 code (parser, validator, CLI envelope) all pass. Opus whole-branch review: ready to merge (0 critical/important; 4 cosmetic minors deferred).
