### PR TITLE
Agent harness parity: portable dispatch and complete Codex/OMP workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ mship spawn "downstream" --work-item <id> --depends-on a,b  # declare at spawn (
 mship depends add/remove/list               # manage task-to-task dependency edges
 mship finish --bypass-deps                 # ship a downstream even if upstream isn't ready
 
+# Agent setup
+mship skill install --only claude,codex,omp  # install bundled skills; pi is an alias for omp
+
 # Inspection
 mship status                            # active task, phase, branch, drift
 mship journal                           # task log with context
@@ -77,6 +80,13 @@ mship reply <thread> "text"             # answer a mailbox thread
 ```
 
 For details, see `mship spawn --help`, [`docs/cli.md`](docs/cli.md), and the `working-with-mothership` skill.
+
+Codex and OMP/Pi discover the same bundle through the user-level
+`.agents/skills/mothership` link, so there is no second skill copy. Existing
+foreign files, directories, and links are skipped unless `--force` is explicit.
+`mship doctor` reports OMP skill discovery separately from the project-local OMP
+lifecycle extension and gives the matching `mship skill install --only omp`
+repair command.
 
 ## What mship gives agents
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,11 +54,18 @@ therefore configured but untrusted, not reported as fully active.
 
 ```bash
 mship bootstrap [--repos a,b] [--token TOK]         # clone missing workspace members (fresh clone -> full workspace)
-mship skill install|list [--only claude,codex,gemini] [--force] [-y]  # install/list mship-bundled agent skills
+mship skill install|list [--only claude,codex,gemini,omp,pi] [--force] [-y]  # pi is the canonical alias for omp
 mship gh preflight                                  # fail-fast check that GitHub auth covers the workspace repos
 mship bind refresh                                  # re-sync bind_files + symlink_dirs from source repos into worktrees
 mship layout init|launch                            # write / launch the mothership zellij layout
 ```
+
+Codex and OMP/Pi use the same user-level `.agents/skills/mothership` link to
+the bundled skills; installing both does not create a second copy. Install
+safe-skips foreign links, files, and directories unless `--force` is explicit.
+`mship doctor` reports OMP skill discovery independently from project lifecycle
+extension compatibility and recommends `mship skill install --only omp` (plus
+`--force` for foreign content) when repair is needed.
 
 `mship relay` manages the reverse-tunnel relay client keys (for `mship serve --relay`, see [`relay-hosting.md`](relay-hosting.md)):
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,6 +37,17 @@ mship commit "message" [--task <slug>]              # commit staged changes acro
 mship depends add|remove|list                       # manage task-to-task dependency edges (#104)
 ```
 
+`mship init --install-hooks` writes the project-local Codex hook files, but it
+does not enable Codex features or trust the project. If setup reports the hook
+capability as disabled or unavailable, run `codex features enable codex_hooks`.
+Then open `/hooks` in Codex to review and trust the project hooks. Trust remains
+a manual action even when the capability is already enabled.
+
+`mship doctor` reports these boundaries separately: whether the project hook
+artifact is valid, whether the Codex hook feature capability is enabled, and
+whether manual project trust remains unresolved. A current registration is
+therefore configured but untrusted, not reported as fully active.
+
 > **Entry point — spawn vs. spec dispatch:** `mship spawn` starts an ad-hoc task directly, but for **spec-driven** work you don't call it first. `mship spec dispatch <id>` (see **Work items & specs** below) is the entry point: it binds an approved spec and **spawns its own task**. Running `spawn` and then `spec dispatch` against the same spec double-creates tasks (#296). Rule of thumb: have an approved spec → `spec dispatch`; ad-hoc chore/bug → `spawn`.
 
 ## Setup & admin

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,7 +214,7 @@ Top-level keys on `mothership.yaml` (alongside `workspace`, `env_runner`, `branc
 | `redact` | Extra `mship export --redacted` regex patterns, unioned with the built-in set. (MOS-102) |
 | `lifecycle_hooks` | Declarative reactions to task / WorkItem / PR lifecycle transitions. Named `lifecycle_hooks` (not `hooks`) to disambiguate from the git commit/push hooks. (MOS-220) |
 | `lifecycle_hooks_default_timeout` | Fallback per-hook timeout in seconds when a `lifecycle_hooks:` entry omits `timeout`. Default: `30`. |
-| `dispatch_models` | Per-mode model map for `mship dispatch` (`implementer` / `reviewer` / `standalone`). Values pass through verbatim to the dispatching harness. Precedence: `--model` flag > this map > built-in defaults (reviewer defaults to a cheaper tier). |
+| `dispatch_models` | Per-mode model map for `mship dispatch` (`implementer` / `reviewer` / `standalone`). Precedence: `--model` flag > this map > built-in defaults; every built-in mode defaults to `inherit`. The sentinel means harness default behavior: the adapter omits its model selector. Explicit configured values are emitted verbatim and require a selector-capable harness adapter; an adapter without a selector rejects them rather than substituting another model. |
 
 ```yaml
 workspace: my-platform

--- a/docs/plans/2026-08-13-agent-harness-parity.md
+++ b/docs/plans/2026-08-13-agent-harness-parity.md
@@ -18,7 +18,7 @@
 
 **Architecture:** Keep `core/agent_hooks.py` as the only owner of session-start context, guarded-edit decisions, inbox continuation, and bounded stop re-entry. Keep model strings opaque in Mothership core: all built-in modes resolve to the sentinel `inherit`, meaning the dispatching harness uses its default model; explicit operator values remain byte-for-byte values interpreted only by a harness adapter. Consolidate Codex capability parsing in `core/codex_hooks.py` so setup and doctor report the same activation state. Install OMP/Pi skills through OMP's documented cross-runtime `~/.agents/skills/` discovery path, reusing the existing foreign-content-safe symlink machinery. Test runtime adapters as translations around the shared policy, not as independent policy implementations.
 
-**Tech Stack:** Python 3.12, Typer, pytest, Markdown-based bundled skills, and Bun for generated OMP TypeScript smoke coverage.
+**Tech Stack:** Python 3.14, Typer, pytest, Markdown-based bundled skills, and Bun for generated OMP TypeScript smoke coverage.
 
 ## Global Constraints
 

--- a/docs/plans/2026-08-13-agent-harness-parity.md
+++ b/docs/plans/2026-08-13-agent-harness-parity.md
@@ -1,0 +1,552 @@
+# Agent Harness Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `agent-harness-parity`
+
+**Goal:** Make Mothership dispatch, setup, skills, context, and lifecycle enforcement portable across Claude Code, Codex, and OMP/Pi without weakening the shared policy in `core/agent_hooks.py`.
+
+## Assumptions checked
+
+- repo topology — **meta**; this WorkItem changes only the `mothership` member and does not alter cross-repo history or release coordination.
+- credential locus — **not applicable**; no credential, token, relay, or egress behavior changes.
+- execution locus — **both local and disposable workers**; all behavior is deterministic from checked-in code, temporary homes, and injected shell results, with optional local Codex/OMP probes used only as smoke evidence.
+- state durability — **existing journal and SDD record**; resolved model values remain persisted in `DispatchRecord`, and no new session-only state is introduced.
+- review surface — **terminal and async-neutral**; diagnostics are CLI `CheckResult` rows and dispatch contracts remain consumable by any controller.
+- agent stream — **existing journal-backed behavior**; this change adds no stream or logging subsystem.
+- dispatched model — **harness default unless explicitly overridden**; `inherit` is portable, while explicit values must be applied by a capable harness adapter or rejected with an actionable error.
+
+**Architecture:** Keep `core/agent_hooks.py` as the only owner of session-start context, guarded-edit decisions, inbox continuation, and bounded stop re-entry. Keep model strings opaque in Mothership core: all built-in modes resolve to the sentinel `inherit`, meaning the dispatching harness uses its default model; explicit operator values remain byte-for-byte values interpreted only by a harness adapter. Consolidate Codex capability parsing in `core/codex_hooks.py` so setup and doctor report the same activation state. Install OMP/Pi skills through OMP's documented cross-runtime `~/.agents/skills/` discovery path, reusing the existing foreign-content-safe symlink machinery. Test runtime adapters as translations around the shared policy, not as independent policy implementations.
+
+**Tech Stack:** Python 3.12, Typer, pytest, Markdown-based bundled skills, and Bun for generated OMP TypeScript smoke coverage.
+
+## Global Constraints
+
+- Do not modify `evaluate_edit`, WorkItem gating, inbox formatting/clearing, stop boundedness, fail-open policy, relay, GitHub, worktree, or PR behavior.
+- Do not write Codex `config.toml`, enable experimental features, or approve project trust.
+- Do not invent a Gemini-specific installer; Gemini remains on its documented native flow.
+- Preserve atomic writes and safe-skip behavior for foreign files, directories, and symlinks.
+- Do not add provider-name translation in Python. `sonnet`, `haiku`, `opus`, or any other operator override remains an opaque string.
+- A runtime adapter may omit a selector only for `inherit`. If an explicit model cannot be selected by the available subagent API, it must stop before dispatch and print how to use `inherit` or a selector-capable tool.
+
+---
+
+<!-- mship:task id=1 acs=ac1,ac2,ac9 -->
+## Task 1: Make dispatch model semantics portable
+
+**Files:**
+- Modify `src/mship/core/dispatch_models.py`
+- Modify `tests/core/test_dispatch_models.py`
+- Modify `tests/core/test_dispatch_stub.py`
+- Modify `tests/cli/test_dispatch.py`
+- Modify `src/mship/skills/subagent-driven-development/SKILL.md`
+- Modify `src/mship/skills/subagent-driven-development/implementer-prompt.md`
+- Modify `src/mship/skills/subagent-driven-development/task-reviewer-prompt.md`
+- Modify `src/mship/skills/subagent-driven-development/re-review-prompt.md`
+- Modify `src/mship/skills/using-mothership/references/codex-tools.md`
+- Modify `src/mship/skills/using-mothership/references/pi-tools.md`
+- Modify `src/mship/skills/working-with-mothership/SKILL.md`
+- Modify `tests/skills/test_skill_dispatch_ergonomics.py`
+- Modify `docs/configuration.md`
+
+**Interfaces and invariants:**
+
+```python
+BUILTIN_MODEL_DEFAULTS: dict[str, str] = {
+    "implementer": "inherit",
+    "standalone": "inherit",
+    "reviewer": "inherit",
+}
+
+
+def resolve_model(
+    mode: str,
+    *,
+    flag: str | None,
+    configured: dict[str, str] | None,
+) -> str:
+    """Return flag > configured value > portable built-in `inherit`."""
+```
+
+`DispatchRecord.model`, the closed stub's `model:` line, and the `emit:` line's model argument remain unchanged fields. An explicit value such as `openai/gpt-5.2` or `vendor/custom-tier` is stored and emitted verbatim. No core function validates, translates, or substitutes it.
+
+- [ ] **Step 1: Write failing portable-default tests.**
+
+  In `tests/core/test_dispatch_models.py`, replace the reviewer-specific expectation and cover all modes plus opaque overrides:
+
+  ```python
+  @pytest.mark.parametrize("mode", ["implementer", "standalone", "reviewer"])
+  def test_builtin_defaults_inherit_harness_model(mode):
+      assert resolve_model(mode, flag=None, configured=None) == "inherit"
+
+
+  def test_operator_model_value_is_opaque_and_verbatim():
+      value = "vendor/custom-tier:2026-08"
+      assert resolve_model("reviewer", flag=None, configured={"reviewer": value}) == value
+  ```
+
+  In `tests/core/test_dispatch_stub.py`, build a record for each mode with `model="inherit"`; assert the closed field set remains `record`, `model`, `mode`, `worktree`, `emit`, and assert none of `sonnet`, `haiku`, or `opus` appears. Add one explicit-model record and assert the exact value appears in both model-bearing lines without replacement.
+
+  In `tests/cli/test_dispatch.py`, change the no-override reviewer regression from `sonnet` to `inherit`, add implementer and standalone no-override cases if those modes are not already covered end-to-end, and retain the existing `--model haiku` precedence test as proof that an operator value is opaque.
+
+- [ ] **Step 2: Run the model tests and confirm the reviewer case fails for the old default.**
+
+  ```bash
+  uv run pytest tests/core/test_dispatch_models.py tests/core/test_dispatch_stub.py tests/cli/test_dispatch.py -q
+  ```
+
+  Expected before implementation: the reviewer default and generated reviewer stub contain `sonnet`.
+
+- [ ] **Step 3: Replace provider-specific defaults and comments in the core owner.**
+
+  Update `dispatch_models.py` exactly as the interface above. Rewrite the module docstring to state:
+
+  ```text
+  `inherit` is a portable sentinel: the controller omits a model selector and
+  lets the harness use its current/default model. Explicit CLI/config values
+  are opaque operator choices passed through unchanged.
+  ```
+
+  Remove claims that an omitted selector necessarily chooses the most expensive tier and remove the cheaper-reviewer rationale. Keep precedence and unknown-mode validation unchanged.
+
+- [ ] **Step 4: Make skill adapters implement the sentinel contract.**
+
+  Replace every template instruction that always fills a `model:` field with this exact branching rule:
+
+  ```text
+  Read the stub's resolved model before dispatch:
+  - `inherit`: omit the harness model selector; the harness default is intended.
+  - any other value: pass it unchanged through a supported model selector.
+  - if the available subagent API has no model selector, do not dispatch with
+    an explicit value. Report: "mship resolved explicit model '<value>', but
+    this subagent API cannot select a model; set this mode to inherit or use a
+    selector-capable dispatch tool."
+  Never translate one provider's model name into another.
+  ```
+
+  Apply the rule to implementer, task-reviewer, and re-review templates. In template-shaped examples, make the selector conditional rather than rendering `model: inherit` as a literal provider model:
+
+  For an explicit resolved value, render the harness selector with that exact value:
+
+  ```text
+  model: vendor/custom-tier
+  ```
+
+  For `inherit`, omit the entire selector field; do not pass the literal string `inherit` to the provider.
+
+  In `codex-tools.md`, document that `inherit` means invoking `spawn_agent` without a model selector; current Codex multi-agent APIs that expose no selector must reject explicit values with the exact actionable message above. In `pi-tools.md`, apply the same rule to the installed `subagent` tool: inspect its schema, pass explicit values only when it exposes a selector, otherwise reject. Claude's Task-style adapter continues to pass explicit values through its model field and omits that field for `inherit`.
+
+  Update `working-with-mothership/SKILL.md` and the model-selection section of `subagent-driven-development/SKILL.md` to describe portable defaults, opaque overrides, and the reject-not-substitute rule. Remove provider-tier assumptions from Mothership-workspace dispatch; retain generic task-complexity guidance only for non-Mothership work where the controller chooses a model itself.
+
+- [ ] **Step 5: Add contract tests for generated skill instructions.**
+
+  In `tests/skills/test_skill_dispatch_ergonomics.py`, load the affected bundled Markdown and assert:
+
+  ```python
+  assert "`inherit`" in text
+  assert "omit" in text
+  assert "cannot select a model" in text
+  assert "Never translate" in text
+  ```
+
+  Add a focused scan over the Mothership dispatch sections and prompt templates—not historical plans or vendor ledgers—proving that default instructions do not prescribe `sonnet`, `haiku`, or `opus`. Assert Codex and Pi references contain both branches: selector application when available and actionable rejection when unavailable.
+
+- [ ] **Step 6: Update configuration documentation.**
+
+  Change `docs/configuration.md` to say that every built-in mode defaults to `inherit`, define the sentinel as harness-default behavior, and state that configured values are emitted verbatim and require a selector-capable harness adapter. Do not list provider model names as defaults.
+
+- [ ] **Step 7: Verify, commit, and journal Task 1.**
+
+  ```bash
+  uv run pytest tests/core/test_dispatch_models.py tests/core/test_dispatch_stub.py tests/cli/test_dispatch.py tests/skills/test_skill_dispatch_ergonomics.py -q
+  mship test --task agent-harness-parity
+  mship commit "feat: make dispatch model defaults portable" --task agent-harness-parity
+  mship journal "portable inherit defaults and explicit model adapter rules implemented; dispatch and skill contract tests passing" --task agent-harness-parity --action committed
+  ```
+<!-- /mship:task -->
+
+<!-- mship:task id=2 acs=ac3,ac4,ac9 -->
+## Task 2: Consolidate Codex activation diagnostics
+
+**Files:**
+- Modify `src/mship/core/codex_hooks.py`
+- Modify `src/mship/cli/init.py`
+- Modify `src/mship/core/doctor.py`
+- Modify `tests/core/test_codex_hooks.py`
+- Modify `tests/cli/test_init.py`
+- Modify `tests/core/test_doctor.py`
+- Modify `docs/cli.md`
+
+**Interfaces and states:**
+
+```python
+CODEX_FEATURE_ENABLE_COMMAND = "codex features enable codex_hooks"
+CODEX_TRUST_ACTION = "open `/hooks` in Codex to review and trust the project hooks"
+CODEX_CAPABILITY_PROBE_TIMEOUT_SECONDS = 5
+
+
+class CodexHookCapability(str, Enum):
+    ABSENT = "absent"
+    UNAVAILABLE = "unavailable"
+    DISABLED = "disabled"
+    ENABLED = "enabled"
+    TIMED_OUT = "timed-out"
+
+
+@dataclass(frozen=True)
+class CodexHookCapabilityResult:
+    state: CodexHookCapability
+    feature_name: str | None = None
+    detail: str = ""
+
+
+def probe_codex_hook_capability(
+    shell: ShellRunner,
+    cwd: Path,
+    *,
+    codex_binary: str | None,
+) -> CodexHookCapabilityResult:
+    """Run and parse `codex features list` without mutating Codex config/trust."""
+```
+
+Accept both feature row names observed across supported versions: `codex_hooks` and `hooks`. Treat a successful row ending in `true` as enabled, a successful row ending in `false` as disabled, missing/unparseable rows or a nonzero exit as unavailable, timeout as timed out, and a missing binary as absent. The probe never executes `features enable` and never opens or approves `/hooks`.
+
+- [ ] **Step 1: Write failing probe-table tests.**
+
+  In `tests/core/test_codex_hooks.py`, parameterize exact `ShellResult` fixtures:
+
+  ```python
+  @pytest.mark.parametrize(
+      ("stdout", "returncode", "expected"),
+      [
+          ("codex_hooks  under-development  false\n", 0, CodexHookCapability.DISABLED),
+          ("hooks experimental true\n", 0, CodexHookCapability.ENABLED),
+          ("multi_agent experimental true\n", 0, CodexHookCapability.UNAVAILABLE),
+          ("", 1, CodexHookCapability.UNAVAILABLE),
+      ],
+  )
+  def test_probe_codex_hook_capability(stdout, returncode, expected):
+      shell = Mock()
+      shell.run.return_value = SimpleNamespace(
+          stdout=stdout,
+          stderr="",
+          returncode=returncode,
+      )
+
+      result = probe_codex_hook_capability(
+          shell,
+          Path("/workspace"),
+          codex_binary="/usr/bin/codex",
+      )
+
+      assert result.state is expected
+      shell.run.assert_called_once_with(
+          "codex features list",
+          cwd=Path("/workspace"),
+          timeout=CODEX_CAPABILITY_PROBE_TIMEOUT_SECONDS,
+      )
+  ```
+
+  Add missing-binary and `subprocess.TimeoutExpired` tests. Assert the shell call is exactly `codex features list`, uses the shared timeout constant, and performs no second command.
+
+- [ ] **Step 2: Write failing init and doctor state-matrix tests.**
+
+  Extend `tests/cli/test_init.py` so `mship init --install-hooks` with current Codex hook files reports:
+
+  - disabled/unavailable: `configured but inactive`, the exact command ``codex features enable codex_hooks``, and the exact `/hooks` trust action;
+  - enabled: `configured; capability enabled; trust still required`, with `/hooks`, and no claim that hooks are active;
+  - absent/timed out: configured but not verified active, with an install/timeout detail and no mutation.
+
+  Extend `tests/core/test_doctor.py` with the same matrix. For current registration plus enabled capability, assert `agent-runtime/codex` may pass but `agent-hooks/codex` remains a warning until manual trust, and no result message contains `fully active`. For disabled/unavailable capability, assert both the enable command and `/hooks` action appear. Snapshot the fake home/config before and after each command and assert byte equality outside the expected project hook artifact.
+
+- [ ] **Step 3: Run the focused tests and observe setup/doctor disagreement.**
+
+  ```bash
+  uv run pytest tests/core/test_codex_hooks.py tests/cli/test_init.py tests/core/test_doctor.py -q
+  ```
+
+  Expected before implementation: init only reports file installation; doctor independently parses capability rows and can call current registration a pass.
+
+- [ ] **Step 4: Implement the shared capability probe in `codex_hooks.py`.**
+
+  Add the enum, result dataclass, constants, and probe signature above beside the existing Codex artifact constants. Parse output without regular-expression inference beyond splitting non-empty lines; compare the first token to the accepted names and the final token to `true`/`false`. Preserve `install_codex_hooks` and `registration_issues` behavior unchanged.
+
+- [ ] **Step 5: Use the probe after installation and in doctor.**
+
+  In `_install_agent_hooks_with_output`, after all per-project Codex artifacts are reconciled, call the shared probe once for the workspace root. Print one warning that describes the aggregate activation state; do not run a probe per repo. Continue printing each artifact's installed/updated/skipped line.
+
+  In `DoctorChecker._agent_integration_checks`, remove the local `features` parsing loop and call the shared probe with the injected `ShellRunner`. Build rows from the result:
+
+  ```text
+  agent-runtime/codex: enabled capability may pass; all other states warn.
+  agent-hooks/codex: malformed/missing/stale registration warns with reinstall action.
+  agent-hooks/codex: current registration warns that it is configured but trust is
+  unverified, and prints the /hooks action; it must not pass as active.
+  ```
+
+  Disabled and unavailable states must include both `codex features enable codex_hooks` and `/hooks`. Enabled state must include only the remaining `/hooks` action. Keep optional runtime absence nonfatal.
+
+- [ ] **Step 6: Document the manual boundary.**
+
+  In `docs/cli.md`, state that `mship init --install-hooks` writes project hook files but does not enable Codex features or trust the project. Include the two explicit operator actions and say `mship doctor` distinguishes artifact validity, feature capability, and unresolved trust.
+
+- [ ] **Step 7: Verify no Codex config/trust mutation, then commit and journal.**
+
+  ```bash
+  uv run pytest tests/core/test_codex_hooks.py tests/cli/test_init.py tests/core/test_doctor.py -q
+  codex features list
+  mship test --task agent-harness-parity
+  mship commit "feat: report Codex hook activation state" --task agent-harness-parity
+  mship journal "Codex setup and doctor now share one read-only capability probe and distinguish configured, enabled, and untrusted states" --task agent-harness-parity --action committed
+  ```
+
+  The live `codex features list` command is observational only. Record its actual `codex_hooks`/`hooks` row in the journal; do not enable it as part of verification.
+<!-- /mship:task -->
+
+<!-- mship:task id=3 acs=ac5,ac6,ac7,ac9 -->
+## Task 3: Add first-class OMP/Pi skills and context
+
+**Files:**
+- Modify `src/mship/core/skill_install.py`
+- Modify `src/mship/cli/skill.py`
+- Modify `src/mship/core/doctor.py`
+- Modify `src/mship/core/context.py`
+- Modify `tests/core/test_skill_install.py`
+- Modify `tests/cli/test_skill.py`
+- Modify `tests/core/test_doctor.py`
+- Modify `tests/cli/test_context.py`
+- Modify `README.md`
+- Modify `docs/cli.md`
+
+**Discovery contract:** OMP's native `agents` discovery provider scans user-level `.agents/skills` and `.agent/skills`. Use the cross-runtime canonical target already used by Codex:
+
+```python
+SHARED_AGENT_SKILLS_TARGET = Path(".agents") / "skills" / "mothership"
+
+
+def shared_agent_skills_target(home: Path | None = None) -> Path:
+    return (home or Path.home()) / SHARED_AGENT_SKILLS_TARGET
+```
+
+Both Codex and OMP installers point the directory-level target at `pkg_skills_source()`. `pi` is a CLI alias normalized to canonical agent name `omp`; it must not produce a second install or health identity.
+
+- [ ] **Step 1: Write failing installer and alias tests.**
+
+  In `tests/core/test_skill_install.py`, add OMP cases proving:
+
+  ```python
+  result = install_for_omp()
+  assert result.agent == "omp"
+  assert result.dest == home / ".agents" / "skills"
+  assert (result.dest / "mothership").resolve() == pkg_skills_source().resolve()
+  assert {p.name for p in (result.dest / "mothership").iterdir() if (p / "SKILL.md").is_file()} == bundled_names
+  ```
+
+  Save `os.readlink(result.dest / "mothership")`, run the installer again, and assert the link text and target tree bytes are unchanged. Reuse the existing collision table to prove foreign symlink/file/directory entries are skipped without `--force`, an owned dangling link is repaired, and `--force` replaces foreign content only when explicitly requested.
+
+  In `tests/cli/test_skill.py`, assert `--only omp` and `--only pi` each produce one canonical `omp` result, `--only codex,omp` does not corrupt or duplicate the shared target, unknown agent validation remains strict, and auto-detection selects OMP when `omp`/`pi` is on PATH or `~/.omp` exists. Update help/list expectations to include `omp` and the `pi` alias.
+
+- [ ] **Step 2: Write failing doctor and context tests.**
+
+  In `tests/core/test_doctor.py`, enable OMP detection and assert a separate `skills/omp` row for current, missing, owned-dangling, stale, and foreign shared targets. Every non-current result must name `mship skill install --only omp`; foreign content must add `--force`. Assert this row is independent of `agent-hooks/omp` and `agent-runtime/omp`.
+
+  In `tests/cli/test_context.py`, parameterize `claude-code`, `codex`, and `omp` and assert their `audience.instructions` values are identical implementer text. Keep explicit negative cases for `--for pi`, `--for unknown`, and `--kind` with a non-reviewer audience unless the public alias is intentionally documented for context; the approved contract adds only canonical `omp`.
+
+- [ ] **Step 3: Run focused tests and confirm OMP is currently rejected.**
+
+  ```bash
+  uv run pytest tests/core/test_skill_install.py tests/cli/test_skill.py tests/core/test_doctor.py tests/cli/test_context.py -q
+  ```
+
+  Expected before implementation: `omp`/`pi` are unknown install targets, no `skills/omp` row exists, and `mship context --for omp` fails validation.
+
+- [ ] **Step 4: Implement the shared discovery target and OMP installer.**
+
+  Replace the Codex-specific target construction with `shared_agent_skills_target()`. Keep `refresh_symlink` as the only collision writer. Implement:
+
+  ```python
+  def install_for_omp(*, force: bool = False) -> AgentInstallResult:
+      src = pkg_skills_source()
+      target = shared_agent_skills_target()
+      outcome = refresh_symlink(src, target, force=force)
+      return AgentInstallResult(
+          agent="omp",
+          dest=target.parent,
+          count=0 if outcome is RefreshOutcome.skipped else 1,
+          skipped=["mothership"] if outcome is RefreshOutcome.skipped else [],
+          replaced=["mothership"] if outcome is RefreshOutcome.replaced else [],
+      )
+  ```
+
+  Refactor `install_for_codex` to use the same target helper without changing its result shape. Add OMP to `_detect_agents` using `omp`, the legacy `pi` executable, or `~/.omp`; do not add Gemini installation behavior.
+
+- [ ] **Step 5: Normalize CLI names and preserve one canonical result.**
+
+  Extend `SUPPORTED_AGENTS` and `_INSTALLERS` with `omp`. Normalize requested names before sorting/deduplicating:
+
+  ```python
+  aliases = {"pi": "omp"}
+  targets = sorted({aliases.get(name, name) for name in wanted})
+  ```
+
+  Validate against the union of canonical names and aliases before normalization. The help text must say `pi` is an alias for `omp`. If both Codex and OMP are selected, each result may report the same discovery target, but the second install must be a byte-idempotent no-op; never create a second private skill copy.
+
+- [ ] **Step 6: Add OMP skill health and context audience.**
+
+  In `doctor.py`, rename the private Codex-only target helper to the shared target owner and use the existing directory-level installed/dangling/foreign classifier for both detected Codex and OMP. Pass an agent-specific repair command into `_format_skill_check` so `skills/omp` recommends `mship skill install --only omp` while existing Claude/Codex guidance remains correct.
+
+  In `context.py`, add `"omp"` to `FOR_VALUES` and map `("omp", None)` to `_IMPLEMENTER_INSTRUCTIONS`. Do not duplicate the instruction string or add a new OMP-specific variant.
+
+- [ ] **Step 7: Update user-facing installation documentation.**
+
+  Update `README.md` and `docs/cli.md` command syntax to include `omp` and canonical Pi alias `pi`. State that Codex and OMP share the `.agents/skills/mothership` link, foreign entries are safe-skipped, and `mship doctor` reports OMP skill availability separately from project lifecycle extension compatibility.
+
+- [ ] **Step 8: Smoke-test in an isolated home, then commit and journal.**
+
+  ```bash
+  uv run pytest tests/core/test_skill_install.py tests/cli/test_skill.py tests/core/test_doctor.py tests/cli/test_context.py -q
+  env HOME=/tmp/mship-omp-skill-smoke uv run mship skill install --only omp --yes
+  env HOME=/tmp/mship-omp-skill-smoke uv run mship skill install --only pi --yes
+  uv run mship context --for omp --task agent-harness-parity
+  mship test --task agent-harness-parity
+  mship commit "feat: add OMP skill and context support" --task agent-harness-parity
+  mship journal "OMP/Pi skill install, independent doctor health, and canonical omp context audience implemented; isolated-home smoke passed" --task agent-harness-parity --action committed
+  ```
+
+  Remove `/tmp/mship-omp-skill-smoke` after confirming the second install leaves the symlink text and target bytes unchanged.
+<!-- /mship:task -->
+
+<!-- mship:task id=4 acs=ac8,ac9 -->
+## Task 4: Prove cross-runtime lifecycle conformance
+
+**Files:**
+- Modify `src/mship/core/claude_settings.py`
+- Modify `src/mship/cli/internal.py`
+- Modify `tests/core/test_claude_settings.py`
+- Create `tests/cli/test_agent_hook_conformance.py`
+- Modify `tests/cli/test_omp_hook.py`
+- Modify `tests/core/test_omp_extension.py`
+- Modify `tests/core/test_codex_hooks.py`
+- Modify `tests/core/test_agent_hooks.py`
+
+**Conformance boundary:** Tests feed runtime-native fixtures into each adapter, normalize the adapter result to `context | allow | deny | continue | stop | error`, and compare semantic kind/message. The tests must call the real hidden CLI adapters; mocking `agent_hooks.py` alone does not prove payload extraction or native result translation.
+
+- [ ] **Step 1: Add failing Claude multi-target extraction tests.**
+
+  Add this owner beside Claude registration logic, not in shared policy:
+
+  ```python
+  def extract_claude_edit_targets(event: dict[str, Any]) -> tuple[str, ...]:
+      """Extract every path represented by Claude Edit/Write/MultiEdit/NotebookEdit."""
+  ```
+
+  In `tests/core/test_claude_settings.py`, cover `file_path`, `notebook_path`, `edits: [{"file_path": "src/a.py"}, {"file_path": "src/b.py"}]`, duplicates, mixed valid/invalid entries, unsupported tools returning `()`, and recognized edit payloads with no path raising `ValueError`. A MultiEdit fixture containing one allowed worktree path and one main-checkout path must expose both targets.
+
+- [ ] **Step 2: Create adapter-fixture helpers and failing conformance cases.**
+
+  In `tests/cli/test_agent_hook_conformance.py`, define three small test-only invokers:
+
+  ```python
+  ADAPTERS = {
+      "claude": invoke_claude_hidden_commands,
+      "codex": invoke_codex_hidden_commands,
+      "omp": invoke_omp_hidden_command,
+  }
+  ```
+
+  Each invoker translates its native CLI stdout/stderr/exit code back to a test-only `{kind, message}` structure. Reuse one bootstrapped workspace/state/message store for these parameterized contracts:
+
+  1. session start with no active task returns the same actionable context text;
+  2. a valid worktree edit allows;
+  3. any denied target in a multi-target fixture denies the whole tool call and names the denied path/reason;
+  4. `MSHIP_ALLOW_MAIN_EDIT=1` allows the same main-checkout fixture for all runtimes;
+  5. `MSHIP_BYPASS_GATE=1` bypasses only the WorkItem clearance gate while preserving main-checkout protection;
+  6. an awaiting human reply or agent event returns `continue` with `mship reply`/action instructions;
+  7. the same stop event with continuation-active state returns `stop` and does not loop;
+  8. a forced adapter exception fails open and reports a warning naming runtime and lifecycle event.
+
+  Assert semantic equivalence, not identical native JSON shape. Claude/Codex exit codes, Codex JSON, and OMP decision envelopes remain runtime-native.
+
+- [ ] **Step 3: Run conformance tests and capture the current failures.**
+
+  ```bash
+  uv run pytest tests/core/test_claude_settings.py tests/cli/test_agent_hook_conformance.py tests/cli/test_omp_hook.py -q
+  ```
+
+  Expected before implementation: Claude does not extract MultiEdit target lists and suppresses adapter failure warnings while Codex/OMP report them.
+
+- [ ] **Step 4: Route Claude extraction through its adapter owner and align failure reporting.**
+
+  In `_guard-edit`, call `extract_claude_edit_targets` for `Runtime.CLAUDE` instead of reading a single `tool_input.file_path`. Preserve Codex extraction and OMP extraction unchanged. Pass every extracted target to `agent_hooks.pre_tool_use`; do not alter `_normalize_targets` or `evaluate_edit`.
+
+  Remove the Claude-only stderr suppression in `_guard-edit`, `_drain`, and `_session-context`. Every caught adapter exception must print:
+
+  ```text
+  mship: <runtime> <lifecycle-event> adapter failed open
+  ```
+
+  and preserve the existing fail-open native result. Never print event bodies, file contents, messages, or exception text.
+
+- [ ] **Step 5: Exercise the generated OMP extension under Bun.**
+
+  Extend `tests/core/test_omp_extension.py` with a behavioral smoke test skipped only when `bun` is unavailable. Install `OMP_EXTENSION_SOURCE` into a temporary project, put a fake `mship` executable first on `PATH`, and import the generated TypeScript from a Bun harness whose fake `pi` records `on`, `sendMessage`, and `logger.warn` calls. Drive the registered handlers with adapter outputs for context, deny, continue, stop, invalid JSON, and nonzero exit. Assert:
+
+  ```text
+  session_start context -> sendMessage(
+      {customType: "mship-session-context", content: "context", display: false},
+      {deliverAs: "nextTurn"},
+  )
+  tool_call deny         -> {block: true, reason: "denied"}
+  session_stop continue  -> {continue: true, additionalContext: "answer inbox"}
+  adapter error          -> warning and no block/forced continuation
+  ```
+
+  Assert exactly `session_start`, `tool_call`, and `session_stop` are registered. Keep the existing deterministic source, sibling-extension preservation, stale replacement, and atomic-write tests.
+
+- [ ] **Step 6: Run the complete focused parity suite.**
+
+  ```bash
+  uv run pytest \
+    tests/core/test_dispatch_models.py \
+    tests/core/test_dispatch_stub.py \
+    tests/cli/test_dispatch.py \
+    tests/core/test_codex_hooks.py \
+    tests/cli/test_init.py \
+    tests/core/test_skill_install.py \
+    tests/cli/test_skill.py \
+    tests/core/test_context.py \
+    tests/cli/test_context.py \
+    tests/core/test_doctor.py \
+    tests/core/test_agent_hooks.py \
+    tests/core/test_claude_settings.py \
+    tests/core/test_omp_extension.py \
+    tests/cli/test_internal.py \
+    tests/cli/test_drain.py \
+    tests/cli/test_omp_hook.py \
+    tests/cli/test_agent_hook_conformance.py \
+    tests/skills/test_skill_dispatch_ergonomics.py -q
+  ```
+
+  All existing Claude, Codex, and OMP lifecycle tests must remain green. Test failures may be fixed only in adapter extraction/translation or test fixtures unless they expose a pre-existing shared-policy bug separately approved by the user.
+
+- [ ] **Step 7: Run live read-only runtime probes and final smoke.**
+
+  ```bash
+  codex features list
+  omp --version
+  uv run mship doctor
+  uv run mship context --for omp --task agent-harness-parity
+  mship test --task agent-harness-parity
+  ```
+
+  Compare `mship doctor` with the actual Codex feature row and OMP version. Do not enable Codex hooks or alter trust. If either binary is unavailable, record that limitation and rely on the injected capability/version tests plus Bun extension smoke; do not claim a live probe ran.
+
+- [ ] **Step 8: Review scope, commit, and journal Task 4.**
+
+  ```bash
+  mship commit "test: enforce agent harness lifecycle parity" --task agent-harness-parity
+  mship journal "cross-runtime fixtures cover session context, multi-target guards, bypasses, inbox continuation, bounded stop, failure reporting, and generated OMP extension execution" --task agent-harness-parity --action committed
+  ```
+
+  Inspect the task-scoped change and confirm there are no user Codex config changes, trust state, generated caches, temporary homes, relay changes, provider translation tables, or Ground Control files.
+<!-- /mship:task -->

--- a/src/mship/cli/context.py
+++ b/src/mship/cli/context.py
@@ -43,7 +43,7 @@ def register(app: typer.Typer, get_container):
         task: Optional[str] = typer.Option(None, "--task", help="Target task slug. Defaults to cwd (worktree) > MSHIP_TASK env var."),
         for_: Optional[str] = typer.Option(
             None, "--for",
-            help="Shape the output for a specific audience: claude-code | codex | human | reviewer.",
+            help="Shape the output for a specific audience: claude-code | codex | omp | human | reviewer.",
         ),
         kind: Optional[str] = typer.Option(
             None, "--kind",

--- a/src/mship/cli/init.py
+++ b/src/mship/cli/init.py
@@ -36,17 +36,20 @@ def _install_agent_hooks_with_output(
     except Exception as e:
         output.warning(f"Stop hook install skipped: {e}")
 
+    codex_registrations_current = True
     for project_root in project_roots:
         try:
             codex = install_codex_hooks(project_root)
             line = f"Codex hooks @ {codex.path}: {codex.status}"
             if codex.message:
                 line += f" ({codex.message})"
-            if codex.status == "skipped":
-                output.warning(line)
-            else:
+            if codex.status in {"installed", "updated", "up to date"}:
                 output.success(line)
+            else:
+                codex_registrations_current = False
+                output.warning(line)
         except Exception as e:
+            codex_registrations_current = False
             output.warning(f"Codex hooks install skipped at {project_root}: {e}")
 
         try:
@@ -61,7 +64,14 @@ def _install_agent_hooks_with_output(
             ws_root,
             codex_binary=shutil.which("codex"),
         )
-        if capability.state in {
+        if not codex_registrations_current:
+            output.warning(
+                "Codex hook installation incomplete: one or more project "
+                "registrations were skipped or failed; run "
+                "`mship init --install-hooks`; capability probe state: "
+                f"{capability.state.value}"
+            )
+        elif capability.state in {
             CodexHookCapability.DISABLED,
             CodexHookCapability.UNAVAILABLE,
         }:

--- a/src/mship/cli/init.py
+++ b/src/mship/cli/init.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 from typing import Optional
 
@@ -7,8 +8,15 @@ from mship.cli.output import Output
 from mship.core.config import ConfigLoader, unique_git_roots, resolve_go_task_files
 from mship.core.init import WorkspaceInitializer, DetectedRepo
 from mship.core.claude_settings import install_session_hook, install_pretooluse_guard_hook, install_stop_hook
-from mship.core.codex_hooks import install_codex_hooks
+from mship.core.codex_hooks import (
+    CODEX_FEATURE_ENABLE_COMMAND,
+    CODEX_TRUST_ACTION,
+    CodexHookCapability,
+    install_codex_hooks,
+    probe_codex_hook_capability,
+)
 from mship.core.omp_extension import install_omp_extension
+from mship.util.shell import ShellRunner
 
 
 def _install_agent_hooks_with_output(
@@ -46,6 +54,32 @@ def _install_agent_hooks_with_output(
             output.success(f"OMP extension @ {omp.path}: {omp.status}")
         except Exception as e:
             output.warning(f"OMP extension install skipped at {project_root}: {e}")
+
+    if project_roots:
+        capability = probe_codex_hook_capability(
+            ShellRunner(),
+            ws_root,
+            codex_binary=shutil.which("codex"),
+        )
+        if capability.state in {
+            CodexHookCapability.DISABLED,
+            CodexHookCapability.UNAVAILABLE,
+        }:
+            output.warning(
+                "Codex hooks configured but inactive: "
+                f"{capability.detail}; run `{CODEX_FEATURE_ENABLE_COMMAND}`; "
+                f"{CODEX_TRUST_ACTION}"
+            )
+        elif capability.state is CodexHookCapability.ENABLED:
+            output.warning(
+                "Codex hooks configured; capability enabled; trust still required: "
+                f"{CODEX_TRUST_ACTION}"
+            )
+        else:
+            output.warning(
+                "Codex hooks configured but not verified active: "
+                f"{capability.detail}; {CODEX_TRUST_ACTION}"
+            )
 
 
 def register(app: typer.Typer, get_container):

--- a/src/mship/cli/init.py
+++ b/src/mship/cli/init.py
@@ -65,10 +65,18 @@ def _install_agent_hooks_with_output(
             codex_binary=shutil.which("codex"),
         )
         if not codex_registrations_current:
-            output.warning(
+            message = (
                 "Codex hook installation incomplete: one or more project "
                 "registrations were skipped or failed; run "
-                "`mship init --install-hooks`; capability probe state: "
+                "`mship init --install-hooks`"
+            )
+            if capability.state in {
+                CodexHookCapability.DISABLED,
+                CodexHookCapability.UNAVAILABLE,
+            }:
+                message += f"; run `{CODEX_FEATURE_ENABLE_COMMAND}`"
+            output.warning(
+                f"{message}; {CODEX_TRUST_ACTION}; capability probe state: "
                 f"{capability.state.value}"
             )
         elif capability.state in {

--- a/src/mship/cli/internal.py
+++ b/src/mship/cli/internal.py
@@ -337,7 +337,10 @@ def register(app: typer.Typer, get_container):
             runtime_id = Runtime(runtime)
             raw = sys.stdin.read()
             event = json.loads(raw) if raw.strip() else {}
-            if runtime_id is Runtime.CODEX:
+            if runtime_id is Runtime.CLAUDE:
+                from mship.core.claude_settings import extract_claude_edit_targets
+                targets = extract_claude_edit_targets(event)
+            elif runtime_id is Runtime.CODEX:
                 from mship.core.codex_hooks import extract_edit_targets
                 targets = extract_edit_targets(event)
             else:
@@ -363,8 +366,7 @@ def register(app: typer.Typer, get_container):
         except typer.Exit:
             raise
         except Exception:
-            if runtime != Runtime.CLAUDE.value:
-                sys.stderr.write(f"mship: {runtime} PreToolUse adapter failed open\n")
+            sys.stderr.write(f"mship: {runtime} PreToolUse adapter failed open\n")
             raise typer.Exit(code=0)
         if decision.kind is DecisionKind.DENY:
             sys.stderr.write(decision.message + "\n")
@@ -394,8 +396,7 @@ def register(app: typer.Typer, get_container):
         except typer.Exit:
             raise
         except Exception:
-            if runtime != Runtime.CLAUDE.value:
-                sys.stderr.write(f"mship: {runtime} Stop adapter failed open\n")
+            sys.stderr.write(f"mship: {runtime} Stop adapter failed open\n")
             raise typer.Exit(code=0)
         if decision.kind is DecisionKind.CONTINUE:
             print(json.dumps({"decision": "block", "reason": decision.message}))
@@ -411,8 +412,7 @@ def register(app: typer.Typer, get_container):
         try:
             decision = session_start(Runtime(runtime), Path.cwd())
         except Exception:
-            if runtime != Runtime.CLAUDE.value:
-                sys.stderr.write(f"mship: {runtime} SessionStart adapter failed open\n")
+            sys.stderr.write(f"mship: {runtime} SessionStart adapter failed open\n")
             raise typer.Exit(code=0)
         if decision.message:
             sys.stdout.write(decision.message + "\n")

--- a/src/mship/cli/skill.py
+++ b/src/mship/cli/skill.py
@@ -18,12 +18,14 @@ from mship.core import skill_install as _si
 from mship.core.skill_install import AgentInstallResult
 
 
-SUPPORTED_AGENTS = ("claude", "codex", "gemini")
+SUPPORTED_AGENTS = ("claude", "codex", "gemini", "omp")
+AGENT_ALIASES = {"pi": "omp"}
 
 
 _INSTALLERS = {
     "claude": _si.install_for_claude,
     "codex":  _si.install_for_codex,
+    "omp": _si.install_for_omp,
     # gemini is not bundled — it has its own `gemini extensions install` flow,
     # which lives outside mship's symlink model. Print guidance instead.
 }
@@ -42,7 +44,14 @@ def register(app: typer.Typer, get_container):
     @app.command(name="skill", rich_help_panel="Setup")
     def skill_cmd(
         action: str = typer.Argument(help="Action: install | list"),
-        only: Optional[str] = typer.Option(None, "--only", help="Comma-separated agents (claude,codex,gemini)"),
+        only: Optional[str] = typer.Option(
+            None,
+            "--only",
+            help=(
+                "Comma-separated agents (claude,codex,gemini,omp); "
+                "pi is an alias for omp"
+            ),
+        ),
         force: bool = typer.Option(False, "--force", help="Override safe-skip on foreign content"),
         yes: bool = typer.Option(False, "--yes", "-y", help="Skip per-agent confirmation prompts"),
     ):
@@ -67,11 +76,11 @@ def _install(output: Output, *, only: Optional[str], force: bool, yes: bool) -> 
     detected = _si._detect_agents()
     if only:
         wanted = {a.strip() for a in only.split(",") if a.strip()}
-        unknown = wanted - set(SUPPORTED_AGENTS)
+        unknown = wanted - set(SUPPORTED_AGENTS) - set(AGENT_ALIASES)
         if unknown:
             output.error(f"Unknown agent(s): {', '.join(sorted(unknown))}")
             raise typer.Exit(code=1)
-        targets = sorted(wanted)
+        targets = sorted({AGENT_ALIASES.get(name, name) for name in wanted})
     else:
         targets = sorted(a for a, present in detected.items() if present)
 

--- a/src/mship/core/claude_settings.py
+++ b/src/mship/core/claude_settings.py
@@ -11,11 +11,42 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 SESSION_COMMAND = "mship _session-context"
 GUARD_COMMAND = "mship _guard-edit"
 GUARD_MATCHER = "Edit|Write|MultiEdit|NotebookEdit"
 DRAIN_COMMAND = "mship _drain"
+
+_EDIT_TOOLS = {"Edit", "Write", "MultiEdit", "NotebookEdit"}
+
+
+def extract_claude_edit_targets(event: dict[str, Any]) -> tuple[str, ...]:
+    """Extract every path represented by Claude Edit/Write/MultiEdit/NotebookEdit."""
+    if event.get("tool_name") not in _EDIT_TOOLS:
+        return ()
+    tool_input = event.get("tool_input")
+    if not isinstance(tool_input, dict):
+        raise ValueError("guarded edit did not contain a target path")
+
+    targets: list[str] = []
+    for key in ("file_path", "notebook_path"):
+        value = tool_input.get(key)
+        if isinstance(value, str) and value:
+            targets.append(value)
+    edits = tool_input.get("edits")
+    if isinstance(edits, list):
+        for edit in edits:
+            if not isinstance(edit, dict):
+                continue
+            value = edit.get("file_path") or edit.get("notebook_path")
+            if isinstance(value, str) and value:
+                targets.append(value)
+    if not targets:
+        raise ValueError("guarded edit did not contain a target path")
+    return tuple(dict.fromkeys(targets))
+
+
 CLAUDE_ENTRIES = {
     "SessionStart": {
         "hooks": [{"type": "command", "command": SESSION_COMMAND}],

--- a/src/mship/core/codex_hooks.py
+++ b/src/mship/core/codex_hooks.py
@@ -6,12 +6,19 @@ import os
 import re
 import shlex
 import tempfile
+import subprocess
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from mship.util.shell import ShellRunner
+
 
 CODEX_HOOKS_PATH = Path(".codex/hooks.json")
+CODEX_FEATURE_ENABLE_COMMAND = "codex features enable codex_hooks"
+CODEX_TRUST_ACTION = "open `/hooks` in Codex to review and trust the project hooks"
+CODEX_CAPABILITY_PROBE_TIMEOUT_SECONDS = 5
 CODEX_COMMANDS = {
     "SessionStart": "mship _session-context --runtime codex",
     "PreToolUse": "mship _guard-edit --runtime codex",
@@ -51,6 +58,75 @@ class CodexInstallResult:
     status: str
     path: Path
     message: str = ""
+
+
+class CodexHookCapability(str, Enum):
+    ABSENT = "absent"
+    UNAVAILABLE = "unavailable"
+    DISABLED = "disabled"
+    ENABLED = "enabled"
+    TIMED_OUT = "timed-out"
+
+
+@dataclass(frozen=True)
+class CodexHookCapabilityResult:
+    state: CodexHookCapability
+    feature_name: str | None = None
+    detail: str = ""
+
+
+def probe_codex_hook_capability(
+    shell: ShellRunner,
+    cwd: Path,
+    *,
+    codex_binary: str | None,
+) -> CodexHookCapabilityResult:
+    """Run and parse `codex features list` without mutating Codex config/trust."""
+    if codex_binary is None:
+        return CodexHookCapabilityResult(
+            CodexHookCapability.ABSENT,
+            detail="Codex is not installed",
+        )
+
+    try:
+        result = shell.run(
+            "codex features list",
+            cwd=cwd,
+            timeout=CODEX_CAPABILITY_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return CodexHookCapabilityResult(
+            CodexHookCapability.TIMED_OUT,
+            detail="Codex hook capability probe timed out",
+        )
+
+    if result.returncode != 0:
+        return CodexHookCapabilityResult(
+            CodexHookCapability.UNAVAILABLE,
+            detail="Codex hook capability is unavailable",
+        )
+
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if not parts or parts[0] not in {"codex_hooks", "hooks"}:
+            continue
+        enabled = parts[-1].lower()
+        if enabled == "true":
+            return CodexHookCapabilityResult(
+                CodexHookCapability.ENABLED,
+                feature_name=parts[0],
+            )
+        if enabled == "false":
+            return CodexHookCapabilityResult(
+                CodexHookCapability.DISABLED,
+                feature_name=parts[0],
+                detail="Codex hook capability is disabled",
+            )
+
+    return CodexHookCapabilityResult(
+        CodexHookCapability.UNAVAILABLE,
+        detail="Codex hook capability is unavailable",
+    )
 
 
 def _deduplicate(values: list[str]) -> tuple[str, ...]:

--- a/src/mship/core/context.py
+++ b/src/mship/core/context.py
@@ -43,7 +43,7 @@ DirtyCheck = Callable[[Path], Optional[bool]]
 # code-quality-reviewer}-prompt.md` so a later migration of those templates
 # to consume this output is a drop-in swap rather than a rewrite.
 
-FOR_VALUES: tuple[str, ...] = ("claude-code", "codex", "human", "reviewer")
+FOR_VALUES: tuple[str, ...] = ("claude-code", "codex", "omp", "human", "reviewer")
 KIND_VALUES: tuple[str, ...] = ("spec", "code-quality")
 
 
@@ -97,6 +97,7 @@ _REVIEWER_CODE_QUALITY_INSTRUCTIONS = (
 _INSTRUCTIONS: dict[tuple[str, Optional[str]], str] = {
     ("claude-code", None): _IMPLEMENTER_INSTRUCTIONS,
     ("codex", None): _IMPLEMENTER_INSTRUCTIONS,
+    ("omp", None): _IMPLEMENTER_INSTRUCTIONS,
     ("human", None): _HUMAN_INSTRUCTIONS,
     ("reviewer", "spec"): _REVIEWER_SPEC_INSTRUCTIONS,
     ("reviewer", "code-quality"): _REVIEWER_CODE_QUALITY_INSTRUCTIONS,
@@ -107,8 +108,8 @@ def _validate_audience(for_: Optional[str], kind: Optional[str]) -> None:
     """Raise AudienceError for any invalid `--for`/`--kind` combination.
 
     Valid: `for_` is None (kind must also be None); `for_` is claude-code /
-    codex / human (kind must be None); `for_` is reviewer (kind must be spec
-    or code-quality).
+    codex / omp / human (kind must be None); `for_` is reviewer (kind must be
+    spec or code-quality).
     """
     if for_ is None:
         if kind is not None:

--- a/src/mship/core/dispatch_models.py
+++ b/src/mship/core/dispatch_models.py
@@ -2,22 +2,18 @@
 
 The dispatcher — not the untrusted worker — owns the model choice. Precedence:
 CLI flag > `dispatch_models:` per-mode map in mothership.yaml > built-in
-per-mode default. Values are operator-chosen strings passed through verbatim
-(harness-specific tier names are not validated here).
+per-mode default.
 
-Upstream superpowers found that an unnamed model silently inherits the
-session's most expensive tier; resolving here makes the choice explicit,
-auditable, and configured in one place.
+`inherit` is a portable sentinel: the controller omits a model selector and
+lets the harness use its current/default model. Explicit CLI/config values
+are opaque operator choices passed through unchanged.
 """
 from __future__ import annotations
 
-# Reviewer work is judgment over prepared files — a cheaper tier by default.
-# "inherit" means: no explicit model; the dispatching harness uses its session
-# model. Implementers default to inherit so a capable session stays capable.
 BUILTIN_MODEL_DEFAULTS: dict[str, str] = {
     "implementer": "inherit",
     "standalone": "inherit",
-    "reviewer": "sonnet",
+    "reviewer": "inherit",
 }
 
 

--- a/src/mship/core/doctor.py
+++ b/src/mship/core/doctor.py
@@ -471,7 +471,11 @@ class DoctorChecker:
         )
         from mship.core.codex_hooks import (
             CODEX_COMMANDS,
+            CODEX_FEATURE_ENABLE_COMMAND,
             CODEX_HOOKS_PATH,
+            CODEX_TRUST_ACTION,
+            CodexHookCapability,
+            probe_codex_hook_capability,
             registration_issues as codex_registration_issues,
         )
         from mship.core.omp_extension import (
@@ -486,6 +490,12 @@ class DoctorChecker:
             return []
         codex_paths = [project_root / CODEX_HOOKS_PATH for project_root in project_roots]
         omp_paths = [project_root / OMP_EXTENSION_PATH for project_root in project_roots]
+        codex_binary = shutil.which("codex")
+        codex_capability = probe_codex_hook_capability(
+            self._shell,
+            root,
+            codex_binary=codex_binary,
+        )
         checks = [
             self._json_hook_check(
                 name="agent-hooks/claude",
@@ -510,16 +520,45 @@ class DoctorChecker:
         ]
         codex_issues = [result.message for result in codex_results if result.status != "pass"]
         if codex_issues:
+            message = "; ".join(codex_issues)
+            reinstall_action = "run `mship init --install-hooks`"
+            if reinstall_action not in message:
+                message += f"; {reinstall_action}"
             checks.append(CheckResult(
                 name="agent-hooks/codex",
                 status="warn",
-                message="; ".join(codex_issues),
+                message=message,
+            ))
+        elif codex_capability.state in {
+            CodexHookCapability.DISABLED,
+            CodexHookCapability.UNAVAILABLE,
+        }:
+            checks.append(CheckResult(
+                name="agent-hooks/codex",
+                status="warn",
+                message=(
+                    "Codex hooks configured but inactive: "
+                    f"{codex_capability.detail}; "
+                    f"run `{CODEX_FEATURE_ENABLE_COMMAND}`; {CODEX_TRUST_ACTION}"
+                ),
+            ))
+        elif codex_capability.state is CodexHookCapability.ENABLED:
+            checks.append(CheckResult(
+                name="agent-hooks/codex",
+                status="warn",
+                message=(
+                    "Codex hooks configured; capability enabled; trust still required: "
+                    f"{CODEX_TRUST_ACTION}"
+                ),
             ))
         else:
             checks.append(CheckResult(
                 name="agent-hooks/codex",
-                status="pass",
-                message="Mothership hooks installed at " + ", ".join(map(str, codex_paths)),
+                status="warn",
+                message=(
+                    "Codex hooks configured but not verified active: "
+                    f"{codex_capability.detail}; {CODEX_TRUST_ACTION}"
+                ),
             ))
 
         omp_issues: list[str] = []
@@ -547,57 +586,29 @@ class DoctorChecker:
                 message="Mothership extension installed at " + ", ".join(map(str, omp_paths)),
             ))
 
-        codex_binary = shutil.which("codex")
-        if codex_binary is None:
+        if codex_capability.state is CodexHookCapability.ENABLED:
+            checks.append(CheckResult(
+                name="agent-runtime/codex",
+                status="pass",
+                message=f"Codex hook capability available at {codex_binary}",
+            ))
+        elif codex_capability.state in {
+            CodexHookCapability.DISABLED,
+            CodexHookCapability.UNAVAILABLE,
+        }:
             checks.append(CheckResult(
                 name="agent-runtime/codex",
                 status="warn",
-                message="Codex is not installed; Claude and OMP integrations remain available",
+                message=(
+                    f"{codex_capability.detail}; "
+                    f"run `{CODEX_FEATURE_ENABLE_COMMAND}`"
+                ),
             ))
         else:
-            try:
-                capability = self._shell.run(
-                    "codex features list",
-                    cwd=root,
-                    timeout=_AGENT_RUNTIME_PROBE_TIMEOUT_SECONDS,
-                )
-            except subprocess.TimeoutExpired:
-                checks.append(CheckResult(
-                    name="agent-runtime/codex",
-                    status="warn",
-                    message="Codex hook capability probe timed out",
-                ))
-            else:
-                features: dict[str, str] = {}
-                for line in capability.stdout.splitlines():
-                    parts = line.split()
-                    if parts and parts[0] in {"hooks", "codex_hooks"}:
-                        features[parts[0]] = parts[-1].lower()
-                feature = features.get("hooks", features.get("codex_hooks"))
-                if capability.returncode != 0 or feature is None:
-                    checks.append(CheckResult(
-                        name="agent-runtime/codex",
-                        status="warn",
-                        message="Codex hook capability is unavailable; this Codex version may be too old",
-                    ))
-                elif feature != "true":
-                    checks.append(CheckResult(
-                        name="agent-runtime/codex",
-                        status="warn",
-                        message="Codex hook capability is disabled; enable `[features].hooks = true` before use",
-                    ))
-                else:
-                    checks.append(CheckResult(
-                        name="agent-runtime/codex",
-                        status="pass",
-                        message=f"Codex hook capability available at {codex_binary}",
-                    ))
-
-        if any(path.is_file() for path in codex_paths):
             checks.append(CheckResult(
-                name="agent-hooks/codex-trust",
+                name="agent-runtime/codex",
                 status="warn",
-                message="Codex project hooks require explicit review/trust; open `/hooks` in Codex",
+                message=codex_capability.detail,
             ))
 
         omp_binary = shutil.which("omp")

--- a/src/mship/core/doctor.py
+++ b/src/mship/core/doctor.py
@@ -558,6 +558,12 @@ class DoctorChecker:
             reinstall_action = "run `mship init --install-hooks`"
             if reinstall_action not in message:
                 message += f"; {reinstall_action}"
+            if codex_capability.state in {
+                CodexHookCapability.DISABLED,
+                CodexHookCapability.UNAVAILABLE,
+            }:
+                message += f"; run `{CODEX_FEATURE_ENABLE_COMMAND}`"
+            message += f"; {CODEX_TRUST_ACTION}"
             checks.append(CheckResult(
                 name="agent-hooks/codex",
                 status="warn",
@@ -645,17 +651,22 @@ class DoctorChecker:
                 message=codex_capability.detail,
             ))
 
-        omp_binary = shutil.which("omp")
+        omp_command = "omp"
+        omp_binary = shutil.which(omp_command)
+        if omp_binary is None:
+            omp_command = "pi"
+            omp_binary = shutil.which(omp_command)
+        runtime_name = "OMP" if omp_command == "omp" else "Pi"
         if omp_binary is None:
             checks.append(CheckResult(
                 name="agent-runtime/omp",
                 status="warn",
-                message="OMP is not installed; Claude and Codex integrations remain available",
+                message="OMP/Pi is not installed; Claude and Codex integrations remain available",
             ))
         else:
             try:
                 version_result = self._shell.run(
-                    "omp --version",
+                    f"{omp_command} --version",
                     cwd=root,
                     timeout=_AGENT_RUNTIME_PROBE_TIMEOUT_SECONDS,
                 )
@@ -663,7 +674,7 @@ class DoctorChecker:
                 checks.append(CheckResult(
                     name="agent-runtime/omp",
                     status="warn",
-                    message="OMP version probe timed out",
+                    message=f"{runtime_name} version probe timed out",
                 ))
             else:
                 match = re.search(r"(\d+)\.(\d+)\.(\d+)", version_result.stdout)
@@ -671,7 +682,7 @@ class DoctorChecker:
                     checks.append(CheckResult(
                         name="agent-runtime/omp",
                         status="warn",
-                        message="could not determine OMP version or extension compatibility",
+                        message=f"could not determine {runtime_name} version or extension compatibility",
                     ))
                 else:
                     version = tuple(int(part) for part in match.groups())
@@ -680,7 +691,7 @@ class DoctorChecker:
                             name="agent-runtime/omp",
                             status="warn",
                             message=(
-                                f"OMP {'.'.join(match.groups())} is too old for this extension; "
+                                f"{runtime_name} {'.'.join(match.groups())} is too old for this extension; "
                                 f"requires {'.'.join(map(str, OMP_MIN_VERSION))} or newer"
                             ),
                         ))
@@ -688,7 +699,7 @@ class DoctorChecker:
                         checks.append(CheckResult(
                             name="agent-runtime/omp",
                             status="pass",
-                            message=f"OMP {'.'.join(match.groups())} supports project extensions",
+                            message=f"{runtime_name} {'.'.join(match.groups())} supports project extensions",
                         ))
         return checks
 

--- a/src/mship/core/doctor.py
+++ b/src/mship/core/doctor.py
@@ -42,8 +42,8 @@ def _claude_target(skill_name: str) -> Path:
     return Path.home() / ".claude" / "skills" / skill_name
 
 
-def _codex_target() -> Path:
-    return Path.home() / ".agents" / "skills" / "mothership"
+def _shared_agent_skills_target() -> Path:
+    return _si.shared_agent_skills_target()
 
 
 def _intended_target(symlink: Path) -> Path:
@@ -54,8 +54,29 @@ def _intended_target(symlink: Path) -> Path:
     return raw
 
 
+def _classify_directory_skill_target(
+    target: Path, pkg_src: Path, total: int
+) -> tuple[int, int, int, int]:
+    """Return installed, dangling, stale, and foreign counts for a shared link."""
+    installed = dangling = stale = foreign = 0
+    if target.is_symlink():
+        intended = _intended_target(target)
+        if target.exists() and intended.resolve() == pkg_src.resolve():
+            installed = total
+        elif _si.is_owned_target(intended):
+            if target.exists():
+                stale = total
+            else:
+                dangling = total
+        else:
+            foreign = total
+    elif target.exists():
+        foreign = total
+    return installed, dangling, stale, foreign
+
+
 def check_skill_availability() -> list[CheckResult]:
-    """One CheckResult per detected agent reporting installed/dangling/foreign."""
+    """One CheckResult per detected agent reporting skill discovery health."""
     results: list[CheckResult] = []
     pkg_src = _si.pkg_skills_source()
     skill_dirs = _si._iter_skill_dirs(pkg_src)
@@ -63,7 +84,7 @@ def check_skill_availability() -> list[CheckResult]:
     detected = _si._detect_agents()
 
     if detected.get("claude"):
-        installed = dangling = foreign = 0
+        installed = dangling = stale = foreign = 0
         for d in skill_dirs:
             target = _claude_target(d.name)
             if not target.exists() and not target.is_symlink():
@@ -73,33 +94,45 @@ def check_skill_availability() -> list[CheckResult]:
                 if target.exists() and intended.resolve() == d.resolve():
                     installed += 1
                 elif _si.is_owned_target(intended):
-                    dangling += 1
+                    if target.exists():
+                        stale += 1
+                    else:
+                        dangling += 1
                 else:
                     foreign += 1
             else:
                 foreign += 1
-        results.append(_format_skill_check("claude", installed, dangling, foreign, total))
+        results.append(_format_skill_check(
+            "claude", installed, dangling, stale, foreign, total,
+            repair_command="mship skill install --only claude",
+        ))
 
-    if detected.get("codex"):
-        target = _codex_target()
-        installed = dangling = foreign = 0
-        if target.is_symlink():
-            intended = _intended_target(target)
-            if target.exists() and intended.resolve() == pkg_src.resolve():
-                installed = total
-            elif _si.is_owned_target(intended):
-                dangling = total
-            else:
-                foreign = total
-        elif target.exists():
-            foreign = total
-        results.append(_format_skill_check("codex", installed, dangling, foreign, total))
+    shared_target = _shared_agent_skills_target()
+    for agent in ("codex", "omp"):
+        if not detected.get(agent):
+            continue
+        installed, dangling, stale, foreign = _classify_directory_skill_target(
+            shared_target, pkg_src, total
+        )
+        results.append(_format_skill_check(
+            agent, installed, dangling, stale, foreign, total,
+            repair_command=f"mship skill install --only {agent}",
+        ))
 
     return results
 
 
-def _format_skill_check(agent: str, installed: int, dangling: int, foreign: int, total: int) -> CheckResult:
-    if installed == total and dangling == 0 and foreign == 0:
+def _format_skill_check(
+    agent: str,
+    installed: int,
+    dangling: int,
+    stale: int,
+    foreign: int,
+    total: int,
+    *,
+    repair_command: str,
+) -> CheckResult:
+    if installed == total and dangling == 0 and stale == 0 and foreign == 0:
         return CheckResult(
             name=f"skills/{agent}", status="pass",
             message=f"{installed}/{total} skills installed and current",
@@ -107,11 +140,12 @@ def _format_skill_check(agent: str, installed: int, dangling: int, foreign: int,
     parts = [f"{installed}/{total} installed"]
     if dangling:
         parts.append(f"{dangling} dangling")
+    if stale:
+        parts.append(f"{stale} stale")
     if foreign:
         parts.append(f"{foreign} foreign (skipped)")
-    msg = ", ".join(parts) + " — run `mship skill install`"
-    if foreign:
-        msg += " (use --force to overwrite foreign entries)"
+        repair_command += " --force"
+    msg = ", ".join(parts) + f" — run `{repair_command}`"
     return CheckResult(name=f"skills/{agent}", status="warn", message=msg)
 
 

--- a/src/mship/core/skill_install.py
+++ b/src/mship/core/skill_install.py
@@ -45,10 +45,17 @@ _RENAMED_SKILLS: dict[str, str] = {
     "using-superpowers": "using-mothership",
 }
 
+SHARED_AGENT_SKILLS_TARGET = Path(".agents") / "skills" / "mothership"
+
 
 def pkg_skills_source() -> Path:
     """Return the package-bundled skills directory."""
     return Path(mship.__file__).parent / "skills"
+
+
+def shared_agent_skills_target(home: Path | None = None) -> Path:
+    """Return the shared Codex and OMP/Pi discovery link."""
+    return (home or Path.home()) / SHARED_AGENT_SKILLS_TARGET
 
 
 def is_owned_target(target: Path) -> bool:
@@ -70,6 +77,7 @@ def is_owned_target(target: Path) -> bool:
 
 class RefreshOutcome(str, Enum):
     created = "created"
+    unchanged = "unchanged"
     replaced = "replaced"
     skipped = "skipped"
 
@@ -93,6 +101,8 @@ def refresh_symlink(src: Path, dst: Path, *, force: bool) -> RefreshOutcome:
         intended = Path(os.readlink(dst))
         if not intended.is_absolute():
             intended = (dst.parent / intended).resolve(strict=False)
+        if intended.resolve(strict=False) == src.resolve(strict=False):
+            return RefreshOutcome.unchanged
         if is_owned_target(intended) or force:
             dst.unlink()
             dst.symlink_to(src)
@@ -161,14 +171,27 @@ def install_for_claude(*, force: bool = False) -> AgentInstallResult:
 def install_for_codex(*, force: bool = False) -> AgentInstallResult:
     """One dir-level symlink at ~/.agents/skills/mothership → <pkg>/skills/."""
     src = pkg_skills_source()
-    dest = Path.home() / ".agents" / "skills"
-    target = dest / "mothership"
+    target = shared_agent_skills_target()
     outcome = refresh_symlink(src, target, force=force)
     skipped = ["mothership"] if outcome == RefreshOutcome.skipped else []
     replaced = ["mothership"] if outcome == RefreshOutcome.replaced else []
     return AgentInstallResult(
-        agent="codex", dest=dest, count=0 if skipped else 1,
+        agent="codex", dest=target.parent, count=0 if skipped else 1,
         skipped=skipped, replaced=replaced,
+    )
+
+
+def install_for_omp(*, force: bool = False) -> AgentInstallResult:
+    """Install the bundle at OMP/Pi's shared user-level discovery target."""
+    src = pkg_skills_source()
+    target = shared_agent_skills_target()
+    outcome = refresh_symlink(src, target, force=force)
+    return AgentInstallResult(
+        agent="omp",
+        dest=target.parent,
+        count=0 if outcome is RefreshOutcome.skipped else 1,
+        skipped=["mothership"] if outcome is RefreshOutcome.skipped else [],
+        replaced=["mothership"] if outcome is RefreshOutcome.replaced else [],
     )
 
 
@@ -179,4 +202,9 @@ def _detect_agents() -> dict[str, bool]:
         "claude": shutil.which("claude") is not None or (home / ".claude").exists(),
         "codex":  shutil.which("codex")  is not None or (home / ".codex").exists(),
         "gemini": shutil.which("gemini") is not None or (home / ".gemini").exists(),
+        "omp": (
+            shutil.which("omp") is not None
+            or shutil.which("pi") is not None
+            or (home / ".omp").exists()
+        ),
     }

--- a/src/mship/skills/VENDOR.md
+++ b/src/mship/skills/VENDOR.md
@@ -82,9 +82,11 @@ Upstream 6.2.0 restructured this skill around its file-passing scripts; re-woven
 
 ### using-mothership/references
 
-Vendored from upstream `using-superpowers/references/` (see structural exclusions). One file diverges:
+Vendored from upstream `using-superpowers/references/` (see structural exclusions). Three files diverge:
 
+- `using-mothership/references/codex-tools.md` — kind 3: dispatch-resolved `inherit` omits the model selector; explicit model values pass through verbatim or produce the exact unsupported-selector error.
 - `using-mothership/references/gemini-tools.md` — residual kind 1: two deliberate upstream skill-namespace (`superpowers`) prefix-drop lines in the dispatch-mapping examples (`subagent-driven-development`, `requesting-code-review`).
+- `using-mothership/references/pi-tools.md` — kind 3: dispatch-resolved `inherit` uses the harness default, while explicit models require a selector-capable subagent tool and otherwise produce the exact unsupported-selector error.
 
 ### verification-before-completion
 

--- a/src/mship/skills/VENDOR.md
+++ b/src/mship/skills/VENDOR.md
@@ -85,7 +85,7 @@ Upstream 6.2.0 restructured this skill around its file-passing scripts; re-woven
 Vendored from upstream `using-superpowers/references/` (see structural exclusions). Three files diverge:
 
 - `using-mothership/references/codex-tools.md` — kind 3: dispatch-resolved `inherit` omits the model selector; explicit model values pass through verbatim or produce the exact unsupported-selector error.
-- `using-mothership/references/gemini-tools.md` — residual kind 1: two deliberate upstream skill-namespace (`superpowers`) prefix-drop lines in the dispatch-mapping examples (`subagent-driven-development`, `requesting-code-review`).
+- `using-mothership/references/gemini-tools.md` — kind 3 + residual kind 1: dispatch-resolved `inherit` omits the model selector; because current `invoke_agent` has no selector, explicit model values produce the exact unsupported-selector error; two deliberate upstream skill-namespace (`superpowers`) prefix-drop lines remain in the dispatch-mapping examples (`subagent-driven-development`, `requesting-code-review`).
 - `using-mothership/references/pi-tools.md` — kind 3: dispatch-resolved `inherit` uses the harness default, while explicit models require a selector-capable subagent tool and otherwise produce the exact unsupported-selector error.
 
 ### verification-before-completion

--- a/src/mship/skills/subagent-driven-development/SKILL.md
+++ b/src/mship/skills/subagent-driven-development/SKILL.md
@@ -185,46 +185,30 @@ conflicts that only emerge from implementation.
 
 ## Model Selection
 
-Use the least powerful model that can handle each role to conserve cost and increase speed.
+**In a Mothership workspace**, `mship dispatch` resolves the model:
+`--model` flag > `dispatch_models:` map in mothership.yaml > the portable
+built-in default. Every built-in mode defaults to `inherit`; explicit
+CLI/config values are opaque operator choices and must remain unchanged.
 
-**Mechanical implementation tasks** (isolated functions, clear specs, 1-2 files): use a fast, cheap model. Most implementation tasks are mechanical when the plan is well-specified.
+Read the stub's resolved model before dispatch:
+- `inherit`: omit the harness model selector; the harness default is intended.
+- any other value: pass it unchanged through a supported model selector.
+- if the available subagent API has no model selector, do not dispatch with
+  an explicit value. Report: "mship resolved explicit model '<value>', but this subagent API cannot select a model; set this mode to inherit or use a selector-capable dispatch tool."
+Never translate one provider's model name into another.
 
-**Integration and judgment tasks** (multi-file coordination, pattern matching, debugging): use a standard model.
+**Outside a Mothership workspace**, where the controller chooses a model
+itself, match capability to task complexity:
+- Mechanical implementation with a complete spec and a small isolated surface:
+  use a fast, economical model.
+- Multi-file integration, debugging, or review requiring judgment: use a
+  generally capable model.
+- Architecture, broad codebase reasoning, and the final whole-branch review:
+  use the most capable available model.
+- For a stuck fix loop, escalate to a more capable available model.
 
-**Architecture and design tasks**: use the most capable available model.
-The final whole-branch review is one of these — dispatch it on the most
-capable available model, not the session default.
-
-**Review tasks**: choose the model with the same judgment, scaled to the
-diff's size, complexity, and risk. A small mechanical diff does not need the
-most capable model; a subtle concurrency change does. Scoped re-reviews of
-small fix diffs take a cheap-to-mid tier.
-
-**Fix-loop escalation (rounds 4-5)**: use a model at least one tier above
-the implementer that got stuck.
-
-**The model is resolved by `mship dispatch`** — `--model` flag >
-`dispatch_models:` map in mothership.yaml > built-in per-mode default — and
-printed in the stub. Pass that resolved model to your platform's dispatch
-mechanism (the Task tool's model field or equivalent); never let the worker
-choose its own model, and never omit the model at dispatch time — an omitted
-model inherits your session's model, often the most capable and most
-expensive, which silently defeats this section. When this section's judgment
-says a task needs a different tier than the configured default, say so with
-`--model`.
-
-**Turn count beats token price.** Wall-clock and context cost scale with how
-many turns a subagent takes, and the cheapest models routinely take 2-3× the
-turns on multi-step work — costing more overall. Use a mid-tier model as the
-floor for reviewers and for implementers working from prose descriptions.
-When the task's plan text contains the complete code to write, the
-implementation is transcription plus testing: use the cheapest tier for
-that implementer. Single-file mechanical fixes also take the cheapest tier.
-
-**Task complexity signals (implementation tasks):**
-- Touches 1-2 files with a complete spec → cheap model
-- Touches multiple files with integration concerns → standard model
-- Requires design judgment or broad codebase understanding → most capable model
+Turn count matters alongside token price: choose a model likely to complete the
+task reliably rather than optimizing for the lowest per-token price alone.
 
 ## The Task Loop
 

--- a/src/mship/skills/subagent-driven-development/implementer-prompt.md
+++ b/src/mship/skills/subagent-driven-development/implementer-prompt.md
@@ -19,10 +19,19 @@ Use this template when dispatching an implementer subagent.
      `worktrees`, …). Use that for step 2.
 2. Run `mship dispatch --task <slug> --plan-task <N>` and read the **stub** it
    prints: record path, resolved model, mode, worktree. The stub's `worktree`
-   is the subagent's cwd and the stub's `model` fills `[MODEL]` below — the
-   model was resolved by the CLI (`--model` > `dispatch_models` config >
-   per-mode default); never let the worker choose, and never substitute your
-   session's model.
+   is the subagent's cwd. The model was resolved by the CLI (`--model` >
+   `dispatch_models` config > per-mode default); never let the worker choose.
+
+Read the stub's resolved model before dispatch:
+- `inherit`: omit the harness model selector; the harness default is intended.
+- any other value: pass it unchanged through a supported model selector.
+- if the available subagent API has no model selector, do not dispatch with
+  an explicit value. Report: "mship resolved explicit model '<value>', but this subagent API cannot select a model; set this mode to inherit or use a selector-capable dispatch tool."
+Never translate one provider's model name into another.
+
+The Task-style template below shows `model: vendor/custom-tier` for an explicit
+resolved value. Replace it with that exact value. For `inherit`, omit the entire
+selector field; do not pass the literal string `inherit` to the provider.
 3. The subagent MUST work in the task's worktree, not the main checkout, and
    MUST commit on the task's feature branch. The mship pre-commit hook will
    refuse commits from the main checkout, but the prompt says this explicitly
@@ -35,8 +44,7 @@ worktree, pick the model per SKILL.md Model Selection, and replace the
 ```
 Subagent (general-purpose):
   description: "Implement Task N: [task name]"
-  model: [MODEL — from the dispatch stub's resolved model line; an omitted
-         model silently inherits the session's most expensive one]
+  model: vendor/custom-tier
   prompt: |
     You are implementing one plan task for the mship task [slug].
 
@@ -193,8 +201,9 @@ Subagent (general-purpose):
 ```
 
 **Placeholders:**
-- `[MODEL]` — the resolved model line from the dispatch stub (never your
-  session's model; outside mothership, choose per SKILL.md Model Selection)
+- `vendor/custom-tier` — an example explicit model value; replace it unchanged
+  with the resolved value, or omit the entire selector field for `inherit`
+  (outside Mothership, choose per SKILL.md Model Selection)
 - `[slug]` — the task slug from the stub
 - `[REPORT_FILE]` — the report path the controller names next to the
   dispatch record the stub printed (record `…/record.json` →

--- a/src/mship/skills/subagent-driven-development/re-review-prompt.md
+++ b/src/mship/skills/subagent-driven-development/re-review-prompt.md
@@ -11,14 +11,23 @@ that the fix itself broke nothing.
 The rebuilt package diffs to the new HEAD, so it contains the whole task's
 diff including the fix commits; this template scopes the re-reviewer to the
 fix range `[FIX_BASE_SHA]..[HEAD_SHA]` within it. The stub's `worktree` is
-the re-reviewer's cwd and the stub's `model` fills `[MODEL]`.
+the re-reviewer's cwd.
+
+Read the stub's resolved model before dispatch:
+- `inherit`: omit the harness model selector; the harness default is intended.
+- any other value: pass it unchanged through a supported model selector.
+- if the available subagent API has no model selector, do not dispatch with
+  an explicit value. Report: "mship resolved explicit model '<value>', but this subagent API cannot select a model; set this mode to inherit or use a selector-capable dispatch tool."
+Never translate one provider's model name into another.
+
+The Task-style template below shows `model: vendor/custom-tier` for an explicit
+resolved value. Replace it with that exact value. For `inherit`, omit the entire
+selector field; do not pass the literal string `inherit` to the provider.
 
 ```
 Subagent (general-purpose):
   description: "Re-review Task N fix round R"
-  model: [MODEL — from the reviewer stub's resolved model line; scoped
-         re-reviews of small fix diffs take a cheap-to-mid tier — say so
-         with --model on the dispatch if the configured default is higher]
+  model: vendor/custom-tier
   prompt: |
     You are re-reviewing one task's fix round. A previous review produced
     findings; an implementer has attempted to fix them. Your job is to
@@ -105,8 +114,8 @@ Subagent (general-purpose):
 ```
 
 **Placeholders:**
-- `[MODEL]` — the resolved model line from the reviewer stub; scoped
-  re-reviews of small fix diffs take a cheap-to-mid tier
+- `vendor/custom-tier` — an example explicit model value; replace it unchanged
+  with the resolved value, or omit the entire selector field for `inherit`
 - `[FINDINGS]` — the Critical/Important findings and spec gaps from the
   previous review, copied verbatim, one per bullet
 - `[REPORT_FILE]` — the implementer's report file (fix reports appended)

--- a/src/mship/skills/subagent-driven-development/task-reviewer-prompt.md
+++ b/src/mship/skills/subagent-driven-development/task-reviewer-prompt.md
@@ -11,17 +11,26 @@ more, nothing less) and is well-built (clean, tested, maintainable)
 It builds the review package (one raw diff file per affected repo +
 `manifest.json`, diffed from the prior dispatch's recorded base to live HEAD)
 under the dispatch record's `review/` directory and prints a closed stub.
-The stub's `worktree` is the reviewer's cwd and the stub's `model` fills
-`[MODEL]` below. The reviewer's own `mship dispatch --emit` prints the
-diff-file paths, the manifest path, the live acceptance criteria, the
-skipped-repo disclosure (if any), and the read-only dual-verdict contract —
-this template adds only what the CLI cannot know.
+The stub's `worktree` is the reviewer's cwd. The reviewer's own
+`mship dispatch --emit` prints the diff-file paths, the manifest path, the live
+acceptance criteria, the skipped-repo disclosure (if any), and the read-only
+dual-verdict contract — this template adds only what the CLI cannot know.
+
+Read the stub's resolved model before dispatch:
+- `inherit`: omit the harness model selector; the harness default is intended.
+- any other value: pass it unchanged through a supported model selector.
+- if the available subagent API has no model selector, do not dispatch with
+  an explicit value. Report: "mship resolved explicit model '<value>', but this subagent API cannot select a model; set this mode to inherit or use a selector-capable dispatch tool."
+Never translate one provider's model name into another.
+
+The Task-style template below shows `model: vendor/custom-tier` for an explicit
+resolved value. Replace it with that exact value. For `inherit`, omit the entire
+selector field; do not pass the literal string `inherit` to the provider.
 
 ```
 Subagent (general-purpose):
   description: "Review Task N (spec + quality)"
-  model: [MODEL — from the reviewer stub's resolved model line; an omitted
-         model silently inherits the session's most expensive one]
+  model: vendor/custom-tier
   prompt: |
     You are reviewing one task's implementation: first whether it matches its
     requirements, then whether it is well-built. This is a task-scoped gate,
@@ -189,9 +198,8 @@ Subagent (general-purpose):
 ```
 
 **Placeholders:**
-- `[MODEL]` — the resolved model line from the reviewer stub (`mship dispatch
-  --mode reviewer` resolves it: `--model` > `dispatch_models` config >
-  per-mode default)
+- `vendor/custom-tier` — an example explicit model value; replace it unchanged
+  with the resolved value, or omit the entire selector field for `inherit`
 - `[PLAN_FILE]` — the plan file path; the reviewer reads only Task N's
   anchored block (the same text the implementer's emit delivered)
 - `[GLOBAL_CONSTRAINTS]` — the binding requirements copied verbatim from

--- a/src/mship/skills/using-mothership/references/codex-tools.md
+++ b/src/mship/skills/using-mothership/references/codex-tools.md
@@ -9,6 +9,20 @@ multi_agent = true
 
 This enables `spawn_agent`, `wait_agent`, and `close_agent` for skills like `dispatching-parallel-agents` and `subagent-driven-development`. When using subagent-driven-development, close reviewer subagents when their review returns. Keep each implementer subagent open until its task's review passes — the fix loop resumes the implementer — then close it. If your harness cannot send another message to a spawned agent, dispatch each fix round as a fresh implementer carrying the brief, the report file, and the findings.
 
+### Resolved model handling
+
+Read the stub's resolved model before dispatch:
+- `inherit`: omit the harness model selector; the harness default is intended.
+  Invoke `spawn_agent without a model selector`.
+- any other value: pass it unchanged through a supported model selector.
+- if the available subagent API has no model selector, do not dispatch with
+  an explicit value. Report: "mship resolved explicit model '<value>', but this subagent API cannot select a model; set this mode to inherit or use a selector-capable dispatch tool."
+Never translate one provider's model name into another.
+
+Current Codex multi-agent APIs expose no model selector, so they must reject an
+explicit resolved value with that actionable message. If a later API exposes a
+supported selector, supply the explicit value through it unchanged.
+
 ## Environment Detection
 
 Skills that create worktrees or finish branches should detect their

--- a/src/mship/skills/using-mothership/references/gemini-tools.md
+++ b/src/mship/skills/using-mothership/references/gemini-tools.md
@@ -31,6 +31,20 @@ User-level skills live at **`~/.gemini/skills/`**, with **`~/.agents/skills/`** 
 
 Gemini CLI dispatches subagents through the `invoke_agent` tool, which takes `agent_name` and `prompt` parameters. The same dispatch is also surfaced as a chat-syntax shortcut: typing `@generalist <prompt>` is equivalent to calling `invoke_agent` with `agent_name: "generalist"`. Built-in agent names include `generalist`, `cli_help`, `codebase_investigator`, and (with browser tooling enabled) `browser_agent`.
 
+### Resolved model handling
+
+Read the stub's resolved model before dispatch:
+- `inherit`: omit the harness model selector; the harness default is intended.
+  Invoke `invoke_agent without a model selector`.
+- any other value: pass it unchanged through a supported model selector.
+- if the available subagent API has no model selector, do not dispatch with
+  an explicit value. Report: "mship resolved explicit model '<value>', but this subagent API cannot select a model; set this mode to inherit or use a selector-capable dispatch tool."
+Never translate one provider's model name into another.
+
+Gemini CLI's current `invoke_agent` API exposes only `agent_name` and `prompt`,
+not a model selector. It therefore accepts `inherit` by omitting a selector and
+must reject every explicit resolved model with the actionable message above.
+
 Skills dispatch with `Subagent (general-purpose):` and either reference a prompt-template file (e.g., `subagent-driven-development`'s `./implementer-prompt.md`) or supply an inline prompt. On Gemini CLI:
 
 | Skill dispatch form | Gemini CLI equivalent |

--- a/src/mship/skills/using-mothership/references/pi-tools.md
+++ b/src/mship/skills/using-mothership/references/pi-tools.md
@@ -9,7 +9,9 @@ Skills speak in actions ("dispatch a subagent", "create a todo", "read a file").
 
 ## Subagents
 
-Pi core does not ship a standard subagent tool. The `pi-subagents` package is a strong optional companion and provides a `subagent` tool with single-agent, chain, parallel, async, forked-context, and resume/status workflows. If no subagent tool is available, do not fabricate `Task` calls; execute sequentially in the current session or explain that the optional subagent capability is not installed.
+Pi core does not ship a standard subagent tool. The `pi-subagents` package is a
+strong optional companion and provides a `subagent` tool with single-agent,
+chain, parallel, async, forked-context, and resume/status workflows.
 
 ### Resolved model handling
 
@@ -21,9 +23,14 @@ model selector, then read the stub's resolved model:
   an explicit value. Report: "mship resolved explicit model '<value>', but this subagent API cannot select a model; set this mode to inherit or use a selector-capable dispatch tool."
 Never translate one provider's model name into another.
 
-Do not assume a particular `pi-subagents` version exposes a selector. Apply an
-explicit value only through a selector present in the installed schema;
-otherwise reject it with the actionable message above instead of substituting.
+Do not assume a particular `pi-subagents` version exposes a selector. If no
+subagent tool is available and the resolved model is `inherit`, do not fabricate
+`Task` calls; execute sequentially in the current session or explain that the
+optional subagent capability is not installed.
+
+If the resolved model is explicit and no selector-capable subagent tool is
+available, do not fall back to sequential execution because that would silently
+ignore the operator's model choice. Report: "mship resolved explicit model '<value>', but this subagent API cannot select a model; set this mode to inherit or use a selector-capable dispatch tool."
 
 ## Task lists
 

--- a/src/mship/skills/using-mothership/references/pi-tools.md
+++ b/src/mship/skills/using-mothership/references/pi-tools.md
@@ -11,6 +11,20 @@ Skills speak in actions ("dispatch a subagent", "create a todo", "read a file").
 
 Pi core does not ship a standard subagent tool. The `pi-subagents` package is a strong optional companion and provides a `subagent` tool with single-agent, chain, parallel, async, forked-context, and resume/status workflows. If no subagent tool is available, do not fabricate `Task` calls; execute sequentially in the current session or explain that the optional subagent capability is not installed.
 
+### Resolved model handling
+
+Before dispatch, find the installed `subagent` tool and inspect its schema for a
+model selector, then read the stub's resolved model:
+- `inherit`: omit the harness model selector; the harness default is intended.
+- any other value: pass it unchanged when it exposes a model selector.
+- if the available subagent API has no model selector, do not dispatch with
+  an explicit value. Report: "mship resolved explicit model '<value>', but this subagent API cannot select a model; set this mode to inherit or use a selector-capable dispatch tool."
+Never translate one provider's model name into another.
+
+Do not assume a particular `pi-subagents` version exposes a selector. Apply an
+explicit value only through a selector present in the installed schema;
+otherwise reject it with the actionable message above instead of substituting.
+
 ## Task lists
 
 Pi core does not ship a standard task-list tool. If a todo/task extension is installed, use its documented tool. Otherwise use Superpowers plan files, checklists in Markdown, or a repo-local `TODO.md` for task tracking. Older Superpowers docs may refer to `TodoWrite`; treat that as the task-tracking action above.

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -206,7 +206,15 @@ Two mship-native primitives for handing work to subagents. Use them instead of h
 
   **Model resolution:** dispatch resolves the subagent's model (`--model` >
   `dispatch_models:` in mothership.yaml > built-in per-mode default) and stamps
-  it in the output — the worker never chooses its own model.
+  it in the output. Every built-in mode defaults to the portable `inherit`
+  sentinel; explicit CLI/config values are opaque operator choices.
+
+  Read the stub's resolved model before dispatch:
+  - `inherit`: omit the harness model selector; the harness default is intended.
+  - any other value: pass it unchanged through a supported model selector.
+  - if the available subagent API has no model selector, do not dispatch with
+    an explicit value. Report: "mship resolved explicit model '<value>', but this subagent API cannot select a model; set this mode to inherit or use a selector-capable dispatch tool."
+  Never translate one provider's model name into another.
 
   **Context isolation (SDD flow):** every dispatch (plan-task or ad-hoc `-i`)
   persists a metadata-only record under `.mothership/sdd/` and prints a **closed stub**

--- a/tests/cli/test_agent_hook_conformance.py
+++ b/tests/cli/test_agent_hook_conformance.py
@@ -115,6 +115,18 @@ def _edit_event(runtime: str, *targets: Path, ignored_path: Path | None = None) 
             "toolName": "edit",
             "input": {"paths": [str(target) for target in targets]},
         }
+    elif runtime == "codex":
+        headers = ("Add", "Update", "Delete")
+        event = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "apply_patch",
+            "tool_input": {
+                "command": "\n".join(
+                    f"*** {headers[min(index, len(headers) - 1)]} File: {target}"
+                    for index, target in enumerate(targets)
+                ),
+            },
+        }
     else:
         event = {
             "hook_event_name": "PreToolUse",
@@ -238,15 +250,28 @@ def test_adapters_ignore_undocumented_event_fields(harness_workspace: HarnessWor
     assert set(outcomes.values()) == {Outcome("allow")}
 
 
+def test_codex_multi_target_fixture_uses_native_apply_patch_headers(tmp_path: Path):
+    targets = tuple(tmp_path / f"{name}.py" for name in ("added", "updated", "deleted"))
+
+    event = _edit_event("codex", *targets)
+
+    assert event["tool_name"] == "apply_patch"
+    patch = event["tool_input"]["command"]
+    assert f"*** Add File: {targets[0]}" in patch
+    assert f"*** Update File: {targets[1]}" in patch
+    assert f"*** Delete File: {targets[2]}" in patch
+
+
 def test_any_denied_target_denies_the_whole_native_multi_target_edit(
     harness_workspace: HarnessWorkspace,
 ):
-    allowed = harness_workspace.worktree / "src" / "a.py"
-    denied = harness_workspace.main / "src" / "b.py"
+    added = harness_workspace.worktree / "src" / "added.py"
+    denied = harness_workspace.main / "src" / "updated.py"
+    deleted = harness_workspace.worktree / "src" / "deleted.py"
 
     outcomes = _outcomes(
         "tool_call",
-        {runtime: _edit_event(runtime, allowed, denied) for runtime in ADAPTERS},
+        {runtime: _edit_event(runtime, added, denied, deleted) for runtime in ADAPTERS},
     )
 
     assert len(set(outcomes.values())) == 1

--- a/tests/cli/test_agent_hook_conformance.py
+++ b/tests/cli/test_agent_hook_conformance.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+import pytest
+from typer.testing import CliRunner, Result
+
+from mship.cli import app, container
+from mship.core.message_store import MessageStore
+from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.workitem_store import WorkItemStore
+
+
+runner = CliRunner()
+
+
+@dataclass(frozen=True)
+class Outcome:
+    kind: str
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class HarnessWorkspace:
+    root: Path
+    main: Path
+    worktree: Path
+    state_dir: Path
+    state_manager: StateManager
+
+
+def _normalize_exit_adapter(result: Result, event_name: str) -> Outcome:
+    warning = result.stderr.strip()
+    if "adapter failed open" in warning:
+        return Outcome("error", warning)
+    if event_name == "session_start":
+        assert result.exit_code == 0
+        return Outcome("context", result.stdout.strip())
+    if event_name == "tool_call":
+        if result.exit_code == 2:
+            return Outcome("deny", warning)
+        assert result.exit_code == 0
+        return Outcome("allow")
+
+    assert result.exit_code == 0
+    if not result.stdout.strip():
+        return Outcome("stop")
+    payload = json.loads(result.stdout)
+    assert payload["decision"] == "block"
+    return Outcome("continue", payload["reason"])
+
+
+def _invoke_exit_adapter(runtime: str, event_name: str, event: dict, env: dict[str, str] | None) -> Outcome:
+    command = {
+        "session_start": "_session-context",
+        "tool_call": "_guard-edit",
+        "session_stop": "_drain",
+    }[event_name]
+    args = [command]
+    if runtime != "claude":
+        args += ["--runtime", runtime]
+    result = runner.invoke(app, args, input=json.dumps(event), env=env)
+    return _normalize_exit_adapter(result, event_name)
+
+
+def invoke_claude_hidden_commands(
+    event_name: str,
+    event: dict,
+    env: dict[str, str] | None = None,
+) -> Outcome:
+    return _invoke_exit_adapter("claude", event_name, event, env)
+
+
+def invoke_codex_hidden_commands(
+    event_name: str,
+    event: dict,
+    env: dict[str, str] | None = None,
+) -> Outcome:
+    return _invoke_exit_adapter("codex", event_name, event, env)
+
+
+def invoke_omp_hidden_command(
+    event_name: str,
+    event: dict,
+    env: dict[str, str] | None = None,
+) -> Outcome:
+    result = runner.invoke(
+        app,
+        ["_omp-hook", event_name],
+        input=json.dumps(event),
+        env=env,
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    if payload["kind"] == "error":
+        return Outcome("error", result.stderr.strip())
+    return Outcome(payload["kind"], payload.get("message", ""))
+
+
+ADAPTERS: dict[str, Callable[[str, dict, dict[str, str] | None], Outcome]] = {
+    "claude": invoke_claude_hidden_commands,
+    "codex": invoke_codex_hidden_commands,
+    "omp": invoke_omp_hidden_command,
+}
+
+
+def _edit_event(runtime: str, *targets: Path, ignored_path: Path | None = None) -> dict:
+    if runtime == "omp":
+        event = {
+            "type": "tool_call",
+            "toolName": "edit",
+            "input": {"paths": [str(target) for target in targets]},
+        }
+    else:
+        event = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "MultiEdit" if len(targets) > 1 else "Edit",
+            "tool_input": {
+                "edits": [{"file_path": str(target)} for target in targets],
+            },
+        }
+    if ignored_path is not None:
+        event["ignored_path"] = str(ignored_path)
+    return event
+
+
+def _stop_event(runtime: str, continuation_active: bool) -> dict:
+    event = {"stop_hook_active": continuation_active}
+    if runtime == "omp":
+        event["type"] = "session_stop"
+    else:
+        event["hook_event_name"] = "Stop"
+    return event
+
+
+@pytest.fixture
+def harness_workspace(tmp_path: Path, monkeypatch) -> HarnessWorkspace:
+    main = tmp_path / "main"
+    (main / "src").mkdir(parents=True)
+    (main / "Taskfile.yml").write_text("version: '3'\n")
+    worktree = tmp_path / ".worktrees" / "t" / "repo"
+    (worktree / "src").mkdir(parents=True)
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    config_path = tmp_path / "mothership.yaml"
+    config_path.write_text(
+        f"workspace: t\nrepos:\n  repo:\n    path: {main}\n    type: library\n"
+    )
+    work_item = WorkItemStore(state_dir / "workitems").create(
+        title="thing",
+        kind="bug",
+        workspace="t",
+        now=datetime.now(timezone.utc),
+    )
+    task = Task(
+        slug="t",
+        description="d",
+        phase="dev",
+        created_at=datetime.now(timezone.utc),
+        affected_repos=["repo"],
+        worktrees={"repo": worktree},
+        branch="feat/t",
+        work_item_id=work_item.id,
+    )
+    state_manager = StateManager(state_dir)
+    state_manager.save(WorkspaceState(tasks={"t": task}))
+
+    container.config.reset()
+    container.state_manager.reset()
+    container.log_manager.reset()
+    container.config_path.override(config_path)
+    container.state_dir.override(state_dir)
+    monkeypatch.chdir(tmp_path)
+    try:
+        yield HarnessWorkspace(tmp_path, main, worktree, state_dir, state_manager)
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset_override()
+        container.config.reset()
+        container.state_manager.reset_override()
+        container.state_manager.reset()
+        container.log_manager.reset()
+
+
+def _outcomes(event_name: str, events: dict[str, dict], env: dict[str, str] | None = None) -> dict[str, Outcome]:
+    return {
+        runtime: invoke(event_name, events[runtime], env)
+        for runtime, invoke in ADAPTERS.items()
+    }
+
+
+def test_session_start_without_active_task_has_equivalent_actionable_context(
+    harness_workspace: HarnessWorkspace,
+):
+    harness_workspace.state_manager.save(WorkspaceState())
+    events = {
+        "claude": {"hook_event_name": "SessionStart", "source": "startup"},
+        "codex": {"hook_event_name": "SessionStart", "source": "startup"},
+        "omp": {"type": "session_start"},
+    }
+
+    outcomes = _outcomes("session_start", events)
+
+    assert len(set(outcomes.values())) == 1
+    outcome = outcomes["claude"]
+    assert outcome.kind == "context"
+    assert "mship spawn" in outcome.message
+
+
+def test_valid_worktree_edit_allows_for_every_runtime(harness_workspace: HarnessWorkspace):
+    target = harness_workspace.worktree / "src" / "a.py"
+
+    outcomes = _outcomes(
+        "tool_call",
+        {runtime: _edit_event(runtime, target) for runtime in ADAPTERS},
+    )
+
+    assert set(outcomes.values()) == {Outcome("allow")}
+
+
+def test_adapters_ignore_undocumented_event_fields(harness_workspace: HarnessWorkspace):
+    target = harness_workspace.worktree / "src" / "a.py"
+    ignored = harness_workspace.main / "src" / "must-not-be-read.py"
+
+    outcomes = _outcomes(
+        "tool_call",
+        {
+            runtime: _edit_event(runtime, target, ignored_path=ignored)
+            for runtime in ADAPTERS
+        },
+    )
+
+    assert set(outcomes.values()) == {Outcome("allow")}
+
+
+def test_any_denied_target_denies_the_whole_native_multi_target_edit(
+    harness_workspace: HarnessWorkspace,
+):
+    allowed = harness_workspace.worktree / "src" / "a.py"
+    denied = harness_workspace.main / "src" / "b.py"
+
+    outcomes = _outcomes(
+        "tool_call",
+        {runtime: _edit_event(runtime, allowed, denied) for runtime in ADAPTERS},
+    )
+
+    assert len(set(outcomes.values())) == 1
+    outcome = outcomes["claude"]
+    assert outcome.kind == "deny"
+    assert str(harness_workspace.worktree / "src" / denied.name) in outcome.message
+    assert "MAIN checkout" in outcome.message
+
+
+def test_allow_main_edit_environment_override_is_equivalent(harness_workspace: HarnessWorkspace):
+    target = harness_workspace.main / "src" / "a.py"
+
+    outcomes = _outcomes(
+        "tool_call",
+        {runtime: _edit_event(runtime, target) for runtime in ADAPTERS},
+        {"MSHIP_ALLOW_MAIN_EDIT": "1"},
+    )
+
+    assert set(outcomes.values()) == {Outcome("allow")}
+
+
+def test_workitem_bypass_preserves_main_checkout_protection(harness_workspace: HarnessWorkspace):
+    state = harness_workspace.state_manager.load()
+    state.tasks["t"].work_item_id = None
+    harness_workspace.state_manager.save(state)
+    worktree_target = harness_workspace.worktree / "src" / "a.py"
+    main_target = harness_workspace.main / "src" / "a.py"
+    env = {"MSHIP_BYPASS_GATE": "1"}
+
+    worktree_outcomes = _outcomes(
+        "tool_call",
+        {runtime: _edit_event(runtime, worktree_target) for runtime in ADAPTERS},
+        env,
+    )
+    main_outcomes = _outcomes(
+        "tool_call",
+        {runtime: _edit_event(runtime, main_target) for runtime in ADAPTERS},
+        env,
+    )
+
+    assert set(worktree_outcomes.values()) == {Outcome("allow")}
+    assert len(set(main_outcomes.values())) == 1
+    assert main_outcomes["claude"].kind == "deny"
+    assert "MAIN checkout" in main_outcomes["claude"].message
+
+
+@pytest.mark.parametrize("pending_kind", ["reply", "event"])
+def test_pending_inbox_work_continues_with_equivalent_actionable_instructions(
+    harness_workspace: HarnessWorkspace,
+    pending_kind: str,
+):
+    store = MessageStore(harness_workspace.state_dir / "messages")
+    now = datetime.now(timezone.utc)
+    thread = store.create_thread("question", "please answer", now)
+    if pending_kind == "event":
+        store.append(thread.id, "agent", "answered opener", now)
+        store.append(thread.id, "agent", "dispatch handoff: act now", now, kind="event")
+
+    outcomes = _outcomes(
+        "session_stop",
+        {runtime: _stop_event(runtime, False) for runtime in ADAPTERS},
+    )
+
+    assert len(set(outcomes.values())) == 1
+    outcome = outcomes["claude"]
+    assert outcome.kind == "continue"
+    if pending_kind == "reply":
+        assert "mship reply" in outcome.message
+    else:
+        assert "FOR THE AGENT" in outcome.message
+        assert "act" in outcome.message
+
+
+def test_continuation_active_stop_is_bounded_for_every_runtime(
+    harness_workspace: HarnessWorkspace,
+):
+    MessageStore(harness_workspace.state_dir / "messages").create_thread(
+        "question", "still pending", datetime.now(timezone.utc)
+    )
+
+    outcomes = _outcomes(
+        "session_stop",
+        {runtime: _stop_event(runtime, True) for runtime in ADAPTERS},
+    )
+
+    assert set(outcomes.values()) == {Outcome("stop")}
+
+
+def test_guard_adapter_exceptions_fail_open_and_warn_without_event_data(
+    harness_workspace: HarnessWorkspace,
+):
+    secret = "event-body-must-not-leak"
+    events = {
+        "claude": {"tool_name": "Edit", "tool_input": {"secret": secret}},
+        "codex": {"tool_name": "Edit", "tool_input": {"secret": secret}},
+        "omp": {"toolName": "edit", "input": {"secret": secret}},
+    }
+
+    outcomes = _outcomes("tool_call", events)
+
+    assert {outcome.kind for outcome in outcomes.values()} == {"error"}
+    for runtime, outcome in outcomes.items():
+        warning = outcome.message.lower()
+        assert runtime in warning
+        assert ("pretooluse" if runtime != "omp" else "tool_call") in warning
+        assert "failed open" in warning
+        assert secret not in outcome.message
+
+
+@pytest.mark.parametrize(
+    ("event_name", "patched_owner", "lifecycle_names"),
+    [
+        ("session_start", "session_start", {"claude": "sessionstart", "codex": "sessionstart", "omp": "session_start"}),
+        ("session_stop", "MessageStore", {"claude": "stop", "codex": "stop", "omp": "session_stop"}),
+    ],
+)
+def test_other_lifecycle_adapter_exceptions_fail_open_and_warn(
+    harness_workspace: HarnessWorkspace,
+    monkeypatch,
+    event_name: str,
+    patched_owner: str,
+    lifecycle_names: dict[str, str],
+):
+    if patched_owner == "session_start":
+        from mship.core import agent_hooks
+
+        monkeypatch.setattr(agent_hooks, "session_start", lambda *_args: (_ for _ in ()).throw(RuntimeError()))
+    else:
+        from mship.core import message_store
+
+        monkeypatch.setattr(message_store, "MessageStore", lambda *_args: (_ for _ in ()).throw(RuntimeError()))
+
+    events = {
+        runtime: (_stop_event(runtime, False) if event_name == "session_stop" else {})
+        for runtime in ADAPTERS
+    }
+    outcomes = _outcomes(event_name, events)
+
+    assert {outcome.kind for outcome in outcomes.values()} == {"error"}
+    for runtime, outcome in outcomes.items():
+        warning = outcome.message.lower()
+        assert runtime in warning
+        assert lifecycle_names[runtime] in warning
+        assert "failed open" in warning

--- a/tests/cli/test_context.py
+++ b/tests/cli/test_context.py
@@ -10,6 +10,7 @@ from typer.testing import CliRunner
 
 from mship.cli import app, container
 from mship.cli.output import reset_output_settings
+from mship.core.context import _IMPLEMENTER_INSTRUCTIONS
 from mship.core.state import StateManager, Task, WorkspaceState
 
 
@@ -129,10 +130,9 @@ def test_context_no_for_flag_omits_audience_key(tmp_path: Path):
         _reset_container()
 
 
-@pytest.mark.parametrize("for_value", ["claude-code", "codex"])
+@pytest.mark.parametrize("for_value", ["claude-code", "codex", "omp"])
 def test_context_for_implementer_emits_audience_block(tmp_path: Path, for_value: str):
-    """ac2: --for claude-code / codex emit the base payload plus an audience
-    block with the implementer framing."""
+    """Canonical implementer audiences emit identical instructions."""
     runner = CliRunner()
     cfg, state_dir = _bootstrap(tmp_path, [])
     container.config.reset()
@@ -147,7 +147,7 @@ def test_context_for_implementer_emits_audience_block(tmp_path: Path, for_value:
         assert data["schema_version"] == "1"  # base payload still present
         assert data["audience"]["for"] == for_value
         assert data["audience"]["kind"] is None
-        assert "mship commit" in data["audience"]["instructions"]
+        assert data["audience"]["instructions"] == _IMPLEMENTER_INSTRUCTIONS
     finally:
         _reset_container()
 
@@ -233,8 +233,11 @@ def test_context_kind_without_for_reviewer_is_rejected(tmp_path: Path):
         _reset_container()
 
 
-def test_context_kind_with_non_reviewer_for_is_rejected(tmp_path: Path):
-    """ac6: --kind with a non-reviewer --for is rejected."""
+@pytest.mark.parametrize("for_value", ["human", "omp"])
+def test_context_kind_with_non_reviewer_for_is_rejected(
+    tmp_path: Path, for_value: str
+):
+    """--kind with any non-reviewer --for is rejected."""
     runner = CliRunner()
     cfg, state_dir = _bootstrap(tmp_path, [])
     container.config.reset()
@@ -243,7 +246,7 @@ def test_context_kind_with_non_reviewer_for_is_rejected(tmp_path: Path):
     container.config_path.override(cfg)
     container.state_dir.override(state_dir)
     try:
-        result = runner.invoke(app, ["context", "--for", "human", "--kind", "spec"])
+        result = runner.invoke(app, ["context", "--for", for_value, "--kind", "spec"])
         assert result.exit_code != 0
         assert "reviewer" in result.output.lower()
     finally:
@@ -267,8 +270,11 @@ def test_context_reviewer_without_kind_is_rejected(tmp_path: Path):
         _reset_container()
 
 
-def test_context_unknown_for_value_is_rejected(tmp_path: Path):
-    """Unknown --for values are rejected with a clean CLI error."""
+@pytest.mark.parametrize("for_value", ["pi", "unknown"])
+def test_context_unknown_for_value_is_rejected(
+    tmp_path: Path, for_value: str
+):
+    """Unknown and alias-only --for values are rejected with a clean CLI error."""
     runner = CliRunner()
     cfg, state_dir = _bootstrap(tmp_path, [])
     container.config.reset()
@@ -277,7 +283,7 @@ def test_context_unknown_for_value_is_rejected(tmp_path: Path):
     container.config_path.override(cfg)
     container.state_dir.override(state_dir)
     try:
-        result = runner.invoke(app, ["context", "--for", "gemini"])
+        result = runner.invoke(app, ["context", "--for", for_value])
         assert result.exit_code != 0
     finally:
         _reset_container()

--- a/tests/cli/test_context.py
+++ b/tests/cli/test_context.py
@@ -314,3 +314,11 @@ def test_context_tty_renders_markdown_audience_block(tmp_path: Path, monkeypatch
     finally:
         reset_output_settings()
         _reset_container()
+
+
+def test_context_help_lists_every_supported_audience():
+    result = CliRunner().invoke(app, ["context", "--help"])
+
+    assert result.exit_code == 0, result.output
+    for audience in ("claude-code", "codex", "omp", "human", "reviewer"):
+        assert audience in result.output

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -571,6 +571,23 @@ def test_stub_flag_is_a_deprecated_noop(tmp_path: Path):
         _reset()
 
 
+def test_implementer_and_standalone_dispatch_default_to_inherit(tmp_path: Path):
+    wt = tmp_path / "wt"; wt.mkdir()
+    cfg, state_dir = _bootstrap(tmp_path, {"only": wt})
+    _override(cfg, state_dir)
+    try:
+        for mode in ("implementer", "standalone"):
+            result = runner.invoke(
+                app,
+                ["dispatch", "--task", "t", "-i", "do the thing", "--mode", mode],
+            )
+            assert result.exit_code == 0, result.output
+            assert "model: inherit" in result.output
+            assert "model=inherit" in result.output
+    finally:
+        _reset()
+
+
 def test_dispatch_model_flag_recorded(tmp_path: Path):
     from mship.core.sdd_store import SddStore
 
@@ -993,9 +1010,11 @@ def test_reviewer_record_write_preserves_review_dir(tmp_path: Path):
         assert result.exit_code == 0, result.output
         result = runner.invoke(app, ["dispatch", "--task", "t", "--mode", "reviewer"])
         assert result.exit_code == 0, result.output
+        assert "model: inherit" in result.output
+        assert "model=inherit" in result.output
         rec = SddStore(state_dir).find_for_slug("t")
         assert rec is not None and rec.mode == "reviewer"
-        assert rec.model == "sonnet"                       # reviewer builtin default
+        assert rec.model == "inherit"                      # portable builtin default
         assert rec.plan_task_id == "1" and rec.acs == ["ac2"]  # pointer fields kept
         review_dir = state_dir / "sdd" / "no-item" / "t" / "review"
         assert (review_dir / "manifest.json").is_file()    # survived the write

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -488,6 +488,81 @@ def test_install_hooks_reports_codex_activation_without_mutating_user_state(
     assert _home_bytes(home) == before
 
 
+@pytest.mark.parametrize("failure_mode", ["skipped", "raised"])
+def test_install_hooks_reports_incomplete_codex_registration_before_activation(
+    tmp_path: Path,
+    monkeypatch,
+    failure_mode: str,
+):
+    from mship.core.codex_hooks import install_codex_hooks as real_install_codex_hooks
+
+    monkeypatch.chdir(tmp_path)
+    roots = [tmp_path / "service-a", tmp_path / "service-b"]
+    for root in roots:
+        (root / ".git" / "hooks").mkdir(parents=True)
+        (root / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    real_install_codex_hooks(roots[0])
+    if failure_mode == "skipped":
+        skipped = roots[1] / ".codex" / "hooks.json"
+        skipped.parent.mkdir(parents=True)
+        skipped.write_text('{"hooks": ')
+    else:
+        def fail_one_root(root: Path):
+            if root == roots[1]:
+                raise OSError("read only")
+            return real_install_codex_hooks(root)
+
+        monkeypatch.setattr("mship.cli.init.install_codex_hooks", fail_one_root)
+
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\n"
+        "repos:\n"
+        "  service-a:\n"
+        "    path: service-a\n"
+        "    type: service\n"
+        "  service-b:\n"
+        "    path: service-b\n"
+        "    type: service\n"
+    )
+    real_which = shutil.which
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda name: "/usr/bin/codex" if name == "codex" else real_which(name),
+    )
+    probe_calls: list[str] = []
+
+    def run_probe(self, command, cwd, env=None, timeout=None):
+        if command == "codex features list":
+            probe_calls.append(command)
+            return ShellResult(
+                returncode=0,
+                stdout="codex_hooks under-development false\n",
+                stderr="",
+            )
+        return ShellResult(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(ShellRunner, "run", run_probe)
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(tmp_path / ".mothership")
+    try:
+        result = runner.invoke(app, ["init", "--install-hooks"])
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+
+    assert result.exit_code == 0, result.output
+    assert "Codex hook installation incomplete" in result.output
+    assert "`mship init --install-hooks`" in result.output
+    assert "Codex hooks configured but" not in result.output
+    assert probe_calls == ["codex features list"]
+
+
 def test_interactive_wizard_emits_git_root_for_single_git_monorepo(tmp_path: Path, monkeypatch):
     """The interactive wizard (plain `mship init` in a TTY) emits the SAME
     relative-path + git_root monorepo config as `--detect` on a single-git

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -1,3 +1,5 @@
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -5,6 +7,7 @@ import yaml
 from typer.testing import CliRunner
 
 from mship.cli import app, container
+from mship.util.shell import ShellRunner, ShellResult
 
 runner = CliRunner()
 
@@ -351,6 +354,138 @@ def test_install_hooks_refreshed_vs_up_to_date_labels(tmp_path: Path, monkeypatc
         container.state_dir.reset_override()
         container.config.reset()
         container.state_manager.reset()
+
+
+def _home_bytes(home: Path) -> dict[Path, bytes]:
+    return {
+        path.relative_to(home): path.read_bytes()
+        for path in home.rglob("*")
+        if path.is_file()
+    }
+
+
+@pytest.mark.parametrize(
+    ("state", "stdout", "returncode", "summary", "needs_enable"),
+    [
+        (
+            "disabled",
+            "codex_hooks under-development false\n",
+            0,
+            "configured but inactive",
+            True,
+        ),
+        (
+            "unavailable",
+            "multi_agent experimental true\n",
+            0,
+            "configured but inactive",
+            True,
+        ),
+        (
+            "enabled",
+            "hooks experimental true\n",
+            0,
+            "configured; capability enabled; trust still required",
+            False,
+        ),
+        (
+            "absent",
+            "",
+            0,
+            "configured but not verified active",
+            False,
+        ),
+        (
+            "timed-out",
+            "",
+            0,
+            "configured but not verified active",
+            False,
+        ),
+    ],
+)
+def test_install_hooks_reports_codex_activation_without_mutating_user_state(
+    tmp_path: Path,
+    monkeypatch,
+    state: str,
+    stdout: str,
+    returncode: int,
+    summary: str,
+    needs_enable: bool,
+):
+    monkeypatch.chdir(tmp_path)
+    home = tmp_path / "home"
+    user_config = home / ".codex" / "config.toml"
+    user_config.parent.mkdir(parents=True)
+    user_config.write_text('[features]\ncodex_hooks = false\n[projects."/workspace"]\ntrust_level = "untrusted"\n')
+    before = _home_bytes(home)
+    monkeypatch.setenv("HOME", str(home))
+
+    roots = [tmp_path / "service-a", tmp_path / "service-b"]
+    for root in roots:
+        (root / ".git" / "hooks").mkdir(parents=True)
+        (root / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: t\n"
+        "repos:\n"
+        "  service-a:\n"
+        "    path: service-a\n"
+        "    type: service\n"
+        "  service-b:\n"
+        "    path: service-b\n"
+        "    type: service\n"
+    )
+
+    real_which = shutil.which
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda name: (
+            None
+            if name == "codex" and state == "absent"
+            else "/usr/bin/codex"
+            if name == "codex"
+            else real_which(name)
+        ),
+    )
+    probe_calls: list[str] = []
+
+    def run_probe(self, command, cwd, env=None, timeout=None):
+        if command != "codex features list":
+            return ShellResult(returncode=0, stdout="", stderr="")
+        probe_calls.append(command)
+        if state == "timed-out":
+            raise subprocess.TimeoutExpired(command, timeout)
+        return ShellResult(returncode=returncode, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(ShellRunner, "run", run_probe)
+    container.config.reset()
+    container.state_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(tmp_path / ".mothership")
+    try:
+        result = runner.invoke(app, ["init", "--install-hooks"])
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+
+    assert result.exit_code == 0, result.output
+    assert summary in result.output
+    assert "open `/hooks` in Codex to review and trust the project hooks" in result.output
+    assert ("`codex features enable codex_hooks`" in result.output) is needs_enable
+    if state == "absent":
+        assert "not installed" in result.output
+        assert probe_calls == []
+    elif state == "timed-out":
+        assert "timed out" in result.output
+        assert probe_calls == ["codex features list"]
+    else:
+        assert probe_calls == ["codex features list"]
+    assert all((root / ".codex" / "hooks.json").is_file() for root in roots)
+    assert _home_bytes(home) == before
 
 
 def test_interactive_wizard_emits_git_root_for_single_git_monorepo(tmp_path: Path, monkeypatch):

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -560,6 +560,8 @@ def test_install_hooks_reports_incomplete_codex_registration_before_activation(
     assert "Codex hook installation incomplete" in result.output
     assert "`mship init --install-hooks`" in result.output
     assert "Codex hooks configured but" not in result.output
+    assert "`codex features enable codex_hooks`" in result.output
+    assert "open `/hooks` in Codex to review and trust the project hooks" in result.output
     assert probe_calls == ["codex features list"]
 
 

--- a/tests/cli/test_output_flags.py
+++ b/tests/cli/test_output_flags.py
@@ -27,9 +27,10 @@ class FakeStream(io.StringIO):
 
 @pytest.fixture(autouse=True)
 def _reset_settings(monkeypatch):
-    # Each test starts from a clean global + no inherited env.
+    # Each test starts from clean output state and a color-capable fake terminal.
     for var in ("MSHIP_JSON", "MSHIP_QUIET", "NO_COLOR"):
         monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
     reset_output_settings()
     yield
     reset_output_settings()

--- a/tests/cli/test_skill.py
+++ b/tests/cli/test_skill.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from typer.testing import CliRunner
 
 from mship.cli import app
@@ -44,6 +46,95 @@ def test_skill_install_only_flag_limits_agents(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     assert (home / ".agents" / "skills" / "mothership").is_symlink()
     assert not (home / ".claude" / "skills").exists()
+
+
+@pytest.mark.parametrize("requested", ["omp", "pi"])
+def test_skill_install_omp_and_pi_emit_one_canonical_result(
+    tmp_path, monkeypatch, requested: str
+):
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    result = runner.invoke(
+        app, ["skill", "install", "--only", requested, "--yes"]
+    )
+
+    assert result.exit_code == 0, result.output
+    installed = json.loads(result.output)["installed"]
+    assert [entry["agent"] for entry in installed] == ["omp"]
+    assert (home / ".agents" / "skills" / "mothership").is_symlink()
+
+
+def test_skill_install_codex_and_omp_share_one_target_without_duplication(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    result = runner.invoke(
+        app, ["skill", "install", "--only", "codex,omp", "--yes"]
+    )
+
+    assert result.exit_code == 0, result.output
+    installed = json.loads(result.output)["installed"]
+    assert [entry["agent"] for entry in installed] == ["codex", "omp"]
+    assert {entry["dest"] for entry in installed} == {
+        str(home / ".agents" / "skills")
+    }
+    assert len(list((home / ".agents" / "skills").iterdir())) == 1
+
+
+def test_skill_install_rejects_unknown_agent():
+    result = runner.invoke(
+        app, ["skill", "install", "--only", "unknown", "--yes"]
+    )
+
+    assert result.exit_code != 0
+    assert "Unknown agent(s): unknown" in result.output
+
+
+@pytest.mark.parametrize("executable", ["omp", "pi"])
+def test_skill_install_auto_detects_omp_executables(
+    tmp_path, monkeypatch, executable: str
+):
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(
+        "mship.core.skill_install.shutil.which",
+        lambda name: f"/usr/bin/{name}" if name == executable else None,
+    )
+
+    result = runner.invoke(app, ["skill", "install", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    installed = json.loads(result.output)["installed"]
+    assert [entry["agent"] for entry in installed] == ["omp"]
+
+
+def test_skill_install_auto_detects_omp_config(tmp_path, monkeypatch):
+    home = tmp_path / "home"; home.mkdir()
+    (home / ".omp").mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(
+        "mship.core.skill_install.shutil.which", lambda name: None
+    )
+
+    result = runner.invoke(app, ["skill", "install", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    installed = json.loads(result.output)["installed"]
+    assert [entry["agent"] for entry in installed] == ["omp"]
+
+
+def test_skill_install_help_names_omp_and_pi_alias():
+    result = runner.invoke(
+        app, ["skill", "install", "--help"], terminal_width=120
+    )
+
+    assert result.exit_code == 0, result.output
+    help_text = " ".join(result.output.lower().split())
+    assert "pi" in help_text
+    assert "alias for omp" in help_text
 
 
 def test_skill_install_warns_about_legacy_codex_mothership_dir(tmp_path, monkeypatch):

--- a/tests/core/test_claude_settings.py
+++ b/tests/core/test_claude_settings.py
@@ -2,7 +2,13 @@ import json as _json
 import json
 from pathlib import Path
 
-from mship.core.claude_settings import install_session_hook, SESSION_COMMAND
+import pytest
+
+from mship.core.claude_settings import (
+    SESSION_COMMAND,
+    extract_claude_edit_targets,
+    install_session_hook,
+)
 
 
 def _hooks(ws: Path):
@@ -63,3 +69,96 @@ def test_install_tolerates_null_hooks_entry(tmp_path):
     assert install_session_hook(tmp_path) == "installed"
     cmds = [h["command"] for e in _hooks(tmp_path) for h in (e.get("hooks") or []) if isinstance(h, dict)]
     assert SESSION_COMMAND in cmds
+
+
+@pytest.mark.parametrize(
+    ("event", "expected"),
+    [
+        (
+            {"tool_name": "Edit", "tool_input": {"file_path": "src/a.py"}},
+            ("src/a.py",),
+        ),
+        (
+            {
+                "tool_name": "NotebookEdit",
+                "tool_input": {"notebook_path": "notebooks/a.ipynb"},
+            },
+            ("notebooks/a.ipynb",),
+        ),
+        (
+            {
+                "tool_name": "MultiEdit",
+                "tool_input": {
+                    "edits": [
+                        {"file_path": "src/a.py"},
+                        {"file_path": "src/b.py"},
+                    ],
+                },
+            },
+            ("src/a.py", "src/b.py"),
+        ),
+        (
+            {
+                "tool_name": "MultiEdit",
+                "tool_input": {
+                    "file_path": "src/a.py",
+                    "edits": [
+                        {"file_path": "src/a.py"},
+                        {"file_path": "src/b.py"},
+                    ],
+                },
+            },
+            ("src/a.py", "src/b.py"),
+        ),
+        (
+            {
+                "tool_name": "MultiEdit",
+                "tool_input": {
+                    "edits": [
+                        None,
+                        {"file_path": ""},
+                        {"file_path": 42},
+                        {"file_path": "src/a.py"},
+                        {"notebook_path": "notebooks/b.ipynb"},
+                    ],
+                },
+            },
+            ("src/a.py", "notebooks/b.ipynb"),
+        ),
+        (
+            {"tool_name": "Bash", "tool_input": {"file_path": "src/a.py"}},
+            (),
+        ),
+    ],
+)
+def test_extracts_documented_claude_edit_targets(event: dict, expected: tuple[str, ...]):
+    assert extract_claude_edit_targets(event) == expected
+
+
+def test_multi_edit_exposes_allowed_and_denied_targets(tmp_path: Path):
+    worktree_target = tmp_path / ".worktrees" / "t" / "repo" / "src" / "a.py"
+    main_target = tmp_path / "repo" / "src" / "b.py"
+
+    assert extract_claude_edit_targets({
+        "tool_name": "MultiEdit",
+        "tool_input": {
+            "edits": [
+                {"file_path": str(worktree_target)},
+                {"file_path": str(main_target)},
+            ],
+        },
+    }) == (str(worktree_target), str(main_target))
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"tool_name": "Edit", "tool_input": {}},
+        {"tool_name": "Write", "tool_input": {"file_path": ""}},
+        {"tool_name": "MultiEdit", "tool_input": {"edits": []}},
+        {"tool_name": "NotebookEdit", "tool_input": None},
+    ],
+)
+def test_recognized_claude_edit_without_targets_is_an_adapter_error(event: dict):
+    with pytest.raises(ValueError, match="target"):
+        extract_claude_edit_targets(event)

--- a/tests/core/test_codex_hooks.py
+++ b/tests/core/test_codex_hooks.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import Mock
 from pathlib import Path
 
 import pytest
@@ -10,6 +13,7 @@ from mship.core.codex_hooks import (
     extract_edit_targets,
     install_codex_hooks,
 )
+import mship.core.codex_hooks as codex_hooks
 
 
 def _event(tool_name: str, tool_input: dict) -> dict:
@@ -227,3 +231,79 @@ def test_atomic_write_failure_preserves_existing_file(tmp_path: Path, monkeypatc
     with pytest.raises(OSError, match="disk full"):
         install_codex_hooks(tmp_path)
     assert path.read_text() == original
+
+
+@pytest.mark.parametrize(
+    ("stdout", "returncode", "expected", "feature_name"),
+    [
+        (
+            "codex_hooks  under-development  false\n",
+            0,
+            "disabled",
+            "codex_hooks",
+        ),
+        ("hooks experimental true\n", 0, "enabled", "hooks"),
+        ("multi_agent experimental true\n", 0, "unavailable", None),
+        ("", 1, "unavailable", None),
+    ],
+)
+def test_probe_codex_hook_capability(
+    stdout: str,
+    returncode: int,
+    expected: str,
+    feature_name: str | None,
+):
+    shell = Mock()
+    shell.run.return_value = SimpleNamespace(
+        stdout=stdout,
+        stderr="",
+        returncode=returncode,
+    )
+
+    result = codex_hooks.probe_codex_hook_capability(
+        shell,
+        Path("/workspace"),
+        codex_binary="/usr/bin/codex",
+    )
+
+    assert result.state.value == expected
+    assert result.feature_name == feature_name
+    shell.run.assert_called_once_with(
+        "codex features list",
+        cwd=Path("/workspace"),
+        timeout=codex_hooks.CODEX_CAPABILITY_PROBE_TIMEOUT_SECONDS,
+    )
+
+
+def test_probe_codex_hook_capability_reports_absent_without_shell_call():
+    shell = Mock()
+
+    result = codex_hooks.probe_codex_hook_capability(
+        shell,
+        Path("/workspace"),
+        codex_binary=None,
+    )
+
+    assert result.state.value == "absent"
+    shell.run.assert_not_called()
+
+
+def test_probe_codex_hook_capability_reports_timeout_without_retry():
+    shell = Mock()
+    shell.run.side_effect = subprocess.TimeoutExpired(
+        cmd="codex features list",
+        timeout=codex_hooks.CODEX_CAPABILITY_PROBE_TIMEOUT_SECONDS,
+    )
+
+    result = codex_hooks.probe_codex_hook_capability(
+        shell,
+        Path("/workspace"),
+        codex_binary="/usr/bin/codex",
+    )
+
+    assert result.state.value == "timed-out"
+    shell.run.assert_called_once_with(
+        "codex features list",
+        cwd=Path("/workspace"),
+        timeout=codex_hooks.CODEX_CAPABILITY_PROBE_TIMEOUT_SECONDS,
+    )

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -605,9 +605,9 @@ def test_no_synthesized_fields_added(tmp_path: Path):
 
 
 def test_for_values_and_kind_values_are_the_documented_closed_set():
-    """q1: the closed set of --for values is claude-code/codex/human/reviewer;
+    """q1: the closed set of --for values includes every supported harness;
     --kind is spec/code-quality."""
-    assert set(FOR_VALUES) == {"claude-code", "codex", "human", "reviewer"}
+    assert set(FOR_VALUES) == {"claude-code", "codex", "omp", "human", "reviewer"}
     assert set(KIND_VALUES) == {"spec", "code-quality"}
 
 
@@ -616,7 +616,7 @@ def test_context_includes_dispatch_models(tmp_path: Path):
     out = _build(WorkspaceState(), _config(tmp_path), log_mgr, tmp_path)
     assert "dispatch_models" in out
     assert out["dispatch_models"]["implementer"] == "inherit"
-    assert out["dispatch_models"]["reviewer"] == "sonnet"
+    assert out["dispatch_models"]["reviewer"] == "inherit"
 
 
 def test_context_dispatch_models_reflects_configured_override(tmp_path: Path):

--- a/tests/core/test_dispatch_models.py
+++ b/tests/core/test_dispatch_models.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mship.core.dispatch_models import resolve_model, BUILTIN_MODEL_DEFAULTS
+from mship.core.dispatch_models import resolve_model
 
 
 def test_flag_wins():
@@ -11,9 +11,14 @@ def test_config_beats_builtin():
     assert resolve_model("reviewer", flag=None, configured={"reviewer": "haiku"}) == "haiku"
 
 
-def test_builtin_default_per_mode():
-    assert resolve_model("implementer", flag=None, configured=None) == BUILTIN_MODEL_DEFAULTS["implementer"]
-    assert resolve_model("reviewer", flag=None, configured=None) == BUILTIN_MODEL_DEFAULTS["reviewer"]
+@pytest.mark.parametrize("mode", ["implementer", "standalone", "reviewer"])
+def test_builtin_defaults_inherit_harness_model(mode):
+    assert resolve_model(mode, flag=None, configured=None) == "inherit"
+
+
+def test_operator_model_value_is_opaque_and_verbatim():
+    value = "vendor/custom-tier:2026-08"
+    assert resolve_model("reviewer", flag=None, configured={"reviewer": value}) == value
 
 
 def test_unknown_mode_raises():

--- a/tests/core/test_dispatch_stub.py
+++ b/tests/core/test_dispatch_stub.py
@@ -1,14 +1,29 @@
+import pytest
+
 from mship.core.dispatch_stub import STUB_FIELDS, build_stub
 from tests.core.test_sdd_store import _record  # reuse the fixture factory
 
 
-def test_stub_contains_exactly_the_closed_fields():
-    rec = _record()
+@pytest.mark.parametrize("mode", ["implementer", "standalone", "reviewer"])
+def test_stub_contains_exactly_the_closed_fields_for_portable_defaults(mode):
+    rec = _record(mode=mode, model="inherit")
     stub = build_stub(rec, record_path="/ws/.mothership/sdd/wi-1/my-task/record.json")
     labels = tuple(line.split(":", 1)[0] for line in stub.splitlines())
     # Every field present, in order, and NOTHING else — a new field must be
     # added to STUB_FIELDS and consciously accepted here (that's the point).
-    assert labels == STUB_FIELDS
+    assert labels == STUB_FIELDS == ("record", "model", "mode", "worktree", "emit")
+    for provider_tier in ("sonnet", "haiku", "opus"):
+        assert provider_tier not in stub
+
+
+def test_stub_emits_explicit_model_verbatim_in_both_model_bearing_lines():
+    value = "vendor/custom-tier:2026-08"
+    stub = build_stub(_record(model=value), record_path="/p/record.json")
+    lines = stub.splitlines()
+
+    assert lines[1] == f"model: {value}"
+    assert f"model={value}" in lines[4]
+    assert stub.count(value) == 2
 
 
 def test_stub_carries_no_prompt_content():

--- a/tests/core/test_doctor.py
+++ b/tests/core/test_doctor.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -421,6 +422,61 @@ def test_skill_check_reports_missing_install(tmp_path, monkeypatch):
     assert by_name["skills/claude"].status == "warn"
     assert "0/1" in by_name["skills/claude"].message
     assert "mship skill install" in by_name["skills/claude"].message
+
+
+@pytest.mark.parametrize(
+    ("state", "status", "detail", "needs_force"),
+    [
+        ("current", "pass", "current", False),
+        ("missing", "warn", "0/2 installed", False),
+        ("dangling", "warn", "dangling", False),
+        ("stale", "warn", "stale", False),
+        ("foreign", "warn", "foreign", True),
+    ],
+)
+def test_omp_skill_check_classifies_shared_target_with_exact_repair(
+    tmp_path, monkeypatch, state, status, detail, needs_force
+):
+    from mship.core.doctor import check_skill_availability
+
+    fake_pkg = _seed_pkg_and_home(tmp_path, monkeypatch, ["a", "b"])
+    monkeypatch.setattr(
+        "mship.core.skill_install._detect_agents",
+        lambda: {"claude": False, "codex": False, "gemini": False, "omp": True},
+    )
+    target = (
+        Path(os.environ["HOME"])
+        / ".agents"
+        / "skills"
+        / "mothership"
+    )
+    if state != "missing":
+        target.parent.mkdir(parents=True)
+    if state == "current":
+        target.symlink_to(fake_pkg)
+    elif state == "dangling":
+        target.symlink_to(fake_pkg / "removed-layout")
+    elif state == "stale":
+        stale = fake_pkg / "stale-layout"
+        stale.mkdir()
+        target.symlink_to(stale)
+    elif state == "foreign":
+        target.mkdir()
+        (target / "SKILL.md").write_text("# foreign\n")
+
+    row = next(
+        result
+        for result in check_skill_availability()
+        if result.name == "skills/omp"
+    )
+
+    assert row.status == status
+    assert detail in row.message
+    if status == "warn":
+        repair = "mship skill install --only omp"
+        if needs_force:
+            repair += " --force"
+        assert f"`{repair}`" in row.message
 
 
 def test_doctor_go_task_pass_when_binary_present(workspace: Path, monkeypatch):
@@ -853,6 +909,9 @@ def _install_all_agent_integrations(workspace: Path) -> None:
 
 def test_doctor_reports_all_agent_integrations_healthy(workspace: Path, monkeypatch):
     _install_all_agent_integrations(workspace)
+    home = workspace / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
     monkeypatch.setattr(
         "mship.core.doctor.shutil.which",
         lambda name: f"/usr/bin/{name}" if name in {"task", "codex", "omp"} else None,
@@ -871,6 +930,8 @@ def test_doctor_reports_all_agent_integrations_healthy(workspace: Path, monkeypa
     assert rows["agent-hooks/omp"].status == "pass"
     assert rows["agent-runtime/codex"].status == "pass"
     assert rows["agent-runtime/omp"].status == "pass"
+    assert rows["skills/omp"].status == "warn"
+    assert "mship skill install --only omp" in rows["skills/omp"].message
     assert "/hooks" in rows["agent-hooks/codex"].message
     assert "fully active" not in " ".join(check.message for check in report.checks)
 

--- a/tests/core/test_doctor.py
+++ b/tests/core/test_doctor.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -797,14 +798,26 @@ def test_doctor_survives_a_topology_failure(workspace: Path, monkeypatch):
     assert any(c.name.endswith("/path") for c in report.checks)
 
 
-def _agent_runtime_shell(*, codex_hooks: bool = True, omp_version: str = "17.2.0"):
+def _agent_runtime_shell(
+    *,
+    codex_state: str = "enabled",
+    omp_version: str = "17.2.0",
+):
     shell = MagicMock(spec=ShellRunner)
 
     def run(command, cwd, env=None, timeout=None):
         if "task --list" in command:
             return ShellResult(returncode=0, stdout="test\nrun\nlint\nsetup\n", stderr="")
         if command == "codex features list":
-            enabled = "true" if codex_hooks else "false"
+            if codex_state == "timed-out":
+                raise subprocess.TimeoutExpired(command, timeout or 0)
+            if codex_state == "unavailable":
+                return ShellResult(
+                    returncode=0,
+                    stdout="multi_agent experimental true\n",
+                    stderr="",
+                )
+            enabled = "true" if codex_state == "enabled" else "false"
             return ShellResult(
                 returncode=0,
                 stdout=f"hooks  stable  {enabled}\n",
@@ -854,12 +867,12 @@ def test_doctor_reports_all_agent_integrations_healthy(workspace: Path, monkeypa
     rows = {check.name: check for check in report.checks}
 
     assert rows["agent-hooks/claude"].status == "pass"
-    assert rows["agent-hooks/codex"].status == "pass"
+    assert rows["agent-hooks/codex"].status == "warn"
     assert rows["agent-hooks/omp"].status == "pass"
     assert rows["agent-runtime/codex"].status == "pass"
     assert rows["agent-runtime/omp"].status == "pass"
-    assert rows["agent-hooks/codex-trust"].status == "warn"
-    assert "/hooks" in rows["agent-hooks/codex-trust"].message
+    assert "/hooks" in rows["agent-hooks/codex"].message
+    assert "fully active" not in " ".join(check.message for check in report.checks)
 
 
 
@@ -900,7 +913,7 @@ def test_doctor_checks_native_integrations_in_configured_repo_roots(
     ).run()
     rows = {check.name: check for check in report.checks}
 
-    assert rows["agent-hooks/codex"].status == "pass"
+    assert rows["agent-hooks/codex"].status == "warn"
     assert rows["agent-hooks/omp"].status == "pass"
 
 
@@ -940,6 +953,7 @@ def test_doctor_reports_malformed_codex_and_stale_omp_artifacts(workspace: Path,
 
     assert rows["agent-hooks/codex"].status == "warn"
     assert "valid JSON" in rows["agent-hooks/codex"].message
+    assert "`mship init --install-hooks`" in rows["agent-hooks/codex"].message
     assert rows["agent-hooks/omp"].status == "warn"
     assert "stale" in rows["agent-hooks/omp"].message
 
@@ -1022,7 +1036,7 @@ def test_doctor_warns_on_disabled_codex_hooks_and_old_omp(workspace: Path, monke
 
     report = DoctorChecker(
         ConfigLoader.load(workspace / "mothership.yaml"),
-        _agent_runtime_shell(codex_hooks=False, omp_version="16.1.19"),
+        _agent_runtime_shell(codex_state="disabled", omp_version="16.1.19"),
         workspace_root=workspace,
         probe_network=False,
     ).run()
@@ -1032,6 +1046,8 @@ def test_doctor_warns_on_disabled_codex_hooks_and_old_omp(workspace: Path, monke
     assert "disabled" in rows["agent-runtime/codex"].message
     assert rows["agent-runtime/omp"].status == "warn"
     assert "too old" in rows["agent-runtime/omp"].message
+    assert "`codex features enable codex_hooks`" in rows["agent-runtime/codex"].message
+    assert "/hooks" in rows["agent-hooks/codex"].message
 
 
 @pytest.mark.parametrize(
@@ -1097,6 +1113,7 @@ def test_doctor_reports_stale_codex_owned_registration(workspace: Path, monkeypa
 
     assert row.status == "warn"
     assert "stale" in row.message
+    assert "`mship init --install-hooks`" in row.message
 
 
 def test_doctor_reports_and_reinstaller_repairs_stale_claude_registration(
@@ -1136,3 +1153,86 @@ def test_doctor_reports_and_reinstaller_repairs_stale_claude_registration(
         check for check in repaired.checks if check.name == "agent-hooks/claude"
     )
     assert repaired_row.status == "pass"
+
+
+def _tree_bytes(root: Path) -> dict[Path, bytes]:
+    return {
+        path.relative_to(root): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+@pytest.mark.parametrize(
+    ("state", "hook_summary", "runtime_status", "needs_enable"),
+    [
+        ("disabled", "configured but inactive", "warn", True),
+        ("unavailable", "configured but inactive", "warn", True),
+        (
+            "enabled",
+            "configured; capability enabled; trust still required",
+            "pass",
+            False,
+        ),
+        ("absent", "configured but not verified active", "warn", False),
+        ("timed-out", "configured but not verified active", "warn", False),
+    ],
+)
+def test_doctor_codex_capability_matrix_is_read_only_and_never_fully_active(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch,
+    state: str,
+    hook_summary: str,
+    runtime_status: str,
+    needs_enable: bool,
+):
+    _install_all_agent_integrations(workspace)
+    home = tmp_path / "home"
+    user_config = home / ".codex" / "config.toml"
+    user_config.parent.mkdir(parents=True)
+    user_config.write_text('[features]\ncodex_hooks = false\n[projects."/workspace"]\ntrust_level = "untrusted"\n')
+    monkeypatch.setenv("HOME", str(home))
+    home_before = _tree_bytes(home)
+    workspace_before = _tree_bytes(workspace)
+    monkeypatch.setattr(
+        "mship.core.doctor.shutil.which",
+        lambda name: (
+            None
+            if name == "codex" and state == "absent"
+            else f"/usr/bin/{name}"
+            if name in {"task", "codex", "omp"}
+            else None
+        ),
+    )
+    shell = _agent_runtime_shell(codex_state=state)
+
+    report = DoctorChecker(
+        ConfigLoader.load(workspace / "mothership.yaml"),
+        shell,
+        workspace_root=workspace,
+        probe_network=False,
+    ).run()
+
+    rows = {check.name: check for check in report.checks}
+    codex_messages = " ".join(
+        check.message for check in report.checks if "codex" in check.name
+    )
+    assert rows["agent-runtime/codex"].status == runtime_status
+    assert rows["agent-hooks/codex"].status == "warn"
+    assert hook_summary in rows["agent-hooks/codex"].message
+    assert "open `/hooks` in Codex to review and trust the project hooks" in codex_messages
+    assert ("`codex features enable codex_hooks`" in codex_messages) is needs_enable
+    assert "fully active" not in codex_messages
+    if state == "absent":
+        assert "not installed" in codex_messages
+    if state == "timed-out":
+        assert "timed out" in codex_messages
+    capability_calls = [
+        call
+        for call in shell.run.call_args_list
+        if call.args[0] == "codex features list"
+    ]
+    assert len(capability_calls) == (0 if state == "absent" else 1)
+    assert _tree_bytes(home) == home_before
+    assert _tree_bytes(workspace) == workspace_before

--- a/tests/core/test_doctor.py
+++ b/tests/core/test_doctor.py
@@ -938,6 +938,34 @@ def test_doctor_reports_all_agent_integrations_healthy(workspace: Path, monkeypa
 
 
 
+def test_doctor_probes_pi_alias_when_omp_binary_is_absent(workspace: Path, monkeypatch):
+    _install_all_agent_integrations(workspace)
+    monkeypatch.setattr(
+        "mship.core.doctor.shutil.which",
+        lambda name: f"/usr/bin/{name}" if name in {"task", "codex", "pi"} else None,
+    )
+    shell = _agent_runtime_shell()
+    normal_run = shell.run.side_effect
+
+    def run(command, cwd, env=None, timeout=None):
+        if command == "pi --version":
+            return ShellResult(returncode=0, stdout="pi v17.2.0\n", stderr="")
+        return normal_run(command, cwd, env=env, timeout=timeout)
+
+    shell.run.side_effect = run
+    report = DoctorChecker(
+        ConfigLoader.load(workspace / "mothership.yaml"),
+        shell,
+        workspace_root=workspace,
+        probe_network=False,
+    ).run()
+    row = next(check for check in report.checks if check.name == "agent-runtime/omp")
+
+    assert row.status == "pass"
+    assert "Pi 17.2.0 supports project extensions" == row.message
+    assert any(call.args[0] == "pi --version" for call in shell.run.call_args_list)
+
+
 def test_doctor_checks_native_integrations_in_configured_repo_roots(
     workspace: Path, monkeypatch
 ):
@@ -1162,11 +1190,14 @@ def test_doctor_reports_stale_codex_owned_registration(workspace: Path, monkeypa
         "command": "mship _guard-edit --runtime codex --legacy",
     })
     path.write_text(json.dumps(data))
-    monkeypatch.setattr("mship.core.doctor.shutil.which", lambda name: None)
+    monkeypatch.setattr(
+        "mship.core.doctor.shutil.which",
+        lambda name: f"/usr/bin/{name}" if name in {"task", "codex"} else None,
+    )
 
     report = DoctorChecker(
         ConfigLoader.load(workspace / "mothership.yaml"),
-        _agent_runtime_shell(),
+        _agent_runtime_shell(codex_state="disabled"),
         workspace_root=workspace,
         probe_network=False,
     ).run()
@@ -1175,6 +1206,8 @@ def test_doctor_reports_stale_codex_owned_registration(workspace: Path, monkeypa
     assert row.status == "warn"
     assert "stale" in row.message
     assert "`mship init --install-hooks`" in row.message
+    assert "`codex features enable codex_hooks`" in row.message
+    assert "open `/hooks` in Codex to review and trust the project hooks" in row.message
 
 
 def test_doctor_reports_and_reinstaller_repairs_stale_claude_registration(

--- a/tests/core/test_omp_extension.py
+++ b/tests/core/test_omp_extension.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import json
+import os
+import shutil
+import subprocess
+
 from pathlib import Path
 
 import pytest
@@ -98,3 +103,123 @@ def test_atomic_write_failure_preserves_existing_extension(tmp_path: Path, monke
     with pytest.raises(OSError, match="disk full"):
         install_omp_extension(tmp_path)
     assert target.read_text() == "// existing\n"
+
+
+def test_generated_extension_executes_native_lifecycle_contract_under_bun(tmp_path: Path):
+    bun = shutil.which("bun")
+    if bun is None:
+        pytest.skip("bun is unavailable")
+
+    install_omp_extension(tmp_path)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_mship = fake_bin / "mship"
+    fake_mship.write_text(
+        """#!/bin/sh
+case "$2" in
+  session_start)
+    printf '%s\n' '{"kind":"context","message":"context"}'
+    ;;
+  tool_call)
+    if [ ! -e "$0.tool-called" ]; then
+      touch "$0.tool-called"
+      printf '%s\n' '{"kind":"deny","message":"denied"}'
+    else
+      printf '%s\n' 'not json'
+    fi
+    ;;
+  session_stop)
+    if [ ! -e "$0.stop-once" ]; then
+      touch "$0.stop-once"
+      printf '%s\n' '{"kind":"continue","message":"answer inbox"}'
+    elif [ ! -e "$0.stop-twice" ]; then
+      touch "$0.stop-twice"
+      printf '%s\n' '{"kind":"stop"}'
+    else
+      exit 7
+    fi
+    ;;
+esac
+"""
+    )
+    fake_mship.chmod(0o755)
+    harness = tmp_path / "harness.ts"
+    harness.write_text(
+        """import extension from \"./.omp/extensions/mship.ts\";
+
+const handlers = new Map<string, Function>();
+const registrations: string[] = [];
+const messages: unknown[] = [];
+const warnings: string[] = [];
+const pi = {
+  on(name: string, handler: Function) {
+    registrations.push(name);
+    handlers.set(name, handler);
+  },
+  sendMessage(...args: unknown[]) {
+    messages.push(args);
+  },
+  logger: {
+    warn(message: string) {
+      warnings.push(message);
+    },
+  },
+};
+extension(pi);
+const ctx = {cwd: process.cwd()};
+
+await handlers.get(\"session_start\")!({type: \"session_start\"}, ctx);
+const deny = await handlers.get(\"tool_call\")!(
+  {type: \"tool_call\", toolName: \"edit\", input: {path: \"src/a.py\"}},
+  ctx,
+);
+const continued = await handlers.get(\"session_stop\")!({type: \"session_stop\"}, ctx);
+const stopped = await handlers.get(\"session_stop\")!({type: \"session_stop\"}, ctx);
+const invalid = await handlers.get(\"tool_call\")!(
+  {type: \"tool_call\", toolName: \"write\", input: {path: \"src/b.py\"}},
+  ctx,
+);
+const nonzero = await handlers.get(\"session_stop\")!({type: \"session_stop\"}, ctx);
+
+console.log(JSON.stringify({
+  registrations,
+  messages,
+  warnings,
+  deny: deny ?? null,
+  continued: continued ?? null,
+  stopped: stopped ?? null,
+  invalid: invalid ?? null,
+  nonzero: nonzero ?? null,
+}));
+"""
+    )
+
+    result = subprocess.run(
+        [bun, str(harness)],
+        cwd=tmp_path,
+        env={**os.environ, "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}"},
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=20,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["registrations"] == ["session_start", "tool_call", "session_stop"]
+    assert payload["messages"] == [[
+        {"customType": "mship-session-context", "content": "context", "display": False},
+        {"deliverAs": "nextTurn"},
+    ]]
+    assert payload["deny"] == {"block": True, "reason": "denied"}
+    assert payload["continued"] == {
+        "continue": True,
+        "additionalContext": "answer inbox",
+    }
+    assert payload["stopped"] is None
+    assert payload["invalid"] is None
+    assert payload["nonzero"] is None
+    assert payload["warnings"] == [
+        "Mothership tool_call hook failed open",
+        "Mothership session_stop hook failed open",
+    ]

--- a/tests/core/test_omp_extension.py
+++ b/tests/core/test_omp_extension.py
@@ -115,31 +115,41 @@ def test_generated_extension_executes_native_lifecycle_contract_under_bun(tmp_pa
     fake_bin.mkdir()
     fake_mship = fake_bin / "mship"
     fake_mship.write_text(
-        """#!/bin/sh
-case "$2" in
-  session_start)
-    printf '%s\n' '{"kind":"context","message":"context"}'
-    ;;
-  tool_call)
-    if [ ! -e "$0.tool-called" ]; then
-      touch "$0.tool-called"
-      printf '%s\n' '{"kind":"deny","message":"denied"}'
-    else
-      printf '%s\n' 'not json'
-    fi
-    ;;
-  session_stop)
-    if [ ! -e "$0.stop-once" ]; then
-      touch "$0.stop-once"
-      printf '%s\n' '{"kind":"continue","message":"answer inbox"}'
-    elif [ ! -e "$0.stop-twice" ]; then
-      touch "$0.stop-twice"
-      printf '%s\n' '{"kind":"stop"}'
-    else
-      exit 7
-    fi
-    ;;
-esac
+        """#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+event_name = sys.argv[2]
+event = json.load(sys.stdin)
+with Path("forwarded-events.jsonl").open("a") as stream:
+    stream.write(json.dumps(event, separators=(",", ":")) + "\\n")
+
+if event_name == "session_start":
+    assert event == {"type": "session_start", "source": "startup"}
+    print(json.dumps({"kind": "context", "message": "context"}))
+elif event_name == "tool_call":
+    assert event["type"] == "tool_call"
+    assert event["toolName"] in {"edit", "write"}
+    path = event["input"]["path"]
+    if path == "src/denied.py":
+        print(json.dumps({"kind": "deny", "message": "denied"}))
+    elif path == "src/allowed.py":
+        print(json.dumps({"kind": "allow"}))
+    elif path == "src/invalid-json.py":
+        print("not json")
+    elif path == "src/nonzero.py":
+        raise SystemExit(7)
+    else:
+        raise AssertionError(path)
+elif event_name == "session_stop":
+    assert event["type"] == "session_stop"
+    if event["stop_hook_active"]:
+        print(json.dumps({"kind": "stop"}))
+    else:
+        print(json.dumps({"kind": "continue", "message": "answer inbox"}))
+else:
+    raise AssertionError(event_name)
 """
     )
     fake_mship.chmod(0o755)
@@ -168,24 +178,38 @@ const pi = {
 extension(pi);
 const ctx = {cwd: process.cwd()};
 
-await handlers.get(\"session_start\")!({type: \"session_start\"}, ctx);
-const deny = await handlers.get(\"tool_call\")!(
-  {type: \"tool_call\", toolName: \"edit\", input: {path: \"src/a.py\"}},
+await handlers.get("session_start")!({type: "session_start", source: "startup"}, ctx);
+const deny = await handlers.get("tool_call")!(
+  {type: "tool_call", toolName: "edit", input: {path: "src/denied.py"}},
   ctx,
 );
-const continued = await handlers.get(\"session_stop\")!({type: \"session_stop\"}, ctx);
-const stopped = await handlers.get(\"session_stop\")!({type: \"session_stop\"}, ctx);
-const invalid = await handlers.get(\"tool_call\")!(
-  {type: \"tool_call\", toolName: \"write\", input: {path: \"src/b.py\"}},
+const allowed = await handlers.get("tool_call")!(
+  {type: "tool_call", toolName: "write", input: {path: "src/allowed.py"}},
   ctx,
 );
-const nonzero = await handlers.get(\"session_stop\")!({type: \"session_stop\"}, ctx);
+const continued = await handlers.get("session_stop")!(
+  {type: "session_stop", stop_hook_active: false},
+  ctx,
+);
+const stopped = await handlers.get("session_stop")!(
+  {type: "session_stop", stop_hook_active: true},
+  ctx,
+);
+const invalid = await handlers.get("tool_call")!(
+  {type: "tool_call", toolName: "write", input: {path: "src/invalid-json.py"}},
+  ctx,
+);
+const nonzero = await handlers.get("tool_call")!(
+  {type: "tool_call", toolName: "edit", input: {path: "src/nonzero.py"}},
+  ctx,
+);
 
 console.log(JSON.stringify({
   registrations,
   messages,
   warnings,
   deny: deny ?? null,
+  allowed: allowed ?? null,
   continued: continued ?? null,
   stopped: stopped ?? null,
   invalid: invalid ?? null,
@@ -203,15 +227,32 @@ console.log(JSON.stringify({
         check=False,
         timeout=20,
     )
-
     assert result.returncode == 0, result.stderr
+    forwarded = [
+        json.loads(line)
+        for line in (tmp_path / "forwarded-events.jsonl").read_text().splitlines()
+    ]
     payload = json.loads(result.stdout)
     assert payload["registrations"] == ["session_start", "tool_call", "session_stop"]
     assert payload["messages"] == [[
         {"customType": "mship-session-context", "content": "context", "display": False},
         {"deliverAs": "nextTurn"},
     ]]
+    assert forwarded == [
+        {"type": "session_start", "source": "startup"},
+        {"type": "tool_call", "toolName": "edit", "input": {"path": "src/denied.py"}},
+        {"type": "tool_call", "toolName": "write", "input": {"path": "src/allowed.py"}},
+        {"type": "session_stop", "stop_hook_active": False},
+        {"type": "session_stop", "stop_hook_active": True},
+        {
+            "type": "tool_call",
+            "toolName": "write",
+            "input": {"path": "src/invalid-json.py"},
+        },
+        {"type": "tool_call", "toolName": "edit", "input": {"path": "src/nonzero.py"}},
+    ]
     assert payload["deny"] == {"block": True, "reason": "denied"}
+    assert payload["allowed"] is None
     assert payload["continued"] == {
         "continue": True,
         "additionalContext": "answer inbox",
@@ -221,5 +262,5 @@ console.log(JSON.stringify({
     assert payload["nonzero"] is None
     assert payload["warnings"] == [
         "Mothership tool_call hook failed open",
-        "Mothership session_stop hook failed open",
+        "Mothership tool_call hook failed open",
     ]

--- a/tests/core/test_skill_install.py
+++ b/tests/core/test_skill_install.py
@@ -1,9 +1,13 @@
 """Unit tests for src/mship/core/skill_install.py."""
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
+import pytest
+
 import mship
+import mship.core.skill_install as skill_install
 from mship.core.skill_install import (
     HISTORICAL_SOURCES,
     AgentInstallResult,
@@ -162,6 +166,113 @@ def test_install_for_codex_creates_one_dir_level_symlink(tmp_path: Path, monkeyp
     assert link.is_symlink()
     assert link.resolve() == fake_pkg.resolve()
     assert result.count == 1
+
+
+def _tree_bytes(root: Path) -> dict[str, bytes]:
+    return {
+        str(path.relative_to(root)): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_install_for_omp_uses_shared_directory_link_idempotently(
+    tmp_path: Path, monkeypatch
+):
+    fake_pkg = _seed_fake_pkg_with_skills(
+        tmp_path, monkeypatch, ["alpha", "beta"]
+    )
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    result = skill_install.install_for_omp(force=False)
+    link = result.dest / "mothership"
+    assert result.agent == "omp"
+    assert result.dest == home / ".agents" / "skills"
+    assert link.resolve() == fake_pkg.resolve()
+    assert {
+        path.name
+        for path in link.iterdir()
+        if (path / "SKILL.md").is_file()
+    } == {"alpha", "beta"}
+
+    link_text = os.readlink(link)
+    target_bytes = _tree_bytes(fake_pkg)
+    repeated = skill_install.install_for_omp(force=False)
+
+    assert repeated.agent == "omp"
+    assert repeated.replaced == []
+    assert os.readlink(link) == link_text
+    assert _tree_bytes(fake_pkg) == target_bytes
+
+
+def test_install_for_omp_repairs_owned_dangling_link(tmp_path: Path, monkeypatch):
+    fake_pkg = _seed_fake_pkg_with_skills(tmp_path, monkeypatch, ["alpha"])
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    link = home / ".agents" / "skills" / "mothership"
+    link.parent.mkdir(parents=True)
+    link.symlink_to(fake_pkg / "removed-layout")
+
+    result = skill_install.install_for_omp(force=False)
+
+    assert result.replaced == ["mothership"]
+    assert link.resolve() == fake_pkg.resolve()
+
+
+@pytest.mark.parametrize("entry_kind", ["symlink", "file", "directory"])
+def test_install_for_omp_safe_skips_foreign_content(
+    tmp_path: Path, monkeypatch, entry_kind: str
+):
+    _seed_fake_pkg_with_skills(tmp_path, monkeypatch, ["alpha"])
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    target = home / ".agents" / "skills" / "mothership"
+    target.parent.mkdir(parents=True)
+    if entry_kind == "symlink":
+        foreign = tmp_path / "foreign"; foreign.mkdir()
+        target.symlink_to(foreign)
+    elif entry_kind == "file":
+        target.write_text("foreign")
+    else:
+        target.mkdir()
+        (target / "foreign").write_text("content")
+
+    result = skill_install.install_for_omp(force=False)
+
+    assert result.skipped == ["mothership"]
+    assert result.count == 0
+    if entry_kind == "symlink":
+        assert target.resolve() == foreign.resolve()
+    elif entry_kind == "file":
+        assert target.read_text() == "foreign"
+    else:
+        assert (target / "foreign").read_text() == "content"
+
+
+@pytest.mark.parametrize("entry_kind", ["symlink", "file", "directory"])
+def test_install_for_omp_force_replaces_foreign_content(
+    tmp_path: Path, monkeypatch, entry_kind: str
+):
+    fake_pkg = _seed_fake_pkg_with_skills(tmp_path, monkeypatch, ["alpha"])
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    target = home / ".agents" / "skills" / "mothership"
+    target.parent.mkdir(parents=True)
+    if entry_kind == "symlink":
+        foreign = tmp_path / "foreign"; foreign.mkdir()
+        target.symlink_to(foreign)
+    elif entry_kind == "file":
+        target.write_text("foreign")
+    else:
+        target.mkdir()
+        (target / "foreign").write_text("content")
+
+    result = skill_install.install_for_omp(force=True)
+
+    assert result.replaced == ["mothership"]
+    assert target.is_symlink()
+    assert target.resolve() == fake_pkg.resolve()
 
 
 # --- Renamed-skills sweep (spec 2026-04-19) ---

--- a/tests/skills/test_skill_dispatch_ergonomics.py
+++ b/tests/skills/test_skill_dispatch_ergonomics.py
@@ -20,6 +20,7 @@ _MODEL_ADAPTER_FILES = (
     ("subagent-driven-development", "task-reviewer-prompt.md"),
     ("subagent-driven-development", "re-review-prompt.md"),
     ("using-mothership", "references/codex-tools.md"),
+    ("using-mothership", "references/gemini-tools.md"),
     ("using-mothership", "references/pi-tools.md"),
     ("working-with-mothership", "SKILL.md"),
 )
@@ -130,6 +131,15 @@ def test_codex_and_pi_references_apply_or_reject_explicit_models():
     assert "inspect its schema" in pi
     assert "when it exposes a model selector" in pi
     assert _UNSUPPORTED_SELECTOR_ERROR in pi
+
+
+def test_gemini_reference_omits_inherit_or_rejects_explicit_models():
+    gemini = _read("using-mothership", "references/gemini-tools.md")
+
+    assert "`inherit`" in gemini
+    assert "invoke_agent without a model selector" in gemini
+    assert _UNSUPPORTED_SELECTOR_ERROR in gemini
+    assert "Never translate" in gemini
 
 
 def test_pi_no_tool_fallback_only_applies_to_inherit():

--- a/tests/skills/test_skill_dispatch_ergonomics.py
+++ b/tests/skills/test_skill_dispatch_ergonomics.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from mship.core.skill_install import pkg_skills_source
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -10,6 +12,26 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 def _read(skill: str, fname: str = "SKILL.md") -> str:
     return (pkg_skills_source() / skill / fname).read_text()
+
+
+_MODEL_ADAPTER_FILES = (
+    ("subagent-driven-development", "SKILL.md"),
+    ("subagent-driven-development", "implementer-prompt.md"),
+    ("subagent-driven-development", "task-reviewer-prompt.md"),
+    ("subagent-driven-development", "re-review-prompt.md"),
+    ("using-mothership", "references/codex-tools.md"),
+    ("using-mothership", "references/pi-tools.md"),
+    ("working-with-mothership", "SKILL.md"),
+)
+
+_UNSUPPORTED_SELECTOR_ERROR = (
+    "mship resolved explicit model '<value>', but this subagent API cannot select "
+    "a model; set this mode to inherit or use a selector-capable dispatch tool."
+)
+
+
+def _section(text: str, heading: str) -> str:
+    return text.split(heading, 1)[1].split("\n## ", 1)[0]
 
 
 def test_writing_plans_documents_task_anchors():
@@ -51,6 +73,71 @@ def test_working_with_mothership_documents_model_resolution():
 
 def test_configuration_docs_cover_dispatch_models():
     assert "dispatch_models" in (_REPO_ROOT / "docs" / "configuration.md").read_text()
+
+
+@pytest.mark.parametrize(("skill", "fname"), _MODEL_ADAPTER_FILES)
+def test_model_adapter_instructions_define_portable_contract(skill: str, fname: str):
+    text = _read(skill, fname)
+    assert "`inherit`" in text
+    assert "omit" in text
+    assert "cannot select a model" in text
+    assert "Never translate" in text
+
+
+@pytest.mark.parametrize(
+    "fname",
+    ("implementer-prompt.md", "task-reviewer-prompt.md", "re-review-prompt.md"),
+)
+def test_claude_prompt_templates_apply_explicit_models_or_omit_inherit(fname: str):
+    text = _read("subagent-driven-development", fname)
+    assert "model: vendor/custom-tier" in text
+    assert "omit the entire selector field" in text
+    assert _UNSUPPORTED_SELECTOR_ERROR in text
+
+
+def test_mothership_dispatch_instructions_prescribe_no_provider_tiers():
+    texts = {
+        "subagent-driven-development model selection": _section(
+            _read("subagent-driven-development"), "## Model Selection"
+        ),
+        "working-with-mothership dispatch": _section(
+            _read("working-with-mothership"),
+            "## Delegating to subagents: `mship context` and `mship dispatch`",
+        ),
+        **{
+            fname: _read("subagent-driven-development", fname)
+            for fname in (
+                "implementer-prompt.md",
+                "task-reviewer-prompt.md",
+                "re-review-prompt.md",
+            )
+        },
+    }
+    for source, text in texts.items():
+        for provider_tier in ("sonnet", "haiku", "opus"):
+            assert provider_tier not in text.lower(), (
+                f"{source} prescribes provider tier {provider_tier!r}"
+            )
+
+
+def test_codex_and_pi_references_apply_or_reject_explicit_models():
+    codex = _read("using-mothership", "references/codex-tools.md")
+    pi = _read("using-mothership", "references/pi-tools.md")
+
+    assert "spawn_agent without a model selector" in codex
+    assert "pass it unchanged" in codex
+    assert _UNSUPPORTED_SELECTOR_ERROR in codex
+    assert "inspect its schema" in pi
+    assert "when it exposes a model selector" in pi
+    assert _UNSUPPORTED_SELECTOR_ERROR in pi
+
+
+def test_configuration_docs_define_portable_dispatch_model_defaults():
+    text = (_REPO_ROOT / "docs" / "configuration.md").read_text()
+    assert "every built-in mode defaults to `inherit`" in text
+    assert "harness default" in text
+    assert "emitted verbatim" in text
+    assert "selector-capable" in text
 
 
 def _skill_markdown_files() -> list[Path]:

--- a/tests/skills/test_skill_dispatch_ergonomics.py
+++ b/tests/skills/test_skill_dispatch_ergonomics.py
@@ -132,6 +132,21 @@ def test_codex_and_pi_references_apply_or_reject_explicit_models():
     assert _UNSUPPORTED_SELECTOR_ERROR in pi
 
 
+def test_pi_no_tool_fallback_only_applies_to_inherit():
+    pi = _read("using-mothership", "references/pi-tools.md")
+    normalized_pi = " ".join(pi.split())
+
+    assert (
+        "If no subagent tool is available and the resolved model is `inherit`"
+        in normalized_pi
+    )
+    assert (
+        "If the resolved model is explicit and no selector-capable subagent tool "
+        "is available"
+    ) in normalized_pi
+    assert _UNSUPPORTED_SELECTOR_ERROR in normalized_pi
+
+
 def test_configuration_docs_define_portable_dispatch_model_defaults():
     text = (_REPO_ROOT / "docs" / "configuration.md").read_text()
     assert "every built-in mode defaults to `inherit`" in text


### PR DESCRIPTION
## Summary
- make dispatch model defaults portable across Claude Code, Codex, Gemini, and OMP/Pi while preserving explicit operator model choices
- add read-only Codex activation diagnostics plus first-class OMP/Pi skill installation, doctor health, and context support
- enforce equivalent lifecycle behavior across Claude, Codex, and OMP/Pi with native-envelope conformance coverage

## Test plan
- [x] `uv run mship test --task agent-harness-parity` — iteration 8 passed with no regressions
- [x] focused dispatch adapter tests — 86 passed
- [x] focused lifecycle conformance tests — 44 passed
- [x] final live agentic-review artifact — `findings: []`
- [x] PR checks — test, build, CodeQL, Socket Security, and agentic review passed
- [x] review threads — zero unresolved

---

## Acceptance criteria

- [x] `ac1` With no `dispatch_models` override, implementer, standalone, and reviewer dispatch stubs contain only portable model behavior; no built-in default or generated instruction names Anthropic `sonnet`, `haiku`, or `opus`, and `inherit` is documented as using the harness default — test:test-runs/8.mothership
- [x] `ac2` An operator-supplied `dispatch_models` value is stored and emitted unchanged, while each supported harness adapter either applies it through a supported model selector or returns an actionable unsupported-selector error instead of silently substituting a model — test:test-runs/8.mothership
- [x] `ac3` When Codex hook files are current but `codex_hooks` is unavailable or false, `mship init --install-hooks` and `mship doctor` report Codex as configured but inactive and print the exact feature-enable and `/hooks` review actions; neither command modifies user Codex configuration or trust — test:test-runs/8.mothership
- [x] `ac4` When Codex hook capability is enabled and the project hook registration is current, health output distinguishes the remaining manual trust requirement from configuration errors without simultaneously presenting the lifecycle integration as fully active — test:test-runs/8.mothership
- [x] `ac5` `mship skill install --only omp` or the canonical Pi alias installs every bundled Mothership skill into the supported OMP/Pi discovery location without overwriting foreign content, and a repeated install is byte-idempotent — test:test-runs/8.mothership
- [x] `ac6` `mship doctor` reports OMP/Pi bundled-skill availability separately from the OMP lifecycle extension and gives an actionable repair command for missing, stale, dangling, or foreign installations — test:test-runs/8.mothership
- [x] `ac7` `mship context --for omp` succeeds and emits the same implementer invariants as `--for claude-code` and `--for codex`; existing audience validation remains strict for unknown values — test:test-runs/8.mothership
- [x] `ac8` Equivalent Claude, Codex, and OMP session-start, guarded-edit, and stop fixtures produce equivalent shared policy decisions, including multi-target extraction, bypass behavior, actionable inbox continuation, bounded stop re-entry, and adapter failure reporting — test:test-runs/8.mothership
- [x] `ac9` Focused runtime integration tests prove Codex capability diagnostics, OMP extension compatibility, skill discovery, and portable dispatch defaults; existing Claude, Codex, and OMP lifecycle contract tests remain green — test:test-runs/8.mothership

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OMP agent support and portable `inherit` dispatch model defaults across harnesses
> - Extends the skill installer, doctor, and CLI to treat OMP (aliased as `pi`) as a first-class agent alongside Claude and Codex, sharing a single `~/.agents/skills/mothership` symlink for skill discovery.
> - Changes the default dispatch model for all built-in modes (including `reviewer`) from concrete tier strings to `'inherit'`, which instructs adapters to omit the model selector and let the harness choose.
> - Adds `probe_codex_hook_capability` in [`codex_hooks.py`](https://github.com/atomikpanda/mothership/pull/466/files#diff-fc140e63c2226b220b170dae6df9f8af81a81c5fd7e0cbd42e7bc57087922a04) to inspect Codex feature state (absent/disabled/unavailable/enabled/timed-out) and surfaces targeted enable/trust guidance in `mship init` and `mship doctor`.
> - Introduces `extract_claude_edit_targets` in [`claude_settings.py`](https://github.com/atomikpanda/mothership/pull/466/files#diff-e661df4af91bb2b0b46ceab9a3846569b235d787335b5fdefe231e1e7e100bc7) and wires it into the `--runtime=claude` pre-tool-use handler so edit target extraction uses Claude-specific semantics.
> - Updates skill docs and agent reference files with a portable model-handling contract: omit selector for `inherit`, pass explicit values verbatim, reject explicit values when the agent API has no model selector.
> - Behavioral Change: `dispatch_models` `reviewer` default changes from `'sonnet'` to `'inherit'`; any adapter that previously received a concrete model string for reviewer mode will now receive `'inherit'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88b4350.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->