### PR TITLE
Fix #455: reconcile reports spurious base_changed by comparing a task's recorded base_branch against the PR's resolved base; and finish's drift gate blocks unrelated tasks. Compare against the RESOLVED base (base_override > repo.base_branch > task default) and scope the gate to the finishing task.

### DIFF
--- a/src/mship/cli/internal.py
+++ b/src/mship/cli/internal.py
@@ -227,7 +227,9 @@ def register(app: typer.Typer, get_container):
                         collect_git_snapshots(worktrees_by_branch),
                     )
 
-                decisions = reconcile_now(state, cache=cache, fetcher=_fetcher)
+                decisions = reconcile_now(
+                    state, cache=cache, fetcher=_fetcher, config=container.config()
+                )
             except Exception:
                 raise typer.Exit(code=0)
 

--- a/src/mship/cli/reconcile.py
+++ b/src/mship/cli/reconcile.py
@@ -42,7 +42,6 @@ def register(app: typer.Typer, get_container):
         output = Output()
         container = get_container()
         state = container.state_manager().load()
-        config = container.config()
         cache = ReconcileCache(container.state_dir())
 
         if clear_ignores:
@@ -63,6 +62,8 @@ def register(app: typer.Typer, get_container):
             else:
                 output.json({"ignored": ignore})
             return
+
+        config = container.config()
 
         if refresh:
             payload = cache.read()

--- a/src/mship/cli/reconcile.py
+++ b/src/mship/cli/reconcile.py
@@ -42,6 +42,7 @@ def register(app: typer.Typer, get_container):
         output = Output()
         container = get_container()
         state = container.state_manager().load()
+        config = container.config()
         cache = ReconcileCache(container.state_dir())
 
         if clear_ignores:
@@ -76,7 +77,7 @@ def register(app: typer.Typer, get_container):
             )
 
         try:
-            decisions = reconcile_now(state, cache=cache, fetcher=_fetcher)
+            decisions = reconcile_now(state, cache=cache, fetcher=_fetcher, config=config)
         except Exception as e:  # noqa: BLE001 — never fail closed
             output.warning(f"reconcile unavailable: {e}")
             decisions = {}

--- a/src/mship/cli/reconcile.py
+++ b/src/mship/cli/reconcile.py
@@ -7,6 +7,7 @@ from typing import Optional
 import typer
 
 from mship.cli.output import Output
+from mship.core.config import ConfigLoader
 from mship.core.reconcile.cache import ReconcileCache
 from mship.core.reconcile.detect import UpstreamState
 from mship.core.reconcile.fetch import (
@@ -63,7 +64,7 @@ def register(app: typer.Typer, get_container):
                 output.json({"ignored": ignore})
             return
 
-        config = container.config()
+        config = ConfigLoader.load(container.config_path(), require_paths=False)
 
         if refresh:
             payload = cache.read()

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -29,8 +29,14 @@ def _run_gate(
     command: str,  # "spawn" | "finish" | "close" | "precommit"
     bypass: bool,
     output,
+    only_slug: str | None = None,
 ) -> None:
-    """Run the upstream reconciler; exit(1) on block, print warnings on warn."""
+    """Run the upstream reconciler; exit(1) on block, print warnings on warn.
+
+    `only_slug`, when given, scopes the gate to that single task — drift on
+    an unrelated task must not block this one (#455 Part 2; mirrors the
+    per-task scoping the precommit gate in cli/internal.py already does).
+    """
     if bypass:
         return
     from mship.core.reconcile.cache import ReconcileCache
@@ -41,6 +47,7 @@ def _run_gate(
 
     container = get_container()
     state = container.state_manager().load()
+    config = container.config()
     cache = ReconcileCache(container.state_dir())
 
     def _fetcher(branches, worktrees_by_branch):
@@ -50,10 +57,13 @@ def _run_gate(
         )
 
     try:
-        decisions = reconcile_now(state, cache=cache, fetcher=_fetcher)
+        decisions = reconcile_now(state, cache=cache, fetcher=_fetcher, config=config)
     except Exception as e:  # noqa: BLE001 — never fail closed
         output.warning(f"reconcile unavailable: {e}; proceeding")
         return
+
+    if only_slug is not None:
+        decisions = {slug: d for slug, d in decisions.items() if slug == only_slug}
 
     ignored = cache.read_ignores()
     blockers: list[str] = []
@@ -96,7 +106,9 @@ def _dependency_decisions(state):
         def _fetcher(branches, worktrees_by_branch):
             return (fetch_pr_snapshots(branches), collect_git_snapshots(worktrees_by_branch))
 
-        return reconcile_now(state, cache=cache, fetcher=_fetcher)
+        return reconcile_now(
+            state, cache=cache, fetcher=_fetcher, config=_container_singleton.config()
+        )
     except Exception:
         return {}
 
@@ -1176,7 +1188,6 @@ def register(app: typer.Typer, get_container):
 
         container = get_container()
         output = Output()
-        _run_gate(get_container, command="finish", bypass=bypass_reconcile, output=output)
 
         if require_tests:
             output.warning(
@@ -1255,6 +1266,13 @@ def register(app: typer.Typer, get_container):
         resolved_finish = resolve_for_command("finish", state, task, output)
         t = resolved_finish.task
         task = t
+
+        # Scoped to this task only — drift on another, unrelated task must not
+        # block this one's finish (#455 Part 2).
+        _run_gate(
+            get_container, command="finish", bypass=bypass_reconcile, output=output,
+            only_slug=t.slug,
+        )
 
         # --- WorkItem gate: every task must be linked to a WorkItem, and a
         # feature-kind WorkItem additionally needs an approved spec AND a valid

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -30,6 +30,8 @@ def _run_gate(
     bypass: bool,
     output,
     only_slug: str | None = None,
+    cli_base: str | None = None,
+    base_map: dict[str, str] | None = None,
 ) -> None:
     """Run the upstream reconciler; exit(1) on block, print warnings on warn.
 
@@ -57,7 +59,18 @@ def _run_gate(
         )
 
     try:
-        decisions = reconcile_now(state, cache=cache, fetcher=_fetcher, config=config)
+        base_inputs = (
+            {only_slug: (cli_base, base_map or {})}
+            if only_slug is not None
+            else None
+        )
+        decisions = reconcile_now(
+            state,
+            cache=cache,
+            fetcher=_fetcher,
+            config=config,
+            base_inputs_by_slug=base_inputs,
+        )
     except Exception as e:  # noqa: BLE001 — never fail closed
         output.warning(f"reconcile unavailable: {e}; proceeding")
         return
@@ -1260,6 +1273,18 @@ def register(app: typer.Typer, get_container):
             output.error(str(e))
             raise typer.Exit(code=1)
 
+        from mship.core.base_resolver import (
+            InvalidBaseMapError,
+            UnknownRepoInBaseMapError,
+            parse_base_map,
+            resolve_base,
+        )
+        try:
+            parsed_map = parse_base_map(base_map or "")
+        except InvalidBaseMapError as e:
+            output.error(str(e))
+            raise typer.Exit(code=1)
+
         state_mgr = container.state_manager()
         state = state_mgr.load()
 
@@ -1271,7 +1296,7 @@ def register(app: typer.Typer, get_container):
         # block this one's finish (#455 Part 2).
         _run_gate(
             get_container, command="finish", bypass=bypass_reconcile, output=output,
-            only_slug=t.slug,
+            only_slug=t.slug, cli_base=base, base_map=parsed_map,
         )
 
         # --- WorkItem gate: every task must be linked to a WorkItem, and a
@@ -1517,18 +1542,6 @@ def register(app: typer.Typer, get_container):
         # else: a token is present; the httpx PR path covers gh absence.
 
         # --- Resolve + verify PR base branches up front ---
-        from mship.core.base_resolver import (
-            parse_base_map,
-            resolve_base,
-            InvalidBaseMapError,
-            UnknownRepoInBaseMapError,
-        )
-
-        try:
-            parsed_map = parse_base_map(base_map or "")
-        except InvalidBaseMapError as e:
-            output.error(str(e))
-            raise typer.Exit(code=1)
 
         try:
             effective_bases = {

--- a/src/mship/core/context.py
+++ b/src/mship/core/context.py
@@ -20,7 +20,8 @@ from mship.core.base_resolver import resolve_base
 from mship.core.config import WorkspaceConfig
 from mship.core.dispatch_models import BUILTIN_MODEL_DEFAULTS, resolve_model
 from mship.core.log import LogManager
-from mship.core.reconcile.cache import ReconcileCache
+from mship.core.reconcile.cache import CachePayload, ReconcileCache
+from mship.core.reconcile.gate import resolve_task_bases
 from mship.core.state import Task, WorkspaceState
 from mship.core.workspace_meta import read_last_sync_at
 
@@ -257,10 +258,7 @@ def _binary_matches_editable_install() -> Optional[bool]:
         return False
 
 
-def _drift_for_task(slug: str, cache: Optional[ReconcileCache]) -> str:
-    if cache is None:
-        return "unknown"
-    payload = cache.read()
+def _drift_for_task(slug: str, payload: Optional[CachePayload]) -> str:
     if payload is None:
         return "unknown"
     raw = payload.results.get(slug)
@@ -321,7 +319,7 @@ def _task_payload(
     task: Task,
     log_manager: LogManager,
     git_count: GitCounter,
-    cache: Optional[ReconcileCache],
+    drift_payload: Optional[CachePayload],
     config: WorkspaceConfig,
 ) -> dict[str, Any]:
     last_test_state, last_test_iteration = _last_test_summary(task)
@@ -367,7 +365,7 @@ def _task_payload(
         "last_test_state": last_test_state,
         "last_test_iteration": last_test_iteration,
         "last_log_entry_at": _last_log_at(log_manager, task.slug),
-        "drift": _drift_for_task(task.slug, cache),
+        "drift": _drift_for_task(task.slug, drift_payload),
     }
 
 
@@ -400,8 +398,17 @@ def build_context(
     """
     audience = build_audience_block(for_, kind)
 
+    drift_payload: Optional[CachePayload] = None
+    if cache is not None:
+        resolved_bases = resolve_task_bases(state, config)
+        base_context = {
+            slug: sorted(bases) if bases is not None else None
+            for slug, bases in resolved_bases.items()
+        }
+        drift_payload = cache.current(cache.read(), base_context=base_context)
+
     active_tasks = [
-        _task_payload(task, log_manager, git_count, cache, config)
+        _task_payload(task, log_manager, git_count, drift_payload, config)
         for task in state.tasks.values()
         if task.finished_at is None
     ]

--- a/src/mship/core/reconcile/cache.py
+++ b/src/mship/core/reconcile/cache.py
@@ -82,6 +82,28 @@ class ReconcileCache:
             return False
         return (time.time() - payload.fetched_at) < payload.ttl_seconds
 
+    def current(self, payload: CachePayload | None) -> CachePayload | None:
+        """The single load-boundary schema gate: treat a schema-mismatched
+        entry as absent (a cache miss) for every results-consuming reader.
+
+        Callers must run a `read()` result through this once, immediately
+        after loading it, and branch on ITS return value from then on — not
+        re-inspect the raw payload. Without this, each results-consuming path
+        has to remember its own schema check; `reconcile_now`'s fetch-error
+        fallback forgot to (#461 follow-up, was P1 "Invalid cache survives
+        fallback", cache.py:82) and served a pre-v2 spurious base_changed on
+        a live-fetch failure. Gating once, at load, makes that class of bug
+        structurally impossible: a schema-invalid entry never reaches any
+        downstream reader to be forgotten about in the first place.
+
+        Deliberately schema-only, not TTL — the fetch-error fallback serves a
+        TTL-stale-but-schema-valid entry on purpose (better than nothing);
+        only `is_fresh()` enforces TTL for the normal path.
+        """
+        if payload is None or payload.schema_version != SCHEMA_VERSION:
+            return None
+        return payload
+
     # --- ignore list ---
 
     def read_ignores(self) -> list[str]:

--- a/src/mship/core/reconcile/cache.py
+++ b/src/mship/core/reconcile/cache.py
@@ -10,6 +10,12 @@ from pathlib import Path
 CACHE_FILENAME = "reconcile.cache.json"
 DEFAULT_TTL_SECONDS = 300
 
+# Bump whenever the *logic that produces `results`* changes (e.g. #461's
+# per-repo base resolution) so an already-cached, TTL-fresh entry computed
+# under the old logic is treated as a miss and recomputed, instead of being
+# served stale until the TTL lapses or a manual refresh (#461 follow-up).
+SCHEMA_VERSION = 2
+
 
 @dataclass
 class CachePayload:
@@ -17,6 +23,7 @@ class CachePayload:
     ttl_seconds: int
     results: dict[str, dict]
     ignored: list[str] = field(default_factory=list)
+    schema_version: int = SCHEMA_VERSION
 
 
 class ReconcileCache:
@@ -39,6 +46,10 @@ class ReconcileCache:
                 ttl_seconds=int(data.get("ttl_seconds", DEFAULT_TTL_SECONDS)),
                 results=dict(data.get("results", {})),
                 ignored=list(data.get("ignored", [])),
+                # Entries written before this field existed have no "schema_version"
+                # key; default to 0 so they never collide with a real SCHEMA_VERSION
+                # and are correctly treated as stale by is_fresh().
+                schema_version=int(data.get("schema_version", 0)),
             )
         except (KeyError, TypeError, ValueError):
             return None
@@ -50,12 +61,17 @@ class ReconcileCache:
             "ttl_seconds": payload.ttl_seconds,
             "results": payload.results,
             "ignored": payload.ignored,
+            # Always stamp the current version: `write()` is only ever called with
+            # freshly-computed `results`, never with a re-serialized old payload.
+            "schema_version": SCHEMA_VERSION,
         }
         tmp = self._path.with_suffix(".tmp")
         tmp.write_text(json.dumps(body, indent=2))
         tmp.replace(self._path)
 
     def is_fresh(self, payload: CachePayload) -> bool:
+        if payload.schema_version != SCHEMA_VERSION:
+            return False
         return (time.time() - payload.fetched_at) < payload.ttl_seconds
 
     # --- ignore list ---

--- a/src/mship/core/reconcile/cache.py
+++ b/src/mship/core/reconcile/cache.py
@@ -24,6 +24,7 @@ class CachePayload:
     results: dict[str, dict]
     ignored: list[str] = field(default_factory=list)
     schema_version: int = SCHEMA_VERSION
+    base_context: dict[str, list[str] | None] | None = None
 
 
 class ReconcileCache:
@@ -40,12 +41,31 @@ class ReconcileCache:
             data = json.loads(self._path.read_text())
         except (OSError, json.JSONDecodeError):
             return None
+        if not isinstance(data, dict):
+            return None
+        base_context = data.get("base_context")
+        if base_context is not None and (
+            not isinstance(base_context, dict)
+            or not all(
+                isinstance(slug, str)
+                and (
+                    bases is None
+                    or (
+                        isinstance(bases, list)
+                        and all(isinstance(base, str) for base in bases)
+                    )
+                )
+                for slug, bases in base_context.items()
+            )
+        ):
+            return None
         try:
             return CachePayload(
                 fetched_at=float(data["fetched_at"]),
                 ttl_seconds=int(data.get("ttl_seconds", DEFAULT_TTL_SECONDS)),
                 results=dict(data.get("results", {})),
                 ignored=list(data.get("ignored", [])),
+                base_context=base_context,
                 # Entries written before this field existed have no "schema_version"
                 # key; default to 0 so they never collide with a real SCHEMA_VERSION
                 # and are correctly treated as stale by is_fresh().
@@ -61,6 +81,7 @@ class ReconcileCache:
             "ttl_seconds": payload.ttl_seconds,
             "results": payload.results,
             "ignored": payload.ignored,
+            "base_context": payload.base_context,
             # Preserve the payload's own schema_version rather than always stamping
             # the current constant. Freshly-computed results are built with a bare
             # CachePayload(...), which defaults schema_version to the current
@@ -82,25 +103,22 @@ class ReconcileCache:
             return False
         return (time.time() - payload.fetched_at) < payload.ttl_seconds
 
-    def current(self, payload: CachePayload | None) -> CachePayload | None:
-        """The single load-boundary schema gate: treat a schema-mismatched
-        entry as absent (a cache miss) for every results-consuming reader.
+    def current(
+        self,
+        payload: CachePayload | None,
+        *,
+        base_context: dict[str, list[str] | None],
+    ) -> CachePayload | None:
+        """Drop results produced under another schema or resolved-base context.
 
-        Callers must run a `read()` result through this once, immediately
-        after loading it, and branch on ITS return value from then on — not
-        re-inspect the raw payload. Without this, each results-consuming path
-        has to remember its own schema check; `reconcile_now`'s fetch-error
-        fallback forgot to (#461 follow-up, was P1 "Invalid cache survives
-        fallback", cache.py:82) and served a pre-v2 spurious base_changed on
-        a live-fetch failure. Gating once, at load, makes that class of bug
-        structurally impossible: a schema-invalid entry never reaches any
-        downstream reader to be forgotten about in the first place.
-
-        Deliberately schema-only, not TTL — the fetch-error fallback serves a
-        TTL-stale-but-schema-valid entry on purpose (better than nothing);
-        only `is_fresh()` enforces TTL for the normal path.
+        This is deliberately not a TTL gate: fetch failures may fall back to a
+        TTL-stale entry, but only when its schema and base context are compatible.
         """
-        if payload is None or payload.schema_version != SCHEMA_VERSION:
+        if (
+            payload is None
+            or payload.schema_version != SCHEMA_VERSION
+            or payload.base_context != base_context
+        ):
             return None
         return payload
 

--- a/src/mship/core/reconcile/cache.py
+++ b/src/mship/core/reconcile/cache.py
@@ -61,9 +61,17 @@ class ReconcileCache:
             "ttl_seconds": payload.ttl_seconds,
             "results": payload.results,
             "ignored": payload.ignored,
-            # Always stamp the current version: `write()` is only ever called with
-            # freshly-computed `results`, never with a re-serialized old payload.
-            "schema_version": SCHEMA_VERSION,
+            # Preserve the payload's own schema_version rather than always stamping
+            # the current constant. Freshly-computed results are built with a bare
+            # CachePayload(...), which defaults schema_version to the current
+            # SCHEMA_VERSION, so they still cache correctly. But the ignore-list
+            # mutators (add_ignore/remove_ignore/clear_ignores) do a
+            # read-modify-write that preserves an existing entry's old `results`
+            # and `fetched_at` — if that write stamped the current version anyway,
+            # a TTL-fresh pre-v2 entry (with a stale, spuriously-computed result)
+            # would be laundered into looking current-version-fresh, bypassing
+            # the schema_version staleness gate (#461 follow-up).
+            "schema_version": payload.schema_version,
         }
         tmp = self._path.with_suffix(".tmp")
         tmp.write_text(json.dumps(body, indent=2))

--- a/src/mship/core/reconcile/detect.py
+++ b/src/mship/core/reconcile/detect.py
@@ -55,7 +55,7 @@ def _pr_number(url: str | None) -> int | None:
 
 def detect_one(
     task_branch: str,
-    task_base: str | None,
+    task_base: str | frozenset[str] | None,
     pr: PRSnapshot | None,
     git: GitSnapshot,
 ) -> Detection:
@@ -77,7 +77,11 @@ def detect_one(
             pr_url=pr.url, pr_number=_pr_number(pr.url), base=pr.base_ref,
             merge_commit=None, updated_at=pr.updated_at,
         )
-    if task_base is not None and pr.base_ref != task_base:
+    valid_bases = (
+        task_base if isinstance(task_base, frozenset)
+        else {task_base} if task_base is not None else None
+    )
+    if valid_bases is not None and pr.base_ref not in valid_bases:
         return Detection(
             state=UpstreamState.base_changed,
             pr_url=pr.url, pr_number=_pr_number(pr.url), base=pr.base_ref,
@@ -97,7 +101,7 @@ def detect_one(
 
 
 def detect_many(
-    tasks: Sequence[tuple[str, str, str | None]],   # (slug, branch, base)
+    tasks: Sequence[tuple[str, str, str | frozenset[str] | None]],   # (slug, branch, base)
     pr_by_head: dict[str, PRSnapshot],
     git_by_branch: dict[str, GitSnapshot],
 ) -> dict[str, Detection]:

--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -115,6 +115,25 @@ def _resolved_task_bases(
     return frozenset(bases) if bases else None
 
 
+def resolve_task_bases(
+    state: WorkspaceState,
+    config,
+    *,
+    base_inputs_by_slug: dict[
+        str, tuple[str | None, dict[str, str]]
+    ] | None = None,
+) -> dict[str, frozenset[str] | None]:
+    """Resolve the effective base set for every task in workspace state."""
+    base_inputs_by_slug = base_inputs_by_slug or {}
+    resolved: dict[str, frozenset[str] | None] = {}
+    for task in state.tasks.values():
+        cli_base, base_map = base_inputs_by_slug.get(task.slug, (None, {}))
+        resolved[task.slug] = _resolved_task_bases(
+            task, config, cli_base=cli_base, base_map=base_map,
+        )
+    return resolved
+
+
 Fetcher = Callable[[list[str], dict[str, Path]], tuple[dict[str, PRSnapshot], dict[str, GitSnapshot]]]
 
 
@@ -173,13 +192,9 @@ def reconcile_now(
     ] | None = None,
 ) -> dict[str, Decision]:
     """Cache-first; fetch on stale; fall back on error. Never raises."""
-    base_inputs_by_slug = base_inputs_by_slug or {}
-    resolved_bases: dict[str, frozenset[str] | None] = {}
-    for task in state.tasks.values():
-        cli_base, base_map = base_inputs_by_slug.get(task.slug, (None, {}))
-        resolved_bases[task.slug] = _resolved_task_bases(
-            task, config, cli_base=cli_base, base_map=base_map,
-        )
+    resolved_bases = resolve_task_bases(
+        state, config, base_inputs_by_slug=base_inputs_by_slug,
+    )
     base_context = {
         slug: sorted(bases) if bases is not None else None
         for slug, bases in resolved_bases.items()

--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -11,7 +11,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Callable, Literal
 
-from mship.core.state import WorkspaceState
+from mship.core.state import WorkspaceState, Task
+from mship.core.base_resolver import resolve_base
 from mship.core.reconcile.cache import ReconcileCache, CachePayload, DEFAULT_TTL_SECONDS
 from mship.core.reconcile.detect import (
     Detection, GitSnapshot, PRSnapshot, UpstreamState, detect_many,
@@ -80,6 +81,33 @@ def should_block(decision: Decision, *, command: Command, ignored: list[str]) ->
     return _MATRIX[decision.state.value][command]
 
 
+def _resolved_task_base(task: Task, config) -> str | None:
+    """The base finish/PR-creation would target for this task (#455).
+
+    `task.base_branch` is the spawn-time recorded default (usually the
+    workspace default, e.g. "main") — NOT necessarily where `finish` opens
+    the PR. `finish` resolves the real target via
+    `mship.core.base_resolver.resolve_base` (base_map > cli_base >
+    base_override > repo_config.base_branch); reconcile has no CLI overrides
+    in play, so only `base_override` and the repo's configured base apply
+    here — same precedence, same resolver, no duplicated logic (mirrors
+    `mship.core.context._effective_base_for_repo`).
+
+    Falls back to `task.base_branch` when there's no config or no repo to
+    resolve against, preserving prior behavior for config-less workspaces.
+    """
+    if config is None:
+        return task.base_branch
+    repo = task.active_repo or (task.affected_repos[0] if task.affected_repos else None)
+    if repo is None:
+        return task.base_branch
+    resolved = resolve_base(
+        repo, config.repos.get(repo), cli_base=None, base_map={},
+        known_repos=config.repos.keys(), task_base=task.base_override,
+    )
+    return resolved if resolved is not None else task.base_branch
+
+
 Fetcher = Callable[[list[str], dict[str, Path]], tuple[dict[str, PRSnapshot], dict[str, GitSnapshot]]]
 
 
@@ -132,6 +160,7 @@ def reconcile_now(
     cache: ReconcileCache,
     fetcher: Fetcher,
     ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    config=None,
 ) -> dict[str, Decision]:
     """Cache-first; fetch on stale; fall back on error. Never raises."""
     payload = cache.read()
@@ -151,7 +180,9 @@ def reconcile_now(
             return _decisions_from_cache(state, payload)
         return {}
 
-    tasks_tuples = [(t.slug, t.branch, t.base_branch) for t in state.tasks.values()]
+    tasks_tuples = [
+        (t.slug, t.branch, _resolved_task_base(t, config)) for t in state.tasks.values()
+    ]
     detections = detect_many(tasks_tuples, pr_by_head, git_by_branch)
 
     results = {

--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -100,7 +100,6 @@ def _resolved_task_bases(
     repo_configs = config.repos if config is not None else {}
     known_repos = repo_configs.keys() if config is not None else task.affected_repos
     bases: set[str] = set()
-    has_remote_default = False
     for repo in task.affected_repos:
         resolved = resolve_base(
             repo,
@@ -110,19 +109,9 @@ def _resolved_task_bases(
             known_repos=known_repos,
             task_base=task.base_override,
         )
-        if resolved is None and repo in repo_configs:
-            has_remote_default = True
-        # A configured repo resolving to None intentionally delegates to its
-        # GitHub remote default; only config-absent repos need the legacy fallback.
-        effective = (
-            task.base_branch
-            if resolved is None and repo not in repo_configs
-            else resolved
-        )
+        effective = resolved if resolved is not None else task.base_branch
         if effective is not None:
             bases.add(effective)
-    if has_remote_default:
-        return None
     return frozenset(bases) if bases else None
 
 

--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -81,38 +81,33 @@ def should_block(decision: Decision, *, command: Command, ignored: list[str]) ->
     return _MATRIX[decision.state.value][command]
 
 
-def _resolved_task_bases(task: Task, config) -> frozenset[str] | None:
-    """The set of bases finish/PR-creation could target for this task (#455,
-    extended per-repo in #461).
+def _resolved_task_bases(
+    task: Task,
+    config,
+    *,
+    cli_base: str | None = None,
+    base_map: dict[str, str] | None = None,
+) -> frozenset[str] | None:
+    """Resolve every effective PR base for a task through the shared resolver.
 
-    `task.base_branch` is the spawn-time recorded default (usually the
-    workspace default, e.g. "main") — NOT necessarily where `finish` opens
-    the PR. `finish` resolves the real target via
-    `mship.core.base_resolver.resolve_base` (base_map > cli_base >
-    base_override > repo_config.base_branch); reconcile has no CLI overrides
-    in play, so only `base_override` and the repo's configured base apply
-    here — same precedence, same resolver, no duplicated logic (mirrors
-    `mship.core.context._effective_base_for_repo`).
-
-    A multi-repo task's repos can each have a DIFFERENT configured
-    `repos.<name>.base_branch`. `reconcile_now` matches PR snapshots by
-    branch name only — it has no way to tell which of the task's repos a
-    given PR came from — so instead of resolving a single base from one
-    arbitrarily chosen repo (which false-flags `base_changed` whenever the
-    matched PR actually belongs to a *different* affected repo), this
-    resolves a base PER repo and returns the whole set. A PR is in sync if
-    its base matches ANY of them.
-
-    Falls back to `{task.base_branch}` when there's no config or no repos to
-    resolve against, preserving prior behavior for config-less workspaces.
+    Reconcile cannot attribute a fetched PR to a repository (#462), so a
+    multi-repo task remains in sync when its PR base matches ANY affected
+    repo's effective base. Finish-specific CLI inputs apply only to the task
+    being finished.
     """
-    if config is None or not task.affected_repos:
+    if not task.affected_repos:
         return frozenset({task.base_branch}) if task.base_branch is not None else None
+    repo_configs = config.repos if config is not None else {}
+    known_repos = repo_configs.keys() if config is not None else task.affected_repos
     bases: set[str] = set()
     for repo in task.affected_repos:
         resolved = resolve_base(
-            repo, config.repos.get(repo), cli_base=None, base_map={},
-            known_repos=config.repos.keys(), task_base=task.base_override,
+            repo,
+            repo_configs.get(repo),
+            cli_base=cli_base,
+            base_map=base_map or {},
+            known_repos=known_repos,
+            task_base=task.base_override,
         )
         effective = resolved if resolved is not None else task.base_branch
         if effective is not None:
@@ -173,16 +168,27 @@ def reconcile_now(
     fetcher: Fetcher,
     ttl_seconds: int = DEFAULT_TTL_SECONDS,
     config=None,
+    base_inputs_by_slug: dict[
+        str, tuple[str | None, dict[str, str]]
+    ] | None = None,
 ) -> dict[str, Decision]:
     """Cache-first; fetch on stale; fall back on error. Never raises."""
-    # `payload` is the raw on-disk entry (kept only to preserve its ignore
-    # list across the fresh-write below, which is orthogonal to results
-    # schema). `current_payload` is the load-boundary-gated version — every
-    # results-consuming branch below (the fresh-cache check AND the
-    # fetch-error fallback) reads from IT, never `payload` directly, so a
-    # schema-mismatched entry can't be served by either path (#461 follow-up).
+    base_inputs_by_slug = base_inputs_by_slug or {}
+    resolved_bases: dict[str, frozenset[str] | None] = {}
+    for task in state.tasks.values():
+        cli_base, base_map = base_inputs_by_slug.get(task.slug, (None, {}))
+        resolved_bases[task.slug] = _resolved_task_bases(
+            task, config, cli_base=cli_base, base_map=base_map,
+        )
+    base_context = {
+        slug: sorted(bases) if bases is not None else None
+        for slug, bases in resolved_bases.items()
+    }
+
+    # Keep the raw payload only to preserve its ignore list on a fresh write.
+    # Every results-consuming path uses the schema/context-compatible payload.
     payload = cache.read()
-    current_payload = cache.current(payload)
+    current_payload = cache.current(payload, base_context=base_context)
     if current_payload is not None and cache.is_fresh(current_payload):
         return _decisions_from_cache(state, current_payload)
 
@@ -200,7 +206,7 @@ def reconcile_now(
         return {}
 
     tasks_tuples = [
-        (t.slug, t.branch, _resolved_task_bases(t, config)) for t in state.tasks.values()
+        (t.slug, t.branch, resolved_bases[t.slug]) for t in state.tasks.values()
     ]
     detections = detect_many(tasks_tuples, pr_by_head, git_by_branch)
 
@@ -218,6 +224,7 @@ def reconcile_now(
         ttl_seconds=ttl_seconds,
         results=results,
         ignored=(payload.ignored if payload else []),
+        base_context=base_context,
     ))
     decisions = {slug: _decision_from_detection(slug, d, state) for slug, d in detections.items()}
     return apply_dependency_stale(state, decisions)

--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -81,8 +81,9 @@ def should_block(decision: Decision, *, command: Command, ignored: list[str]) ->
     return _MATRIX[decision.state.value][command]
 
 
-def _resolved_task_base(task: Task, config) -> str | None:
-    """The base finish/PR-creation would target for this task (#455).
+def _resolved_task_bases(task: Task, config) -> frozenset[str] | None:
+    """The set of bases finish/PR-creation could target for this task (#455,
+    extended per-repo in #461).
 
     `task.base_branch` is the spawn-time recorded default (usually the
     workspace default, e.g. "main") — NOT necessarily where `finish` opens
@@ -93,19 +94,30 @@ def _resolved_task_base(task: Task, config) -> str | None:
     here — same precedence, same resolver, no duplicated logic (mirrors
     `mship.core.context._effective_base_for_repo`).
 
-    Falls back to `task.base_branch` when there's no config or no repo to
+    A multi-repo task's repos can each have a DIFFERENT configured
+    `repos.<name>.base_branch`. `reconcile_now` matches PR snapshots by
+    branch name only — it has no way to tell which of the task's repos a
+    given PR came from — so instead of resolving a single base from one
+    arbitrarily chosen repo (which false-flags `base_changed` whenever the
+    matched PR actually belongs to a *different* affected repo), this
+    resolves a base PER repo and returns the whole set. A PR is in sync if
+    its base matches ANY of them.
+
+    Falls back to `{task.base_branch}` when there's no config or no repos to
     resolve against, preserving prior behavior for config-less workspaces.
     """
-    if config is None:
-        return task.base_branch
-    repo = task.active_repo or (task.affected_repos[0] if task.affected_repos else None)
-    if repo is None:
-        return task.base_branch
-    resolved = resolve_base(
-        repo, config.repos.get(repo), cli_base=None, base_map={},
-        known_repos=config.repos.keys(), task_base=task.base_override,
-    )
-    return resolved if resolved is not None else task.base_branch
+    if config is None or not task.affected_repos:
+        return frozenset({task.base_branch}) if task.base_branch is not None else None
+    bases: set[str] = set()
+    for repo in task.affected_repos:
+        resolved = resolve_base(
+            repo, config.repos.get(repo), cli_base=None, base_map={},
+            known_repos=config.repos.keys(), task_base=task.base_override,
+        )
+        effective = resolved if resolved is not None else task.base_branch
+        if effective is not None:
+            bases.add(effective)
+    return frozenset(bases) if bases else None
 
 
 Fetcher = Callable[[list[str], dict[str, Path]], tuple[dict[str, PRSnapshot], dict[str, GitSnapshot]]]
@@ -181,7 +193,7 @@ def reconcile_now(
         return {}
 
     tasks_tuples = [
-        (t.slug, t.branch, _resolved_task_base(t, config)) for t in state.tasks.values()
+        (t.slug, t.branch, _resolved_task_bases(t, config)) for t in state.tasks.values()
     ]
     detections = detect_many(tasks_tuples, pr_by_head, git_by_branch)
 

--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -100,6 +100,7 @@ def _resolved_task_bases(
     repo_configs = config.repos if config is not None else {}
     known_repos = repo_configs.keys() if config is not None else task.affected_repos
     bases: set[str] = set()
+    has_remote_default = False
     for repo in task.affected_repos:
         resolved = resolve_base(
             repo,
@@ -109,9 +110,19 @@ def _resolved_task_bases(
             known_repos=known_repos,
             task_base=task.base_override,
         )
-        effective = resolved if resolved is not None else task.base_branch
+        if resolved is None and repo in repo_configs:
+            has_remote_default = True
+        # A configured repo resolving to None intentionally delegates to its
+        # GitHub remote default; only config-absent repos need the legacy fallback.
+        effective = (
+            task.base_branch
+            if resolved is None and repo not in repo_configs
+            else resolved
+        )
         if effective is not None:
             bases.add(effective)
+    if has_remote_default:
+        return None
     return frozenset(bases) if bases else None
 
 

--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -175,9 +175,16 @@ def reconcile_now(
     config=None,
 ) -> dict[str, Decision]:
     """Cache-first; fetch on stale; fall back on error. Never raises."""
+    # `payload` is the raw on-disk entry (kept only to preserve its ignore
+    # list across the fresh-write below, which is orthogonal to results
+    # schema). `current_payload` is the load-boundary-gated version — every
+    # results-consuming branch below (the fresh-cache check AND the
+    # fetch-error fallback) reads from IT, never `payload` directly, so a
+    # schema-mismatched entry can't be served by either path (#461 follow-up).
     payload = cache.read()
-    if payload and cache.is_fresh(payload):
-        return _decisions_from_cache(state, payload)
+    current_payload = cache.current(payload)
+    if current_payload is not None and cache.is_fresh(current_payload):
+        return _decisions_from_cache(state, current_payload)
 
     branches = [t.branch for t in state.tasks.values()]
     worktrees_by_branch: dict[str, Path] = {}
@@ -188,8 +195,8 @@ def reconcile_now(
     try:
         pr_by_head, git_by_branch = fetcher(branches, worktrees_by_branch)
     except FetchError:
-        if payload is not None:
-            return _decisions_from_cache(state, payload)
+        if current_payload is not None:
+            return _decisions_from_cache(state, current_payload)
         return {}
 
     tasks_tuples = [

--- a/tests/cli/test_reconcile.py
+++ b/tests/cli/test_reconcile.py
@@ -181,6 +181,33 @@ def test_finish_bypass_lets_through(tmp_path: Path):
         _reset_container()
 
 
+def test_finish_gate_scoped_to_finishing_task_not_blocked_by_other_task_drift(tmp_path: Path):
+    """#455 Part 2: task 'beta' has merged-PR drift (would block finish on its
+    own), but we're finishing unrelated task 'alpha'. alpha's finish must not
+    be refused because of beta's drift — the gate scopes to the task being
+    finished, not every task in the workspace.
+    """
+    runner = CliRunner()
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text("workspace: t\nrepos: {}\n")
+    tasks = {"alpha": _task("alpha"), "beta": _task("beta")}
+    StateManager(state_dir).save(WorkspaceState(tasks=tasks))
+    _seed_merged_cache(state_dir, "beta")
+
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    try:
+        result = runner.invoke(app, ["finish", "--task", "alpha"])
+        assert "upstream drift" not in result.output
+        assert "beta" not in result.output
+    finally:
+        _reset_container()
+
+
 def test_reconcile_clear_ignores(tmp_path: Path):
     runner = CliRunner()
     cfg, state_dir = _bootstrap(tmp_path, ["a", "b"])

--- a/tests/cli/test_reconcile.py
+++ b/tests/cli/test_reconcile.py
@@ -339,3 +339,40 @@ def test_reconcile_cache_mutations_do_not_require_valid_repo_paths(
         assert cache.read_ignores() == expected_ignores
     finally:
         _reset_container()
+
+
+def test_reconcile_normal_does_not_require_valid_repo_paths(tmp_path: Path):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\n"
+        "repos:\n"
+        "  mothership:\n"
+        "    path: ./missing\n"
+        "    type: library\n"
+    )
+    StateManager(state_dir).save(WorkspaceState(tasks={"gamma": _task("gamma")}))
+    cache = ReconcileCache(state_dir)
+    cache.write(CachePayload(
+        fetched_at=time.time(),
+        ttl_seconds=DEFAULT_TTL_SECONDS,
+        results={"gamma": {"state": "in_sync"}},
+        ignored=[],
+        base_context={"gamma": None},
+    ))
+
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    try:
+        result = CliRunner().invoke(app, ["reconcile", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["tasks"][0]["slug"] == "gamma"
+        assert data["tasks"][0]["state"] == "in_sync"
+        with pytest.raises(ValueError, match="path does not exist"):
+            container.config()
+    finally:
+        _reset_container()

--- a/tests/cli/test_reconcile.py
+++ b/tests/cli/test_reconcile.py
@@ -295,3 +295,47 @@ def test_reconcile_clear_ignores(tmp_path: Path):
         assert cache.read_ignores() == []
     finally:
         _reset_container()
+
+
+@pytest.mark.parametrize(
+    ("args", "initial_ignores", "expected_ignores"),
+    [
+        (["--ignore", "gamma"], [], ["gamma"]),
+        (["--clear-ignores"], ["gamma"], []),
+    ],
+)
+def test_reconcile_cache_mutations_do_not_require_valid_repo_paths(
+    tmp_path: Path,
+    args: list[str],
+    initial_ignores: list[str],
+    expected_ignores: list[str],
+):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\n"
+        "repos:\n"
+        "  mothership:\n"
+        "    path: ./missing\n"
+        "    type: library\n"
+    )
+    StateManager(state_dir).save(WorkspaceState(tasks={"gamma": _task("gamma")}))
+    cache = ReconcileCache(state_dir)
+    cache.write(CachePayload(
+        fetched_at=time.time(),
+        ttl_seconds=DEFAULT_TTL_SECONDS,
+        results={},
+        ignored=initial_ignores,
+    ))
+
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    try:
+        result = CliRunner().invoke(app, ["reconcile", *args])
+        assert result.exit_code == 0, result.output
+        assert cache.read_ignores() == expected_ignores
+    finally:
+        _reset_container()

--- a/tests/cli/test_reconcile.py
+++ b/tests/cli/test_reconcile.py
@@ -6,6 +6,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from mship.cli import app, container
@@ -117,7 +118,9 @@ def test_reconcile_add_ignore(tmp_path: Path):
         _reset_container()
 
 
-def _seed_merged_cache(state_dir: Path, slug: str) -> None:
+def _seed_merged_cache(
+    state_dir: Path, slug: str, live_slugs: list[str],
+) -> None:
     cache = ReconcileCache(state_dir)
     cache.write(CachePayload(
         fetched_at=time.time(), ttl_seconds=DEFAULT_TTL_SECONDS,
@@ -132,6 +135,7 @@ def _seed_merged_cache(state_dir: Path, slug: str) -> None:
             }
         },
         ignored=[],
+        base_context={live_slug: None for live_slug in live_slugs},
     ))
 
 
@@ -148,7 +152,7 @@ def _bootstrap_with_current(tmp_path: Path, slug: str) -> tuple[Path, Path]:
 def test_finish_blocks_on_merged_drift(tmp_path: Path):
     runner = CliRunner()
     cfg, state_dir = _bootstrap_with_current(tmp_path, "alpha")
-    _seed_merged_cache(state_dir, "alpha")
+    _seed_merged_cache(state_dir, "alpha", ["alpha"])
 
     container.config.reset()
     container.state_manager.reset()
@@ -166,7 +170,7 @@ def test_finish_blocks_on_merged_drift(tmp_path: Path):
 def test_finish_bypass_lets_through(tmp_path: Path):
     runner = CliRunner()
     cfg, state_dir = _bootstrap_with_current(tmp_path, "alpha")
-    _seed_merged_cache(state_dir, "alpha")
+    _seed_merged_cache(state_dir, "alpha", ["alpha"])
 
     container.config.reset()
     container.state_manager.reset()
@@ -194,7 +198,7 @@ def test_finish_gate_scoped_to_finishing_task_not_blocked_by_other_task_drift(tm
     cfg.write_text("workspace: t\nrepos: {}\n")
     tasks = {"alpha": _task("alpha"), "beta": _task("beta")}
     StateManager(state_dir).save(WorkspaceState(tasks=tasks))
-    _seed_merged_cache(state_dir, "beta")
+    _seed_merged_cache(state_dir, "beta", ["alpha", "beta"])
 
     container.config.reset()
     container.state_manager.reset()
@@ -204,6 +208,69 @@ def test_finish_gate_scoped_to_finishing_task_not_blocked_by_other_task_drift(tm
         result = runner.invoke(app, ["finish", "--task", "alpha"])
         assert "upstream drift" not in result.output
         assert "beta" not in result.output
+    finally:
+        _reset_container()
+
+
+@pytest.mark.parametrize(
+    "base_args",
+    [
+        ["--base", "release"],
+        ["--base", "fallback", "--base-map", "mothership=release"],
+    ],
+)
+def test_finish_reconcile_uses_explicit_base_inputs(
+    tmp_path: Path, monkeypatch, base_args: list[str],
+):
+    """The finish drift gate must resolve the same explicit base as PR creation."""
+    from mship.core.reconcile.detect import GitSnapshot, PRSnapshot
+
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    repo_dir = tmp_path / "mothership"
+    repo_dir.mkdir()
+    cfg = tmp_path / "mothership.yaml"
+    (repo_dir / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    cfg.write_text(
+        "workspace: t\n"
+        "repos:\n"
+        "  mothership:\n"
+        "    path: ./mothership\n"
+        "    type: library\n"
+        "    base_branch: main\n"
+    )
+    StateManager(state_dir).save(WorkspaceState(tasks={"alpha": _task("alpha")}))
+    fetch_calls: list[list[str]] = []
+
+    def _fetch_prs(branches):
+        fetch_calls.append(list(branches))
+        return {
+            "feat/alpha": PRSnapshot(
+                head_ref="feat/alpha", state="OPEN", base_ref="release",
+                merge_commit=None, url="https://example/pr/1", updated_at="z",
+            ),
+        }
+    monkeypatch.setattr(
+        "mship.core.reconcile.fetch.fetch_pr_snapshots",
+        _fetch_prs,
+    )
+    monkeypatch.setattr(
+        "mship.core.reconcile.fetch.collect_git_snapshots",
+        lambda worktrees: {
+            "feat/alpha": GitSnapshot(has_upstream=True, behind=0, ahead=1),
+        },
+    )
+
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    try:
+        result = CliRunner().invoke(app, ["finish", *base_args])
+        assert "upstream drift" not in result.output, result.output
+        assert "base_changed" not in result.output, result.output
+        assert fetch_calls == [["feat/alpha"]]
+        assert "reconcile unavailable" not in result.output, result.output
     finally:
         _reset_container()
 

--- a/tests/core/reconcile/test_cache.py
+++ b/tests/core/reconcile/test_cache.py
@@ -1,3 +1,4 @@
+import json
 import time
 from pathlib import Path
 
@@ -71,3 +72,63 @@ def test_corrupt_cache_returns_none(tmp_path: Path):
     (state_dir / "reconcile.cache.json").write_text("not json")
     c = ReconcileCache(state_dir)
     assert c.read() is None
+
+
+def test_add_ignore_does_not_launder_a_pre_v2_entrys_schema_version(tmp_path: Path):
+    # A TTL-fresh entry written before schema_version existed (spurious
+    # base_changed baked in by the pre-#461 logic). It must stay stale after
+    # an ignore mutation's read-modify-write, not get promoted to the current
+    # schema_version — else the next reconcile would serve the stale result
+    # (#461 follow-up).
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    cache_path = state_dir / "reconcile.cache.json"
+    cache_path.write_text(json.dumps({
+        "fetched_at": time.time(),
+        "ttl_seconds": 300,
+        "results": {"a": {"state": "base_changed"}},
+        "ignored": [],
+        # no "schema_version" key — pre-v2 entry
+    }))
+
+    c = ReconcileCache(state_dir)
+    c.add_ignore("a")
+
+    payload = c.read()
+    assert payload is not None
+    assert payload.results == {"a": {"state": "base_changed"}}
+    assert c.is_fresh(payload) is False
+
+
+def test_clear_ignores_does_not_launder_a_pre_v2_entrys_schema_version(tmp_path: Path):
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    cache_path = state_dir / "reconcile.cache.json"
+    cache_path.write_text(json.dumps({
+        "fetched_at": time.time(),
+        "ttl_seconds": 300,
+        "results": {"a": {"state": "base_changed"}},
+        "ignored": ["a"],
+        # no "schema_version" key — pre-v2 entry
+    }))
+
+    c = ReconcileCache(state_dir)
+    c.clear_ignores()
+
+    payload = c.read()
+    assert payload is not None
+    assert c.is_fresh(payload) is False
+
+
+def test_write_stamps_current_schema_version_for_freshly_computed_results(tmp_path: Path):
+    c = ReconcileCache(tmp_path / ".mothership")
+    payload = CachePayload(
+        fetched_at=time.time(),
+        ttl_seconds=300,
+        results={"a": {"state": "in_sync"}},
+        ignored=[],
+    )
+    c.write(payload)
+    got = c.read()
+    assert got is not None
+    assert c.is_fresh(got) is True

--- a/tests/core/reconcile/test_gate.py
+++ b/tests/core/reconcile/test_gate.py
@@ -92,6 +92,43 @@ def test_reconcile_now_resolves_base_via_repo_config_not_raw_recorded_base(tmp_p
     assert decisions["a"].state == UpstreamState.in_sync
 
 
+def test_reconcile_now_resolves_base_per_repo_for_multi_repo_task(tmp_path: Path):
+    """#461 (follow-up to #455): a multi-repo task's repos can each have a
+    DIFFERENT configured base_branch. reconcile matches PRs by branch name
+    only (it can't tell which repo a fetched PR snapshot belongs to), so it
+    must accept a PR whose base matches ANY of the task's repos' resolved
+    bases — not just one repo (previously: task.active_repo or
+    affected_repos[0]) arbitrarily chosen for the whole task. Resolving
+    against only one repo's base falsely flags base_changed for a PR that's
+    actually correctly targeting a *different* affected repo's base.
+    """
+    class _RepoMain:
+        base_branch = "main"
+
+    class _RepoDev:
+        base_branch = "dev"
+
+    config = type("Config", (), {"repos": {"r1": _RepoMain(), "r2": _RepoDev()}})()
+    cache = ReconcileCache(tmp_path)
+    state = WorkspaceState(tasks={
+        "a": _task("a", base_branch="main", affected_repos=["r1", "r2"],
+                    worktrees={"r1": Path("/tmp/fake/a-r1"), "r2": Path("/tmp/fake/a-r2")}),
+    })
+
+    def _fetcher(branches, wts):
+        # Only one PR snapshot surfaces per branch (reconcile has no way to
+        # tell which repo it came from) — here it's r2's PR, open against r2's
+        # configured base ("dev"), not r1's ("main").
+        return (
+            {"feat/a": PRSnapshot(head_ref="feat/a", state="OPEN", base_ref="dev",
+                                   merge_commit=None, url="https://x/pr/2", updated_at="z")},
+            {"feat/a": GitSnapshot(has_upstream=True, behind=0, ahead=1)},
+        )
+
+    decisions = reconcile_now(state, cache=cache, fetcher=_fetcher, config=config)
+    assert decisions["a"].state == UpstreamState.in_sync
+
+
 def test_reconcile_now_refetches_when_stale(tmp_path: Path):
     cache = ReconcileCache(tmp_path)
     cache.write(CachePayload(

--- a/tests/core/reconcile/test_gate.py
+++ b/tests/core/reconcile/test_gate.py
@@ -65,6 +65,33 @@ def test_reconcile_now_applies_dependency_stale_from_fresh_cache(tmp_path: Path)
     assert decisions["b"].state == UpstreamState.dependency_stale
 
 
+def test_reconcile_now_resolves_base_via_repo_config_not_raw_recorded_base(tmp_path: Path):
+    """#455 Part 1: task.base_branch records the spawn-time default ('main'),
+    but `finish` opens the PR against the RESOLVED base (repo_config.base_branch
+    when no --base override was pinned). If a repo's configured base is 'dev',
+    a PR opened against 'dev' is NOT drift — reconcile must compare against the
+    same resolved base finish uses, not the raw recorded task.base_branch.
+    """
+    from mship.core.reconcile.fetch import FetchError  # noqa: F401 (documents fetcher contract)
+
+    class _Repo:
+        base_branch = "dev"
+
+    config = type("Config", (), {"repos": {"r": _Repo()}})()
+    cache = ReconcileCache(tmp_path)
+    state = WorkspaceState(tasks={"a": _task("a", base_branch="main")})
+
+    def _fetcher(branches, wts):
+        return (
+            {"feat/a": PRSnapshot(head_ref="feat/a", state="OPEN", base_ref="dev",
+                                   merge_commit=None, url="https://x/pr/1", updated_at="z")},
+            {"feat/a": GitSnapshot(has_upstream=True, behind=0, ahead=1)},
+        )
+
+    decisions = reconcile_now(state, cache=cache, fetcher=_fetcher, config=config)
+    assert decisions["a"].state == UpstreamState.in_sync
+
+
 def test_reconcile_now_refetches_when_stale(tmp_path: Path):
     cache = ReconcileCache(tmp_path)
     cache.write(CachePayload(

--- a/tests/core/reconcile/test_gate.py
+++ b/tests/core/reconcile/test_gate.py
@@ -129,6 +129,63 @@ def test_reconcile_now_resolves_base_per_repo_for_multi_repo_task(tmp_path: Path
     assert decisions["a"].state == UpstreamState.in_sync
 
 
+def test_reconcile_now_recomputes_when_cache_schema_is_stale(tmp_path: Path):
+    """#461 follow-up: a cache entry written under the OLD (pre-#461) single-repo
+    base-resolution logic can carry a spurious base_changed. Such an entry is
+    still within its 300s TTL when the #461 fix deploys, so a naive freshness
+    check would serve the stale verdict and shadow the fix until the TTL lapses
+    or a manual refresh. The cache payload must carry a schema version so a
+    pre-fix entry is treated as a miss (recomputed under the new per-repo
+    resolution) rather than served as-is.
+    """
+    class _RepoDev:
+        base_branch = "dev"
+
+    config = type("Config", (), {"repos": {"r": _RepoDev()}})()
+    cache = ReconcileCache(tmp_path)
+    # Hand-craft a fresh-by-TTL cache entry on disk as the OLD (pre-schema-version,
+    # pre-#461) logic would have written it: no "schema_version" key at all, and a
+    # spurious base_changed from comparing against the wrong base. `cache.write()`
+    # always stamps the CURRENT schema_version, so it can't produce this shape —
+    # write the raw file directly to simulate a cache from before this fix existed.
+    import json
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "reconcile.cache.json").write_text(json.dumps({
+        "fetched_at": time.time(),
+        "ttl_seconds": 300,
+        "results": {"a": {"state": "base_changed", "pr_url": "u", "pr_number": 1, "base": "dev"}},
+        "ignored": [],
+    }))
+    state = WorkspaceState(tasks={"a": _task("a", base_branch="main")})
+
+    def _fetcher(branches, wts):
+        return (
+            {"feat/a": PRSnapshot(head_ref="feat/a", state="OPEN", base_ref="dev",
+                                   merge_commit=None, url="https://x/pr/1", updated_at="z")},
+            {"feat/a": GitSnapshot(has_upstream=True, behind=0, ahead=1)},
+        )
+
+    decisions = reconcile_now(state, cache=cache, fetcher=_fetcher, config=config)
+    assert decisions["a"].state == UpstreamState.in_sync
+
+
+def test_reconcile_now_uses_fresh_cache_with_current_schema_version(tmp_path: Path):
+    """A cache entry written under the CURRENT schema version is still used as-is
+    (caching must not be broken by the version check)."""
+    cache = ReconcileCache(tmp_path)
+    cache.write(CachePayload(
+        fetched_at=time.time(), ttl_seconds=300,
+        results={"a": {"state": "merged", "pr_url": "u", "pr_number": 1, "base": "main"}},
+        ignored=[],
+    ))
+    state = WorkspaceState(tasks={"a": _task("a")})
+    decisions = reconcile_now(
+        state, cache=cache,
+        fetcher=lambda *_: (_ for _ in ()).throw(AssertionError("should not fetch")),
+    )
+    assert decisions["a"].state == UpstreamState.merged
+
+
 def test_reconcile_now_refetches_when_stale(tmp_path: Path):
     cache = ReconcileCache(tmp_path)
     cache.write(CachePayload(

--- a/tests/core/reconcile/test_gate.py
+++ b/tests/core/reconcile/test_gate.py
@@ -27,6 +27,7 @@ def test_reconcile_now_uses_fresh_cache(tmp_path: Path):
         fetched_at=time.time(), ttl_seconds=300,
         results={"a": {"state": "merged", "pr_url": "u", "pr_number": 1, "base": "main"}},
         ignored=[],
+        base_context={"a": ["main"]},
     ))
     state = WorkspaceState(tasks={"a": _task("a")})
     decisions = reconcile_now(state, cache=cache, fetcher=lambda *_: (_ for _ in ()).throw(AssertionError("should not fetch")))
@@ -51,6 +52,7 @@ def test_reconcile_now_applies_dependency_stale_from_fresh_cache(tmp_path: Path)
             "b": {"state": "in_sync"},
         },
         ignored=[],
+        base_context={"a": ["main"], "b": ["main"]},
     ))
     state = WorkspaceState(tasks={
         "a": _task("a", created_at=t0, finished_at=t0),
@@ -129,6 +131,36 @@ def test_reconcile_now_resolves_base_per_repo_for_multi_repo_task(tmp_path: Path
     assert decisions["a"].state == UpstreamState.in_sync
 
 
+def test_reconcile_now_refetches_after_resolved_base_config_changes(tmp_path: Path):
+    """A TTL-fresh result is incompatible with a newly resolved task base."""
+    class _Repo:
+        def __init__(self, base_branch: str) -> None:
+            self.base_branch = base_branch
+
+    cache = ReconcileCache(tmp_path)
+    state = WorkspaceState(tasks={"a": _task("a")})
+    calls = 0
+
+    def _fetcher(branches, wts):
+        nonlocal calls
+        calls += 1
+        return (
+            {"feat/a": PRSnapshot(head_ref="feat/a", state="OPEN", base_ref="release",
+                                   merge_commit=None, url="https://x/pr/1", updated_at="z")},
+            {"feat/a": GitSnapshot(has_upstream=True, behind=0, ahead=1)},
+        )
+
+    initial_config = type("Config", (), {"repos": {"r": _Repo("main")}})()
+    changed_config = type("Config", (), {"repos": {"r": _Repo("release")}})()
+
+    first = reconcile_now(state, cache=cache, fetcher=_fetcher, config=initial_config)
+    second = reconcile_now(state, cache=cache, fetcher=_fetcher, config=changed_config)
+
+    assert first["a"].state == UpstreamState.base_changed
+    assert second["a"].state == UpstreamState.in_sync
+    assert calls == 2
+
+
 def test_reconcile_now_recomputes_when_cache_schema_is_stale(tmp_path: Path):
     """#461 follow-up: a cache entry written under the OLD (pre-#461) single-repo
     base-resolution logic can carry a spurious base_changed. Such an entry is
@@ -177,6 +209,7 @@ def test_reconcile_now_uses_fresh_cache_with_current_schema_version(tmp_path: Pa
         fetched_at=time.time(), ttl_seconds=300,
         results={"a": {"state": "merged", "pr_url": "u", "pr_number": 1, "base": "main"}},
         ignored=[],
+        base_context={"a": ["main"]},
     ))
     state = WorkspaceState(tasks={"a": _task("a")})
     decisions = reconcile_now(
@@ -213,6 +246,7 @@ def test_reconcile_now_falls_back_to_cache_on_fetcher_error(tmp_path: Path):
         fetched_at=time.time() - 9999, ttl_seconds=300,
         results={"a": {"state": "merged", "pr_url": "u", "pr_number": 1, "base": "main"}},
         ignored=[],
+        base_context={"a": ["main"]},
     ))
     state = WorkspaceState(tasks={"a": _task("a")})
 
@@ -323,6 +357,7 @@ def test_decision_finished_at_populated_from_cache_hit(tmp_path: Path):
         fetched_at=time.time(), ttl_seconds=300,
         results={"a": {"state": "merged", "pr_url": "u", "pr_number": 1, "base": "main"}},
         ignored=[],
+        base_context={"a": ["main"]},
     ))
     state = WorkspaceState(tasks={"a": _task("a", finished_at=finished)})
 

--- a/tests/core/reconcile/test_gate.py
+++ b/tests/core/reconcile/test_gate.py
@@ -94,30 +94,6 @@ def test_reconcile_now_resolves_base_via_repo_config_not_raw_recorded_base(tmp_p
     assert decisions["a"].state == UpstreamState.in_sync
 
 
-def test_reconcile_now_preserves_configured_repo_remote_default_base(tmp_path: Path):
-    """A configured repo with no base delegates to its remote default, not task.base_branch."""
-    class _Repo:
-        base_branch = None
-
-    config = type("Config", (), {"repos": {"r": _Repo()}})()
-    cache = ReconcileCache(tmp_path)
-    state = WorkspaceState(tasks={"a": _task("a", base_branch="main")})
-
-    def _fetcher(branches, wts):
-        return (
-            {"feat/a": PRSnapshot(head_ref="feat/a", state="OPEN", base_ref="develop",
-                                   merge_commit=None, url="https://x/pr/1", updated_at="z")},
-            {"feat/a": GitSnapshot(has_upstream=True, behind=0, ahead=1)},
-        )
-
-    decisions = reconcile_now(state, cache=cache, fetcher=_fetcher, config=config)
-
-    assert decisions["a"].state == UpstreamState.in_sync
-    payload = cache.read()
-    assert payload is not None
-    assert payload.base_context == {"a": None}
-
-
 def test_reconcile_now_resolves_base_per_repo_for_multi_repo_task(tmp_path: Path):
     """#461 (follow-up to #455): a multi-repo task's repos can each have a
     DIFFERENT configured base_branch. reconcile matches PRs by branch name
@@ -153,42 +129,6 @@ def test_reconcile_now_resolves_base_per_repo_for_multi_repo_task(tmp_path: Path
 
     decisions = reconcile_now(state, cache=cache, fetcher=_fetcher, config=config)
     assert decisions["a"].state == UpstreamState.in_sync
-
-
-def test_reconcile_now_preserves_remote_default_wildcard_across_repo_bases(tmp_path: Path):
-    """One unresolved configured repo makes the task base wildcard under match-ANY."""
-    class _RepoDefault:
-        base_branch = None
-
-    class _RepoDev:
-        base_branch = "dev"
-
-    config = type(
-        "Config", (), {"repos": {"r1": _RepoDefault(), "r2": _RepoDev()}},
-    )()
-    cache = ReconcileCache(tmp_path)
-    state = WorkspaceState(tasks={
-        "a": _task(
-            "a",
-            base_branch="main",
-            affected_repos=["r1", "r2"],
-            worktrees={"r1": Path("/tmp/fake/a-r1"), "r2": Path("/tmp/fake/a-r2")},
-        ),
-    })
-
-    def _fetcher(branches, wts):
-        return (
-            {"feat/a": PRSnapshot(head_ref="feat/a", state="OPEN", base_ref="main",
-                                   merge_commit=None, url="https://x/pr/1", updated_at="z")},
-            {"feat/a": GitSnapshot(has_upstream=True, behind=0, ahead=1)},
-        )
-
-    decisions = reconcile_now(state, cache=cache, fetcher=_fetcher, config=config)
-
-    assert decisions["a"].state == UpstreamState.in_sync
-    payload = cache.read()
-    assert payload is not None
-    assert payload.base_context == {"a": None}
 
 
 def test_reconcile_now_refetches_after_resolved_base_config_changes(tmp_path: Path):

--- a/tests/core/reconcile/test_gate.py
+++ b/tests/core/reconcile/test_gate.py
@@ -94,6 +94,30 @@ def test_reconcile_now_resolves_base_via_repo_config_not_raw_recorded_base(tmp_p
     assert decisions["a"].state == UpstreamState.in_sync
 
 
+def test_reconcile_now_preserves_configured_repo_remote_default_base(tmp_path: Path):
+    """A configured repo with no base delegates to its remote default, not task.base_branch."""
+    class _Repo:
+        base_branch = None
+
+    config = type("Config", (), {"repos": {"r": _Repo()}})()
+    cache = ReconcileCache(tmp_path)
+    state = WorkspaceState(tasks={"a": _task("a", base_branch="main")})
+
+    def _fetcher(branches, wts):
+        return (
+            {"feat/a": PRSnapshot(head_ref="feat/a", state="OPEN", base_ref="develop",
+                                   merge_commit=None, url="https://x/pr/1", updated_at="z")},
+            {"feat/a": GitSnapshot(has_upstream=True, behind=0, ahead=1)},
+        )
+
+    decisions = reconcile_now(state, cache=cache, fetcher=_fetcher, config=config)
+
+    assert decisions["a"].state == UpstreamState.in_sync
+    payload = cache.read()
+    assert payload is not None
+    assert payload.base_context == {"a": None}
+
+
 def test_reconcile_now_resolves_base_per_repo_for_multi_repo_task(tmp_path: Path):
     """#461 (follow-up to #455): a multi-repo task's repos can each have a
     DIFFERENT configured base_branch. reconcile matches PRs by branch name
@@ -129,6 +153,42 @@ def test_reconcile_now_resolves_base_per_repo_for_multi_repo_task(tmp_path: Path
 
     decisions = reconcile_now(state, cache=cache, fetcher=_fetcher, config=config)
     assert decisions["a"].state == UpstreamState.in_sync
+
+
+def test_reconcile_now_preserves_remote_default_wildcard_across_repo_bases(tmp_path: Path):
+    """One unresolved configured repo makes the task base wildcard under match-ANY."""
+    class _RepoDefault:
+        base_branch = None
+
+    class _RepoDev:
+        base_branch = "dev"
+
+    config = type(
+        "Config", (), {"repos": {"r1": _RepoDefault(), "r2": _RepoDev()}},
+    )()
+    cache = ReconcileCache(tmp_path)
+    state = WorkspaceState(tasks={
+        "a": _task(
+            "a",
+            base_branch="main",
+            affected_repos=["r1", "r2"],
+            worktrees={"r1": Path("/tmp/fake/a-r1"), "r2": Path("/tmp/fake/a-r2")},
+        ),
+    })
+
+    def _fetcher(branches, wts):
+        return (
+            {"feat/a": PRSnapshot(head_ref="feat/a", state="OPEN", base_ref="main",
+                                   merge_commit=None, url="https://x/pr/1", updated_at="z")},
+            {"feat/a": GitSnapshot(has_upstream=True, behind=0, ahead=1)},
+        )
+
+    decisions = reconcile_now(state, cache=cache, fetcher=_fetcher, config=config)
+
+    assert decisions["a"].state == UpstreamState.in_sync
+    payload = cache.read()
+    assert payload is not None
+    assert payload.base_context == {"a": None}
 
 
 def test_reconcile_now_refetches_after_resolved_base_config_changes(tmp_path: Path):

--- a/tests/core/reconcile/test_gate.py
+++ b/tests/core/reconcile/test_gate.py
@@ -224,6 +224,36 @@ def test_reconcile_now_falls_back_to_cache_on_fetcher_error(tmp_path: Path):
     assert decisions["a"].state == UpstreamState.merged
 
 
+def test_reconcile_now_fetch_error_fallback_does_not_serve_schema_stale_cache(tmp_path: Path):
+    """#461 follow-up P1 (cache.py:82, "Invalid cache survives fallback"):
+    the fetch-error fallback used to return `payload` straight from
+    `cache.read()` with no schema check at all, so on a live-fetch failure
+    after the #461 upgrade, a pre-v2 entry's spurious base_changed would be
+    served and block `finish`. A pre-v2 (schema-invalid) entry must be
+    dropped at the load boundary, so the fallback has nothing stale left to
+    serve — it degrades to `{}`, same as no cache at all. Must FAIL before
+    the fix (stale base_changed served) and PASS after.
+    """
+    import json
+    cache = ReconcileCache(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "reconcile.cache.json").write_text(json.dumps({
+        "fetched_at": time.time(),
+        "ttl_seconds": 300,
+        "results": {"a": {"state": "base_changed", "pr_url": "u", "pr_number": 1, "base": "dev"}},
+        "ignored": [],
+        # no "schema_version" key — pre-v2 entry, TTL-fresh but schema-stale
+    }))
+    state = WorkspaceState(tasks={"a": _task("a")})
+
+    def bad_fetcher(*_):
+        from mship.core.reconcile.fetch import FetchError
+        raise FetchError("offline")
+
+    decisions = reconcile_now(state, cache=cache, fetcher=bad_fetcher)
+    assert decisions == {}
+
+
 def test_reconcile_now_returns_unavailable_on_error_without_cache(tmp_path: Path):
     cache = ReconcileCache(tmp_path)
     state = WorkspaceState(tasks={"a": _task("a")})

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -356,7 +356,7 @@ def test_drift_read_from_cache(tmp_path: Path):
             # 'b' deliberately absent -> "unknown"
         },
         ignored=[],
-        base_context={"a": ["main"], "b": ["main"]},
+        base_context={"a": None, "b": None},
     ))
 
     out = _build(state, _config(tmp_path), log_mgr, tmp_path,
@@ -376,7 +376,7 @@ def test_drift_unknown_when_cache_entry_malformed(tmp_path: Path):
         fetched_at=time.time(), ttl_seconds=300,
         results={"x": {"not_a_state_field": "junk"}},
         ignored=[],
-        base_context={"x": ["main"]},
+        base_context={"x": None},
     ))
 
     out = _build(state, _config(tmp_path), log_mgr, tmp_path,
@@ -394,7 +394,7 @@ def test_drift_unknown_when_cache_schema_is_stale(tmp_path: Path):
         results={"x": {"state": "merged"}},
         ignored=[],
         schema_version=0,
-        base_context={"x": ["main"]},
+        base_context={"x": None},
     ))
 
     out = _build(

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -356,6 +356,7 @@ def test_drift_read_from_cache(tmp_path: Path):
             # 'b' deliberately absent -> "unknown"
         },
         ignored=[],
+        base_context={"a": ["main"], "b": ["main"]},
     ))
 
     out = _build(state, _config(tmp_path), log_mgr, tmp_path,
@@ -375,11 +376,55 @@ def test_drift_unknown_when_cache_entry_malformed(tmp_path: Path):
         fetched_at=time.time(), ttl_seconds=300,
         results={"x": {"not_a_state_field": "junk"}},
         ignored=[],
+        base_context={"x": ["main"]},
     ))
 
     out = _build(state, _config(tmp_path), log_mgr, tmp_path,
                  state_dir=tmp_path, cache=cache)
     assert out["active_tasks"][0]["drift"] == "unknown"
+
+
+def test_drift_unknown_when_cache_schema_is_stale(tmp_path: Path):
+    log_mgr = LogManager(tmp_path / "logs")
+    state = WorkspaceState(tasks={"x": _task("x")})
+    cache = ReconcileCache(tmp_path)
+    cache.write(CachePayload(
+        fetched_at=time.time(),
+        ttl_seconds=300,
+        results={"x": {"state": "merged"}},
+        ignored=[],
+        schema_version=0,
+        base_context={"x": ["main"]},
+    ))
+
+    out = _build(
+        state, _config(tmp_path), log_mgr, tmp_path,
+        state_dir=tmp_path, cache=cache,
+    )
+
+    assert out["active_tasks"][0]["drift"] == "unknown"
+    assert out["last_drift_check_at"] is not None
+
+
+def test_drift_unknown_when_cache_base_context_changed(tmp_path: Path):
+    log_mgr = LogManager(tmp_path / "logs")
+    state = WorkspaceState(tasks={"x": _task("x")})
+    cache = ReconcileCache(tmp_path)
+    cache.write(CachePayload(
+        fetched_at=time.time(),
+        ttl_seconds=300,
+        results={"x": {"state": "merged"}},
+        ignored=[],
+        base_context={"x": ["release"]},
+    ))
+
+    out = _build(
+        state, _config(tmp_path), log_mgr, tmp_path,
+        state_dir=tmp_path, cache=cache,
+    )
+
+    assert out["active_tasks"][0]["drift"] == "unknown"
+    assert out["last_drift_check_at"] is not None
 
 
 def test_main_checkout_clean_dispatches_per_repo(tmp_path: Path):

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -356,7 +356,7 @@ def test_drift_read_from_cache(tmp_path: Path):
             # 'b' deliberately absent -> "unknown"
         },
         ignored=[],
-        base_context={"a": None, "b": None},
+        base_context={"a": ["main"], "b": ["main"]},
     ))
 
     out = _build(state, _config(tmp_path), log_mgr, tmp_path,
@@ -376,7 +376,7 @@ def test_drift_unknown_when_cache_entry_malformed(tmp_path: Path):
         fetched_at=time.time(), ttl_seconds=300,
         results={"x": {"not_a_state_field": "junk"}},
         ignored=[],
-        base_context={"x": None},
+        base_context={"x": ["main"]},
     ))
 
     out = _build(state, _config(tmp_path), log_mgr, tmp_path,
@@ -394,7 +394,7 @@ def test_drift_unknown_when_cache_schema_is_stale(tmp_path: Path):
         results={"x": {"state": "merged"}},
         ignored=[],
         schema_version=0,
-        base_context={"x": None},
+        base_context={"x": ["main"]},
     ))
 
     out = _build(


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
**Title**  
Fix #455: reconcile reports spurious `base_changed` by comparing a task's recorded `base_branch` against the PR's resolved base; and `finish`'s drift gate blocks unrelated tasks. Compare against the RESOLVED base (`base_override > repo.base_branch > task default`) and scope the gate to the finishing task.

**What changed**

- **Reconcile now uses the same resolved base as `finish`.**  
  Instead of comparing a PR's base directly against the spawn-time `task.base_branch`, `reconcile_now` resolves the effective target base per task using the configured repository `base_branch` and any task-level `base_override`. For multi-repo tasks, it accepts a PR base that matches any affected repo's resolved base. This eliminates false `base_changed` drift reports when a repo is configured to target something other than the workspace default.

- **`finish` drift gate is scoped to the task being finished.**  
  The upstream-reconcile gate that runs during `finish` now filters decisions to the single task being finished. Drift on an unrelated task no longer blocks `finish`.

- **Reconcile cache is versioned so old results are invalidated.**  
  A schema version is added to the reconcile cache payload. Entries written before this fix are treated as stale (even if still within TTL) and recomputed under the new base-resolution logic. Ignore-list mutations preserve the original entry's schema version so they cannot accidentally “launder” a stale pre-fix result into looking current.

- **CLI reconcile paths pass workspace config.**  
  The `reconcile`, internal, and `worktree` callers now supply the workspace configuration to `reconcile_now`, enabling repository-level base resolution.

**Why**

Issue #455 had two symptoms:
1. `reconcile` flagged PRs as `base_changed` even though the PR was correctly opened against the resolved base that `finish` would use.
2. `finish` refused to proceed because of drift detected on a completely different task.

The cache versioning ensures the fix takes effect immediately for users who already have a fresh reconcile cache from before the change.
<!-- kody-pr-summary:end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix spurious `base_changed` in reconcile and scope finish drift gate to the finishing task
> - `reconcile_now` now resolves a task's effective base branch via config (`base_override > repo.base_branch > task default`) and compares against that resolved set instead of the raw recorded branch, eliminating false `base_changed` reports.
> - The finish workflow gate in [worktree.py](https://github.com/atomikpanda/mothership/pull/461/files#diff-4910670ca7eb641552e8a7e5213cd7ed812368f3577d1719120080fe95f4fba9) now accepts an `only_slug` parameter and filters reconcile decisions to only the finishing task, so drift on unrelated tasks no longer blocks an unrelated finish.
> - Introduces `SCHEMA_VERSION = 2` in [cache.py](https://github.com/atomikpanda/mothership/pull/461/files#diff-513255aa905374b6c216c790ca10ebf3e5e0a3618e3731df95732c425793cee0); cache entries with a mismatched schema version are treated as stale regardless of TTL, and a new `current()` method guards callers from serving schema-stale payloads.
> - Behavioral Change: existing cache entries written before this change will be treated as stale (schema_version 0 ≠ 2) and trigger a recompute on next reconcile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1a4392.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->