### PR TITLE
Serialize remote execution per task

### DIFF
--- a/src/mship/core/remote_exec.py
+++ b/src/mship/core/remote_exec.py
@@ -51,7 +51,6 @@ Wire contract (Task 5's client parses this):
 from __future__ import annotations
 
 import errno
-import fcntl
 import hashlib
 import io
 import queue
@@ -64,6 +63,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, Protocol
+
+try:
+    import fcntl
+except ModuleNotFoundError:
+    fcntl = None
 
 from mship.core import capture as _cap
 from mship.core import remote_setup
@@ -140,9 +144,10 @@ class RemoteExecDeps:
     double duty for git commands and the streamed task run (see
     `ShellLike`). `workspace_root` anchors where remote worktrees live:
     `<workspace_root>/.worktrees/<task>/<repo>`, mirroring the local
-    `WorktreeManager` hub layout. `cancel_event` requests contained POSIX
-    process-group cleanup when the client disconnects; the public runner
-    rejects hosts that cannot provide that guarantee before taking the lock.
+    `WorktreeManager` hub layout. `cancel_event` requests cleanup of processes
+    that remain in the spawned POSIX process group when the client disconnects;
+    the public runner rejects hosts that cannot provide that guarantee before
+    taking the lock.
     """
 
     config: WorkspaceConfig
@@ -159,6 +164,9 @@ def _acquire_task_execution_lock(
     workspace_root: Path,
     task: str,
 ) -> io.TextIOWrapper:
+    if fcntl is None:
+        raise OSError("POSIX file locking is unavailable")
+
     lock_dir = workspace_root / ".mothership" / "remote-exec-locks"
     lock_dir.mkdir(parents=True, exist_ok=True)
     digest = hashlib.sha256(task.encode("utf-8")).hexdigest()

--- a/src/mship/core/remote_exec.py
+++ b/src/mship/core/remote_exec.py
@@ -56,7 +56,6 @@ import hashlib
 import io
 import queue
 import shutil
-import subprocess
 import tarfile
 import tempfile
 import threading
@@ -69,7 +68,7 @@ from mship.core import remote_setup
 from mship.core.config import WorkspaceConfig
 from mship.core.run_ref import RunRefNameError
 from mship.core.run_ref import run_ref as build_run_ref
-from mship.util.shell import ShellCancelled
+from mship.util.shell import ShellCancelled, _terminate_owned_process_group
 from mship.util.taskfile import taskfile_has_target
 
 VERBS: tuple[str, ...] = ("run", "capture", "build")
@@ -456,81 +455,28 @@ def _stream_proc_lines(
     return True
 
 
-def _terminate_proc(proc) -> None:
-    """Best-effort stop and reap a possibly-still-running task subprocess.
-
-    Called from `run_verb_stream`'s per-repo `finally` so a client disconnect
-    does not orphan the go-task process or release its task lock while the
-    process is still alive.
-    """
-    if proc is None:
+def _terminate_proc(proc, *, completed: bool) -> None:
+    """Stop abnormal task trees; leave normally reaped groups untouched."""
+    if proc is None or completed:
         return
-    poll = getattr(proc, "poll", None)
+
     try:
-        if callable(poll) and poll() is not None:
-            return
+        _terminate_owned_process_group(proc)
     except Exception:
-        pass
-
-    import os as _os
-    import signal as _signal
-
-    stopped = False
-    pid = getattr(proc, "pid", None)
-    if (
-        _os.name != "nt"
-        and isinstance(pid, int)
-        and pid > 0
-        and hasattr(_os, "killpg")
-    ):
-        try:
-            _os.killpg(pid, _signal.SIGTERM)
-            stopped = True
-        except (ProcessLookupError, OSError):
-            pass
-    if not stopped:
+        # Preserve cleanup for lightweight Popen-shaped fakes that do not expose
+        # the full process-group surface.
         terminate = getattr(proc, "terminate", None)
-        if callable(terminate):
-            try:
-                terminate()
-                stopped = True
-            except Exception:
-                pass
-    if not stopped:
-        return
-
+        if not callable(terminate):
+            return
+        try:
+            terminate()
+        except Exception:
+            return
     wait = getattr(proc, "wait", None)
     if not callable(wait):
         return
     try:
-        wait(timeout=1)
-        return
-    except TypeError:
-        # Lightweight test doubles commonly expose wait() without Popen's
-        # timeout parameter; termination above makes that call nonblocking.
-        try:
-            wait()
-        except Exception:
-            pass
-        return
-    except subprocess.TimeoutExpired:
-        pass
-    except Exception:
-        return
-
-    try:
-        if (
-            _os.name != "nt"
-            and isinstance(pid, int)
-            and pid > 0
-            and hasattr(_os, "killpg")
-        ):
-            _os.killpg(pid, _signal.SIGKILL)
-        else:
-            kill = getattr(proc, "kill", None)
-            if callable(kill):
-                kill()
-        wait(timeout=1)
+        wait()
     except Exception:
         pass
 
@@ -788,14 +734,16 @@ def _run_verb_stream_unlocked(
         yield f"setup: {repo_name} (task {actual_setup})\n".encode("utf-8")
         env_runner = repo_config.env_runner or config.env_runner
         command = shell.build_command(f"task {actual_setup}", env_runner)
+        completed = False
         proc = None
         try:
             proc = shell.run_streaming(command, cwd=worktree_path, env=None)
             if not (yield from _stream_proc_lines(proc, deps.cancel_event)):
                 return False
             setup_code = proc.wait()
+            completed = True
         finally:
-            _terminate_proc(proc)
+            _terminate_proc(proc, completed=completed)
 
         if setup_code != 0:
             # Surface setup's OWN failure rather than letting the verb run
@@ -847,6 +795,7 @@ def _run_verb_stream_unlocked(
         # and while the task subprocess is still running (FIX 8).
         out_dir: Path | None = None
         proc = None
+        completed = False
         try:
             env: dict[str, str] | None = None
             if verb == "capture":
@@ -863,6 +812,7 @@ def _run_verb_stream_unlocked(
             if not (yield from _stream_proc_lines(proc, deps.cancel_event)):
                 return
             exit_code = proc.wait()
+            completed = True
 
             if verb == "capture":
                 artifacts = _cap.discover_artifacts(out_dir, kinds or []) if exit_code == 0 else []
@@ -880,7 +830,7 @@ def _run_verb_stream_unlocked(
                     ).encode("utf-8")
                     exit_code = 1
         finally:
-            _terminate_proc(proc)
+            _terminate_proc(proc, completed=completed)
             if out_dir is not None:
                 shutil.rmtree(out_dir, ignore_errors=True)
 

--- a/src/mship/core/remote_exec.py
+++ b/src/mship/core/remote_exec.py
@@ -70,7 +70,12 @@ from mship.core import remote_setup
 from mship.core.config import WorkspaceConfig
 from mship.core.run_ref import RunRefNameError
 from mship.core.run_ref import run_ref as build_run_ref
-from mship.util.shell import ShellCancelled, _terminate_owned_process_group
+from mship.util.shell import (
+    ShellCancellationUnsupported,
+    ShellCancelled,
+    _terminate_owned_process_group,
+    ensure_cancellable_shell_supported,
+)
 from mship.util.taskfile import taskfile_has_target
 
 VERBS: tuple[str, ...] = ("run", "capture", "build")
@@ -135,8 +140,9 @@ class RemoteExecDeps:
     double duty for git commands and the streamed task run (see
     `ShellLike`). `workspace_root` anchors where remote worktrees live:
     `<workspace_root>/.worktrees/<task>/<repo>`, mirroring the local
-    `WorktreeManager` hub layout. `cancel_event` lets the HTTP response stop a
-    quiet subprocess promptly when its client disconnects.
+    `WorktreeManager` hub layout. `cancel_event` requests contained POSIX
+    process-group cleanup when the client disconnects; the public runner
+    rejects hosts that cannot provide that guarantee before taking the lock.
     """
 
     config: WorkspaceConfig
@@ -524,7 +530,19 @@ def run_verb_stream(
     nonce: str,
     run_ref_repos: list[str] | None = None,
 ) -> Iterator[bytes]:
-    """Run one remote execution stream while owning its per-task process lock."""
+    """Run one remote execution stream while owning its per-task process lock.
+
+    Cancellable streams fail with framed infrastructure data before locking or
+    execution when this host cannot safely observe process-group cleanup.
+    """
+    if deps.cancel_event is not None:
+        try:
+            ensure_cancellable_shell_supported()
+        except ShellCancellationUnsupported as exc:
+            yield f"error: remote execution unavailable: {exc}\n".encode("utf-8")
+            yield f"{EXIT_MARKER}:{nonce} 1\n".encode("utf-8")
+            return
+
     try:
         lock_file = _acquire_task_execution_lock(deps.workspace_root, task)
     except BlockingIOError:

--- a/src/mship/core/remote_exec.py
+++ b/src/mship/core/remote_exec.py
@@ -641,7 +641,14 @@ def _run_verb_stream_unlocked(
     hub = _hub_dir(deps.workspace_root, task)
     branch = config.branch_pattern.replace("{slug}", task)
 
-    unknown_repos = [r for r in repos if r not in config.repos]
+    # Select names through the trusted server configuration. These values are
+    # subsequently used in worktree paths, git refs/arguments, task names, and
+    # command working directories. Preserve the client's order and duplicates
+    # for execution while rebuilding each selected value from the server-owned
+    # key objects.
+    configured_names = {name: name for name in config.repos}
+    requested_names = [*repos, *(run_ref_repos or [])]
+    unknown_repos = [name for name in requested_names if name not in configured_names]
     if unknown_repos:
         yield (
             f"error: unknown repo(s) {', '.join(unknown_repos)}; known "
@@ -650,16 +657,18 @@ def _run_verb_stream_unlocked(
         yield f"{EXIT_MARKER}:{nonce} 2\n".encode("utf-8")
         return
 
-    scratch_repos = sorted(set(run_ref_repos or []))
+    repos = [configured_names[name] for name in repos]
+    scratch_repos = sorted({
+        configured_names[name] for name in (run_ref_repos or [])
+    })
     run_refs: dict[str, str] = {}
     for scratch_repo in scratch_repos:
         try:
             run_refs[scratch_repo] = build_run_ref(task, scratch_repo)
         except RunRefNameError as exc:
-            # The ref is interpolated into git commands run with shell=True, so
-            # a name that cannot form one is refused before anything runs — as
-            # stream DATA, never a raised exception mid-generator, matching the
-            # unknown-repo guard above.
+            # A name that cannot form a ref is refused before anything runs —
+            # as stream DATA, never a raised exception mid-generator, matching
+            # the unknown-repo guard above.
             yield f"error: cannot build a run ref for this request: {exc}\n".encode("utf-8")
             yield f"{EXIT_MARKER}:{nonce} 2\n".encode("utf-8")
             return

--- a/src/mship/core/remote_exec.py
+++ b/src/mship/core/remote_exec.py
@@ -50,6 +50,8 @@ Wire contract (Task 5's client parses this):
 """
 from __future__ import annotations
 
+import fcntl
+import hashlib
 import io
 import queue
 import shutil
@@ -132,6 +134,22 @@ class RemoteExecDeps:
 
 def _hub_dir(workspace_root: Path, task: str) -> Path:
     return workspace_root / ".worktrees" / task
+
+
+def _acquire_task_execution_lock(
+    workspace_root: Path,
+    task: str,
+) -> io.TextIOWrapper:
+    lock_dir = workspace_root / ".mothership" / "remote-exec-locks"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256(task.encode("utf-8")).hexdigest()
+    lock_file = (lock_dir / f"{digest}.lock").open("a+")
+    try:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BaseException:
+        lock_file.close()
+        raise
+    return lock_file
 
 
 def _git_rev(shell: ShellLike, cwd: Path, ref: str) -> str | None:
@@ -355,6 +373,50 @@ def _build_artifact_tar(artifacts: list[_cap.Artifact]) -> bytes:
 
 
 def run_verb_stream(
+    verb: str,
+    task: str,
+    repos: list[str],
+    platform: str | None,
+    *,
+    deps: RemoteExecDeps,
+    kind: str = "all",
+    nonce: str,
+    run_ref_repos: list[str] | None = None,
+) -> Iterator[bytes]:
+    """Run one remote execution stream while owning its per-task process lock."""
+    try:
+        lock_file = _acquire_task_execution_lock(deps.workspace_root, task)
+    except BlockingIOError:
+        yield (
+            f"error: remote task {task!r} is already running; "
+            "try again after it finishes\n"
+        ).encode("utf-8")
+        yield f"{EXIT_MARKER}:{nonce} 2\n".encode("utf-8")
+        return
+    except (OSError, UnicodeError):
+        yield b"error: remote-task locking failed; execution was not started\n"
+        yield f"{EXIT_MARKER}:{nonce} 1\n".encode("utf-8")
+        return
+
+    try:
+        yield from _run_verb_stream_unlocked(
+            verb,
+            task,
+            repos,
+            platform,
+            deps=deps,
+            kind=kind,
+            nonce=nonce,
+            run_ref_repos=run_ref_repos,
+        )
+    finally:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        finally:
+            lock_file.close()
+
+
+def _run_verb_stream_unlocked(
     verb: str,
     task: str,
     repos: list[str],

--- a/src/mship/core/remote_exec.py
+++ b/src/mship/core/remote_exec.py
@@ -56,6 +56,7 @@ import hashlib
 import io
 import queue
 import shutil
+import subprocess
 import tarfile
 import tempfile
 import threading
@@ -68,6 +69,7 @@ from mship.core import remote_setup
 from mship.core.config import WorkspaceConfig
 from mship.core.run_ref import RunRefNameError
 from mship.core.run_ref import run_ref as build_run_ref
+from mship.util.shell import ShellCancelled
 from mship.util.taskfile import taskfile_has_target
 
 VERBS: tuple[str, ...] = ("run", "capture", "build")
@@ -107,7 +109,14 @@ class ShellLike(Protocol):
     output can be drained incrementally. Same shapes as the real
     `ShellRunner` — tests inject a fake implementing just this surface."""
 
-    def run(self, command: str, cwd: Path, env: dict[str, str] | None = None): ...
+    def run(
+        self,
+        command: str,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+        *,
+        cancel_event: threading.Event | None = None,
+    ): ...
 
     def run_streaming(self, command: str, cwd: Path, env: dict[str, str] | None = None): ...
 
@@ -160,15 +169,42 @@ def _acquire_task_execution_lock(
     return lock_file
 
 
-def _git_rev(shell: ShellLike, cwd: Path, ref: str) -> str | None:
-    result = shell.run(f"git rev-parse {ref}", cwd=cwd)
+def _run_shell(
+    shell: ShellLike,
+    command: str,
+    cwd: Path,
+    *,
+    cancel_event: threading.Event | None,
+):
+    if cancel_event is None:
+        return shell.run(command, cwd=cwd)
+    return shell.run(command, cwd=cwd, cancel_event=cancel_event)
+
+
+def _git_rev(
+    shell: ShellLike,
+    cwd: Path,
+    ref: str,
+    *,
+    cancel_event: threading.Event | None = None,
+) -> str | None:
+    result = _run_shell(
+        shell,
+        f"git rev-parse {ref}",
+        cwd,
+        cancel_event=cancel_event,
+    )
     if result.returncode != 0:
         return None
     return result.stdout.strip()
 
 
 def check_base_freshness(
-    shell: ShellLike, repo_path: Path, base_branch: str | None
+    shell: ShellLike,
+    repo_path: Path,
+    base_branch: str | None,
+    *,
+    cancel_event: threading.Event | None = None,
 ) -> str | None:
     """MOS-203: before materializing, make sure this repo's knowledge of the
     task's base branch is current — auto-fetch it and, if origin had moved,
@@ -182,9 +218,24 @@ def check_base_freshness(
     """
     if not base_branch:
         return None
-    before = _git_rev(shell, repo_path, f"origin/{base_branch}")
-    shell.run(f"git fetch origin {base_branch}", cwd=repo_path)
-    after = _git_rev(shell, repo_path, f"origin/{base_branch}")
+    before = _git_rev(
+        shell,
+        repo_path,
+        f"origin/{base_branch}",
+        cancel_event=cancel_event,
+    )
+    _run_shell(
+        shell,
+        f"git fetch origin {base_branch}",
+        repo_path,
+        cancel_event=cancel_event,
+    )
+    after = _git_rev(
+        shell,
+        repo_path,
+        f"origin/{base_branch}",
+        cancel_event=cancel_event,
+    )
     if before is not None and after is not None and before != after:
         return (
             f"warning: base '{base_branch}' was behind origin "
@@ -193,14 +244,26 @@ def check_base_freshness(
     return None
 
 
-def _run_checked(shell: ShellLike, command: str, cwd: Path, *, repo_name: str) -> None:
+def _run_checked(
+    shell: ShellLike,
+    command: str,
+    cwd: Path,
+    *,
+    repo_name: str,
+    cancel_event: threading.Event | None = None,
+) -> None:
     """Run a git plumbing command that MUST succeed for the branch worktree
     to be usable. Raises `MaterializeError` (naming the repo, the failing
     command, and its stderr) on a non-zero exit rather than letting
     `run_verb_stream` continue on to run the task against a missing/stale
     worktree (Task 6 hardening — previously every `materialize_worktree`
     call site ignored `ShellResult.returncode` entirely)."""
-    result = shell.run(command, cwd=cwd)
+    result = _run_shell(
+        shell,
+        command,
+        cwd,
+        cancel_event=cancel_event,
+    )
     if result.returncode != 0:
         stderr = (result.stderr or "").strip()
         detail = f": {stderr}" if stderr else f" (exit {result.returncode})"
@@ -217,6 +280,7 @@ def materialize_worktree(
     *,
     repo_name: str,
     run_ref: str | None = None,
+    cancel_event: threading.Event | None = None,
 ) -> None:
     """Ensure `worktree_path` is a git worktree of `repo_path` holding the
     revision this run is supposed to execute.
@@ -250,9 +314,27 @@ def materialize_worktree(
             # succeeds even when the worktree is dirty from the last run
             # (verified); the reset then moves detached HEAD without ever moving
             # a branch.
-            _run_checked(shell, "git checkout --detach", worktree_path, repo_name=repo_name)
-            _run_checked(shell, f"git reset --hard {run_ref}", worktree_path, repo_name=repo_name)
-            _run_checked(shell, "git clean -fd", worktree_path, repo_name=repo_name)
+            _run_checked(
+                shell,
+                "git checkout --detach",
+                worktree_path,
+                repo_name=repo_name,
+                cancel_event=cancel_event,
+            )
+            _run_checked(
+                shell,
+                f"git reset --hard {run_ref}",
+                worktree_path,
+                repo_name=repo_name,
+                cancel_event=cancel_event,
+            )
+            _run_checked(
+                shell,
+                "git clean -fd",
+                worktree_path,
+                repo_name=repo_name,
+                cancel_event=cancel_event,
+            )
         else:
             worktree_path.parent.mkdir(parents=True, exist_ok=True)
             _run_checked(
@@ -260,14 +342,39 @@ def materialize_worktree(
                 f"git worktree add --detach {worktree_path} {run_ref}",
                 repo_path,
                 repo_name=repo_name,
+                cancel_event=cancel_event,
             )
         return
 
-    _run_checked(shell, f"git fetch origin {branch}", repo_path, repo_name=repo_name)
+    _run_checked(
+        shell,
+        f"git fetch origin {branch}",
+        repo_path,
+        repo_name=repo_name,
+        cancel_event=cancel_event,
+    )
     if (worktree_path / ".git").exists():
-        _run_checked(shell, f"git fetch origin {branch}", worktree_path, repo_name=repo_name)
-        _run_checked(shell, f"git checkout {branch}", worktree_path, repo_name=repo_name)
-        _run_checked(shell, f"git reset --hard origin/{branch}", worktree_path, repo_name=repo_name)
+        _run_checked(
+            shell,
+            f"git fetch origin {branch}",
+            worktree_path,
+            repo_name=repo_name,
+            cancel_event=cancel_event,
+        )
+        _run_checked(
+            shell,
+            f"git checkout {branch}",
+            worktree_path,
+            repo_name=repo_name,
+            cancel_event=cancel_event,
+        )
+        _run_checked(
+            shell,
+            f"git reset --hard origin/{branch}",
+            worktree_path,
+            repo_name=repo_name,
+            cancel_event=cancel_event,
+        )
     else:
         worktree_path.parent.mkdir(parents=True, exist_ok=True)
         _run_checked(
@@ -275,6 +382,7 @@ def materialize_worktree(
             f"git worktree add -B {branch} {worktree_path} origin/{branch}",
             repo_path,
             repo_name=repo_name,
+            cancel_event=cancel_event,
         )
 
 
@@ -317,11 +425,25 @@ def _stream_proc_lines(
     """Yield each stdout/stderr line from `proc` as UTF-8 bytes AS IT'S
     PRODUCED (not buffered until the process exits) — this is what makes
     `run_verb_stream` a live stream rather than a final blob. Returns once
-    both drain threads have hit EOF and the queue is empty, or returns False
-    when the response reports that its client disconnected."""
+    both pipes are drained and the process has exited, or returns False when
+    the response reports that its client disconnected."""
     q: "queue.Queue[str]" = queue.Queue()
     threads = _drain_to_queue(proc, q)
-    while any(t.is_alive() for t in threads) or not q.empty():
+    poll = getattr(proc, "poll", None)
+
+    def process_is_running() -> bool:
+        if not callable(poll):
+            return False
+        try:
+            return poll() is None
+        except Exception:
+            return False
+
+    while (
+        any(t.is_alive() for t in threads)
+        or not q.empty()
+        or process_is_running()
+    ):
         if cancel_event is not None and cancel_event.is_set():
             return False
         try:
@@ -335,44 +457,82 @@ def _stream_proc_lines(
 
 
 def _terminate_proc(proc) -> None:
-    """Best-effort stop a possibly-still-running task subprocess.
+    """Best-effort stop and reap a possibly-still-running task subprocess.
 
     Called from `run_verb_stream`'s per-repo `finally` so a client disconnect
-    (a GeneratorExit raised at a `yield` while the task is mid-run) doesn't
-    orphan the go-task process. A process that already exited (the normal path,
-    after `proc.wait()`) short-circuits via `poll()` and is a no-op.
-
-    `ShellRunner.run_streaming` launches the task in its own session
-    (`start_new_session=True` on POSIX), so the process is its own group leader
-    — signal the whole group (`killpg`) to also catch grandchildren. Falls back
-    to `proc.terminate()` on Windows, when there's no real OS pid (a test fake),
-    or when the group is already gone.
+    does not orphan the go-task process or release its task lock while the
+    process is still alive.
     """
     if proc is None:
         return
     poll = getattr(proc, "poll", None)
     try:
         if callable(poll) and poll() is not None:
-            return  # already exited — nothing to signal
+            return
     except Exception:
         pass
 
     import os as _os
     import signal as _signal
 
+    stopped = False
     pid = getattr(proc, "pid", None)
-    if _os.name != "nt" and isinstance(pid, int) and pid > 0 and hasattr(_os, "killpg"):
+    if (
+        _os.name != "nt"
+        and isinstance(pid, int)
+        and pid > 0
+        and hasattr(_os, "killpg")
+    ):
         try:
             _os.killpg(pid, _signal.SIGTERM)
-            return
+            stopped = True
         except (ProcessLookupError, OSError):
             pass
-    terminate = getattr(proc, "terminate", None)
-    if callable(terminate):
+    if not stopped:
+        terminate = getattr(proc, "terminate", None)
+        if callable(terminate):
+            try:
+                terminate()
+                stopped = True
+            except Exception:
+                pass
+    if not stopped:
+        return
+
+    wait = getattr(proc, "wait", None)
+    if not callable(wait):
+        return
+    try:
+        wait(timeout=1)
+        return
+    except TypeError:
+        # Lightweight test doubles commonly expose wait() without Popen's
+        # timeout parameter; termination above makes that call nonblocking.
         try:
-            terminate()
+            wait()
         except Exception:
             pass
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    except Exception:
+        return
+
+    try:
+        if (
+            _os.name != "nt"
+            and isinstance(pid, int)
+            and pid > 0
+            and hasattr(_os, "killpg")
+        ):
+            _os.killpg(pid, _signal.SIGKILL)
+        else:
+            kill = getattr(proc, "kill", None)
+            if callable(kill):
+                kill()
+        wait(timeout=1)
+    except Exception:
+        pass
 
 
 def _build_artifact_tar(artifacts: list[_cap.Artifact]) -> bytes:
@@ -544,11 +704,11 @@ def _run_verb_stream_unlocked(
     def _ensure_materialized(top_repo: str) -> Iterator[bytes]:
         """Materialize a TOP-LEVEL repo's task-branch worktree at
         `<hub>/<repo>`, recording it in `materialized`. A generator so it can
-        yield the base-freshness warning (see `check_base_freshness`) and, on
-        failure, the error line + trailing exit sentinel straight into the
-        stream. Its `yield from` value (PEP 380) is True on success, False if
-        the materialize failed — in which case the exit sentinel has ALREADY
-        been emitted and the caller MUST `return` to abort the whole request.
+        yield the base-freshness warning or a clean materialization error through
+        the stream. Its `yield from` value (PEP 380) is True on success, False
+        if materialization fails or the client disconnects. A materialization
+        failure has already emitted its exit sentinel; cancellation simply
+        unwinds so the response can close.
 
         Idempotent: a repo already in `materialized` (e.g. a parent brought in
         while resolving an earlier `git_root` child, then reached again in the
@@ -561,20 +721,32 @@ def _run_verb_stream_unlocked(
         worktree_path = hub / top_repo
         ref = run_refs.get(top_repo)
 
-        if ref is None:
-            # Origin is the source of truth for this repo, so make sure this
-            # host's view of its base is current first (MOS-203). Skipped
-            # entirely on the scratch-ref path: nothing there comes from origin,
-            # and a fetch would be pure latency.
-            warning = check_base_freshness(shell, repo_path, rc.base_branch)
-            if warning is not None:
-                yield f"{warning}\n".encode("utf-8")
-
         try:
+            if ref is None:
+                # Origin is the source of truth for this repo, so make sure this
+                # host's view of its base is current first (MOS-203). Skipped
+                # entirely on the scratch-ref path: nothing there comes from
+                # origin, and a fetch would be pure latency.
+                warning = check_base_freshness(
+                    shell,
+                    repo_path,
+                    rc.base_branch,
+                    cancel_event=deps.cancel_event,
+                )
+                if warning is not None:
+                    yield f"{warning}\n".encode("utf-8")
+
             materialize_worktree(
-                shell, repo_path, worktree_path, branch,
-                repo_name=top_repo, run_ref=ref,
+                shell,
+                repo_path,
+                worktree_path,
+                branch,
+                repo_name=top_repo,
+                run_ref=ref,
+                cancel_event=deps.cancel_event,
             )
+        except ShellCancelled:
+            return False
         except MaterializeError as exc:
             yield f"error: {exc}\n".encode("utf-8")
             yield f"{EXIT_MARKER}:{nonce} 1\n".encode("utf-8")

--- a/src/mship/core/remote_exec.py
+++ b/src/mship/core/remote_exec.py
@@ -546,8 +546,8 @@ def run_verb_stream(
     if deps.cancel_event is not None:
         try:
             ensure_cancellable_shell_supported()
-        except ShellCancellationUnsupported as exc:
-            yield f"error: remote execution unavailable: {exc}\n".encode("utf-8")
+        except ShellCancellationUnsupported:
+            yield b"error: remote execution unavailable; execution was not started\n"
             yield f"{EXIT_MARKER}:{nonce} 1\n".encode("utf-8")
             return
 

--- a/src/mship/core/remote_exec.py
+++ b/src/mship/core/remote_exec.py
@@ -50,6 +50,7 @@ Wire contract (Task 5's client parses this):
 """
 from __future__ import annotations
 
+import errno
 import fcntl
 import hashlib
 import io
@@ -124,12 +125,14 @@ class RemoteExecDeps:
     double duty for git commands and the streamed task run (see
     `ShellLike`). `workspace_root` anchors where remote worktrees live:
     `<workspace_root>/.worktrees/<task>/<repo>`, mirroring the local
-    `WorktreeManager` hub layout.
+    `WorktreeManager` hub layout. `cancel_event` lets the HTTP response stop a
+    quiet subprocess promptly when its client disconnects.
     """
 
     config: WorkspaceConfig
     shell: ShellLike
     workspace_root: Path
+    cancel_event: threading.Event | None = None
 
 
 def _hub_dir(workspace_root: Path, task: str) -> Path:
@@ -146,6 +149,11 @@ def _acquire_task_execution_lock(
     lock_file = (lock_dir / f"{digest}.lock").open("a+")
     try:
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        lock_file.close()
+        if exc.errno in {errno.EACCES, errno.EAGAIN, errno.EWOULDBLOCK}:
+            raise BlockingIOError(exc.errno, exc.strerror) from exc
+        raise
     except BaseException:
         lock_file.close()
         raise
@@ -302,14 +310,20 @@ def _drain_to_queue(proc, q: "queue.Queue[str]") -> list[threading.Thread]:
     return threads
 
 
-def _stream_proc_lines(proc) -> Iterator[bytes]:
+def _stream_proc_lines(
+    proc,
+    cancel_event: threading.Event | None = None,
+) -> Iterator[bytes]:
     """Yield each stdout/stderr line from `proc` as UTF-8 bytes AS IT'S
     PRODUCED (not buffered until the process exits) — this is what makes
     `run_verb_stream` a live stream rather than a final blob. Returns once
-    both drain threads have hit EOF and the queue is empty."""
+    both drain threads have hit EOF and the queue is empty, or returns False
+    when the response reports that its client disconnected."""
     q: "queue.Queue[str]" = queue.Queue()
     threads = _drain_to_queue(proc, q)
     while any(t.is_alive() for t in threads) or not q.empty():
+        if cancel_event is not None and cancel_event.is_set():
+            return False
         try:
             line = q.get(timeout=0.05)
         except queue.Empty:
@@ -317,6 +331,7 @@ def _stream_proc_lines(proc) -> Iterator[bytes]:
         yield line.encode("utf-8", errors="replace")
     for t in threads:
         t.join(timeout=1.0)
+    return True
 
 
 def _terminate_proc(proc) -> None:
@@ -604,7 +619,8 @@ def _run_verb_stream_unlocked(
         proc = None
         try:
             proc = shell.run_streaming(command, cwd=worktree_path, env=None)
-            yield from _stream_proc_lines(proc)
+            if not (yield from _stream_proc_lines(proc, deps.cancel_event)):
+                return False
             setup_code = proc.wait()
         finally:
             _terminate_proc(proc)
@@ -672,7 +688,8 @@ def _run_verb_stream_unlocked(
 
             command = shell.build_command(f"task {actual_task_name}", env_runner)
             proc = shell.run_streaming(command, cwd=worktree_path, env=env)
-            yield from _stream_proc_lines(proc)
+            if not (yield from _stream_proc_lines(proc, deps.cancel_event)):
+                return
             exit_code = proc.wait()
 
             if verb == "capture":

--- a/src/mship/core/remote_exec.py
+++ b/src/mship/core/remote_exec.py
@@ -55,10 +55,12 @@ import fcntl
 import hashlib
 import io
 import queue
+import shlex
 import shutil
 import tarfile
 import tempfile
 import threading
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, Protocol
@@ -103,14 +105,14 @@ class MaterializeError(Exception):
 
 class ShellLike(Protocol):
     """The subset of `mship.util.shell.ShellRunner` this module needs.
-    `.run` issues git plumbing (fetch/worktree add/reset, base-freshness
+    `.run_argv` issues git plumbing (fetch/worktree add/reset, base-freshness
     probes); `.run_streaming` launches the go-task target itself so its
     output can be drained incrementally. Same shapes as the real
     `ShellRunner` — tests inject a fake implementing just this surface."""
 
-    def run(
+    def run_argv(
         self,
-        command: str,
+        args: Sequence[str],
         cwd: Path,
         env: dict[str, str] | None = None,
         *,
@@ -170,14 +172,16 @@ def _acquire_task_execution_lock(
 
 def _run_shell(
     shell: ShellLike,
-    command: str,
+    args: Sequence[str],
     cwd: Path,
     *,
     cancel_event: threading.Event | None,
 ):
-    if cancel_event is None:
-        return shell.run(command, cwd=cwd)
-    return shell.run(command, cwd=cwd, cancel_event=cancel_event)
+    return shell.run_argv(
+        args,
+        cwd=cwd,
+        cancel_event=cancel_event,
+    )
 
 
 def _git_rev(
@@ -189,7 +193,7 @@ def _git_rev(
 ) -> str | None:
     result = _run_shell(
         shell,
-        f"git rev-parse {ref}",
+        ["git", "rev-parse", ref],
         cwd,
         cancel_event=cancel_event,
     )
@@ -225,7 +229,7 @@ def check_base_freshness(
     )
     _run_shell(
         shell,
-        f"git fetch origin {base_branch}",
+        ["git", "fetch", "origin", base_branch],
         repo_path,
         cancel_event=cancel_event,
     )
@@ -245,7 +249,7 @@ def check_base_freshness(
 
 def _run_checked(
     shell: ShellLike,
-    command: str,
+    args: Sequence[str],
     cwd: Path,
     *,
     repo_name: str,
@@ -259,13 +263,14 @@ def _run_checked(
     call site ignored `ShellResult.returncode` entirely)."""
     result = _run_shell(
         shell,
-        command,
+        args,
         cwd,
         cancel_event=cancel_event,
     )
     if result.returncode != 0:
         stderr = (result.stderr or "").strip()
         detail = f": {stderr}" if stderr else f" (exit {result.returncode})"
+        command = shlex.join(args)
         raise MaterializeError(
             f"branch-materialize failed for repo {repo_name!r}: `{command}`{detail}"
         )
@@ -315,21 +320,21 @@ def materialize_worktree(
             # a branch.
             _run_checked(
                 shell,
-                "git checkout --detach",
+                ["git", "checkout", "--detach"],
                 worktree_path,
                 repo_name=repo_name,
                 cancel_event=cancel_event,
             )
             _run_checked(
                 shell,
-                f"git reset --hard {run_ref}",
+                ["git", "reset", "--hard", run_ref],
                 worktree_path,
                 repo_name=repo_name,
                 cancel_event=cancel_event,
             )
             _run_checked(
                 shell,
-                "git clean -fd",
+                ["git", "clean", "-fd"],
                 worktree_path,
                 repo_name=repo_name,
                 cancel_event=cancel_event,
@@ -338,7 +343,14 @@ def materialize_worktree(
             worktree_path.parent.mkdir(parents=True, exist_ok=True)
             _run_checked(
                 shell,
-                f"git worktree add --detach {worktree_path} {run_ref}",
+                [
+                    "git",
+                    "worktree",
+                    "add",
+                    "--detach",
+                    str(worktree_path),
+                    run_ref,
+                ],
                 repo_path,
                 repo_name=repo_name,
                 cancel_event=cancel_event,
@@ -347,7 +359,7 @@ def materialize_worktree(
 
     _run_checked(
         shell,
-        f"git fetch origin {branch}",
+        ["git", "fetch", "origin", branch],
         repo_path,
         repo_name=repo_name,
         cancel_event=cancel_event,
@@ -355,21 +367,21 @@ def materialize_worktree(
     if (worktree_path / ".git").exists():
         _run_checked(
             shell,
-            f"git fetch origin {branch}",
+            ["git", "fetch", "origin", branch],
             worktree_path,
             repo_name=repo_name,
             cancel_event=cancel_event,
         )
         _run_checked(
             shell,
-            f"git checkout {branch}",
+            ["git", "checkout", branch],
             worktree_path,
             repo_name=repo_name,
             cancel_event=cancel_event,
         )
         _run_checked(
             shell,
-            f"git reset --hard origin/{branch}",
+            ["git", "reset", "--hard", f"origin/{branch}"],
             worktree_path,
             repo_name=repo_name,
             cancel_event=cancel_event,
@@ -378,7 +390,15 @@ def materialize_worktree(
         worktree_path.parent.mkdir(parents=True, exist_ok=True)
         _run_checked(
             shell,
-            f"git worktree add -B {branch} {worktree_path} origin/{branch}",
+            [
+                "git",
+                "worktree",
+                "add",
+                "-B",
+                branch,
+                str(worktree_path),
+                f"origin/{branch}",
+            ],
             repo_path,
             repo_name=repo_name,
             cancel_event=cancel_event,

--- a/src/mship/core/run_ref.py
+++ b/src/mship/core/run_ref.py
@@ -23,41 +23,66 @@ this module only refuses to build a name it cannot make safe.
 """
 from __future__ import annotations
 
-import re
 
 RUN_REF_PREFIX = "refs/mship/run/"
+_RUN_REF_SEGMENT_CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-"
 
 # One safe task/repository segment, shared with the remote exec boundary in
-# `core/serve.py`. This string is interpolated into `git push` /
-# `git reset --hard` run through a shell, and `core/remote_setup.py` derives a
-# filename from the same values. `.` and `..` are excluded outright so no
-# traversal segment can exist.
-#
-# Anchored `\Z`, not `$`: Python's `$` also matches BEFORE a trailing newline,
-# so `$` accepts `api\n` — and a trailing newline TERMINATES a shell command,
-# which is the one character this charset exists to keep out.
-_SEGMENT_RE = re.compile(r"\A(?!\.{1,2}\Z)[A-Za-z0-9._-]+\Z")
-
-
-def is_run_ref_segment(value: str) -> bool:
-    """Whether `value` is one safe task/repository run-ref segment."""
-    return bool(_SEGMENT_RE.match(value or ""))
+# `core/serve.py`. `.` and `..` are excluded outright so no traversal segment
+# can exist.
 
 
 class RunRefNameError(ValueError):
     """A task or repo name that cannot appear in a run ref."""
 
 
+def canonical_run_ref_segment(value: str) -> str:
+    """Validate and rebuild one safe task/repository run-ref segment."""
+    if not value or value in {".", ".."}:
+        raise RunRefNameError(
+            f"name {value!r} cannot be used in a run ref; it must match "
+            "[A-Za-z0-9._-]+ and not be '.' or '..'"
+        )
+
+    safe_characters = []
+    for character in value:
+        safe_index = _RUN_REF_SEGMENT_CHARACTERS.find(character)
+        if safe_index < 0:
+            raise RunRefNameError(
+                f"name {value!r} cannot be used in a run ref; it must match "
+                "[A-Za-z0-9._-]+ and not be '.' or '..'"
+            )
+        safe_characters.append(_RUN_REF_SEGMENT_CHARACTERS[safe_index])
+    return "".join(safe_characters)
+
+
+def is_run_ref_segment(value: str) -> bool:
+    """Whether `value` is one safe task/repository run-ref segment."""
+    try:
+        canonical_run_ref_segment(value)
+    except RunRefNameError:
+        return False
+    return True
+
+
 def run_ref(task: str, repo: str) -> str:
     """`refs/mship/run/<task>/<repo>` — per task AND per git repo, so two tasks
     or two repos running remotely at once cannot overwrite each other's refs."""
-    for label, value in (("task", task), ("repo", repo)):
-        if not is_run_ref_segment(value):
-            raise RunRefNameError(
-                f"{label} name {value!r} cannot be used in a run ref; it must "
-                f"match [A-Za-z0-9._-]+ and not be '.' or '..'"
-            )
-    return f"{RUN_REF_PREFIX}{task}/{repo}"
+    try:
+        canonical_task = canonical_run_ref_segment(task)
+    except RunRefNameError:
+        raise RunRefNameError(
+            f"task name {task!r} cannot be used in a run ref; it must match "
+            "[A-Za-z0-9._-]+ and not be '.' or '..'"
+        ) from None
+    try:
+        canonical_repo = canonical_run_ref_segment(repo)
+    except RunRefNameError:
+        raise RunRefNameError(
+            f"repo name {repo!r} cannot be used in a run ref; it must match "
+            "[A-Za-z0-9._-]+ and not be '.' or '..'"
+        ) from None
+    return f"{RUN_REF_PREFIX}{canonical_task}/{canonical_repo}"
 
 
 def is_run_ref(name: str) -> bool:

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1547,6 +1547,7 @@ def create_app(
 
     import anyio
     from fastapi.responses import StreamingResponse
+    from starlette.requests import ClientDisconnect
 
     from mship.core import remote_exec
     from mship.core.run_ref import RunRefNameError, canonical_run_ref_segment
@@ -1566,28 +1567,40 @@ def create_app(
                 self._cancel_event.set()
 
         async def __call__(self, scope, receive, send):
+            # Older Starlette versions in our supported FastAPI range do not
+            # implement the ASGI 2.4 send-error disconnect contract.
+            spec_version = tuple(map(
+                int,
+                scope.get("asgi", {}).get("spec_version", "2.0").split("."),
+            ))
             try:
-                try:
-                    async with anyio.create_task_group() as task_group:
-                        async def wrap(func):
-                            await func()
-                            task_group.cancel_scope.cancel()
+                if spec_version >= (2, 4):
+                    try:
+                        await self.stream_response(send)
+                    except OSError:
+                        raise ClientDisconnect()
+                else:
+                    try:
+                        async with anyio.create_task_group() as task_group:
+                            async def wrap(func):
+                                await func()
+                                task_group.cancel_scope.cancel()
 
-                        task_group.start_soon(
-                            wrap,
-                            partial(self.stream_response, send),
+                            task_group.start_soon(
+                                wrap,
+                                partial(self.stream_response, send),
+                            )
+                            await wrap(partial(self.listen_for_disconnect, receive))
+                    except BaseExceptionGroup as exceptions:
+                        if len(exceptions.exceptions) != 1:
+                            raise
+                        exception = exceptions.exceptions[0]
+                        context = (
+                            None
+                            if exception.__suppress_context__
+                            else exception.__context__
                         )
-                        await wrap(partial(self.listen_for_disconnect, receive))
-                except BaseExceptionGroup as exceptions:
-                    if len(exceptions.exceptions) != 1:
-                        raise
-                    exception = exceptions.exceptions[0]
-                    context = (
-                        None
-                        if exception.__suppress_context__
-                        else exception.__context__
-                    )
-                    raise exception from exception.__cause__ or context
+                        raise exception from exception.__cause__ or context
             finally:
                 self._cancel_event.set()
                 self._sync_iterator.close()

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1545,10 +1545,11 @@ def create_app(
     import secrets
     from functools import partial
 
+    import anyio
+    from fastapi.responses import StreamingResponse
+
     from mship.core import remote_exec
     from mship.core.run_ref import is_run_ref_segment
-    from fastapi.responses import StreamingResponse
-    from starlette._utils import create_collapsing_task_group
 
     class _RemoteExecStreamingResponse(StreamingResponse):
         """Own the sync generator until HTTP streaming has fully stopped."""
@@ -1566,16 +1567,27 @@ def create_app(
 
         async def __call__(self, scope, receive, send):
             try:
-                async with create_collapsing_task_group() as task_group:
-                    async def wrap(func):
-                        await func()
-                        task_group.cancel_scope.cancel()
+                try:
+                    async with anyio.create_task_group() as task_group:
+                        async def wrap(func):
+                            await func()
+                            task_group.cancel_scope.cancel()
 
-                    task_group.start_soon(
-                        wrap,
-                        partial(self.stream_response, send),
+                        task_group.start_soon(
+                            wrap,
+                            partial(self.stream_response, send),
+                        )
+                        await wrap(partial(self.listen_for_disconnect, receive))
+                except BaseExceptionGroup as exceptions:
+                    if len(exceptions.exceptions) != 1:
+                        raise
+                    exception = exceptions.exceptions[0]
+                    context = (
+                        None
+                        if exception.__suppress_context__
+                        else exception.__context__
                     )
-                    await wrap(partial(self.listen_for_disconnect, receive))
+                    raise exception from exception.__cause__ or context
             finally:
                 self._cancel_event.set()
                 self._sync_iterator.close()

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1549,7 +1549,7 @@ def create_app(
     from fastapi.responses import StreamingResponse
 
     from mship.core import remote_exec
-    from mship.core.run_ref import is_run_ref_segment
+    from mship.core.run_ref import RunRefNameError, canonical_run_ref_segment
 
     class _RemoteExecStreamingResponse(StreamingResponse):
         """Own the sync generator until HTTP streaming has fully stopped."""
@@ -1595,9 +1595,9 @@ def create_app(
             if self.background is not None:
                 await self.background()
 
-    # A task name becomes both a `.worktrees` path segment and shell-backed
-    # git/task input. Validate it against the shared run-ref segment contract
-    # before any remote work or streaming response begins.
+    # A task name becomes both a `.worktrees` path segment and git/task input.
+    # Canonicalize it at the authenticated endpoint before any remote work or
+    # streaming response begins.
 
     @app.post("/exec/{verb}")
     async def post_exec(verb: str, body: ExecBody):
@@ -1616,7 +1616,9 @@ def create_app(
                     "restart `mship serve --relay`"
                 ),
             )
-        if not is_run_ref_segment(body.task):
+        try:
+            task = canonical_run_ref_segment(body.task)
+        except RunRefNameError:
             raise HTTPException(status_code=400, detail="invalid task name")
         cancel_event = threading.Event()
         deps = remote_exec.RemoteExecDeps(
@@ -1635,7 +1637,7 @@ def create_app(
         # The response owns the sync generator and signals its subprocess drain
         # before waiting for AnyIO's in-flight threadpool `next()` to return.
         gen = remote_exec.run_verb_stream(
-            verb, body.task, body.repos, body.platform,
+            verb, task, body.repos, body.platform,
             kind=body.kind, deps=deps, nonce=nonce,
             run_ref_repos=body.run_ref_repos,
         )

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1543,11 +1543,45 @@ def create_app(
     # reaching into pr_manager's — same class, its own lifetime.
 
     import secrets
+    from functools import partial
 
     from mship.core import remote_exec
     from mship.core.run_ref import is_run_ref_segment
     from fastapi.responses import StreamingResponse
-    from starlette.concurrency import iterate_in_threadpool
+    from starlette._utils import create_collapsing_task_group
+
+    class _RemoteExecStreamingResponse(StreamingResponse):
+        """Own the sync generator until HTTP streaming has fully stopped."""
+
+        def __init__(self, content, *, cancel_event, **kwargs):
+            self._sync_iterator = content
+            self._cancel_event = cancel_event
+            super().__init__(content, **kwargs)
+
+        async def listen_for_disconnect(self, receive):
+            try:
+                await super().listen_for_disconnect(receive)
+            finally:
+                self._cancel_event.set()
+
+        async def __call__(self, scope, receive, send):
+            try:
+                async with create_collapsing_task_group() as task_group:
+                    async def wrap(func):
+                        await func()
+                        task_group.cancel_scope.cancel()
+
+                    task_group.start_soon(
+                        wrap,
+                        partial(self.stream_response, send),
+                    )
+                    await wrap(partial(self.listen_for_disconnect, receive))
+            finally:
+                self._cancel_event.set()
+                self._sync_iterator.close()
+
+            if self.background is not None:
+                await self.background()
 
     # A task name becomes both a `.worktrees` path segment and shell-backed
     # git/task input. Validate it against the shared run-ref segment contract
@@ -1572,8 +1606,12 @@ def create_app(
             )
         if not is_run_ref_segment(body.task):
             raise HTTPException(status_code=400, detail="invalid task name")
+        cancel_event = threading.Event()
         deps = remote_exec.RemoteExecDeps(
-            config=config, shell=ShellRunner(), workspace_root=workspace_root,
+            config=config,
+            shell=ShellRunner(),
+            workspace_root=workspace_root,
+            cancel_event=cancel_event,
         )
         # Per-request anti-spoof nonce (FIX 2): the task can't predict it, and
         # it's returned as a response HEADER (sent before the streamed body, so
@@ -1582,16 +1620,16 @@ def create_app(
         # to print a bare `__MSHIP_EXIT__ 0` is therefore just output, never a
         # forged exit code.
         nonce = secrets.token_hex(8)
-        # `run_verb_stream` is a plain sync generator doing blocking subprocess
-        # + git I/O; `iterate_in_threadpool` pulls each chunk in the threadpool
-        # so it never blocks the event loop (see the module docstring).
+        # The response owns the sync generator and signals its subprocess drain
+        # before waiting for AnyIO's in-flight threadpool `next()` to return.
         gen = remote_exec.run_verb_stream(
             verb, body.task, body.repos, body.platform,
             kind=body.kind, deps=deps, nonce=nonce,
             run_ref_repos=body.run_ref_repos,
         )
-        return StreamingResponse(
-            iterate_in_threadpool(gen),
+        return _RemoteExecStreamingResponse(
+            gen,
+            cancel_event=cancel_event,
             media_type="application/octet-stream",
             headers={"X-Mship-Exec-Nonce": nonce},
         )

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1573,34 +1573,36 @@ def create_app(
                 int,
                 scope.get("asgi", {}).get("spec_version", "2.0").split("."),
             ))
-            try:
-                if spec_version >= (2, 4):
-                    try:
-                        await self.stream_response(send)
-                    except OSError:
-                        raise ClientDisconnect()
-                else:
-                    try:
-                        async with anyio.create_task_group() as task_group:
-                            async def wrap(func):
-                                await func()
-                                task_group.cancel_scope.cancel()
+            async def stream_response_with_disconnect():
+                try:
+                    await self.stream_response(send)
+                except OSError:
+                    raise ClientDisconnect()
 
-                            task_group.start_soon(
-                                wrap,
-                                partial(self.stream_response, send),
-                            )
-                            await wrap(partial(self.listen_for_disconnect, receive))
-                    except BaseExceptionGroup as exceptions:
-                        if len(exceptions.exceptions) != 1:
-                            raise
-                        exception = exceptions.exceptions[0]
-                        context = (
-                            None
-                            if exception.__suppress_context__
-                            else exception.__context__
-                        )
-                        raise exception from exception.__cause__ or context
+            stream_response = (
+                stream_response_with_disconnect
+                if spec_version >= (2, 4)
+                else partial(self.stream_response, send)
+            )
+            try:
+                try:
+                    async with anyio.create_task_group() as task_group:
+                        async def wrap(func):
+                            await func()
+                            task_group.cancel_scope.cancel()
+
+                        task_group.start_soon(wrap, stream_response)
+                        await wrap(partial(self.listen_for_disconnect, receive))
+                except BaseExceptionGroup as exceptions:
+                    if len(exceptions.exceptions) != 1:
+                        raise
+                    exception = exceptions.exceptions[0]
+                    context = (
+                        None
+                        if exception.__suppress_context__
+                        else exception.__context__
+                    )
+                    raise exception from exception.__cause__ or context
             finally:
                 self._cancel_event.set()
                 self._sync_iterator.close()

--- a/src/mship/util/shell.py
+++ b/src/mship/util/shell.py
@@ -31,7 +31,7 @@ def _has_owned_process_group(proc: subprocess.Popen) -> bool:
 
 
 def _linux_group_has_executable_member(process_group: int) -> bool:
-    unreadable = False
+    found_member = False
     try:
         entries = os.scandir("/proc")
     except OSError:
@@ -42,19 +42,28 @@ def _linux_group_has_executable_member(process_group: int) -> bool:
             if not entry.name.isdigit():
                 continue
             try:
-                stat = (Path(entry.path) / "stat").read_text()
-                fields = stat[stat.rfind(")") + 2 :].split()
+                stat = (Path(entry.path) / "stat").read_bytes()
+                fields = stat[stat.rfind(b")") + 2 :].split()
                 state = fields[0]
                 member_group = int(fields[2])
             except FileNotFoundError:
                 continue
             except (OSError, IndexError, ValueError):
-                unreadable = True
+                try:
+                    member_group = os.getpgid(int(entry.name))
+                except ProcessLookupError:
+                    continue
+                except OSError:
+                    return _has_owned_process_group_id(process_group)
+                if member_group == process_group:
+                    return True
                 continue
-            if member_group == process_group and state not in {"X", "Z", "x"}:
-                return True
+            if member_group == process_group:
+                found_member = True
+                if state not in {b"X", b"Z", b"x"}:
+                    return True
 
-    return unreadable and _has_owned_process_group_id(process_group)
+    return not found_member and _has_owned_process_group_id(process_group)
 
 
 def _has_owned_process_group_id(process_group: int) -> bool:
@@ -79,6 +88,16 @@ def _signal_owned_process(proc: subprocess.Popen, *, force: bool = False) -> Non
             return
         proc.kill() if force else proc.terminate()
     except ProcessLookupError:
+        pass
+
+
+def _reap_owned_process_leader(proc: subprocess.Popen) -> None:
+    wait = getattr(proc, "wait", None)
+    if not callable(wait):
+        return
+    try:
+        wait()
+    except Exception:
         pass
 
 
@@ -107,6 +126,7 @@ def _terminate_owned_process_group(
         return
 
     if force:
+        _reap_owned_process_leader(proc)
         _wait_for_owned_process_group_quiescence(proc)
         return
 
@@ -115,6 +135,7 @@ def _terminate_owned_process_group(
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             _signal_owned_process(proc, force=True)
+            _reap_owned_process_leader(proc)
             _wait_for_owned_process_group_quiescence(proc)
             return
         time.sleep(min(_CANCELLATION_CHECK_INTERVAL, remaining))

--- a/src/mship/util/shell.py
+++ b/src/mship/util/shell.py
@@ -21,7 +21,7 @@ class ShellCancelled(Exception):
 
 
 class ShellCancellationUnsupported(RuntimeError):
-    """This host cannot safely contain and observe a cancellable command."""
+    """This host cannot safely create and observe a cancellation process group."""
 
 
 _CANCELLATION_CHECK_INTERVAL = 0.05
@@ -46,7 +46,7 @@ def _read_linux_process_status(process_dir: Path) -> tuple[bytes, int]:
 
 
 def ensure_cancellable_shell_supported() -> None:
-    """Fail before spawn unless cancellable process trees are observable."""
+    """Fail before spawn unless an owned cancellation group is observable."""
     if os.name != "posix":
         platform = "Windows" if os.name == "nt" else os.name
         raise ShellCancellationUnsupported(
@@ -173,7 +173,11 @@ def _terminate_owned_process_group(
     *,
     force: bool = False,
 ) -> None:
-    """Stop an abnormal command tree and wait until no member can execute."""
+    """Stop members that remain in the spawned process group.
+
+    Descendants that create another session or process group are outside this
+    selected process-group cancellation contract.
+    """
     _signal_owned_process(proc, force=force)
     if os.name == "nt" or not _has_owned_process_group(proc):
         return
@@ -199,7 +203,7 @@ def _stop_and_reap(
     *,
     force: bool = False,
 ) -> tuple[str, str]:
-    """Stop an owned command tree and reap its leader before returning."""
+    """Stop the owned process group and reap its original leader."""
     _terminate_owned_process_group(proc, force=force)
     try:
         return proc.communicate(timeout=_TERMINATION_GRACE_SECONDS)
@@ -333,8 +337,9 @@ class ShellRunner:
     ) -> subprocess.Popen:
         """Run a command with stdout/stderr streaming (for logs, run).
 
-        Launches the subprocess in its own process group so signal delivery
-        can reach the whole tree (including grandchildren) on termination.
+        Launches the subprocess in its own process group. Cancellation can
+        signal processes that remain in that spawned PGID; descendants that
+        create another session or process group are outside this contract.
         """
         run_env = None
         if env:

--- a/src/mship/util/shell.py
+++ b/src/mship/util/shell.py
@@ -1,6 +1,7 @@
 import os
 import signal
 import subprocess
+import sys
 import threading
 import time
 from dataclasses import dataclass
@@ -26,14 +27,44 @@ def _has_owned_process_group(proc: subprocess.Popen) -> bool:
     pid = getattr(proc, "pid", None)
     if os.name == "nt" or not isinstance(pid, int) or pid <= 0:
         return False
+    return _has_owned_process_group_id(pid)
+
+
+def _linux_group_has_executable_member(process_group: int) -> bool:
+    unreadable = False
     try:
-        os.killpg(pid, 0)
+        entries = os.scandir("/proc")
+    except OSError:
+        return _has_owned_process_group_id(process_group)
+
+    with entries:
+        for entry in entries:
+            if not entry.name.isdigit():
+                continue
+            try:
+                stat = (Path(entry.path) / "stat").read_text()
+                fields = stat[stat.rfind(")") + 2 :].split()
+                state = fields[0]
+                member_group = int(fields[2])
+            except FileNotFoundError:
+                continue
+            except (OSError, IndexError, ValueError):
+                unreadable = True
+                continue
+            if member_group == process_group and state not in {"X", "Z", "x"}:
+                return True
+
+    return unreadable and _has_owned_process_group_id(process_group)
+
+
+def _has_owned_process_group_id(process_group: int) -> bool:
+    try:
+        os.killpg(process_group, 0)
     except ProcessLookupError:
         return False
     except PermissionError:
         return True
     return True
-
 
 
 def _signal_owned_process(proc: subprocess.Popen, *, force: bool = False) -> None:
@@ -51,22 +82,40 @@ def _signal_owned_process(proc: subprocess.Popen, *, force: bool = False) -> Non
         pass
 
 
+def _wait_for_owned_process_group_quiescence(proc: subprocess.Popen) -> None:
+    pid = getattr(proc, "pid", None)
+    if os.name == "nt" or not isinstance(pid, int) or pid <= 0:
+        return
+
+    if sys.platform.startswith("linux"):
+        while _linux_group_has_executable_member(pid):
+            time.sleep(_CANCELLATION_CHECK_INTERVAL)
+        return
+
+    while _has_owned_process_group_id(pid):
+        time.sleep(_CANCELLATION_CHECK_INTERVAL)
+
+
 def _terminate_owned_process_group(
     proc: subprocess.Popen,
     *,
     force: bool = False,
 ) -> None:
-    """Stop an abnormal command tree, including descendants of a dead leader."""
+    """Stop an abnormal command tree and wait until no member can execute."""
     _signal_owned_process(proc, force=force)
     if os.name == "nt" or not _has_owned_process_group(proc):
         return
 
-    deadline = time.monotonic() + (0 if force else _TERMINATION_GRACE_SECONDS)
+    if force:
+        _wait_for_owned_process_group_quiescence(proc)
+        return
+
+    deadline = time.monotonic() + _TERMINATION_GRACE_SECONDS
     while _has_owned_process_group(proc):
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            if not force:
-                _signal_owned_process(proc, force=True)
+            _signal_owned_process(proc, force=True)
+            _wait_for_owned_process_group_quiescence(proc)
             return
         time.sleep(min(_CANCELLATION_CHECK_INTERVAL, remaining))
 

--- a/src/mship/util/shell.py
+++ b/src/mship/util/shell.py
@@ -1,5 +1,8 @@
 import os
+import signal
 import subprocess
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -11,6 +14,40 @@ class ShellResult:
     stderr: str
 
 
+class ShellCancelled(Exception):
+    """A cancellable shell command was stopped before it completed."""
+
+
+_CANCELLATION_CHECK_INTERVAL = 0.05
+
+
+def _signal_owned_process(proc: subprocess.Popen, *, force: bool = False) -> None:
+    try:
+        if os.name == "nt":
+            if proc.poll() is not None:
+                return
+            proc.kill() if force else proc.terminate()
+        else:
+            # Signal the group even if its leader has already exited: children
+            # may still hold the captured pipes open and must be stopped too.
+            os.killpg(proc.pid, signal.SIGKILL if force else signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+
+
+def _stop_and_reap(
+    proc: subprocess.Popen,
+    *,
+    force: bool = False,
+) -> tuple[str, str]:
+    _signal_owned_process(proc, force=force)
+    try:
+        return proc.communicate(timeout=1)
+    except subprocess.TimeoutExpired:
+        _signal_owned_process(proc, force=True)
+        return proc.communicate()
+
+
 class ShellRunner:
     """Wraps subprocess execution with optional env_runner prefixing."""
 
@@ -20,31 +57,77 @@ class ShellRunner:
         return command
 
     def run(
-        self, command: str, cwd: Path, env: dict[str, str] | None = None,
+        self,
+        command: str,
+        cwd: Path,
+        env: dict[str, str] | None = None,
         timeout: float | None = None,
+        cancel_event: threading.Event | None = None,
     ) -> ShellResult:
         """Run `command` and capture output. `timeout` (seconds) raises
-        `subprocess.TimeoutExpired` if the command hasn't finished by then —
-        used by lifecycle hooks (core/lifecycle_hooks.py) to bound a hook's
-        runtime; other callers simply don't pass it (no timeout, unchanged
-        behavior)."""
+        `subprocess.TimeoutExpired` if the command hasn't finished by then.
+        When `cancel_event` is supplied, the command owns a process group that
+        is terminated and reaped before `ShellCancelled` is raised. The default
+        path remains `subprocess.run` for all existing callers."""
         run_env = None
         if env:
             run_env = {**os.environ, **env}
-        result = subprocess.run(
-            command,
-            shell=True,
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            env=run_env,
-            timeout=timeout,
-        )
-        return ShellResult(
-            returncode=result.returncode,
-            stdout=result.stdout,
-            stderr=result.stderr,
-        )
+        if cancel_event is None:
+            result = subprocess.run(
+                command,
+                shell=True,
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                env=run_env,
+                timeout=timeout,
+            )
+            return ShellResult(
+                returncode=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+            )
+
+        kwargs = {
+            "shell": True,
+            "cwd": cwd,
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.PIPE,
+            "text": True,
+            "env": run_env,
+        }
+        if os.name == "nt":
+            kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            kwargs["start_new_session"] = True
+        proc = subprocess.Popen(command, **kwargs)
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            if cancel_event.is_set():
+                _stop_and_reap(proc)
+                raise ShellCancelled(f"shell command cancelled: {command}")
+
+            wait_timeout = _CANCELLATION_CHECK_INTERVAL
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    stdout, stderr = _stop_and_reap(proc, force=True)
+                    raise subprocess.TimeoutExpired(
+                        command,
+                        timeout,
+                        output=stdout,
+                        stderr=stderr,
+                    )
+                wait_timeout = min(wait_timeout, remaining)
+            try:
+                stdout, stderr = proc.communicate(timeout=wait_timeout)
+            except subprocess.TimeoutExpired:
+                continue
+            return ShellResult(
+                returncode=proc.returncode,
+                stdout=stdout,
+                stderr=stderr,
+            )
 
     def run_task(
         self,

--- a/src/mship/util/shell.py
+++ b/src/mship/util/shell.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import threading
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -164,25 +165,47 @@ class ShellRunner:
         return command
 
     def run(
+        self, command: str, cwd: Path, env: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> ShellResult:
+        """Run `command` and capture output. `timeout` (seconds) raises
+        `subprocess.TimeoutExpired` if the command hasn't finished by then —
+        used by lifecycle hooks (core/lifecycle_hooks.py) to bound a hook's
+        runtime; other callers simply don't pass it (no timeout, unchanged
+        behavior)."""
+        run_env = None
+        if env:
+            run_env = {**os.environ, **env}
+        result = subprocess.run(
+            command,
+            shell=True,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            env=run_env,
+            timeout=timeout,
+        )
+        return ShellResult(
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+
+    def run_argv(
         self,
-        command: str,
+        args: Sequence[str],
         cwd: Path,
         env: dict[str, str] | None = None,
         timeout: float | None = None,
         cancel_event: threading.Event | None = None,
     ) -> ShellResult:
-        """Run `command` and capture output. `timeout` (seconds) raises
-        `subprocess.TimeoutExpired` if the command hasn't finished by then.
-        When `cancel_event` is supplied, the command owns a process group that
-        is terminated and reaped before `ShellCancelled` is raised. The default
-        path remains `subprocess.run` for all existing callers."""
+        """Run structured arguments without a shell, with optional cancellation."""
         run_env = None
         if env:
             run_env = {**os.environ, **env}
         if cancel_event is None:
             result = subprocess.run(
-                command,
-                shell=True,
+                args,
                 cwd=cwd,
                 capture_output=True,
                 text=True,
@@ -196,7 +219,6 @@ class ShellRunner:
             )
 
         kwargs = {
-            "shell": True,
             "cwd": cwd,
             "stdout": subprocess.PIPE,
             "stderr": subprocess.PIPE,
@@ -207,12 +229,12 @@ class ShellRunner:
             kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
         else:
             kwargs["start_new_session"] = True
-        proc = subprocess.Popen(command, **kwargs)
+        proc = subprocess.Popen(args, **kwargs)
         deadline = None if timeout is None else time.monotonic() + timeout
         while True:
             if cancel_event.is_set():
                 _stop_and_reap(proc)
-                raise ShellCancelled(f"shell command cancelled: {command}")
+                raise ShellCancelled(f"shell command cancelled: {args!r}")
 
             wait_timeout = _CANCELLATION_CHECK_INTERVAL
             if deadline is not None:
@@ -220,7 +242,7 @@ class ShellRunner:
                 if remaining <= 0:
                     stdout, stderr = _stop_and_reap(proc, force=True)
                     raise subprocess.TimeoutExpired(
-                        command,
+                        args,
                         timeout,
                         output=stdout,
                         stderr=stderr,

--- a/src/mship/util/shell.py
+++ b/src/mship/util/shell.py
@@ -19,20 +19,56 @@ class ShellCancelled(Exception):
 
 
 _CANCELLATION_CHECK_INTERVAL = 0.05
+_TERMINATION_GRACE_SECONDS = 1.0
+
+
+def _has_owned_process_group(proc: subprocess.Popen) -> bool:
+    pid = getattr(proc, "pid", None)
+    if os.name == "nt" or not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        os.killpg(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
 
 
 def _signal_owned_process(proc: subprocess.Popen, *, force: bool = False) -> None:
+    pid = getattr(proc, "pid", None)
     try:
-        if os.name == "nt":
-            if proc.poll() is not None:
-                return
-            proc.kill() if force else proc.terminate()
-        else:
-            # Signal the group even if its leader has already exited: children
-            # may still hold the captured pipes open and must be stopped too.
-            os.killpg(proc.pid, signal.SIGKILL if force else signal.SIGTERM)
+        if os.name != "nt" and isinstance(pid, int) and pid > 0:
+            # The group can outlive and be reaped after its leader. Abnormal
+            # cleanup still owns that group, so signal it by the original pgid.
+            os.killpg(pid, signal.SIGKILL if force else signal.SIGTERM)
+            return
+        if proc.poll() is not None:
+            return
+        proc.kill() if force else proc.terminate()
     except ProcessLookupError:
         pass
+
+
+def _terminate_owned_process_group(
+    proc: subprocess.Popen,
+    *,
+    force: bool = False,
+) -> None:
+    """Stop an abnormal command tree, including descendants of a dead leader."""
+    _signal_owned_process(proc, force=force)
+    if os.name == "nt" or not _has_owned_process_group(proc):
+        return
+
+    deadline = time.monotonic() + (0 if force else _TERMINATION_GRACE_SECONDS)
+    while _has_owned_process_group(proc):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            if not force:
+                _signal_owned_process(proc, force=True)
+            return
+        time.sleep(min(_CANCELLATION_CHECK_INTERVAL, remaining))
 
 
 def _stop_and_reap(
@@ -40,9 +76,10 @@ def _stop_and_reap(
     *,
     force: bool = False,
 ) -> tuple[str, str]:
-    _signal_owned_process(proc, force=force)
+    """Stop an owned command tree and reap its leader before returning."""
+    _terminate_owned_process_group(proc, force=force)
     try:
-        return proc.communicate(timeout=1)
+        return proc.communicate(timeout=_TERMINATION_GRACE_SECONDS)
     except subprocess.TimeoutExpired:
         _signal_owned_process(proc, force=True)
         return proc.communicate()

--- a/src/mship/util/shell.py
+++ b/src/mship/util/shell.py
@@ -20,8 +20,13 @@ class ShellCancelled(Exception):
     """A cancellable shell command was stopped before it completed."""
 
 
+class ShellCancellationUnsupported(RuntimeError):
+    """This host cannot safely contain and observe a cancellable command."""
+
+
 _CANCELLATION_CHECK_INTERVAL = 0.05
 _TERMINATION_GRACE_SECONDS = 1.0
+_PROC_ROOT = "/proc"
 
 
 def _has_owned_process_group(proc: subprocess.Popen) -> bool:
@@ -31,10 +36,58 @@ def _has_owned_process_group(proc: subprocess.Popen) -> bool:
     return _has_owned_process_group_id(pid)
 
 
+def _read_linux_process_status(process_dir: Path) -> tuple[bytes, int]:
+    stat = (process_dir / "stat").read_bytes()
+    closing_paren = stat.rfind(b")")
+    if closing_paren < 0:
+        raise ValueError("process stat has no command boundary")
+    fields = stat[closing_paren + 2 :].split()
+    return fields[0], int(fields[2])
+
+
+def ensure_cancellable_shell_supported() -> None:
+    """Fail before spawn unless cancellable process trees are observable."""
+    if os.name != "posix":
+        platform = "Windows" if os.name == "nt" else os.name
+        raise ShellCancellationUnsupported(
+            "cancellable shell execution requires POSIX process groups; "
+            f"{platform} is unsupported"
+        )
+    if not sys.platform.startswith("linux"):
+        return
+
+    try:
+        entries = os.scandir(_PROC_ROOT)
+    except OSError as exc:
+        raise ShellCancellationUnsupported(
+            "cancellable shell execution requires a readable Linux "
+            f"process-status filesystem at {_PROC_ROOT}"
+        ) from exc
+
+    last_error: Exception | None = None
+    with entries:
+        for entry in entries:
+            if not entry.name.isdigit():
+                continue
+            try:
+                _read_linux_process_status(Path(entry.path))
+            except FileNotFoundError:
+                continue
+            except (OSError, IndexError, ValueError) as exc:
+                last_error = exc
+                continue
+            return
+
+    raise ShellCancellationUnsupported(
+        "cancellable shell execution requires readable, parseable numeric "
+        f"process status entries at {_PROC_ROOT}"
+    ) from last_error
+
+
 def _linux_group_has_executable_member(process_group: int) -> bool:
     found_member = False
     try:
-        entries = os.scandir("/proc")
+        entries = os.scandir(_PROC_ROOT)
     except OSError:
         return _has_owned_process_group_id(process_group)
 
@@ -43,10 +96,9 @@ def _linux_group_has_executable_member(process_group: int) -> bool:
             if not entry.name.isdigit():
                 continue
             try:
-                stat = (Path(entry.path) / "stat").read_bytes()
-                fields = stat[stat.rfind(b")") + 2 :].split()
-                state = fields[0]
-                member_group = int(fields[2])
+                state, member_group = _read_linux_process_status(
+                    Path(entry.path)
+                )
             except FileNotFoundError:
                 continue
             except (OSError, IndexError, ValueError):
@@ -199,7 +251,14 @@ class ShellRunner:
         timeout: float | None = None,
         cancel_event: threading.Event | None = None,
     ) -> ShellResult:
-        """Run structured arguments without a shell, with optional cancellation."""
+        """Run structured arguments without a shell.
+
+        Cancellation requires POSIX process groups. Linux additionally requires
+        readable process status so cleanup can distinguish executable members
+        from zombies before returning.
+        """
+        if cancel_event is not None:
+            ensure_cancellable_shell_supported()
         run_env = None
         if env:
             run_env = {**os.environ, **env}
@@ -224,11 +283,8 @@ class ShellRunner:
             "stderr": subprocess.PIPE,
             "text": True,
             "env": run_env,
+            "start_new_session": True,
         }
-        if os.name == "nt":
-            kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
-        else:
-            kwargs["start_new_session"] = True
         proc = subprocess.Popen(args, **kwargs)
         deadline = None if timeout is None else time.monotonic() + timeout
         while True:

--- a/tests/core/test_run_ref.py
+++ b/tests/core/test_run_ref.py
@@ -1,6 +1,7 @@
 """`refs/mship/run/<task>/<repo>` — the throwaway namespace, and the only place
 its shape is decided."""
 import pytest
+from mship.core import run_ref as run_ref_module
 
 from mship.core.run_ref import (
     RUN_REF_PREFIX,
@@ -14,6 +15,34 @@ from mship.core.run_ref import (
 @pytest.mark.parametrize("value", ["t1", "release.v2_build-1"])
 def test_run_ref_segment_accepts_safe_values(value):
     assert is_run_ref_segment(value)
+
+
+def test_canonical_segment_returns_rebuilt_safe_value():
+    value = "".join(["release", ".", "v2", "_build", "-1"])
+
+    canonical = run_ref_module.canonical_run_ref_segment(value)
+
+    assert canonical == value
+    assert canonical is not value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        ".",
+        "..",
+        "../escape",
+        "a/b",
+        "with space",
+        "semi;colon",
+        "dollar$",
+        "api\n",
+    ],
+)
+def test_canonical_segment_rejects_every_unsafe_value(value):
+    with pytest.raises(RunRefNameError):
+        run_ref_module.canonical_run_ref_segment(value)
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -13,6 +13,8 @@ Two layers are covered:
 """
 from __future__ import annotations
 
+import asyncio
+import errno
 import fcntl
 import hashlib
 import io
@@ -326,6 +328,110 @@ def test_run_verb_stream_client_disconnect_cleans_up_tempdir_and_proc(tmp_path):
     assert not capture_dir.exists(), "the capture temp dir must be removed on disconnect"
 
 
+def test_exec_http_disconnect_terminates_quiet_proc_and_releases_task_lock(
+    tmp_path,
+    monkeypatch,
+):
+    started = threading.Event()
+    terminated = threading.Event()
+    unblock = threading.Event()
+
+    class _BlockingStream:
+        def readline(self):
+            unblock.wait(timeout=5)
+            return ""
+
+        def close(self):
+            pass
+
+    class _QuietProc:
+        pid = None
+        stdout = _BlockingStream()
+        stderr = _BlockingStream()
+
+        def wait(self):
+            unblock.wait(timeout=5)
+            return 0
+
+        def poll(self):
+            return 0 if unblock.is_set() else None
+
+        def terminate(self):
+            terminated.set()
+            unblock.set()
+
+    class _SignalingShellRunner(_FakeShellRunner):
+        def run_streaming(self, command, cwd, env=None):
+            proc = super().run_streaming(command, cwd, env=env)
+            started.set()
+            return proc
+
+    fake = _SignalingShellRunner(streaming_proc=_QuietProc())
+    _patch_shell(monkeypatch, fake)
+    app = _app(tmp_path)
+    response_messages = []
+    request_sent = False
+
+    async def receive():
+        nonlocal request_sent
+        if not request_sent:
+            request_sent = True
+            return {
+                "type": "http.request",
+                "body": b'{"task":"t1","repos":["api"]}',
+                "more_body": False,
+            }
+        assert await asyncio.to_thread(started.wait, 10)
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        response_messages.append(message)
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/exec/run",
+        "raw_path": b"/exec/run",
+        "query_string": b"",
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+
+    async def disconnect_request() -> bool:
+        app_task = asyncio.create_task(app(scope, receive, send))
+        stopped = False
+        try:
+            assert await asyncio.to_thread(started.wait, 10)
+            stopped = await asyncio.to_thread(terminated.wait, 1)
+        finally:
+            if not stopped:
+                unblock.set()
+            await asyncio.wait_for(app_task, timeout=10)
+        return stopped
+
+    assert asyncio.run(disconnect_request())
+    assert response_messages[0]["type"] == "http.response.start"
+
+    replacement_fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["replacement\n"]),
+    )
+    replacement_deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path), shell=replacement_fake, workspace_root=tmp_path,
+    )
+    assert list(remote_exec.run_verb_stream(
+        "run", "t1", ["api"], None,
+        deps=replacement_deps, nonce="replacementnonce",
+    ))[-2:] == [
+        b"replacement\n",
+        b"__MSHIP_EXIT__:replacementnonce 0\n",
+    ]
+
+
 def test_concurrent_same_task_is_refused_while_different_task_runs(tmp_path):
     gate = threading.Event()
     first_fake = _FakeShellRunner(streaming_proc=_FakeProc(
@@ -505,6 +611,27 @@ def test_task_lock_failure_to_flock_fails_closed(tmp_path, monkeypatch):
         streaming_proc=_FakeProc(stdout_lines=["must not run\n"]),
     )
     _assert_task_lock_failure(tmp_path, fake, "flocknonce")
+
+
+def test_task_lock_eacces_from_flock_is_contention(tmp_path, monkeypatch):
+    def deny_flock(_fd, _operation):
+        raise PermissionError(errno.EACCES, "injected contention")
+
+    monkeypatch.setattr(fcntl, "flock", deny_flock)
+    fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["must not run\n"]),
+    )
+    deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path), shell=fake, workspace_root=tmp_path,
+    )
+    assert list(remote_exec.run_verb_stream(
+        "run", "t1", ["api"], None, deps=deps, nonce="eaccesnonce",
+    )) == [
+        b"error: remote task 't1' is already running; try again after it finishes\n",
+        b"__MSHIP_EXIT__:eaccesnonce 2\n",
+    ]
+    assert not fake.run_calls
+    assert not fake.streaming_calls
 
 
 def test_run_verb_stream_unknown_verb_raises(tmp_path):

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -21,6 +21,7 @@ import io
 import multiprocessing
 import os
 import signal
+import shlex
 import sys
 import tarfile
 import threading
@@ -80,13 +81,11 @@ class _FakeProc:
 
 
 class _FakeShellRunner:
-    """Stands in for `mship.util.shell.ShellRunner`. `.run()` records every
-    git command issued (command, cwd) and returns a canned `ShellResult`
-    looked up by exact command string (`rev_responses` supports a list per
-    command so successive calls to the SAME command — e.g. a base-freshness
-    probe before and after a fetch — can return different results, modeling
-    origin having moved). `.run_streaming()` returns the canned `_FakeProc`
-    and records what it was invoked with."""
+    """Stands in for `mship.util.shell.ShellRunner`. `.run_argv()` records
+    each git command as display text plus cwd and returns a canned
+    `ShellResult` looked up by that text (`rev_responses` supports successive
+    responses for repeated commands). `.run_streaming()` returns the canned
+    `_FakeProc` and records what it was invoked with."""
 
     def __init__(self, *, streaming_proc=None, rev_responses=None):
         self.run_calls: list[tuple[str, Path]] = []
@@ -107,6 +106,14 @@ class _FakeShellRunner:
         if seq:
             return seq.pop(0) if len(seq) > 1 else seq[0]
         return ShellResult(returncode=0, stdout="", stderr="")
+
+    def run_argv(self, args, cwd, env=None, cancel_event=None):
+        return self.run(
+            shlex.join(args),
+            cwd,
+            env=env,
+            cancel_event=cancel_event,
+        )
 
     def run_streaming(self, command, cwd, env=None):
         self.streaming_calls.append({"command": command, "cwd": Path(cwd), "env": env})
@@ -506,9 +513,9 @@ def test_exec_http_disconnect_cancels_blocked_materialization(
         return proc
 
     class _ObservedShellRunner(shell_module.ShellRunner):
-        def run(self, *args, **kwargs):
+        def run_argv(self, *args, **kwargs):
             try:
-                return super().run(*args, **kwargs)
+                return super().run_argv(*args, **kwargs)
             finally:
                 operation_finished.set()
 
@@ -1487,6 +1494,42 @@ def _host_repo_with_run_ref(tmp_path: Path) -> tuple[Path, str, str]:
     _real_git("reset", "-q", "--hard", tip, cwd=repo)
     assert _real_git("remote", cwd=repo) == ""      # nothing to fetch from
     return repo, tip, scratch
+
+
+def test_materialization_passes_dynamic_values_as_single_argv_elements(tmp_path):
+    class _ArgvOnlyShell:
+        def __init__(self):
+            self.calls = []
+
+        def run(self, *args, **kwargs):
+            pytest.fail("materialization used the string shell boundary")
+
+        def run_argv(self, args, cwd, env=None, cancel_event=None):
+            self.calls.append((list(args), Path(cwd), cancel_event))
+            return ShellResult(returncode=0, stdout="", stderr="")
+
+    shell = _ArgvOnlyShell()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    worktree = tmp_path / "worktree;literal"
+    run_ref = "refs/mship/run/task;literal/api"
+
+    remote_exec.materialize_worktree(
+        shell,
+        repo,
+        worktree,
+        "feat/task",
+        repo_name="api",
+        run_ref=run_ref,
+    )
+
+    assert shell.calls == [
+        (
+            ["git", "worktree", "add", "--detach", str(worktree), run_ref],
+            repo,
+            None,
+        ),
+    ]
 
 
 def test_materialize_from_a_run_ref_creates_a_detached_worktree(tmp_path):

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -972,6 +972,76 @@ def test_run_verb_stream_unknown_repo_among_known_ones_rejects_before_any_task_r
     assert not fake.streaming_calls
 
 
+def test_generator_selects_server_owned_repo_names_preserving_request_order(
+    tmp_path,
+    monkeypatch,
+):
+    config = _config(tmp_path)
+    server_api = next(iter(config.repos))
+    server_web = "".join(["w", "eb"])
+    web_path = tmp_path / "web"
+    web_path.mkdir()
+    config.repos[server_web] = RepoConfig(path=web_path, type="service")
+
+    external_api = (" " + server_api)[1:]
+    external_web = (" " + server_web)[1:]
+    assert external_api == server_api and external_api is not server_api
+    assert external_web == server_web and external_web is not server_web
+
+    materialized_names = []
+    run_ref_names = []
+
+    def observe_materialize(
+        shell,
+        repo_path,
+        worktree_path,
+        branch,
+        *,
+        repo_name,
+        run_ref=None,
+        cancel_event=None,
+    ):
+        materialized_names.append(repo_name)
+
+    def observe_run_ref(task, repo):
+        run_ref_names.append(repo)
+        return f"refs/mship/run/{task}/{repo}"
+
+    monkeypatch.setattr(remote_exec, "materialize_worktree", observe_materialize)
+    monkeypatch.setattr(remote_exec, "build_run_ref", observe_run_ref)
+    fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["ok\n"]),
+    )
+    deps = remote_exec.RemoteExecDeps(
+        config=config,
+        shell=fake,
+        workspace_root=tmp_path,
+    )
+
+    lines = list(remote_exec.run_verb_stream(
+        "run",
+        "t1",
+        [external_web, external_api, external_web],
+        None,
+        deps=deps,
+        nonce="canonicalrepos",
+        run_ref_repos=[external_web, external_api, external_web],
+    ))
+
+    assert lines[-1] == b"__MSHIP_EXIT__:canonicalrepos 0\n"
+    assert len(materialized_names) == 2
+    assert materialized_names[0] is server_web
+    assert materialized_names[1] is server_api
+    assert len(run_ref_names) == 2
+    assert any(name is server_api for name in run_ref_names)
+    assert any(name is server_web for name in run_ref_names)
+    assert [call["cwd"].name for call in fake.streaming_calls] == [
+        server_web,
+        server_api,
+        server_web,
+    ]
+
+
 def test_exec_unknown_repo_in_request_fails_cleanly_not_500(tmp_path, monkeypatch):
     """Through the HTTP layer: an unknown repo name is conveyed as DATA (200
     + an error line + non-zero exit sentinel), exactly like a failing task —
@@ -1189,6 +1259,36 @@ def test_exec_accepts_safe_segment_task_name(tmp_path, monkeypatch):
 
     assert response.status_code == 200
     assert fake.streaming_calls
+
+
+def test_exec_passes_canonical_task_to_execution(tmp_path, monkeypatch):
+    from mship.core import run_ref as run_ref_module
+
+    received_tasks = []
+
+    def canonicalize(task):
+        assert task == "external-task"
+        return "canonical-task"
+
+    def observe_stream(verb, task, repos, platform, *, nonce, **kwargs):
+        received_tasks.append(task)
+        yield f"{remote_exec.EXIT_MARKER}:{nonce} 0\n".encode()
+
+    monkeypatch.setattr(
+        run_ref_module,
+        "canonical_run_ref_segment",
+        canonicalize,
+        raising=False,
+    )
+    monkeypatch.setattr(remote_exec, "run_verb_stream", observe_stream)
+
+    response = TestClient(_app(tmp_path)).post(
+        "/exec/run",
+        json={"task": "external-task", "repos": ["api"]},
+    )
+
+    assert response.status_code == 200
+    assert received_tasks == ["canonical-task"]
 
 
 def test_exec_run_materializes_new_worktree_and_streams_output(tmp_path, monkeypatch):

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
+from starlette.requests import ClientDisconnect
 
 from mship.core import remote_exec
 from mship.core.config import RepoConfig, WorkspaceConfig
@@ -486,6 +487,78 @@ def test_exec_http_disconnect_terminates_quiet_proc_and_releases_task_lock(
     _patch_shell(monkeypatch, fake)
     app = _app(tmp_path)
     _disconnect_exec_request(app, started, terminated, unblock.set)
+    _assert_same_task_replacement(tmp_path)
+
+
+def test_exec_asgi24_send_disconnect_reaps_proc_and_releases_task_lock(
+    tmp_path,
+    monkeypatch,
+):
+    started = threading.Event()
+    terminated = threading.Event()
+    reaped = threading.Event()
+    unblock = threading.Event()
+
+    class _OneLineAliveProc:
+        pid = None
+        stdout = _GatedStdout(
+            ["owned\n", ""],
+            gate=unblock,
+            gate_before=1,
+        )
+        stderr = io.StringIO("")
+
+        def wait(self):
+            unblock.wait(timeout=5)
+            reaped.set()
+            return 0
+
+        def poll(self):
+            return 0 if unblock.is_set() else None
+
+        def terminate(self):
+            terminated.set()
+            unblock.set()
+
+    class _SignalingShellRunner(_FakeShellRunner):
+        def run_streaming(self, command, cwd, env=None):
+            proc = super().run_streaming(command, cwd, env=env)
+            started.set()
+            return proc
+
+    fake = _SignalingShellRunner(streaming_proc=_OneLineAliveProc())
+    _patch_shell(monkeypatch, fake)
+    app = _app(tmp_path)
+    scope = _exec_asgi_scope()
+    scope["asgi"] = {"version": "3.0", "spec_version": "2.4"}
+    receive_calls = 0
+
+    async def receive():
+        nonlocal receive_calls
+        receive_calls += 1
+        if receive_calls == 1:
+            return {
+                "type": "http.request",
+                "body": b'{"task":"t1","repos":["api"]}',
+                "more_body": False,
+            }
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    async def send(message):
+        if message["type"] == "http.response.body" and message["body"]:
+            assert started.is_set()
+            raise OSError("client disconnected")
+
+    try:
+        with pytest.raises(ClientDisconnect):
+            asyncio.run(app(scope, receive, send))
+    finally:
+        unblock.set()
+
+    assert terminated.is_set()
+    assert reaped.is_set()
+    assert receive_calls == 1
     _assert_same_task_replacement(tmp_path)
 
 

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -954,6 +954,105 @@ def test_concurrent_process_contends_for_same_task_lock(tmp_path):
     assert proc.exitcode == 0
 
 
+
+def _make_linux_proc_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setattr(shell_module.os, "name", "posix")
+    monkeypatch.setattr(shell_module.sys, "platform", "linux")
+    monkeypatch.setattr(
+        shell_module,
+        "_PROC_ROOT",
+        tmp_path / "unavailable-proc",
+        raising=False,
+    )
+
+
+def test_cancellable_remote_preflight_fails_before_lock_or_shell_work(
+    tmp_path,
+    monkeypatch,
+):
+    _make_linux_proc_unavailable(tmp_path, monkeypatch)
+    fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["must not run\n"]),
+    )
+    deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path),
+        shell=fake,
+        workspace_root=tmp_path,
+        cancel_event=threading.Event(),
+    )
+
+    lines = list(remote_exec.run_verb_stream(
+        "run",
+        "t1",
+        ["api"],
+        None,
+        deps=deps,
+        nonce="unsupportednonce",
+    ))
+
+    assert b"remote execution unavailable" in lines[0]
+    assert b"process-status" in lines[0]
+    assert lines[-1] == b"__MSHIP_EXIT__:unsupportednonce 1\n"
+    assert not (tmp_path / ".mothership" / "remote-exec-locks").exists()
+    assert not fake.run_calls
+    assert not fake.streaming_calls
+
+
+def test_exec_cancellable_preflight_failure_is_framed_before_work(
+    tmp_path,
+    monkeypatch,
+):
+    _make_linux_proc_unavailable(tmp_path, monkeypatch)
+    fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["must not run\n"]),
+    )
+    _patch_shell(monkeypatch, fake)
+
+    response = TestClient(_app(tmp_path)).post(
+        "/exec/run",
+        json={"task": "t1", "repos": ["api"]},
+    )
+
+    nonce = _nonce_of(response)
+    lines = response.content.splitlines()
+    assert response.status_code == 200
+    assert b"remote execution unavailable" in lines[0]
+    assert b"process-status" in lines[0]
+    assert lines[-1] == _exit_line(nonce, 1).encode()
+    assert not (tmp_path / ".mothership" / "remote-exec-locks").exists()
+    assert not fake.run_calls
+    assert not fake.streaming_calls
+
+
+def test_direct_remote_without_cancellation_does_not_require_linux_proc(
+    tmp_path,
+    monkeypatch,
+):
+    _make_linux_proc_unavailable(tmp_path, monkeypatch)
+    fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["ran\n"]),
+    )
+    deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path),
+        shell=fake,
+        workspace_root=tmp_path,
+    )
+
+    lines = list(remote_exec.run_verb_stream(
+        "run",
+        "t1",
+        ["api"],
+        None,
+        deps=deps,
+        nonce="directnonce",
+    ))
+
+    assert lines[-2:] == [
+        b"ran\n",
+        b"__MSHIP_EXIT__:directnonce 0\n",
+    ]
+    assert fake.streaming_calls
+
 def test_task_lock_failure_to_create_directory_fails_closed(tmp_path):
     (tmp_path / ".mothership").write_text("not a directory")
     fake = _FakeShellRunner(

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -328,6 +328,34 @@ def test_run_verb_stream_client_disconnect_cleans_up_tempdir_and_proc(tmp_path):
     assert not capture_dir.exists(), "the capture temp dir must be removed on disconnect"
 
 
+def test_exec_response_does_not_require_create_collapsing_task_group(
+    tmp_path,
+    monkeypatch,
+):
+    from starlette import _utils as starlette_utils
+
+    monkeypatch.delattr(
+        starlette_utils,
+        "create_collapsing_task_group",
+    )
+    fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["ok\n"]),
+    )
+    _patch_shell(monkeypatch, fake)
+
+    response = TestClient(_app(tmp_path)).post(
+        "/exec/run",
+        json={"task": "t1", "repos": ["api"]},
+    )
+
+    assert response.status_code == 200
+    nonce = _nonce_of(response)
+    lines, artifacts, exit_line = _parse_exec_stream(response.content, nonce)
+    assert lines == ["ok"]
+    assert artifacts is None
+    assert exit_line == _exit_line(nonce, 0)
+
+
 def test_exec_http_disconnect_terminates_quiet_proc_and_releases_task_lock(
     tmp_path,
     monkeypatch,

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -19,6 +19,7 @@ import fcntl
 import hashlib
 import io
 import multiprocessing
+import sys
 import tarfile
 import threading
 from pathlib import Path
@@ -30,6 +31,7 @@ from mship.core import remote_exec
 from mship.core.config import RepoConfig, WorkspaceConfig
 from mship.core.serve import ExecBody, create_app
 from mship.core.state import StateManager
+from mship.util import shell as shell_module
 from mship.util.shell import ShellResult
 
 
@@ -86,7 +88,9 @@ class _FakeShellRunner:
     def __init__(self, *, streaming_proc=None, rev_responses=None):
         self.run_calls: list[tuple[str, Path]] = []
         self.streaming_calls: list[dict] = []
-        self._rev_responses = {k: list(v) for k, v in (rev_responses or {}).items()}
+        self._rev_responses = {
+            k: list(v) for k, v in (rev_responses or {}).items()
+        }
         self._streaming_proc = streaming_proc
 
     def build_command(self, command, env_runner=None):
@@ -94,7 +98,7 @@ class _FakeShellRunner:
             return f"{env_runner} {command}"
         return command
 
-    def run(self, command, cwd, env=None):
+    def run(self, command, cwd, env=None, cancel_event=None):
         self.run_calls.append((command, Path(cwd)))
         seq = self._rev_responses.get(command)
         if seq:
@@ -240,6 +244,79 @@ def _assert_task_lock_failure(
     assert lines[-1] == f"{remote_exec.EXIT_MARKER}:{nonce} 1\n".encode()
     assert not fake.run_calls
     assert not fake.streaming_calls
+
+
+def _exec_asgi_scope() -> dict:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/exec/run",
+        "raw_path": b"/exec/run",
+        "query_string": b"",
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+
+
+def _disconnect_exec_request(app, started, stopped, cleanup) -> list[dict]:
+    response_messages: list[dict] = []
+    request_sent = False
+
+    async def receive():
+        nonlocal request_sent
+        if not request_sent:
+            request_sent = True
+            return {
+                "type": "http.request",
+                "body": b'{"task":"t1","repos":["api"]}',
+                "more_body": False,
+            }
+        assert await asyncio.to_thread(started.wait, 10)
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        response_messages.append(message)
+
+    async def disconnect_request() -> bool:
+        app_task = asyncio.create_task(
+            app(_exec_asgi_scope(), receive, send),
+        )
+        stopped_by_disconnect = False
+        try:
+            assert await asyncio.to_thread(started.wait, 10)
+            stopped_by_disconnect = await asyncio.to_thread(stopped.wait, 1)
+        finally:
+            if not stopped_by_disconnect:
+                cleanup()
+            await asyncio.wait_for(app_task, timeout=10)
+        return stopped_by_disconnect
+
+    assert asyncio.run(disconnect_request())
+    assert response_messages[0]["type"] == "http.response.start"
+    return response_messages
+
+
+def _assert_same_task_replacement(workspace_root: Path) -> None:
+    replacement_fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["replacement\n"]),
+    )
+    replacement_deps = remote_exec.RemoteExecDeps(
+        config=_config(workspace_root),
+        shell=replacement_fake,
+        workspace_root=workspace_root,
+    )
+    assert list(remote_exec.run_verb_stream(
+        "run", "t1", ["api"], None,
+        deps=replacement_deps, nonce="replacementnonce",
+    ))[-2:] == [
+        b"replacement\n",
+        b"__MSHIP_EXIT__:replacementnonce 0\n",
+    ]
 
 
 def _parse_exec_stream(content: bytes, nonce: str):
@@ -398,67 +475,97 @@ def test_exec_http_disconnect_terminates_quiet_proc_and_releases_task_lock(
     fake = _SignalingShellRunner(streaming_proc=_QuietProc())
     _patch_shell(monkeypatch, fake)
     app = _app(tmp_path)
-    response_messages = []
-    request_sent = False
+    _disconnect_exec_request(app, started, terminated, unblock.set)
+    _assert_same_task_replacement(tmp_path)
 
-    async def receive():
-        nonlocal request_sent
-        if not request_sent:
-            request_sent = True
-            return {
-                "type": "http.request",
-                "body": b'{"task":"t1","repos":["api"]}',
-                "more_body": False,
-            }
-        assert await asyncio.to_thread(started.wait, 10)
-        return {"type": "http.disconnect"}
 
-    async def send(message):
-        response_messages.append(message)
+def test_exec_http_disconnect_cancels_blocked_materialization(
+    tmp_path,
+    monkeypatch,
+):
+    started = threading.Event()
+    operation_finished = threading.Event()
+    processes = []
+    real_popen = shell_module.subprocess.Popen
 
-    scope = {
-        "type": "http",
-        "asgi": {"version": "3.0", "spec_version": "2.3"},
-        "http_version": "1.1",
-        "method": "POST",
-        "scheme": "http",
-        "path": "/exec/run",
-        "raw_path": b"/exec/run",
-        "query_string": b"",
-        "headers": [(b"content-type", b"application/json")],
-        "client": ("127.0.0.1", 12345),
-        "server": ("testserver", 80),
-        "root_path": "",
-    }
+    def blocking_popen(_command, **kwargs):
+        proc = real_popen(
+            [sys.executable, "-c", "import signal; signal.pause()"],
+            cwd=kwargs.get("cwd"),
+            stdout=kwargs.get("stdout"),
+            stderr=kwargs.get("stderr"),
+            text=kwargs.get("text"),
+            env=kwargs.get("env"),
+            start_new_session=True,
+        )
+        processes.append(proc)
+        started.set()
+        return proc
 
-    async def disconnect_request() -> bool:
-        app_task = asyncio.create_task(app(scope, receive, send))
-        stopped = False
-        try:
-            assert await asyncio.to_thread(started.wait, 10)
-            stopped = await asyncio.to_thread(terminated.wait, 1)
-        finally:
-            if not stopped:
-                unblock.set()
-            await asyncio.wait_for(app_task, timeout=10)
-        return stopped
+    class _ObservedShellRunner(shell_module.ShellRunner):
+        def run(self, *args, **kwargs):
+            try:
+                return super().run(*args, **kwargs)
+            finally:
+                operation_finished.set()
 
-    assert asyncio.run(disconnect_request())
-    assert response_messages[0]["type"] == "http.response.start"
-
-    replacement_fake = _FakeShellRunner(
-        streaming_proc=_FakeProc(stdout_lines=["replacement\n"]),
+    monkeypatch.setattr(shell_module.subprocess, "Popen", blocking_popen)
+    monkeypatch.setattr(
+        "mship.core.serve.ShellRunner",
+        lambda: _ObservedShellRunner(),
     )
-    replacement_deps = remote_exec.RemoteExecDeps(
-        config=_config(tmp_path), shell=replacement_fake, workspace_root=tmp_path,
+    app = _app(tmp_path)
+
+    _disconnect_exec_request(
+        app,
+        started,
+        operation_finished,
+        lambda: processes[0].terminate(),
     )
-    assert list(remote_exec.run_verb_stream(
-        "run", "t1", ["api"], None,
-        deps=replacement_deps, nonce="replacementnonce",
-    ))[-2:] == [
-        b"replacement\n",
-        b"__MSHIP_EXIT__:replacementnonce 0\n",
-    ]
+
+    assert processes[0].returncode is not None
+    _assert_same_task_replacement(tmp_path)
+
+
+def test_exec_http_disconnect_terminates_proc_after_pipe_eof(
+    tmp_path,
+    monkeypatch,
+):
+    started = threading.Event()
+    terminated = threading.Event()
+    reaped = threading.Event()
+    unblock = threading.Event()
+
+    class _EofAliveProc:
+        pid = None
+        stdout = io.StringIO("")
+        stderr = io.StringIO("")
+
+        def wait(self):
+            unblock.wait(timeout=5)
+            reaped.set()
+            return 0
+
+        def poll(self):
+            return 0 if unblock.is_set() else None
+
+        def terminate(self):
+            terminated.set()
+            unblock.set()
+
+    class _SignalingShellRunner(_FakeShellRunner):
+        def run_streaming(self, command, cwd, env=None):
+            proc = super().run_streaming(command, cwd, env=env)
+            started.set()
+            return proc
+
+    fake = _SignalingShellRunner(streaming_proc=_EofAliveProc())
+    _patch_shell(monkeypatch, fake)
+    app = _app(tmp_path)
+
+    _disconnect_exec_request(app, started, terminated, unblock.set)
+    assert reaped.is_set()
+    _assert_same_task_replacement(tmp_path)
 
 
 def test_concurrent_same_task_is_refused_while_different_task_runs(tmp_path):
@@ -733,7 +840,7 @@ def test_run_verb_stream_materialize_failure_surfaces_repo_and_stops(tmp_path, m
     the repo, via the same data-conveyed error-line + non-zero-exit pattern."""
     fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["should not run\n"], returncode=0))
 
-    def _failing_run(command, cwd, env=None):
+    def _failing_run(command, cwd, env=None, cancel_event=None):
         fake.run_calls.append((command, Path(cwd)))
         if command.startswith("git worktree add"):
             return ShellResult(returncode=128, stdout="", stderr="fatal: could not create worktree")
@@ -833,7 +940,7 @@ def test_run_verb_stream_git_root_child_parent_materialize_failure_stops_cleanly
     task runs."""
     fake = _FakeShellRunner(streaming_proc=_FakeProc(stdout_lines=["should not run\n"], returncode=0))
 
-    def _failing_run(command, cwd, env=None):
+    def _failing_run(command, cwd, env=None, cancel_event=None):
         fake.run_calls.append((command, Path(cwd)))
         if command.startswith("git worktree add"):
             return ShellResult(returncode=128, stdout="", stderr="fatal: could not create worktree")
@@ -1723,8 +1830,13 @@ class _MaterializingShellRunner(_FakeShellRunner):
     way to pin that ordering.
     """
 
-    def run(self, command, cwd, env=None):
-        result = super().run(command, cwd, env=env)
+    def run(self, command, cwd, env=None, cancel_event=None):
+        result = super().run(
+            command,
+            cwd,
+            env=env,
+            cancel_event=cancel_event,
+        )
         if command.startswith("git worktree add"):
             # `git worktree add -B <branch> <worktree_path> origin/<branch>`
             worktree_path = Path(command.split()[5])

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -20,7 +20,6 @@ import hashlib
 import io
 import multiprocessing
 import os
-import select
 import signal
 import sys
 import tarfile
@@ -572,7 +571,10 @@ def test_exec_http_disconnect_terminates_proc_after_pipe_eof(
     _assert_same_task_replacement(tmp_path)
 
 
-@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group contract")
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux /proc process-state contract",
+)
 def test_cancelled_stream_kills_descendant_before_task_lock_release(
     tmp_path,
     monkeypatch,
@@ -657,7 +659,7 @@ while True:
 
     descendant_pid = int(ready_path.read_text())
     process_group = os.getpgid(descendant_pid)
-    pid_fd = os.pidfd_open(descendant_pid) if hasattr(os, "pidfd_open") else None
+    proc_stat = Path(f"/proc/{descendant_pid}/stat")
     assert process_group == processes[0].pid
     try:
         cancel_event.set()
@@ -666,27 +668,16 @@ while True:
         assert not errors
         assert (process_group, signal.SIGKILL) in signals
 
-        if pid_fd is not None:
-            readable, _, _ = select.select([pid_fd], [], [], 2)
-            assert readable, "descendant survived public task-lock release"
-        else:
-            deadline = time.monotonic() + 2
-            while time.monotonic() < deadline:
-                proc_stat = Path(f"/proc/{descendant_pid}/stat")
-                try:
-                    if proc_stat.exists() and proc_stat.read_text().split()[2] == "Z":
-                        break
-                    os.kill(descendant_pid, 0)
-                except ProcessLookupError:
-                    break
-                threading.Event().wait(0.01)
-            else:
-                pytest.fail("descendant survived public task-lock release")
-
+        try:
+            descendant_state = proc_stat.read_text().split()[2]
+        except FileNotFoundError:
+            descendant_state = None
+        assert descendant_state in {None, "X", "Z"}, (
+            "descendant was executable when the public task lock was released: "
+            f"{descendant_state}"
+        )
         _assert_same_task_replacement(tmp_path)
     finally:
-        if pid_fd is not None:
-            os.close(pid_fd)
         try:
             os.killpg(process_group, signal.SIGKILL)
         except ProcessLookupError:

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -990,8 +990,10 @@ def test_cancellable_remote_preflight_fails_before_lock_or_shell_work(
         nonce="unsupportednonce",
     ))
 
-    assert b"remote execution unavailable" in lines[0]
-    assert b"process-status" in lines[0]
+    assert lines[0] == (
+        b"error: remote execution unavailable; execution was not started\n"
+    )
+    assert b"unavailable-proc" not in b"".join(lines)
     assert lines[-1] == b"__MSHIP_EXIT__:unsupportednonce 1\n"
     assert not (tmp_path / ".mothership" / "remote-exec-locks").exists()
     assert not fake.run_calls
@@ -1016,9 +1018,71 @@ def test_exec_cancellable_preflight_failure_is_framed_before_work(
     nonce = _nonce_of(response)
     lines = response.content.splitlines()
     assert response.status_code == 200
-    assert b"remote execution unavailable" in lines[0]
-    assert b"process-status" in lines[0]
+    assert lines[0] == (
+        b"error: remote execution unavailable; execution was not started"
+    )
+    assert b"unavailable-proc" not in response.content
     assert lines[-1] == _exit_line(nonce, 1).encode()
+    assert not (tmp_path / ".mothership" / "remote-exec-locks").exists()
+    assert not fake.run_calls
+    assert not fake.streaming_calls
+
+
+def test_cancellation_infrastructure_detail_is_redacted_from_direct_and_http(
+    tmp_path,
+    monkeypatch,
+):
+    sensitive = "/secret/process-status/unique-marker"
+
+    def reject_cancellation():
+        raise remote_exec.ShellCancellationUnsupported(sensitive)
+
+    monkeypatch.setattr(
+        remote_exec,
+        "ensure_cancellable_shell_supported",
+        reject_cancellation,
+    )
+    fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["must not run\n"]),
+    )
+    deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path),
+        shell=fake,
+        workspace_root=tmp_path,
+        cancel_event=threading.Event(),
+    )
+    expected_error = (
+        b"error: remote execution unavailable; execution was not started\n"
+    )
+
+    direct = list(remote_exec.run_verb_stream(
+        "run",
+        "t1",
+        ["api"],
+        None,
+        deps=deps,
+        nonce="redactednonce",
+    ))
+
+    assert direct == [
+        expected_error,
+        b"__MSHIP_EXIT__:redactednonce 1\n",
+    ]
+    assert sensitive.encode() not in b"".join(direct)
+
+    _patch_shell(monkeypatch, fake)
+    response = TestClient(_app(tmp_path)).post(
+        "/exec/run",
+        json={"task": "t1", "repos": ["api"]},
+    )
+    nonce = _nonce_of(response)
+
+    assert response.status_code == 200
+    assert response.content.splitlines() == [
+        expected_error.rstrip(b"\n"),
+        _exit_line(nonce, 1).encode(),
+    ]
+    assert sensitive.encode() not in response.content
     assert not (tmp_path / ".mothership" / "remote-exec-locks").exists()
     assert not fake.run_calls
     assert not fake.streaming_calls

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -274,7 +274,14 @@ def _exec_asgi_scope() -> dict:
     }
 
 
-def _disconnect_exec_request(app, started, stopped, cleanup) -> list[dict]:
+def _disconnect_exec_request(
+    app,
+    started,
+    stopped,
+    cleanup,
+    *,
+    spec_version: str = "2.3",
+) -> list[dict]:
     response_messages: list[dict] = []
     request_sent = False
 
@@ -288,15 +295,18 @@ def _disconnect_exec_request(app, started, stopped, cleanup) -> list[dict]:
                 "more_body": False,
             }
         assert await asyncio.to_thread(started.wait, 10)
+        assert [message["type"] for message in response_messages] == [
+            "http.response.start",
+        ]
         return {"type": "http.disconnect"}
 
     async def send(message):
         response_messages.append(message)
 
     async def disconnect_request() -> bool:
-        app_task = asyncio.create_task(
-            app(_exec_asgi_scope(), receive, send),
-        )
+        scope = _exec_asgi_scope()
+        scope["asgi"]["spec_version"] = spec_version
+        app_task = asyncio.create_task(app(scope, receive, send))
         stopped_by_disconnect = False
         try:
             assert await asyncio.to_thread(started.wait, 10)
@@ -490,6 +500,67 @@ def test_exec_http_disconnect_terminates_quiet_proc_and_releases_task_lock(
     _assert_same_task_replacement(tmp_path)
 
 
+def test_exec_asgi24_idle_disconnect_reaps_proc_and_releases_task_lock(
+    tmp_path,
+    monkeypatch,
+):
+    started = threading.Event()
+    terminated = threading.Event()
+    reaped = threading.Event()
+    unblock = threading.Event()
+
+    class _BlockingStream:
+        def readline(self):
+            unblock.wait(timeout=5)
+            return ""
+
+        def close(self):
+            pass
+
+    class _QuietProc:
+        pid = None
+        stdout = _BlockingStream()
+        stderr = _BlockingStream()
+
+        def wait(self):
+            unblock.wait(timeout=5)
+            reaped.set()
+            return 0
+
+        def poll(self):
+            return 0 if unblock.is_set() else None
+
+        def terminate(self):
+            terminated.set()
+            unblock.set()
+
+    class _SignalingShellRunner(_FakeShellRunner):
+        def run_streaming(self, command, cwd, env=None):
+            proc = super().run_streaming(command, cwd, env=env)
+            started.set()
+            return proc
+
+    fake = _SignalingShellRunner(streaming_proc=_QuietProc())
+    _patch_shell(monkeypatch, fake)
+    app = _app(tmp_path)
+
+    messages = _disconnect_exec_request(
+        app,
+        started,
+        terminated,
+        unblock.set,
+        spec_version="2.4",
+    )
+
+    assert reaped.is_set()
+    assert all(
+        not message.get("body")
+        for message in messages
+        if message["type"] == "http.response.body"
+    )
+    _assert_same_task_replacement(tmp_path)
+
+
 def test_exec_asgi24_send_disconnect_reaps_proc_and_releases_task_lock(
     tmp_path,
     monkeypatch,
@@ -558,7 +629,7 @@ def test_exec_asgi24_send_disconnect_reaps_proc_and_releases_task_lock(
 
     assert terminated.is_set()
     assert reaped.is_set()
-    assert receive_calls == 1
+    assert receive_calls == 2
     _assert_same_task_replacement(tmp_path)
 
 

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -13,11 +13,15 @@ Two layers are covered:
 """
 from __future__ import annotations
 
+import fcntl
+import hashlib
 import io
+import multiprocessing
 import tarfile
 import threading
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from mship.core import remote_exec
@@ -190,6 +194,52 @@ def _exit_line(nonce: str, code: int) -> str:
     return f"{remote_exec.EXIT_MARKER}:{nonce} {code}"
 
 
+def _hold_remote_exec_stream(
+    workspace_root: str,
+    ready,
+    release,
+) -> None:
+    root = Path(workspace_root)
+    fake = _FakeShellRunner()
+    deps = remote_exec.RemoteExecDeps(
+        config=_config(root), shell=fake, workspace_root=root,
+    )
+    stream = remote_exec.run_verb_stream(
+        "run", "t1", ["unknown"], None, deps=deps, nonce="processholder",
+    )
+    try:
+        first = next(stream)
+        if b"unknown repo" not in first:
+            raise AssertionError(first)
+        ready.set()
+        if not release.wait(timeout=10):
+            raise TimeoutError("parent did not release the held remote execution stream")
+    finally:
+        stream.close()
+
+
+def _task_lock_path(workspace_root: Path, task: str) -> Path:
+    digest = hashlib.sha256(task.encode("utf-8")).hexdigest()
+    return workspace_root / ".mothership" / "remote-exec-locks" / f"{digest}.lock"
+
+
+def _assert_task_lock_failure(
+    workspace_root: Path,
+    fake: _FakeShellRunner,
+    nonce: str,
+) -> None:
+    deps = remote_exec.RemoteExecDeps(
+        config=_config(workspace_root), shell=fake, workspace_root=workspace_root,
+    )
+    lines = list(remote_exec.run_verb_stream(
+        "run", "t1", ["api"], None, deps=deps, nonce=nonce,
+    ))
+    assert b"remote-task locking" in lines[0]
+    assert lines[-1] == f"{remote_exec.EXIT_MARKER}:{nonce} 1\n".encode()
+    assert not fake.run_calls
+    assert not fake.streaming_calls
+
+
 def _parse_exec_stream(content: bytes, nonce: str):
     """Mirror the client-side parse of the `/exec/{verb}` wire framing: text
     lines, optionally one `__MSHIP_ARTIFACTS__:<nonce> <n>` marker followed by
@@ -274,6 +324,187 @@ def test_run_verb_stream_client_disconnect_cleans_up_tempdir_and_proc(tmp_path):
 
     assert proc.terminated, "the running task subprocess must be terminated on disconnect"
     assert not capture_dir.exists(), "the capture temp dir must be removed on disconnect"
+
+
+def test_concurrent_same_task_is_refused_while_different_task_runs(tmp_path):
+    gate = threading.Event()
+    first_fake = _FakeShellRunner(streaming_proc=_FakeProc(
+        stdout_lines=["first\n", "second\n"], gate=gate, gate_before=1,
+    ))
+    first_deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path), shell=first_fake, workspace_root=tmp_path,
+    )
+    first = remote_exec.run_verb_stream(
+        "run", "t1", ["api"], None, deps=first_deps, nonce="firstnonce",
+    )
+    assert next(first) == b"first\n"
+
+    different_fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["different\n"]),
+    )
+    different_deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path), shell=different_fake, workspace_root=tmp_path,
+    )
+    assert list(remote_exec.run_verb_stream(
+        "run", "t2", ["api"], None, deps=different_deps, nonce="differentnonce",
+    )) == [
+        b"different\n",
+        b"__MSHIP_EXIT__:differentnonce 0\n",
+    ]
+
+    contender_fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["must not run\n"]),
+    )
+    contender_deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path), shell=contender_fake, workspace_root=tmp_path,
+    )
+    contender = list(remote_exec.run_verb_stream(
+        "run", "t1", ["api"], None,
+        deps=contender_deps, nonce="contendernonce",
+    ))
+    assert contender == [
+        b"error: remote task 't1' is already running; try again after it finishes\n",
+        b"__MSHIP_EXIT__:contendernonce 2\n",
+    ]
+    assert not contender_fake.run_calls
+    assert not contender_fake.streaming_calls
+
+    first.close()
+    assert _task_lock_path(tmp_path, "t1").is_file()
+
+    replacement_fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["replacement\n"]),
+    )
+    replacement_deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path), shell=replacement_fake, workspace_root=tmp_path,
+    )
+    assert list(remote_exec.run_verb_stream(
+        "run", "t1", ["api"], None,
+        deps=replacement_deps, nonce="replacementnonce",
+    ))[-2:] == [
+        b"replacement\n",
+        b"__MSHIP_EXIT__:replacementnonce 0\n",
+    ]
+
+
+@pytest.mark.parametrize("returncode", [0, 7])
+def test_task_lock_releases_after_stream_exhaustion(tmp_path, returncode):
+    first_fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["finished\n"], returncode=returncode),
+    )
+    first_deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path), shell=first_fake, workspace_root=tmp_path,
+    )
+    assert list(remote_exec.run_verb_stream(
+        "run", "t1", ["api"], None, deps=first_deps, nonce="firstnonce",
+    ))[-1] == f"__MSHIP_EXIT__:firstnonce {returncode}\n".encode()
+    assert _task_lock_path(tmp_path, "t1").is_file()
+
+    next_fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["next\n"]),
+    )
+    next_deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path), shell=next_fake, workspace_root=tmp_path,
+    )
+    assert list(remote_exec.run_verb_stream(
+        "run", "t1", ["api"], None, deps=next_deps, nonce="nextnonce",
+    ))[-2:] == [
+        b"next\n",
+        b"__MSHIP_EXIT__:nextnonce 0\n",
+    ]
+
+
+def test_task_lock_releases_when_execution_raises(tmp_path):
+    class _RaisingShellRunner(_FakeShellRunner):
+        def run_streaming(self, command, cwd, env=None):
+            self.streaming_calls.append(
+                {"command": command, "cwd": Path(cwd), "env": env},
+            )
+            raise RuntimeError("streaming exploded")
+
+    failing_deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path),
+        shell=_RaisingShellRunner(),
+        workspace_root=tmp_path,
+    )
+    with pytest.raises(RuntimeError, match="streaming exploded"):
+        list(remote_exec.run_verb_stream(
+            "run", "t1", ["api"], None, deps=failing_deps, nonce="failingnonce",
+        ))
+    assert _task_lock_path(tmp_path, "t1").is_file()
+
+    next_fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["recovered\n"]),
+    )
+    next_deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path), shell=next_fake, workspace_root=tmp_path,
+    )
+    assert list(remote_exec.run_verb_stream(
+        "run", "t1", ["api"], None, deps=next_deps, nonce="nextnonce",
+    ))[-2:] == [
+        b"recovered\n",
+        b"__MSHIP_EXIT__:nextnonce 0\n",
+    ]
+
+
+def test_concurrent_process_contends_for_same_task_lock(tmp_path):
+    ctx = multiprocessing.get_context("spawn")
+    ready = ctx.Event()
+    release = ctx.Event()
+    proc = ctx.Process(
+        target=_hold_remote_exec_stream,
+        args=(str(tmp_path), ready, release),
+    )
+    proc.start()
+    try:
+        assert ready.wait(timeout=10)
+        fake = _FakeShellRunner()
+        deps = remote_exec.RemoteExecDeps(
+            config=_config(tmp_path), shell=fake, workspace_root=tmp_path,
+        )
+        contender = list(remote_exec.run_verb_stream(
+            "run", "t1", ["unknown"], None,
+            deps=deps, nonce="processcontender",
+        ))
+        assert contender == [
+            b"error: remote task 't1' is already running; try again after it finishes\n",
+            b"__MSHIP_EXIT__:processcontender 2\n",
+        ]
+    finally:
+        release.set()
+        proc.join(timeout=10)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=10)
+    assert proc.exitcode == 0
+
+
+def test_task_lock_failure_to_create_directory_fails_closed(tmp_path):
+    (tmp_path / ".mothership").write_text("not a directory")
+    fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["must not run\n"]),
+    )
+    _assert_task_lock_failure(tmp_path, fake, "mkdirnonce")
+
+
+def test_task_lock_failure_to_open_file_fails_closed(tmp_path):
+    lock_file = _task_lock_path(tmp_path, "t1")
+    lock_file.mkdir(parents=True)
+    fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["must not run\n"]),
+    )
+    _assert_task_lock_failure(tmp_path, fake, "opennonce")
+
+
+def test_task_lock_failure_to_flock_fails_closed(tmp_path, monkeypatch):
+    def fail_flock(_fd, _operation):
+        raise OSError("injected lock failure")
+
+    monkeypatch.setattr(fcntl, "flock", fail_flock)
+    fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["must not run\n"]),
+    )
+    _assert_task_lock_failure(tmp_path, fake, "flocknonce")
 
 
 def test_run_verb_stream_unknown_verb_raises(tmp_path):

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -19,9 +19,13 @@ import fcntl
 import hashlib
 import io
 import multiprocessing
+import os
+import select
+import signal
 import sys
 import tarfile
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -289,7 +293,7 @@ def _disconnect_exec_request(app, started, stopped, cleanup) -> list[dict]:
         stopped_by_disconnect = False
         try:
             assert await asyncio.to_thread(started.wait, 10)
-            stopped_by_disconnect = await asyncio.to_thread(stopped.wait, 1)
+            stopped_by_disconnect = await asyncio.to_thread(stopped.wait, 5)
         finally:
             if not stopped_by_disconnect:
                 cleanup()
@@ -566,6 +570,164 @@ def test_exec_http_disconnect_terminates_proc_after_pipe_eof(
     _disconnect_exec_request(app, started, terminated, unblock.set)
     assert reaped.is_set()
     _assert_same_task_replacement(tmp_path)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group contract")
+def test_cancelled_stream_kills_descendant_before_task_lock_release(
+    tmp_path,
+    monkeypatch,
+):
+    ready_path = tmp_path / "stream-descendant-ready"
+    child_code = """
+import os
+import signal
+import sys
+from pathlib import Path
+
+read_fd, write_fd = os.pipe()
+child_pid = os.fork()
+if child_pid == 0:
+    os.close(read_fd)
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    os.close(1)
+    os.close(2)
+    os.write(write_fd, b"ready")
+    os.close(write_fd)
+    while True:
+        signal.pause()
+
+os.close(write_fd)
+os.read(read_fd, 5)
+os.close(read_fd)
+Path(sys.argv[1]).write_text(str(child_pid))
+while True:
+    signal.pause()
+"""
+    processes = []
+
+    class _ProcessTreeShellRunner(_FakeShellRunner):
+        def run_streaming(self, command, cwd, env=None):
+            proc = shell_module.subprocess.Popen(
+                [sys.executable, "-c", child_code, str(ready_path)],
+                cwd=tmp_path,
+                stdout=shell_module.subprocess.PIPE,
+                stderr=shell_module.subprocess.PIPE,
+                text=True,
+                start_new_session=True,
+            )
+            processes.append(proc)
+            return proc
+    signals: list[tuple[int, int]] = []
+    real_killpg = os.killpg
+
+    def observed_killpg(process_group, signum):
+        signals.append((process_group, signum))
+        return real_killpg(process_group, signum)
+
+    monkeypatch.setattr(shell_module.os, "killpg", observed_killpg)
+
+    cancel_event = threading.Event()
+    deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path),
+        shell=_ProcessTreeShellRunner(),
+        workspace_root=tmp_path,
+        cancel_event=cancel_event,
+    )
+    errors: list[BaseException] = []
+
+    def consume_stream() -> None:
+        try:
+            list(remote_exec.run_verb_stream(
+                "run",
+                "t1",
+                ["api"],
+                None,
+                deps=deps,
+                nonce="descendantnonce",
+            ))
+        except BaseException as exc:
+            errors.append(exc)
+
+    stream_thread = threading.Thread(target=consume_stream, daemon=True)
+    stream_thread.start()
+    deadline = time.monotonic() + 5
+    while not ready_path.exists() and time.monotonic() < deadline:
+        threading.Event().wait(0.01)
+    assert ready_path.exists(), "descendant did not report readiness"
+
+    descendant_pid = int(ready_path.read_text())
+    process_group = os.getpgid(descendant_pid)
+    pid_fd = os.pidfd_open(descendant_pid) if hasattr(os, "pidfd_open") else None
+    assert process_group == processes[0].pid
+    try:
+        cancel_event.set()
+        stream_thread.join(timeout=5)
+        assert not stream_thread.is_alive(), "cancelled stream did not return"
+        assert not errors
+        assert (process_group, signal.SIGKILL) in signals
+
+        if pid_fd is not None:
+            readable, _, _ = select.select([pid_fd], [], [], 2)
+            assert readable, "descendant survived public task-lock release"
+        else:
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                proc_stat = Path(f"/proc/{descendant_pid}/stat")
+                try:
+                    if proc_stat.exists() and proc_stat.read_text().split()[2] == "Z":
+                        break
+                    os.kill(descendant_pid, 0)
+                except ProcessLookupError:
+                    break
+                threading.Event().wait(0.01)
+            else:
+                pytest.fail("descendant survived public task-lock release")
+
+        _assert_same_task_replacement(tmp_path)
+    finally:
+        if pid_fd is not None:
+            os.close(pid_fd)
+        try:
+            os.killpg(process_group, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+def test_normal_stream_does_not_signal_reaped_process_group(
+    tmp_path,
+    monkeypatch,
+):
+    signals = []
+
+    def record_killpg(process_group, signum):
+        signals.append((process_group, signum))
+
+    monkeypatch.setattr(shell_module.os, "killpg", record_killpg)
+
+    class _CompletedProc(_FakeProc):
+        pid = 424242
+
+        def poll(self):
+            return 0
+
+    fake = _FakeShellRunner(
+        streaming_proc=_CompletedProc(stdout_lines=["done\n"]),
+    )
+    deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path),
+        shell=fake,
+        workspace_root=tmp_path,
+    )
+
+    assert list(remote_exec.run_verb_stream(
+        "run",
+        "t1",
+        ["api"],
+        None,
+        deps=deps,
+        nonce="normalnonce",
+    ))[-1] == b"__MSHIP_EXIT__:normalnonce 0\n"
+    assert not signals
 
 
 def test_concurrent_same_task_is_refused_while_different_task_runs(tmp_path):

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -1053,6 +1053,65 @@ def test_direct_remote_without_cancellation_does_not_require_linux_proc(
     ]
     assert fake.streaming_calls
 
+
+def test_remote_modules_import_when_fcntl_is_unavailable():
+    script = """
+import builtins
+
+real_import = builtins.__import__
+
+def import_without_fcntl(name, *args, **kwargs):
+    if name == "fcntl":
+        raise ModuleNotFoundError("fcntl unavailable")
+    return real_import(name, *args, **kwargs)
+
+builtins.__import__ = import_without_fcntl
+from mship.core import remote_client, remote_exec
+print(remote_client.EXIT_MARKER, remote_client.ARTIFACT_MARKER)
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "__MSHIP_EXIT__ __MSHIP_ARTIFACTS__"
+
+
+def test_remote_without_fcntl_fails_locking_before_shell_work(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(remote_exec, "fcntl", None)
+    fake = _FakeShellRunner(
+        streaming_proc=_FakeProc(stdout_lines=["must not run\n"]),
+    )
+    deps = remote_exec.RemoteExecDeps(
+        config=_config(tmp_path),
+        shell=fake,
+        workspace_root=tmp_path,
+    )
+
+    lines = list(remote_exec.run_verb_stream(
+        "run",
+        "t1",
+        ["api"],
+        None,
+        deps=deps,
+        nonce="nofcntlnonce",
+    ))
+
+    assert lines == [
+        b"error: remote-task locking failed; execution was not started\n",
+        b"__MSHIP_EXIT__:nofcntlnonce 1\n",
+    ]
+    assert not (tmp_path / ".mothership" / "remote-exec-locks").exists()
+    assert not fake.run_calls
+    assert not fake.streaming_calls
+
 def test_task_lock_failure_to_create_directory_fails_closed(tmp_path):
     (tmp_path / ".mothership").write_text("not a directory")
     fake = _FakeShellRunner(

--- a/tests/core/test_serve_exec.py
+++ b/tests/core/test_serve_exec.py
@@ -337,6 +337,7 @@ def test_exec_response_does_not_require_create_collapsing_task_group(
     monkeypatch.delattr(
         starlette_utils,
         "create_collapsing_task_group",
+        raising=False,
     )
     fake = _FakeShellRunner(
         streaming_proc=_FakeProc(stdout_lines=["ok\n"]),

--- a/tests/util/test_shell.py
+++ b/tests/util/test_shell.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 from pathlib import Path
 
 import pytest
-
+from mship.util import shell as shell_module
 from mship.util.shell import ShellCancelled, ShellRunner, ShellResult
 
 
@@ -204,3 +204,109 @@ while True:
             os.killpg(process_group, signal.SIGKILL)
         except ProcessLookupError:
             pass
+
+
+@pytest.mark.parametrize("platform", ["darwin", "linux"])
+def test_forced_group_cleanup_reaps_leader_before_absence_wait(
+    monkeypatch,
+    platform,
+):
+    killed = threading.Event()
+    reaped = threading.Event()
+    descendant_absent = threading.Event()
+    cleanup_done = threading.Event()
+    events: list[str] = []
+
+    class _KilledLeader:
+        pid = 424242
+
+        def poll(self):
+            return None
+
+        def wait(self):
+            events.append("reap")
+            reaped.set()
+            return -signal.SIGKILL
+
+    proc = _KilledLeader()
+
+    def fake_killpg(process_group, signum):
+        assert process_group == proc.pid
+        if signum == signal.SIGKILL:
+            events.append("kill")
+            killed.set()
+            return
+        if signum == 0:
+            events.append("probe")
+            if reaped.is_set() and descendant_absent.is_set():
+                raise ProcessLookupError
+
+    monkeypatch.setattr(shell_module.sys, "platform", platform)
+    monkeypatch.setattr(shell_module.os, "killpg", fake_killpg)
+    if platform == "linux":
+        monkeypatch.setattr(
+            shell_module,
+            "_linux_group_has_executable_member",
+            lambda process_group: shell_module._has_owned_process_group_id(
+                process_group
+            ),
+        )
+
+    def cleanup() -> None:
+        shell_module._terminate_owned_process_group(proc)
+        cleanup_done.set()
+
+    cleanup_thread = threading.Thread(target=cleanup, daemon=True)
+    cleanup_thread.start()
+    try:
+        assert killed.wait(timeout=2), "cleanup did not escalate to SIGKILL"
+        assert reaped.wait(timeout=1), "leader was not reaped after SIGKILL"
+        assert not cleanup_done.is_set(), "cleanup ignored the surviving descendant"
+        descendant_absent.set()
+        assert cleanup_done.wait(timeout=1), "cleanup did not observe group absence"
+        assert events.index("reap") > events.index("kill")
+    finally:
+        reaped.set()
+        descendant_absent.set()
+        cleanup_thread.join(timeout=2)
+
+
+def test_linux_group_scan_accepts_non_utf8_process_name(tmp_path, monkeypatch):
+    process_dir = tmp_path / "123"
+    process_dir.mkdir()
+    (process_dir / "stat").write_bytes(
+        b"123 (\xff process) S 1 424242 0 0 0 0 0\n"
+    )
+    real_scandir = os.scandir
+
+    def scan_test_proc(path):
+        assert path == "/proc"
+        return real_scandir(tmp_path)
+
+    monkeypatch.setattr(shell_module.os, "scandir", scan_test_proc)
+
+    assert shell_module._linux_group_has_executable_member(424242)
+
+
+def test_linux_group_scan_accepts_zombie_with_unreadable_unrelated_stat(
+    tmp_path,
+    monkeypatch,
+):
+    zombie_dir = tmp_path / "123"
+    zombie_dir.mkdir()
+    (zombie_dir / "stat").write_bytes(
+        b"123 (zombie) Z 1 424242 0 0 0 0 0\n"
+    )
+    unreadable_dir = tmp_path / "456"
+    unreadable_dir.mkdir()
+    (unreadable_dir / "stat").write_bytes(b"malformed")
+    real_scandir = os.scandir
+
+    monkeypatch.setattr(
+        shell_module.os,
+        "scandir",
+        lambda path: real_scandir(tmp_path),
+    )
+    monkeypatch.setattr(shell_module.os, "killpg", lambda group, signum: None)
+
+    assert not shell_module._linux_group_has_executable_member(424242)

--- a/tests/util/test_shell.py
+++ b/tests/util/test_shell.py
@@ -141,6 +141,91 @@ def test_run_argv_passes_shell_metacharacters_literally(tmp_path):
     assert not side_effect.exists()
 
 
+def _successful_popen():
+    popen = MagicMock()
+    popen.return_value.communicate.return_value = ("ok\n", "")
+    popen.return_value.returncode = 0
+    return popen
+
+
+def test_cancellable_run_argv_rejects_windows_before_spawn(monkeypatch):
+    cwd = Path(".")
+    popen = _successful_popen()
+    monkeypatch.setattr(
+        shell_module.subprocess,
+        "CREATE_NEW_PROCESS_GROUP",
+        0x00000200,
+        raising=False,
+    )
+    monkeypatch.setattr(shell_module.os, "name", "nt")
+    monkeypatch.setattr(shell_module.subprocess, "Popen", popen)
+
+    with pytest.raises(RuntimeError, match="Windows") as exc_info:
+        ShellRunner().run_argv(
+            ["command"],
+            cwd=cwd,
+            cancel_event=threading.Event(),
+        )
+
+    assert exc_info.type.__name__ == "ShellCancellationUnsupported"
+    popen.assert_not_called()
+
+
+def test_cancellable_run_argv_rejects_unreadable_linux_proc_before_spawn(
+    tmp_path,
+    monkeypatch,
+):
+    popen = _successful_popen()
+    monkeypatch.setattr(shell_module.os, "name", "posix")
+    monkeypatch.setattr(shell_module.sys, "platform", "linux")
+    monkeypatch.setattr(
+        shell_module,
+        "_PROC_ROOT",
+        tmp_path / "unavailable-proc",
+        raising=False,
+    )
+    monkeypatch.setattr(shell_module.subprocess, "Popen", popen)
+
+    with pytest.raises(RuntimeError, match="process-status") as exc_info:
+        ShellRunner().run_argv(
+            ["command"],
+            cwd=tmp_path,
+            cancel_event=threading.Event(),
+        )
+
+    assert exc_info.type.__name__ == "ShellCancellationUnsupported"
+    popen.assert_not_called()
+
+
+@pytest.mark.parametrize("platform", ["darwin", "linux"])
+def test_cancellable_run_argv_accepts_supported_posix_hosts(
+    tmp_path,
+    monkeypatch,
+    platform,
+):
+    proc_root = tmp_path / "proc"
+    if platform == "linux":
+        process_dir = proc_root / "123"
+        process_dir.mkdir(parents=True)
+        (process_dir / "stat").write_bytes(
+            b"123 (python) S 1 123 0 0 0 0 0\n"
+        )
+    popen = _successful_popen()
+    monkeypatch.setattr(shell_module.os, "name", "posix")
+    monkeypatch.setattr(shell_module.sys, "platform", platform)
+    monkeypatch.setattr(shell_module, "_PROC_ROOT", proc_root, raising=False)
+    monkeypatch.setattr(shell_module.subprocess, "Popen", popen)
+
+    result = ShellRunner().run_argv(
+        ["command"],
+        cwd=tmp_path,
+        cancel_event=threading.Event(),
+    )
+
+    assert result.returncode == 0
+    popen.assert_called_once()
+
+
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"),
     reason="Linux /proc process-state contract",

--- a/tests/util/test_shell.py
+++ b/tests/util/test_shell.py
@@ -1,10 +1,17 @@
+import os
+import select
+import shlex
+import signal
 import subprocess
+import sys
+import threading
+import time
 from unittest.mock import MagicMock, patch
 from pathlib import Path
 
 import pytest
 
-from mship.util.shell import ShellRunner, ShellResult
+from mship.util.shell import ShellCancelled, ShellRunner, ShellResult
 
 
 def test_run_streaming_uses_start_new_session_on_unix():
@@ -114,3 +121,94 @@ def test_run_raises_timeout_expired_when_command_exceeds_timeout():
     runner = ShellRunner()
     with pytest.raises(subprocess.TimeoutExpired):
         runner.run("sleep 2", cwd=Path("."), timeout=0.1)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group contract")
+def test_cancelled_run_kills_descendant_after_leader_exits(tmp_path):
+    ready_path = tmp_path / "descendant-ready"
+    child_code = """
+import os
+import signal
+import sys
+from pathlib import Path
+
+read_fd, write_fd = os.pipe()
+child_pid = os.fork()
+if child_pid == 0:
+    os.close(read_fd)
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    os.close(1)
+    os.close(2)
+    os.write(write_fd, b"ready")
+    os.close(write_fd)
+    while True:
+        signal.pause()
+
+os.close(write_fd)
+os.read(read_fd, 5)
+os.close(read_fd)
+Path(sys.argv[1]).write_text(str(child_pid))
+while True:
+    signal.pause()
+"""
+    command = " ".join(
+        (
+            shlex.quote(sys.executable),
+            "-c",
+            shlex.quote(child_code),
+            shlex.quote(str(ready_path)),
+        )
+    )
+    cancel_event = threading.Event()
+    errors: list[BaseException] = []
+
+    def run_command() -> None:
+        try:
+            ShellRunner().run(
+                command,
+                cwd=tmp_path,
+                cancel_event=cancel_event,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    runner_thread = threading.Thread(target=run_command, daemon=True)
+    runner_thread.start()
+    deadline = time.monotonic() + 5
+    while not ready_path.exists() and time.monotonic() < deadline:
+        threading.Event().wait(0.01)
+    assert ready_path.exists(), "descendant did not report readiness"
+
+    descendant_pid = int(ready_path.read_text())
+    process_group = os.getpgid(descendant_pid)
+    pid_fd = os.pidfd_open(descendant_pid) if hasattr(os, "pidfd_open") else None
+    try:
+        cancel_event.set()
+        runner_thread.join(timeout=5)
+        assert not runner_thread.is_alive(), "cancelled runner did not return"
+        assert len(errors) == 1
+        assert isinstance(errors[0], ShellCancelled)
+
+        if pid_fd is not None:
+            readable, _, _ = select.select([pid_fd], [], [], 2)
+            assert readable, "SIGTERM-ignoring descendant survived runner cleanup"
+        else:
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                proc_stat = Path(f"/proc/{descendant_pid}/stat")
+                try:
+                    if proc_stat.exists() and proc_stat.read_text().split()[2] == "Z":
+                        break
+                    os.kill(descendant_pid, 0)
+                except ProcessLookupError:
+                    break
+                threading.Event().wait(0.01)
+            else:
+                pytest.fail("SIGTERM-ignoring descendant survived runner cleanup")
+    finally:
+        if pid_fd is not None:
+            os.close(pid_fd)
+        try:
+            os.killpg(process_group, signal.SIGKILL)
+        except ProcessLookupError:
+            pass

--- a/tests/util/test_shell.py
+++ b/tests/util/test_shell.py
@@ -1,5 +1,4 @@
 import os
-import select
 import shlex
 import signal
 import subprocess
@@ -123,7 +122,10 @@ def test_run_raises_timeout_expired_when_command_exceeds_timeout():
         runner.run("sleep 2", cwd=Path("."), timeout=0.1)
 
 
-@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group contract")
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux /proc process-state contract",
+)
 def test_cancelled_run_kills_descendant_after_leader_exits(tmp_path):
     ready_path = tmp_path / "descendant-ready"
     child_code = """
@@ -181,7 +183,7 @@ while True:
 
     descendant_pid = int(ready_path.read_text())
     process_group = os.getpgid(descendant_pid)
-    pid_fd = os.pidfd_open(descendant_pid) if hasattr(os, "pidfd_open") else None
+    proc_stat = Path(f"/proc/{descendant_pid}/stat")
     try:
         cancel_event.set()
         runner_thread.join(timeout=5)
@@ -189,25 +191,15 @@ while True:
         assert len(errors) == 1
         assert isinstance(errors[0], ShellCancelled)
 
-        if pid_fd is not None:
-            readable, _, _ = select.select([pid_fd], [], [], 2)
-            assert readable, "SIGTERM-ignoring descendant survived runner cleanup"
-        else:
-            deadline = time.monotonic() + 2
-            while time.monotonic() < deadline:
-                proc_stat = Path(f"/proc/{descendant_pid}/stat")
-                try:
-                    if proc_stat.exists() and proc_stat.read_text().split()[2] == "Z":
-                        break
-                    os.kill(descendant_pid, 0)
-                except ProcessLookupError:
-                    break
-                threading.Event().wait(0.01)
-            else:
-                pytest.fail("SIGTERM-ignoring descendant survived runner cleanup")
+        try:
+            descendant_state = proc_stat.read_text().split()[2]
+        except FileNotFoundError:
+            descendant_state = None
+        assert descendant_state in {None, "X", "Z"}, (
+            "SIGTERM-ignoring descendant was executable when runner cleanup returned: "
+            f"{descendant_state}"
+        )
     finally:
-        if pid_fd is not None:
-            os.close(pid_fd)
         try:
             os.killpg(process_group, signal.SIGKILL)
         except ProcessLookupError:

--- a/tests/util/test_shell.py
+++ b/tests/util/test_shell.py
@@ -1,5 +1,4 @@
 import os
-import shlex
 import signal
 import subprocess
 import sys
@@ -122,6 +121,26 @@ def test_run_raises_timeout_expired_when_command_exceeds_timeout():
         runner.run("sleep 2", cwd=Path("."), timeout=0.1)
 
 
+def test_run_argv_passes_shell_metacharacters_literally(tmp_path):
+    side_effect = tmp_path / "must-not-exist"
+    literal = f"value; touch {side_effect}"
+
+    result = ShellRunner().run_argv(
+        [
+            sys.executable,
+            "-c",
+            "import sys; print(sys.argv[1])",
+            literal,
+        ],
+        cwd=tmp_path,
+        cancel_event=threading.Event(),
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == literal
+    assert not side_effect.exists()
+
+
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"),
     reason="Linux /proc process-state contract",
@@ -153,20 +172,18 @@ Path(sys.argv[1]).write_text(str(child_pid))
 while True:
     signal.pause()
 """
-    command = " ".join(
-        (
-            shlex.quote(sys.executable),
-            "-c",
-            shlex.quote(child_code),
-            shlex.quote(str(ready_path)),
-        )
-    )
+    command = [
+        sys.executable,
+        "-c",
+        child_code,
+        str(ready_path),
+    ]
     cancel_event = threading.Event()
     errors: list[BaseException] = []
 
     def run_command() -> None:
         try:
-            ShellRunner().run(
+            ShellRunner().run_argv(
                 command,
                 cwd=tmp_path,
                 cancel_event=cancel_event,


### PR DESCRIPTION
## Summary

- serialize remote `/exec` streams with a nonblocking cross-process lock keyed by the full SHA-256 task identity
- refuse same-task contenders through the existing nonce-tagged byte-stream protocol before repository, setup, verb, artifact, or cleanup work
- release the lock and terminate quiet subprocesses on actual ASGI disconnects; classify portable flock contention without misclassifying lock-path permission failures

## Test plan

- [x] `mship test --task fix-435-remote-exec-lock` — iteration 3 passed after final review fixes, no regressions
- [x] `uv run --frozen pytest -q tests/core/test_serve_exec.py` — 64 passed
- [x] `task lint` — exit 0 (`no linter configured`)
- [x] deterministic same-process, multiprocessing, real ASGI disconnect, persistent lock-file, and fail-closed infrastructure regressions
- [x] task spec/code-quality review clean; final-review findings fixed and scoped re-review clean

Closes #435
---

## Acceptance criteria

- [x] `ac1` `core/remote_exec.py` makes public `run_verb_stream` the sole per-task lock owner and holds the lock while iterating the complete existing execution generator. — test:test-runs/3:mothership, test:test-runs/3.mothership
- [x] `ac2` The lock path is `<workspace_root>/.mothership/remote-exec-locks/<full lowercase SHA-256 of the raw task>.lock`, so even direct internal callers cannot turn a task value into path traversal. — test:test-runs/3:mothership, test:test-runs/3.mothership
- [x] `ac3` Lock acquisition uses exclusive nonblocking `fcntl.flock`; same-task contention is refused immediately without queueing or polling. — test:test-runs/3:mothership, test:test-runs/3.mothership
- [x] `ac4` While one same-task stream is active, a contender emits an actionable already-running error followed by the existing nonce-tagged exit sentinel with status 2 and makes zero repository, setup, verb, artifact, cleanup, shell-run, or shell-stream calls. — test:test-runs/3:mothership, test:test-runs/3.mothership
- [x] `ac5` Normal exhaustion, successful execution, task-reported failure, unexpected exception, explicit generator close, and `GeneratorExit`/client disconnect all release the lock; the same task can execute again afterward. — test:test-runs/3:mothership, test:test-runs/3.mothership
- [x] `ac6` Two streams for different task values use different locks and can execute concurrently. — test:test-runs/3:mothership, test:test-runs/3.mothership
- [x] `ac7` A multiprocessing test with explicit synchronization proves same-task exclusion across independent processes sharing one workspace. — test:test-runs/3:mothership, test:test-runs/3.mothership
- [x] `ac8` Failure to create the lock directory or open/acquire the lock file fails closed with an error and nonce-tagged nonzero exit sentinel before execution begins. — test:test-runs/3:mothership, test:test-runs/3.mothership
- [x] `ac9` Contention and lock-infrastructure errors preserve the existing HTTP 200 byte-stream framing and request nonce contract. — test:test-runs/3:mothership, test:test-runs/3.mothership
- [x] `ac10` Empty lock files may remain after release and do not prevent later acquisition; process termination relies on kernel descriptor cleanup rather than file deletion. — test:test-runs/3:mothership, test:test-runs/3.mothership
- [x] `ac11` All existing uncontended remote execution tests continue to pass, including materialization, setup, output, task-failure, nonce, artifact, cleanup, and disconnect behavior. — test:test-runs/3:mothership, test:test-runs/3.mothership