### PR TITLE
product_assumptions Wave 3a: mship plan assumptions check --emit + result --from-json (record + deterministic trigger cross-check, plan-hash bound) + status + approve, plan-dev gate in phase.transition, and a serve API endpoint for pending flags

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,6 +172,31 @@ modes aren't fetchable by GitHub, so the PR names the artifact instead of
 showing it. Embedding therefore means the screenshots are readable by anyone
 who can read the repo the pull request targets.
 
+## Product assumptions (`assumption_storage`, `assumption_gate`)
+
+The product-assumptions system (#444) makes agents explicitly disposition the
+assumptions a plan is built on. Two workspace-level fields govern it:
+
+`assumption_storage` — where this workspace's L1 assumptions doc
+(`docs/product_assumptions.md`) lives, mirroring `spec_storage`'s modes:
+`committed` (default, plaintext + pushed), `local` (plaintext but git-ignored),
+or `encrypted` (Fernet ciphertext, unreadable without `.mothership/spec-key`).
+Applied transparently by `core/assumptions.py`; an invalid value fails loud at
+config load.
+
+`assumption_gate` — the L4 plan→dev gate. `off` (default) enforces nothing:
+merging the feature does not change existing behaviour, so the gate rolls out
+dark. `enforce` additionally requires a **fresh, fully-approved**
+`PlanCheckResult` before a feature WorkItem may transition `plan → dev` — every
+assumption the checker flagged as not-covered (or left un-dispositioned) must
+carry an explicit `mship plan assumptions approve <axis>` sign-off. Freshness is
+plan-hash bound, so editing the plan after a check re-arms the gate.
+
+```yaml
+assumption_storage: committed   # committed | local | encrypted
+assumption_gate: off            # off | enforce
+```
+
 ## Workspace-level fields
 
 Top-level keys on `mothership.yaml` (alongside `workspace`, `env_runner`, `branch_pattern`, `audit`, and `repos`, all covered above):

--- a/src/mship/cli/plan.py
+++ b/src/mship/cli/plan.py
@@ -22,6 +22,10 @@ def register(parent: typer.Typer, get_container):
         no_args_is_help=True,
     )
 
+    from mship.cli.plan_assumptions import register as register_plan_assumptions
+
+    register_plan_assumptions(plan_app, get_container)
+
     @plan_app.command("check-assumptions")
     def check_assumptions(
         task: Optional[str] = typer.Option(None, "--task", help="Task slug; resolves the plan via the docs/plans/<date>-<slug>.md convention."),

--- a/src/mship/cli/plan_assumptions.py
+++ b/src/mship/cli/plan_assumptions.py
@@ -180,7 +180,7 @@ def register(plan_app: typer.Typer, get_container):
         plan_text = plan_path.read_text()
         request_text = _request_text(workspace_root, task_obj)
 
-        flags = flags_from_verdicts(verdicts) + cross_check(
+        flags = flags_from_verdicts(verdicts, rows) + cross_check(
             verdicts, rows,
             plan_text=plan_text,
             task_text=request_text,
@@ -193,31 +193,34 @@ def register(plan_app: typer.Typer, get_container):
         # wipe sign-offs. A CHANGED plan (different hash) correctly drops them —
         # an approval against the old plan mustn't survive an edit (Wave 3a review).
         pcstore = PlanCheckStore(workspace_root / ".mothership")
-        prior = pcstore.get(task_obj.slug)
-        if prior is not None and prior.plan_hash == new_hash:
-            # Key on (axis, source) only — NOT the checker's free-text reason.
-            # (axis, source) is unique per check run (one checker flag per axis,
-            # one cross-check flag per axis), and the human signed off on "this
-            # axis, for this plan version" — the plan_hash already pins the
-            # version. Including the LLM-paraphrased reason would silently drop a
-            # real sign-off when the checker re-runs and re-words the same gap.
-            approved = {
-                (f.axis, f.source): f for f in prior.flags if f.approved
-            }
-            for f in flags:
-                keep = approved.get((f.axis, f.source))
-                if keep is not None:
-                    f.approved = True
-                    f.approved_by = keep.approved_by
-                    f.approved_reason = keep.approved_reason
+        # Lock spans read-prior → merge approvals → save so a concurrent approve
+        # (or a second result) can't clobber this write (Greptile #451).
+        with pcstore.transaction(task_obj.slug):
+            prior = pcstore.get(task_obj.slug)
+            if prior is not None and prior.plan_hash == new_hash:
+                # Key on (axis, source) only — NOT the checker's free-text reason.
+                # (axis, source) is unique per check run (one checker flag per axis,
+                # one cross-check flag per axis), and the human signed off on "this
+                # axis, for this plan version" — the plan_hash already pins the
+                # version. Including the LLM-paraphrased reason would silently drop a
+                # real sign-off when the checker re-runs and re-words the same gap.
+                approved = {
+                    (f.axis, f.source): f for f in prior.flags if f.approved
+                }
+                for f in flags:
+                    keep = approved.get((f.axis, f.source))
+                    if keep is not None:
+                        f.approved = True
+                        f.approved_by = keep.approved_by
+                        f.approved_reason = keep.approved_reason
 
-        check_result = PlanCheckResult(
-            task_slug=task_obj.slug,
-            plan_hash=new_hash,
-            verdicts=verdicts,
-            flags=flags,
-        )
-        pcstore.save(check_result)
+            check_result = PlanCheckResult(
+                task_slug=task_obj.slug,
+                plan_hash=new_hash,
+                verdicts=verdicts,
+                flags=flags,
+            )
+            pcstore.save(check_result)
 
         pending = sum(1 for f in flags if not f.approved)
 
@@ -297,24 +300,27 @@ def register(plan_app: typer.Typer, get_container):
         )
 
         store = PlanCheckStore(workspace_root / ".mothership")
-        stored = store.get(task_obj.slug)
-        if stored is None:
-            output.error(f"No stored plan-check for {task_obj.slug}.")
-            raise typer.Exit(1)
+        # Lock spans get → mutate → save so a concurrent approve/result can't
+        # overwrite this sign-off (Greptile #451).
+        with store.transaction(task_obj.slug):
+            stored = store.get(task_obj.slug)
+            if stored is None:
+                output.error(f"No stored plan-check for {task_obj.slug}.")
+                raise typer.Exit(1)
 
-        target_axis = _normalize_axis(axis)
-        match = next(
-            (f for f in stored.flags if not f.approved and _normalize_axis(f.axis) == target_axis),
-            None,
-        )
-        if match is None:
-            output.error(f"No pending flag for axis {axis!r} on {task_obj.slug}.")
-            raise typer.Exit(1)
+            target_axis = _normalize_axis(axis)
+            match = next(
+                (f for f in stored.flags if not f.approved and _normalize_axis(f.axis) == target_axis),
+                None,
+            )
+            if match is None:
+                output.error(f"No pending flag for axis {axis!r} on {task_obj.slug}.")
+                raise typer.Exit(1)
 
-        match.approved = True
-        match.approved_reason = reason
-        match.approved_by = os.environ.get("USER") or "unknown"
-        store.save(stored)
+            match.approved = True
+            match.approved_reason = reason
+            match.approved_by = os.environ.get("USER") or "unknown"
+            store.save(stored)
 
         pending = sum(1 for f in stored.flags if not f.approved)
 

--- a/src/mship/cli/plan_assumptions.py
+++ b/src/mship/cli/plan_assumptions.py
@@ -175,6 +175,24 @@ def register(plan_app: typer.Typer, get_container):
             output.error(f"Invalid verdicts JSON from --from-json: {e}")
             raise typer.Exit(1)
 
+        # Fail loud on duplicate axes: downstream keys verdicts by normalized axis
+        # (last-wins), so a duplicate `covered` verdict would silently erase a
+        # `not-covered` gap for the same axis and let the gate pass — a false
+        # negative in exactly the direction this system must never fail (Greptile
+        # #451 re-review). One verdict per axis; reject ambiguous input at the edge.
+        from collections import Counter
+
+        from mship.core.plan import _normalize_axis
+
+        axis_counts = Counter(_normalize_axis(v.axis) for v in verdicts)
+        dups = sorted(axis for axis, n in axis_counts.items() if n > 1)
+        if dups:
+            output.error(
+                f"Duplicate axis verdict(s) in --from-json: {', '.join(dups)}. "
+                "Return exactly one verdict per axis."
+            )
+            raise typer.Exit(1)
+
         store = AssumptionStore(workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root))
         rows = store.load()
         plan_text = plan_path.read_text()

--- a/src/mship/cli/plan_assumptions.py
+++ b/src/mship/cli/plan_assumptions.py
@@ -51,7 +51,7 @@ def _resolve_common(get_container, task: Optional[str], plan: Optional[str], out
     cli/plan.py's check-assumptions), the resolved Task (via the same
     resolver every state-changing verb uses), and the resolved plan path."""
     from mship.core.config import ConfigLoader
-    from mship.core.plan import resolve_plan_path
+    from mship.core.plan import effective_plan_path
 
     container = get_container()
     config_path = Path(container.config_path())
@@ -66,7 +66,10 @@ def _resolve_common(get_container, task: Optional[str], plan: Optional[str], out
     resolved = resolve_for_command("plan assumptions", state, task, output)
     task_obj = resolved.task
 
-    plan_path = resolve_plan_path(task_obj.slug, plan, workspace_root, docs_dir)
+    # Resolve the plan the SAME way the gate and serve do (WorkItem plan_path,
+    # else convention) so the recorded plan_hash matches theirs — a linked-plan
+    # WorkItem was otherwise mis-gated (Wave 3a review).
+    plan_path = effective_plan_path(task_obj, workspace_root, docs_dir, cli_plan=plan)
     if plan_path is None:
         where = f"for task {task_obj.slug!r}" if plan is None else f"at {plan!r}"
         output.error(f"No plan found {where}.")
@@ -184,13 +187,37 @@ def register(plan_app: typer.Typer, get_container):
             affected_repos=list(task_obj.affected_repos),
         )
 
+        new_hash = plan_hash(plan_text)
+        # Carry over prior approvals when RE-checking the SAME plan (unchanged
+        # hash): re-running the checker to refresh a verdict shouldn't silently
+        # wipe sign-offs. A CHANGED plan (different hash) correctly drops them —
+        # an approval against the old plan mustn't survive an edit (Wave 3a review).
+        pcstore = PlanCheckStore(workspace_root / ".mothership")
+        prior = pcstore.get(task_obj.slug)
+        if prior is not None and prior.plan_hash == new_hash:
+            # Key on (axis, source) only — NOT the checker's free-text reason.
+            # (axis, source) is unique per check run (one checker flag per axis,
+            # one cross-check flag per axis), and the human signed off on "this
+            # axis, for this plan version" — the plan_hash already pins the
+            # version. Including the LLM-paraphrased reason would silently drop a
+            # real sign-off when the checker re-runs and re-words the same gap.
+            approved = {
+                (f.axis, f.source): f for f in prior.flags if f.approved
+            }
+            for f in flags:
+                keep = approved.get((f.axis, f.source))
+                if keep is not None:
+                    f.approved = True
+                    f.approved_by = keep.approved_by
+                    f.approved_reason = keep.approved_reason
+
         check_result = PlanCheckResult(
             task_slug=task_obj.slug,
-            plan_hash=plan_hash(plan_text),
+            plan_hash=new_hash,
             verdicts=verdicts,
             flags=flags,
         )
-        PlanCheckStore(Path(container.state_dir())).save(check_result)
+        pcstore.save(check_result)
 
         pending = sum(1 for f in flags if not f.approved)
 
@@ -219,11 +246,11 @@ def register(plan_app: typer.Typer, get_container):
         from mship.core.plan_check import PlanCheckStore, plan_hash
 
         output = Output()
-        container, _workspace_root, _docs_dir, task_obj, plan_path = _resolve_common(
+        container, workspace_root, _docs_dir, task_obj, plan_path = _resolve_common(
             get_container, task, plan, output
         )
 
-        stored = PlanCheckStore(Path(container.state_dir())).get(task_obj.slug)
+        stored = PlanCheckStore(workspace_root / ".mothership").get(task_obj.slug)
         if stored is None:
             if output.human_mode:
                 output.print(f"No stored plan-check for {task_obj.slug}.")
@@ -265,11 +292,11 @@ def register(plan_app: typer.Typer, get_container):
         from mship.core.plan_check import PlanCheckStore
 
         output = Output()
-        container, _workspace_root, _docs_dir, task_obj, _plan_path = _resolve_common(
+        container, workspace_root, _docs_dir, task_obj, _plan_path = _resolve_common(
             get_container, task, plan, output
         )
 
-        store = PlanCheckStore(Path(container.state_dir()))
+        store = PlanCheckStore(workspace_root / ".mothership")
         stored = store.get(task_obj.slug)
         if stored is None:
             output.error(f"No stored plan-check for {task_obj.slug}.")

--- a/src/mship/cli/plan_assumptions.py
+++ b/src/mship/cli/plan_assumptions.py
@@ -1,0 +1,210 @@
+"""`mship plan assumptions` sub-group: the cold-checker workflow for plan
+assumption coverage (product-assumptions-wave-3a, #444).
+
+Two verbs:
+
+- `check --emit` prints a fixed-shape prompt — the original request/spec
+  text, the current assumption rows, and the finished plan text, plus an
+  instruction to return per-row verdicts as JSON. `mship` never calls an LLM
+  itself; it only builds and prints this prompt. Deliberately excludes the
+  journal, any reasoning trace, and codegraph context — the checker judges
+  the plan cold, the same way a reviewer with no session history would.
+- `result --from-json` ingests those verdicts, deterministically cross-checks
+  them against the plan/task text (`core.plan_check.cross_check`), and saves
+  a `PlanCheckResult` keyed to the plan's hash.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from mship.cli._resolve import resolve_for_command
+from mship.cli.output import Output
+
+_PROMPT_INSTRUCTION = (
+    "Judge this plan cold, using only the request, the assumption rows, and "
+    "the finished plan shown above -- nothing else about how or why the work "
+    "was done. For each assumption row, return a JSON array of objects "
+    'shaped {"axis": <axis name>, "verdict": "covered"|"not-covered"|"n-a", '
+    '"reason": <one line>}, judging strictly on whether the finished plan '
+    "actually addresses that axis."
+)
+
+
+def _request_text(workspace_root: Path, task_obj) -> str:
+    """Original request/spec text: the bound spec's title+body when the task
+    has one, else the task's free-text description."""
+    if task_obj.spec_id:
+        from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+
+        store = SpecStore(workspace_root / SPECS_DIRNAME)
+        spec = store.read_strict(task_obj.spec_id)
+        if spec is not None:
+            return f"{spec.title}\n\n{spec.body}".strip()
+    return task_obj.description
+
+
+def _resolve_common(get_container, task: Optional[str], plan: Optional[str], output: Output):
+    """Shared setup for both verbs: workspace_root/docs_dir (mirrors
+    cli/plan.py's check-assumptions), the resolved Task (via the same
+    resolver every state-changing verb uses), and the resolved plan path."""
+    from mship.core.config import ConfigLoader
+    from mship.core.plan import resolve_plan_path
+
+    container = get_container()
+    config_path = Path(container.config_path())
+    workspace_root = config_path.parent
+    docs_dir = (
+        ConfigLoader.load(config_path, require_paths=False).docs_dir
+        if config_path.is_file()
+        else "docs"
+    )
+
+    state = container.state_manager().load()
+    resolved = resolve_for_command("plan assumptions", state, task, output)
+    task_obj = resolved.task
+
+    plan_path = resolve_plan_path(task_obj.slug, plan, workspace_root, docs_dir)
+    if plan_path is None:
+        where = f"for task {task_obj.slug!r}" if plan is None else f"at {plan!r}"
+        output.error(f"No plan found {where}.")
+        raise typer.Exit(1)
+
+    return container, workspace_root, docs_dir, task_obj, plan_path
+
+
+def register(plan_app: typer.Typer, get_container):
+    assumptions_app = typer.Typer(
+        name="assumptions",
+        help="Cold-checker prompt for plan assumption coverage, and its results.",
+        no_args_is_help=True,
+    )
+
+    @assumptions_app.command("check")
+    def check(
+        task: Optional[str] = typer.Option(
+            None, "--task", help="Task slug; resolved like other state-changing commands (cwd/MSHIP_TASK fallback)."
+        ),
+        plan: Optional[str] = typer.Option(None, "--plan", help="Explicit plan path (workspace-relative)."),
+        emit: bool = typer.Option(False, "--emit", help="Print the cold-checker prompt to stdout."),
+    ):
+        """Print the cold-checker prompt for `mship plan assumptions result` to
+        consume. mship does not call an LLM itself."""
+        from mship.core.assumptions import AssumptionStore, resolve_mode
+
+        output = Output()
+        if not emit:
+            output.error("`mship plan assumptions check` requires --emit.")
+            raise typer.Exit(1)
+
+        _container, workspace_root, docs_dir, task_obj, plan_path = _resolve_common(
+            get_container, task, plan, output
+        )
+
+        request_text = _request_text(workspace_root, task_obj)
+        store = AssumptionStore(workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root))
+        rows_block = store.render()
+        plan_text = plan_path.read_text()
+
+        prompt = (
+            "# Original request/spec\n\n"
+            f"{request_text}\n\n"
+            f"{rows_block}\n"
+            "# Finished plan\n\n"
+            f"{plan_text}\n\n"
+            "# Instruction\n\n"
+            f"{_PROMPT_INSTRUCTION}\n"
+        )
+        output.print(prompt)
+
+    @assumptions_app.command("result")
+    def result(
+        from_json: str = typer.Option(
+            ..., "--from-json", help="Path to the checker's verdicts JSON, or - for stdin."
+        ),
+        task: Optional[str] = typer.Option(
+            None, "--task", help="Task slug; resolved like other state-changing commands (cwd/MSHIP_TASK fallback)."
+        ),
+        plan: Optional[str] = typer.Option(None, "--plan", help="Explicit plan path (workspace-relative)."),
+    ):
+        """Ingest per-axis checker verdicts, deterministically cross-check them
+        against the plan/task text, and save the combined result."""
+        import json
+        import sys
+
+        from pydantic import ValidationError
+
+        from mship.core.assumptions import AssumptionStore, resolve_mode
+        from mship.core.plan_check import (
+            AxisVerdict,
+            PlanCheckResult,
+            PlanCheckStore,
+            cross_check,
+            flags_from_verdicts,
+            plan_hash,
+        )
+
+        output = Output()
+        container, workspace_root, docs_dir, task_obj, plan_path = _resolve_common(
+            get_container, task, plan, output
+        )
+
+        if from_json == "-":
+            raw = sys.stdin.read()
+        else:
+            try:
+                raw = Path(from_json).read_text()
+            except OSError as e:
+                output.error(f"Cannot read --from-json {from_json!r}: {e}")
+                raise typer.Exit(1)
+
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as e:
+            output.error(f"Invalid JSON from --from-json: {e}")
+            raise typer.Exit(1)
+
+        try:
+            verdicts = [AxisVerdict(**item) for item in payload]
+        except (TypeError, ValidationError) as e:
+            output.error(f"Invalid verdicts JSON from --from-json: {e}")
+            raise typer.Exit(1)
+
+        store = AssumptionStore(workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root))
+        rows = store.load()
+        plan_text = plan_path.read_text()
+        request_text = _request_text(workspace_root, task_obj)
+
+        flags = flags_from_verdicts(verdicts) + cross_check(
+            verdicts, rows,
+            plan_text=plan_text,
+            task_text=request_text,
+            affected_repos=list(task_obj.affected_repos),
+        )
+
+        check_result = PlanCheckResult(
+            task_slug=task_obj.slug,
+            plan_hash=plan_hash(plan_text),
+            verdicts=verdicts,
+            flags=flags,
+        )
+        PlanCheckStore(Path(container.state_dir())).save(check_result)
+
+        pending = sum(1 for f in flags if not f.approved)
+
+        if output.human_mode:
+            output.success(
+                f"Saved plan-check for {task_obj.slug}: {len(flags)} flag(s), {pending} pending."
+            )
+        else:
+            output.json({
+                "task": task_obj.slug,
+                "plan_hash": check_result.plan_hash,
+                "verdicts": [v.model_dump() for v in verdicts],
+                "flags": [f.model_dump() for f in flags],
+                "pending": pending,
+            })
+
+    plan_app.add_typer(assumptions_app)

--- a/src/mship/cli/plan_assumptions.py
+++ b/src/mship/cli/plan_assumptions.py
@@ -144,6 +144,7 @@ def register(plan_app: typer.Typer, get_container):
             AxisVerdict,
             PlanCheckResult,
             PlanCheckStore,
+            assumptions_hash,
             cross_check,
             flags_from_verdicts,
             plan_hash,
@@ -237,6 +238,7 @@ def register(plan_app: typer.Typer, get_container):
             check_result = PlanCheckResult(
                 task_slug=task_obj.slug,
                 plan_hash=new_hash,
+                assumptions_hash=assumptions_hash(rows),
                 verdicts=verdicts,
                 flags=flags,
             )
@@ -264,12 +266,14 @@ def register(plan_app: typer.Typer, get_container):
         ),
         plan: Optional[str] = typer.Option(None, "--plan", help="Explicit plan path (workspace-relative)."),
     ):
-        """Report whether the stored plan-check for this task is fresh (plan
-        unchanged since the check), stale (plan edited after), or absent."""
-        from mship.core.plan_check import PlanCheckStore, plan_hash
+        """Report whether the stored plan-check for this task is fresh (plan AND
+        assumption set unchanged since the check), stale (either edited after), or
+        absent."""
+        from mship.core.assumptions import AssumptionStore, resolve_mode
+        from mship.core.plan_check import PlanCheckStore, is_fresh
 
         output = Output()
-        container, workspace_root, _docs_dir, task_obj, plan_path = _resolve_common(
+        container, workspace_root, docs_dir, task_obj, plan_path = _resolve_common(
             get_container, task, plan, output
         )
 
@@ -281,7 +285,8 @@ def register(plan_app: typer.Typer, get_container):
                 output.json({"task": task_obj.slug, "fresh": False, "pending": 0, "flags": []})
             return
 
-        fresh = stored.plan_hash == plan_hash(plan_path.read_text())
+        rows = AssumptionStore(workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root)).load()
+        fresh = is_fresh(stored, plan_path.read_text(), rows)
         pending = sum(1 for f in stored.flags if not f.approved)
 
         if output.human_mode:

--- a/src/mship/cli/plan_assumptions.py
+++ b/src/mship/cli/plan_assumptions.py
@@ -207,4 +207,98 @@ def register(plan_app: typer.Typer, get_container):
                 "pending": pending,
             })
 
+    @assumptions_app.command("status")
+    def status(
+        task: Optional[str] = typer.Option(
+            None, "--task", help="Task slug; resolved like other state-changing commands (cwd/MSHIP_TASK fallback)."
+        ),
+        plan: Optional[str] = typer.Option(None, "--plan", help="Explicit plan path (workspace-relative)."),
+    ):
+        """Report whether the stored plan-check for this task is fresh (plan
+        unchanged since the check), stale (plan edited after), or absent."""
+        from mship.core.plan_check import PlanCheckStore, plan_hash
+
+        output = Output()
+        container, _workspace_root, _docs_dir, task_obj, plan_path = _resolve_common(
+            get_container, task, plan, output
+        )
+
+        stored = PlanCheckStore(Path(container.state_dir())).get(task_obj.slug)
+        if stored is None:
+            if output.human_mode:
+                output.print(f"No stored plan-check for {task_obj.slug}.")
+            else:
+                output.json({"task": task_obj.slug, "fresh": False, "pending": 0, "flags": []})
+            return
+
+        fresh = stored.plan_hash == plan_hash(plan_path.read_text())
+        pending = sum(1 for f in stored.flags if not f.approved)
+
+        if output.human_mode:
+            state = "fresh" if fresh else "stale"
+            output.print(f"{task_obj.slug}: {state}, {pending} pending flag(s).")
+            for f in stored.flags:
+                mark = "approved" if f.approved else "pending"
+                output.print(f"  [{mark}] {f.axis} ({f.source}): {f.reason}")
+        else:
+            output.json({
+                "task": task_obj.slug,
+                "fresh": fresh,
+                "pending": pending,
+                "flags": [f.model_dump() for f in stored.flags],
+            })
+
+    @assumptions_app.command("approve")
+    def approve(
+        axis: str = typer.Argument(..., help="Axis name of the pending flag to approve."),
+        reason: Optional[str] = typer.Option(None, "--reason", help="Why this flag is approved."),
+        task: Optional[str] = typer.Option(
+            None, "--task", help="Task slug; resolved like other state-changing commands (cwd/MSHIP_TASK fallback)."
+        ),
+        plan: Optional[str] = typer.Option(None, "--plan", help="Explicit plan path (workspace-relative)."),
+    ):
+        """Mark the matching pending flag as approved (human sign-off) and
+        re-save. The only way a flag clears."""
+        import os
+
+        from mship.core.plan import _normalize_axis
+        from mship.core.plan_check import PlanCheckStore
+
+        output = Output()
+        container, _workspace_root, _docs_dir, task_obj, _plan_path = _resolve_common(
+            get_container, task, plan, output
+        )
+
+        store = PlanCheckStore(Path(container.state_dir()))
+        stored = store.get(task_obj.slug)
+        if stored is None:
+            output.error(f"No stored plan-check for {task_obj.slug}.")
+            raise typer.Exit(1)
+
+        target_axis = _normalize_axis(axis)
+        match = next(
+            (f for f in stored.flags if not f.approved and _normalize_axis(f.axis) == target_axis),
+            None,
+        )
+        if match is None:
+            output.error(f"No pending flag for axis {axis!r} on {task_obj.slug}.")
+            raise typer.Exit(1)
+
+        match.approved = True
+        match.approved_reason = reason
+        match.approved_by = os.environ.get("USER") or "unknown"
+        store.save(stored)
+
+        pending = sum(1 for f in stored.flags if not f.approved)
+
+        if output.human_mode:
+            output.success(f"Approved {axis!r} for {task_obj.slug}: {pending} pending flag(s) remain.")
+        else:
+            output.json({
+                "task": task_obj.slug,
+                "axis": match.axis,
+                "pending": pending,
+                "flags": [f.model_dump() for f in stored.flags],
+            })
+
     plan_app.add_typer(assumptions_app)

--- a/src/mship/cli/plan_assumptions.py
+++ b/src/mship/cli/plan_assumptions.py
@@ -216,18 +216,20 @@ def register(plan_app: typer.Typer, get_container):
         with pcstore.transaction(task_obj.slug):
             prior = pcstore.get(task_obj.slug)
             if prior is not None and prior.plan_hash == new_hash:
-                # Key on (axis, source) only — NOT the checker's free-text reason.
-                # (axis, source) is unique per check run (one checker flag per axis,
-                # one cross-check flag per axis), and the human signed off on "this
-                # axis, for this plan version" — the plan_hash already pins the
-                # version. Including the LLM-paraphrased reason would silently drop a
-                # real sign-off when the checker re-runs and re-words the same gap.
+                # Key on (axis, source) — NOT the checker's free-text reason, which
+                # re-words harmlessly and would drop real sign-offs. But an approval
+                # is bound to the exact assumption it approved: carry it over only
+                # when the row's DEFINITION fingerprint (options/position/triggers)
+                # also still matches, so editing what the assumption MEANS drops the
+                # stale sign-off even on an unchanged plan (Greptile #451). plan_hash
+                # (outer guard) + axis_fingerprint together pin everything the
+                # approval was granted against.
                 approved = {
                     (f.axis, f.source): f for f in prior.flags if f.approved
                 }
                 for f in flags:
                     keep = approved.get((f.axis, f.source))
-                    if keep is not None:
+                    if keep is not None and keep.axis_fingerprint == f.axis_fingerprint:
                         f.approved = True
                         f.approved_by = keep.approved_by
                         f.approved_reason = keep.approved_reason

--- a/src/mship/core/assumptions.py
+++ b/src/mship/core/assumptions.py
@@ -119,7 +119,9 @@ class AssumptionStore:
         if not self.path.is_file():
             return []
         text = self._decode(self.path)
-        return _parse_table(text)
+        rows = _parse_table(text)
+        _reject_duplicate_axes(rows)
+        return rows
 
     def axes(self) -> list[str]:
         return [_normalize_axis(row.axis) for row in self.load()]
@@ -147,6 +149,7 @@ class AssumptionStore:
                         f"assumption {row.axis!r}: {col} contains a newline; "
                         "table cells must be single-line"
                     )
+        _reject_duplicate_axes(rows)
         path = self.path
         path.parent.mkdir(parents=True, exist_ok=True)
         text = _render_table(rows)
@@ -243,6 +246,25 @@ def resolve_mode(workspace_root: Path) -> AssumptionMode:
 
     config = ConfigLoader.load(cfg_path, require_paths=False)
     return getattr(config, "assumption_storage", "committed")
+
+
+def _reject_duplicate_axes(rows: list[AssumptionRow]) -> None:
+    """Fail loud if two rows normalize to the same axis. Downstream keys verdicts
+    by normalized axis (core/plan_check.py), so a duplicate row would resolve the
+    same verdict for both and leave the second assumption with no independent
+    disposition — an unchecked assumption could then pass the plan→dev gate
+    (Greptile #451). Enforced at BOTH the read (load) and write (save) boundaries
+    so no duplicate can reach the verdict→flag path from any source; the axis set
+    is the store's single source of truth and must stay unique."""
+    from collections import Counter
+
+    counts = Counter(_normalize_axis(row.axis) for row in rows)
+    dups = sorted(axis for axis, n in counts.items() if n > 1)
+    if dups:
+        raise ValueError(
+            f"duplicate assumption axis/axes (normalized): {', '.join(dups)}. "
+            "Each axis must be unique; merge or rename the rows."
+        )
 
 
 def _parse_table(text: str) -> list[AssumptionRow]:

--- a/src/mship/core/config.py
+++ b/src/mship/core/config.py
@@ -358,6 +358,12 @@ class WorkspaceConfig(BaseModel):
     # core/assumptions.py::AssumptionStore; an invalid value fails loud at
     # config load, same as `spec_storage`.
     assumption_storage: Literal["committed", "local", "encrypted"] = "committed"
+    # L4 plan→dev gate (#444): "off" (default) — merging this does NOT enforce
+    # anything; existing plan-exists gate is unchanged. "enforce" additionally
+    # requires a fresh, fully-approved `PlanCheckResult` (core/plan_check.py)
+    # before a feature WorkItem may transition plan→dev. See core/workitem_gate.py
+    # ::_feature_assumption_gate_reason.
+    assumption_gate: Literal["off", "enforce"] = "off"
     # Storage mode for acceptance-criterion artifact evidence. `None` inherits
     # `spec_storage` — the safe default, so evidence is governed exactly like the
     # spec it backs unless an operator deliberately diverges (prose is bytes,

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -94,11 +94,20 @@ class PhaseManager:
                     # already skips this call entirely as the escape hatch;
                     # without --bypass-spec-gate we still want a clean,
                     # actionable SpecGateError instead of a traceback.
+                    # L4 assumption gate (#444) is opt-in: only enforced when
+                    # `assumption_gate: enforce` in mothership.yaml. Off by
+                    # default so merging this doesn't newly block anyone.
+                    # --bypass-plan-gate also drops this clause — it's built
+                    # on top of the plan clause and inert without a plan.
+                    assumption_gate_enforced = (
+                        self._config is not None and self._config.assumption_gate == "enforce"
+                    )
                     try:
                         gate_result = check_task_gate(
                             task,
                             self._workspace_root,
                             require_plan=not bypass_plan_gate,
+                            require_assumption_gate=assumption_gate_enforced and not bypass_plan_gate,
                         )
                     except Exception as e:
                         raise SpecGateError(
@@ -106,15 +115,20 @@ class PhaseManager:
                         ) from e
                     if not gate_result.ok:
                         raise SpecGateError(gate_result.reason)
-                    # A plan-gate bypass only counts if the plan clause WOULD have
-                    # blocked (not a no-op override on a non-feature item or when a
-                    # plan is already present). Compute it here, but DON'T log yet —
-                    # a later gate below can still reject the transition, and we must
-                    # not record a bypass for a transition that then fails (Greptile).
+                    # A plan-gate bypass only counts if the plan (or assumption)
+                    # clause WOULD have blocked (not a no-op override on a
+                    # non-feature item or when a plan is already present and
+                    # assumptions are approved). Compute it here, but DON'T log
+                    # yet — a later gate below can still reject the transition,
+                    # and we must not record a bypass for a transition that then
+                    # fails (Greptile).
                     if bypass_plan_gate:
                         try:
                             with_plan = check_task_gate(
-                                task, self._workspace_root, require_plan=True
+                                task,
+                                self._workspace_root,
+                                require_plan=True,
+                                require_assumption_gate=assumption_gate_enforced,
                             )
                         except Exception:
                             with_plan = None

--- a/src/mship/core/plan.py
+++ b/src/mship/core/plan.py
@@ -144,3 +144,23 @@ def resolve_plan_path(
             return None
         return p if p.is_file() else None
     return discover_plan_path(root, task_slug, docs_dir)
+
+
+def effective_plan_path(task, workspace_root, docs_dir: str = "docs", *, cli_plan: str | None = None):
+    """THE plan for a task, resolved identically at every L4 site — the CLI that
+    RECORDS a check, the plan→dev gate, and the serve endpoint. An explicit
+    `--plan` wins; else the task's WorkItem `plan_path`; else the
+    `docs/plans/<date>-<slug>.md` convention. Single source of truth so the
+    `plan_hash` the recorder computes equals the hash the gate and serve compute
+    — a linked-plan WorkItem (`mship item link-plan`) was otherwise hashed at the
+    convention path by the CLI but at the linked path by the gate, permanently
+    mis-gating it (Wave 3a whole-branch review)."""
+    plan_ref = cli_plan
+    if plan_ref is None:
+        wid = getattr(task, "work_item_id", None)
+        if wid:
+            from mship.core.workitem_store import WorkItemStore
+
+            wi = WorkItemStore(Path(workspace_root) / ".mothership" / "workitems").get(wid)
+            plan_ref = getattr(wi, "plan_path", None) if wi else None
+    return resolve_plan_path(task.slug, plan_ref, Path(workspace_root), docs_dir)

--- a/src/mship/core/plan_check.py
+++ b/src/mship/core/plan_check.py
@@ -20,8 +20,11 @@ __all__ = [
     "Flag",
     "PlanCheckResult",
     "PlanCheckStore",
+    "assumptions_hash",
+    "axis_fingerprint",
     "cross_check",
     "flags_from_verdicts",
+    "is_fresh",
     "plan_hash",
 ]
 
@@ -66,9 +69,39 @@ def axis_fingerprint(row: "AssumptionRow") -> str:
     return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
+def assumptions_hash(rows: list["AssumptionRow"]) -> str:
+    """Order-independent hash of the CURRENT assumption SET's definitions. A
+    stored plan-check is fresh only while this still matches: adding, removing, or
+    editing ANY row invalidates it, forcing a re-check so a newly-added assumption
+    gets a disposition and an edited one loses its stale approval. Pairs with
+    `plan_hash` — freshness = plan unchanged AND assumptions unchanged (#444)."""
+    return hashlib.sha256(
+        "\x1f".join(sorted(axis_fingerprint(r) for r in rows)).encode()
+    ).hexdigest()[:16]
+
+
+def is_fresh(stored: "PlanCheckResult", plan_text: str, rows: list["AssumptionRow"]) -> bool:
+    """THE freshness contract, shared by the plan→dev gate, `status`, and serve so
+    none can drift: a stored check is fresh iff the plan AND the assumption set are
+    both unchanged since it was recorded. A record predating assumption-hashing
+    (`assumptions_hash is None`) is NOT fresh — fail toward re-checking (Greptile
+    #451: the gate must notice a changed/added assumption, not only a changed plan)."""
+    return (
+        stored.plan_hash == plan_hash(plan_text)
+        and stored.assumptions_hash is not None
+        and stored.assumptions_hash == assumptions_hash(rows)
+    )
+
+
 class PlanCheckResult(BaseModel):
     task_slug: str
     plan_hash: str
+    # Hash of the assumption SET this check was recorded against (see
+    # `assumptions_hash`). A stored check is fresh only while BOTH the plan and
+    # the assumption set are unchanged — the gate enforces this, so adding or
+    # editing a row invalidates the record even on an unchanged plan (Greptile
+    # #451). Optional for backward-compat with pre-hash records (treated as stale).
+    assumptions_hash: str | None = None
     verdicts: list[AxisVerdict]
     flags: list[Flag]
 

--- a/src/mship/core/plan_check.py
+++ b/src/mship/core/plan_check.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel
+
+__all__ = [
+    "AxisVerdict",
+    "Flag",
+    "PlanCheckResult",
+    "PlanCheckStore",
+    "flags_from_verdicts",
+    "plan_hash",
+]
+
+
+def plan_hash(plan_text: str) -> str:
+    """sha256 hex of `plan_text` with trailing whitespace stripped per line and a
+    single trailing newline, so cosmetic whitespace edits don't churn the hash."""
+    normalized = "\n".join(line.rstrip() for line in plan_text.splitlines()) + "\n"
+    return hashlib.sha256(normalized.encode()).hexdigest()
+
+
+class AxisVerdict(BaseModel):
+    axis: str
+    verdict: Literal["covered", "not-covered", "n-a"]
+    reason: str
+
+
+class Flag(BaseModel):
+    axis: str
+    source: Literal["checker", "cross-check"]
+    reason: str
+    approved: bool = False
+    approved_by: str | None = None
+    approved_reason: str | None = None
+
+
+class PlanCheckResult(BaseModel):
+    task_slug: str
+    plan_hash: str
+    verdicts: list[AxisVerdict]
+    flags: list[Flag]
+
+
+def flags_from_verdicts(verdicts: list[AxisVerdict]) -> list[Flag]:
+    """One `source="checker"` flag per `not-covered` verdict; `covered`/`n-a` produce none."""
+    return [
+        Flag(axis=v.axis, source="checker", reason=v.reason)
+        for v in verdicts
+        if v.verdict == "not-covered"
+    ]
+
+
+class PlanCheckStore:
+    """Filesystem registry for plan-check results: one JSON file per task, under
+    `<state_dir>/plan-checks/`."""
+
+    def __init__(self, state_dir: Path) -> None:
+        self._dir = Path(state_dir) / "plan-checks"
+
+    def path(self, task_slug: str) -> Path:
+        return self._dir / f"{task_slug}.json"
+
+    def save(self, result: PlanCheckResult) -> Path:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        path = self.path(result.task_slug)
+        fd, tmp = tempfile.mkstemp(dir=self._dir, suffix=".json.tmp")
+        try:
+            with open(fd, "w") as f:
+                f.write(result.model_dump_json(indent=2))
+            Path(tmp).replace(path)
+        except Exception:
+            Path(tmp).unlink(missing_ok=True)
+            raise
+        return path
+
+    def get(self, task_slug: str) -> PlanCheckResult | None:
+        path = self.path(task_slug)
+        if not path.is_file():
+            return None
+        return PlanCheckResult.model_validate_json(path.read_text())

--- a/src/mship/core/plan_check.py
+++ b/src/mship/core/plan_check.py
@@ -3,15 +3,21 @@ from __future__ import annotations
 import hashlib
 import tempfile
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel
+
+from mship.core.plan import _normalize_axis
+
+if TYPE_CHECKING:
+    from mship.core.assumptions import AssumptionRow
 
 __all__ = [
     "AxisVerdict",
     "Flag",
     "PlanCheckResult",
     "PlanCheckStore",
+    "cross_check",
     "flags_from_verdicts",
     "plan_hash",
 ]
@@ -53,6 +59,73 @@ def flags_from_verdicts(verdicts: list[AxisVerdict]) -> list[Flag]:
         for v in verdicts
         if v.verdict == "not-covered"
     ]
+
+
+def _triggers_match(triggers: str, plan_text: str, task_text: str, affected_repos: list[str]) -> bool:
+    """A row's `triggers` cell is comma-separated tokens. A `foo/*` token matches by
+    prefix `foo/` against either text blob; a plain token matches as a case-insensitive
+    substring of either text blob, or equals an `affected_repos` entry (case-insensitive)."""
+    haystacks = [plan_text.lower(), task_text.lower()]
+    repos_lower = [r.lower() for r in affected_repos]
+    for raw_token in triggers.split(","):
+        token = raw_token.strip().lower()
+        if not token:
+            continue
+        if token.endswith("/*"):
+            prefix = token[:-1]  # keep trailing "/"
+            if any(prefix in haystack for haystack in haystacks):
+                return True
+        else:
+            if any(token in haystack for haystack in haystacks):
+                return True
+            if token in repos_lower:
+                return True
+    return False
+
+
+def cross_check(
+    verdicts: list[AxisVerdict],
+    rows: list["AssumptionRow"],
+    *,
+    plan_text: str,
+    task_text: str,
+    affected_repos: list[str],
+) -> list[Flag]:
+    """Deterministic (no LLM) trigger cross-check: for each assumption row whose
+    `triggers` match the plan/task context, the plan must have addressed that axis
+    as `covered` or `not-covered`. A matching `n-a` verdict, or no verdict at all,
+    is a contradiction between the declared position and the plan's own triggers —
+    surfaced as a `source="cross-check"` flag. Only adds flags; never removes the
+    checker's own `not-covered` flags."""
+    verdict_by_axis = {_normalize_axis(v.axis): v for v in verdicts}
+    flags: list[Flag] = []
+    for row in rows:
+        if not _triggers_match(row.triggers, plan_text, task_text, affected_repos):
+            continue
+        verdict = verdict_by_axis.get(_normalize_axis(row.axis))
+        if verdict is None:
+            flags.append(
+                Flag(
+                    axis=row.axis,
+                    source="cross-check",
+                    reason=(
+                        f"triggers for '{row.axis}' match this plan/task, but the plan "
+                        "has no verdict for this axis"
+                    ),
+                )
+            )
+        elif verdict.verdict == "n-a":
+            flags.append(
+                Flag(
+                    axis=row.axis,
+                    source="cross-check",
+                    reason=(
+                        f"triggers for '{row.axis}' match this plan/task, but the plan "
+                        "declared it n/a"
+                    ),
+                )
+            )
+    return flags
 
 
 class PlanCheckStore:

--- a/src/mship/core/plan_check.py
+++ b/src/mship/core/plan_check.py
@@ -43,9 +43,27 @@ class Flag(BaseModel):
     axis: str
     source: Literal["checker", "cross-check"]
     reason: str
+    # Fingerprint of the assumption ROW's definition (options/position/triggers)
+    # this flag was generated from. A human sign-off is bound to the exact
+    # assumption it approved: on a same-plan re-check the approval carries over
+    # only when this fingerprint still matches, so editing what the assumption
+    # MEANS (without touching the plan) correctly drops the stale approval
+    # (Greptile #451). Optional for backward-compat with pre-fingerprint records.
+    axis_fingerprint: str | None = None
     approved: bool = False
     approved_by: str | None = None
     approved_reason: str | None = None
+
+
+def axis_fingerprint(row: "AssumptionRow") -> str:
+    """Stable hash of an assumption row's DEFINITION — the operator-authored
+    meaning (options/position/triggers), keyed under the normalized axis. NOT the
+    checker's free-text reason (that re-words harmlessly). Used to bind an
+    approval to the exact assumption it was granted against."""
+    raw = "\x1f".join([
+        _normalize_axis(row.axis), row.options, row.position, row.triggers,
+    ])
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
 class PlanCheckResult(BaseModel):
@@ -77,10 +95,12 @@ def flags_from_verdicts(verdicts: list[AxisVerdict], rows: list["AssumptionRow"]
         if v is None:
             flags.append(
                 Flag(axis=row.axis, source="checker",
-                     reason="checker returned no verdict for this row")
+                     reason="checker returned no verdict for this row",
+                     axis_fingerprint=axis_fingerprint(row))
             )
         elif v.verdict == "not-covered":
-            flags.append(Flag(axis=row.axis, source="checker", reason=v.reason))
+            flags.append(Flag(axis=row.axis, source="checker", reason=v.reason,
+                              axis_fingerprint=axis_fingerprint(row)))
     return flags
 
 
@@ -144,6 +164,7 @@ def cross_check(
                         f"triggers for '{row.axis}' match this plan/task, but the plan "
                         "declared it n/a"
                     ),
+                    axis_fingerprint=axis_fingerprint(row),
                 )
             )
     return flags

--- a/src/mship/core/plan_check.py
+++ b/src/mship/core/plan_check.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import re
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -53,13 +55,33 @@ class PlanCheckResult(BaseModel):
     flags: list[Flag]
 
 
-def flags_from_verdicts(verdicts: list[AxisVerdict]) -> list[Flag]:
-    """One `source="checker"` flag per `not-covered` verdict; `covered`/`n-a` produce none."""
-    return [
-        Flag(axis=v.axis, source="checker", reason=v.reason)
-        for v in verdicts
-        if v.verdict == "not-covered"
-    ]
+def flags_from_verdicts(verdicts: list[AxisVerdict], rows: list["AssumptionRow"]) -> list[Flag]:
+    """One `source="checker"` pending flag per CANONICAL row the checker did not
+    dispose of as covered/n-a — driven by `rows`, NOT by the verdict array, so the
+    gate enforces completeness:
+
+    - a `not-covered` verdict → pending flag (reason = the checker's line);
+    - NO verdict for the row (the checker's JSON omitted it) → pending flag. An
+      omitted row must never silently pass the plan→dev gate — that is exactly the
+      "disposition every assumption" invariant this system exists to hold (#444);
+    - `covered`/`n-a` → no checker flag (a triggered `n-a` is still caught by
+      `cross_check`).
+
+    Verdicts whose axis is NOT a current row are IGNORED — an invented or
+    misspelled axis must not manufacture a phantom flag the operator then has to
+    approve for a row that does not exist."""
+    verdict_by_axis = {_normalize_axis(v.axis): v for v in verdicts}
+    flags: list[Flag] = []
+    for row in rows:
+        v = verdict_by_axis.get(_normalize_axis(row.axis))
+        if v is None:
+            flags.append(
+                Flag(axis=row.axis, source="checker",
+                     reason="checker returned no verdict for this row")
+            )
+        elif v.verdict == "not-covered":
+            flags.append(Flag(axis=row.axis, source="checker", reason=v.reason))
+    return flags
 
 
 def _triggers_match(triggers: str, plan_text: str, task_text: str, affected_repos: list[str]) -> bool:
@@ -100,9 +122,12 @@ def cross_check(
 ) -> list[Flag]:
     """Deterministic (no LLM) trigger cross-check: for each assumption row whose
     `triggers` match the plan/task context, the plan must have addressed that axis
-    as `covered` or `not-covered`. A matching `n-a` verdict, or no verdict at all,
-    is a contradiction between the declared position and the plan's own triggers —
-    surfaced as a `source="cross-check"` flag. Only adds flags; never removes the
+    as `covered` or `not-covered`. A matching `n-a` verdict is a contradiction
+    between the declared position and the plan's own triggers — surfaced as a
+    `source="cross-check"` flag. A row with no verdict at all is NOT handled here:
+    `flags_from_verdicts` already raises a completeness flag for every
+    un-dispositioned row (triggered or not), so flagging it again here would force
+    the operator to approve the same row twice. Only adds flags; never removes the
     checker's own `not-covered` flags."""
     verdict_by_axis = {_normalize_axis(v.axis): v for v in verdicts}
     flags: list[Flag] = []
@@ -110,18 +135,7 @@ def cross_check(
         if not _triggers_match(row.triggers, plan_text, task_text, affected_repos):
             continue
         verdict = verdict_by_axis.get(_normalize_axis(row.axis))
-        if verdict is None:
-            flags.append(
-                Flag(
-                    axis=row.axis,
-                    source="cross-check",
-                    reason=(
-                        f"triggers for '{row.axis}' match this plan/task, but the plan "
-                        "has no verdict for this axis"
-                    ),
-                )
-            )
-        elif verdict.verdict == "n-a":
+        if verdict is not None and verdict.verdict == "n-a":
             flags.append(
                 Flag(
                     axis=row.axis,
@@ -143,7 +157,37 @@ class PlanCheckStore:
         self._dir = Path(state_dir) / "plan-checks"
 
     def path(self, task_slug: str) -> Path:
+        # Validate the slug the same way WorkItemStore._path does — a task_slug is
+        # always a state-validated key upstream, but a per-id file store must not
+        # let a stray separator/`..` escape the plan-checks dir at the boundary.
+        if (not task_slug or "/" in task_slug or "\\" in task_slug
+                or task_slug in (".", "..") or task_slug.startswith(".")):
+            raise ValueError(f"unsafe task slug: {task_slug!r}")
         return self._dir / f"{task_slug}.json"
+
+    def _lock_path(self, task_slug: str) -> Path:
+        """Per-task lock file (`<slug>.json.lock`). Reuses `path`'s slug
+        validation; not matched by any `*.json` read glob."""
+        p = self.path(task_slug)
+        return p.with_name(p.name + ".lock")
+
+    @contextmanager
+    def transaction(self, task_slug: str):
+        """Exclusive per-task advisory lock spanning a read-modify-write (mirrors
+        WorkItemStore._locked). `result` and `approve` both get→mutate→save the
+        same task record; without a lock spanning the whole transaction, an
+        approval overlapping a checker refresh (or two approvals) can silently
+        clobber each other's write. Per-task granularity lets different tasks
+        proceed in parallel."""
+        self._dir.mkdir(parents=True, exist_ok=True)
+        lock_path = self._lock_path(task_slug)
+        lock_path.touch(exist_ok=True)
+        with open(lock_path, "r+") as lf:
+            fcntl.flock(lf, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lf, fcntl.LOCK_UN)
 
     def save(self, result: PlanCheckResult) -> Path:
         self._dir.mkdir(parents=True, exist_ok=True)

--- a/src/mship/core/plan_check.py
+++ b/src/mship/core/plan_check.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -62,9 +63,12 @@ def flags_from_verdicts(verdicts: list[AxisVerdict]) -> list[Flag]:
 
 
 def _triggers_match(triggers: str, plan_text: str, task_text: str, affected_repos: list[str]) -> bool:
-    """A row's `triggers` cell is comma-separated tokens. A `foo/*` token matches by
-    prefix `foo/` against either text blob; a plain token matches as a case-insensitive
-    substring of either text blob, or equals an `affected_repos` entry (case-insensitive)."""
+    """A row's `triggers` cell is comma-separated tokens. A `foo/*` token matches a
+    `foo/` path SEGMENT (segment boundary, not mid-word — so `run/*` does NOT match
+    `prerun/config`); a plain token matches on a WORD boundary (so `run` does NOT
+    match `brunch`, and `UI` does NOT match `build`) or equals an `affected_repos`
+    entry. Word/segment boundaries keep the cross-check precise — false flags spend
+    the scarce resource, operator attention (#444 backtest)."""
     haystacks = [plan_text.lower(), task_text.lower()]
     repos_lower = [r.lower() for r in affected_repos]
     for raw_token in triggers.split(","):
@@ -72,11 +76,14 @@ def _triggers_match(triggers: str, plan_text: str, task_text: str, affected_repo
         if not token:
             continue
         if token.endswith("/*"):
-            prefix = token[:-1]  # keep trailing "/"
-            if any(prefix in haystack for haystack in haystacks):
+            # `foo/` must start a path segment: at string start or after a non-word,
+            # non-slash char (so `prerun/` does not satisfy `run/*`).
+            pat = r"(?:^|[^\w/])" + re.escape(token[:-1])
+            if any(re.search(pat, h) for h in haystacks):
                 return True
         else:
-            if any(token in haystack for haystack in haystacks):
+            pat = r"\b" + re.escape(token) + r"\b"
+            if any(re.search(pat, h) for h in haystacks):
                 return True
             if token in repos_lower:
                 return True

--- a/src/mship/core/plan_check.py
+++ b/src/mship/core/plan_check.py
@@ -157,13 +157,21 @@ class PlanCheckStore:
         self._dir = Path(state_dir) / "plan-checks"
 
     def path(self, task_slug: str) -> Path:
-        # Validate the slug the same way WorkItemStore._path does — a task_slug is
-        # always a state-validated key upstream, but a per-id file store must not
-        # let a stray separator/`..` escape the plan-checks dir at the boundary.
-        if (not task_slug or "/" in task_slug or "\\" in task_slug
-                or task_slug in (".", "..") or task_slug.startswith(".")):
+        # `slug` can reach here from an HTTP path param (serve
+        # /plan-assumptions/{slug}), so treat it as untrusted at this boundary.
+        # Resolve the candidate and require it to sit DIRECTLY inside plan-checks/
+        # — a positive containment proof (the sanitizer pattern that clears
+        # CodeQL py/path-injection, mirroring resolve_plan_path's is_relative_to
+        # guard), which also subsumes any separator / `..` / absolute-path slug.
+        # Callers still validate the slug against state.tasks upstream; this is
+        # defense in depth, not the only guard.
+        if not task_slug:
+            raise ValueError("empty task slug")
+        base = self._dir.resolve()
+        candidate = (base / f"{task_slug}.json").resolve()
+        if candidate.parent != base:
             raise ValueError(f"unsafe task slug: {task_slug!r}")
-        return self._dir / f"{task_slug}.json"
+        return candidate
 
     def _lock_path(self, task_slug: str) -> Path:
         """Per-task lock file (`<slug>.json.lock`). Reuses `path`'s slug

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -672,6 +672,38 @@ def create_app(
             raise HTTPException(status_code=404, detail=f"no task {slug!r}")
         return jsonable_encoder(log_manager.read(slug, last=50))
 
+    @app.get("/plan-assumptions/{slug}")
+    def get_plan_assumptions(slug: str):
+        """Read-only, LLM-free pending-flags envelope for the Wave 3a
+        plan-check gate — the contract Ground Control (Wave 3b) consumes.
+        Same shape `mship plan assumptions status` prints
+        (`cli/plan_assumptions.py::status`): `fresh` compares the stored
+        result's `plan_hash` against the CURRENT plan text's hash (docs_dir
+        resolved the same way, off this machine's own committed
+        `docs/plans/`, not a task worktree)."""
+        from mship.core.plan import resolve_plan_path
+        from mship.core.plan_check import PlanCheckStore, plan_hash
+
+        state = state_manager.load()
+        if slug not in state.tasks:
+            raise HTTPException(status_code=404, detail=f"no task {slug!r}")
+
+        docs_dir = getattr(config, "docs_dir", "docs") if config is not None else "docs"
+        plan_check_store = PlanCheckStore(workspace_root / ".mothership")
+        stored = plan_check_store.get(slug)
+        if stored is None:
+            return {"task": slug, "fresh": False, "pending": 0, "flags": []}
+
+        plan_path = resolve_plan_path(slug, None, workspace_root, docs_dir)
+        fresh = plan_path is not None and stored.plan_hash == plan_hash(plan_path.read_text())
+        pending = sum(1 for f in stored.flags if not f.approved)
+        return {
+            "task": slug,
+            "fresh": fresh,
+            "pending": pending,
+            "flags": [f.model_dump() for f in stored.flags],
+        }
+
     # --- gh-token: two brokers, one contract ---
     # Both brokers return the same shape {"token", "expires_at", "repositories"}.
     # Broker selection is decided PURELY by whether App creds (gh_app_id AND

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -681,8 +681,9 @@ def create_app(
         result's `plan_hash` against the CURRENT plan text's hash (docs_dir
         resolved the same way, off this machine's own committed
         `docs/plans/`, not a task worktree)."""
+        from mship.core.assumptions import AssumptionStore, resolve_mode
         from mship.core.plan import effective_plan_path
-        from mship.core.plan_check import PlanCheckStore, plan_hash
+        from mship.core.plan_check import PlanCheckStore, is_fresh
 
         state = state_manager.load()
         if slug not in state.tasks:
@@ -694,10 +695,14 @@ def create_app(
         if stored is None:
             return {"task": slug, "fresh": False, "pending": 0, "flags": []}
 
-        # SAME resolution as the gate + CLI recorder (WorkItem plan_path, else
-        # convention) so `fresh` here agrees with the gate (Wave 3a review).
+        # SAME freshness contract as the gate + CLI (plan_hash AND assumptions_hash,
+        # same plan resolution) so `fresh` here agrees with the gate (Wave 3a
+        # review; Greptile #451 assumption-set staleness).
         plan_path = effective_plan_path(state.tasks[slug], workspace_root, docs_dir)
-        fresh = plan_path is not None and stored.plan_hash == plan_hash(plan_path.read_text())
+        rows = AssumptionStore(
+            workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root)
+        ).load()
+        fresh = plan_path is not None and is_fresh(stored, plan_path.read_text(), rows)
         pending = sum(1 for f in stored.flags if not f.approved)
         return {
             "task": slug,

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -681,7 +681,7 @@ def create_app(
         result's `plan_hash` against the CURRENT plan text's hash (docs_dir
         resolved the same way, off this machine's own committed
         `docs/plans/`, not a task worktree)."""
-        from mship.core.plan import resolve_plan_path
+        from mship.core.plan import effective_plan_path
         from mship.core.plan_check import PlanCheckStore, plan_hash
 
         state = state_manager.load()
@@ -694,7 +694,9 @@ def create_app(
         if stored is None:
             return {"task": slug, "fresh": False, "pending": 0, "flags": []}
 
-        plan_path = resolve_plan_path(slug, None, workspace_root, docs_dir)
+        # SAME resolution as the gate + CLI recorder (WorkItem plan_path, else
+        # convention) so `fresh` here agrees with the gate (Wave 3a review).
+        plan_path = effective_plan_path(state.tasks[slug], workspace_root, docs_dir)
         fresh = plan_path is not None and stored.plan_hash == plan_hash(plan_path.read_text())
         pending = sum(1 for f in stored.flags if not f.approved)
         return {

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -173,8 +173,9 @@ def _feature_assumption_gate_reason(wi: WorkItem, task, workspace_root: Path) ->
     resolves — callers run this after the plan-exists gate, so a missing/
     unreadable plan here is reported the same as "no check on record" rather
     than duplicating `_feature_has_plan`'s error."""
+    from mship.core.assumptions import AssumptionStore, resolve_mode
     from mship.core.plan import effective_plan_path
-    from mship.core.plan_check import PlanCheckStore, plan_hash
+    from mship.core.plan_check import PlanCheckStore, is_fresh
 
     no_check_msg = (
         "no fresh plan-assumption check on record — run "
@@ -182,16 +183,27 @@ def _feature_assumption_gate_reason(wi: WorkItem, task, workspace_root: Path) ->
     )
     # SAME resolution as the CLI recorder + serve (WorkItem plan_path, else
     # convention) so the hash we check matches the hash that was recorded.
-    p = effective_plan_path(task, workspace_root, _docs_dir(workspace_root))
+    docs_dir = _docs_dir(workspace_root)
+    p = effective_plan_path(task, workspace_root, docs_dir)
     if p is None:
         return no_check_msg
     try:
-        current_hash = plan_hash(p.read_text())
+        plan_text = p.read_text()
     except (OSError, UnicodeDecodeError):
+        return no_check_msg
+    # Freshness is vs BOTH the plan AND the current assumption set — a changed or
+    # newly-added assumption (plan untouched) must re-block the gate, not ride an
+    # obsolete stored check (Greptile #451). A store that can't load (malformed /
+    # missing key) fails safe: block with the re-check message.
+    try:
+        rows = AssumptionStore(
+            Path(workspace_root), docs_dir=docs_dir, mode=resolve_mode(workspace_root)
+        ).load()
+    except Exception:
         return no_check_msg
     store = PlanCheckStore(Path(workspace_root) / ".mothership")
     result = store.get(task.slug)
-    if result is None or result.plan_hash != current_hash:
+    if result is None or not is_fresh(result, plan_text, rows):
         return no_check_msg
     pending = [f.axis for f in result.flags if not f.approved]
     if pending:

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -173,16 +173,16 @@ def _feature_assumption_gate_reason(wi: WorkItem, task, workspace_root: Path) ->
     resolves — callers run this after the plan-exists gate, so a missing/
     unreadable plan here is reported the same as "no check on record" rather
     than duplicating `_feature_has_plan`'s error."""
-    from mship.core.plan import resolve_plan_path
+    from mship.core.plan import effective_plan_path
     from mship.core.plan_check import PlanCheckStore, plan_hash
 
     no_check_msg = (
         "no fresh plan-assumption check on record — run "
         "`mship plan assumptions check --emit` (agent runs it) then `result --from-json`"
     )
-    p = resolve_plan_path(
-        task.slug, getattr(wi, "plan_path", None), workspace_root, _docs_dir(workspace_root)
-    )
+    # SAME resolution as the CLI recorder + serve (WorkItem plan_path, else
+    # convention) so the hash we check matches the hash that was recorded.
+    p = effective_plan_path(task, workspace_root, _docs_dir(workspace_root))
     if p is None:
         return no_check_msg
     try:

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -23,11 +23,16 @@ class GateResult:
     reason: str | None = None  # actionable message when not ok
 
 
-def check_task_gate(task, workspace_root: Path, require_plan: bool = False) -> GateResult:
+def check_task_gate(
+    task, workspace_root: Path, require_plan: bool = False, require_assumption_gate: bool = False
+) -> GateResult:
     """Universal: a task must have a WorkItem. Kind-gated: a feature WorkItem
     must have an approved spec. When `require_plan` is set — only at phase
     plan→dev and finish, never at spawn — a feature WorkItem must ALSO have a
-    valid implementation plan. bug/chore/question need only the WorkItem."""
+    valid implementation plan. When `require_assumption_gate` is also set
+    (opt-in via `assumption_gate: enforce` in mothership.yaml, #444 L4) a
+    feature WorkItem must ALSO have a fresh, fully-approved plan-assumption
+    check on record. bug/chore/question need only the WorkItem."""
     if getattr(task, "work_item_id", None) is None:
         return GateResult(False, "no WorkItem — create one with `mship item new --kind <kind>` "
                                  "and spawn with `--work-item <id>` (or pass `--hotfix` to override)")
@@ -44,6 +49,10 @@ def check_task_gate(task, workspace_root: Path, require_plan: bool = False) -> G
                                  f"write one (writing-plans) at {dd}/plans/<date>-{task.slug}.md, or link it "
                                  f"with `mship item link-plan {task.work_item_id} <path>`. "
                                  f"Use --bypass-plan-gate / --hotfix to skip.")
+    if require_assumption_gate and wi.kind == "feature":
+        reason = _feature_assumption_gate_reason(wi, task, workspace_root)
+        if reason is not None:
+            return GateResult(False, reason)
     return GateResult(True)
 
 
@@ -155,6 +164,42 @@ def _feature_has_plan(wi: WorkItem, task, workspace_root: Path) -> bool:
         # / binary file (UnicodeDecodeError). Treat as no valid plan so the gate
         # fails with its actionable message, NOT the generic corrupt-store error.
         return False
+
+
+def _feature_assumption_gate_reason(wi: WorkItem, task, workspace_root: Path) -> str | None:
+    """L4 assumption gate (#444): None if the feature's plan-assumption check is
+    fresh (`plan_hash` matches the current plan text) AND every flag is
+    approved; otherwise an actionable message. Only meaningful once a plan
+    resolves — callers run this after the plan-exists gate, so a missing/
+    unreadable plan here is reported the same as "no check on record" rather
+    than duplicating `_feature_has_plan`'s error."""
+    from mship.core.plan import resolve_plan_path
+    from mship.core.plan_check import PlanCheckStore, plan_hash
+
+    no_check_msg = (
+        "no fresh plan-assumption check on record — run "
+        "`mship plan assumptions check --emit` (agent runs it) then `result --from-json`"
+    )
+    p = resolve_plan_path(
+        task.slug, getattr(wi, "plan_path", None), workspace_root, _docs_dir(workspace_root)
+    )
+    if p is None:
+        return no_check_msg
+    try:
+        current_hash = plan_hash(p.read_text())
+    except (OSError, UnicodeDecodeError):
+        return no_check_msg
+    store = PlanCheckStore(Path(workspace_root) / ".mothership")
+    result = store.get(task.slug)
+    if result is None or result.plan_hash != current_hash:
+        return no_check_msg
+    pending = [f.axis for f in result.flags if not f.approved]
+    if pending:
+        return (
+            f"{len(pending)} assumption(s) need sign-off: "
+            f"`mship plan assumptions approve <axis>` (pending: {', '.join(pending)})"
+        )
+    return None
 
 
 def log_hotfix(workspace_root: Path, where: str, task_slug: str) -> None:

--- a/tests/cli/test_plan_assumptions.py
+++ b/tests/cli/test_plan_assumptions.py
@@ -414,6 +414,52 @@ def test_result_preserves_prior_approvals_when_plan_unchanged(tmp_path):
     assert len(match) == 1 and match[0].approved is False
 
 
+def test_result_drops_approval_when_assumption_definition_changes(tmp_path):
+    """A sign-off is bound to the assumption it approved: editing the row's
+    definition (position/options/triggers) drops the stale approval even on an
+    unchanged plan, so the changed assumption gets fresh review (Greptile #451)."""
+    from mship.core.assumptions import AssumptionRow, AssumptionStore
+    from mship.core.plan_check import PlanCheckStore
+
+    store = AssumptionStore(tmp_path)
+    store.seed()
+
+    plan_path = _write_plan(tmp_path, "2026-07-30-t1.md", "# Plan\n\nStable body.\n")
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps([
+        {"axis": "repo topology", "verdict": "not-covered", "reason": "a gap"},
+    ]))
+
+    runner = CliRunner()
+    app = _app(tmp_path, task=_task())
+
+    def _result():
+        return runner.invoke(app, [
+            "plan", "assumptions", "result",
+            "--task", "t1", "--plan", str(plan_path), "--from-json", str(verdicts_file),
+        ])
+
+    assert _result().exit_code == 0
+    assert runner.invoke(app, [
+        "plan", "assumptions", "approve", "repo topology",
+        "--reason", "ok for the old definition", "--task", "t1", "--plan", str(plan_path),
+    ]).exit_code == 0
+
+    # Change what the "repo topology" assumption MEANS (its position), plan untouched.
+    rows = store.load()
+    edited = [
+        AssumptionRow(axis=r.axis, options=r.options, position="**single** (was meta)", triggers=r.triggers)
+        if r.axis == "repo topology" else r
+        for r in rows
+    ]
+    store.save(edited)
+
+    assert _result().exit_code == 0
+    match = [f for f in PlanCheckStore(tmp_path / ".mothership").get("t1").flags
+             if f.axis == "repo topology"]
+    assert len(match) == 1 and match[0].approved is False
+
+
 def test_result_at_linked_nonconvention_plan_lets_gate_pass(tmp_path):
     """End-to-end: a feature WorkItem whose plan is linked at a NON-convention
     path. `result` (no --plan) must record the check against the SAME plan the

--- a/tests/cli/test_plan_assumptions.py
+++ b/tests/cli/test_plan_assumptions.py
@@ -236,6 +236,7 @@ def test_status_reports_fresh_false_when_plan_changed_after_check(tmp_path):
 
 
 def test_approve_clears_exactly_one_pending_flag_and_drops_pending_count(tmp_path):
+    from mship.core.assumptions import SEED_ROWS
     from mship.core.plan_check import PlanCheckStore
 
     AssumptionStore = __import__("mship.core.assumptions", fromlist=["AssumptionStore"]).AssumptionStore
@@ -243,10 +244,18 @@ def test_approve_clears_exactly_one_pending_flag_and_drops_pending_count(tmp_pat
 
     plan_path = _write_plan(tmp_path, "2026-07-30-t1.md", "# Plan\n\nNo mention of anything special here.\n")
 
+    # A COMPLETE verdict set (every seed row) so only repo topology is pending —
+    # an omitted row now flags too (completeness gate), so partial verdicts would
+    # leave more than one pending flag.
+    verdicts = [
+        {"axis": row.axis, "verdict": "covered", "reason": "ok"}
+        for row in SEED_ROWS if row.axis != "repo topology"
+    ]
+    verdicts.append(
+        {"axis": "repo topology", "verdict": "not-covered", "reason": "plan never says how repos are handled"}
+    )
     verdicts_file = tmp_path / "verdicts.json"
-    verdicts_file.write_text(json.dumps([
-        {"axis": "repo topology", "verdict": "not-covered", "reason": "plan never says how repos are handled"},
-    ]))
+    verdicts_file.write_text(json.dumps(verdicts))
 
     runner = CliRunner()
     app = _app(tmp_path, task=_task())

--- a/tests/cli/test_plan_assumptions.py
+++ b/tests/cli/test_plan_assumptions.py
@@ -321,3 +321,110 @@ def test_approve_unknown_or_already_covered_axis_exits_1(tmp_path):
         ["plan", "assumptions", "approve", "nonexistent axis", "--task", "t1", "--plan", str(plan_path)],
     )
     assert res.exit_code == 1
+
+
+def test_result_preserves_prior_approvals_when_plan_unchanged(tmp_path):
+    """Re-running the checker against the SAME plan (unchanged hash) must NOT
+    wipe a human sign-off; a CHANGED plan correctly drops it (Wave 3a review)."""
+    from mship.core.plan_check import PlanCheckStore
+
+    AssumptionStore = __import__("mship.core.assumptions", fromlist=["AssumptionStore"]).AssumptionStore
+    AssumptionStore(tmp_path).seed()
+
+    plan_path = _write_plan(tmp_path, "2026-07-30-t1.md", "# Plan\n\nOriginal body.\n")
+
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps([
+        {"axis": "repo topology", "verdict": "not-covered", "reason": "plan never says how repos are handled"},
+    ]))
+
+    runner = CliRunner()
+    app = _app(tmp_path, task=_task())
+
+    def _result():
+        return runner.invoke(app, [
+            "plan", "assumptions", "result",
+            "--task", "t1", "--plan", str(plan_path), "--from-json", str(verdicts_file),
+        ])
+
+    assert _result().exit_code == 0
+    res = runner.invoke(app, [
+        "plan", "assumptions", "approve", "repo topology",
+        "--reason", "signed off", "--task", "t1", "--plan", str(plan_path),
+    ])
+    assert res.exit_code == 0, res.output
+
+    # Re-check the SAME plan text -> the sign-off survives.
+    assert _result().exit_code == 0
+    stored = PlanCheckStore(tmp_path / ".mothership").get("t1")
+    match = [f for f in stored.flags if f.axis == "repo topology"]
+    assert len(match) == 1 and match[0].approved is True
+    assert match[0].approved_reason == "signed off"
+
+    # Re-running the cold checker on the SAME plan may RE-WORD the same gap. The
+    # sign-off keys on (axis, source), not the LLM's free-text reason, so a
+    # re-phrased reason must NOT drop a real approval (Wave 3a re-review).
+    verdicts_file.write_text(json.dumps([
+        {"axis": "repo topology", "verdict": "not-covered", "reason": "totally different wording for the same gap"},
+    ]))
+    assert _result().exit_code == 0
+    stored = PlanCheckStore(tmp_path / ".mothership").get("t1")
+    match = [f for f in stored.flags if f.axis == "repo topology"]
+    assert len(match) == 1 and match[0].approved is True
+
+    # Edit the plan -> hash changes -> the stale approval is dropped.
+    plan_path.write_text("# Plan\n\nOriginal body, now edited.\n")
+    assert _result().exit_code == 0
+    stored = PlanCheckStore(tmp_path / ".mothership").get("t1")
+    match = [f for f in stored.flags if f.axis == "repo topology"]
+    assert len(match) == 1 and match[0].approved is False
+
+
+def test_result_at_linked_nonconvention_plan_lets_gate_pass(tmp_path):
+    """End-to-end: a feature WorkItem whose plan is linked at a NON-convention
+    path. `result` (no --plan) must record the check against the SAME plan the
+    gate reads (the WorkItem's linked plan_path), so a fresh, flag-free check
+    makes the assumption gate pass. Before the shared `effective_plan_path`, the
+    CLI hashed the convention path while the gate hashed the linked path, so the
+    hashes never matched and the WorkItem was permanently mis-gated."""
+    from mship.core.assumptions import AssumptionStore, SEED_ROWS
+    from mship.core.spec import Spec
+    from mship.core.spec_store import SpecStore
+    from mship.core.workitem_gate import check_task_gate
+    from mship.core.workitem_store import WorkItemStore
+
+    AssumptionStore(tmp_path).seed()
+
+    # Feature WorkItem + approved spec so only the assumption gate is in play.
+    now = datetime.now(timezone.utc)
+    specs = SpecStore(tmp_path / "specs")
+    specs.save(Spec(id="spec-1", title="Spec", status="approved", created_at=now, updated_at=now))
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="add thing", kind="feature", workspace="ws", now=now)
+    items.link_spec(wi.id, "spec-1", now=now)
+
+    # Plan lives OFF the convention path; link it explicitly.
+    plan_body = "# Plan\n\n<!-- mship:task id=1 -->\n### Task 1\n<!-- /mship:task -->\n"
+    custom = tmp_path / "custom" / "myplan.md"
+    custom.parent.mkdir(parents=True)
+    custom.write_text(plan_body)
+    items.link_plan(wi.id, "custom/myplan.md", now=now)
+
+    task = _task(work_item_id=wi.id)
+
+    # Every axis covered, no trigger words -> zero flags.
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps(
+        [{"axis": row.axis, "verdict": "covered", "reason": "ok"} for row in SEED_ROWS]
+    ))
+
+    runner = CliRunner()
+    app = _app(tmp_path, task=task)
+    # No --plan: effective_plan_path must follow the WorkItem's linked plan_path.
+    res = runner.invoke(app, [
+        "plan", "assumptions", "result", "--task", "t1", "--from-json", str(verdicts_file),
+    ])
+    assert res.exit_code == 0, res.output
+
+    gate = check_task_gate(task, tmp_path, require_plan=True, require_assumption_gate=True)
+    assert gate.ok is True, gate.reason

--- a/tests/cli/test_plan_assumptions.py
+++ b/tests/cli/test_plan_assumptions.py
@@ -130,6 +130,31 @@ def test_result_not_covered_stores_pending_checker_flag(tmp_path):
     assert data["pending"] >= 1
 
 
+def test_result_rejects_duplicate_axis_verdicts(tmp_path):
+    """A duplicate axis (last-wins keying) could let a `covered` duplicate erase a
+    `not-covered` gap and pass the gate — a false negative. Reject at ingestion
+    (Greptile #451 re-review)."""
+    AssumptionStore = __import__("mship.core.assumptions", fromlist=["AssumptionStore"]).AssumptionStore
+    AssumptionStore(tmp_path).seed()
+
+    plan_path = _write_plan(tmp_path, "2026-07-30-t1.md", "# Plan\n\nbody\n")
+
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps([
+        {"axis": "repo topology", "verdict": "not-covered", "reason": "a real gap"},
+        {"axis": "Repo  Topology", "verdict": "covered", "reason": "duplicate that would erase the gap"},
+    ]))
+
+    res = CliRunner().invoke(
+        _app(tmp_path, task=_task()),
+        ["plan", "assumptions", "result", "--task", "t1", "--plan", str(plan_path),
+         "--from-json", str(verdicts_file)],
+    )
+    assert res.exit_code == 1
+    assert "duplicate axis" in res.output.lower()
+    assert "repo topology" in res.output.lower()
+
+
 def test_result_na_verdict_on_triggered_axis_stores_cross_check_flag(tmp_path):
     from mship.core.assumptions import AssumptionStore, SEED_ROWS
     from mship.core.plan_check import PlanCheckStore

--- a/tests/cli/test_plan_assumptions.py
+++ b/tests/cli/test_plan_assumptions.py
@@ -197,3 +197,127 @@ def test_result_stored_plan_hash_matches_plan_text(tmp_path):
     stored = PlanCheckStore(tmp_path / ".mothership").get("t1")
     assert stored is not None
     assert stored.plan_hash == plan_hash(plan_path.read_text())
+
+
+def test_status_reports_fresh_false_when_plan_changed_after_check(tmp_path):
+    AssumptionStore = __import__("mship.core.assumptions", fromlist=["AssumptionStore"]).AssumptionStore
+    AssumptionStore(tmp_path).seed()
+
+    plan_path = _write_plan(tmp_path, "2026-07-30-t1.md", "# Plan\n\nOriginal body.\n")
+
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps([
+        {"axis": "repo topology", "verdict": "covered", "reason": "ok"},
+    ]))
+
+    runner = CliRunner()
+    app = _app(tmp_path, task=_task())
+    res = runner.invoke(
+        app,
+        [
+            "plan", "assumptions", "result",
+            "--task", "t1", "--plan", str(plan_path),
+            "--from-json", str(verdicts_file),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+
+    # Plan changes after the check was stored -> hash mismatch -> stale.
+    plan_path.write_text("# Plan\n\nOriginal body, now edited.\n")
+
+    res = runner.invoke(
+        app,
+        ["plan", "assumptions", "status", "--task", "t1", "--plan", str(plan_path)],
+    )
+    assert res.exit_code == 0, res.output
+    data = json.loads(res.output)
+    assert data["task"] == "t1"
+    assert data["fresh"] is False
+
+
+def test_approve_clears_exactly_one_pending_flag_and_drops_pending_count(tmp_path):
+    from mship.core.plan_check import PlanCheckStore
+
+    AssumptionStore = __import__("mship.core.assumptions", fromlist=["AssumptionStore"]).AssumptionStore
+    AssumptionStore(tmp_path).seed()
+
+    plan_path = _write_plan(tmp_path, "2026-07-30-t1.md", "# Plan\n\nNo mention of anything special here.\n")
+
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps([
+        {"axis": "repo topology", "verdict": "not-covered", "reason": "plan never says how repos are handled"},
+    ]))
+
+    runner = CliRunner()
+    app = _app(tmp_path, task=_task())
+    res = runner.invoke(
+        app,
+        [
+            "plan", "assumptions", "result",
+            "--task", "t1", "--plan", str(plan_path),
+            "--from-json", str(verdicts_file),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+
+    before = PlanCheckStore(tmp_path / ".mothership").get("t1")
+    pending_before = sum(1 for f in before.flags if not f.approved)
+    assert pending_before == 1
+
+    res = runner.invoke(
+        app,
+        [
+            "plan", "assumptions", "approve", "repo topology",
+            "--reason", "signed off by hand",
+            "--task", "t1", "--plan", str(plan_path),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+
+    after = PlanCheckStore(tmp_path / ".mothership").get("t1")
+    pending_after = sum(1 for f in after.flags if not f.approved)
+    assert pending_after == pending_before - 1
+
+    matching = [f for f in after.flags if f.axis == "repo topology"]
+    assert len(matching) == 1
+    assert matching[0].approved is True
+    assert matching[0].approved_reason == "signed off by hand"
+    assert matching[0].approved_by
+
+
+def test_approve_unknown_or_already_covered_axis_exits_1(tmp_path):
+    AssumptionStore = __import__("mship.core.assumptions", fromlist=["AssumptionStore"]).AssumptionStore
+    AssumptionStore(tmp_path).seed()
+
+    plan_path = _write_plan(tmp_path, "2026-07-30-t1.md", "# Plan\n\nNo mention of anything special here.\n")
+
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps([
+        {"axis": "repo topology", "verdict": "covered", "reason": "handled explicitly"},
+    ]))
+
+    runner = CliRunner()
+    app = _app(tmp_path, task=_task())
+    res = runner.invoke(
+        app,
+        [
+            "plan", "assumptions", "result",
+            "--task", "t1", "--plan", str(plan_path),
+            "--from-json", str(verdicts_file),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+
+    # Axis has a verdict but no pending flag (it was covered, not not-covered).
+    res = runner.invoke(
+        app,
+        ["plan", "assumptions", "approve", "repo topology", "--task", "t1", "--plan", str(plan_path)],
+    )
+    assert res.exit_code == 1
+
+    # Axis that never existed at all.
+    res = runner.invoke(
+        app,
+        ["plan", "assumptions", "approve", "nonexistent axis", "--task", "t1", "--plan", str(plan_path)],
+    )
+    assert res.exit_code == 1

--- a/tests/cli/test_plan_assumptions.py
+++ b/tests/cli/test_plan_assumptions.py
@@ -1,0 +1,199 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+from mship.core.state import StateManager, Task, WorkspaceState
+
+
+def _task(slug="t1", **kw) -> Task:
+    defaults = dict(
+        slug=slug,
+        description="Add retry logic for flaky pushes.",
+        phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["mothership"],
+        branch="feat/x",
+    )
+    defaults.update(kw)
+    return Task(**defaults)
+
+
+def _app(tmp_path, task: Task | None = None):
+    from mship.cli.plan import register
+
+    class FakeContainer:
+        def config_path(self):
+            return str(tmp_path / "mothership.yaml")
+
+        def state_dir(self):
+            return tmp_path / ".mothership"
+
+        def state_manager(self):
+            return StateManager(tmp_path / ".mothership")
+
+    container = FakeContainer()
+    if task is not None:
+        container.state_manager().save(WorkspaceState(tasks={task.slug: task}))
+
+    app = typer.Typer()
+    register(app, lambda: container)
+    return app
+
+
+def _write_plan(tmp_path: Path, name: str, body: str) -> Path:
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True, exist_ok=True)
+    path = plans / name
+    path.write_text(body)
+    return path
+
+
+def test_check_emit_contains_axes_plan_text_and_no_journal_or_trace_markers(tmp_path):
+    from mship.core.assumptions import AssumptionStore, SEED_ROWS
+    from mship.core.log import LogManager
+
+    AssumptionStore(tmp_path).seed()
+
+    plan_body = "# My Plan\n\nSome unique plan sentence XYZZY-PLAN-MARKER.\n"
+    plan_path = _write_plan(tmp_path, "2026-07-30-t1.md", plan_body)
+
+    # A real journal entry with a unique marker: the prompt must not surface
+    # journal/trace/codegraph content, only the request/rows/plan inputs.
+    mgr = LogManager(tmp_path / ".mothership" / "logs")
+    mgr.create("t1")
+    mgr.append("t1", "JOURNAL-CANARY-998877 codegraph reasoning trace", action="note")
+
+    runner = CliRunner()
+    res = runner.invoke(
+        _app(tmp_path, task=_task()),
+        ["plan", "assumptions", "check", "--task", "t1", "--plan", str(plan_path), "--emit"],
+    )
+    assert res.exit_code == 0, res.output
+
+    out = res.output
+    for row in SEED_ROWS:
+        assert row.axis in out
+    assert "XYZZY-PLAN-MARKER" in out
+    assert "JOURNAL-CANARY-998877" not in out
+
+
+def test_check_without_emit_errors(tmp_path):
+    from mship.core.assumptions import AssumptionStore
+
+    AssumptionStore(tmp_path).seed()
+    plan_path = _write_plan(tmp_path, "2026-07-30-t1.md", "# Plan\n")
+
+    runner = CliRunner()
+    res = runner.invoke(
+        _app(tmp_path, task=_task()),
+        ["plan", "assumptions", "check", "--task", "t1", "--plan", str(plan_path)],
+    )
+    assert res.exit_code != 0
+
+
+def test_result_not_covered_stores_pending_checker_flag(tmp_path):
+    from mship.core.plan_check import PlanCheckStore
+
+    AssumptionStore = __import__("mship.core.assumptions", fromlist=["AssumptionStore"]).AssumptionStore
+    AssumptionStore(tmp_path).seed()
+
+    plan_body = "# Plan\n\nNo mention of anything special here.\n"
+    plan_path = _write_plan(tmp_path, "2026-07-30-t1.md", plan_body)
+
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps([
+        {"axis": "repo topology", "verdict": "not-covered", "reason": "plan never says how repos are handled"},
+    ]))
+
+    runner = CliRunner()
+    res = runner.invoke(
+        _app(tmp_path, task=_task()),
+        [
+            "plan", "assumptions", "result",
+            "--task", "t1", "--plan", str(plan_path),
+            "--from-json", str(verdicts_file),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+
+    stored = PlanCheckStore(tmp_path / ".mothership").get("t1")
+    assert stored is not None
+    checker_flags = [f for f in stored.flags if f.source == "checker" and f.axis == "repo topology"]
+    assert len(checker_flags) == 1
+    assert checker_flags[0].approved is False
+
+    data = json.loads(res.output)
+    assert data["task"] == "t1"
+    assert data["pending"] >= 1
+
+
+def test_result_na_verdict_on_triggered_axis_stores_cross_check_flag(tmp_path):
+    from mship.core.assumptions import AssumptionStore, SEED_ROWS
+    from mship.core.plan_check import PlanCheckStore
+
+    AssumptionStore(tmp_path).seed()
+
+    # "auth" is a trigger word for the "credential locus" axis; putting it in
+    # the plan text should force a disposition for that axis.
+    plan_body = "# Plan\n\nThis plan adds auth handling to the login flow.\n"
+    plan_path = _write_plan(tmp_path, "2026-07-30-t1.md", plan_body)
+
+    # Cover every other axis so only the credential-locus n/a produces a flag.
+    verdicts = [
+        {"axis": row.axis, "verdict": "covered", "reason": "n/a for this test"}
+        for row in SEED_ROWS
+        if row.axis != "credential locus"
+    ]
+    verdicts.append({"axis": "credential locus", "verdict": "n-a", "reason": "declared not applicable"})
+
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps(verdicts))
+
+    runner = CliRunner()
+    res = runner.invoke(
+        _app(tmp_path, task=_task()),
+        [
+            "plan", "assumptions", "result",
+            "--task", "t1", "--plan", str(plan_path),
+            "--from-json", str(verdicts_file),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+
+    stored = PlanCheckStore(tmp_path / ".mothership").get("t1")
+    assert stored is not None
+    cross_flags = [f for f in stored.flags if f.source == "cross-check" and f.axis == "credential locus"]
+    assert len(cross_flags) == 1
+
+
+def test_result_stored_plan_hash_matches_plan_text(tmp_path):
+    from mship.core.assumptions import AssumptionStore
+    from mship.core.plan_check import PlanCheckStore, plan_hash
+
+    AssumptionStore(tmp_path).seed()
+
+    plan_body = "# Plan\n\nHash-check body.\n"
+    plan_path = _write_plan(tmp_path, "2026-07-30-t1.md", plan_body)
+
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps([
+        {"axis": "repo topology", "verdict": "covered", "reason": "ok"},
+    ]))
+
+    runner = CliRunner()
+    res = runner.invoke(
+        _app(tmp_path, task=_task()),
+        [
+            "plan", "assumptions", "result",
+            "--task", "t1", "--plan", str(plan_path),
+            "--from-json", str(verdicts_file),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+
+    stored = PlanCheckStore(tmp_path / ".mothership").get("t1")
+    assert stored is not None
+    assert stored.plan_hash == plan_hash(plan_path.read_text())

--- a/tests/core/test_assumptions.py
+++ b/tests/core/test_assumptions.py
@@ -79,3 +79,34 @@ def test_malformed_store_raises_on_load(tmp_path):
     )
     with pytest.raises(ValueError, match="malformed"):
         AssumptionStore(tmp_path).load()
+
+
+def test_duplicate_axes_rejected_on_save(tmp_path):
+    """Two rows normalizing to the same axis would resolve one verdict and leave
+    the second assumption undispositioned — a gate bypass. Reject at the write
+    boundary (Greptile #451)."""
+    import pytest
+    from mship.core.assumptions import AssumptionRow, AssumptionStore
+    store = AssumptionStore(tmp_path)
+    with pytest.raises(ValueError, match="duplicate assumption axis"):
+        store.save([
+            AssumptionRow(axis="repo topology", options="a/b", position="x", triggers="t"),
+            AssumptionRow(axis="Repo  Topology", options="a/b", position="y", triggers="t"),
+        ])
+
+
+def test_duplicate_axes_rejected_on_load(tmp_path):
+    """The read boundary also rejects a hand-edited store with duplicate axes, so
+    a duplicate can't reach the verdict→flag path from a file we didn't write
+    (Greptile #451)."""
+    import pytest
+    from mship.core.assumptions import AssumptionStore
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "product_assumptions.md").write_text(
+        "| axis | options | position | triggers |\n"
+        "| -- | -- | -- | -- |\n"
+        "| repo topology | a/b | x | t |\n"
+        "| Repo Topology | a/b | y | t |\n"
+    )
+    with pytest.raises(ValueError, match="duplicate assumption axis"):
+        AssumptionStore(tmp_path).load()

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -722,11 +722,16 @@ def test_plan_to_dev_bypass_plan_gate_still_enforces_spec(tmp_path: Path):
 
 
 def _save_plan_check(tmp_path: Path, slug: str, plan_text: str, flags=None):
-    from mship.core.plan_check import PlanCheckResult, PlanCheckStore, plan_hash
+    from mship.core.assumptions import AssumptionStore
+    from mship.core.plan_check import (
+        PlanCheckResult, PlanCheckStore, assumptions_hash, plan_hash,
+    )
 
+    rows = AssumptionStore(tmp_path).seed()
     PlanCheckStore(tmp_path / ".mothership").save(
         PlanCheckResult(
-            task_slug=slug, plan_hash=plan_hash(plan_text), verdicts=[], flags=flags or [],
+            task_slug=slug, plan_hash=plan_hash(plan_text),
+            assumptions_hash=assumptions_hash(rows), verdicts=[], flags=flags or [],
         )
     )
 

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -452,7 +452,7 @@ def test_a7_dispatched_spec_also_satisfies_gate(
 # (workitem-mandatory-kind-gated-approval)
 # ---------------------------------------------------------------------------
 
-def _workitem_gate_env(tmp_path: Path):
+def _workitem_gate_env(tmp_path: Path, assumption_gate: str = "off"):
     """Build a (StateManager, PhaseManager) pair with workspace_root wired in,
     but no task saved yet — callers save their own task/WorkItem combination."""
     from mship.core.config import RepoConfig, WorkspaceConfig
@@ -463,6 +463,7 @@ def _workitem_gate_env(tmp_path: Path):
     config = WorkspaceConfig(
         workspace="test",
         repos={"shared": RepoConfig(path=Path("./shared"), type="library")},
+        assumption_gate=assumption_gate,
     )
     pm = PhaseManager(sm, MagicMock(spec=LogManager), config=config, workspace_root=tmp_path)
     return sm, pm
@@ -711,6 +712,114 @@ def test_plan_to_dev_bypass_plan_gate_still_enforces_spec(tmp_path: Path):
     sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
     with pytest.raises(SpecGateError, match="approved spec"):
         pm.transition("wi-task", "dev", bypass_plan_gate=True)
+
+
+# ---------------------------------------------------------------------------
+# Task 5: L4 assumption gate at plan→dev (assumption_gate: enforce), #444.
+# Opt-in via WorkspaceConfig.assumption_gate — "off" (default) is a no-op;
+# "enforce" additionally requires a fresh, fully-approved PlanCheckResult.
+# ---------------------------------------------------------------------------
+
+
+def _save_plan_check(tmp_path: Path, slug: str, plan_text: str, flags=None):
+    from mship.core.plan_check import PlanCheckResult, PlanCheckStore, plan_hash
+
+    PlanCheckStore(tmp_path / ".mothership").save(
+        PlanCheckResult(
+            task_slug=slug, plan_hash=plan_hash(plan_text), verdicts=[], flags=flags or [],
+        )
+    )
+
+
+def test_plan_to_dev_assumption_gate_off_ignores_missing_check(tmp_path: Path):
+    """Default assumption_gate="off" must not enforce L4 at all — plan→dev
+    behaves exactly as before this task, even with no PlanCheckResult."""
+    wi = _seed_feature_wi_with_approved_spec(tmp_path)
+    _write_plan_doc(tmp_path)
+    sm, pm = _workitem_gate_env(tmp_path, assumption_gate="off")
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+    result = pm.transition("wi-task", "dev")
+    assert result.new_phase == "dev"
+
+
+def test_plan_to_dev_assumption_gate_enforced_blocks_without_check(tmp_path: Path):
+    wi = _seed_feature_wi_with_approved_spec(tmp_path)
+    _write_plan_doc(tmp_path)
+    sm, pm = _workitem_gate_env(tmp_path, assumption_gate="enforce")
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+    with pytest.raises(SpecGateError, match="plan assumptions check"):
+        pm.transition("wi-task", "dev")
+
+
+def test_plan_to_dev_assumption_gate_enforced_blocks_stale_check(tmp_path: Path):
+    wi = _seed_feature_wi_with_approved_spec(tmp_path)
+    _write_plan_doc(tmp_path)
+    _save_plan_check(tmp_path, "wi-task", "# a different plan\n")
+    sm, pm = _workitem_gate_env(tmp_path, assumption_gate="enforce")
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+    with pytest.raises(SpecGateError, match="plan assumptions check"):
+        pm.transition("wi-task", "dev")
+
+
+def test_plan_to_dev_assumption_gate_enforced_blocks_pending_flag(tmp_path: Path):
+    from mship.core.plan_check import Flag
+
+    wi = _seed_feature_wi_with_approved_spec(tmp_path)
+    _write_plan_doc(tmp_path)
+    _save_plan_check(
+        tmp_path, "wi-task", _PLAN_DOC,
+        flags=[Flag(axis="rollout", source="checker", reason="not covered")],
+    )
+    sm, pm = _workitem_gate_env(tmp_path, assumption_gate="enforce")
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+    with pytest.raises(SpecGateError, match="sign-off") as exc_info:
+        pm.transition("wi-task", "dev")
+    assert "rollout" in str(exc_info.value)
+
+
+def test_plan_to_dev_assumption_gate_enforced_passes_fresh_all_approved(tmp_path: Path):
+    from mship.core.plan_check import Flag
+
+    wi = _seed_feature_wi_with_approved_spec(tmp_path)
+    _write_plan_doc(tmp_path)
+    _save_plan_check(
+        tmp_path, "wi-task", _PLAN_DOC,
+        flags=[Flag(axis="rollout", source="checker", reason="ok", approved=True)],
+    )
+    sm, pm = _workitem_gate_env(tmp_path, assumption_gate="enforce")
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+    result = pm.transition("wi-task", "dev")
+    assert result.new_phase == "dev"
+
+
+def test_plan_to_dev_assumption_gate_enforced_bug_unaffected(tmp_path: Path):
+    """A bug WorkItem is never plan/assumption gated, even with enforce on."""
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="fix it", kind="bug", workspace="test",
+                      now=datetime(2026, 4, 10, tzinfo=timezone.utc))
+    sm, pm = _workitem_gate_env(tmp_path, assumption_gate="enforce")
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+    result = pm.transition("wi-task", "dev")
+    assert result.new_phase == "dev"
+
+
+def test_plan_to_dev_assumption_gate_enforced_bypass_plan_gate_allows_and_logs(tmp_path: Path):
+    """--bypass-plan-gate is built on top of the plan clause and drops the
+    assumption clause too — same bypass, one flag."""
+    import json
+
+    wi = _seed_feature_wi_with_approved_spec(tmp_path)
+    _write_plan_doc(tmp_path)  # plan present, but NO PlanCheckResult on record
+    sm, pm = _workitem_gate_env(tmp_path, assumption_gate="enforce")
+    sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
+
+    result = pm.transition("wi-task", "dev", bypass_plan_gate=True)
+    assert result.new_phase == "dev"
+
+    log_path = tmp_path / ".mothership" / "bypass-log.jsonl"
+    assert log_path.is_file()
+    line = json.loads(log_path.read_text().splitlines()[-1])
+    assert line["op"] == "phase-dev-plan"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_plan_check.py
+++ b/tests/core/test_plan_check.py
@@ -88,6 +88,21 @@ def test_plan_check_store_get_absent_returns_none(tmp_path):
     assert store.get("no-such-task") is None
 
 
+def test_plan_check_store_rejects_path_traversal_slug(tmp_path):
+    """`slug` can arrive from an HTTP path param (serve /plan-assumptions/{slug}),
+    so a traversal/separator/absolute slug must not escape plan-checks/ — the
+    resolved path must sit directly inside it (CodeQL py/path-injection #38/#39)."""
+    import pytest
+    store = PlanCheckStore(tmp_path)
+    # Slugs that would escape plan-checks/ (separators or absolute) must raise.
+    for bad in ["../evil", "../../etc/passwd", "sub/dir", "/etc/passwd"]:
+        with pytest.raises(ValueError):
+            store.path(bad)
+        # get()/is_file must not read outside the dir either
+        with pytest.raises(ValueError):
+            store.get(bad)
+
+
 def _repo_topology_row() -> AssumptionRow:
     return AssumptionRow(
         axis="repo topology",

--- a/tests/core/test_plan_check.py
+++ b/tests/core/test_plan_check.py
@@ -22,23 +22,51 @@ def test_plan_hash_changes_on_content_edit():
     assert plan_hash(a) != plan_hash(b)
 
 
+def _row(axis: str, triggers: str = "") -> AssumptionRow:
+    return AssumptionRow(axis=axis, options="a / b", position="**a**", triggers=triggers)
+
+
 def test_flags_from_verdicts_only_not_covered():
+    rows = [_row("rollback"), _row("security"), _row("perf")]
     verdicts = [
         AxisVerdict(axis="rollback", verdict="covered", reason="handled in step 3"),
         AxisVerdict(axis="security", verdict="not-covered", reason="no auth check"),
         AxisVerdict(axis="perf", verdict="n-a", reason="no hot path"),
     ]
-    flags = flags_from_verdicts(verdicts)
+    flags = flags_from_verdicts(verdicts, rows)
     assert len(flags) == 1
     assert flags[0] == Flag(axis="security", source="checker", reason="no auth check")
 
 
 def test_flags_from_verdicts_none_when_all_covered_or_na():
+    rows = [_row("rollback"), _row("perf")]
     verdicts = [
         AxisVerdict(axis="rollback", verdict="covered", reason="ok"),
         AxisVerdict(axis="perf", verdict="n-a", reason="n/a"),
     ]
-    assert flags_from_verdicts(verdicts) == []
+    assert flags_from_verdicts(verdicts, rows) == []
+
+
+def test_flags_from_verdicts_missing_row_is_flagged():
+    """A canonical row the checker OMITS a verdict for must still flag — an
+    un-dispositioned row can't silently pass the gate (Greptile #451)."""
+    rows = [_row("rollback"), _row("security")]
+    verdicts = [AxisVerdict(axis="rollback", verdict="covered", reason="ok")]
+    flags = flags_from_verdicts(verdicts, rows)
+    assert len(flags) == 1
+    assert flags[0].axis == "security"
+    assert flags[0].source == "checker"
+
+
+def test_flags_from_verdicts_ignores_unknown_axis():
+    """A verdict for an axis that is NOT a current row (invented/misspelled) must
+    NOT create a phantom flag the operator has to approve (Greptile #451)."""
+    rows = [_row("rollback")]
+    verdicts = [
+        AxisVerdict(axis="rollback", verdict="covered", reason="ok"),
+        AxisVerdict(axis="totally-made-up", verdict="not-covered", reason="phantom"),
+    ]
+    assert flags_from_verdicts(verdicts, rows) == []
 
 
 def test_plan_check_store_roundtrip(tmp_path):
@@ -113,14 +141,19 @@ def test_cross_check_no_flag_when_triggered_and_not_covered():
     assert flags == []
 
 
-def test_cross_check_flags_triggered_axis_with_no_verdict_at_all():
+def test_cross_check_no_longer_flags_missing_verdict():
+    """A row with no verdict is a COMPLETENESS failure owned by
+    flags_from_verdicts (which flags every un-dispositioned row, triggered or
+    not). cross_check must NOT also flag it, or a triggered+missing row would be
+    flagged twice and the operator would have to approve the same row twice
+    (Greptile #451)."""
     rows = [_repo_topology_row()]
     flags = cross_check(
         [], rows, plan_text="we'll add a git/clone step", task_text="", affected_repos=[]
     )
-    assert len(flags) == 1
-    assert flags[0].axis == "repo topology"
-    assert flags[0].source == "cross-check"
+    assert flags == []
+    # The completeness net still catches it:
+    assert len(flags_from_verdicts([], rows)) == 1
 
 
 def test_cross_check_prefix_token_matches_by_prefix_not_substring():
@@ -173,7 +206,7 @@ def test_cross_check_never_removes_checker_flags():
     is additive at the caller."""
     rows = [_repo_topology_row()]
     verdicts = [AxisVerdict(axis="repo topology", verdict="not-covered", reason="missing")]
-    checker_flags = flags_from_verdicts(verdicts)
+    checker_flags = flags_from_verdicts(verdicts, rows)
     cc_flags = cross_check(
         verdicts, rows, plan_text="we'll add a git/clone step", task_text="", affected_repos=[]
     )

--- a/tests/core/test_plan_check.py
+++ b/tests/core/test_plan_check.py
@@ -1,8 +1,10 @@
+from mship.core.assumptions import AssumptionRow
 from mship.core.plan_check import (
     AxisVerdict,
     Flag,
     PlanCheckResult,
     PlanCheckStore,
+    cross_check,
     flags_from_verdicts,
     plan_hash,
 )
@@ -56,3 +58,124 @@ def test_plan_check_store_roundtrip(tmp_path):
 def test_plan_check_store_get_absent_returns_none(tmp_path):
     store = PlanCheckStore(tmp_path)
     assert store.get("no-such-task") is None
+
+
+def _repo_topology_row() -> AssumptionRow:
+    return AssumptionRow(
+        axis="repo topology",
+        options="single / mono / meta",
+        position="**meta**",
+        triggers="git/*, workspace/*, clone, branch, push",
+    )
+
+
+def test_cross_check_flags_triggered_axis_declared_na():
+    rows = [_repo_topology_row()]
+    verdicts = [AxisVerdict(axis="repo topology", verdict="n-a", reason="not relevant")]
+    flags = cross_check(
+        verdicts, rows, plan_text="we'll add a git/clone step", task_text="", affected_repos=[]
+    )
+    assert len(flags) == 1
+    assert flags[0].axis == "repo topology"
+    assert flags[0].source == "cross-check"
+
+
+def test_cross_check_no_flag_when_triggers_dont_match():
+    rows = [_repo_topology_row()]
+    verdicts = [AxisVerdict(axis="repo topology", verdict="n-a", reason="not relevant")]
+    flags = cross_check(
+        verdicts,
+        rows,
+        plan_text="just some unrelated prose",
+        task_text="nothing here either",
+        affected_repos=[],
+    )
+    assert flags == []
+
+
+def test_cross_check_no_flag_when_triggered_and_covered():
+    rows = [_repo_topology_row()]
+    verdicts = [AxisVerdict(axis="repo topology", verdict="covered", reason="handled")]
+    flags = cross_check(
+        verdicts, rows, plan_text="we'll add a git/clone step", task_text="", affected_repos=[]
+    )
+    assert flags == []
+
+
+def test_cross_check_no_flag_when_triggered_and_not_covered():
+    """not-covered is already surfaced by flags_from_verdicts; cross-check shouldn't
+    duplicate it."""
+    rows = [_repo_topology_row()]
+    verdicts = [AxisVerdict(axis="repo topology", verdict="not-covered", reason="missing")]
+    flags = cross_check(
+        verdicts, rows, plan_text="we'll add a git/clone step", task_text="", affected_repos=[]
+    )
+    assert flags == []
+
+
+def test_cross_check_flags_triggered_axis_with_no_verdict_at_all():
+    rows = [_repo_topology_row()]
+    flags = cross_check(
+        [], rows, plan_text="we'll add a git/clone step", task_text="", affected_repos=[]
+    )
+    assert len(flags) == 1
+    assert flags[0].axis == "repo topology"
+    assert flags[0].source == "cross-check"
+
+
+def test_cross_check_prefix_token_matches_by_prefix_not_substring():
+    rows = [_repo_topology_row()]
+    verdicts = [AxisVerdict(axis="repo topology", verdict="n-a", reason="not relevant")]
+    # "workspace/*" should match "workspace/foo" but not a bare "workspace" mention.
+    flags = cross_check(
+        verdicts,
+        rows,
+        plan_text="touches workspace/foo module",
+        task_text="",
+        affected_repos=[],
+    )
+    assert len(flags) == 1
+
+    flags_no_match = cross_check(
+        verdicts,
+        rows,
+        plan_text="this workspace needs review",
+        task_text="",
+        affected_repos=[],
+    )
+    assert flags_no_match == []
+
+
+def test_cross_check_case_insensitive_substring_match():
+    rows = [_repo_topology_row()]
+    verdicts = [AxisVerdict(axis="repo topology", verdict="n-a", reason="not relevant")]
+    flags = cross_check(
+        verdicts, rows, plan_text="we ran a BRANCH cleanup", task_text="", affected_repos=[]
+    )
+    assert len(flags) == 1
+
+
+def test_cross_check_matches_affected_repos_entry():
+    rows = [_repo_topology_row()]
+    verdicts = [AxisVerdict(axis="repo topology", verdict="n-a", reason="not relevant")]
+    flags = cross_check(
+        verdicts,
+        rows,
+        plan_text="nothing relevant here",
+        task_text="",
+        affected_repos=["clone"],
+    )
+    assert len(flags) == 1
+
+
+def test_cross_check_never_removes_checker_flags():
+    """cross_check only returns cross-check flags; combining with flags_from_verdicts
+    is additive at the caller."""
+    rows = [_repo_topology_row()]
+    verdicts = [AxisVerdict(axis="repo topology", verdict="not-covered", reason="missing")]
+    checker_flags = flags_from_verdicts(verdicts)
+    cc_flags = cross_check(
+        verdicts, rows, plan_text="we'll add a git/clone step", task_text="", affected_repos=[]
+    )
+    assert len(checker_flags) == 1
+    assert cc_flags == []

--- a/tests/core/test_plan_check.py
+++ b/tests/core/test_plan_check.py
@@ -179,3 +179,20 @@ def test_cross_check_never_removes_checker_flags():
     )
     assert len(checker_flags) == 1
     assert cc_flags == []
+
+
+def test_cross_check_prefix_matches_segment_not_midword():
+    """`run/*` must match `run/foo` (real segment) but NOT `prerun/config`
+    (mid-word) — a false flag spends operator attention (#444 backtest)."""
+    from mship.core.plan_check import _triggers_match
+    assert _triggers_match("run/*", "touches run/config today", "", []) is True
+    assert _triggers_match("run/*", "touches prerun/config today", "", []) is False
+
+
+def test_cross_check_plain_token_matches_on_word_boundary_only():
+    """`run` matches the whole word `run` but NOT `brunch`; `UI` not in `build`."""
+    from mship.core.plan_check import _triggers_match
+    assert _triggers_match("run", "we run the worker", "", []) is True
+    assert _triggers_match("run", "we had brunch after", "", []) is False
+    assert _triggers_match("ui", "the review UI card", "", []) is True
+    assert _triggers_match("ui", "we build the thing", "", []) is False

--- a/tests/core/test_plan_check.py
+++ b/tests/core/test_plan_check.py
@@ -35,7 +35,8 @@ def test_flags_from_verdicts_only_not_covered():
     ]
     flags = flags_from_verdicts(verdicts, rows)
     assert len(flags) == 1
-    assert flags[0] == Flag(axis="security", source="checker", reason="no auth check")
+    assert (flags[0].axis, flags[0].source, flags[0].reason) == ("security", "checker", "no auth check")
+    assert flags[0].axis_fingerprint  # stamped from the row's definition
 
 
 def test_flags_from_verdicts_none_when_all_covered_or_na():

--- a/tests/core/test_plan_check.py
+++ b/tests/core/test_plan_check.py
@@ -1,0 +1,58 @@
+from mship.core.plan_check import (
+    AxisVerdict,
+    Flag,
+    PlanCheckResult,
+    PlanCheckStore,
+    flags_from_verdicts,
+    plan_hash,
+)
+
+
+def test_plan_hash_stable_across_trailing_whitespace_only_edits():
+    a = "line one   \nline two\n"
+    b = "line one\nline two   \n"
+    assert plan_hash(a) == plan_hash(b)
+
+
+def test_plan_hash_changes_on_content_edit():
+    a = "line one\nline two\n"
+    b = "line one\nline THREE\n"
+    assert plan_hash(a) != plan_hash(b)
+
+
+def test_flags_from_verdicts_only_not_covered():
+    verdicts = [
+        AxisVerdict(axis="rollback", verdict="covered", reason="handled in step 3"),
+        AxisVerdict(axis="security", verdict="not-covered", reason="no auth check"),
+        AxisVerdict(axis="perf", verdict="n-a", reason="no hot path"),
+    ]
+    flags = flags_from_verdicts(verdicts)
+    assert len(flags) == 1
+    assert flags[0] == Flag(axis="security", source="checker", reason="no auth check")
+
+
+def test_flags_from_verdicts_none_when_all_covered_or_na():
+    verdicts = [
+        AxisVerdict(axis="rollback", verdict="covered", reason="ok"),
+        AxisVerdict(axis="perf", verdict="n-a", reason="n/a"),
+    ]
+    assert flags_from_verdicts(verdicts) == []
+
+
+def test_plan_check_store_roundtrip(tmp_path):
+    store = PlanCheckStore(tmp_path)
+    result = PlanCheckResult(
+        task_slug="task-1",
+        plan_hash=plan_hash("some plan text\n"),
+        verdicts=[AxisVerdict(axis="rollback", verdict="not-covered", reason="missing")],
+        flags=[Flag(axis="rollback", source="checker", reason="missing")],
+    )
+    saved_path = store.save(result)
+    assert saved_path == store.path("task-1")
+    assert saved_path.is_file()
+    assert store.get("task-1") == result
+
+
+def test_plan_check_store_get_absent_returns_none(tmp_path):
+    store = PlanCheckStore(tmp_path)
+    assert store.get("no-such-task") is None

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -127,6 +127,7 @@ def test_get_plan_assumptions_pending_flag(tmp_path):
         "pending": 1,
         "flags": [{
             "axis": "repo topology", "source": "checker", "reason": "not addressed",
+            "axis_fingerprint": None,
             "approved": False, "approved_by": None, "approved_reason": None,
         }],
     }

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -108,13 +108,18 @@ def _write_plan(tmp_path: Path, name: str, body: str) -> Path:
 
 
 def test_get_plan_assumptions_pending_flag(tmp_path):
-    from mship.core.plan_check import Flag, PlanCheckResult, PlanCheckStore, plan_hash
+    from mship.core.assumptions import AssumptionStore
+    from mship.core.plan_check import (
+        Flag, PlanCheckResult, PlanCheckStore, assumptions_hash, plan_hash,
+    )
 
     sm, log = _seed_task(tmp_path)
+    rows = AssumptionStore(tmp_path).seed()
     plan_path = _write_plan(tmp_path, "2026-07-30-dq.md", "# Plan\n\nSome body.\n")
     PlanCheckStore(tmp_path / ".mothership").save(PlanCheckResult(
         task_slug="dq",
         plan_hash=plan_hash(plan_path.read_text()),
+        assumptions_hash=assumptions_hash(rows),
         verdicts=[],
         flags=[Flag(axis="repo topology", source="checker", reason="not addressed")],
     ))

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -99,6 +99,48 @@ def test_journal(tmp_path):
     assert client.get("/journal/nope").status_code == 404
 
 
+def _write_plan(tmp_path: Path, name: str, body: str) -> Path:
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True, exist_ok=True)
+    path = plans / name
+    path.write_text(body)
+    return path
+
+
+def test_get_plan_assumptions_pending_flag(tmp_path):
+    from mship.core.plan_check import Flag, PlanCheckResult, PlanCheckStore, plan_hash
+
+    sm, log = _seed_task(tmp_path)
+    plan_path = _write_plan(tmp_path, "2026-07-30-dq.md", "# Plan\n\nSome body.\n")
+    PlanCheckStore(tmp_path / ".mothership").save(PlanCheckResult(
+        task_slug="dq",
+        plan_hash=plan_hash(plan_path.read_text()),
+        verdicts=[],
+        flags=[Flag(axis="repo topology", source="checker", reason="not addressed")],
+    ))
+
+    client = TestClient(_app_with(tmp_path, sm, log))
+    body = client.get("/plan-assumptions/dq").json()
+    assert body == {
+        "task": "dq",
+        "fresh": True,
+        "pending": 1,
+        "flags": [{
+            "axis": "repo topology", "source": "checker", "reason": "not addressed",
+            "approved": False, "approved_by": None, "approved_reason": None,
+        }],
+    }
+
+
+def test_get_plan_assumptions_absent_result(tmp_path):
+    sm, log = _seed_task(tmp_path)
+    client = TestClient(_app_with(tmp_path, sm, log))
+    assert client.get("/plan-assumptions/dq").json() == {
+        "task": "dq", "fresh": False, "pending": 0, "flags": [],
+    }
+    assert client.get("/plan-assumptions/nope").status_code == 404
+
+
 def test_post_is_405(tmp_path):
     # No write routes registered → POST to a GET path is 405 (Method Not Allowed).
     r = TestClient(_app(tmp_path)).post("/specs/dq/review")

--- a/tests/core/test_store_concurrency.py
+++ b/tests/core/test_store_concurrency.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from mship.core.message_store import MessageStore
+from mship.core.plan_check import Flag, PlanCheckResult, PlanCheckStore
 from mship.core.workitem_store import ThreadAlreadyLinkedError, WorkItemStore
 
 _BASE = datetime(2026, 7, 12, 12, 0, tzinfo=timezone.utc)
@@ -149,6 +150,58 @@ def _claim_shared_thread_worker(workitems_dir_str: str, item_id: str, thread_id:
         store.add_thread(item_id, thread_id)
     except ThreadAlreadyLinkedError:
         pass  # a concurrent worker won the race first; exclusive membership held
+
+
+# ---------------------------------------------------------------------------
+# PlanCheckStore.transaction: N processes each approving DISTINCT flags on ONE
+# task record. Without the exclusive per-task lock spanning get->approve->save,
+# concurrent approvals clobber each other (Greptile #451).
+# ---------------------------------------------------------------------------
+
+def _approve_worker(state_dir_str: str, slug: str, axes: list[str]) -> None:
+    store = PlanCheckStore(Path(state_dir_str))
+    for axis in axes:
+        with store.transaction(slug):
+            result = store.get(slug)
+            for f in result.flags:
+                if f.axis == axis:
+                    f.approved = True
+            store.save(result)
+
+
+def test_concurrent_approvals_to_same_task_do_not_lose_updates(tmp_path: Path):
+    state_dir = tmp_path / ".mothership"
+    store = PlanCheckStore(state_dir)
+
+    workers, rounds = 8, 4
+    total = workers * rounds
+    store.save(PlanCheckResult(
+        task_slug="t",
+        plan_hash="h",
+        verdicts=[],
+        flags=[Flag(axis=f"axis-{i}", source="checker", reason="x") for i in range(total)],
+    ))
+
+    procs = [
+        multiprocessing.Process(
+            target=_approve_worker,
+            args=(str(state_dir), "t", [f"axis-{w * rounds + j}" for j in range(rounds)]),
+        )
+        for w in range(workers)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+        assert p.exitcode == 0, f"worker crashed (exitcode={p.exitcode})"
+
+    got = store.get("t")
+    assert got is not None
+    approved = {f.axis for f in got.flags if f.approved}
+    expected = {f"axis-{i}" for i in range(total)}
+    missing = expected - approved
+    assert not missing, f"lost {len(missing)} approvals: {sorted(missing)}"
+    assert all(f.approved for f in got.flags)
 
 
 def test_concurrent_add_same_thread_to_different_items_stays_exclusive(tmp_path: Path):

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -217,10 +217,19 @@ def test_bug_never_plan_gated(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _save_plan_check(tmp_path, slug, plan_text, flags=None):
-    from mship.core.plan_check import PlanCheckResult, PlanCheckStore, plan_hash
+def _save_plan_check(tmp_path, slug, plan_text, flags=None, rows=None):
+    """Seed the assumption store and record a check keyed to BOTH the plan and the
+    current assumption set (the freshness contract the gate now enforces)."""
+    from mship.core.assumptions import AssumptionStore
+    from mship.core.plan_check import (
+        PlanCheckResult, PlanCheckStore, assumptions_hash, plan_hash,
+    )
+    seeded = AssumptionStore(tmp_path).seed() if rows is None else rows
     PlanCheckStore(tmp_path / ".mothership").save(
-        PlanCheckResult(task_slug=slug, plan_hash=plan_hash(plan_text), verdicts=[], flags=flags or [])
+        PlanCheckResult(
+            task_slug=slug, plan_hash=plan_hash(plan_text),
+            assumptions_hash=assumptions_hash(seeded), verdicts=[], flags=flags or [],
+        )
     )
 
 
@@ -280,6 +289,31 @@ def test_assumption_gate_passes_when_fresh_and_all_approved(tmp_path):
                       flags=[Flag(axis="rollout", source="checker", reason="ok", approved=True)])
     res = check_task_gate(task, tmp_path, require_plan=True, require_assumption_gate=True)
     assert res.ok is True
+
+
+def test_assumption_gate_reblocks_when_assumption_set_changes(tmp_path):
+    """The gate's freshness is vs BOTH plan and assumption set: editing a row or
+    adding one after approval — plan untouched — must re-block, not ride the stale
+    stored check (Greptile #451)."""
+    from mship.core.assumptions import AssumptionRow, AssumptionStore
+    from mship.core.plan_check import Flag
+
+    _items, _wi, task = _approved_feature(tmp_path)
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "2026-07-12-t.md").write_text(_PLAN_WITH_TASK)
+    seeded = AssumptionStore(tmp_path).seed()
+    _save_plan_check(tmp_path, "t", _PLAN_WITH_TASK, rows=seeded,
+                      flags=[Flag(axis="rollout", source="checker", reason="ok", approved=True)])
+    assert check_task_gate(task, tmp_path, require_plan=True, require_assumption_gate=True).ok is True
+
+    # Add a new assumption row (plan unchanged) -> stored check is now stale.
+    AssumptionStore(tmp_path).save(
+        seeded + [AssumptionRow(axis="brand new axis", options="a/b", position="x", triggers="t")]
+    )
+    res = check_task_gate(task, tmp_path, require_plan=True, require_assumption_gate=True)
+    assert res.ok is False
+    assert "plan assumptions check" in res.reason
 
 
 def test_bug_never_assumption_gated(tmp_path):

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -210,6 +210,85 @@ def test_bug_never_plan_gated(tmp_path):
     assert check_task_gate(task, tmp_path, require_plan=True).ok is True
 
 
+# ---------------------------------------------------------------------------
+# L4 assumption gate (#444): opt-in via `require_assumption_gate` — a feature
+# WorkItem must ALSO have a fresh, fully-approved PlanCheckResult. Off by
+# default (require_assumption_gate=False), mirroring require_plan's rollout.
+# ---------------------------------------------------------------------------
+
+
+def _save_plan_check(tmp_path, slug, plan_text, flags=None):
+    from mship.core.plan_check import PlanCheckResult, PlanCheckStore, plan_hash
+    PlanCheckStore(tmp_path / ".mothership").save(
+        PlanCheckResult(task_slug=slug, plan_hash=plan_hash(plan_text), verdicts=[], flags=flags or [])
+    )
+
+
+def test_assumption_gate_not_required_by_default(tmp_path):
+    _items, _wi, task = _approved_feature(tmp_path)
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "2026-07-12-t.md").write_text(_PLAN_WITH_TASK)
+    res = check_task_gate(task, tmp_path, require_plan=True, require_assumption_gate=False)
+    assert res.ok is True
+
+
+def test_assumption_gate_blocks_when_no_check_on_record(tmp_path):
+    _items, _wi, task = _approved_feature(tmp_path)
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "2026-07-12-t.md").write_text(_PLAN_WITH_TASK)
+    res = check_task_gate(task, tmp_path, require_plan=True, require_assumption_gate=True)
+    assert res.ok is False
+    assert "plan assumptions check" in res.reason
+
+
+def test_assumption_gate_blocks_when_stale(tmp_path):
+    _items, _wi, task = _approved_feature(tmp_path)
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "2026-07-12-t.md").write_text(_PLAN_WITH_TASK)
+    _save_plan_check(tmp_path, "t", "# stale plan text\n")
+    res = check_task_gate(task, tmp_path, require_plan=True, require_assumption_gate=True)
+    assert res.ok is False
+    assert "plan assumptions check" in res.reason
+
+
+def test_assumption_gate_blocks_when_flag_pending(tmp_path):
+    from mship.core.plan_check import Flag
+
+    _items, _wi, task = _approved_feature(tmp_path)
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "2026-07-12-t.md").write_text(_PLAN_WITH_TASK)
+    _save_plan_check(tmp_path, "t", _PLAN_WITH_TASK,
+                      flags=[Flag(axis="rollout", source="checker", reason="not covered")])
+    res = check_task_gate(task, tmp_path, require_plan=True, require_assumption_gate=True)
+    assert res.ok is False
+    assert "sign-off" in res.reason
+    assert "rollout" in res.reason
+
+
+def test_assumption_gate_passes_when_fresh_and_all_approved(tmp_path):
+    from mship.core.plan_check import Flag
+
+    _items, _wi, task = _approved_feature(tmp_path)
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "2026-07-12-t.md").write_text(_PLAN_WITH_TASK)
+    _save_plan_check(tmp_path, "t", _PLAN_WITH_TASK,
+                      flags=[Flag(axis="rollout", source="checker", reason="ok", approved=True)])
+    res = check_task_gate(task, tmp_path, require_plan=True, require_assumption_gate=True)
+    assert res.ok is True
+
+
+def test_bug_never_assumption_gated(tmp_path):
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="fix it", kind="bug", workspace="ws", now=_now())
+    task = _task(work_item_id=wi.id)
+    assert check_task_gate(task, tmp_path, require_plan=True, require_assumption_gate=True).ok is True
+
+
 def test_workitem_migrate_shares_the_same_approved_statuses_object():
     """workitem_migrate must import (not redefine) workitem_gate's set —
     an identity check, not just an equality check, so a stray local copy


### PR DESCRIPTION
**product_assumptions (#444) — Wave 3a / L4 (mothership side).**

The agent-run cold checker, its deterministic cross-check, the plan→dev
assumption gate, and a serve endpoint for pending flags. This is one wave of the
multi-wave `productassumptionsmd` spec — earlier waves shipped separately, later
waves remain gated.

## What this PR delivers

- **`mship plan assumptions check --emit`** — builds the fixed-shape cold-checker
  prompt (original request + current assumption rows + finished plan + a
  return-JSON instruction). mship never calls an LLM; the agent runs the prompt.
  Deliberately excludes journal / reasoning trace / codegraph — the checker
  judges the plan cold.
- **`mship plan assumptions result --from-json`** — ingests per-row verdicts,
  runs a deterministic in-code trigger cross-check (`core.plan_check.cross_check`,
  word/segment-boundary matching) that can only ADD flags, and records a
  `PlanCheckResult` keyed to the plan's hash. (**ac5**)
- **`status` / `approve`** — report freshness (plan-hash staleness) and record
  human sign-off; approvals are the only way a flag clears.
- **plan→dev gate** — `check_task_gate(require_assumption_gate=…)` blocks a
  feature WorkItem's plan→dev transition until every flag is fresh and approved.
  Opt-in via `assumption_gate: off|enforce` in mothership.yaml (default `off`,
  safe rollout — mirrors the plan gate). (**ac6**, mothership side)
- **serve** — `GET /plan-assumptions/{slug}` exposes pending flags for a future
  Ground Control surface.

## Acceptance criteria

- **ac5** (Wave 3 / L4 — agent-run checker + mship record + deterministic
  cross-check) — delivered.
- **ac6** (Wave 3 / L4 — gate) — mothership side delivered (phase.transition
  gate + serve endpoint). The Ground Control **flag UI** is Wave 3b (deferred,
  no ground-control commits in this PR).

## Not in this PR

- ac1–ac4 shipped in #448 (backtest + L3) and #450 (L1 store + L2 injection).
- ac6 Ground Control UI → Wave 3b. ac7 (L5 rejection→row) → Wave 4 (needs #447).
  ac8/ac9 (L0 fixtures + health metrics) → Wave 5.

## Review

Built subagent-driven (fresh implementer + per-task review per task), then a
whole-branch review ("with fixes"). Fixes applied in the final commit: a shared
`core.plan.effective_plan_path` unifies plan resolution across the CLI recorder,
the gate, and serve (a `link-plan` WorkItem was otherwise mis-gated — recorder
hashed the convention path, gate hashed the linked path); PlanCheckStore location
unified to `<workspace>/.mothership`; approvals preserved on a same-plan re-check
(keyed on axis+source, not the LLM's free-text reason), dropped on a plan edit.
A scoped re-review confirmed all findings addressed. Full `mship test` green on
both repos, 0 regressions.
