### PR TITLE
Enroll Mothership repositories in advisory agentic review

### DIFF
--- a/.github/workflows/agentic-review.yml
+++ b/.github/workflows/agentic-review.yml
@@ -1,0 +1,17 @@
+name: agentic-review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    uses: atomikpanda/agentic-review/.github/workflows/agentic-review.yml@v1
+    secrets:
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+    with:
+      central_ref: v1

--- a/.github/workflows/agentic-review.yml
+++ b/.github/workflows/agentic-review.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   review:
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     uses: atomikpanda/agentic-review/.github/workflows/agentic-review.yml@v1
     secrets:
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
## Summary

- enroll this repository in `atomikpanda/agentic-review@v1`
- review every same-repository PR with inline, advisory findings
- grant only source-read and PR-comment permissions

## Verification

- semantic workflow contract check passes
- `uses:` and `central_ref` are both pinned to `v1`
- live agentic-review reruns succeeded: [Mothership](https://github.com/atomikpanda/mothership/actions/runs/31733033222) and [Ground Control](https://github.com/atomikpanda/ground-control/actions/runs/31733028105)
- accepted rollout policy: both refs track the reviewed moving `v1` release line
- accepted trust boundary: `atomikpanda` is the only repository writer; fork and Dependabot PRs receive no review secret

---

## Acceptance criteria

- [x] `ac1` One audited Mothership-managed cross-repository chore/task tracks the enrollment changes in both `atomikpanda/mothership` and `atomikpanda/ground-control`. — test:test-runs/1.ground-control
- [x] `ac2` Each repository contains a valid `.github/workflows/agentic-review.yml` triggered on `pull_request` types `opened`, `reopened`, `ready_for_review`, and `synchronize`. — test:test-runs/1.ground-control
- [x] `ac3` Each caller grants only `contents: read` and `pull-requests: write`, calls `atomikpanda/agentic-review/.github/workflows/agentic-review.yml@v1`, maps the repository `OPENROUTER_API_KEY` secret, and passes `central_ref: v1`. — test:test-runs/1.ground-control
- [x] `ac4` Both callers retain the reusable workflow defaults for inline suggestions and comment-only enforcement; no custom model, prompt, skills, or `fail_on_findings: true` override is present. — test:test-runs/1.ground-control
- [x] `ac5` One dedicated spend-limited OpenRouter key is stored independently as the `OPENROUTER_API_KEY` Actions secret in both repositories without the value appearing in repository files, task artifacts, command output, or Actions logs. — test:test-runs/1.ground-control
- [x] `ac6` The enrollment pull request in each repository triggers agentic-review and completes with a visible review result or comment before merge. — test:test-runs/1.ground-control
- [x] `ac7` Both caller configurations leave `fail_on_findings` false or omitted and make no branch-protection change, so agentic-review findings remain advisory rather than merge-blocking. — test:test-runs/1.ground-control
- [x] `ac8` Fork pull requests remain skipped by the reusable workflow and cannot use the repository OpenRouter secret. — test:test-runs/1.ground-control
- [x] `ac9` The enrollment changes modify only the two caller workflow files; no Mothership runtime hook, application code, workspace configuration, PR-Agent configuration, custom prompt, model override, or unrelated file is changed. — test:test-runs/1.ground-control
- [x] `ac10` The rollback procedure is defined in the implementation plan: remove both caller workflows, delete both repository secrets, confirm both callers are absent, then revoke the shared OpenRouter key; executing rollback is not part of enrollment. — test:test-runs/1.ground-control
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `agentic-review-for-mothership`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/66 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/465 | this PR |

⚠ Merge in order: ground-control → mothership

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enroll Mothership repositories in advisory agentic review via GitHub Actions
> Adds [agentic-review.yml](.github/workflows/agentic-review.yml), a GitHub Actions workflow that triggers on pull request events (opened, reopened, ready_for_review, synchronize) and runs an agentic code review via the reusable `atomikpanda/agentic-review` workflow at `v1`. The job is skipped for `dependabot[bot]` PRs and requires the `OPENROUTER_API_KEY` secret.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d0a01d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
