### PR TITLE
Durable queryable spec rejections (#447): record request-changes as a durable action=rejected journal event + mship spec rejections query. Build from docs/plans/2026-07-31-durable-queryable-spec-rejections.md

### DIFF
--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -623,7 +623,7 @@ def register(parent: typer.Typer, get_container):
         """
         import os
 
-        from mship.core.spec import InvalidTransition
+        from mship.core.spec import InvalidTransition, validate_transition
         from mship.core.spec_transition import record_rejection, request_changes_spec
         output = Output()
         container = get_container()
@@ -633,16 +633,18 @@ def register(parent: typer.Typer, get_container):
             output.error(f"No spec with id {spec_id!r}.")
             raise typer.Exit(1)
         try:
-            request_changes_spec(spec, store, reason)
+            validate_transition(spec.status, "draft")
         except InvalidTransition as e:
             output.error(str(e))
             raise typer.Exit(1)
-        # MOS-215: the reason is persisted on the spec (surfaced by `spec
-        # show`/`review`) in addition to being journaled to the task log.
+        # #447 review: the durable rejection record must be written BEFORE the
+        # status transition, and a write failure must fail loud (not be
+        # swallowed) — otherwise a journal-append failure could leave the spec
+        # durably flipped to draft with no record of why it was rejected
+        # (CLAUDE.md: fail loud at the boundary; never swallow exceptions).
+        # This also supersedes the old decorative "spec request-changes: …"
+        # log line — the structured record below is the parsed source now.
         try:
-            container.log_manager().append(spec.id, f"spec request-changes: {reason}")
-            # #447: also record a durable, append-only `rejected` journal event
-            # (survives approve_spec nulling clarification_reason later).
             record_rejection(
                 container.log_manager(),
                 spec.id,
@@ -650,8 +652,13 @@ def register(parent: typer.Typer, get_container):
                 reason,
                 datetime.now(timezone.utc),
             )
-        except Exception:
-            pass
+        except ValueError as e:
+            output.error(str(e))
+            raise typer.Exit(1)
+        except Exception as e:
+            output.error(f"Could not record rejection: {e}")
+            raise typer.Exit(1)
+        request_changes_spec(spec, store, reason)
         if output.human_mode:
             output.success(f"Requested changes ({spec.status}): {reason}")
         else:
@@ -668,6 +675,13 @@ def register(parent: typer.Typer, get_container):
         on `spec request-changes`), whose text is `json.dumps({actor, reason})`.
         Malformed entries are skipped, not fatal — the journal is append-only
         and outlives any one writer's format.
+
+        `--all` scans every log file directly (`LogManager.list_slugs()`)
+        rather than `SpecStore.list()`, so a rejection whose spec was later
+        deleted is still found — the whole point of a durable, append-only
+        record. Filtering by `action == "rejected"` naturally excludes
+        non-spec (task) logs sharing the same directory. Results are sorted
+        chronologically across specs.
         """
         import json as _json
 
@@ -697,10 +711,10 @@ def register(parent: typer.Typer, get_container):
             return out
 
         if all_specs:
-            store = _spec_store()
             records: list[dict] = []
-            for spec in store.list():
-                records.extend(_spec_rejections(spec.id))
+            for sid in log_manager.list_slugs():
+                records.extend(_spec_rejections(sid))
+            records.sort(key=lambda r: r["timestamp"])
         else:
             records = _spec_rejections(spec_id)
 

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -5,6 +5,7 @@ task-optional, frontmatter-structured. See #145.
 """
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Optional
 
 import typer
@@ -620,8 +621,10 @@ def register(parent: typer.Typer, get_container):
         MOS-240: `needs_clarification` is gone; "needs clarification" is now the
         non-null `clarification_reason` carried by the editable `draft` status.
         """
+        import os
+
         from mship.core.spec import InvalidTransition
-        from mship.core.spec_transition import request_changes_spec
+        from mship.core.spec_transition import record_rejection, request_changes_spec
         output = Output()
         container = get_container()
         store = _spec_store()
@@ -638,6 +641,15 @@ def register(parent: typer.Typer, get_container):
         # show`/`review`) in addition to being journaled to the task log.
         try:
             container.log_manager().append(spec.id, f"spec request-changes: {reason}")
+            # #447: also record a durable, append-only `rejected` journal event
+            # (survives approve_spec nulling clarification_reason later).
+            record_rejection(
+                container.log_manager(),
+                spec.id,
+                os.environ.get("USER") or "unknown",
+                reason,
+                datetime.now(timezone.utc),
+            )
         except Exception:
             pass
         if output.human_mode:

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -657,6 +657,62 @@ def register(parent: typer.Typer, get_container):
         else:
             output.json({"id": spec.id, "status": spec.status, "reason": reason})
 
+    @spec_app.command("rejections")
+    def rejections(
+        spec_id: Optional[str] = typer.Argument(None, help="Spec id to list rejections for."),
+        all_specs: bool = typer.Option(False, "--all", help="Aggregate rejections across every spec."),
+    ):
+        """List a spec's durable rejection history (#447), or --all to aggregate.
+
+        Reads `action="rejected"` journal entries (written by `record_rejection`
+        on `spec request-changes`), whose text is `json.dumps({actor, reason})`.
+        Malformed entries are skipped, not fatal — the journal is append-only
+        and outlives any one writer's format.
+        """
+        import json as _json
+
+        output = Output()
+        if (spec_id is None) == (not all_specs):
+            output.error("Provide a spec id, or --all to aggregate across every spec.")
+            raise typer.Exit(1)
+
+        container = get_container()
+        log_manager = container.log_manager()
+
+        def _spec_rejections(sid: str) -> list[dict]:
+            out = []
+            for entry in log_manager.read(sid):
+                if entry.action != "rejected":
+                    continue
+                try:
+                    payload = _json.loads(entry.message)
+                except (ValueError, TypeError):
+                    continue
+                out.append({
+                    "spec_id": sid,
+                    "actor": payload.get("actor"),
+                    "reason": payload.get("reason"),
+                    "timestamp": entry.timestamp.isoformat(),
+                })
+            return out
+
+        if all_specs:
+            store = _spec_store()
+            records: list[dict] = []
+            for spec in store.list():
+                records.extend(_spec_rejections(spec.id))
+        else:
+            records = _spec_rejections(spec_id)
+
+        if output.human_mode:
+            if not records:
+                output.print("[dim]No rejections recorded.[/dim]")
+            for r in records:
+                prefix = f"{r['spec_id']}: " if all_specs else ""
+                output.print(f"{prefix}{r['timestamp']} {r['actor']}: {r['reason']}")
+        else:
+            output.json(records)
+
     @spec_app.command("list")
     def list_specs():
         """List all specs (TTY: table; non-TTY: JSON envelope)."""

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -623,8 +623,8 @@ def register(parent: typer.Typer, get_container):
         """
         import os
 
-        from mship.core.spec import InvalidTransition, validate_transition
-        from mship.core.spec_transition import record_rejection, request_changes_spec
+        from mship.core.spec import InvalidTransition
+        from mship.core.spec_transition import request_changes_spec
         output = Output()
         container = get_container()
         store = _spec_store()
@@ -632,33 +632,26 @@ def register(parent: typer.Typer, get_container):
         if spec is None:
             output.error(f"No spec with id {spec_id!r}.")
             raise typer.Exit(1)
+        # #458 P1 class fix: the durable rejection record is now written
+        # inside `request_changes_spec` itself (record-then-transition,
+        # fail-loud on a write failure — CLAUDE.md: fail loud at the
+        # boundary), so every caller — CLI, serve, and the TUI views — gets
+        # it automatically instead of each remembering its own
+        # `record_rejection` call. This also supersedes the old decorative
+        # "spec request-changes: …" log line — the structured record is the
+        # parsed source now.
         try:
-            validate_transition(spec.status, "draft")
-        except InvalidTransition as e:
-            output.error(str(e))
-            raise typer.Exit(1)
-        # #447 review: the durable rejection record must be written BEFORE the
-        # status transition, and a write failure must fail loud (not be
-        # swallowed) — otherwise a journal-append failure could leave the spec
-        # durably flipped to draft with no record of why it was rejected
-        # (CLAUDE.md: fail loud at the boundary; never swallow exceptions).
-        # This also supersedes the old decorative "spec request-changes: …"
-        # log line — the structured record below is the parsed source now.
-        try:
-            record_rejection(
-                container.log_manager(),
-                spec.id,
-                os.environ.get("USER") or "unknown",
-                reason,
-                datetime.now(timezone.utc),
+            request_changes_spec(
+                spec, store, reason,
+                log_manager=container.log_manager(),
+                actor=os.environ.get("USER") or "unknown",
             )
         except ValueError as e:
             output.error(str(e))
             raise typer.Exit(1)
-        except Exception as e:
-            output.error(f"Could not record rejection: {e}")
+        except InvalidTransition as e:
+            output.error(str(e))
             raise typer.Exit(1)
-        request_changes_spec(spec, store, reason)
         if output.human_mode:
             output.success(f"Requested changes ({spec.status}): {reason}")
         else:
@@ -701,6 +694,11 @@ def register(parent: typer.Typer, get_container):
                 try:
                     payload = _json.loads(entry.message)
                 except (ValueError, TypeError):
+                    continue
+                # P1 (#458): a valid-but-non-dict payload (`null`, a number, an
+                # array) passes json.loads but must not reach `.get()` — skip
+                # it the same as a not-json-at-all entry.
+                if not isinstance(payload, dict):
                     continue
                 out.append({
                     "spec_id": sid,

--- a/src/mship/core/log.py
+++ b/src/mship/core/log.py
@@ -82,6 +82,15 @@ class LogManager:
     def _log_path(self, task_slug: str) -> Path:
         return self._logs_dir / f"{task_slug}.md"
 
+    def list_slugs(self) -> list[str]:
+        """Every slug with an existing log file (tasks and specs share this
+        store, keyed by slug/id). Used to scan the whole journal — e.g. for
+        durable spec-rejection records (#447) that must survive their spec
+        being deleted from the SpecStore."""
+        if not self._logs_dir.exists():
+            return []
+        return sorted(p.stem for p in self._logs_dir.glob("*.md"))
+
     def create(self, task_slug: str) -> None:
         self._logs_dir.mkdir(parents=True, exist_ok=True)
         path = self._log_path(task_slug)

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -976,25 +976,30 @@ def create_app(
     @app.post("/specs/{spec_id}/request-changes")
     def post_request_changes(spec_id: str, body: ReasonBody):
         spec = _load_or_404(spec_id)
+        # #447 review: every durable rejection record must carry real reason
+        # text — reject empty/whitespace before anything is written.
+        if not body.reason or not body.reason.strip():
+            raise HTTPException(status_code=400, detail="reason must not be empty")
         # MOS-240: request-changes sends the spec back to the editable `draft`
         # status carrying a non-null clarification_reason (the dropped
         # needs_clarification status is now expressed by that field alone).
         try:
-            request_changes_spec(spec, store, body.reason)
+            validate_transition(spec.status, "draft")
         except InvalidTransition as e:
             raise HTTPException(status_code=409, detail=str(e))
-        review = build_review(spec)
+        # #447 review: the durable rejection record must be written BEFORE the
+        # status transition, and a write failure must fail loud (propagate,
+        # not be swallowed) — otherwise a journal-append failure could leave
+        # the spec durably flipped to draft with no record of why (CLAUDE.md:
+        # fail loud at the boundary). This also supersedes the old decorative
+        # "spec request-changes (api): …" log line — the structured record
+        # below is the parsed source now.
         if log_manager is not None:
-            try:
-                log_manager.append(spec.id, f"spec request-changes (api): {body.reason}")
-                # #447: also record a durable, append-only `rejected` journal
-                # event (survives approve_spec nulling clarification_reason).
-                record_rejection(
-                    log_manager, spec.id, "operator", body.reason, datetime.now(timezone.utc)
-                )
-            except Exception:
-                pass
-        return review
+            record_rejection(
+                log_manager, spec.id, "operator", body.reason, datetime.now(timezone.utc)
+            )
+        request_changes_spec(spec, store, body.reason)
+        return build_review(spec)
 
     @app.post("/specs/{spec_id}/archive")
     def post_archive(spec_id: str):

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -27,7 +27,12 @@ from mship.core.gh_app import GhAppError, mint_installation_token, resolve_insta
 from mship.core.pr import PRManager
 from mship.core.pr_watcher import PrWatcher
 from mship.core.spec import SpecDraft
-from mship.core.spec_transition import ApprovalBlocked, approve_spec, request_changes_spec
+from mship.core.spec_transition import (
+    ApprovalBlocked,
+    approve_spec,
+    record_rejection,
+    request_changes_spec,
+)
 from mship.core.view.thread_links import index_thread_work_items
 from mship.core.workitem import Phase
 from mship.util.shell import ShellRunner
@@ -982,6 +987,11 @@ def create_app(
         if log_manager is not None:
             try:
                 log_manager.append(spec.id, f"spec request-changes (api): {body.reason}")
+                # #447: also record a durable, append-only `rejected` journal
+                # event (survives approve_spec nulling clarification_reason).
+                record_rejection(
+                    log_manager, spec.id, "operator", body.reason, datetime.now(timezone.utc)
+                )
             except Exception:
                 pass
         return review

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -30,7 +30,6 @@ from mship.core.spec import SpecDraft
 from mship.core.spec_transition import (
     ApprovalBlocked,
     approve_spec,
-    record_rejection,
     request_changes_spec,
 )
 from mship.core.view.thread_links import index_thread_work_items
@@ -987,18 +986,14 @@ def create_app(
             validate_transition(spec.status, "draft")
         except InvalidTransition as e:
             raise HTTPException(status_code=409, detail=str(e))
-        # #447 review: the durable rejection record must be written BEFORE the
-        # status transition, and a write failure must fail loud (propagate,
-        # not be swallowed) — otherwise a journal-append failure could leave
-        # the spec durably flipped to draft with no record of why (CLAUDE.md:
-        # fail loud at the boundary). This also supersedes the old decorative
-        # "spec request-changes (api): …" log line — the structured record
-        # below is the parsed source now.
-        if log_manager is not None:
-            record_rejection(
-                log_manager, spec.id, "operator", body.reason, datetime.now(timezone.utc)
-            )
-        request_changes_spec(spec, store, body.reason)
+        # #458 P1 class fix: the durable rejection record is now written
+        # inside `request_changes_spec` itself (record-then-transition,
+        # fail-loud on a write failure), so every caller — CLI, serve, and
+        # the TUI views — gets it automatically instead of each remembering
+        # its own `record_rejection` call. This also supersedes the old
+        # decorative "spec request-changes (api): …" log line — the
+        # structured record is the parsed source now.
+        request_changes_spec(spec, store, body.reason, log_manager=log_manager, actor="operator")
         return build_review(spec)
 
     @app.post("/specs/{spec_id}/archive")

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -65,6 +65,14 @@ class SpecStore:
             storage = storage_from_workspace(self._dir)
         self._storage = storage
 
+    @property
+    def workspace_root(self) -> Path:
+        """The workspace root this store's specs live under (`<root>/specs`).
+        Reuses `SpecStorage`'s already-computed root — the single place that
+        derives it — so callers needing e.g. `<root>/.mothership/logs`
+        (view/actions.py's LogManager) don't restate the convention."""
+        return self._storage.workspace_root
+
     def path_for(self, spec: Spec) -> Path:
         """Logical `.md` stem for a spec: `<specs_dir>/<created_at date>-<id>.md`.
 

--- a/src/mship/core/spec_transition.py
+++ b/src/mship/core/spec_transition.py
@@ -54,11 +54,22 @@ def record_rejection(
     and nulled by `approve_spec`), the journal is append-only, so this record
     survives later transitions — the durable, queryable rejection history.
 
+    Must be called BEFORE the status transition at every call site (CLI +
+    serve): if the append raises, the caller must propagate it (fail loud,
+    never swallow — CLAUDE.md) and must not have flipped the spec's status
+    yet, so a write failure leaves a consistent, retryable state instead of a
+    draft-without-record.
+
+    Raises `ValueError` for an empty/whitespace-only `reason` — every durable
+    record must carry real reason text.
+
     `now` is accepted for interface symmetry with the other transition
     helpers, but `LogManager.append` stamps its own timestamp, so it is not
     threaded through.
     """
     del now
+    if not reason or not reason.strip():
+        raise ValueError("reason must not be empty")
     log_manager.append(
         spec_id, json.dumps({"actor": actor, "reason": reason}), action="rejected"
     )

--- a/src/mship/core/spec_transition.py
+++ b/src/mship/core/spec_transition.py
@@ -7,13 +7,21 @@ store write (SpecStore.save = tempfile + os.replace). Callers own only their own
 concerns (HTTP status mapping, CLI output, journal appends, view messaging)."""
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 
+from mship.core.log import LogManager
 from mship.core.spec import InvalidTransition, Spec, validate_transition
 from mship.core.spec_approve import approval_blockers
 from mship.core.spec_store import SpecStore
 
-__all__ = ["ApprovalBlocked", "InvalidTransition", "approve_spec", "request_changes_spec"]
+__all__ = [
+    "ApprovalBlocked",
+    "InvalidTransition",
+    "approve_spec",
+    "record_rejection",
+    "request_changes_spec",
+]
 
 
 class ApprovalBlocked(Exception):
@@ -35,6 +43,25 @@ def approve_spec(spec: Spec, store: SpecStore, *, bypass_gate: bool = False) -> 
     spec.clarification_reason = None
     spec.updated_at = datetime.now(timezone.utc)
     store.save(spec)
+
+
+def record_rejection(
+    log_manager: LogManager, spec_id: str, actor: str, reason: str, now: datetime
+) -> None:
+    """Append a durable, append-only `rejected` journal event for `spec_id`.
+
+    Unlike `Spec.clarification_reason` (overwritten by the next request-changes
+    and nulled by `approve_spec`), the journal is append-only, so this record
+    survives later transitions — the durable, queryable rejection history.
+
+    `now` is accepted for interface symmetry with the other transition
+    helpers, but `LogManager.append` stamps its own timestamp, so it is not
+    threaded through.
+    """
+    del now
+    log_manager.append(
+        spec_id, json.dumps({"actor": actor, "reason": reason}), action="rejected"
+    )
 
 
 def request_changes_spec(spec: Spec, store: SpecStore, reason: str) -> None:

--- a/src/mship/core/spec_transition.py
+++ b/src/mship/core/spec_transition.py
@@ -75,10 +75,34 @@ def record_rejection(
     )
 
 
-def request_changes_spec(spec: Spec, store: SpecStore, reason: str) -> None:
-    """needs_review/approved -> draft carrying `reason`. Raises InvalidTransition."""
+def request_changes_spec(
+    spec: Spec,
+    store: SpecStore,
+    reason: str,
+    *,
+    log_manager: LogManager | None,
+    actor: str,
+    now: datetime | None = None,
+) -> None:
+    """needs_review/approved -> draft carrying `reason`. Raises InvalidTransition.
+
+    Writes the durable rejection record itself (record_rejection), in this
+    order: reject empty/whitespace reason -> validate_transition -> durable
+    record -> status flip -> save. Folding the record into the shared
+    transition (rather than leaving it to each caller) is the class fix for
+    #458 P1: the CLI, serve, and the TUI views (core/view/actions.py) all
+    call this one function, so none of them can transition a spec without
+    also logging why — the earlier per-caller convention let the view path
+    (`mship view queue/spec/workitem`) silently skip it.
+    """
+    if not reason or not reason.strip():
+        raise ValueError("reason must not be empty")
     validate_transition(spec.status, "draft")
+    if now is None:
+        now = datetime.now(timezone.utc)
+    if log_manager is not None:
+        record_rejection(log_manager, spec.id, actor, reason, now)
     spec.status = "draft"
     spec.clarification_reason = reason
-    spec.updated_at = datetime.now(timezone.utc)
+    spec.updated_at = now
     store.save(spec)

--- a/src/mship/core/view/actions.py
+++ b/src/mship/core/view/actions.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from mship.core.log import LogManager
 from mship.core.spec import InvalidTransition
 from mship.core.spec_store import SpecStore
 from mship.core.spec_transition import ApprovalBlocked, approve_spec, request_changes_spec
@@ -49,8 +50,16 @@ def request_changes_by_id(store: SpecStore, spec_id: str | None, reason: str) ->
     reason = (reason or "").strip()
     if not reason:
         return ActionOutcome(False, "Request-changes needs a reason.")
+    # P1 (#458): route the durable rejection record through the same
+    # LogManager convention as the CLI/serve (`<workspace_root>/.mothership/
+    # logs`), so this TUI path (queue/spec/workitem views) can no longer
+    # transition a spec without also logging why — the bug this class fix
+    # closes.
+    log_manager = LogManager(store.workspace_root / ".mothership" / "logs")
     try:
-        request_changes_spec(spec, store, reason)
+        request_changes_spec(spec, store, reason, log_manager=log_manager, actor="operator")
     except InvalidTransition as e:
+        return ActionOutcome(False, str(e))
+    except ValueError as e:
         return ActionOutcome(False, str(e))
     return ActionOutcome(True, f"Requested changes on {spec_id}.", new_status="draft")

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -625,6 +625,26 @@ def test_spec_request_changes_persists_reason_and_logs(configured_app_with_task:
     assert any("tighten scope" in e.message for e in entries)
 
 
+def test_spec_request_changes_records_durable_rejection(configured_app_with_task: Path, tmp_path):
+    """#447: request-changes must also append a durable, append-only
+    `rejected` journal event carrying {actor, reason} as JSON — distinct
+    from `clarification_reason`, which a later approve_spec() nulls."""
+    import json
+
+    from mship.core.log import LogManager
+
+    _apply_dq(tmp_path)
+    result = runner.invoke(app, ["spec", "request-changes", "dq", "--reason", "tighten scope"])
+    assert result.exit_code == 0, result.output
+
+    log = LogManager(configured_app_with_task / ".mothership" / "logs")
+    rejected = [e for e in log.read("dq") if e.action == "rejected"]
+    assert len(rejected) == 1
+    payload = json.loads(rejected[0].message)
+    assert payload["reason"] == "tighten scope"
+    assert payload["actor"]
+
+
 def test_spec_apply_revising_clears_clarification_reason(configured_app_with_task: Path, tmp_path):
     """Applying a revised draft moves draft -> needs_review (MOS-240); the
     stale reason from the earlier request-changes must not linger."""

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -645,6 +645,39 @@ def test_spec_request_changes_records_durable_rejection(configured_app_with_task
     assert payload["actor"]
 
 
+def test_spec_request_changes_fails_loud_when_journal_write_fails(
+    configured_app_with_task: Path, tmp_path, monkeypatch,
+):
+    """#447 review: a durable-write failure must FAIL LOUD (non-zero exit,
+    no success reported) and must NOT leave the spec flipped to draft —
+    the record-then-transition ordering means a failed append leaves the
+    spec's status untouched, so the operator can retry cleanly."""
+    import mship.core.spec_transition as st
+
+    _apply_dq(tmp_path)
+
+    def _boom(*a, **kw):
+        raise OSError("disk full")
+    monkeypatch.setattr(st, "record_rejection", _boom)
+
+    result = runner.invoke(app, ["spec", "request-changes", "dq", "--reason", "tighten scope"])
+    assert result.exit_code != 0
+    assert "success" not in result.output.lower()
+
+    spec = _store(configured_app_with_task).find_by_id("dq")
+    assert spec.status == "needs_review"
+    assert spec.clarification_reason is None
+
+
+def test_spec_request_changes_rejects_empty_reason(configured_app_with_task: Path, tmp_path):
+    _apply_dq(tmp_path)
+    result = runner.invoke(app, ["spec", "request-changes", "dq", "--reason", "   "])
+    assert result.exit_code != 0
+
+    spec = _store(configured_app_with_task).find_by_id("dq")
+    assert spec.status == "needs_review"
+
+
 def test_spec_apply_revising_clears_clarification_reason(configured_app_with_task: Path, tmp_path):
     """Applying a revised draft moves draft -> needs_review (MOS-240); the
     stale reason from the earlier request-changes must not linger."""

--- a/tests/cli/test_spec_rejections.py
+++ b/tests/cli/test_spec_rejections.py
@@ -127,6 +127,26 @@ def test_rejections_skips_malformed_entry(configured_app_with_task: Path, tmp_pa
     assert data[0]["reason"] == "tighten scope"
 
 
+def test_rejections_skips_non_dict_json_entry(configured_app_with_task: Path, tmp_path):
+    """P1 (#458): a valid-but-non-dict JSON payload (`null`, a number, an
+    array) passes `json.loads` but must not reach `.get()` unconditionally —
+    that crashes the whole query instead of just skipping the bad entry,
+    same as the existing not-json-at-all handling."""
+    _apply(tmp_path, "dq")
+    _reject("dq", "tighten scope")
+
+    log_manager = container.log_manager()
+    log_manager.append("dq", "null", action="rejected")
+    log_manager.append("dq", "42", action="rejected")
+    log_manager.append("dq", "[1, 2]", action="rejected")
+
+    result = runner.invoke(app, ["spec", "rejections", "dq"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert len(data) == 1
+    assert data[0]["reason"] == "tighten scope"
+
+
 def test_rejections_no_id_and_no_all_errors(configured_app_with_task: Path):
     result = runner.invoke(app, ["spec", "rejections"])
     assert result.exit_code != 0

--- a/tests/cli/test_spec_rejections.py
+++ b/tests/cli/test_spec_rejections.py
@@ -151,7 +151,27 @@ def test_rejections_all_finds_deleted_spec(configured_app_with_task: Path, tmp_p
     assert data[0]["reason"] == "tighten scope"
 
 
-def test_rejections_all_is_time_sorted_across_specs(configured_app_with_task: Path, tmp_path):
+def test_rejections_all_is_time_sorted_across_specs(configured_app_with_task: Path, tmp_path, monkeypatch):
+    """`LogManager` stamps second-resolution timestamps, and `--all` visits
+    specs alphabetically (`dq` before `other`) — so without explicit sorting,
+    two `dq` records written either side of an `other` record in the same
+    wall-clock second would still land adjacent in the output, masking the
+    bug. Force strictly increasing timestamps so the assertion actually
+    exercises the sort rather than getting lucky on insertion order."""
+    import itertools
+    from datetime import datetime as real_datetime, timedelta
+
+    import mship.core.log as log_mod
+
+    counter = itertools.count()
+
+    class _FakeDateTime(real_datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return real_datetime(2026, 7, 31, tzinfo=timezone.utc) + timedelta(seconds=next(counter))
+
+    monkeypatch.setattr(log_mod, "datetime", _FakeDateTime)
+
     _apply(tmp_path, "dq")
     _reject("dq", "first")
     _apply(tmp_path, "other")

--- a/tests/cli/test_spec_rejections.py
+++ b/tests/cli/test_spec_rejections.py
@@ -130,3 +130,38 @@ def test_rejections_skips_malformed_entry(configured_app_with_task: Path, tmp_pa
 def test_rejections_no_id_and_no_all_errors(configured_app_with_task: Path):
     result = runner.invoke(app, ["spec", "rejections"])
     assert result.exit_code != 0
+
+
+def test_rejections_all_finds_deleted_spec(configured_app_with_task: Path, tmp_path):
+    """#447 review: rejections are durable/append-only and must survive their
+    spec being deleted — `--all` scans the log directory directly rather than
+    filtering through `SpecStore.list()`."""
+    _apply(tmp_path, "dq")
+    _reject("dq", "tighten scope")
+
+    # Delete the spec itself; the journal file (and its rejected entry) stays.
+    store = _store(tmp_path)
+    store.path_for(store.find_by_id("dq")).unlink()
+    assert store.find_by_id("dq") is None
+
+    result = runner.invoke(app, ["spec", "rejections", "--all"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert [r["spec_id"] for r in data] == ["dq"]
+    assert data[0]["reason"] == "tighten scope"
+
+
+def test_rejections_all_is_time_sorted_across_specs(configured_app_with_task: Path, tmp_path):
+    _apply(tmp_path, "dq")
+    _reject("dq", "first")
+    _apply(tmp_path, "other")
+    _reject("other", "second")
+    _apply(tmp_path, "dq")
+    _reject("dq", "third")
+
+    result = runner.invoke(app, ["spec", "rejections", "--all"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert [r["reason"] for r in data] == ["first", "second", "third"]
+    timestamps = [r["timestamp"] for r in data]
+    assert timestamps == sorted(timestamps)

--- a/tests/cli/test_spec_rejections.py
+++ b/tests/cli/test_spec_rejections.py
@@ -1,0 +1,132 @@
+"""Tests for #447: `mship spec rejections [<id>] [--all]`.
+
+Mirrors the `configured_app_with_task` real-container pattern used by the
+request-changes tests in test_spec.py (rejections are recorded via
+`record_rejection`, called from `spec request-changes`).
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.spec_store import SpecStore
+from mship.core.state import StateManager, Task, WorkspaceState
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def configured_app_with_task(workspace: Path):
+    state_dir = workspace / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    container.config.reset()
+    container.state_manager.reset()
+    container.log_manager.reset()
+    container.config_path.override(workspace / "mothership.yaml")
+    container.state_dir.override(state_dir)
+
+    mgr = StateManager(state_dir)
+    task = Task(
+        slug="add-labels",
+        description="Add labels to tasks",
+        phase="plan",
+        created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        affected_repos=["shared", "auth-service"],
+        branch="feat/add-labels",
+    )
+    mgr.save(WorkspaceState(tasks={"add-labels": task}))
+
+    yield workspace
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override()
+    container.config.reset()
+    container.state_manager.reset_override()
+    container.state_manager.reset()
+    container.log_manager.reset()
+
+
+def _store(workspace: Path) -> SpecStore:
+    return SpecStore(workspace / "specs")
+
+
+def _draft_json() -> str:
+    return json.dumps({
+        "problem": "P", "user_story": "U", "approach": "A",
+        "acceptance_criteria": ["view questions"], "open_questions": ["Android?"],
+        "non_goals": ["chat"], "risks": [], "affected_repos": ["mothership"],
+    })
+
+
+def _apply(tmp_path: Path, spec_id: str):
+    runner.invoke(app, ["spec", "new", "--title", "Decision queue", "--id", spec_id])
+    jf = tmp_path / f"{spec_id}-draft.json"
+    jf.write_text(_draft_json())
+    runner.invoke(app, ["spec", "apply", spec_id, "--from-json", str(jf)])
+
+
+def _reject(spec_id: str, reason: str):
+    return runner.invoke(app, ["spec", "request-changes", spec_id, "--reason", reason])
+
+
+def test_rejections_lists_records_for_a_spec(configured_app_with_task: Path, tmp_path):
+    _apply(tmp_path, "dq")
+    _reject("dq", "tighten scope")
+    _apply(tmp_path, "dq")  # back to needs_review so a 2nd reject is legal
+    _reject("dq", "still too broad")
+
+    result = runner.invoke(app, ["spec", "rejections", "dq"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert [r["reason"] for r in data] == ["tighten scope", "still too broad"]
+    for r in data:
+        assert "actor" in r
+        assert "timestamp" in r
+    # chronological
+    timestamps = [r["timestamp"] for r in data]
+    assert timestamps == sorted(timestamps)
+
+
+def test_rejections_all_aggregates_across_specs(configured_app_with_task: Path, tmp_path):
+    _apply(tmp_path, "dq")
+    _reject("dq", "tighten scope")
+    _apply(tmp_path, "other")
+    _reject("other", "wrong approach")
+
+    result = runner.invoke(app, ["spec", "rejections", "--all"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert len(data) == 2
+    spec_ids = {r["spec_id"] for r in data}
+    assert spec_ids == {"dq", "other"}
+    reasons = {r["reason"] for r in data}
+    assert reasons == {"tighten scope", "wrong approach"}
+
+
+def test_rejections_skips_malformed_entry(configured_app_with_task: Path, tmp_path):
+    _apply(tmp_path, "dq")
+    _reject("dq", "tighten scope")
+
+    # Hand-write a malformed action=rejected entry directly onto the log.
+    log_manager = container.log_manager()
+    log_manager.append("dq", "not json at all", action="rejected")
+
+    result = runner.invoke(app, ["spec", "rejections", "dq"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    # only the well-formed entry survives
+    assert len(data) == 1
+    assert data[0]["reason"] == "tighten scope"
+
+
+def test_rejections_no_id_and_no_all_errors(configured_app_with_task: Path):
+    result = runner.invoke(app, ["spec", "rejections"])
+    assert result.exit_code != 0

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
 from pathlib import Path
+
+import pytest
 from fastapi.testclient import TestClient
 
 from mship.core.message_store import MessageStore
@@ -461,6 +463,35 @@ def test_post_request_changes_records_durable_rejection(tmp_path):
     assert len(rejected) == 1
     payload = json.loads(rejected[0].message)
     assert payload == {"actor": "operator", "reason": "tighten scope"}
+
+
+def test_post_request_changes_fails_loud_when_journal_write_fails(tmp_path, monkeypatch):
+    """#447 review: a durable-write failure must propagate (not be swallowed)
+    and must leave the spec's status untouched — record-then-transition
+    ordering means a failed append happens before the spec ever flips to
+    draft, so the operator sees a real error and can retry cleanly."""
+    import mship.core.serve as serve_mod
+
+    _seed_spec(tmp_path)
+    log = LogManager(tmp_path / ".mothership" / "logs")
+    client = TestClient(_app_with(tmp_path, StateManager(tmp_path / ".mothership"), log))
+
+    def _boom(*a, **kw):
+        raise OSError("disk full")
+    monkeypatch.setattr(serve_mod, "record_rejection", _boom)
+
+    with pytest.raises(OSError):
+        client.post("/specs/dq/request-changes", json={"reason": "tighten scope"})
+
+    assert SpecStore(tmp_path / "specs").find_by_id("dq").status == "needs_review"
+
+
+def test_post_request_changes_rejects_empty_reason(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    r = client.post("/specs/dq/request-changes", json={"reason": "   "})
+    assert r.status_code == 400
+    assert SpecStore(tmp_path / "specs").find_by_id("dq").status == "needs_review"
 
 
 def test_get_review_includes_clarification_reason(tmp_path):

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -470,7 +470,7 @@ def test_post_request_changes_fails_loud_when_journal_write_fails(tmp_path, monk
     and must leave the spec's status untouched — record-then-transition
     ordering means a failed append happens before the spec ever flips to
     draft, so the operator sees a real error and can retry cleanly."""
-    import mship.core.serve as serve_mod
+    import mship.core.spec_transition as st
 
     _seed_spec(tmp_path)
     log = LogManager(tmp_path / ".mothership" / "logs")
@@ -478,7 +478,7 @@ def test_post_request_changes_fails_loud_when_journal_write_fails(tmp_path, monk
 
     def _boom(*a, **kw):
         raise OSError("disk full")
-    monkeypatch.setattr(serve_mod, "record_rejection", _boom)
+    monkeypatch.setattr(st, "record_rejection", _boom)
 
     with pytest.raises(OSError):
         client.post("/specs/dq/request-changes", json={"reason": "tighten scope"})

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -445,6 +445,24 @@ def test_post_request_changes_persists_reason(tmp_path):
     assert client.get("/specs/dq").json()["clarification_reason"] == "tighten scope"
 
 
+def test_post_request_changes_records_durable_rejection(tmp_path):
+    """#447: the serve request-changes handler must also append a durable,
+    append-only `rejected` journal event (actor="operator"), independent of
+    `clarification_reason` on the spec (which approve_spec later nulls)."""
+    import json
+
+    _seed_spec(tmp_path)
+    log = LogManager(tmp_path / ".mothership" / "logs")
+    client = TestClient(_app_with(tmp_path, StateManager(tmp_path / ".mothership"), log))
+    r = client.post("/specs/dq/request-changes", json={"reason": "tighten scope"})
+    assert r.status_code == 200
+
+    rejected = [e for e in log.read("dq") if e.action == "rejected"]
+    assert len(rejected) == 1
+    payload = json.loads(rejected[0].message)
+    assert payload == {"actor": "operator", "reason": "tighten scope"}
+
+
 def test_get_review_includes_clarification_reason(tmp_path):
     _seed_spec(tmp_path)
     client = TestClient(_app(tmp_path))

--- a/tests/core/test_spec_rejection_record.py
+++ b/tests/core/test_spec_rejection_record.py
@@ -4,6 +4,8 @@ approve_spec() nulling clarification_reason on the spec itself."""
 import json
 from datetime import datetime, timezone
 
+import pytest
+
 from mship.core.log import LogManager
 from mship.core.spec_transition import record_rejection
 
@@ -29,3 +31,15 @@ def test_rejection_entry_survives_later_appends(tmp_path):
     )
     lm.append("spec-1", "spec approved", action="approved")
     assert [e for e in lm.read("spec-1") if e.action == "rejected"]
+
+
+@pytest.mark.parametrize("reason", ["", "   ", "\n\t"])
+def test_record_rejection_rejects_empty_reason(tmp_path, reason):
+    """#447 review: every durable record must carry real reason text."""
+    lm = LogManager(tmp_path / ".mothership" / "logs")
+    with pytest.raises(ValueError):
+        record_rejection(
+            lm, "spec-1", actor="alice", reason=reason,
+            now=datetime(2026, 7, 31, tzinfo=timezone.utc),
+        )
+    assert lm.read("spec-1") == []

--- a/tests/core/test_spec_rejection_record.py
+++ b/tests/core/test_spec_rejection_record.py
@@ -1,0 +1,31 @@
+"""record_rejection: a durable, append-only `rejected` journal event written
+at request-changes time (CLI + serve), so a rejection survives a later
+approve_spec() nulling clarification_reason on the spec itself."""
+import json
+from datetime import datetime, timezone
+
+from mship.core.log import LogManager
+from mship.core.spec_transition import record_rejection
+
+
+def test_record_rejection_writes_durable_rejected_entry(tmp_path):
+    lm = LogManager(tmp_path / ".mothership" / "logs")
+    record_rejection(
+        lm, "spec-1", actor="alice", reason="metarepo not considered",
+        now=datetime(2026, 7, 31, tzinfo=timezone.utc),
+    )
+    entries = [e for e in lm.read("spec-1") if e.action == "rejected"]
+    assert len(entries) == 1
+    payload = json.loads(entries[0].message)
+    assert payload == {"actor": "alice", "reason": "metarepo not considered"}
+
+
+def test_rejection_entry_survives_later_appends(tmp_path):
+    """Append-only: a later entry (e.g. a re-approval note) does not erase it."""
+    lm = LogManager(tmp_path / ".mothership" / "logs")
+    record_rejection(
+        lm, "spec-1", actor="alice", reason="r1",
+        now=datetime(2026, 7, 31, tzinfo=timezone.utc),
+    )
+    lm.append("spec-1", "spec approved", action="approved")
+    assert [e for e in lm.read("spec-1") if e.action == "rejected"]

--- a/tests/core/test_spec_transition.py
+++ b/tests/core/test_spec_transition.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
+import json
 from datetime import datetime, timezone
 
 import pytest
 
+from mship.core.log import LogManager
 from mship.core.spec import AcceptanceCriterion, InvalidTransition, OpenQuestion, Spec
 from mship.core.spec_store import SpecStore
 from mship.core.spec_transition import ApprovalBlocked, approve_spec, request_changes_spec
@@ -46,10 +48,37 @@ def test_request_changes_sends_to_draft_with_reason(tmp_path):
     store = SpecStore(tmp_path / "specs")
     spec = _reviewable()
     store.save(spec)
-    request_changes_spec(spec, store, "tighten AC2")
+    log = LogManager(tmp_path / "logs")
+    request_changes_spec(spec, store, "tighten AC2", log_manager=log, actor="alice")
     reloaded = store.find_by_id("s1")
     assert reloaded.status == "draft"
     assert reloaded.clarification_reason == "tighten AC2"
+
+
+def test_request_changes_records_durable_rejection(tmp_path):
+    """P1 (#458): the durable rejection record must be written by
+    `request_changes_spec` itself, so every caller (CLI/serve/view) gets it
+    automatically instead of remembering a separate `record_rejection` call."""
+    store = SpecStore(tmp_path / "specs")
+    spec = _reviewable()
+    store.save(spec)
+    log = LogManager(tmp_path / "logs")
+    request_changes_spec(spec, store, "tighten AC2", log_manager=log, actor="alice")
+    rejected = [e for e in log.read("s1") if e.action == "rejected"]
+    assert len(rejected) == 1
+    payload = json.loads(rejected[0].message)
+    assert payload == {"actor": "alice", "reason": "tighten AC2"}
+
+
+def test_request_changes_rejects_empty_reason_before_any_write(tmp_path):
+    store = SpecStore(tmp_path / "specs")
+    spec = _reviewable()
+    store.save(spec)
+    log = LogManager(tmp_path / "logs")
+    with pytest.raises(ValueError):
+        request_changes_spec(spec, store, "   ", log_manager=log, actor="alice")
+    assert store.find_by_id("s1").status == "needs_review"
+    assert log.read("s1") == []
 
 
 def test_approve_illegal_status_raises_invalid_transition(tmp_path):

--- a/tests/core/view/test_actions.py
+++ b/tests/core/view/test_actions.py
@@ -52,3 +52,24 @@ def test_missing_spec_is_safe(tmp_path):
     store = SpecStore(tmp_path / "specs")
     assert not approve_spec_by_id(store, "nope").ok
     assert not approve_spec_by_id(store, None).ok
+
+
+def test_request_changes_by_id_writes_durable_rejection_record(tmp_path):
+    """P1 (#458): the TUI request-changes path (`mship view queue/spec/
+    workitem`) must record a durable rejection just like CLI/serve — before
+    this fix, `request_changes_by_id` transitioned the spec without ever
+    calling `record_rejection`, silently dropping a whole rejection path
+    from the journal."""
+    import json
+
+    from mship.core.log import LogManager
+
+    store = _store(tmp_path)
+    out = request_changes_by_id(store, "s1", "tighten AC2")
+    assert out.ok and out.new_status == "draft"
+
+    log = LogManager(tmp_path / ".mothership" / "logs")
+    rejected = [e for e in log.read("s1") if e.action == "rejected"]
+    assert len(rejected) == 1
+    payload = json.loads(rejected[0].message)
+    assert payload == {"actor": "operator", "reason": "tighten AC2"}


### PR DESCRIPTION
**Durable, queryable spec rejections (#447) — substrate for #444 Wave 4 / L5.**

## Problem

`mship spec request-changes` required a reason but stored it only in `spec.clarification_reason`, which `approve_spec()` **nulls on re-approval** — so rejection history was erased and unqueryable. That blocks the L5 rejection→row ratchet (it needs a durable rejection event to turn into an assumption row) and starved the #444 backtest (no real rejected plans).

## What this PR delivers

- **Durable, append-only rejection record.** At `request-changes` — both the CLI and the serve HTTP path — a journal entry with `action="rejected"` carrying `{actor, reason}` (JSON) is written, keyed by spec id. Because the journal is append-only, it **survives re-approval** (unlike `clarification_reason`). Actor = host `USER` (CLI) / `"operator"` (serve). No new store, no new `Spec` field.
- **Fail-loud, consistent ordering.** The durable record is written **before** the status transition and its failure propagates (not swallowed) — so a journal-write failure leaves the spec un-flipped and retryable rather than a `draft`-without-record. Empty/whitespace reasons are rejected at both paths.
- **Query:** `mship spec rejections <id>` (that spec's rejections) and `--all` (scans the log files via `LogManager.list_slugs()`, so a **deleted** spec's rejections still surface — the point of a durable record — sorted chronologically). Malformed/legacy entries are skipped, never fatal.

## Acceptance criteria (all covered by tests)

- ac1/ac2 — durable `{spec_id, actor, reason, timestamp}` record surviving re-approval, both CLI + serve.
- ac3 — reason required (empty rejected) at rejection time.
- ac4/ac5 — `rejections <id>` + `--all` enumeration (incl. deleted-spec via log-glob).
- ac6 — malformed entry skipped, not fatal.

## Scope

Spec-only — there is no plan-review/reject lifecycle in the codebase, so plan rejection is out of scope. Non-goals: the L5 ratchet itself (#444 Wave 4, this only lays substrate) and backfilling history.

## Review

Built subagent-driven; whole-branch (opus) review caught that the durable write was best-effort (swallowed) — fixed to fail-loud + record-before-transition. Scoped re-review clean (one accepted note: the inverse `store.save`-fails-after-record case fails *loud* and is rare; record-first is correct because transition-first would reintroduce the silent lost-record bug). Full `mship test` green.
