### PR TITLE
product_assumptions Wave 3c: GET /plan-assumptions list endpoint + Ground Control Queue card (deep-links to 3b Task Detail). Build from docs/plans/2026-07-31-productassumptions-wave-3c.md

### DIFF
--- a/src/mship/core/plan_check.py
+++ b/src/mship/core/plan_check.py
@@ -269,3 +269,11 @@ class PlanCheckStore:
         if not path.is_file():
             return None
         return PlanCheckResult.model_validate_json(path.read_text())
+
+    def list_slugs(self) -> list[str]:
+        """Task slugs with a stored plan-check (`<dir>/*.json` stems). Empty when the
+        dir doesn't exist. Lets the serve list endpoint enumerate without reaching
+        into the private dir."""
+        if not self._dir.is_dir():
+            return []
+        return sorted(p.stem for p in self._dir.glob("*.json"))

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -677,6 +677,19 @@ def create_app(
             raise HTTPException(status_code=404, detail=f"no task {slug!r}")
         return jsonable_encoder(log_manager.read(slug, last=50))
 
+    def _task_assumption_summary(slug: str, stored, rows, docs_dir: str, state) -> dict:
+        """`{task, fresh, pending}` for one stored `PlanCheckResult` — the freshness
+        contract shared by the per-task envelope and the fleet-wide list endpoint
+        (SAME plan_hash + assumptions_hash comparison as the gate + CLI, so `fresh`
+        here agrees with the gate; Wave 3a review, Greptile #451)."""
+        from mship.core.plan import effective_plan_path
+        from mship.core.plan_check import is_fresh
+
+        plan_path = effective_plan_path(state.tasks[slug], workspace_root, docs_dir)
+        fresh = plan_path is not None and is_fresh(stored, plan_path.read_text(), rows)
+        pending = sum(1 for f in stored.flags if not f.approved)
+        return {"task": slug, "fresh": fresh, "pending": pending}
+
     def _plan_assumptions_envelope(slug: str) -> dict:
         """Shared envelope builder for GET and POST /plan-assumptions/{slug} —
         same shape `mship plan assumptions status` prints
@@ -686,8 +699,7 @@ def create_app(
         `docs/plans/`, not a task worktree). Caller is responsible for the
         404-on-unknown-task check before calling this."""
         from mship.core.assumptions import AssumptionStore, resolve_mode
-        from mship.core.plan import effective_plan_path
-        from mship.core.plan_check import PlanCheckStore, is_fresh
+        from mship.core.plan_check import PlanCheckStore
 
         state = state_manager.load()
         docs_dir = getattr(config, "docs_dir", "docs") if config is not None else "docs"
@@ -696,21 +708,36 @@ def create_app(
         if stored is None:
             return {"task": slug, "fresh": False, "pending": 0, "flags": []}
 
-        # SAME freshness contract as the gate + CLI (plan_hash AND assumptions_hash,
-        # same plan resolution) so `fresh` here agrees with the gate (Wave 3a
-        # review; Greptile #451 assumption-set staleness).
-        plan_path = effective_plan_path(state.tasks[slug], workspace_root, docs_dir)
         rows = AssumptionStore(
             workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root)
         ).load()
-        fresh = plan_path is not None and is_fresh(stored, plan_path.read_text(), rows)
-        pending = sum(1 for f in stored.flags if not f.approved)
-        return {
-            "task": slug,
-            "fresh": fresh,
-            "pending": pending,
-            "flags": [f.model_dump() for f in stored.flags],
-        }
+        summary = _task_assumption_summary(slug, stored, rows, docs_dir, state)
+        return {**summary, "flags": [f.model_dump() for f in stored.flags]}
+
+    @app.get("/plan-assumptions")
+    def list_plan_assumptions():
+        """Fleet-wide pending-flags summary — one row per task with a stored
+        plan-check, reusing the same freshness/pending computation as the
+        per-task envelope. `rows` (the workspace assumption set) is loaded
+        once for the whole list, not per task."""
+        from mship.core.assumptions import AssumptionStore, resolve_mode
+        from mship.core.plan_check import PlanCheckStore
+
+        state = state_manager.load()
+        docs_dir = getattr(config, "docs_dir", "docs") if config is not None else "docs"
+        rows = AssumptionStore(
+            workspace_root, docs_dir=docs_dir, mode=resolve_mode(workspace_root)
+        ).load()
+        pcstore = PlanCheckStore(workspace_root / ".mothership")
+        out = []
+        for slug in pcstore.list_slugs():
+            if slug not in state.tasks:
+                continue
+            stored = pcstore.get(slug)
+            if stored is None:
+                continue
+            out.append(_task_assumption_summary(slug, stored, rows, docs_dir, state))
+        return out
 
     @app.get("/plan-assumptions/{slug}")
     def get_plan_assumptions(slug: str):

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -736,7 +736,17 @@ def create_app(
             stored = pcstore.get(slug)
             if stored is None:
                 continue
-            out.append(_task_assumption_summary(slug, stored, rows, docs_dir, state))
+            try:
+                out.append(_task_assumption_summary(slug, stored, rows, docs_dir, state))
+            except (OSError, UnicodeDecodeError):
+                # This task's plan went missing/unreadable between the check
+                # being recorded and this read (e.g. pruned by `mship close`
+                # while the stored plan-check lingered). Skip just this task
+                # rather than 500-ing the whole fleet list (Greptile P1,
+                # Wave 3c) — the per-task GET/POST endpoints already 404/degrade
+                # this case for a single task; the list must not let one bad
+                # task blank the Queue cards for every other task.
+                continue
         return out
 
     @app.get("/plan-assumptions/{slug}")

--- a/tests/core/test_plan_check.py
+++ b/tests/core/test_plan_check.py
@@ -104,6 +104,17 @@ def test_plan_check_store_rejects_path_traversal_slug(tmp_path):
             store.get(bad)
 
 
+def test_list_slugs_returns_stored_task_slugs(tmp_path):
+    store = PlanCheckStore(tmp_path)
+    store.save(PlanCheckResult(task_slug="a", plan_hash="h", assumptions_hash="x", verdicts=[], flags=[]))
+    store.save(PlanCheckResult(task_slug="b", plan_hash="h", assumptions_hash="x", verdicts=[], flags=[]))
+    assert sorted(store.list_slugs()) == ["a", "b"]
+
+
+def test_list_slugs_empty_when_no_dir(tmp_path):
+    assert PlanCheckStore(tmp_path / "nope").list_slugs() == []
+
+
 def _repo_topology_row() -> AssumptionRow:
     return AssumptionRow(
         axis="repo topology",

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -170,6 +170,22 @@ def test_post_plan_assumptions_approve_marks_flag_and_returns_envelope(tmp_path)
     assert flag["approved_reason"] == "ok"
 
 
+def test_get_plan_assumptions_list_returns_pending_per_task(tmp_path):
+    from mship.core.assumptions import AssumptionStore
+    from mship.core.plan_check import Flag, PlanCheckResult, PlanCheckStore, assumptions_hash, plan_hash
+    sm, log = _seed_task(tmp_path)          # task "dq"
+    rows = AssumptionStore(tmp_path).seed()
+    plan_path = _write_plan(tmp_path, "2026-07-30-dq.md", "# Plan\n\nBody.\n")
+    PlanCheckStore(tmp_path / ".mothership").save(PlanCheckResult(
+        task_slug="dq", plan_hash=plan_hash(plan_path.read_text()),
+        assumptions_hash=assumptions_hash(rows), verdicts=[],
+        flags=[Flag(axis="repo topology", source="checker", reason="gap")]))
+    client = TestClient(_app_with(tmp_path, sm, log))
+    body = client.get("/plan-assumptions").json()
+    row = next(r for r in body if r["task"] == "dq")
+    assert row["pending"] == 1 and row["fresh"] is True
+
+
 def test_post_plan_assumptions_approve_unknown_axis_404(tmp_path):
     from mship.core.assumptions import AssumptionStore
     from mship.core.plan_check import (

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -186,6 +186,59 @@ def test_get_plan_assumptions_list_returns_pending_per_task(tmp_path):
     assert row["pending"] == 1 and row["fresh"] is True
 
 
+def test_get_plan_assumptions_list_tolerates_one_task_unreadable_plan(tmp_path):
+    """A task's plan file can go bad-encoding/unreadable between the stored
+    plan-check lingering and the plan being pruned (e.g. `mship close`) —
+    that task's summary must be skipped, not blow up the WHOLE list (500),
+    which would blank the Queue cards for every other task too (Greptile P1,
+    Wave 3c)."""
+    from mship.core.assumptions import AssumptionStore
+    from mship.core.plan_check import Flag, PlanCheckResult, PlanCheckStore, assumptions_hash, plan_hash
+
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    sm = StateManager(state_dir)
+    sm.save(WorkspaceState(tasks={
+        "dq": Task(slug="dq", description="d", phase="dev",
+                   created_at=datetime(2026, 6, 14, tzinfo=timezone.utc),
+                   affected_repos=["mothership"], branch="feat/dq"),
+        "ok": Task(slug="ok", description="d", phase="dev",
+                   created_at=datetime(2026, 6, 14, tzinfo=timezone.utc),
+                   affected_repos=["mothership"], branch="feat/ok"),
+    }))
+    log = LogManager(state_dir / "logs")
+
+    rows = AssumptionStore(tmp_path).seed()
+
+    # "dq"'s plan file is present but unreadable text (bad encoding) — the
+    # race the finding describes (plan removed/corrupted after the check was
+    # recorded, before the list endpoint reads it).
+    bad_plan = _write_plan(tmp_path, "2026-07-30-dq.md", "placeholder")
+    bad_plan.write_bytes(b"\xff\xfe not valid utf-8")
+    PlanCheckStore(tmp_path / ".mothership").save(PlanCheckResult(
+        task_slug="dq", plan_hash="irrelevant",
+        assumptions_hash=assumptions_hash(rows), verdicts=[],
+        flags=[Flag(axis="repo topology", source="checker", reason="gap")],
+    ))
+
+    # "ok" is a perfectly healthy task with a fresh, readable plan.
+    ok_plan = _write_plan(tmp_path, "2026-07-30-ok.md", "# Plan\n\nBody.\n")
+    PlanCheckStore(tmp_path / ".mothership").save(PlanCheckResult(
+        task_slug="ok", plan_hash=plan_hash(ok_plan.read_text()),
+        assumptions_hash=assumptions_hash(rows), verdicts=[],
+        flags=[Flag(axis="repo topology", source="checker", reason="gap")],
+    ))
+
+    client = TestClient(_app_with(tmp_path, sm, log))
+    r = client.get("/plan-assumptions")
+    assert r.status_code == 200
+    body = r.json()
+    slugs = [row["task"] for row in body]
+    assert "dq" not in slugs
+    row = next(row for row in body if row["task"] == "ok")
+    assert row["pending"] == 1 and row["fresh"] is True
+
+
 def test_post_plan_assumptions_approve_unknown_axis_404(tmp_path):
     from mship.core.assumptions import AssumptionStore
     from mship.core.plan_check import (


### PR DESCRIPTION
**product_assumptions (#444) — Wave 3c / ac6, mothership side (fleet-wide list endpoint).**

Pairs with ground-control#65 (the Queue card). The push/notification half of #454 is **deferred** (GC has no FCM; needs new gate→message-store wiring) — this wave is the pull surface only.

## What this PR delivers

- **`GET /plan-assumptions`** — a list endpoint returning `{task, fresh, pending}` for every task that has a stored plan-check and still exists in state, so Ground Control's Queue can show pending assumptions across *all* tasks in one call (no N+1 over the per-task `GET /plan-assumptions/{slug}`).
- **`PlanCheckStore.list_slugs()`** — enumerates stored plan-checks (`*.json` stems; `[]` when absent) without reaching into the private dir.
- Reuses Wave 3b's exact freshness/pending computation (`is_fresh` + un-approved-flag count), factored into a shared helper so the per-task GET keeps its identical `{task, fresh, pending, flags}` shape; the workspace assumption rows are loaded once for the whole list.

## Acceptance criteria

- **ac6** — the fleet-wide serve surface for the Ground Control flag object.

## Review

Whole-branch (opus) review: contract matches the GC DTO field-for-field; the per-task GET/POST shapes are unchanged by the refactor. Full `mship test` green, both repos.
