### PR TITLE
product_assumptions Wave 2: L1 assumptions store (docs-dir, optional encryption) + L2 deterministic plan-phase injection

### DIFF
--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -108,6 +108,7 @@ def get_container(required: bool = True) -> "Container | None":
 
 
 # Register command modules
+from mship.cli import assumptions as _assumptions_mod
 from mship.cli import audit as _audit_mod
 from mship.cli import bind as _bind_mod
 from mship.cli import capture as _capture_mod
@@ -174,6 +175,7 @@ def run() -> None:
     app()
 
 
+_assumptions_mod.register(app, get_container)
 _audit_mod.register(app, get_container)
 _bind_mod.register(app, get_container)
 _capture_mod.register(app, get_container)

--- a/src/mship/cli/assumptions.py
+++ b/src/mship/cli/assumptions.py
@@ -24,11 +24,24 @@ def register(parent: typer.Typer, get_container):
         from pathlib import Path
         from mship.core.assumptions import AssumptionStore, resolve_mode
 
+        from mship.core.config import ConfigLoader
+
         container = get_container()
         config_path = Path(container.config_path())
         workspace_root = config_path.parent
         mode = resolve_mode(workspace_root)
-        return AssumptionStore(workspace_root, mode=mode)
+        # Honor a non-default docs_dir — check-assumptions and the plan-phase
+        # injection both read from <docs_dir>/product_assumptions.md, so the CLI
+        # that EDITS it must write to the same place or the operator's edits are
+        # invisible to the very consumers this feature feeds (final-review #2).
+        # Resolve from the config file (like resolve_mode); fall back only when
+        # there is no config file, so a malformed config still fails loud.
+        docs_dir = (
+            ConfigLoader.load(config_path, require_paths=False).docs_dir
+            if config_path.is_file()
+            else "docs"
+        )
+        return AssumptionStore(workspace_root, docs_dir=docs_dir, mode=mode)
 
     def _rows_to_dicts(rows) -> list[dict]:
         return [

--- a/src/mship/cli/assumptions.py
+++ b/src/mship/cli/assumptions.py
@@ -43,6 +43,15 @@ def register(parent: typer.Typer, get_container):
         )
         return AssumptionStore(workspace_root, docs_dir=docs_dir, mode=mode)
 
+    def _seed(store, output):
+        """seed() (create-if-absent, else load), surfacing a malformed-store
+        ValueError as a clean CLI error instead of a traceback (Greptile #450)."""
+        try:
+            return store.seed()
+        except ValueError as e:
+            output.error(str(e))
+            raise typer.Exit(1)
+
     def _rows_to_dicts(rows) -> list[dict]:
         return [
             {
@@ -59,7 +68,7 @@ def register(parent: typer.Typer, get_container):
         """List assumption rows, auto-seeding the store if absent."""
         output = Output()
         store = _store()
-        rows = store.seed()
+        rows = _seed(store, output)
 
         if output.human_mode:
             output.table(
@@ -86,7 +95,7 @@ def register(parent: typer.Typer, get_container):
 
         output = Output()
         store = _store()
-        rows = store.load()
+        rows = _seed(store, output)
         rows.append(AssumptionRow(axis=axis, options=options, position=position, triggers=triggers))
         warning = store.save(rows)
         if warning:
@@ -109,7 +118,7 @@ def register(parent: typer.Typer, get_container):
 
         output = Output()
         store = _store()
-        rows = store.load()
+        rows = _seed(store, output)
 
         idx = next((i for i, r in enumerate(rows) if r.axis == axis), None)
         if idx is None:
@@ -139,6 +148,11 @@ def register(parent: typer.Typer, get_container):
         into a plan, or L2 tooling)."""
         output = Output()
         store = _store()
-        output.print(store.render())
+        try:
+            block = store.render()
+        except ValueError as e:
+            output.error(str(e))
+            raise typer.Exit(1)
+        output.print(block)
 
     parent.add_typer(assumptions_app, rich_help_panel="Work items & specs")

--- a/src/mship/cli/assumptions.py
+++ b/src/mship/cli/assumptions.py
@@ -1,0 +1,131 @@
+"""`mship assumptions` sub-app: manage the L1 product-assumptions doc
+(`docs/product_assumptions.md`) that `mship plan check-assumptions` checks
+plans against (product-assumptions-wave-2)."""
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+
+from mship.cli.output import Output
+
+
+def register(parent: typer.Typer, get_container):
+    assumptions_app = typer.Typer(
+        name="assumptions",
+        help="Manage the L1 product-assumptions doc (`docs/product_assumptions.md`).",
+        no_args_is_help=True,
+    )
+
+    def _store():
+        """The workspace's assumption store in its configured
+        `assumption_storage` mode. Mirrors `cli/spec.py`'s `_spec_store` —
+        every verb reads/writes through the same mode-aware AssumptionStore."""
+        from pathlib import Path
+        from mship.core.assumptions import AssumptionStore, resolve_mode
+
+        container = get_container()
+        config_path = Path(container.config_path())
+        workspace_root = config_path.parent
+        mode = resolve_mode(workspace_root)
+        return AssumptionStore(workspace_root, mode=mode)
+
+    def _rows_to_dicts(rows) -> list[dict]:
+        return [
+            {
+                "axis": r.axis,
+                "options": r.options,
+                "position": r.position,
+                "triggers": r.triggers,
+            }
+            for r in rows
+        ]
+
+    @assumptions_app.command("list")
+    def list_cmd():
+        """List assumption rows, auto-seeding the store if absent."""
+        output = Output()
+        store = _store()
+        rows = store.seed()
+
+        if output.human_mode:
+            output.table(
+                "Assumptions",
+                ["axis", "options", "position", "triggers"],
+                [[r.axis, r.options, r.position, r.triggers] for r in rows],
+            )
+        else:
+            output.json({
+                "rows": _rows_to_dicts(rows),
+                "count": len(rows),
+                "path": str(store.path),
+            })
+
+    @assumptions_app.command("add")
+    def add(
+        axis: str = typer.Option(..., "--axis", help="Assumption axis name."),
+        options: str = typer.Option(..., "--options", help="Candidate options for this axis."),
+        position: str = typer.Option(..., "--position", help="The taken position."),
+        triggers: str = typer.Option(..., "--triggers", help="Keywords/patterns that trigger this axis."),
+    ):
+        """Append a new assumption row."""
+        from mship.core.assumptions import AssumptionRow
+
+        output = Output()
+        store = _store()
+        rows = store.load()
+        rows.append(AssumptionRow(axis=axis, options=options, position=position, triggers=triggers))
+        warning = store.save(rows)
+        if warning:
+            output.warning(warning)
+
+        if output.human_mode:
+            output.success(f"Added assumption axis {axis!r}.")
+        else:
+            output.json({"axis": axis, "count": len(rows), "path": str(store.path)})
+
+    @assumptions_app.command("edit")
+    def edit(
+        axis: str = typer.Argument(..., help="Axis name to edit (must exist)."),
+        options: Optional[str] = typer.Option(None, "--options"),
+        position: Optional[str] = typer.Option(None, "--position"),
+        triggers: Optional[str] = typer.Option(None, "--triggers"),
+    ):
+        """Edit an existing assumption row's options/position/triggers."""
+        from dataclasses import replace
+
+        output = Output()
+        store = _store()
+        rows = store.load()
+
+        idx = next((i for i, r in enumerate(rows) if r.axis == axis), None)
+        if idx is None:
+            output.error(f"No assumption axis {axis!r}. Known: {', '.join(r.axis for r in rows) or '(none)'}.")
+            raise typer.Exit(1)
+
+        updates = {}
+        if options is not None:
+            updates["options"] = options
+        if position is not None:
+            updates["position"] = position
+        if triggers is not None:
+            updates["triggers"] = triggers
+        rows[idx] = replace(rows[idx], **updates)
+        warning = store.save(rows)
+        if warning:
+            output.warning(warning)
+
+        if output.human_mode:
+            output.success(f"Updated assumption axis {axis!r}.")
+        else:
+            output.json({"axis": axis, "path": str(store.path)})
+
+    @assumptions_app.command("render")
+    def render():
+        """Print the `## Assumptions checked` markdown block (for manual pasting
+        into a plan, or L2 tooling)."""
+        output = Output()
+        store = _store()
+        output.print(store.render())
+
+    parent.add_typer(assumptions_app, rich_help_panel="Work items & specs")

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -193,6 +193,7 @@ def register(app: typer.Typer, get_container):
                 return
             journal_entries, agents_md_path = _journal_and_agents(container, task_obj.slug)
             base_sha_info = _d.collect_base_sha_info(Path(rec.worktree), rec.base_branch)
+            docs_dir = getattr(container.config(), "docs_dir", "docs")
             try:
                 prompt, warnings = build_emitted_prompt(
                     rec,
@@ -205,6 +206,7 @@ def register(app: typer.Typer, get_container):
                     agents_md_path=agents_md_path,
                     pkg_skills_source=pkg_skills_source(),
                     state=state,
+                    docs_dir=docs_dir,
                 )
             except (OSError, ValueError) as e:
                 output.error(f"cannot derive the prompt from the record: {e}")

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -15,11 +15,19 @@ from mship.cli._resolve import resolve_for_command
 from mship.cli.output import Output
 from mship.core import dispatch as _d
 from mship.core.base_resolver import resolve_base
+from cryptography.fernet import InvalidToken as _InvalidToken
 from mship.core.dispatch_emit import (
     build_emitted_prompt,
     resolve_acceptance,
     resolve_instruction_and_acs,
 )
+from mship.core.spec_key import SpecKeyMissing as _SpecKeyMissing
+
+# Errors deriving an emitted prompt from a record. Includes the encrypted-store
+# key errors (missing key, or a bad/corrupt key) raised by plan-phase assumption
+# injection reading an encrypted store — e.g. a worker that has the encrypted
+# doc but not the key. Flat tuple: an except clause can't nest a sub-tuple.
+_EMIT_ERRORS = (OSError, ValueError, _SpecKeyMissing, _InvalidToken)
 from mship.core.dispatch_models import resolve_model
 from mship.core.dispatch_stub import build_stub
 from mship.core.review_package import (
@@ -208,7 +216,10 @@ def register(app: typer.Typer, get_container):
                     state=state,
                     docs_dir=docs_dir,
                 )
-            except (OSError, ValueError) as e:
+            except _EMIT_ERRORS as e:
+                # Includes the encrypted-store key errors from plan-phase
+                # assumption injection — surface a clean error, not a raw
+                # traceback (fail loud, cleanly).
                 output.error(f"cannot derive the prompt from the record: {e}")
                 raise typer.Exit(code=1)
             for w in warnings:

--- a/src/mship/cli/dispatch.py
+++ b/src/mship/cli/dispatch.py
@@ -480,5 +480,17 @@ def register(app: typer.Typer, get_container):
             mode=mode,
             model=resolved_model,
         )
+        # Deterministic assumption injection applies to the --full inline prompt
+        # too, not just --emit — otherwise a plan-phase --full dispatch silently
+        # omits the assumptions (Greptile #450).
+        try:
+            from mship.core.dispatch_emit import append_plan_assumptions
+
+            _wr = Path(container.config_path()).parent
+            _dd = getattr(container.config(), "docs_dir", "docs")
+            prompt = append_plan_assumptions(prompt, task_obj, _wr, _dd)
+        except _EMIT_ERRORS as e:
+            output.error(f"cannot inject assumptions into the prompt: {e}")
+            raise typer.Exit(code=1)
         # Print directly to stdout (NOT via Output.json — this is meant to be piped).
         print(prompt)

--- a/src/mship/cli/plan.py
+++ b/src/mship/cli/plan.py
@@ -58,7 +58,13 @@ def register(parent: typer.Typer, get_container):
             raise typer.Exit(1)
 
         store = AssumptionStore(workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root))
-        expected = store.axes() if store.path.is_file() else list(SEED_AXES)
+        try:
+            expected = store.axes() if store.path.is_file() else list(SEED_AXES)
+        except ValueError as e:
+            # A malformed store must fail loud, not silently shrink the expected
+            # set and let an incomplete plan pass coverage (Greptile #450).
+            output.error(str(e))
+            raise typer.Exit(1)
 
         missing = missing_assumption_axes(resolved.read_text(), expected)
         ok = not missing

--- a/src/mship/cli/plan.py
+++ b/src/mship/cli/plan.py
@@ -29,6 +29,7 @@ def register(parent: typer.Typer, get_container):
     ):
         """Report which seed assumption axes the plan's 'Assumptions checked'
         block leaves undispositioned. Advisory only — always exits 0."""
+        from mship.core.assumptions import AssumptionStore, resolve_mode
         from mship.core.config import ConfigLoader
         from mship.core.plan import SEED_AXES, missing_assumption_axes, resolve_plan_path
 
@@ -56,7 +57,10 @@ def register(parent: typer.Typer, get_container):
             output.error(f"No plan found {where}.")
             raise typer.Exit(1)
 
-        missing = missing_assumption_axes(resolved.read_text(), SEED_AXES)
+        store = AssumptionStore(workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root))
+        expected = store.axes() if store.path.is_file() else list(SEED_AXES)
+
+        missing = missing_assumption_axes(resolved.read_text(), expected)
         ok = not missing
 
         if output.human_mode:
@@ -70,7 +74,7 @@ def register(parent: typer.Typer, get_container):
         else:
             output.json({
                 "plan": str(resolved),
-                "expected": list(SEED_AXES),
+                "expected": expected,
                 "missing": missing,
                 "ok": ok,
             })

--- a/src/mship/core/assumptions.py
+++ b/src/mship/core/assumptions.py
@@ -217,6 +217,20 @@ def _render_table(rows: list[AssumptionRow]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def resolve_mode(workspace_root: Path) -> AssumptionMode:
+    """Best-effort read of `assumption_storage` from the workspace's
+    mothership.yaml. Mirrors `spec_storage.resolve_mode` (single source of
+    truth is the workspace config; no config file -> committed; an invalid
+    value fails loud via the config model)."""
+    cfg_path = Path(workspace_root) / "mothership.yaml"
+    if not cfg_path.is_file():
+        return "committed"
+    from mship.core.config import ConfigLoader
+
+    config = ConfigLoader.load(cfg_path, require_paths=False)
+    return getattr(config, "assumption_storage", "committed")
+
+
 def _parse_table(text: str) -> list[AssumptionRow]:
     lines = [line for line in text.splitlines() if line.strip().startswith("|")]
     if len(lines) < 2:

--- a/src/mship/core/assumptions.py
+++ b/src/mship/core/assumptions.py
@@ -246,9 +246,18 @@ def resolve_mode(workspace_root: Path) -> AssumptionMode:
 
 
 def _parse_table(text: str) -> list[AssumptionRow]:
+    """Parse the canonical table. FAILS LOUD on a malformed store rather than
+    silently returning a reduced row set — a dropped row would make an
+    incomplete plan pass coverage and shrink the injected/authoritative set
+    (Greptile #450). No table at all → [] (an absent/empty store is legitimate);
+    a broken header/separator or a wrong-cell-count row → ValueError."""
     lines = [line for line in text.splitlines() if line.strip().startswith("|")]
-    if len(lines) < 2:
+    if not lines:
         return []
+    if len(lines) < 2:
+        raise ValueError(
+            "malformed assumptions store: missing table header/separator"
+        )
     rows = []
     for line in lines[2:]:  # skip header + separator
         body = line.strip()
@@ -256,6 +265,9 @@ def _parse_table(text: str) -> list[AssumptionRow]:
         body = body[:-1] if body.endswith("|") else body
         cells = [cell.strip() for cell in _split_unescaped_pipes(body)]
         if len(cells) != len(_COLUMNS):
-            continue
+            raise ValueError(
+                f"malformed assumptions store: row has {len(cells)} cells, "
+                f"expected {len(_COLUMNS)}: {line.strip()!r}"
+            )
         rows.append(AssumptionRow(**dict(zip(_COLUMNS, cells))))
     return rows

--- a/src/mship/core/assumptions.py
+++ b/src/mship/core/assumptions.py
@@ -179,12 +179,40 @@ class AssumptionStore:
             raise
 
 
+# A literal `|` in a cell would otherwise be read as a column separator and
+# silently drop the whole row on load. Escape on render, unescape on parse, and
+# split only on UNescaped pipes — free-text cells (position/options edited by
+# hand via `mship assumptions`) are round-trip safe (Greptile #448 Wave-2 review).
+_ESCAPED_PIPE = "\\|"
+
+
+def _split_unescaped_pipes(body: str) -> list[str]:
+    """Split a table row body on `|`, treating `\\|` as a literal pipe."""
+    cells: list[str] = []
+    buf: list[str] = []
+    i = 0
+    while i < len(body):
+        if body[i] == "\\" and i + 1 < len(body) and body[i + 1] == "|":
+            buf.append("|")
+            i += 2
+            continue
+        if body[i] == "|":
+            cells.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(body[i])
+        i += 1
+    cells.append("".join(buf))
+    return cells
+
+
 def _render_table(rows: list[AssumptionRow]) -> str:
     header = "| " + " | ".join(_COLUMNS) + " |"
     separator = "| " + " | ".join("--" for _ in _COLUMNS) + " |"
     lines = [header, separator]
     for row in rows:
-        cells = [getattr(row, col) for col in _COLUMNS]
+        cells = [getattr(row, col).replace("|", _ESCAPED_PIPE) for col in _COLUMNS]
         lines.append("| " + " | ".join(cells) + " |")
     return "\n".join(lines) + "\n"
 
@@ -195,7 +223,10 @@ def _parse_table(text: str) -> list[AssumptionRow]:
         return []
     rows = []
     for line in lines[2:]:  # skip header + separator
-        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        body = line.strip()
+        body = body[1:] if body.startswith("|") else body
+        body = body[:-1] if body.endswith("|") else body
+        cells = [cell.strip() for cell in _split_unescaped_pipes(body)]
         if len(cells) != len(_COLUMNS):
             continue
         rows.append(AssumptionRow(**dict(zip(_COLUMNS, cells))))

--- a/src/mship/core/assumptions.py
+++ b/src/mship/core/assumptions.py
@@ -1,0 +1,202 @@
+"""L1 store for product assumptions (product-assumptions-wave-2).
+
+A single markdown-canonical doc, `docs/product_assumptions.md` (or `.md.enc`
+under `mode="encrypted"`), holding the axis/options/position/triggers table
+that a planning agent must disposition against. Mirrors `SpecStorage`'s
+atomic-write + suffix-driven-read pattern and reuses `core.spec_key` for
+optional at-rest encryption — no second encryption implementation."""
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from mship.core import spec_key
+from mship.core.plan import _normalize_axis
+from mship.util.git import GitRunner
+
+AssumptionMode = Literal["committed", "local", "encrypted"]
+
+DOC_NAME = "product_assumptions.md"
+ENC_SUFFIX = ".enc"
+SOFT_CAP = 20
+
+_COLUMNS = ("axis", "options", "position", "triggers")
+
+
+@dataclass(frozen=True)
+class AssumptionRow:
+    axis: str
+    options: str
+    position: str
+    triggers: str
+
+
+# The 7 seed rows (with the backtest's 4 wording refinements folded in). Single
+# seed definition — `AssumptionStore.seed()` is the only writer of these.
+SEED_ROWS: tuple[AssumptionRow, ...] = (
+    AssumptionRow(
+        axis="repo topology",
+        options="single / mono / meta",
+        position=(
+            "**meta** — the *workspace-under-management* is N repos, "
+            "independent histories, shipped together"
+        ),
+        triggers="git/*, workspace/*, clone, branch, push",
+    ),
+    AssumptionRow(
+        axis="credential locus",
+        options="worker / relay / egress host",
+        position="**attach-at-relay**; worker never holds the real credential",
+        triggers="auth, token, push, credential",
+    ),
+    AssumptionRow(
+        axis="execution locus",
+        options="local / disposable cloud worker",
+        position="**both**; cloud is the priority path",
+        triggers="run, dispatch, worker, remote",
+    ),
+    AssumptionRow(
+        axis="state durability",
+        options="in-session / durable journal",
+        position="**journal**; must survive process death",
+        triggers="state, journal, persist, resume",
+    ),
+    AssumptionRow(
+        axis="review surface",
+        options="terminal / async client",
+        position=(
+            "**undecided — flag it** (D1). Disposition rule: *covered* when a "
+            "plan surfaces/respects the open choice; *not-covered* only when "
+            "it silently declares one surface canonical"
+        ),
+        triggers="review, approve, verdict, UI",
+    ),
+    AssumptionRow(
+        axis="agent stream",
+        options="live stream / journal-backed async",
+        position=(
+            "**journal-backed**. Scope: all run output (shell + agent), not "
+            "agent-session output only"
+        ),
+        triggers="stream, output, follow, log",
+    ),
+    AssumptionRow(
+        axis="dispatched model",
+        options="orchestrator-class / weaker",
+        position="**assume weaker**. N/A unless the plan itself dispatches agent work",
+        triggers="(applies whenever the plan dispatches agent work)",
+    ),
+)
+
+
+class AssumptionStore:
+    """Markdown-canonical store for `docs/product_assumptions.md[.enc]`."""
+
+    def __init__(
+        self,
+        workspace_root: Path,
+        *,
+        docs_dir: str = "docs",
+        mode: AssumptionMode = "committed",
+        git: GitRunner | None = None,
+    ) -> None:
+        self.workspace_root = Path(workspace_root)
+        self.docs_dir = docs_dir
+        self.mode: AssumptionMode = mode
+        self._git = git or GitRunner()
+
+    @property
+    def path(self) -> Path:
+        base = self.workspace_root / self.docs_dir / DOC_NAME
+        if self.mode == "encrypted":
+            return base.with_name(base.name + ENC_SUFFIX)
+        return base
+
+    # --- read --------------------------------------------------------
+    def load(self) -> list[AssumptionRow]:
+        if not self.path.is_file():
+            return []
+        text = self._decode(self.path)
+        return _parse_table(text)
+
+    def axes(self) -> list[str]:
+        return [_normalize_axis(row.axis) for row in self.load()]
+
+    def render(self) -> str:
+        rows = self.load()
+        lines = ["## Assumptions checked"]
+        for row in rows:
+            lines.append(f"- {row.axis} — options: {row.options} · position: {row.position}")
+        return "\n".join(lines) + "\n"
+
+    # --- write -------------------------------------------------------
+    def save(self, rows: list[AssumptionRow]) -> str | None:
+        path = self.path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        text = _render_table(rows)
+        if self.mode == "encrypted":
+            key = spec_key.load_or_generate_key(self.workspace_root, git=self._git)
+            self._atomic_write_bytes(path, spec_key.encrypt(key, text))
+        else:
+            self._atomic_write_bytes(path, text.encode("utf-8"))
+            if self.mode == "local":
+                self._git.add_to_gitignore(self.workspace_root, f"{self.docs_dir}/{DOC_NAME}")
+        if len(rows) > SOFT_CAP:
+            return (
+                f"warning: {len(rows)} assumption rows exceeds the soft cap of "
+                f"{SOFT_CAP}; consider pruning stale axes"
+            )
+        return None
+
+    def seed(self) -> list[AssumptionRow]:
+        if self.path.is_file():
+            return self.load()
+        self.save(list(SEED_ROWS))
+        return list(SEED_ROWS)
+
+    # --- helpers -------------------------------------------------------
+    def _decode(self, path: Path) -> str:
+        if path.name.endswith(ENC_SUFFIX):
+            key = spec_key.load_key(self.workspace_root)
+            if key is None:
+                raise spec_key.SpecKeyMissing(
+                    f"encrypted assumptions store requires a key at "
+                    f"{spec_key.keyfile_path(self.workspace_root)}, but none was found."
+                )
+            return spec_key.decrypt(key, path.read_bytes())
+        return path.read_text()
+
+    def _atomic_write_bytes(self, path: Path, data: bytes) -> None:
+        fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+        try:
+            with open(fd, "wb") as f:
+                f.write(data)
+            Path(tmp).replace(path)
+        except Exception:
+            Path(tmp).unlink(missing_ok=True)
+            raise
+
+
+def _render_table(rows: list[AssumptionRow]) -> str:
+    header = "| " + " | ".join(_COLUMNS) + " |"
+    separator = "| " + " | ".join("--" for _ in _COLUMNS) + " |"
+    lines = [header, separator]
+    for row in rows:
+        cells = [getattr(row, col) for col in _COLUMNS]
+        lines.append("| " + " | ".join(cells) + " |")
+    return "\n".join(lines) + "\n"
+
+
+def _parse_table(text: str) -> list[AssumptionRow]:
+    lines = [line for line in text.splitlines() if line.strip().startswith("|")]
+    if len(lines) < 2:
+        return []
+    rows = []
+    for line in lines[2:]:  # skip header + separator
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) != len(_COLUMNS):
+            continue
+        rows.append(AssumptionRow(**dict(zip(_COLUMNS, cells))))
+    return rows

--- a/src/mship/core/assumptions.py
+++ b/src/mship/core/assumptions.py
@@ -125,8 +125,12 @@ class AssumptionStore:
         return [_normalize_axis(row.axis) for row in self.load()]
 
     def render(self) -> str:
+        """The injected/rendered block. Header is 'Assumptions to disposition'
+        (a directive) — deliberately NOT the L3 plan-block name 'Assumptions
+        checked', which is the header the *plan* must contain; reusing it here
+        would both read as already-done and risk being echoed into the plan."""
         rows = self.load()
-        lines = ["## Assumptions checked"]
+        lines = ["## Assumptions to disposition"]
         for row in rows:
             lines.append(f"- {row.axis} — options: {row.options} · position: {row.position}")
         return "\n".join(lines) + "\n"

--- a/src/mship/core/assumptions.py
+++ b/src/mship/core/assumptions.py
@@ -137,6 +137,16 @@ class AssumptionStore:
 
     # --- write -------------------------------------------------------
     def save(self, rows: list[AssumptionRow]) -> str | None:
+        # A newline in a cell would break the one-row-per-line markdown table and
+        # silently drop the row on load (the remaining hole after pipe-escaping).
+        # Reject at the boundary rather than corrupt the store (fail loud).
+        for row in rows:
+            for col in _COLUMNS:
+                if "\n" in getattr(row, col) or "\r" in getattr(row, col):
+                    raise ValueError(
+                        f"assumption {row.axis!r}: {col} contains a newline; "
+                        "table cells must be single-line"
+                    )
         path = self.path
         path.parent.mkdir(parents=True, exist_ok=True)
         text = _render_table(rows)

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -352,6 +352,12 @@ class WorkspaceConfig(BaseModel):
     # unreadable without `.mothership/spec-key`. Applied transparently by
     # core/spec_storage.py; an invalid value fails loud at config load.
     spec_storage: Literal["committed", "local", "encrypted"] = "committed"
+    # Where this workspace's L1 product-assumptions doc
+    # (`docs/product_assumptions.md`) lives — mirrors `spec_storage`'s modes and
+    # semantics (committed/local/encrypted). Applied transparently by
+    # core/assumptions.py::AssumptionStore; an invalid value fails loud at
+    # config load, same as `spec_storage`.
+    assumption_storage: Literal["committed", "local", "encrypted"] = "committed"
     # Storage mode for acceptance-criterion artifact evidence. `None` inherits
     # `spec_storage` — the safe default, so evidence is governed exactly like the
     # spec it backs unless an operator deliberately diverges (prose is bytes,

--- a/src/mship/core/dispatch_emit.py
+++ b/src/mship/core/dispatch_emit.py
@@ -175,6 +175,7 @@ def build_emitted_prompt(
             workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root)
         )
         store.seed()
-        prompt += "\n\n## Assumptions to disposition\n" + store.render()
+        # render() already carries the "## Assumptions to disposition" header.
+        prompt += "\n\n" + store.render()
 
     return prompt, warnings

--- a/src/mship/core/dispatch_emit.py
+++ b/src/mship/core/dispatch_emit.py
@@ -168,14 +168,29 @@ def build_emitted_prompt(
     )
 
     resolved_task = task if task is not None else _minimal_task(rec)
-    if resolved_task.phase == "plan":
-        from mship.core.assumptions import AssumptionStore, resolve_mode
-
-        store = AssumptionStore(
-            workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root)
-        )
-        store.seed()
-        # render() already carries the "## Assumptions to disposition" header.
-        prompt += "\n\n" + store.render()
+    prompt = append_plan_assumptions(prompt, resolved_task, workspace_root, docs_dir)
 
     return prompt, warnings
+
+
+def append_plan_assumptions(
+    prompt: str, task, workspace_root: Path, docs_dir: str = "docs"
+) -> str:
+    """Append the rendered product-assumptions table to a PLAN-phase task's
+    prompt (deterministic L2 injection); no-op for other phases.
+
+    Shared by `build_emitted_prompt` (`--emit`) AND the `--full` inline dispatch
+    path (`cli/dispatch.py`) so EVERY plan-dispatch route injects — otherwise a
+    `--full` dispatch silently omits the assumptions (Greptile #450). May raise
+    for an encrypted store without a key / a malformed store; callers surface it
+    cleanly (they catch OSError/ValueError/key errors)."""
+    if task.phase != "plan":
+        return prompt
+    from mship.core.assumptions import AssumptionStore, resolve_mode
+
+    store = AssumptionStore(
+        workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root)
+    )
+    store.seed()
+    # render() already carries the "## Assumptions to disposition" header.
+    return prompt + "\n\n" + store.render()

--- a/src/mship/core/dispatch_emit.py
+++ b/src/mship/core/dispatch_emit.py
@@ -118,6 +118,7 @@ def build_emitted_prompt(
     agents_md_path: Path | None = None,
     pkg_skills_source: Path | None = None,
     state=None,
+    docs_dir: str = "docs",
 ) -> tuple[str, list]:
     """Return (prompt, warnings) — the full dispatch prompt derived live.
 
@@ -135,6 +136,13 @@ def build_emitted_prompt(
 
     `spec` supplies live acceptance text for the record's AC ids. An unknown
     AC id, or acs with spec=None, appends a string warning (never an error).
+
+    - docs_dir: workspace docs directory, used only to locate the product
+      assumptions store (see below). Default "docs".
+
+    Plan-phase tasks (`task.phase == "plan"`) get the product assumptions
+    table auto-appended (auto-seeded if absent) so the planner receives the
+    rows to disposition without a separate fetch. Other phases are unaffected.
     """
     instruction, ac_ids, warnings = resolve_instruction_and_acs(rec, workspace_root)
     acceptance, ac_warnings = resolve_acceptance(ac_ids, spec)
@@ -158,4 +166,15 @@ def build_emitted_prompt(
         model=rec.model,
         acceptance=acceptance,
     )
+
+    resolved_task = task if task is not None else _minimal_task(rec)
+    if resolved_task.phase == "plan":
+        from mship.core.assumptions import AssumptionStore, resolve_mode
+
+        store = AssumptionStore(
+            workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root)
+        )
+        store.seed()
+        prompt += "\n\n## Assumptions to disposition\n" + store.render()
+
     return prompt, warnings

--- a/tests/cli/test_assumptions_cli.py
+++ b/tests/cli/test_assumptions_cli.py
@@ -108,3 +108,27 @@ def test_cli_honors_non_default_docs_dir(tmp_path):
     assert res.exit_code == 0, res.output
     assert (tmp_path / "customdocs" / "product_assumptions.md").is_file()
     assert not (tmp_path / "docs" / "product_assumptions.md").exists()
+
+
+def test_add_on_fresh_workspace_seeds_baseline_first(tmp_path):
+    """`add` as the FIRST assumptions command must seed the 7 baseline rows, not
+    save only the added one and drop the baseline (Greptile #450)."""
+    from mship.core.assumptions import SEED_ROWS
+    res = CliRunner().invoke(_app(tmp_path), [
+        "assumptions", "add", "--axis", "new axis", "--options", "a/b",
+        "--position", "p", "--triggers", "t",
+    ])
+    assert res.exit_code == 0, res.output
+    assert json.loads(res.output)["count"] == len(SEED_ROWS) + 1  # 7 seed + 1, not 1
+
+
+def test_list_on_malformed_store_errors_cleanly(tmp_path):
+    """A malformed store surfaces a clean CLI error, not a traceback (Greptile #450)."""
+    (tmp_path / "mothership.yaml").write_text("workspace: t\nrepos: {}\n")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "product_assumptions.md").write_text(
+        "| axis | options | position | triggers |\n| -- | -- | -- | -- |\n| a | b | c |\n"
+    )
+    res = CliRunner().invoke(_app(tmp_path), ["assumptions", "list"])
+    assert res.exit_code == 1
+    assert "malformed" in res.output

--- a/tests/cli/test_assumptions_cli.py
+++ b/tests/cli/test_assumptions_cli.py
@@ -95,3 +95,16 @@ def test_encrypted_mode_writes_enc_file(tmp_path):
     assert res.exit_code == 0, res.output
     assert (tmp_path / "docs" / "product_assumptions.md.enc").is_file()
     assert not (tmp_path / "docs" / "product_assumptions.md").exists()
+
+
+def test_cli_honors_non_default_docs_dir(tmp_path):
+    """`mship assumptions` must write to <docs_dir>/ so its edits are visible to
+    check-assumptions and the plan-phase injection, which honor docs_dir
+    (final-review #2)."""
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\nrepos: {}\ndocs_dir: customdocs\n"
+    )
+    res = CliRunner().invoke(_app(tmp_path), ["assumptions", "list"])  # auto-seeds
+    assert res.exit_code == 0, res.output
+    assert (tmp_path / "customdocs" / "product_assumptions.md").is_file()
+    assert not (tmp_path / "docs" / "product_assumptions.md").exists()

--- a/tests/cli/test_assumptions_cli.py
+++ b/tests/cli/test_assumptions_cli.py
@@ -1,0 +1,97 @@
+import json
+
+import typer
+from typer.testing import CliRunner
+
+
+def _app(tmp_path):
+    from mship.cli.assumptions import register
+
+    class FakeContainer:
+        def config_path(self):
+            return str(tmp_path / "mothership.yaml")
+
+    app = typer.Typer()
+    register(app, lambda: FakeContainer())
+    return app
+
+
+def test_list_auto_seeds_fresh_workspace(tmp_path):
+    runner = CliRunner()
+    res = runner.invoke(_app(tmp_path), ["assumptions", "list"])
+    assert res.exit_code == 0, res.output
+    data = json.loads(res.output)
+    assert data["count"] == 7
+    assert len(data["rows"]) == 7
+    assert data["rows"][0]["axis"] == "repo topology"
+    assert (tmp_path / "docs" / "product_assumptions.md").is_file()
+
+
+def test_add_appends_row(tmp_path):
+    runner = CliRunner()
+    app = _app(tmp_path)
+    runner.invoke(app, ["assumptions", "list"])  # seed first
+    res = runner.invoke(
+        app,
+        [
+            "assumptions",
+            "add",
+            "--axis",
+            "new axis",
+            "--options",
+            "a / b",
+            "--position",
+            "**a**",
+            "--triggers",
+            "foo, bar",
+        ],
+    )
+    assert res.exit_code == 0, res.output
+
+    from mship.core.assumptions import AssumptionStore
+
+    store = AssumptionStore(tmp_path, docs_dir="docs")
+    rows = store.load()
+    assert len(rows) == 8
+    assert any(r.axis == "new axis" and r.position == "**a**" for r in rows)
+
+
+def test_edit_changes_position(tmp_path):
+    runner = CliRunner()
+    app = _app(tmp_path)
+    runner.invoke(app, ["assumptions", "list"])  # seed first
+    res = runner.invoke(
+        app,
+        ["assumptions", "edit", "repo topology", "--position", "**changed**"],
+    )
+    assert res.exit_code == 0, res.output
+
+    from mship.core.assumptions import AssumptionStore
+
+    store = AssumptionStore(tmp_path, docs_dir="docs")
+    rows = store.load()
+    row = next(r for r in rows if r.axis == "repo topology")
+    assert row.position == "**changed**"
+
+
+def test_render_prints_all_axes(tmp_path):
+    runner = CliRunner()
+    app = _app(tmp_path)
+    runner.invoke(app, ["assumptions", "list"])  # seed first
+    res = runner.invoke(app, ["assumptions", "render"])
+    assert res.exit_code == 0, res.output
+    from mship.core.assumptions import SEED_ROWS
+
+    for row in SEED_ROWS:
+        assert row.axis in res.output
+
+
+def test_encrypted_mode_writes_enc_file(tmp_path):
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: test\nassumption_storage: encrypted\n"
+    )
+    runner = CliRunner()
+    res = runner.invoke(_app(tmp_path), ["assumptions", "list"])
+    assert res.exit_code == 0, res.output
+    assert (tmp_path / "docs" / "product_assumptions.md.enc").is_file()
+    assert not (tmp_path / "docs" / "product_assumptions.md").exists()

--- a/tests/cli/test_dispatch_assumptions_injection.py
+++ b/tests/cli/test_dispatch_assumptions_injection.py
@@ -1,0 +1,80 @@
+"""`mship dispatch --emit` auto-appends the rendered assumption table when
+the resolved task is in the plan phase (product-assumptions-wave-2, Task 4:
+L2 deterministic injection). Non-plan phases are unaffected."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.assumptions import SEED_ROWS
+from mship.core.state import StateManager, Task, WorkspaceState
+
+runner = CliRunner()
+
+
+def _bootstrap(tmp_path: Path, phase: str) -> tuple[Path, Path]:
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text("workspace: t\nrepos: {}\n")
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    task = Task(
+        slug="t", description="d", phase=phase,
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["only"], worktrees={"only": wt}, branch="feat/t",
+        base_branch="main",
+    )
+    StateManager(state_dir).save(WorkspaceState(tasks={"t": task}))
+    return cfg, state_dir
+
+
+def _override(cfg, state_dir):
+    container.config.reset(); container.state_manager.reset(); container.log_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+
+
+def _reset():
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override()
+    container.config.reset()
+    container.state_manager.reset_override()
+    container.state_manager.reset()
+    container.log_manager.reset()
+
+
+def test_emit_for_plan_phase_task_appends_assumption_table(tmp_path: Path):
+    cfg, state_dir = _bootstrap(tmp_path, phase="plan")
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(
+            app, ["dispatch", "--task", "t", "-i", "plan the thing"]
+        )
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--emit"])
+        assert result.exit_code == 0, result.output
+        assert "## Assumptions to disposition" in result.output
+        for row in SEED_ROWS:
+            assert row.axis in result.output
+    finally:
+        _reset()
+
+
+def test_emit_for_non_plan_phase_task_omits_assumption_block(tmp_path: Path):
+    cfg, state_dir = _bootstrap(tmp_path, phase="dev")
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(
+            app, ["dispatch", "--task", "t", "-i", "build the thing"]
+        )
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--emit"])
+        assert result.exit_code == 0, result.output
+        assert "## Assumptions to disposition" not in result.output
+    finally:
+        _reset()

--- a/tests/cli/test_dispatch_assumptions_injection.py
+++ b/tests/cli/test_dispatch_assumptions_injection.py
@@ -78,3 +78,24 @@ def test_emit_for_non_plan_phase_task_omits_assumption_block(tmp_path: Path):
         assert "## Assumptions to disposition" not in result.output
     finally:
         _reset()
+
+
+def test_emit_plan_phase_encrypted_store_missing_key_errors_cleanly(tmp_path: Path):
+    """An encrypted assumptions store with no key (worker without it) must fail
+    the plan-phase emit CLEANLY (exit 1 + message), not a raw traceback
+    (final-review #1)."""
+    from mship.core import spec_key
+    from mship.core.assumptions import AssumptionStore, SEED_ROWS
+    cfg, state_dir = _bootstrap(tmp_path, phase="plan")
+    cfg.write_text("workspace: t\nrepos: {}\nassumption_storage: encrypted\n")
+    AssumptionStore(tmp_path, mode="encrypted").save(list(SEED_ROWS))  # generates key
+    spec_key.keyfile_path(tmp_path).unlink()  # simulate a worker without the key
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "plan it"])
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(app, ["dispatch", "--task", "t", "--emit"])
+        assert result.exit_code == 1
+        assert "cannot derive the prompt" in result.output
+    finally:
+        _reset()

--- a/tests/cli/test_dispatch_assumptions_injection.py
+++ b/tests/cli/test_dispatch_assumptions_injection.py
@@ -99,3 +99,29 @@ def test_emit_plan_phase_encrypted_store_missing_key_errors_cleanly(tmp_path: Pa
         assert "cannot derive the prompt" in result.output
     finally:
         _reset()
+
+
+def test_full_dispatch_for_plan_phase_injects_assumptions(tmp_path: Path):
+    """`dispatch --full` (the inline prompt path) must ALSO inject assumptions
+    for a plan-phase task — not only `--emit` (Greptile #450)."""
+    cfg, state_dir = _bootstrap(tmp_path, phase="plan")
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "plan it", "--full"])
+        assert result.exit_code == 0, result.output
+        assert "## Assumptions to disposition" in result.output
+        for row in SEED_ROWS:
+            assert row.axis in result.output
+    finally:
+        _reset()
+
+
+def test_full_dispatch_for_non_plan_phase_omits_assumptions(tmp_path: Path):
+    cfg, state_dir = _bootstrap(tmp_path, phase="dev")
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["dispatch", "--task", "t", "-i", "build it", "--full"])
+        assert result.exit_code == 0, result.output
+        assert "## Assumptions to disposition" not in result.output
+    finally:
+        _reset()

--- a/tests/cli/test_plan_check_assumptions.py
+++ b/tests/cli/test_plan_check_assumptions.py
@@ -31,3 +31,40 @@ def test_check_assumptions_ok_when_all_covered(tmp_path):
     res = runner.invoke(_app(tmp_path), ["plan", "check-assumptions", "--plan", str(plans / "2026-07-29-y.md")])
     data = json.loads(res.output)
     assert data["ok"] is True and data["missing"] == []
+
+def test_check_assumptions_reads_expected_from_store_when_present(tmp_path):
+    from mship.core.assumptions import AssumptionRow, AssumptionStore
+    from mship.core.plan import SEED_AXES
+
+    store = AssumptionStore(tmp_path)
+    rows = store.seed()
+    rows.append(AssumptionRow(axis="new axis", options="a / b", position="a", triggers="new"))
+    store.save(rows)
+
+    plans = tmp_path / "docs" / "plans"; plans.mkdir(parents=True)
+    body = "## Assumptions checked\n" + "".join(f"- {a} — ok\n" for a in SEED_AXES)
+    (plans / "2026-07-29-z.md").write_text(body)
+
+    runner = CliRunner()
+    res = runner.invoke(_app(tmp_path), ["plan", "check-assumptions", "--plan", str(plans / "2026-07-29-z.md")])
+    assert res.exit_code == 0, res.output
+    data = json.loads(res.output)
+    assert data["ok"] is False
+    assert "new axis" in data["missing"]
+    assert "new axis" in data["expected"]
+
+def test_check_assumptions_falls_back_to_seed_axes_with_no_store(tmp_path):
+    from mship.core.plan import SEED_AXES
+
+    plans = tmp_path / "docs" / "plans"; plans.mkdir(parents=True)
+    body = "## Assumptions checked\n" + "".join(f"- {a} — ok\n" for a in SEED_AXES)
+    (plans / "2026-07-29-w.md").write_text(body)
+
+    assert not (tmp_path / "docs" / "product_assumptions.md").exists()
+
+    runner = CliRunner()
+    res = runner.invoke(_app(tmp_path), ["plan", "check-assumptions", "--plan", str(plans / "2026-07-29-w.md")])
+    assert res.exit_code == 0, res.output
+    data = json.loads(res.output)
+    assert data["ok"] is True and data["missing"] == []
+    assert data["expected"] == list(SEED_AXES)

--- a/tests/core/test_assumptions.py
+++ b/tests/core/test_assumptions.py
@@ -65,3 +65,17 @@ def test_newline_in_cell_rejected_on_save(tmp_path):
     store = AssumptionStore(tmp_path)
     with pytest.raises(ValueError, match="newline"):
         store.save([AssumptionRow(axis="x", options="a/b", position="line1\nline2", triggers="t")])
+
+
+def test_malformed_store_raises_on_load(tmp_path):
+    """A malformed canonical file must FAIL LOUD, not silently return a reduced
+    row set (which would let an incomplete plan pass + shrink injection)
+    (Greptile #450)."""
+    import pytest
+    from mship.core.assumptions import AssumptionStore
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "product_assumptions.md").write_text(
+        "| axis | options | position | triggers |\n| -- | -- | -- | -- |\n| a | b | c |\n"  # 3 cells
+    )
+    with pytest.raises(ValueError, match="malformed"):
+        AssumptionStore(tmp_path).load()

--- a/tests/core/test_assumptions.py
+++ b/tests/core/test_assumptions.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from mship.core.assumptions import AssumptionRow, AssumptionStore, SEED_ROWS
+
+
+def test_seed_writes_seven_rows_and_is_idempotent(tmp_path):
+    store = AssumptionStore(tmp_path)
+    rows = store.seed()
+    assert len(rows) == 7
+    assert store.path == tmp_path / "docs" / "product_assumptions.md"
+    assert store.path.is_file()
+    again = AssumptionStore(tmp_path).seed()   # second call: no overwrite, same rows
+    assert [r.axis for r in again] == [r.axis for r in rows]
+
+
+def test_round_trip_preserves_all_columns(tmp_path):
+    store = AssumptionStore(tmp_path)
+    store.save(list(SEED_ROWS))
+    loaded = store.load()
+    assert loaded == list(SEED_ROWS)
+
+
+def test_axes_are_normalized_in_order(tmp_path):
+    store = AssumptionStore(tmp_path); store.seed()
+    assert store.axes()[0] == "repo topology"
+    assert "dispatched model" in store.axes()
+
+
+def test_encrypted_mode_writes_enc_and_round_trips(tmp_path):
+    store = AssumptionStore(tmp_path, mode="encrypted")
+    store.save(list(SEED_ROWS))
+    assert store.path.name.endswith(".md.enc")
+    assert (tmp_path / "docs" / "product_assumptions.md").exists() is False
+    assert AssumptionStore(tmp_path, mode="encrypted").load() == list(SEED_ROWS)
+
+
+def test_load_missing_returns_empty(tmp_path):
+    assert AssumptionStore(tmp_path).load() == []
+
+
+def test_soft_cap_warns_over_twenty(tmp_path):
+    rows = [AssumptionRow(axis=f"a{i}", options="x/y", position="x", triggers="t") for i in range(21)]
+    store = AssumptionStore(tmp_path)
+    warn = store.save(rows)  # returns a warning string (or None under cap)
+    assert warn and "20" in warn

--- a/tests/core/test_assumptions.py
+++ b/tests/core/test_assumptions.py
@@ -43,3 +43,15 @@ def test_soft_cap_warns_over_twenty(tmp_path):
     store = AssumptionStore(tmp_path)
     warn = store.save(rows)  # returns a warning string (or None under cap)
     assert warn and "20" in warn
+
+
+def test_pipe_in_cell_round_trips_without_row_loss(tmp_path):
+    """A literal `|` in a free-text cell must survive save/load, not silently
+    drop the row (Greptile Wave-2 review). Reachable once `mship assumptions
+    add/edit` lets a human type arbitrary position/options text."""
+    from mship.core.assumptions import AssumptionRow, AssumptionStore
+    rows = [AssumptionRow(axis="repo topology", options="single | mono | meta",
+                          position="meta | shipped together", triggers="git/*")]
+    store = AssumptionStore(tmp_path)
+    store.save(rows)
+    assert store.load() == rows

--- a/tests/core/test_assumptions.py
+++ b/tests/core/test_assumptions.py
@@ -55,3 +55,13 @@ def test_pipe_in_cell_round_trips_without_row_loss(tmp_path):
     store = AssumptionStore(tmp_path)
     store.save(rows)
     assert store.load() == rows
+
+
+def test_newline_in_cell_rejected_on_save(tmp_path):
+    """A newline in a cell would break the one-row-per-line table and drop the
+    row on load — reject it at the boundary (final-review #3)."""
+    import pytest
+    from mship.core.assumptions import AssumptionRow, AssumptionStore
+    store = AssumptionStore(tmp_path)
+    with pytest.raises(ValueError, match="newline"):
+        store.save([AssumptionRow(axis="x", options="a/b", position="line1\nline2", triggers="t")])

--- a/tests/core/test_config_assumption_storage.py
+++ b/tests/core/test_config_assumption_storage.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from mship.core.config import ConfigLoader, WorkspaceConfig
+
+
+def test_assumption_storage_defaults_to_committed():
+    cfg = WorkspaceConfig(workspace="demo")
+    assert cfg.assumption_storage == "committed"
+
+
+def test_assumption_storage_accepts_each_mode():
+    for mode in ("committed", "local", "encrypted"):
+        assert (
+            WorkspaceConfig(workspace="demo", assumption_storage=mode).assumption_storage
+            == mode
+        )
+
+
+def test_invalid_assumption_storage_value_rejected_by_model():
+    with pytest.raises(ValidationError):
+        WorkspaceConfig(workspace="demo", assumption_storage="public")
+
+
+def test_invalid_assumption_storage_fails_at_config_load(tmp_path: Path):
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: demo\nassumption_storage: public\n"
+    )
+    with pytest.raises(ValidationError):
+        ConfigLoader.load(tmp_path / "mothership.yaml", require_paths=False)


### PR DESCRIPTION
Implements **Wave 2 of `product_assumptions.md`** (issue #444) — the L1 store (**ac3**) and L2 deterministic injection (**ac4**). Builds on Wave 1 (#448). Remaining layers (L4 checker/gate, L5 ratchet, L0 fixtures) stay tracked on #444.

## What's in this PR

**L1 — the store (ac3)**
- `src/mship/core/assumptions.py`: `AssumptionRow` + `SEED_ROWS` (7 seed rows, with the backtest's 4 wording refinements) + `AssumptionStore` — a single markdown-canonical doc `docs/product_assumptions.md`, **optional at-rest encryption** (`assumption_storage: committed | local | encrypted`) reusing `core/spec_key.py` (no second crypto), atomic write, ~20-row soft cap, and pipe/newline-safe cells.
- `mship assumptions list | add | edit | render` (`list` auto-seeds a fresh workspace).
- `check-assumptions` now sources the expected axes from the **store** (falling back to `SEED_AXES` when no store exists), so `SEED_AXES` demotes from runtime source to seed/fallback — single source of truth moves to the doc.

**L2 — deterministic injection (ac4)**
- `core/dispatch_emit.py`: `build_emitted_prompt` auto-appends the rendered assumption table to a **plan-phase** task's emitted prompt (`mship dispatch --emit`). All rows, unfiltered, late. Non-plan phases are unaffected. The planner receives the rows without having to fetch them — the agent can't skip it. (Header is "Assumptions to disposition", deliberately distinct from the L3 plan-block "Assumptions checked".)

The spec's "read-only projection into enrollment repos" is intentionally dropped — deterministic injection delivers the rows, superseding it.

## Acceptance criteria delivered
- [x] `ac3` — L1 store + `mship assumptions` CLI + source-swap.
- [x] `ac4` — L2 deterministic plan-phase injection.

## Deferred (NOT in this PR — tracked on #444)
- [ ] `ac5`/`ac6` — Wave 3 / L4 (agent-run checker + deterministic cross-check + Ground Control flag + plan→dev gate).
- [ ] `ac7` — Wave 4 / L5 (rejection→row ratchet; needs #447).
- [ ] `ac8`/`ac9` — Wave 5 / L0 (metarepo fixtures + import-linter + health metrics).

## Testing & review
`mship test` green on the final commit (mothership + ground-control, no regressions). Per-task reviews approved (Tasks 1–3); the opus whole-branch review flagged 3 Important issues — encrypted-store `--emit` crash, a `docs_dir` single-source-of-truth mismatch, and newline-in-cell data-loss — all fixed and confirmed by a scoped re-review (17/17 focused).
