### PR TITLE
product_assumptions Wave 5: L0 minimal — shared metarepo dev-phase fixture + checker canary. Build from docs/plans/2026-07-30-productassumptions-wave-5.md

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,6 +246,83 @@ def workspace_monorepo_app(tmp_path: Path):
     container.shell.reset_override()
 
 
+@pytest.fixture
+def metarepo_workspace(tmp_path: Path):
+    """Create a 5-repo metarepo-style workspace with tags and dep types."""
+    from unittest.mock import MagicMock
+    from mship.cli import container
+    from mship.util.shell import ShellResult, ShellRunner
+
+    for name in ["shared-swift", "backend", "ios-app", "android-app", "macos-app"]:
+        d = tmp_path / name
+        d.mkdir()
+        (d / "Taskfile.yml").write_text(f"version: '3'\ntasks:\n  test:\n    cmds:\n      - echo {name}\n")
+        subprocess.run(["git", "init", str(d)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "init"],
+            cwd=d, check=True, capture_output=True,
+            env={**os.environ, "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t.com",
+                 "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t.com"},
+        )
+
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text("""\
+workspace: my-platform
+repos:
+  shared-swift:
+    path: ./shared-swift
+    type: library
+    tags: [apple]
+  backend:
+    path: ./backend
+    type: service
+    tags: [backend]
+  ios-app:
+    path: ./ios-app
+    type: service
+    tags: [apple, mobile]
+    depends_on:
+      - repo: shared-swift
+        type: compile
+      - repo: backend
+        type: runtime
+  android-app:
+    path: ./android-app
+    type: service
+    tags: [android, mobile]
+    depends_on:
+      - repo: backend
+        type: runtime
+  macos-app:
+    path: ./macos-app
+    type: service
+    tags: [apple, desktop]
+    depends_on:
+      - repo: shared-swift
+        type: compile
+      - repo: backend
+        type: runtime
+""")
+
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+
+    mock_shell = MagicMock(spec=ShellRunner)
+    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok\n", stderr="")
+    mock_shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
+    container.shell.override(mock_shell)
+
+    yield tmp_path, mock_shell
+
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset()
+    container.state_manager.reset()
+    container.shell.reset_override()
+
+
 def _sh_switch(*args, cwd, env=None):
     """Shell helper for switch_workspace fixture (sets git author env vars)."""
     e = {**os.environ,

--- a/tests/core/test_assumptions_canary.py
+++ b/tests/core/test_assumptions_canary.py
@@ -1,0 +1,35 @@
+"""L0 canary (ac9): 'a flag rate near zero is a defect'. A known-bad plan — the
+canonical failure this whole system exists to catch: a git feature designed
+considering only single-repo / monorepo, with metarepo (the product's core
+divergence) ignored — MUST still be flagged. If the seed rows or the deterministic
+cross-check ever regress so this passes silently, these tests fail loudly."""
+from mship.core.assumptions import SEED_ROWS
+from mship.core.plan_check import AxisVerdict, cross_check, flags_from_verdicts
+
+# A plan whose text triggers the repo-topology axis (mentions git/clone) but whose
+# disposition wrongly declares it n/a — the metarepo option was never considered.
+_KNOWN_BAD_PLAN = (
+    "# Plan\n\nAdd a git clone step and handle the single-repo and monorepo layouts.\n"
+)
+
+
+def test_canary_cross_check_flags_ignored_metarepo_divergence():
+    rows = list(SEED_ROWS)
+    verdicts = [AxisVerdict(axis="repo topology", verdict="n-a",
+                            reason="only single/mono considered")]
+    flags = cross_check(verdicts, rows, plan_text=_KNOWN_BAD_PLAN, task_text="", affected_repos=[])
+    assert any(f.axis == "repo topology" for f in flags), (
+        "CANARY TRIPPED: the deterministic cross-check no longer flags the metarepo "
+        "divergence — the flag rate has gone to zero, which is a defect (#444 ac9)."
+    )
+
+
+def test_canary_completeness_flags_omitted_row():
+    """A plan the checker returns NO verdict for a seed row on must still flag that
+    row (completeness) — a silent omission cannot pass."""
+    rows = list(SEED_ROWS)
+    flags = flags_from_verdicts([], rows)  # checker returned nothing
+    assert flags, "CANARY TRIPPED: an all-omitted verdict set produced zero flags."
+    assert {f.axis for f in flags} >= {r.axis for r in SEED_ROWS}, (
+        "CANARY TRIPPED: not every un-dispositioned seed row was flagged."
+    )

--- a/tests/test_scaling_integration.py
+++ b/tests/test_scaling_integration.py
@@ -1,92 +1,13 @@
 """Integration test: parallel tiers, tag filtering, dependency types."""
-import os
-import subprocess
-from pathlib import Path
-from unittest.mock import MagicMock
 from datetime import datetime, timezone
 
-import pytest
 import yaml
 from typer.testing import CliRunner
 
-from mship.cli import app, container
+from mship.cli import app
 from mship.core.state import StateManager, Task, WorkspaceState
-from mship.util.shell import ShellResult, ShellRunner
 
 runner = CliRunner()
-
-
-@pytest.fixture
-def metarepo_workspace(tmp_path: Path):
-    """Create a 5-repo metarepo-style workspace with tags and dep types."""
-    for name in ["shared-swift", "backend", "ios-app", "android-app", "macos-app"]:
-        d = tmp_path / name
-        d.mkdir()
-        (d / "Taskfile.yml").write_text(f"version: '3'\ntasks:\n  test:\n    cmds:\n      - echo {name}\n")
-        subprocess.run(["git", "init", str(d)], check=True, capture_output=True)
-        subprocess.run(
-            ["git", "commit", "--allow-empty", "-m", "init"],
-            cwd=d, check=True, capture_output=True,
-            env={**os.environ, "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t.com",
-                 "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t.com"},
-        )
-
-    cfg = tmp_path / "mothership.yaml"
-    cfg.write_text("""\
-workspace: my-platform
-repos:
-  shared-swift:
-    path: ./shared-swift
-    type: library
-    tags: [apple]
-  backend:
-    path: ./backend
-    type: service
-    tags: [backend]
-  ios-app:
-    path: ./ios-app
-    type: service
-    tags: [apple, mobile]
-    depends_on:
-      - repo: shared-swift
-        type: compile
-      - repo: backend
-        type: runtime
-  android-app:
-    path: ./android-app
-    type: service
-    tags: [android, mobile]
-    depends_on:
-      - repo: backend
-        type: runtime
-  macos-app:
-    path: ./macos-app
-    type: service
-    tags: [apple, desktop]
-    depends_on:
-      - repo: shared-swift
-        type: compile
-      - repo: backend
-        type: runtime
-""")
-
-    state_dir = tmp_path / ".mothership"
-    state_dir.mkdir()
-    container.config_path.override(cfg)
-    container.state_dir.override(state_dir)
-
-    mock_shell = MagicMock(spec=ShellRunner)
-    mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok\n", stderr="")
-    mock_shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
-    container.shell.override(mock_shell)
-
-    yield tmp_path, mock_shell
-
-    container.config_path.reset_override()
-    container.state_dir.reset_override()
-    container.config.reset()
-    container.state_manager.reset()
-    container.shell.reset_override()
 
 
 def test_metarepo_spawn_and_test_all(metarepo_workspace):

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -210,6 +210,18 @@ def test_bug_never_plan_gated(tmp_path):
     assert check_task_gate(task, tmp_path, require_plan=True).ok is True
 
 
+def test_feature_plan_gate_passes_with_metarepo_layout(tmp_path, metarepo_workspace):
+    """The plan->dev gate must work against the product's core layout (metarepo),
+    not only single/2-repo -- L0 makes metarepo a first-class dev-phase fixture."""
+    workspace_root, _mock_shell = metarepo_workspace
+    _items, _wi, task = _approved_feature(workspace_root)
+    plans = workspace_root / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "2026-07-12-t.md").write_text(_PLAN_WITH_TASK)
+    res = check_task_gate(task, workspace_root, require_plan=True)
+    assert res.ok is True
+
+
 # ---------------------------------------------------------------------------
 # L4 assumption gate (#444): opt-in via `require_assumption_gate` — a feature
 # WorkItem must ALSO have a fresh, fully-approved PlanCheckResult. Off by


### PR DESCRIPTION
**product_assumptions (#444) — Wave 5 / L0 (minimal).** Test-infrastructure only; no product-code change.

Delivers the durable, non-speculative core of L0. The import-linter + row-graduation + metrics-dashboard machinery is **deliberately deferred** (tracked as a follow-up) — see below.

## What this PR delivers

- **Metarepo as a first-class dev-phase test fixture** (ac8, fixture half) — promotes the metarepo workspace fixture out of `test_scaling_integration.py` into a shared `tests/conftest.py::metarepo_workspace`, and exercises the plan→dev gate (`check_task_gate(..., require_plan=True)`) against a real metarepo layout — so the product's core assumption (metarepo, not single/mono) is tested where it matters.
- **The canary** (ac9) — `tests/core/test_assumptions_canary.py` feeds the *canonical known-bad plan* (a git feature considering only single-repo/monorepo, metarepo ignored) through the real deterministic checker (`cross_check` / `flags_from_verdicts`) and asserts it still flags. This operationalizes "a flag rate near zero is a defect": if the seed rows or the cross-check ever regress so the canonical divergence stops being caught, CI fails loudly. **Sanity-checked to bite** — it fails when the repo-topology trigger is neutered, then reverts.

## Acceptance criteria

- **ac8** — metarepo-as-dev-phase-fixture half delivered. (import-linter boundary contracts + row-graduation → deferred.)
- **ac9** — canary delivered. (header-vs-body consistency, rows-graduated, file-size metrics dashboard → deferred.)

## Deliberately deferred (not a gap — a decision)

import-linter + the row-graduation mechanism + a health-metrics dashboard are **not** built here. Rationale: import-linter only fits import-shaped assumptions, several seed rows (e.g. the `undecided` "review surface") can't graduate by any mechanism, and file-size/graduated-count metrics are only meaningful once graduation exists — so building that machinery now would retire zero rows, which is exactly the speculative over-building this whole system exists to prevent. It will be built when a row is actually ready to graduate.

## Review

Both tasks TDD (metarepo gate test red→green; canary passes against the working checker and was verified to fail when the checker is neutered). Full mothership suite green, 0 regressions.
