### PR TITLE
Harden remote exec task-name boundary

### DIFF
--- a/src/mship/core/remote_setup.py
+++ b/src/mship/core/remote_setup.py
@@ -36,9 +36,9 @@ FIRST_MATERIALIZATION_KEY = "first-materialization"
 
 _UNSAFE = re.compile(r"[^A-Za-z0-9_-]")
 
-# How much of each name the filename carries for a human to read. `_TASK_NAME_RE`
-# bounds the charset of a task arriving over the wire but NOT its length, and a
-# name can be short enough for `.worktrees/<task>` yet overflow NAME_MAX (255)
+# How much of each name the filename carries for a human to read. The shared
+# run-ref segment predicate bounds a task's charset but NOT its length. A name
+# can be short enough for `.worktrees/<task>` yet overflow NAME_MAX (255)
 # once the repo and digest land beside it. Two of these plus the separators and
 # the digest come to 224 bytes, and `_safe` leaves only single-byte characters,
 # so the count is the byte count. Truncating costs nothing but legibility
@@ -49,9 +49,8 @@ _READABLE_MAX = 100
 def _safe(name: str) -> str:
     """A filename component that cannot escape its directory.
 
-    The task name arrives over the wire, where `core/serve.py`'s `_TASK_NAME_RE`
-    permits `.` and `/` — so `../..` would otherwise be a legal path component
-    here.
+    Direct callers may bypass serve's validation, so sanitize again here as
+    defense in depth.
     """
     return (_UNSAFE.sub("-", name) or "unnamed")[:_READABLE_MAX]
 

--- a/src/mship/core/run_ref.py
+++ b/src/mship/core/run_ref.py
@@ -27,17 +27,21 @@ import re
 
 RUN_REF_PREFIX = "refs/mship/run/"
 
-# One path segment of the ref. Deliberately NARROWER than the task-name charset
-# `core/serve.py` accepts for `/exec` (`^[A-Za-z0-9._/-]+$`, which allows `/` and
-# a bare `.`): this string is interpolated into `git push` / `git reset --hard`
-# run through a shell, and `core/remote_setup.py` derives a filename from the
-# same values. `.` and `..` are excluded outright so no traversal segment can
-# exist.
+# One safe task/repository segment, shared with the remote exec boundary in
+# `core/serve.py`. This string is interpolated into `git push` /
+# `git reset --hard` run through a shell, and `core/remote_setup.py` derives a
+# filename from the same values. `.` and `..` are excluded outright so no
+# traversal segment can exist.
 #
 # Anchored `\Z`, not `$`: Python's `$` also matches BEFORE a trailing newline,
 # so `$` accepts `api\n` — and a trailing newline TERMINATES a shell command,
 # which is the one character this charset exists to keep out.
 _SEGMENT_RE = re.compile(r"\A(?!\.{1,2}\Z)[A-Za-z0-9._-]+\Z")
+
+
+def is_run_ref_segment(value: str) -> bool:
+    """Whether `value` is one safe task/repository run-ref segment."""
+    return bool(_SEGMENT_RE.match(value or ""))
 
 
 class RunRefNameError(ValueError):
@@ -48,7 +52,7 @@ def run_ref(task: str, repo: str) -> str:
     """`refs/mship/run/<task>/<repo>` — per task AND per git repo, so two tasks
     or two repos running remotely at once cannot overwrite each other's refs."""
     for label, value in (("task", task), ("repo", repo)):
-        if not _SEGMENT_RE.match(value or ""):
+        if not is_run_ref_segment(value):
             raise RunRefNameError(
                 f"{label} name {value!r} cannot be used in a run ref; it must "
                 f"match [A-Za-z0-9._-]+ and not be '.' or '..'"
@@ -65,4 +69,4 @@ def is_run_ref(name: str) -> bool:
     if not name.startswith(RUN_REF_PREFIX):
         return False
     segments = name[len(RUN_REF_PREFIX):].split("/")
-    return len(segments) == 2 and all(_SEGMENT_RE.match(s) for s in segments)
+    return len(segments) == 2 and all(is_run_ref_segment(s) for s in segments)

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1542,19 +1542,16 @@ def create_app(
     # A fresh `ShellRunner` per request (like `gh_token_shell` above) rather than
     # reaching into pr_manager's — same class, its own lifetime.
 
-    import re
     import secrets
 
     from mship.core import remote_exec
+    from mship.core.run_ref import is_run_ref_segment
     from fastapi.responses import StreamingResponse
     from starlette.concurrency import iterate_in_threadpool
 
-    # A task name is interpolated into `branch_pattern` and then into git
-    # `fetch`/`checkout`/`reset`/`worktree add` run with `shell=True` on the
-    # remote — so validate it here, BEFORE any StreamingResponse is built, and
-    # reject anything outside this safe charset (fail fast, never reaching the
-    # shell). Mirrors the slug charset the rest of mship uses for task names.
-    _TASK_NAME_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+    # A task name becomes both a `.worktrees` path segment and shell-backed
+    # git/task input. Validate it against the shared run-ref segment contract
+    # before any remote work or streaming response begins.
 
     @app.post("/exec/{verb}")
     async def post_exec(verb: str, body: ExecBody):
@@ -1573,9 +1570,7 @@ def create_app(
                     "restart `mship serve --relay`"
                 ),
             )
-        if not _TASK_NAME_RE.match(body.task):
-            # Never reaches the shell — a shell-metacharacter task name (e.g.
-            # "x; rm -rf ~ #") is refused up front, not streamed as data.
+        if not is_run_ref_segment(body.task):
             raise HTTPException(status_code=400, detail="invalid task name")
         deps = remote_exec.RemoteExecDeps(
             config=config, shell=ShellRunner(), workspace_root=workspace_root,

--- a/tests/core/test_remote_setup.py
+++ b/tests/core/test_remote_setup.py
@@ -170,9 +170,8 @@ def test_the_pair_cannot_be_confused_across_its_boundary(tmp_path):
 
 
 def test_a_long_name_still_produces_a_writable_file(tmp_path):
-    """`_TASK_NAME_RE` bounds the charset of a task arriving over the wire but
-    not its length, and a name can be short enough for `.worktrees/<task>` yet
-    overflow NAME_MAX once the suffix lands. Recording happens AFTER setup
+    """Direct callers can supply task and repo names long enough to overflow
+    NAME_MAX once the suffix lands. Recording happens AFTER setup
     succeeded, so an unwritable path throws away work already done."""
     path = key_file(tmp_path, "t" * 300, "r" * 300)
     assert len(path.name.encode("utf-8")) <= 255
@@ -189,8 +188,8 @@ def test_long_names_sharing_a_truncated_prefix_stay_distinct(tmp_path):
 
 
 def test_a_task_name_cannot_escape_the_state_directory(tmp_path):
-    """The task name arrives over the wire, where `core/serve.py` permits `/`
-    and `.`, so `../..` would otherwise be a legal path component here."""
+    """`key_file` sanitizes task and repo values as defense for direct callers,
+    regardless of endpoint validation."""
     path = key_file(tmp_path, "../../etc", "api")
     root = (tmp_path / ".mothership").resolve()
     assert root in path.resolve().parents

--- a/tests/core/test_run_ref.py
+++ b/tests/core/test_run_ref.py
@@ -2,7 +2,26 @@
 its shape is decided."""
 import pytest
 
-from mship.core.run_ref import RUN_REF_PREFIX, RunRefNameError, is_run_ref, run_ref
+from mship.core.run_ref import (
+    RUN_REF_PREFIX,
+    RunRefNameError,
+    is_run_ref,
+    is_run_ref_segment,
+    run_ref,
+)
+
+
+@pytest.mark.parametrize("value", ["t1", "release.v2_build-1"])
+def test_run_ref_segment_accepts_safe_values(value):
+    assert is_run_ref_segment(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", ".", "..", "../escape", "a/b", "with space", "semi;colon", "api\n"],
+)
+def test_run_ref_segment_rejects_unsafe_values(value):
+    assert not is_run_ref_segment(value)
 
 
 def test_ref_is_per_task_and_per_repo():

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -495,24 +495,46 @@ def test_exec_without_config_is_503(tmp_path, monkeypatch):
     assert r.status_code == 503
 
 
-def test_exec_rejects_shell_metachar_task_name_before_any_command(tmp_path, monkeypatch):
-    """FIX 3 (injection): `task` is interpolated into `branch_pattern` and then
-    into git commands run with shell=True on the remote. A task name with shell
-    metacharacters must be rejected with a 400 BEFORE the StreamingResponse is
-    built — never reaching the shell, and running NOTHING."""
-    fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["pwned\n"], returncode=0))
+def test_exec_rejects_unsafe_task_name_before_any_command(tmp_path, monkeypatch):
+    fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["pwned\n"], returncode=0)
+    )
     _patch_shell(monkeypatch, fake)
     client = TestClient(_app(tmp_path))
 
-    r = client.post(
-        "/exec/run",
-        json={"task": "x; touch /tmp/pwned; #", "repos": ["api"]},
-    )
-    assert r.status_code == 400
-    assert "invalid task name" in r.json()["detail"]
-    # Nothing ran: no git plumbing, no task.
+    for task in (
+        "../escape",
+        "a/b",
+        ".",
+        "..",
+        "",
+        "api\n",
+        "x; touch /tmp/pwned; #",
+    ):
+        response = client.post(
+            "/exec/run",
+            json={"task": task, "repos": ["api"]},
+        )
+        assert response.status_code == 400, task
+        assert response.json()["detail"] == "invalid task name"
+
     assert not fake.run_calls
     assert not fake.streaming_calls
+
+
+def test_exec_accepts_safe_segment_task_name(tmp_path, monkeypatch):
+    fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["ok\n"], returncode=0)
+    )
+    _patch_shell(monkeypatch, fake)
+
+    response = TestClient(_app(tmp_path)).post(
+        "/exec/run",
+        json={"task": "release.v2_build-1", "repos": ["api"]},
+    )
+
+    assert response.status_code == 200
+    assert fake.streaming_calls
 
 
 def test_exec_run_materializes_new_worktree_and_streams_output(tmp_path, monkeypatch):
@@ -1016,11 +1038,11 @@ def test_a_git_root_child_is_materialized_from_its_parents_scratch_ref(tmp_path)
 
 
 def test_a_task_name_that_cannot_form_a_ref_fails_cleanly(tmp_path):
-    """The ref reaches a shell here, so a name that cannot form one is refused
-    BEFORE anything runs — as stream DATA (an error line + a non-zero exit
-    sentinel), never a raised exception mid-generator, matching how the
-    unknown-repo guard already behaves. `/exec` accepts `/` in a task name;
-    `run_ref` does not."""
+    """This direct `remote_exec` unit path deliberately bypasses `/exec` and
+    still rejects an invalid ref before commands run. The failure is stream data
+    (an error line plus a non-zero exit sentinel), not a raised exception
+    mid-generator, matching the unknown-repo guard.
+    """
     fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["ok\n"]))
     deps = remote_exec.RemoteExecDeps(
         config=_config(tmp_path), shell=fake, workspace_root=tmp_path,


### PR DESCRIPTION
## Summary

- share one strict run-ref segment predicate across run-ref construction, ref recognition, and authenticated remote `/exec` task validation
- reject traversal, slash, bare-dot, newline, whitespace, and shell-metacharacter task names before filesystem, shell, stream, or task work
- preserve valid dotted, underscored, and hyphenated task names and retain downstream defense-in-depth checks

## Test plan

- [x] strict TDD: traversal endpoint regression failed with HTTP 200 before the fix; public predicate contract failed before export
- [x] `uv run --frozen pytest -q tests/core/test_run_ref.py tests/core/test_remote_setup.py tests/core/test_serve_exec.py` — 103 passed
- [x] `uv run --frozen pytest -q tests/core/test_remote_setup.py` after review correction — 21 passed
- [x] `task lint` — no linter configured, command passes
- [x] `mship plan check-assumptions --plan docs/plans/2026-08-14-fix-434-remote-task-name.md` — all axes covered
- [x] `mship test --task fix-434-remote-task-name` iteration 2 — pass, no regressions

Closes #434

---

## Acceptance criteria

- [x] `ac1` A public predicate in `core/run_ref.py` returns true for non-empty task-name segments containing only ASCII letters, digits, `.`, `_`, and `-`, except that bare `.` and bare `..` return false. — test:test-runs/2.mothership
- [x] `ac2` The predicate uses full-string matching, so inputs containing `/`, whitespace, shell metacharacters, or a trailing newline return false. — test:test-runs/2.mothership
- [x] `ac3` `run_ref()`, `is_run_ref()`, and serve's authenticated `POST /exec/{verb}` task-name validation use the same public predicate as their single validation-semantic owner. — test:test-runs/2.mothership
- [x] `ac4` For each endpoint input `../escape`, `a/b`, `.`, `..`, the empty string, a value with a trailing newline, and a value containing shell metacharacters, the endpoint returns the existing HTTP 400 invalid-task-name response. — test:test-runs/2.mothership
- [x] `ac5` For every invalid endpoint case, tests prove zero fake shell run calls and zero fake shell stream calls; validation occurs before any `RemoteExecDeps` work or `StreamingResponse` creation and no filesystem or task work is performed. — test:test-runs/2.mothership
- [x] `ac6` The endpoint accepts a valid task name containing dots, underscores, and hyphens. — test:test-runs/2.mothership
- [x] `ac7` Direct `remote_exec` and `run_ref` validation remains in place as defense in depth. — test:test-runs/2.mothership
- [x] `ac8` All existing `run_ref` tests pass without behavioral changes. — test:test-runs/2.mothership
- [x] `ac9` Any stale test prose claiming that `/exec` accepts slash-containing task names is corrected. — test:test-runs/2.mothership
- [x] `ac10` The complete test suite relevant to serve, remote exec, and run refs passes. — test:test-runs/2.mothership