### PR TITLE
product_assumptions Wave 3b: Ground Control view + approve for plan-assumption flags (serve POST approve + GC Task Detail). Build from docs/plans/2026-07-30-productassumptions-wave-3b.md

### DIFF
--- a/src/mship/cli/plan_assumptions.py
+++ b/src/mship/cli/plan_assumptions.py
@@ -317,6 +317,11 @@ def register(plan_app: typer.Typer, get_container):
         import os
 
         from mship.core.plan import _normalize_axis
+        from mship.core.plan_assumptions_transition import (
+            NoStoredCheck,
+            UnknownAxis,
+            approve_flag,
+        )
         from mship.core.plan_check import PlanCheckStore
 
         output = Output()
@@ -325,28 +330,18 @@ def register(plan_app: typer.Typer, get_container):
         )
 
         store = PlanCheckStore(workspace_root / ".mothership")
-        # Lock spans get → mutate → save so a concurrent approve/result can't
-        # overwrite this sign-off (Greptile #451).
-        with store.transaction(task_obj.slug):
-            stored = store.get(task_obj.slug)
-            if stored is None:
-                output.error(f"No stored plan-check for {task_obj.slug}.")
-                raise typer.Exit(1)
+        approved_by = os.environ.get("USER") or "unknown"
+        try:
+            stored = approve_flag(store, task_obj.slug, axis, reason, approved_by)
+        except NoStoredCheck:
+            output.error(f"No stored plan-check for {task_obj.slug}.")
+            raise typer.Exit(1)
+        except UnknownAxis:
+            output.error(f"No pending flag for axis {axis!r} on {task_obj.slug}.")
+            raise typer.Exit(1)
 
-            target_axis = _normalize_axis(axis)
-            match = next(
-                (f for f in stored.flags if not f.approved and _normalize_axis(f.axis) == target_axis),
-                None,
-            )
-            if match is None:
-                output.error(f"No pending flag for axis {axis!r} on {task_obj.slug}.")
-                raise typer.Exit(1)
-
-            match.approved = True
-            match.approved_reason = reason
-            match.approved_by = os.environ.get("USER") or "unknown"
-            store.save(stored)
-
+        target_axis = _normalize_axis(axis)
+        match = next(f for f in stored.flags if _normalize_axis(f.axis) == target_axis)
         pending = sum(1 for f in stored.flags if not f.approved)
 
         if output.human_mode:

--- a/src/mship/cli/plan_assumptions.py
+++ b/src/mship/cli/plan_assumptions.py
@@ -316,28 +316,40 @@ def register(plan_app: typer.Typer, get_container):
         re-save. The only way a flag clears."""
         import os
 
+        from mship.core.assumptions import AssumptionStore, resolve_mode
         from mship.core.plan import _normalize_axis
         from mship.core.plan_assumptions_transition import (
             NoStoredCheck,
+            StaleCheck,
             UnknownAxis,
             approve_flag,
         )
         from mship.core.plan_check import PlanCheckStore
 
         output = Output()
-        container, workspace_root, _docs_dir, task_obj, _plan_path = _resolve_common(
+        container, workspace_root, docs_dir, task_obj, plan_path = _resolve_common(
             get_container, task, plan, output
         )
 
         store = PlanCheckStore(workspace_root / ".mothership")
         approved_by = os.environ.get("USER") or "unknown"
+        plan_text = plan_path.read_text()
+        rows = AssumptionStore(workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root)).load()
         try:
-            stored = approve_flag(store, task_obj.slug, axis, reason, approved_by)
+            stored = approve_flag(
+                store, task_obj.slug, axis, reason, approved_by,
+                plan_text=plan_text, rows=rows,
+            )
         except NoStoredCheck:
             output.error(f"No stored plan-check for {task_obj.slug}.")
             raise typer.Exit(1)
         except UnknownAxis:
             output.error(f"No pending flag for axis {axis!r} on {task_obj.slug}.")
+            raise typer.Exit(1)
+        except StaleCheck:
+            output.error(
+                "plan or assumptions changed since the check; re-run `mship plan assumptions result` first."
+            )
             raise typer.Exit(1)
 
         target_axis = _normalize_axis(axis)

--- a/src/mship/core/plan_assumptions_transition.py
+++ b/src/mship/core/plan_assumptions_transition.py
@@ -1,0 +1,42 @@
+"""The single approve-a-plan-assumption-flag mutation, shared by the CLI verb
+(`mship plan assumptions approve`) and the serve endpoint
+(`POST /plan-assumptions/{slug}/approve`) so they cannot drift — mirrors how
+spec approve/verdict live in core/spec_transition.py rather than inline in serve.
+"""
+from __future__ import annotations
+
+from mship.core.plan import _normalize_axis
+from mship.core.plan_check import PlanCheckResult, PlanCheckStore
+
+
+class NoStoredCheck(Exception):
+    """No plan-check result on record for the task — nothing to approve."""
+
+
+class UnknownAxis(Exception):
+    """No flag for the given axis (it is not a current row, or was dispositioned
+    covered/N-A so it never produced a flag)."""
+
+
+def approve_flag(
+    store: PlanCheckStore, slug: str, axis: str, reason: str | None, approved_by: str,
+) -> PlanCheckResult:
+    """Approve the pending flag for `axis` on `slug`. Idempotent: an already-approved
+    axis returns the stored result unchanged. Raises NoStoredCheck / UnknownAxis.
+    The whole read-modify-write runs under the per-task exclusive lock so a
+    concurrent checker refresh or double-approve cannot clobber it."""
+    norm = _normalize_axis(axis)
+    with store.transaction(slug):
+        stored = store.get(slug)
+        if stored is None:
+            raise NoStoredCheck(slug)
+        match = next((f for f in stored.flags if _normalize_axis(f.axis) == norm), None)
+        if match is None:
+            raise UnknownAxis(axis)
+        if match.approved:
+            return stored  # idempotent no-op
+        match.approved = True
+        match.approved_reason = reason
+        match.approved_by = approved_by
+        store.save(stored)
+        return stored

--- a/src/mship/core/plan_assumptions_transition.py
+++ b/src/mship/core/plan_assumptions_transition.py
@@ -5,8 +5,13 @@ spec approve/verdict live in core/spec_transition.py rather than inline in serve
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from mship.core.plan import _normalize_axis
-from mship.core.plan_check import PlanCheckResult, PlanCheckStore
+from mship.core.plan_check import PlanCheckResult, PlanCheckStore, is_fresh
+
+if TYPE_CHECKING:
+    from mship.core.assumptions import AssumptionRow
 
 
 class NoStoredCheck(Exception):
@@ -18,18 +23,29 @@ class UnknownAxis(Exception):
     covered/N-A so it never produced a flag)."""
 
 
+class StaleCheck(Exception):
+    """The stored check no longer matches the current plan text and/or
+    assumption set — the server is the freshness authority, so approving a
+    stale check is refused rather than silently accepted (Greptile #453: a
+    stale approval is discarded by the next `result` anyway, and would leave
+    the plan->dev gate blocked while looking like it succeeded)."""
+
+
 def approve_flag(
     store: PlanCheckStore, slug: str, axis: str, reason: str | None, approved_by: str,
+    *, plan_text: str, rows: list["AssumptionRow"],
 ) -> PlanCheckResult:
     """Approve the pending flag for `axis` on `slug`. Idempotent: an already-approved
-    axis returns the stored result unchanged. Raises NoStoredCheck / UnknownAxis.
-    The whole read-modify-write runs under the per-task exclusive lock so a
+    axis returns the stored result unchanged. Raises NoStoredCheck / UnknownAxis /
+    StaleCheck. The whole read-modify-write runs under the per-task exclusive lock so a
     concurrent checker refresh or double-approve cannot clobber it."""
     norm = _normalize_axis(axis)
     with store.transaction(slug):
         stored = store.get(slug)
         if stored is None:
             raise NoStoredCheck(slug)
+        if not is_fresh(stored, plan_text, rows):
+            raise StaleCheck(slug)
         match = next((f for f in stored.flags if _normalize_axis(f.axis) == norm), None)
         if match is None:
             raise UnknownAxis(axis)

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -121,6 +121,11 @@ class PhaseOverrideBody(BaseModel):
     phase: Phase | None = None
 
 
+class PlanFlagApproveBody(BaseModel):
+    axis: str
+    reason: str | None = None
+
+
 class ExecBody(BaseModel):
     """POST /exec/{verb} request body — see `mship.core.remote_exec` for the
     full wire contract (how the response streams task output + exit code)."""
@@ -672,23 +677,19 @@ def create_app(
             raise HTTPException(status_code=404, detail=f"no task {slug!r}")
         return jsonable_encoder(log_manager.read(slug, last=50))
 
-    @app.get("/plan-assumptions/{slug}")
-    def get_plan_assumptions(slug: str):
-        """Read-only, LLM-free pending-flags envelope for the Wave 3a
-        plan-check gate — the contract Ground Control (Wave 3b) consumes.
-        Same shape `mship plan assumptions status` prints
+    def _plan_assumptions_envelope(slug: str) -> dict:
+        """Shared envelope builder for GET and POST /plan-assumptions/{slug} —
+        same shape `mship plan assumptions status` prints
         (`cli/plan_assumptions.py::status`): `fresh` compares the stored
         result's `plan_hash` against the CURRENT plan text's hash (docs_dir
         resolved the same way, off this machine's own committed
-        `docs/plans/`, not a task worktree)."""
+        `docs/plans/`, not a task worktree). Caller is responsible for the
+        404-on-unknown-task check before calling this."""
         from mship.core.assumptions import AssumptionStore, resolve_mode
         from mship.core.plan import effective_plan_path
         from mship.core.plan_check import PlanCheckStore, is_fresh
 
         state = state_manager.load()
-        if slug not in state.tasks:
-            raise HTTPException(status_code=404, detail=f"no task {slug!r}")
-
         docs_dir = getattr(config, "docs_dir", "docs") if config is not None else "docs"
         plan_check_store = PlanCheckStore(workspace_root / ".mothership")
         stored = plan_check_store.get(slug)
@@ -710,6 +711,43 @@ def create_app(
             "pending": pending,
             "flags": [f.model_dump() for f in stored.flags],
         }
+
+    @app.get("/plan-assumptions/{slug}")
+    def get_plan_assumptions(slug: str):
+        """Read-only, LLM-free pending-flags envelope for the Wave 3a
+        plan-check gate — the contract Ground Control (Wave 3b) consumes."""
+        state = state_manager.load()
+        if slug not in state.tasks:
+            raise HTTPException(status_code=404, detail=f"no task {slug!r}")
+        return _plan_assumptions_envelope(slug)
+
+    @app.post("/plan-assumptions/{slug}/approve")
+    def approve_plan_assumption(slug: str, body: PlanFlagApproveBody):
+        """Operator sign-off on a pending plan-assumption flag — the write
+        counterpart to GET /plan-assumptions/{slug}, sharing its envelope via
+        `_plan_assumptions_envelope`. Delegates the mutation to
+        `mship.core.plan_assumptions_transition.approve_flag` (shared with the
+        CLI verb `mship plan assumptions approve`) so they cannot drift."""
+        from mship.core.plan_assumptions_transition import (
+            NoStoredCheck, UnknownAxis, approve_flag,
+        )
+        from mship.core.plan_check import PlanCheckStore
+
+        state = state_manager.load()
+        if slug not in state.tasks:
+            raise HTTPException(status_code=404, detail=f"no task {slug!r}")
+        store = PlanCheckStore(workspace_root / ".mothership")
+        try:
+            approve_flag(store, slug, body.axis, body.reason, approved_by="operator")
+        except NoStoredCheck:
+            raise HTTPException(
+                status_code=404, detail=f"no plan-assumption check for {slug!r}"
+            )
+        except UnknownAxis:
+            raise HTTPException(
+                status_code=404, detail=f"no pending flag for axis {body.axis!r}"
+            )
+        return _plan_assumptions_envelope(slug)
 
     # --- gh-token: two brokers, one contract ---
     # Both brokers return the same shape {"token", "expires_at", "repositories"}.

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -728,8 +728,10 @@ def create_app(
         `_plan_assumptions_envelope`. Delegates the mutation to
         `mship.core.plan_assumptions_transition.approve_flag` (shared with the
         CLI verb `mship plan assumptions approve`) so they cannot drift."""
+        from mship.core.assumptions import AssumptionStore, resolve_mode
+        from mship.core.plan import effective_plan_path
         from mship.core.plan_assumptions_transition import (
-            NoStoredCheck, UnknownAxis, approve_flag,
+            NoStoredCheck, StaleCheck, UnknownAxis, approve_flag,
         )
         from mship.core.plan_check import PlanCheckStore
 
@@ -737,8 +739,17 @@ def create_app(
         if slug not in state.tasks:
             raise HTTPException(status_code=404, detail=f"no task {slug!r}")
         store = PlanCheckStore(workspace_root / ".mothership")
+        docs_dir = getattr(config, "docs_dir", "docs") if config is not None else "docs"
+        plan_path = effective_plan_path(state.tasks[slug], workspace_root, docs_dir)
+        plan_text = plan_path.read_text() if plan_path is not None else ""
+        rows = AssumptionStore(
+            workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root)
+        ).load()
         try:
-            approve_flag(store, slug, body.axis, body.reason, approved_by="operator")
+            approve_flag(
+                store, slug, body.axis, body.reason, approved_by="operator",
+                plan_text=plan_text, rows=rows,
+            )
         except NoStoredCheck:
             raise HTTPException(
                 status_code=404, detail=f"no plan-assumption check for {slug!r}"
@@ -746,6 +757,11 @@ def create_app(
         except UnknownAxis:
             raise HTTPException(
                 status_code=404, detail=f"no pending flag for axis {body.axis!r}"
+            )
+        except StaleCheck:
+            raise HTTPException(
+                status_code=409,
+                detail="plan or assumptions changed since this check; re-run `mship plan assumptions result`",
             )
         return _plan_assumptions_envelope(slug)
 

--- a/tests/cli/test_plan_assumptions.py
+++ b/tests/cli/test_plan_assumptions.py
@@ -357,6 +357,43 @@ def test_approve_unknown_or_already_covered_axis_exits_1(tmp_path):
     assert res.exit_code == 1
 
 
+def test_approve_exits_1_when_plan_changed_since_the_check_ran(tmp_path):
+    """The server (here: the CLI verb, which shares the same core transition)
+    is the freshness authority — approving against a plan that was edited
+    after the checker ran must be refused, not silently accepted only to be
+    discarded by the next `result` (Greptile #453)."""
+    AssumptionStore = __import__("mship.core.assumptions", fromlist=["AssumptionStore"]).AssumptionStore
+    AssumptionStore(tmp_path).seed()
+
+    plan_path = _write_plan(tmp_path, "2026-07-30-t1.md", "# Plan\n\nOriginal body.\n")
+
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps([
+        {"axis": "repo topology", "verdict": "not-covered", "reason": "plan never says how repos are handled"},
+    ]))
+
+    runner = CliRunner()
+    app = _app(tmp_path, task=_task())
+    res = runner.invoke(
+        app,
+        [
+            "plan", "assumptions", "result",
+            "--task", "t1", "--plan", str(plan_path),
+            "--from-json", str(verdicts_file),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+
+    # plan edited AFTER the check was recorded
+    plan_path.write_text("# Plan\n\nOriginal body, now revised.\n")
+
+    res = runner.invoke(
+        app,
+        ["plan", "assumptions", "approve", "repo topology", "--task", "t1", "--plan", str(plan_path)],
+    )
+    assert res.exit_code == 1
+
+
 def test_result_preserves_prior_approvals_when_plan_unchanged(tmp_path):
     """Re-running the checker against the SAME plan (unchanged hash) must NOT
     wipe a human sign-off; a CHANGED plan correctly drops it (Wave 3a review)."""

--- a/tests/core/test_plan_assumptions_transition.py
+++ b/tests/core/test_plan_assumptions_transition.py
@@ -1,14 +1,18 @@
 import pytest
-from mship.core.plan_check import Flag, PlanCheckResult, PlanCheckStore, plan_hash
+from mship.core.assumptions import SEED_ROWS
+from mship.core.plan_check import Flag, PlanCheckResult, PlanCheckStore, assumptions_hash, plan_hash
 from mship.core.plan_assumptions_transition import (
-    approve_flag, NoStoredCheck, UnknownAxis,
+    approve_flag, NoStoredCheck, StaleCheck, UnknownAxis,
 )
 
+PLAN_TEXT = "p\n"
+ROWS = list(SEED_ROWS)
 
-def _seed(tmp_path, flags):
+
+def _seed(tmp_path, flags, plan_text=PLAN_TEXT, rows=ROWS):
     store = PlanCheckStore(tmp_path / ".mothership")
     store.save(PlanCheckResult(
-        task_slug="t", plan_hash=plan_hash("p\n"), assumptions_hash="h",
+        task_slug="t", plan_hash=plan_hash(plan_text), assumptions_hash=assumptions_hash(rows),
         verdicts=[], flags=flags,
     ))
     return store
@@ -16,7 +20,10 @@ def _seed(tmp_path, flags):
 
 def test_approve_flag_marks_the_axis_and_records_operator(tmp_path):
     store = _seed(tmp_path, [Flag(axis="repo topology", source="checker", reason="gap")])
-    result = approve_flag(store, "t", "Repo  Topology", reason="ok", approved_by="operator")
+    result = approve_flag(
+        store, "t", "Repo  Topology", reason="ok", approved_by="operator",
+        plan_text=PLAN_TEXT, rows=ROWS,
+    )
     match = [f for f in result.flags if f.axis == "repo topology"]
     assert len(match) == 1
     assert match[0].approved is True
@@ -29,7 +36,10 @@ def test_approve_flag_marks_the_axis_and_records_operator(tmp_path):
 def test_approve_flag_is_idempotent_on_already_approved(tmp_path):
     store = _seed(tmp_path, [Flag(axis="repo topology", source="checker", reason="g", approved=True,
                                    approved_by="operator")])
-    result = approve_flag(store, "t", "repo topology", reason="again", approved_by="operator")
+    result = approve_flag(
+        store, "t", "repo topology", reason="again", approved_by="operator",
+        plan_text=PLAN_TEXT, rows=ROWS,
+    )
     match = [f for f in result.flags if f.axis == "repo topology"]
     assert match[0].approved is True
     assert match[0].approved_reason is None  # unchanged; not overwritten by the no-op
@@ -38,10 +48,37 @@ def test_approve_flag_is_idempotent_on_already_approved(tmp_path):
 def test_approve_flag_unknown_axis_raises(tmp_path):
     store = _seed(tmp_path, [Flag(axis="repo topology", source="checker", reason="g")])
     with pytest.raises(UnknownAxis):
-        approve_flag(store, "t", "not a row", reason=None, approved_by="operator")
+        approve_flag(
+            store, "t", "not a row", reason=None, approved_by="operator",
+            plan_text=PLAN_TEXT, rows=ROWS,
+        )
 
 
 def test_approve_flag_no_stored_check_raises(tmp_path):
     store = PlanCheckStore(tmp_path / ".mothership")
     with pytest.raises(NoStoredCheck):
-        approve_flag(store, "t", "repo topology", reason=None, approved_by="operator")
+        approve_flag(
+            store, "t", "repo topology", reason=None, approved_by="operator",
+            plan_text=PLAN_TEXT, rows=ROWS,
+        )
+
+
+def test_approve_flag_raises_stale_check_when_plan_changed_since_recorded(tmp_path):
+    store = _seed(tmp_path, [Flag(axis="repo topology", source="checker", reason="gap")])
+    with pytest.raises(StaleCheck):
+        approve_flag(
+            store, "t", "repo topology", reason=None, approved_by="operator",
+            plan_text="a different plan entirely\n", rows=ROWS,
+        )
+    # the stale approve must not have mutated the stored check
+    assert store.get("t").flags[0].approved is False
+
+
+def test_approve_flag_raises_stale_check_when_assumptions_changed_since_recorded(tmp_path):
+    store = _seed(tmp_path, [Flag(axis="repo topology", source="checker", reason="gap")])
+    changed_rows = ROWS[1:]  # a row was removed from the set since the check ran
+    with pytest.raises(StaleCheck):
+        approve_flag(
+            store, "t", "repo topology", reason=None, approved_by="operator",
+            plan_text=PLAN_TEXT, rows=changed_rows,
+        )

--- a/tests/core/test_plan_assumptions_transition.py
+++ b/tests/core/test_plan_assumptions_transition.py
@@ -1,0 +1,47 @@
+import pytest
+from mship.core.plan_check import Flag, PlanCheckResult, PlanCheckStore, plan_hash
+from mship.core.plan_assumptions_transition import (
+    approve_flag, NoStoredCheck, UnknownAxis,
+)
+
+
+def _seed(tmp_path, flags):
+    store = PlanCheckStore(tmp_path / ".mothership")
+    store.save(PlanCheckResult(
+        task_slug="t", plan_hash=plan_hash("p\n"), assumptions_hash="h",
+        verdicts=[], flags=flags,
+    ))
+    return store
+
+
+def test_approve_flag_marks_the_axis_and_records_operator(tmp_path):
+    store = _seed(tmp_path, [Flag(axis="repo topology", source="checker", reason="gap")])
+    result = approve_flag(store, "t", "Repo  Topology", reason="ok", approved_by="operator")
+    match = [f for f in result.flags if f.axis == "repo topology"]
+    assert len(match) == 1
+    assert match[0].approved is True
+    assert match[0].approved_by == "operator"
+    assert match[0].approved_reason == "ok"
+    # persisted
+    assert store.get("t").flags[0].approved is True
+
+
+def test_approve_flag_is_idempotent_on_already_approved(tmp_path):
+    store = _seed(tmp_path, [Flag(axis="repo topology", source="checker", reason="g", approved=True,
+                                   approved_by="operator")])
+    result = approve_flag(store, "t", "repo topology", reason="again", approved_by="operator")
+    match = [f for f in result.flags if f.axis == "repo topology"]
+    assert match[0].approved is True
+    assert match[0].approved_reason is None  # unchanged; not overwritten by the no-op
+
+
+def test_approve_flag_unknown_axis_raises(tmp_path):
+    store = _seed(tmp_path, [Flag(axis="repo topology", source="checker", reason="g")])
+    with pytest.raises(UnknownAxis):
+        approve_flag(store, "t", "not a row", reason=None, approved_by="operator")
+
+
+def test_approve_flag_no_stored_check_raises(tmp_path):
+    store = PlanCheckStore(tmp_path / ".mothership")
+    with pytest.raises(NoStoredCheck):
+        approve_flag(store, "t", "repo topology", reason=None, approved_by="operator")

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -188,6 +188,34 @@ def test_post_plan_assumptions_approve_unknown_axis_404(tmp_path):
     assert r.status_code == 404
 
 
+def test_post_plan_assumptions_approve_stale_check_409(tmp_path):
+    """The stored check was recorded against an OLDER plan text than what's on
+    disk now — the server must refuse the approve (409), not silently accept
+    it and leave the plan->dev gate (which uses is_fresh) still blocked
+    (Greptile #453)."""
+    from mship.core.assumptions import AssumptionStore
+    from mship.core.plan_check import (
+        Flag, PlanCheckResult, PlanCheckStore, assumptions_hash, plan_hash,
+    )
+    sm, log = _seed_task(tmp_path)
+    rows = AssumptionStore(tmp_path).seed()
+    plan_path = _write_plan(tmp_path, "2026-07-30-dq.md", "# Plan\n\nBody.\n")
+    PlanCheckStore(tmp_path / ".mothership").save(PlanCheckResult(
+        task_slug="dq", plan_hash=plan_hash("# Plan\n\nOLD body the check ran against.\n"),
+        assumptions_hash=assumptions_hash(rows), verdicts=[],
+        flags=[Flag(axis="repo topology", source="checker", reason="gap")],
+    ))
+    # plan_path on disk ("# Plan\n\nBody.\n") no longer matches the hash the
+    # check was recorded against ("...OLD body...")
+
+    client = TestClient(_app_with(tmp_path, sm, log))
+    r = client.post("/plan-assumptions/dq/approve", json={"axis": "repo topology"})
+    assert r.status_code == 409
+
+    stored = PlanCheckStore(tmp_path / ".mothership").get("dq")
+    assert stored.flags[0].approved is False  # not mutated by the rejected approve
+
+
 def test_post_plan_assumptions_approve_unknown_task_404(tmp_path):
     sm, log = _seed_task(tmp_path)
     client = TestClient(_app_with(tmp_path, sm, log))

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -147,6 +147,54 @@ def test_get_plan_assumptions_absent_result(tmp_path):
     assert client.get("/plan-assumptions/nope").status_code == 404
 
 
+def test_post_plan_assumptions_approve_marks_flag_and_returns_envelope(tmp_path):
+    from mship.core.assumptions import AssumptionStore
+    from mship.core.plan_check import (
+        Flag, PlanCheckResult, PlanCheckStore, assumptions_hash, plan_hash,
+    )
+    sm, log = _seed_task(tmp_path)
+    rows = AssumptionStore(tmp_path).seed()
+    plan_path = _write_plan(tmp_path, "2026-07-30-dq.md", "# Plan\n\nBody.\n")
+    PlanCheckStore(tmp_path / ".mothership").save(PlanCheckResult(
+        task_slug="dq", plan_hash=plan_hash(plan_path.read_text()),
+        assumptions_hash=assumptions_hash(rows), verdicts=[],
+        flags=[Flag(axis="repo topology", source="checker", reason="gap")],
+    ))
+    client = TestClient(_app_with(tmp_path, sm, log))
+    body = client.post("/plan-assumptions/dq/approve",
+                       json={"axis": "repo topology", "reason": "ok"}).json()
+    assert body["pending"] == 0
+    flag = body["flags"][0]
+    assert flag["approved"] is True
+    assert flag["approved_by"] == "operator"
+    assert flag["approved_reason"] == "ok"
+
+
+def test_post_plan_assumptions_approve_unknown_axis_404(tmp_path):
+    from mship.core.assumptions import AssumptionStore
+    from mship.core.plan_check import (
+        Flag, PlanCheckResult, PlanCheckStore, assumptions_hash, plan_hash,
+    )
+    sm, log = _seed_task(tmp_path)
+    rows = AssumptionStore(tmp_path).seed()
+    _write_plan(tmp_path, "2026-07-30-dq.md", "# Plan\n\nBody.\n")
+    PlanCheckStore(tmp_path / ".mothership").save(PlanCheckResult(
+        task_slug="dq", plan_hash=plan_hash("# Plan\n\nBody.\n"),
+        assumptions_hash=assumptions_hash(rows), verdicts=[],
+        flags=[Flag(axis="repo topology", source="checker", reason="gap")],
+    ))
+    client = TestClient(_app_with(tmp_path, sm, log))
+    r = client.post("/plan-assumptions/dq/approve", json={"axis": "no such axis"})
+    assert r.status_code == 404
+
+
+def test_post_plan_assumptions_approve_unknown_task_404(tmp_path):
+    sm, log = _seed_task(tmp_path)
+    client = TestClient(_app_with(tmp_path, sm, log))
+    r = client.post("/plan-assumptions/nope/approve", json={"axis": "x"})
+    assert r.status_code == 404
+
+
 def test_post_is_405(tmp_path):
     # No write routes registered → POST to a GET path is 405 (Method Not Allowed).
     r = TestClient(_app(tmp_path)).post("/specs/dq/review")


### PR DESCRIPTION
**product_assumptions (#444) — Wave 3b / ac6, mothership side.**

The serve write-path that lets the operator approve a plan-assumption flag from the phone (Ground Control). Pairs with ground-control#64 (the phone UI). The L4 record/gate/read shipped in #451 (Wave 3a).

## What this PR delivers

- **`core/plan_assumptions_transition.py::approve_flag(store, slug, axis, reason, approved_by)`** — the single approve mutation, now shared by the CLI verb and the serve handler so they cannot drift (the divergence class that generated several Wave 3a review rounds). Runs the whole read-modify-write inside `PlanCheckStore.transaction` (per-task flock); idempotent on an already-approved axis; raises `NoStoredCheck` / `UnknownAxis`.
- **`POST /plan-assumptions/{slug}/approve`** — body `{axis, reason?}`, records `approved_by="operator"` (the spec mandates *explicit human approval*; one shared token, no per-user identity → `"operator"` is the honest human proxy). Returns the SAME `{task, fresh, pending, flags}` envelope as the GET (the GET envelope-builder was extracted into a shared helper so they can't diverge). 404 on unknown task / no stored check / unknown axis. Inherits the app-wide bearer auth.
- CLI `mship plan assumptions approve` refactored to call the shared helper (keeps the host `USER` attribution for terminal use).

## Acceptance criteria

- **ac6** (Wave 3 / L4 — "explicit human approval passes") — mothership approve write-path delivered. The gate (#451) already honors the persisted `approved` flags; this closes the phone→store→gate loop on the server side.

## Review

Built subagent-driven; combined mothership review (6/6 obligations, no defects) + whole-branch review + a fresh-eyes spec review (SHIP). Full `mship test` green, both repos, 0 regressions.

## Follow-up

"Flags route to the human" is currently pull-not-push (Task Detail only) — the fleet-wide Queue card + push notification is deferred to Wave 3c (tracked separately).
