### PR TITLE
Mothership daemon provisioning and supervision (#470): mship daemon install/start/stop/restart/status/logs/run + supervised mshipd

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -1,0 +1,99 @@
+# The Mothership daemon (`mship daemon`)
+
+One supervised daemon process per OS user per host, shipped from the same
+package as the CLI. The daemon makes a host reachable/operable without a
+terminal (#469); v1 (#470) is the lifecycle substrate: provisioning,
+supervision, singleton-ness, logs, and status. It serves no workspaces (#472),
+opens no tunnel (#471), and supervises no workers (#473) yet — those arrive as
+sibling capabilities behind the seams reported by `mship daemon status`.
+
+## Lifecycle
+
+```bash
+mship daemon install   # render + enable the OS-user unit, verify linger (Linux)
+mship daemon start
+mship daemon stop
+mship daemon restart   # consults restart blockers first (the #473 recovery seam)
+mship daemon status
+mship daemon logs      # tails rotated logs, no journald needed
+mship daemon run       # foreground/debug, no supervisor
+```
+
+`mship serve` is unchanged: a foreground/API dev surface. Ordinary local mship
+commands never require the daemon.
+
+## Paths
+
+- State: `~/.mothership/daemon/` (per OS user — the daemon is workspace-agnostic)
+- Lease: `~/.mothership/daemon/daemon.lease` (flock held for the daemon's lifetime)
+- Logs: `~/.mothership/daemon/logs/daemon.log` (rotated, 5MB x 3)
+- Start history: `~/.mothership/daemon/start-history.json` (crash-loop visibility)
+- Control socket: `$XDG_RUNTIME_DIR/mship/daemon.sock`, else
+  `~/.mothership/daemon/run/daemon.sock`. Status probes prefer the socket path
+  recorded in the lease (the daemon's env and your shell can disagree about
+  `XDG_RUNTIME_DIR`).
+
+## Why linger is mandatory (Linux)
+
+A `systemd --user` unit is torn down when the user's last session ends —
+precisely the moment a headless daemon is needed. `mship daemon install` runs
+`loginctl enable-linger` and verifies `Linger=yes`, and `status` re-warns
+whenever linger is off.
+
+## Loser-exits-0 policy
+
+Two `mshipd` processes can race (supervisor + `daemon run`, or concurrent cold
+starts). The lease flock decides the winner; the loser probes the holder's
+control socket:
+
+- holder answers `/health` → the loser exits **0**. launchd's
+  `KeepAlive.SuccessfulExit=false` relaunches on *any* nonzero exit every
+  `ThrottleInterval` — a permanent hot loop — so 0 is the only supervisor-safe
+  loser status on both OSes. The log line naming the holder pid is the
+  diagnostic.
+- holder never answers → exit **1** (contended-but-dead) so the supervisor
+  retries rather than parking "inactive-success" with zero daemons.
+
+The held flock is the liveness authority; the recorded pid is diagnostic only
+(pid reuse must never read as "already running"). No CLI/status path ever
+touches the lease flock.
+
+## Upgrades
+
+Merging does not deploy (same reality as `redeploy-serve.sh`): a running daemon
+keeps executing the version it imported at start. Deploy =
+`uv tool install --force --no-cache <path>` then `mship daemon restart`.
+`status` shows "restart required: daemon vA, CLI vB" whenever the running
+daemon's version differs from the CLI's (exact-match policy; CI bumps a patch
+per merge).
+
+## macOS caveats
+
+- The LaunchAgent is bootstrapped in the `user/<uid>` domain so provisioning
+  works over SSH with no GUI session (`gui/<uid>` fails there with
+  "Bootstrap failed: 5: Input/output error").
+- Reboot-survival on a headless Mac requires a login session (enable
+  auto-login); a system-domain LaunchDaemon is out of scope for v1.
+
+## Manual/VM verification checklist
+
+The suite fakes the supervisor boundary; these OS-contract behaviors need a
+real VM pass:
+
+1. **Linger:** `mship daemon install && mship daemon start`, close every SSH
+   session, wait 60s, reconnect → daemon still running (`mship daemon status`).
+2. **Crash recovery:** `kill -9 <pid>` → daemon back within ~5s
+   (`RestartSec=5`); `status` shows an unclean start.
+3. **Reboot:** reboot the host, no SSH login → daemon running (verify from a
+   second host or after login; the point is it started without one).
+4. **Headless macOS:** `mship daemon install` over SSH with no GUI session
+   succeeds (user-domain bootstrap).
+5. **Crash loop:** make `mshipd` exit nonzero immediately (e.g. temporarily
+   break the venv) → systemd reaches `start-limit-hit` within ~5 failures and
+   `mship daemon status` shows the unclean-start count + `failed` state.
+6. **Upgrade:** `uv tool install --force --no-cache <new>` → `status` shows
+   "restart required" → `mship daemon restart` → `status` clean, new version
+   reported.
+7. **Concurrent cold start:** run `mship daemon start` while `mship daemon run`
+   is already active in a shell → exactly one daemon survives; the loser logs
+   the holder pid and exits 0.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,6 +13,9 @@ Requires Python 3.14+ and [uv](https://docs.astral.sh/uv/). Optional but
 recommended: [go-task](https://taskfile.dev) (task execution) and
 [gh](https://cli.github.com) (`mship finish` uses it to open PRs).
 
+The install also provides `mshipd`, the always-on host daemon — managed via
+`mship daemon ...` ([docs/daemon.md](daemon.md)), never invoked directly.
+
 ## Create a workspace
 
 From the directory that contains your repo(s) — one repo, several, or a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 
 [project.scripts]
 mship = "mship.cli:run"
+mshipd = "mship.core.daemon.run:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -116,6 +116,7 @@ from mship.cli import bootstrap as _bootstrap_mod
 from mship.cli import block as _block_mod
 from mship.cli import commit as _commit_mod
 from mship.cli import context as _context_mod
+from mship.cli import daemon as _daemon_mod
 from mship.cli import debug as _debug_mod
 from mship.cli import depends as _depends_mod
 from mship.cli import dispatch as _dispatch_mod
@@ -183,6 +184,7 @@ _bootstrap_mod.register(app, get_container)
 _block_mod.register(app, get_container)
 _commit_mod.register(app, get_container)
 _context_mod.register(app, get_container)
+_daemon_mod.register(app, get_container)
 _debug_mod.register(app, get_container)
 _depends_mod.register(app, get_container)
 _dispatch_mod.register(app, get_container)

--- a/src/mship/cli/daemon.py
+++ b/src/mship/cli/daemon.py
@@ -106,7 +106,25 @@ def register(parent: typer.Typer, get_container):
             history_entries=read_history(start_history_path(home)),
             now=datetime.now(timezone.utc),
         )
-        out.print(st.render())
+        if out.json_mode:
+            out.json(
+                {
+                    "running": st.running,
+                    "supervised": st.supervised,
+                    "compatible": st.compatible,
+                    "pid": st.pid,
+                    "daemon_version": st.daemon_version,
+                    "cli_version": st.cli_version,
+                    "uptime_s": st.uptime_s,
+                    "socket": st.socket,
+                    "supervisor": {"state": st.supervisor.state, "detail": st.supervisor.detail},
+                    "linger": st.linger,
+                    "unclean_starts": st.unclean_starts,
+                    "lines": st.lines,
+                }
+            )
+        else:
+            out.print(st.render())
 
     @daemon_app.command("logs")
     def logs(n: int = typer.Option(100, "-n", "--lines", help="Lines to show.")):

--- a/src/mship/cli/daemon.py
+++ b/src/mship/cli/daemon.py
@@ -1,0 +1,122 @@
+"""`mship daemon` — lifecycle surface for the per-host Mothership daemon (#470).
+
+Thin over the injectable supervisor seam; core raises typed exceptions, only
+this layer raises `typer.Exit`. `get_container` is accepted for the house
+`register(app, get_container)` shape but NEVER resolved into a workspace — the
+daemon is workspace-agnostic until #472.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import typer
+
+import mship
+from mship.core.daemon.history import read_history
+from mship.core.daemon.lease import read_lease_record
+from mship.core.daemon.paths import lease_path, start_history_path
+from mship.core.daemon.status import build_status, probe_daemon, restart_blockers
+from mship.core.daemon.supervisor import DaemonSupervisorError, pick_supervisor
+from mship.core.daemon.units import DaemonExecResolutionError, resolve_mshipd_argv
+from mship.cli.output import Output
+
+
+def _daemon_main() -> int:
+    from mship.core.daemon.run import main
+
+    return main()
+
+
+def register(parent: typer.Typer, get_container):
+    daemon_app = typer.Typer(
+        name="daemon",
+        help="Manage the per-host Mothership daemon (one supervised mshipd per OS user).",
+        no_args_is_help=True,
+    )
+
+    def _supervisor():
+        return pick_supervisor()
+
+    @daemon_app.command("install")
+    def install():
+        """Install + enable the OS-user supervisor unit (systemd --user / launchd)."""
+        out = Output()
+        sup = _supervisor()
+        if not sup.available():
+            out.error(
+                "no reachable OS supervisor (user manager) on this host — persistence is "
+                "not possible here; use `mship daemon run` for a foreground daemon."
+            )
+            raise typer.Exit(1)
+        try:
+            argv = resolve_mshipd_argv()
+            sup.install(argv)
+        except (DaemonExecResolutionError, DaemonSupervisorError) as e:
+            out.error(str(e))
+            raise typer.Exit(1)
+        out.print("daemon installed and enabled — start it with `mship daemon start`")
+
+    @daemon_app.command("start")
+    def start():
+        out = Output()
+        try:
+            _supervisor().start()
+        except DaemonSupervisorError as e:
+            out.error(str(e))
+            raise typer.Exit(1)
+        out.print("daemon started")
+
+    @daemon_app.command("stop")
+    def stop():
+        out = Output()
+        try:
+            _supervisor().stop()
+        except DaemonSupervisorError as e:
+            out.error(str(e))
+            raise typer.Exit(1)
+        out.print("daemon stopped")
+
+    @daemon_app.command("restart")
+    def restart():
+        out = Output()
+        blockers = restart_blockers()
+        if blockers:
+            out.error("restart refused:\n" + "\n".join(f"  - {b}" for b in blockers))
+            raise typer.Exit(1)
+        try:
+            _supervisor().restart()
+        except DaemonSupervisorError as e:
+            out.error(str(e))
+            raise typer.Exit(1)
+        out.print("daemon restarted")
+
+    @daemon_app.command("status")
+    def status():
+        out = Output()
+        home = Path.home()
+        sup = _supervisor()
+        st = build_status(
+            supervisor_state=sup.query(),
+            linger=sup.linger_state(),
+            lease_info=read_lease_record(lease_path(home)),
+            health=probe_daemon(home=home, env=os.environ),
+            cli_version=mship.__version__,
+            history_entries=read_history(start_history_path(home)),
+            now=datetime.now(timezone.utc),
+        )
+        out.print(st.render())
+
+    @daemon_app.command("logs")
+    def logs(n: int = typer.Option(100, "-n", "--lines", help="Lines to show.")):
+        out = Output()
+        for line in _supervisor().logs_tail(n):
+            out.print(line)
+
+    @daemon_app.command("run")
+    def run():
+        """Run the daemon in the foreground (debug / no-supervisor hosts)."""
+        raise typer.Exit(_daemon_main())
+
+    parent.add_typer(daemon_app, rich_help_panel="Runtime")

--- a/src/mship/core/daemon/__init__.py
+++ b/src/mship/core/daemon/__init__.py
@@ -1,0 +1,8 @@
+"""The Mothership daemon (#470): one supervised host control-plane process per
+OS user per host, shipped from the same package as the CLI.
+
+v1 is deliberately a minimal shell — singleton lease, rotated logs, start
+history, unix control socket. It serves no workspaces (#472), opens no tunnel
+(#471), and supervises no workers (#473); those arrive behind the capability
+seams reported by the control app.
+"""

--- a/src/mship/core/daemon/__main__.py
+++ b/src/mship/core/daemon/__main__.py
@@ -1,0 +1,7 @@
+"""`python -m mship.core.daemon` — fallback exec form when no `mshipd` script
+is resolvable (the `python -m mship.ci.version_bump` precedent)."""
+import sys
+
+from mship.core.daemon.run import main
+
+sys.exit(main())

--- a/src/mship/core/daemon/control.py
+++ b/src/mship/core/daemon/control.py
@@ -1,0 +1,73 @@
+"""Daemon control app + client-side socket probe.
+
+`version` is `mship.__version__` captured ONCE by the caller at process start —
+the guarded single source of truth (`src/mship/__init__.py`, pinned by
+`tests/test_version.py`). Not importlib.metadata: both sides answering
+"unknown" on absent dist metadata would mask real skew.
+
+Filesystem perms on the unix socket are the auth; no bearer token locally.
+Remote traffic stays on the #471 tunnel path.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+# CLI<->daemon control-protocol version; bump on breaking payload changes.
+PROTOCOL = 1
+
+_PROBE_TIMEOUT_S = 3.0
+
+
+def create_control_app(*, started_at: datetime, version: str, socket_path: str):
+    """Tiny closure app factory (the `core/serve.py::create_app` style)."""
+    from fastapi import FastAPI
+
+    app = FastAPI(title="mshipd control", docs_url=None, redoc_url=None)
+
+    @app.get("/health")
+    def health():
+        now = datetime.now(timezone.utc)
+        return {
+            "status": "ok",
+            "pid": os.getpid(),
+            "mship_version": version,
+            "protocol": PROTOCOL,
+            "started_at": started_at.isoformat(),
+            "uptime_s": (now - started_at).total_seconds(),
+            "socket": socket_path,
+            "capabilities": {
+                "serve": False,  # #472: serve becomes a daemon capability with the registry
+                "tunnel": False,  # #471: relay tunnel registration
+                "registry": False,  # #472: workspace discovery/registry
+                "runner": False,  # #473: unattended worker supervision
+            },
+        }
+
+    return app
+
+
+def probe_control_socket(
+    socket_path: str | Path, *, client_factory: Callable | None = None
+) -> dict | None:
+    """GET /health over the unix socket. Never raises (the
+    `relay/health.py::probe_health` contract): any failure → None."""
+    try:
+        if client_factory is None:
+            import httpx
+
+            client_factory = lambda **kw: httpx.Client(
+                transport=httpx.HTTPTransport(uds=str(socket_path)), **kw
+            )
+        client = client_factory(timeout=_PROBE_TIMEOUT_S)
+        try:
+            r = client.get("http://mshipd/health")
+            if r.status_code != 200:
+                return None
+            return r.json()
+        finally:
+            client.close()
+    except Exception:
+        return None

--- a/src/mship/core/daemon/history.py
+++ b/src/mship/core/daemon/history.py
@@ -1,0 +1,85 @@
+"""Durable start/stop history + the crash-loop detector.
+
+Daemon-owned so crash-loop visibility behaves identically under systemd,
+launchd, and `daemon run` — no NRestarts/`launchctl print` parsing. A start is
+UNCLEAN when it is not preceded by a clean stop; only unclean starts count
+toward a loop. `run.py` appends the clean-stop entry when uvicorn returns
+normally (graceful shutdown).
+
+Atomic 0600 tmp+replace writes (the `run_host/store.py` pattern) are safe here
+— nothing flocks this file (the lease file is the one that must never be
+replaced).
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+MAX_ENTRIES = 20
+LOOP_WINDOW_S = 600
+LOOP_THRESHOLD = 3
+
+
+@dataclass(frozen=True)
+class HistoryEntry:
+    kind: Literal["start", "clean_stop"]
+    at: datetime
+
+
+def read_history(path: Path) -> list[HistoryEntry]:
+    try:
+        raw = json.loads(path.read_text())
+        return [HistoryEntry(kind=e["kind"], at=datetime.fromisoformat(e["at"])) for e in raw]
+    except (OSError, ValueError, KeyError, TypeError):
+        return []  # missing or corrupt → start fresh
+
+
+def _append(path: Path, kind: str, now: datetime) -> None:
+    entries = read_history(path)
+    entries.append(HistoryEntry(kind=kind, at=now))  # type: ignore[arg-type]
+    entries = entries[-MAX_ENTRIES:]
+    payload = json.dumps([{"kind": e.kind, "at": e.at.isoformat()} for e in entries])
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    tmp = path.with_name(path.name + ".tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, payload.encode())
+    finally:
+        os.close(fd)
+    tmp.replace(path)
+
+
+def append_start(path: Path, now: datetime) -> None:
+    _append(path, "start", now)
+
+
+def append_clean_stop(path: Path, now: datetime) -> None:
+    _append(path, "clean_stop", now)
+
+
+def unclean_start_count(
+    entries: list[HistoryEntry], now: datetime, *, window_s: float = LOOP_WINDOW_S
+) -> int:
+    """Starts inside the window whose immediately preceding entry is not a
+    clean stop (crash/kill respawns, not operator restarts)."""
+    count = 0
+    for i, e in enumerate(entries):
+        if e.kind != "start" or (now - e.at).total_seconds() > window_s:
+            continue
+        if i == 0 or entries[i - 1].kind != "clean_stop":
+            count += 1
+    return count
+
+
+def is_crash_looping(
+    entries: list[HistoryEntry],
+    now: datetime,
+    *,
+    window_s: float = LOOP_WINDOW_S,
+    threshold: int = LOOP_THRESHOLD,
+) -> bool:
+    return unclean_start_count(entries, now, window_s=window_s) >= threshold

--- a/src/mship/core/daemon/lease.py
+++ b/src/mship/core/daemon/lease.py
@@ -1,0 +1,112 @@
+"""Single-instance daemon lease: a lifetime-held flock on the lease file.
+
+Contract (#470): THE HELD FLOCK IS THE LIVENESS AUTHORITY; the recorded pid is
+diagnostic only. This is deliberately stronger than `inbox_lease._pid_alive`'s
+signal-0 probe — a recycled pid must never read as "daemon running".
+
+The lease JSON `{pid, started_at, version, socket_path}` doubles as the runtime
+record. It is written IN PLACE through the locked fd (ftruncate + write +
+fsync): a tmp+os.replace write is explicitly wrong here because os.replace
+swaps the inode, stranding the lifetime flock on the old unlinked inode so
+every later acquirer flocks the fresh file and "wins", voiding the guard
+(`test_late_arrival_after_write_loses`).
+
+No CLI/status path may instantiate this class: a status probe that transiently
+flocks the lease can race a starting daemon into its loser path. Status reads
+the JSON only (`status.py`).
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class LeaseInfo:
+    """Holder diagnostics read from the lease record. `pid is None` means
+    "held by unknown" — the flock is held but the record was unreadable
+    (holder mid-write)."""
+
+    pid: int | None
+    started_at: str | None = None
+    version: str | None = None
+    socket_path: str | None = None
+
+
+_READ_RETRIES = 5
+_READ_RETRY_DELAY_S = 0.03
+
+
+class DaemonLease:
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._fd: int | None = None
+
+    def try_acquire(self, *, version: str, socket_path: str) -> LeaseInfo | None:
+        """Win → write the record through the locked fd, keep the flock for the
+        process lifetime, return None. Lose → return the holder's LeaseInfo
+        (pid=None when the record stays unreadable after brief retries)."""
+        self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        fd = os.open(self._path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            os.close(fd)
+            return self._read_holder()
+        # Won: record ourselves through the SAME fd — never replace the file.
+        payload = json.dumps(
+            {
+                "pid": os.getpid(),
+                "started_at": datetime.now(timezone.utc).isoformat(),
+                "version": version,
+                "socket_path": socket_path,
+            }
+        ).encode()
+        os.ftruncate(fd, 0)
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.write(fd, payload)
+        os.fsync(fd)
+        self._fd = fd
+        return None
+
+    def _read_holder(self) -> LeaseInfo:
+        for attempt in range(_READ_RETRIES):
+            try:
+                raw = json.loads(self._path.read_text())
+                return LeaseInfo(
+                    pid=int(raw["pid"]),
+                    started_at=raw.get("started_at"),
+                    version=raw.get("version"),
+                    socket_path=raw.get("socket_path"),
+                )
+            except (OSError, ValueError, KeyError, TypeError):
+                if attempt < _READ_RETRIES - 1:
+                    time.sleep(_READ_RETRY_DELAY_S)  # winner may be mid-write
+        return LeaseInfo(pid=None)
+
+    def release(self) -> None:
+        """Explicit release for tests/clean shutdown; the OS also releases the
+        flock on process exit (the crash path needs no cleanup code)."""
+        if self._fd is not None:
+            fcntl.flock(self._fd, fcntl.LOCK_UN)
+            os.close(self._fd)
+            self._fd = None
+
+
+def read_lease_record(path: Path) -> LeaseInfo | None:
+    """Read-only diagnostics for status paths — NEVER takes the flock."""
+    try:
+        raw = json.loads(path.read_text())
+        return LeaseInfo(
+            pid=int(raw["pid"]),
+            started_at=raw.get("started_at"),
+            version=raw.get("version"),
+            socket_path=raw.get("socket_path"),
+        )
+    except (OSError, ValueError, KeyError, TypeError):
+        return None

--- a/src/mship/core/daemon/paths.py
+++ b/src/mship/core/daemon/paths.py
@@ -1,0 +1,43 @@
+"""Daemon filesystem layout — pure functions over explicit `home`/`env`.
+
+All daemon state is per-OS-user (`~/.mothership/daemon/`, beside the per-machine
+relay identity in `mship.core.relay.keys`), never per-workspace: the daemon is
+workspace-agnostic until #472. Injectable-`home` style follows `relay/keys.py`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+
+def daemon_state_dir(home: Path) -> Path:
+    return home / ".mothership" / "daemon"
+
+
+def daemon_log_dir(home: Path) -> Path:
+    return daemon_state_dir(home) / "logs"
+
+
+def lease_path(home: Path) -> Path:
+    return daemon_state_dir(home) / "daemon.lease"
+
+
+def start_history_path(home: Path) -> Path:
+    return daemon_state_dir(home) / "start-history.json"
+
+
+def daemon_socket_path(env: Mapping[str, str], home: Path) -> Path:
+    """Control-socket path: `$XDG_RUNTIME_DIR/mship/daemon.sock`, else a 0700
+    dir under the state dir (macOS, some containers). NOTE: the daemon and a
+    probing CLI can legitimately compute different paths when their
+    environments differ (systemd-provided XDG_RUNTIME_DIR vs a bare shell) —
+    probes must prefer the socket_path recorded in the lease (`status.py`).
+    """
+    runtime = env.get("XDG_RUNTIME_DIR")
+    if runtime:
+        sock_dir = Path(runtime) / "mship"
+    else:
+        sock_dir = daemon_state_dir(home) / "run"
+    sock_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    sock_dir.chmod(0o700)
+    return sock_dir / "daemon.sock"

--- a/src/mship/core/daemon/paths.py
+++ b/src/mship/core/daemon/paths.py
@@ -26,7 +26,7 @@ def start_history_path(home: Path) -> Path:
     return daemon_state_dir(home) / "start-history.json"
 
 
-def daemon_socket_path(env: Mapping[str, str], home: Path) -> Path:
+def daemon_socket_path(env: Mapping[str, str], home: Path, *, create: bool = False) -> Path:
     """Control-socket path: `$XDG_RUNTIME_DIR/mship/daemon.sock`, else a 0700
     dir under the state dir (macOS, some containers). NOTE: the daemon and a
     probing CLI can legitimately compute different paths when their
@@ -38,6 +38,10 @@ def daemon_socket_path(env: Mapping[str, str], home: Path) -> Path:
         sock_dir = Path(runtime) / "mship"
     else:
         sock_dir = daemon_state_dir(home) / "run"
-    sock_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-    sock_dir.chmod(0o700)
+    if create:
+        # Only the daemon itself creates the dir; probe/status paths must stay
+        # pure — a stale/unwritable XDG_RUNTIME_DIR in an SSH env would
+        # otherwise crash `mship daemon status` with PermissionError.
+        sock_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        sock_dir.chmod(0o700)
     return sock_dir / "daemon.sock"

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -86,7 +86,7 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
     import mship
 
     version = mship.__version__  # captured once at process start (the version boundary)
-    socket_path = paths.daemon_socket_path(env, home)
+    socket_path = paths.daemon_socket_path(env, home, create=True)
 
     daemon_lease = lease_mod.DaemonLease(paths.lease_path(home))
     holder = daemon_lease.try_acquire(version=version, socket_path=str(socket_path))

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -1,0 +1,129 @@
+"""`mshipd` — the daemon process entrypoint (same package as the CLI).
+
+Import-minimal at module top: stdlib + paths/lease/history only. The
+FastAPI/uvicorn/control imports are deferred into `main()` AFTER the history
+append so a broken-upgrade ImportError still lands in history and the rotating
+log (`test_broken_import_still_appends_history`).
+
+Sequence: rotating logs → lease → loser path (probe holder; live → exit 0,
+dead → exit 1) → history start → unlink stale socket → uvicorn over the unix
+socket → clean-stop entry on normal return. SIGTERM relies on uvicorn's default
+graceful shutdown — no bespoke signal code. The OS supervisor owns
+restart/backoff; there is deliberately no retry loop here.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Mapping
+
+from mship.core.daemon import history, lease as lease_mod, paths
+
+log = logging.getLogger(__name__)
+
+_LOG_MAX_BYTES = 5 * 1024 * 1024
+_LOG_BACKUPS = 3
+
+# Loser-with-dead-holder → nonzero so the supervisor retries; a wedged
+# non-serving holder must never park the unit "inactive-success" with zero
+# daemons. Confirmed-live holder → 0 (the only supervisor-safe loser status:
+# launchd KeepAlive.SuccessfulExit=false relaunches on ANY nonzero exit).
+_EXIT_CONTENDED_DEAD = 1
+
+
+def _probe(socket_path) -> dict | None:
+    """Seam for tests; deferred import keeps module top stdlib-only."""
+    from mship.core.daemon.control import probe_control_socket
+
+    return probe_control_socket(socket_path)
+
+
+def _import_server_stack():
+    """Deferred FastAPI/uvicorn import — the seam the broken-upgrade test patches."""
+    import uvicorn
+
+    from mship.core.daemon.control import create_control_app
+
+    return uvicorn, create_control_app
+
+
+def _configure_logging(home: Path) -> None:
+    log_dir = paths.daemon_log_dir(home)
+    log_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    handler = RotatingFileHandler(
+        log_dir / "daemon.log", maxBytes=_LOG_MAX_BYTES, backupCount=_LOG_BACKUPS
+    )
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(handler)
+    # Route uvicorn's own loggers into the same rotating file (uvicorn otherwise
+    # installs stderr handlers — journald-only on Linux, discarded on macOS).
+    for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+        lg = logging.getLogger(name)
+        lg.addHandler(handler)
+        lg.setLevel(logging.INFO)
+
+
+def main(home: Path | None = None, env: Mapping[str, str] | None = None) -> int:
+    home = home if home is not None else Path.home()
+    env = env if env is not None else os.environ
+    _configure_logging(home)
+    try:
+        return _run(home, env)
+    except Exception:
+        # The one artifact needed to diagnose a crash loop: without this a
+        # crashing daemon leaves an empty rotated log.
+        log.exception("mshipd crashed")
+        return 1
+
+
+def _run(home: Path, env: Mapping[str, str]) -> int:
+    import mship
+
+    version = mship.__version__  # captured once at process start (the version boundary)
+    socket_path = paths.daemon_socket_path(env, home)
+
+    daemon_lease = lease_mod.DaemonLease(paths.lease_path(home))
+    holder = daemon_lease.try_acquire(version=version, socket_path=str(socket_path))
+    if holder is not None:
+        probe_target = holder.socket_path or str(socket_path)
+        if _probe(probe_target) is not None:
+            log.info("mshipd already running (pid %s) — standing down", holder.pid)
+            return 0
+        log.error(
+            "lease is held (pid %s) but its daemon never answered %s — contended-but-dead; exiting for supervisor retry",
+            holder.pid,
+            probe_target,
+        )
+        return _EXIT_CONTENDED_DEAD
+
+    started_at = datetime.now(timezone.utc)
+    history.append_start(paths.start_history_path(home), started_at)
+    try:
+        uvicorn, create_control_app = _import_server_stack()
+    except BaseException:
+        log.exception("mshipd failed to import its server stack (broken upgrade?)")
+        return 1
+
+    # Safe to unlink: winning the lease proves no live daemon owns the socket.
+    try:
+        socket_path.unlink()
+        log.info("removed stale control socket %s", socket_path)
+    except FileNotFoundError:
+        pass
+
+    log.info("mshipd %s starting on %s (pid %s)", version, socket_path, os.getpid())
+    app = create_control_app(started_at=started_at, version=version, socket_path=str(socket_path))
+    uvicorn.run(app, uds=str(socket_path), log_config=None)
+    history.append_clean_stop(paths.start_history_path(home), datetime.now(timezone.utc))
+    log.info("mshipd stopped cleanly")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via __main__.py
+    sys.exit(main())

--- a/src/mship/core/daemon/status.py
+++ b/src/mship/core/daemon/status.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Literal, Mapping
 
 from mship.core.daemon.control import probe_control_socket
-from mship.core.daemon.history import HistoryEntry, unclean_start_count
+from mship.core.daemon.history import HistoryEntry, is_crash_looping, unclean_start_count
 from mship.core.daemon.lease import LeaseInfo, read_lease_record
 from mship.core.daemon.paths import daemon_socket_path, lease_path
 from mship.core.daemon.supervisor import SupervisorState
@@ -95,8 +95,12 @@ def build_status(
     lines.append(f"supervisor: {supervisor_state.state}" + (f" ({supervisor_state.detail})" if supervisor_state.detail else ""))
     if not compatible:
         lines.append(f"restart required: daemon v{daemon_version}, CLI v{cli_version}")
-    if unclean:
+    if is_crash_looping(history_entries, now, window_s=_LOOP_WINDOW_S):
         lines.append(f"crash loop: {unclean} unclean starts in last 10m")
+    elif unclean:
+        # Below the loop threshold: informational, not an alarm — one kill -9
+        # or startup failure is not a crash loop.
+        lines.append(f"unclean starts: {unclean} in last 10m")
     if linger == "no":
         lines.append("warning: linger is OFF — the daemon dies when your last SSH session ends; run `loginctl enable-linger`")
     elif linger == "unknown":

--- a/src/mship/core/daemon/status.py
+++ b/src/mship/core/daemon/status.py
@@ -1,0 +1,122 @@
+"""Daemon status assembly — pure over injected inputs.
+
+The lease file is READ-ONLY JSON diagnostics here (`read_lease_record`); this
+path never takes the lease flock — a transient flock from status could race a
+starting daemon into its loser path. Liveness is decided by the socket probe +
+supervisor state.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Literal, Mapping
+
+from mship.core.daemon.control import probe_control_socket
+from mship.core.daemon.history import HistoryEntry, unclean_start_count
+from mship.core.daemon.lease import LeaseInfo, read_lease_record
+from mship.core.daemon.paths import daemon_socket_path, lease_path
+from mship.core.daemon.supervisor import SupervisorState
+
+
+def restart_blockers() -> list[str]:
+    """The #473 recovery handoff: reasons a daemon restart must be refused
+    (e.g. active unattended workers whose recovery semantics can't yet prove
+    no-duplicate-launch). Empty in v1 — #473 fills the function, not the
+    control flow: `mship daemon restart` already consults this gate."""
+    return []
+
+
+def probe_daemon(*, home: Path, env: Mapping[str, str]) -> dict | None:
+    """Probe /health at the LEASE-recorded socket path; only with no lease at
+    all fall back to the computed path. The daemon (systemd-provided
+    XDG_RUNTIME_DIR) and the invoking shell can compute different paths — a
+    healthy daemon must not render 'unresponsive' from env divergence."""
+    record = read_lease_record(lease_path(home))
+    if record is not None and record.socket_path:
+        return probe_control_socket(record.socket_path)
+    return probe_control_socket(daemon_socket_path(env, home))
+
+
+_LOOP_WINDOW_S = 600
+
+
+@dataclass(frozen=True)
+class DaemonStatus:
+    running: bool
+    supervised: bool
+    compatible: bool
+    pid: int | None
+    daemon_version: str | None
+    cli_version: str
+    uptime_s: float | None
+    socket: str | None
+    supervisor: SupervisorState
+    linger: Literal["yes", "no", "unknown"]
+    unclean_starts: int
+    lease_info: LeaseInfo | None
+    lines: list[str] = field(default_factory=list)
+
+    def render(self) -> str:
+        return "\n".join(self.lines)
+
+
+def build_status(
+    *,
+    supervisor_state: SupervisorState,
+    linger: Literal["yes", "no", "unknown"],
+    lease_info: LeaseInfo | None,
+    health: dict | None,
+    cli_version: str,
+    history_entries: list[HistoryEntry],
+    now: datetime,
+) -> DaemonStatus:
+    running = health is not None
+    supervised = supervisor_state.state == "active"
+    daemon_version = health.get("mship_version") if health else None
+    compatible = daemon_version == cli_version if daemon_version else True
+    unclean = unclean_start_count(history_entries, now, window_s=_LOOP_WINDOW_S)
+
+    lines: list[str] = []
+    if running:
+        lines.append(f"daemon: running (pid {health['pid']}, v{daemon_version}, uptime {int(health.get('uptime_s', 0))}s)")
+        lines.append(f"socket: {health.get('socket')}")
+        if not supervised:
+            lines.append(
+                "warning: running outside the supervisor — will not survive logout/reboot; "
+                "run `mship daemon install` / `mship daemon start`"
+            )
+    elif lease_info is not None:
+        # A stale lease alone never reads as "already running" — but a record
+        # with no answering socket is worth distinguishing from nothing at all.
+        lines.append(f"daemon: unresponsive (lease pid {lease_info.pid}, socket not answering)")
+    else:
+        lines.append("daemon: not running")
+    lines.append(f"supervisor: {supervisor_state.state}" + (f" ({supervisor_state.detail})" if supervisor_state.detail else ""))
+    if not compatible:
+        lines.append(f"restart required: daemon v{daemon_version}, CLI v{cli_version}")
+    if unclean:
+        lines.append(f"crash loop: {unclean} unclean starts in last 10m")
+    if linger == "no":
+        lines.append("warning: linger is OFF — the daemon dies when your last SSH session ends; run `loginctl enable-linger`")
+    elif linger == "unknown":
+        lines.append("linger: unknown")
+    lines.append("tunnel: not configured (#471)")
+    lines.append("workspaces: registry pending (#472)")
+    lines.append("runner: not configured (#473)")
+
+    return DaemonStatus(
+        running=running,
+        supervised=supervised,
+        compatible=compatible,
+        pid=health.get("pid") if health else (lease_info.pid if lease_info else None),
+        daemon_version=daemon_version,
+        cli_version=cli_version,
+        uptime_s=health.get("uptime_s") if health else None,
+        socket=health.get("socket") if health else None,
+        supervisor=supervisor_state,
+        linger=linger,
+        unclean_starts=unclean,
+        lease_info=lease_info,
+        lines=lines,
+    )

--- a/src/mship/core/daemon/supervisor.py
+++ b/src/mship/core/daemon/supervisor.py
@@ -208,6 +208,13 @@ class LaunchdSupervisor(_BaseSupervisor):
         log_dir = daemon_log_dir(self._home)
         log_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
         plist_path.write_text(render_launchd_plist(argv, log_dir))
+        # Re-install: launchd rejects a duplicate bootstrap of a loaded label,
+        # and the running job would keep the OLD plist. Boot the label out
+        # first (tolerated when not loaded), then bootstrap the new plist.
+        try:
+            self._launchctl("bootout", self._target)
+        except OSError:
+            pass
         # user/<uid>, never gui/<uid>: bootstrap must work over SSH with no GUI
         # session (the headless provisioning path).
         self._checked("bootstrap", f"user/{self._uid}", str(plist_path))

--- a/src/mship/core/daemon/supervisor.py
+++ b/src/mship/core/daemon/supervisor.py
@@ -1,0 +1,240 @@
+"""OS-supervisor adapters: the single injectable boundary for every
+systemctl/launchctl/loginctl invocation in the daemon feature.
+
+Linux availability probes the USER MANAGER, not the binary: many containers and
+minimal hosts ship `systemctl` with no user manager running (`docker exec`,
+no-pam_systemd SSH), where any `--user` call dies with a bus error. macOS uses
+the `user/<uid>` launchd domain, not `gui/<uid>` — gui-domain operations fail
+over SSH with no GUI session ("Bootstrap failed: 5: Input/output error"),
+which is exactly the headless provisioning scenario #469/#470 describe.
+
+Crash-loop DETECTION is `history.py`'s job (OS-agnostic); `query()` only maps
+raw supervisor state.
+"""
+from __future__ import annotations
+
+import getpass
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Literal
+
+from mship.core.daemon.paths import daemon_log_dir
+from mship.core.daemon.units import (
+    LAUNCHD_LABEL,
+    SYSTEMD_UNIT_NAME,
+    launchd_plist_path,
+    render_launchd_plist,
+    render_systemd_unit,
+    systemd_unit_path,
+)
+
+_RUN_FALLBACK = "no supervisor is reachable — use `mship daemon run` for a foreground daemon"
+
+
+class DaemonSupervisorError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class SupervisorState:
+    state: Literal["active", "failed", "absent", "unreachable"]
+    detail: str = ""
+
+
+def _default_run(argv: list[str], **kw) -> subprocess.CompletedProcess:
+    return subprocess.run(argv, capture_output=True, text=True, **kw)
+
+
+class _BaseSupervisor:
+    def __init__(self, *, home: Path, run_cmd: Callable = _default_run) -> None:
+        self._home = home
+        self._run = run_cmd
+
+    def logs_tail(self, n: int) -> list[str]:
+        """Last N lines across daemon.log + rotated siblings — pure Python, no
+        journalctl (the phone-only-client case needs OS-independent logs)."""
+        log_dir = daemon_log_dir(self._home)
+        files = sorted(
+            log_dir.glob("daemon.log*"),
+            key=lambda p: int(p.suffix[1:]) if p.suffix[1:].isdigit() else 0,
+            reverse=True,  # highest numeric suffix = oldest first
+        )
+        lines: list[str] = []
+        for f in files:
+            try:
+                lines.extend(f.read_text().splitlines())
+            except OSError:
+                continue
+        return lines[-n:]
+
+
+class SystemdUserSupervisor(_BaseSupervisor):
+    def __init__(
+        self, *, home: Path, user: str | None = None, run_cmd: Callable = _default_run
+    ) -> None:
+        super().__init__(home=home, run_cmd=run_cmd)
+        self._user = user or getpass.getuser()
+
+    def _systemctl(self, *args: str) -> subprocess.CompletedProcess:
+        return self._run(["systemctl", "--user", *args])
+
+    def _checked(self, *args: str) -> subprocess.CompletedProcess:
+        try:
+            r = self._systemctl(*args)
+        except OSError as e:
+            raise DaemonSupervisorError(f"systemctl --user {' '.join(args)} failed: {e}; {_RUN_FALLBACK}") from e
+        if r.returncode != 0:
+            raise DaemonSupervisorError(
+                f"systemctl --user {' '.join(args)} failed: {r.stderr.strip() or r.stdout.strip()}; {_RUN_FALLBACK}"
+            )
+        return r
+
+    def available(self) -> bool:
+        """Any manager reply — even `degraded` (nonzero) — proves reachability;
+        a bus/connection error (or no systemctl at all) means unavailable."""
+        try:
+            r = self._systemctl("is-system-running")
+        except (OSError, Exception):
+            return False
+        reply = (r.stdout or "").strip()
+        if reply and "connect to bus" not in (r.stderr or ""):
+            return True
+        return False
+
+    def install(self, argv: list[str]) -> None:
+        unit_path = systemd_unit_path(self._home)
+        unit_path.parent.mkdir(parents=True, exist_ok=True)
+        unit_path.write_text(render_systemd_unit(argv))
+        self._checked("daemon-reload")
+        self._checked("enable", SYSTEMD_UNIT_NAME.removesuffix(".service"))
+        # Linger is mandatory: without it the user unit is torn down when the
+        # last SSH session ends — precisely the moment the daemon is needed.
+        try:
+            r = self._run(["loginctl", "enable-linger", self._user])
+        except OSError as e:
+            raise DaemonSupervisorError(f"loginctl enable-linger failed: {e}") from e
+        if r.returncode != 0:
+            raise DaemonSupervisorError(f"loginctl enable-linger failed: {r.stderr.strip()}")
+        if self.linger_state() != "yes":
+            raise DaemonSupervisorError(
+                "loginctl enable-linger did not stick (Linger!=yes) — without linger the "
+                "daemon dies when your last SSH session ends. Check `loginctl show-user`."
+            )
+
+    def start(self) -> None:
+        self._checked("start", SYSTEMD_UNIT_NAME.removesuffix(".service"))
+
+    def stop(self) -> None:
+        self._checked("stop", SYSTEMD_UNIT_NAME.removesuffix(".service"))
+
+    def restart(self) -> None:
+        self._checked("restart", SYSTEMD_UNIT_NAME.removesuffix(".service"))
+
+    def query(self) -> SupervisorState:
+        try:
+            r = self._systemctl(
+                "show", SYSTEMD_UNIT_NAME.removesuffix(".service"), "--property=ActiveState,SubState"
+            )
+        except OSError as e:
+            return SupervisorState("unreachable", str(e))
+        if r.returncode != 0:
+            return SupervisorState("unreachable", r.stderr.strip())
+        props = dict(
+            line.split("=", 1) for line in r.stdout.splitlines() if "=" in line
+        )
+        active = props.get("ActiveState")
+        if active is None:
+            return SupervisorState("absent", "unparseable systemctl show output")
+        if active == "active":
+            return SupervisorState("active", props.get("SubState", ""))
+        if active == "failed":
+            return SupervisorState("failed", props.get("SubState", ""))
+        return SupervisorState("absent", f"{active}/{props.get('SubState', '')}")
+
+    def linger_state(self) -> Literal["yes", "no", "unknown"]:
+        try:
+            r = self._run(["loginctl", "show-user", self._user, "--property=Linger"])
+        except OSError:
+            return "unknown"
+        if r.returncode != 0:
+            return "unknown"
+        value = r.stdout.strip().removeprefix("Linger=")
+        return value if value in ("yes", "no") else "unknown"
+
+
+class LaunchdSupervisor(_BaseSupervisor):
+    def __init__(self, *, home: Path, uid: int | None = None, run_cmd: Callable = _default_run) -> None:
+        super().__init__(home=home, run_cmd=run_cmd)
+        self._uid = uid if uid is not None else os.getuid()
+
+    @property
+    def _target(self) -> str:
+        return f"user/{self._uid}/{LAUNCHD_LABEL}"
+
+    def _launchctl(self, *args: str) -> subprocess.CompletedProcess:
+        return self._run(["launchctl", *args])
+
+    def _checked(self, *args: str) -> subprocess.CompletedProcess:
+        try:
+            r = self._launchctl(*args)
+        except OSError as e:
+            raise DaemonSupervisorError(f"launchctl {' '.join(args)} failed: {e}; {_RUN_FALLBACK}") from e
+        if r.returncode != 0:
+            raise DaemonSupervisorError(
+                f"launchctl {' '.join(args)} failed: {r.stderr.strip() or r.stdout.strip()}; {_RUN_FALLBACK}"
+            )
+        return r
+
+    def available(self) -> bool:
+        try:
+            r = self._launchctl("print", f"user/{self._uid}")
+        except (OSError, Exception):
+            return False
+        return r.returncode == 0
+
+    def install(self, argv: list[str]) -> None:
+        plist_path = launchd_plist_path(self._home)
+        plist_path.parent.mkdir(parents=True, exist_ok=True)
+        plist_path.write_text(render_launchd_plist(argv, daemon_log_dir(self._home)))
+        # user/<uid>, never gui/<uid>: bootstrap must work over SSH with no GUI
+        # session (the headless provisioning path).
+        self._checked("bootstrap", f"user/{self._uid}", str(plist_path))
+
+    def start(self) -> None:
+        self._checked("kickstart", self._target)
+
+    def stop(self) -> None:
+        self._checked("bootout", self._target)
+
+    def restart(self) -> None:
+        self._checked("kickstart", "-k", self._target)
+
+    def query(self) -> SupervisorState:
+        try:
+            r = self._launchctl("print", self._target)
+        except OSError as e:
+            return SupervisorState("unreachable", str(e))
+        if r.returncode != 0:
+            err = (r.stderr or "") + (r.stdout or "")
+            if "Could not find service" in err:
+                return SupervisorState("absent", err.strip())
+            return SupervisorState("unreachable", err.strip())
+        if "state = running" in r.stdout:
+            return SupervisorState("active")
+        return SupervisorState("absent", "loaded but not running")
+
+    def linger_state(self) -> Literal["yes", "no", "unknown"]:
+        return "unknown"  # not applicable on macOS
+
+    def linger_supported(self) -> bool:
+        return False
+
+
+def pick_supervisor(*, home: Path | None = None, platform: str = sys.platform):
+    home = home if home is not None else Path.home()
+    if platform == "darwin":
+        return LaunchdSupervisor(home=home)
+    return SystemdUserSupervisor(home=home)

--- a/src/mship/core/daemon/supervisor.py
+++ b/src/mship/core/daemon/supervisor.py
@@ -141,7 +141,12 @@ class SystemdUserSupervisor(_BaseSupervisor):
         except OSError as e:
             return SupervisorState("unreachable", str(e))
         if r.returncode != 0:
-            return SupervisorState("unreachable", r.stderr.strip())
+            # A reachable manager answers "not found" for an uninstalled unit —
+            # that is absent, not unreachable (pre-install `daemon status`).
+            error = (r.stderr or r.stdout or "").strip()
+            if "not found" in error.lower() or "could not be found" in error.lower():
+                return SupervisorState("absent", error)
+            return SupervisorState("unreachable", error)
         props = dict(
             line.split("=", 1) for line in r.stdout.splitlines() if "=" in line
         )
@@ -198,18 +203,29 @@ class LaunchdSupervisor(_BaseSupervisor):
     def install(self, argv: list[str]) -> None:
         plist_path = launchd_plist_path(self._home)
         plist_path.parent.mkdir(parents=True, exist_ok=True)
-        plist_path.write_text(render_launchd_plist(argv, daemon_log_dir(self._home)))
+        # launchd opens StandardOutPath/StandardErrorPath itself before exec —
+        # on a fresh account the job silently never starts if this dir is missing.
+        log_dir = daemon_log_dir(self._home)
+        log_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        plist_path.write_text(render_launchd_plist(argv, log_dir))
         # user/<uid>, never gui/<uid>: bootstrap must work over SSH with no GUI
         # session (the headless provisioning path).
         self._checked("bootstrap", f"user/{self._uid}", str(plist_path))
 
     def start(self) -> None:
+        # stop() boots the service OUT of the domain (the only true stop under
+        # KeepAlive — a signal-killed job would just be relaunched), so start
+        # must re-bootstrap when the service is no longer loaded.
+        if self.query().state == "absent":
+            self._checked("bootstrap", f"user/{self._uid}", str(launchd_plist_path(self._home)))
         self._checked("kickstart", self._target)
 
     def stop(self) -> None:
         self._checked("bootout", self._target)
 
     def restart(self) -> None:
+        if self.query().state == "absent":  # same unloaded-target class as start()
+            self._checked("bootstrap", f"user/{self._uid}", str(launchd_plist_path(self._home)))
         self._checked("kickstart", "-k", self._target)
 
     def query(self) -> SupervisorState:

--- a/src/mship/core/daemon/units.py
+++ b/src/mship/core/daemon/units.py
@@ -1,0 +1,111 @@
+"""Supervisor unit rendering + mshipd exec resolution.
+
+Exec resolution is sibling-first: `Path(sys.executable).parent / "mshipd"`
+(same venv bin dir ⇒ provably the same installed distribution — exactly the uv
+tool-install layout), else a `which("mshipd")` VERIFIED to live under the
+invoking CLI's `sys.prefix`, else `<sys.executable> -m mship.core.daemon`.
+
+A which() hit OUTSIDE sys.prefix (stale uv-tool shim while running `uv run
+mship` from a checkout — the documented worktree workflow) refuses: baking a
+worktree venv's python into a persistent unit would make `uv tool install
+--force` + `mship daemon restart` (the deploy step) silently deploy nothing.
+
+Heredoc-style unit constants follow the repo's one unit-generation precedent
+(`scripts/relay-bootstrap.sh`).
+"""
+from __future__ import annotations
+
+import shlex
+import shutil
+import sys
+from pathlib import Path
+from typing import Callable
+
+SYSTEMD_UNIT_NAME = "mship-daemon.service"
+LAUNCHD_LABEL = "com.mothership.daemon"
+
+
+class DaemonExecResolutionError(RuntimeError):
+    pass
+
+
+def resolve_mshipd_argv(which: Callable[[str], str | None] = shutil.which) -> list[str]:
+    exe = Path(sys.executable)
+    sibling = exe.parent / "mshipd"
+    if sibling.exists():
+        return [str(sibling)]
+    found = which("mshipd")
+    if found is not None:
+        found_path = Path(found)
+        try:
+            inside_prefix = found_path.resolve().is_relative_to(Path(sys.prefix).resolve())
+        except OSError:
+            inside_prefix = False
+        if inside_prefix:
+            return [str(found_path)]
+        raise DaemonExecResolutionError(
+            f"mshipd on PATH ({found}) belongs to a different installation than this "
+            f"mship CLI ({sys.prefix}) — you are likely running mship from a dev tree; "
+            "install the tool first (uv tool install --force <path>) and re-run "
+            "mship daemon install."
+        )
+    return [str(exe), "-m", "mship.core.daemon"]
+
+
+def render_systemd_unit(argv: list[str]) -> str:
+    exec_start = shlex.join(argv)
+    # StartLimit* live in [Unit]; Restart*/ExecStart in [Service]. Section
+    # placement is load-bearing — systemd silently ignores misplaced directives.
+    return f"""\
+[Unit]
+Description=Mothership daemon (mshipd) — host control plane
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+ExecStart={exec_start}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"""
+
+
+def render_launchd_plist(argv: list[str], log_dir: Path) -> str:
+    program_args = "\n".join(f"        <string>{a}</string>" for a in argv)
+    return f"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{LAUNCHD_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+{program_args}
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+    <key>StandardOutPath</key>
+    <string>{log_dir / "launchd.out.log"}</string>
+    <key>StandardErrorPath</key>
+    <string>{log_dir / "launchd.err.log"}</string>
+</dict>
+</plist>
+"""
+
+
+def systemd_unit_path(home: Path) -> Path:
+    return home / ".config" / "systemd" / "user" / SYSTEMD_UNIT_NAME
+
+
+def launchd_plist_path(home: Path) -> Path:
+    return home / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"

--- a/src/mship/core/daemon/units.py
+++ b/src/mship/core/daemon/units.py
@@ -73,34 +73,22 @@ WantedBy=default.target
 
 
 def render_launchd_plist(argv: list[str], log_dir: Path) -> str:
-    program_args = "\n".join(f"        <string>{a}</string>" for a in argv)
-    return f"""\
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>{LAUNCHD_LABEL}</string>
-    <key>ProgramArguments</key>
-    <array>
-{program_args}
-    </array>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
-    <key>ThrottleInterval</key>
-    <integer>5</integer>
-    <key>StandardOutPath</key>
-    <string>{log_dir / "launchd.out.log"}</string>
-    <key>StandardErrorPath</key>
-    <string>{log_dir / "launchd.err.log"}</string>
-</dict>
-</plist>
-"""
+    # plistlib, not string templating: argv/log paths land in XML, and a path
+    # containing &, <, > would otherwise render a plist launchctl rejects.
+    import plistlib
+
+    return plistlib.dumps(
+        {
+            "Label": LAUNCHD_LABEL,
+            "ProgramArguments": list(argv),
+            "RunAtLoad": True,
+            "KeepAlive": {"SuccessfulExit": False},
+            "ThrottleInterval": 5,
+            "StandardOutPath": str(log_dir / "launchd.out.log"),
+            "StandardErrorPath": str(log_dir / "launchd.err.log"),
+        },
+        sort_keys=False,
+    ).decode()
 
 
 def systemd_unit_path(home: Path) -> Path:

--- a/tests/cli/test_daemon.py
+++ b/tests/cli/test_daemon.py
@@ -153,3 +153,24 @@ def test_daemon_status_outside_workspace(tmp_path, monkeypatch):
     res = runner.invoke(real_app, ["daemon", "status"])
     assert res.exit_code == 0, res.output
     assert "not running" in res.output
+
+
+def test_status_json_mode_emits_json(cli, monkeypatch):
+    """`mship --json daemon status` / piped stdout must yield parseable JSON
+    (agentic review P2), not the rendered text block."""
+    import json as _json
+
+    from mship.cli.output import configure_output, reset_output_settings
+
+    app, fake = cli
+    monkeypatch.setattr(daemon_mod, "probe_daemon", lambda **kw: None)
+    configure_output(json=True)
+    try:
+        res = runner.invoke(app, ["daemon", "status"])
+    finally:
+        reset_output_settings()
+    assert res.exit_code == 0, res.output
+    payload = _json.loads(res.output)
+    assert payload["running"] is False
+    assert payload["cli_version"] == mship.__version__
+    assert isinstance(payload["lines"], list)

--- a/tests/cli/test_daemon.py
+++ b/tests/cli/test_daemon.py
@@ -1,0 +1,155 @@
+"""`mship daemon ...` CLI: thin over the supervisor seam. All supervisor
+interaction is monkeypatched (`pick_supervisor` → recording fake, the
+`tests/cli/test_relay_enroll_server.py` seam style)."""
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+import mship
+import mship.cli.daemon as daemon_mod
+from mship.core.daemon.supervisor import DaemonSupervisorError, SupervisorState
+
+runner = CliRunner()
+
+
+class FakeSupervisor:
+    def __init__(self, *, available=True, state="active", linger="yes"):
+        self._available = available
+        self._state = state
+        self._linger = linger
+        self.calls: list[str] = []
+
+    def available(self):
+        self.calls.append("available")
+        return self._available
+
+    def install(self, argv):
+        self.calls.append(f"install:{argv}")
+
+    def start(self):
+        self.calls.append("start")
+
+    def stop(self):
+        self.calls.append("stop")
+
+    def restart(self):
+        self.calls.append("restart")
+
+    def query(self):
+        self.calls.append("query")
+        return SupervisorState(self._state)
+
+    def linger_state(self):
+        return self._linger
+
+    def logs_tail(self, n):
+        self.calls.append(f"logs:{n}")
+        return ["line-1", "line-2"]
+
+
+@pytest.fixture
+def cli(monkeypatch, tmp_path):
+    fake = FakeSupervisor()
+    monkeypatch.setattr(daemon_mod, "pick_supervisor", lambda **kw: fake)
+    monkeypatch.setattr(daemon_mod, "resolve_mshipd_argv", lambda: ["/venv/bin/mshipd"])
+    monkeypatch.setattr(daemon_mod.Path, "home", classmethod(lambda cls: tmp_path))
+    app = typer.Typer()
+    daemon_mod.register(app, lambda required=True: None)
+    return app, fake
+
+
+def test_all_subcommands_registered(cli):
+    app, _ = cli
+    res = runner.invoke(app, ["daemon", "--help"])
+    assert res.exit_code == 0
+    for cmd in ("install", "start", "stop", "restart", "status", "logs", "run"):
+        assert cmd in res.output
+
+
+def test_install_happy_path(cli):
+    app, fake = cli
+    res = runner.invoke(app, ["daemon", "install"])
+    assert res.exit_code == 0, res.output
+    assert any(c.startswith("install:") for c in fake.calls)
+
+
+def test_install_no_supervisor_fails_loudly(monkeypatch, tmp_path):
+    fake = FakeSupervisor(available=False)
+    monkeypatch.setattr(daemon_mod, "pick_supervisor", lambda **kw: fake)
+    monkeypatch.setattr(daemon_mod, "resolve_mshipd_argv", lambda: ["/venv/bin/mshipd"])
+    app = typer.Typer()
+    daemon_mod.register(app, lambda required=True: None)
+    res = runner.invoke(app, ["daemon", "install"])
+    assert res.exit_code == 1
+    assert "mship daemon run" in res.output
+    assert not any(c.startswith("install:") for c in fake.calls)
+
+
+def test_restart_consults_blockers_first(cli, monkeypatch):
+    app, fake = cli
+    monkeypatch.setattr(daemon_mod, "restart_blockers", lambda: ["active unattended worker w-1"])
+    res = runner.invoke(app, ["daemon", "restart"])
+    assert res.exit_code == 1
+    assert "active unattended worker w-1" in res.output
+    assert "restart" not in fake.calls  # no supervisor call after refusal
+
+
+def test_restart_proceeds_when_unblocked(cli):
+    app, fake = cli
+    res = runner.invoke(app, ["daemon", "restart"])
+    assert res.exit_code == 0, res.output
+    assert "restart" in fake.calls
+
+
+def test_status_renders_skew_and_warnings(cli, monkeypatch):
+    app, fake = cli
+    fake._state = "absent"
+    monkeypatch.setattr(
+        daemon_mod,
+        "probe_daemon",
+        lambda **kw: {
+            "status": "ok",
+            "pid": 7,
+            "mship_version": "0.0.1",
+            "protocol": 1,
+            "uptime_s": 5.0,
+            "socket": "/s.sock",
+        },
+    )
+    res = runner.invoke(app, ["daemon", "status"])
+    assert res.exit_code == 0, res.output
+    assert f"CLI v{mship.__version__}" in res.output
+    assert "restart required" in res.output
+    assert "outside the supervisor" in res.output
+
+
+def test_logs_prints_tail(cli):
+    app, fake = cli
+    res = runner.invoke(app, ["daemon", "logs"])
+    assert res.exit_code == 0
+    assert "line-1" in res.output and "line-2" in res.output
+
+
+def test_run_invokes_daemon_main(cli, monkeypatch):
+    app, fake = cli
+    monkeypatch.setattr(daemon_mod, "_daemon_main", lambda: 3)
+    res = runner.invoke(app, ["daemon", "run"])
+    assert res.exit_code == 3
+    assert fake.calls == []  # no supervisor interaction on the foreground path
+
+
+def test_daemon_status_outside_workspace(tmp_path, monkeypatch):
+    """Through the real global app, from a directory with no mothership.yaml:
+    no workspace discovery on any daemon path."""
+    from mship.cli import app as real_app
+
+    fake = FakeSupervisor()
+    monkeypatch.setattr(daemon_mod, "pick_supervisor", lambda **kw: fake)
+    monkeypatch.setattr(daemon_mod, "probe_daemon", lambda **kw: None)
+    monkeypatch.setattr(daemon_mod.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.chdir(tmp_path)
+    res = runner.invoke(real_app, ["daemon", "status"])
+    assert res.exit_code == 0, res.output
+    assert "not running" in res.output

--- a/tests/core/daemon/test_control.py
+++ b/tests/core/daemon/test_control.py
@@ -1,0 +1,88 @@
+"""Control app: the daemon's local identity surface. Version is captured at
+process start (the upgrade-in-place lie #470 calls out), capabilities are the
+#471/#472/#473 seams."""
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+import mship
+from mship.core.daemon.control import PROTOCOL, create_control_app, probe_control_socket
+
+STARTED = datetime(2026, 8, 16, 11, 0, 0, tzinfo=timezone.utc)
+
+
+def _client(version: str = "0.5.52") -> TestClient:
+    app = create_control_app(started_at=STARTED, version=version, socket_path="/run/mship/daemon.sock")
+    return TestClient(app)
+
+
+def test_health_payload_shape():
+    now = datetime.now(timezone.utc)
+    r = _client().get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["mship_version"] == "0.5.52"
+    assert body["protocol"] == PROTOCOL
+    assert body["started_at"] == STARTED.isoformat()
+    assert body["socket"] == "/run/mship/daemon.sock"
+    assert body["pid"] > 0
+    assert body["uptime_s"] >= (now - STARTED).total_seconds() - 5
+    assert body["capabilities"] == {
+        "serve": False,
+        "tunnel": False,
+        "registry": False,
+        "runner": False,
+    }
+
+
+def test_version_is_captured_at_start_not_reread(monkeypatch):
+    client = _client(version="0.5.51")
+    monkeypatch.setattr(mship, "__version__", "9.9.9")
+    assert client.get("/health").json()["mship_version"] == "0.5.51"
+
+
+def test_probe_control_socket_never_raises(tmp_path):
+    # No daemon on this socket: probe returns None, no exception.
+    assert probe_control_socket(tmp_path / "absent.sock") is None
+
+
+def test_probe_control_socket_returns_payload():
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"status": "ok", "mship_version": "1"}
+
+    class FakeClient:
+        def __init__(self, **kw):
+            pass
+
+        def get(self, url, **kw):
+            return FakeResponse()
+
+        def close(self):
+            pass
+
+    payload = probe_control_socket("/some.sock", client_factory=FakeClient)
+    assert payload == {"status": "ok", "mship_version": "1"}
+
+
+def test_probe_control_socket_non_200_is_none():
+    class FakeResponse:
+        status_code = 500
+
+        def json(self):  # pragma: no cover - not reached
+            return {}
+
+    class FakeClient:
+        def __init__(self, **kw):
+            pass
+
+        def get(self, url, **kw):
+            return FakeResponse()
+
+        def close(self):
+            pass
+
+    assert probe_control_socket("/some.sock", client_factory=FakeClient) is None

--- a/tests/core/daemon/test_history.py
+++ b/tests/core/daemon/test_history.py
@@ -1,0 +1,83 @@
+"""Start history is the OS-agnostic crash-loop detector's data: identical under
+systemd, launchd, and `daemon run`. Only UNCLEAN starts (not preceded by a
+clean stop) count toward a loop, so routine operator restarts never cry wolf."""
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from mship.core.daemon.history import (
+    HistoryEntry,
+    append_clean_stop,
+    append_start,
+    is_crash_looping,
+    read_history,
+    unclean_start_count,
+)
+
+NOW = datetime(2026, 8, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _t(seconds_ago: float) -> datetime:
+    return NOW - timedelta(seconds=seconds_ago)
+
+
+def test_append_and_read_roundtrip(tmp_path: Path):
+    path = tmp_path / "start-history.json"
+    append_start(path, _t(30))
+    append_clean_stop(path, _t(20))
+    append_start(path, _t(10))
+    entries = read_history(path)
+    assert [e.kind for e in entries] == ["start", "clean_stop", "start"]
+    assert entries[0].at == _t(30)
+
+
+def test_history_trims_to_last_20(tmp_path: Path):
+    path = tmp_path / "h.json"
+    for i in range(25):
+        append_start(path, _t(1000 - i))
+    assert len(read_history(path)) == 20
+
+
+def test_corrupt_file_starts_fresh(tmp_path: Path):
+    path = tmp_path / "h.json"
+    path.write_text("{not json")
+    assert read_history(path) == []
+    append_start(path, NOW)
+    assert len(read_history(path)) == 1
+
+
+def test_missing_file_reads_empty(tmp_path: Path):
+    assert read_history(tmp_path / "absent.json") == []
+
+
+def test_under_threshold_not_looping():
+    entries = [HistoryEntry("start", _t(100)), HistoryEntry("start", _t(50))]
+    assert not is_crash_looping(entries, NOW, window_s=600, threshold=3)
+
+
+def test_threshold_unclean_starts_in_window_loops():
+    entries = [HistoryEntry("start", _t(300)), HistoryEntry("start", _t(200)), HistoryEntry("start", _t(100))]
+    assert is_crash_looping(entries, NOW, window_s=600, threshold=3)
+
+
+def test_old_entries_outside_window_ignored():
+    entries = [
+        HistoryEntry("start", _t(5000)),
+        HistoryEntry("start", _t(4000)),
+        HistoryEntry("start", _t(100)),
+    ]
+    assert not is_crash_looping(entries, NOW, window_s=600, threshold=3)
+    assert unclean_start_count(entries, NOW, window_s=600) == 1
+
+
+def test_operator_restarts_do_not_cry_loop():
+    """start/stop/start/stop/start inside the window: every restart is clean."""
+    entries = [
+        HistoryEntry("start", _t(500)),
+        HistoryEntry("clean_stop", _t(400)),
+        HistoryEntry("start", _t(300)),
+        HistoryEntry("clean_stop", _t(200)),
+        HistoryEntry("start", _t(100)),
+    ]
+    assert not is_crash_looping(entries, NOW, window_s=600, threshold=3)
+    # Only the first start is unclean (no preceding clean stop).
+    assert unclean_start_count(entries, NOW, window_s=600) == 1

--- a/tests/core/daemon/test_lease.py
+++ b/tests/core/daemon/test_lease.py
@@ -1,0 +1,147 @@
+"""Single-instance lease: the held flock is the liveness authority; the
+recorded pid is diagnostic only. Cross-process cases use real multiprocessing
+(the `tests/core/test_store_concurrency.py` precedent) because flock is
+per-open-file-description — a second acquire in the SAME process would succeed
+and prove nothing.
+"""
+import json
+import multiprocessing
+import os
+from pathlib import Path
+
+import pytest
+
+from mship.core.daemon.lease import DaemonLease, LeaseInfo
+
+
+def _acquire_and_report(path: str, q: multiprocessing.Queue, hold_s: float = 0.0):
+    lease = DaemonLease(Path(path))
+    holder = lease.try_acquire(version="1.0", socket_path="/tmp/x.sock")
+    if holder is None:
+        q.put(("won", os.getpid()))
+        if hold_s:
+            import time
+
+            time.sleep(hold_s)
+    else:
+        q.put(("lost", holder.pid))
+
+
+def _spawn(target, *args):
+    ctx = multiprocessing.get_context("spawn")
+    p = ctx.Process(target=target, args=args)
+    p.start()
+    return p
+
+
+def test_acquire_creates_lease_and_holds_flock(tmp_path: Path):
+    path = tmp_path / "daemon.lease"
+    lease = DaemonLease(path)
+    assert lease.try_acquire(version="0.5.52", socket_path="/run/s.sock") is None
+    raw = json.loads(path.read_text())
+    assert raw["pid"] == os.getpid()
+    assert raw["version"] == "0.5.52"
+    assert raw["socket_path"] == "/run/s.sock"
+    assert raw["started_at"]
+
+    # A child process must lose and see this process as the holder.
+    q = multiprocessing.get_context("spawn").Queue()
+    p = _spawn(_acquire_and_report, str(path), q)
+    outcome, pid = q.get(timeout=30)
+    p.join(timeout=30)
+    assert outcome == "lost"
+    assert pid == os.getpid()
+    lease.release()
+
+
+def test_late_arrival_after_write_loses(tmp_path: Path):
+    """Winner acquires AND completes its JSON write; a late arrival must lose.
+
+    Deterministically catches the inode-swap failure mode: any tmp+os.replace
+    write would leave the winner's flock on an unlinked inode, so the late
+    arrival would flock the fresh file and 'win'. This is also the steady-state
+    `daemon run`-while-unit-is-up case.
+    """
+    path = tmp_path / "daemon.lease"
+    lease = DaemonLease(path)
+    assert lease.try_acquire(version="1", socket_path="/s") is None  # write completed
+
+    q = multiprocessing.get_context("spawn").Queue()
+    p = _spawn(_acquire_and_report, str(path), q)
+    outcome, _pid = q.get(timeout=30)
+    p.join(timeout=30)
+    assert outcome == "lost"
+    lease.release()
+
+
+def test_stale_lease_dead_pid_is_reclaimed(tmp_path: Path):
+    path = tmp_path / "daemon.lease"
+    path.write_text(
+        json.dumps(
+            {"pid": 2**22 + 1, "started_at": "2026-01-01T00:00:00+00:00", "version": "0", "socket_path": "/s"}
+        )
+    )
+    lease = DaemonLease(path)
+    assert lease.try_acquire(version="1", socket_path="/s2") is None
+    assert json.loads(path.read_text())["pid"] == os.getpid()
+    lease.release()
+
+
+def test_pid_reuse_does_not_read_as_running(tmp_path: Path):
+    """A lease pointing at a LIVE but unrelated process (our parent) with no
+    flock held is still reclaimed: the flock is the authority, not the pid."""
+    path = tmp_path / "daemon.lease"
+    live_unrelated = os.getppid()
+    path.write_text(
+        json.dumps(
+            {"pid": live_unrelated, "started_at": "2026-01-01T00:00:00+00:00", "version": "0", "socket_path": "/s"}
+        )
+    )
+    lease = DaemonLease(path)
+    assert lease.try_acquire(version="1", socket_path="/s2") is None
+    lease.release()
+
+
+def test_concurrent_cold_start_converges(tmp_path: Path):
+    path = tmp_path / "daemon.lease"
+    ctx = multiprocessing.get_context("spawn")
+    q = ctx.Queue()
+    procs = [_spawn(_acquire_and_report, str(path), q, 2.0) for _ in range(5)]
+    outcomes = [q.get(timeout=60) for _ in procs]
+    for p in procs:
+        p.join(timeout=60)
+    wins = [o for o in outcomes if o[0] == "won"]
+    losses = [o for o in outcomes if o[0] == "lost"]
+    assert len(wins) == 1
+    assert len(losses) == 4
+    # Losers report the winner's pid or None ("held by unknown" mid-write race);
+    # never a second win.
+    winner_pid = wins[0][1]
+    assert all(pid in (winner_pid, None) for _, pid in losses)
+
+
+def test_loser_mid_write_returns_unknown_holder(tmp_path: Path):
+    """Flock held but the record unreadable after retries → LeaseInfo(pid=None)."""
+    path = tmp_path / "daemon.lease"
+    lease = DaemonLease(path)
+    assert lease.try_acquire(version="1", socket_path="/s") is None
+    # Simulate an in-progress write: truncate the record through the fd.
+    os.ftruncate(lease._fd, 0)
+
+    q = multiprocessing.get_context("spawn").Queue()
+    p = _spawn(_acquire_and_report, str(path), q)
+    outcome, pid = q.get(timeout=30)
+    p.join(timeout=30)
+    assert outcome == "lost"
+    assert pid is None
+    lease.release()
+
+
+def test_release_allows_reacquire(tmp_path: Path):
+    path = tmp_path / "daemon.lease"
+    lease = DaemonLease(path)
+    assert lease.try_acquire(version="1", socket_path="/s") is None
+    lease.release()
+    lease2 = DaemonLease(path)
+    assert lease2.try_acquire(version="2", socket_path="/s") is None
+    lease2.release()

--- a/tests/core/daemon/test_paths.py
+++ b/tests/core/daemon/test_paths.py
@@ -21,22 +21,38 @@ def test_state_dir_and_derivatives(tmp_path: Path):
 
 def test_socket_prefers_xdg_runtime_dir(tmp_path: Path):
     runtime = tmp_path / "runtime"
-    sock = daemon_socket_path({"XDG_RUNTIME_DIR": str(runtime)}, tmp_path / "home")
+    sock = daemon_socket_path({"XDG_RUNTIME_DIR": str(runtime)}, tmp_path / "home", create=True)
     assert sock == runtime / "mship" / "daemon.sock"
     assert sock.parent.is_dir()
 
 
 def test_socket_falls_back_under_state_dir(tmp_path: Path):
     home = tmp_path / "home"
-    sock = daemon_socket_path({}, home)
+    sock = daemon_socket_path({}, home, create=True)
     assert sock == daemon_state_dir(home) / "run" / "daemon.sock"
     assert sock.parent.is_dir()
 
 
 def test_created_dirs_are_private(tmp_path: Path):
     home = tmp_path / "home"
-    sock = daemon_socket_path({}, home)
+    sock = daemon_socket_path({}, home, create=True)
     assert (sock.parent.stat().st_mode & 0o777) == 0o700
     runtime = tmp_path / "runtime"
-    sock2 = daemon_socket_path({"XDG_RUNTIME_DIR": str(runtime)}, home)
+    sock2 = daemon_socket_path({"XDG_RUNTIME_DIR": str(runtime)}, home, create=True)
     assert (sock2.parent.stat().st_mode & 0o777) == 0o700
+
+
+def test_default_is_pure_no_dirs_created(tmp_path: Path):
+    """Probe/status paths must not create dirs: a stale/unwritable
+    XDG_RUNTIME_DIR would crash `mship daemon status` (agentic review P2)."""
+    runtime = tmp_path / "runtime"
+    sock = daemon_socket_path({"XDG_RUNTIME_DIR": str(runtime)}, tmp_path / "home")
+    assert sock == runtime / "mship" / "daemon.sock"
+    assert not sock.parent.exists()
+
+
+def test_unwritable_runtime_dir_does_not_raise_by_default(tmp_path: Path):
+    blocked = tmp_path / "blocked"
+    blocked.mkdir(mode=0o500)
+    sock = daemon_socket_path({"XDG_RUNTIME_DIR": str(blocked / "rt")}, tmp_path / "home")
+    assert sock.name == "daemon.sock"  # computed, nothing raised

--- a/tests/core/daemon/test_paths.py
+++ b/tests/core/daemon/test_paths.py
@@ -1,0 +1,42 @@
+"""Daemon path derivation is pure: explicit `home` + `env`, no ambient reads."""
+from pathlib import Path
+
+from mship.core.daemon.paths import (
+    daemon_log_dir,
+    daemon_socket_path,
+    daemon_state_dir,
+    lease_path,
+    start_history_path,
+)
+
+
+def test_state_dir_and_derivatives(tmp_path: Path):
+    home = tmp_path
+    state = daemon_state_dir(home)
+    assert state == home / ".mothership" / "daemon"
+    assert daemon_log_dir(home) == state / "logs"
+    assert lease_path(home) == state / "daemon.lease"
+    assert start_history_path(home) == state / "start-history.json"
+
+
+def test_socket_prefers_xdg_runtime_dir(tmp_path: Path):
+    runtime = tmp_path / "runtime"
+    sock = daemon_socket_path({"XDG_RUNTIME_DIR": str(runtime)}, tmp_path / "home")
+    assert sock == runtime / "mship" / "daemon.sock"
+    assert sock.parent.is_dir()
+
+
+def test_socket_falls_back_under_state_dir(tmp_path: Path):
+    home = tmp_path / "home"
+    sock = daemon_socket_path({}, home)
+    assert sock == daemon_state_dir(home) / "run" / "daemon.sock"
+    assert sock.parent.is_dir()
+
+
+def test_created_dirs_are_private(tmp_path: Path):
+    home = tmp_path / "home"
+    sock = daemon_socket_path({}, home)
+    assert (sock.parent.stat().st_mode & 0o777) == 0o700
+    runtime = tmp_path / "runtime"
+    sock2 = daemon_socket_path({"XDG_RUNTIME_DIR": str(runtime)}, home)
+    assert (sock2.parent.stat().st_mode & 0o777) == 0o700

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -1,0 +1,180 @@
+"""mshipd run loop: lease → history → logs → uvicorn over the unix socket.
+
+Loser exit-code policy (cross-OS, decided up front): confirmed-live holder →
+exit 0 (launchd's KeepAlive.SuccessfulExit=false relaunches on ANY nonzero exit
+every ThrottleInterval — a permanent hot loop; systemd Restart=on-failure
+already skips 0). Contended-but-dead → nonzero so the supervisor retries.
+"""
+import json
+import logging
+import multiprocessing
+import tomllib
+from pathlib import Path
+
+import pytest
+
+import mship.core.daemon.run as run_mod
+from mship.core.daemon.history import read_history
+from mship.core.daemon.lease import DaemonLease
+from mship.core.daemon.paths import daemon_log_dir, daemon_socket_path, lease_path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture
+def env_home(tmp_path, monkeypatch):
+    """Isolated home + env for main(); returns (home, env)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    env = {}
+    # Reset logging state main() configures so tests stay independent.
+    yield home, env
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        root.removeHandler(h)
+        h.close()
+    for name in ("uvicorn", "uvicorn.error"):
+        lg = logging.getLogger(name)
+        for h in list(lg.handlers):
+            lg.removeHandler(h)
+            h.close()
+
+
+def _capture_uvicorn(monkeypatch):
+    seen = {}
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", lambda app, **k: seen.update(k))
+    return seen
+
+
+def test_main_acquires_lease_then_serves_socket(env_home, monkeypatch):
+    home, env = env_home
+    seen = _capture_uvicorn(monkeypatch)
+    lease_seen_held_by_uvicorn = {}
+
+    import uvicorn
+
+    real_update = seen.update
+
+    def fake_run(app, **k):
+        # By the time uvicorn is entered, lease + history must already exist.
+        lease_seen_held_by_uvicorn["lease"] = json.loads(lease_path(home).read_text())
+        lease_seen_held_by_uvicorn["history"] = [e.kind for e in read_history(run_mod.paths.start_history_path(home))]
+        real_update(k)
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+    rc = run_mod.main(home=home, env=env)
+    assert rc == 0
+    assert seen["uds"] == str(daemon_socket_path(env, home))
+    assert "host" not in seen and "port" not in seen
+    assert seen["log_config"] is None
+    assert lease_seen_held_by_uvicorn["lease"]["pid"] > 0
+    assert "start" in lease_seen_held_by_uvicorn["history"]
+
+
+def _hold_lease(path_str: str, sock_str: str, ready: multiprocessing.Event, done: multiprocessing.Event):
+    lease = DaemonLease(Path(path_str))
+    assert lease.try_acquire(version="held", socket_path=sock_str) is None
+    ready.set()
+    done.wait(timeout=60)
+
+
+@pytest.fixture
+def foreign_holder(env_home):
+    """A child process holding the lease; yields the socket path it recorded."""
+    home, env = env_home
+    sock = str(home / "held.sock")
+    ctx = multiprocessing.get_context("spawn")
+    ready, done = ctx.Event(), ctx.Event()
+    p = ctx.Process(target=_hold_lease, args=(str(lease_path(home)), sock, ready, done))
+    p.start()
+    assert ready.wait(timeout=30)
+    yield sock
+    done.set()
+    p.join(timeout=30)
+
+
+def test_lost_race_with_live_holder_exits_zero(env_home, foreign_holder, monkeypatch, caplog):
+    home, env = env_home
+    called = _capture_uvicorn(monkeypatch)
+    monkeypatch.setattr(run_mod, "_probe", lambda sock: {"status": "ok"} if str(sock) == foreign_holder else None)
+    with caplog.at_level(logging.INFO):
+        rc = run_mod.main(home=home, env=env)
+    assert rc == 0
+    assert called == {}  # uvicorn never entered
+    assert any("already running" in r.message for r in caplog.records)
+
+
+def test_lost_race_with_dead_holder_exits_nonzero(env_home, foreign_holder, monkeypatch):
+    home, env = env_home
+    called = _capture_uvicorn(monkeypatch)
+    monkeypatch.setattr(run_mod, "_probe", lambda sock: None)  # holder never answers
+    rc = run_mod.main(home=home, env=env)
+    assert rc != 0
+    assert called == {}
+
+
+def test_stale_socket_file_is_removed_before_bind(env_home, monkeypatch):
+    home, env = env_home
+    _capture_uvicorn(monkeypatch)
+    sock = daemon_socket_path(env, home)
+    sock.touch()  # leftover from kill -9
+    assert run_mod.main(home=home, env=env) == 0
+    assert not sock.exists()
+
+
+def test_rotating_log_handler_configured(env_home, monkeypatch):
+    home, env = env_home
+    _capture_uvicorn(monkeypatch)
+    assert run_mod.main(home=home, env=env) == 0
+    log_file = daemon_log_dir(home) / "daemon.log"
+    assert log_file.exists()
+    handlers = logging.getLogger().handlers
+    rotating = [h for h in handlers if h.__class__.__name__ == "RotatingFileHandler"]
+    assert rotating, "root logger must carry the rotating handler"
+    for name in ("uvicorn", "uvicorn.error"):
+        lg = logging.getLogger(name)
+        assert any(h in rotating for h in lg.handlers), f"{name} not routed to daemon.log"
+
+
+def test_uncaught_exception_lands_in_daemon_log(env_home, monkeypatch):
+    home, env = env_home
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", lambda app, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    rc = run_mod.main(home=home, env=env)
+    assert rc != 0
+    assert "boom" in (daemon_log_dir(home) / "daemon.log").read_text()
+
+
+def test_broken_import_still_appends_history(env_home, monkeypatch):
+    """The botched-upgrade class: new on-disk code fails to import. History and
+    the log must still record the attempt before the nonzero exit."""
+    home, env = env_home
+
+    def broken_import():
+        raise ImportError("missing dep after upgrade")
+
+    monkeypatch.setattr(run_mod, "_import_server_stack", broken_import)
+    rc = run_mod.main(home=home, env=env)
+    assert rc != 0
+    assert [e.kind for e in read_history(run_mod.paths.start_history_path(home))] == ["start"]
+    assert "missing dep after upgrade" in (daemon_log_dir(home) / "daemon.log").read_text()
+
+
+def test_clean_stop_recorded(env_home, monkeypatch):
+    home, env = env_home
+    _capture_uvicorn(monkeypatch)
+    assert run_mod.main(home=home, env=env) == 0
+    kinds = [e.kind for e in read_history(run_mod.paths.start_history_path(home))]
+    assert kinds == ["start", "clean_stop"]
+
+
+def test_entrypoint_registered():
+    """pyproject-parsed, not entry_points() metadata — installed-dist metadata
+    can be stale vs pythonpath=["src"] (the tests/test_version.py precedent)."""
+    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
+        pyproject = tomllib.load(f)
+    assert pyproject["project"]["scripts"]["mshipd"] == "mship.core.daemon.run:main"
+    assert callable(run_mod.main)

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -118,7 +118,7 @@ def test_lost_race_with_dead_holder_exits_nonzero(env_home, foreign_holder, monk
 def test_stale_socket_file_is_removed_before_bind(env_home, monkeypatch):
     home, env = env_home
     _capture_uvicorn(monkeypatch)
-    sock = daemon_socket_path(env, home)
+    sock = daemon_socket_path(env, home, create=True)
     sock.touch()  # leftover from kill -9
     assert run_mod.main(home=home, env=env) == 0
     assert not sock.exists()

--- a/tests/core/daemon/test_status.py
+++ b/tests/core/daemon/test_status.py
@@ -1,0 +1,144 @@
+"""Status assembly: all inputs injected; the lease file is read-only JSON
+diagnostics on this path — never opened for locking."""
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import mship.core.daemon.status as status_mod
+from mship.core.daemon.history import HistoryEntry
+from mship.core.daemon.lease import LeaseInfo
+from mship.core.daemon.status import build_status, restart_blockers
+from mship.core.daemon.supervisor import SupervisorState
+
+NOW = datetime(2026, 8, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+HEALTH = {
+    "status": "ok",
+    "pid": 4242,
+    "mship_version": "0.5.52",
+    "protocol": 1,
+    "started_at": "2026-08-16T11:00:00+00:00",
+    "uptime_s": 3600.0,
+    "socket": "/run/user/1000/mship/daemon.sock",
+    "capabilities": {"serve": False, "tunnel": False, "registry": False, "runner": False},
+}
+
+
+def _status(**kw):
+    defaults = dict(
+        supervisor_state=SupervisorState("active"),
+        linger="yes",
+        lease_info=LeaseInfo(pid=4242, socket_path="/run/user/1000/mship/daemon.sock"),
+        health=HEALTH,
+        cli_version="0.5.52",
+        history_entries=[],
+        now=NOW,
+    )
+    defaults.update(kw)
+    return build_status(**defaults)
+
+
+def test_healthy_rendering():
+    s = _status()
+    assert s.running is True
+    assert s.pid == 4242
+    assert s.daemon_version == "0.5.52"
+    assert s.compatible is True
+    assert s.supervised is True
+    rendered = s.render()
+    assert "tunnel: not configured (#471)" in rendered
+    assert "workspaces: registry pending (#472)" in rendered
+    assert "runner: not configured (#473)" in rendered
+
+
+def test_version_skew_detected():
+    s = _status(health={**HEALTH, "mship_version": "0.5.51"}, cli_version="0.5.52")
+    assert s.compatible is False
+    assert "restart required: daemon v0.5.51, CLI v0.5.52" in s.render()
+
+
+def test_absent_rendering():
+    """No lease record + failed probe + inactive supervisor → absent. A stale
+    lease alone never reads as 'already running'."""
+    s = _status(lease_info=None, health=None, supervisor_state=SupervisorState("absent"))
+    assert s.running is False
+    assert "not running" in s.render()
+
+
+def test_unresponsive_rendering():
+    s = _status(health=None)
+    assert s.running is False
+    assert "unresponsive" in s.render()
+
+
+def test_crash_loop_rendering():
+    entries = [HistoryEntry("start", NOW.replace(minute=57 - i)) for i in range(3)]
+    s = _status(history_entries=entries)
+    assert "3 unclean starts in last 10m" in s.render()
+
+
+def test_healthy_but_unsupervised_warns():
+    """The normal result of `mship daemon run` in a shell: never render plain
+    'healthy', which would pretend persistence exists."""
+    s = _status(supervisor_state=SupervisorState("absent"))
+    assert s.running is True
+    assert s.supervised is False
+    rendered = s.render()
+    assert "outside the supervisor" in rendered
+    assert "will not survive" in rendered
+
+
+def test_linger_off_warns():
+    s = _status(linger="no")
+    assert "linger" in s.render().lower()
+    assert "warning" in s.render().lower()
+
+
+def test_probe_uses_lease_socket_path(tmp_path, monkeypatch):
+    """XDG_RUNTIME_DIR can differ between the daemon's systemd-provided env and
+    the invoking shell — the probe must hit the LEASE's recorded path, else a
+    healthy daemon renders 'unresponsive' purely from env divergence."""
+    probed = {}
+
+    def fake_probe(sock, **kw):
+        probed["path"] = str(sock)
+        return HEALTH
+
+    monkeypatch.setattr(status_mod, "probe_control_socket", fake_probe)
+    home = tmp_path
+    lease_file = home / ".mothership" / "daemon" / "daemon.lease"
+    lease_file.parent.mkdir(parents=True)
+    lease_file.write_text(
+        '{"pid": 1, "started_at": "2026-08-16T11:00:00+00:00", "version": "1", "socket_path": "/daemon/env/mship.sock"}'
+    )
+    payload = status_mod.probe_daemon(home=home, env={"XDG_RUNTIME_DIR": str(tmp_path / "cli-env")})
+    assert payload == HEALTH
+    assert probed["path"] == "/daemon/env/mship.sock"
+
+    # No lease at all → falls back to the computed path.
+    lease_file.unlink()
+    status_mod.probe_daemon(home=home, env={"XDG_RUNTIME_DIR": str(tmp_path / "cli-env")})
+    assert probed["path"] == str(tmp_path / "cli-env" / "mship" / "daemon.sock")
+
+
+def test_status_never_touches_the_lease_flock(tmp_path, monkeypatch):
+    """Liveness is the socket probe + supervisor state; a status probe that
+    transiently flocks the lease can race a starting daemon into its loser
+    path."""
+    import fcntl
+
+    def forbidden(*a, **kw):  # pragma: no cover - failure path
+        raise AssertionError("status path acquired a lock on the lease file")
+
+    monkeypatch.setattr(fcntl, "flock", forbidden)
+    monkeypatch.setattr(status_mod, "probe_control_socket", lambda sock, **kw: None)
+    home = tmp_path
+    lease_file = home / ".mothership" / "daemon" / "daemon.lease"
+    lease_file.parent.mkdir(parents=True)
+    lease_file.write_text('{"pid": 1, "socket_path": "/x.sock"}')
+    status_mod.probe_daemon(home=home, env={})
+
+
+def test_restart_blockers_empty_in_v1():
+    assert restart_blockers() == []

--- a/tests/core/daemon/test_status.py
+++ b/tests/core/daemon/test_status.py
@@ -142,3 +142,13 @@ def test_status_never_touches_the_lease_flock(tmp_path, monkeypatch):
 
 def test_restart_blockers_empty_in_v1():
     assert restart_blockers() == []
+
+
+def test_single_unclean_start_is_not_labeled_crash_loop():
+    """One kill -9 is informational, not an alarm: the crash-loop label is
+    gated on history.is_crash_looping's threshold."""
+    entries = [HistoryEntry("start", NOW.replace(minute=58))]
+    s = _status(history_entries=entries)
+    rendered = s.render()
+    assert "crash loop" not in rendered
+    assert "unclean starts: 1 in last 10m" in rendered

--- a/tests/core/daemon/test_supervisor.py
+++ b/tests/core/daemon/test_supervisor.py
@@ -188,3 +188,42 @@ def test_logs_tail_spans_rotated_siblings(tmp_path):
 def test_pick_supervisor():
     assert isinstance(pick_supervisor(platform="linux"), SystemdUserSupervisor)
     assert isinstance(pick_supervisor(platform="darwin"), LaunchdSupervisor)
+
+
+def test_macos_install_creates_log_dir(tmp_path):
+    """launchd opens StandardOutPath itself before exec — a missing log dir
+    means the RunAtLoad job silently never starts on a fresh account."""
+    from mship.core.daemon.paths import daemon_log_dir
+
+    sup, _ = _mac(tmp_path)
+    sup.install(["/venv/bin/mshipd"])
+    assert daemon_log_dir(tmp_path).is_dir()
+
+
+def test_macos_start_rebootstraps_after_stop(tmp_path):
+    """stop() boots the service out of the domain; start()/restart() must
+    re-bootstrap an absent service before kickstarting it."""
+    sup, rec = _mac(tmp_path, {"print": _fail(stderr="Could not find service")})
+    sup.start()
+    cmds = [" ".join(c) for c in rec.calls]
+    assert any("bootstrap user/501" in c for c in cmds)
+    assert any("kickstart user/501" in c for c in cmds)
+
+    sup2, rec2 = _mac(tmp_path, {"print": _fail(stderr="Could not find service")})
+    sup2.restart()
+    cmds2 = [" ".join(c) for c in rec2.calls]
+    assert any("bootstrap user/501" in c for c in cmds2)
+
+
+def test_macos_start_skips_bootstrap_when_loaded(tmp_path):
+    sup, rec = _mac(tmp_path, {"print": _ok("state = running\npid = 1\n")})
+    sup.start()
+    cmds = [" ".join(c) for c in rec.calls]
+    assert not any("bootstrap" in c for c in cmds)
+
+
+def test_linux_query_unit_not_found_is_absent(tmp_path):
+    """A reachable manager answering 'not found' for an uninstalled unit is
+    absent, not unreachable (the pre-install `daemon status` case)."""
+    sup, _ = _linux(tmp_path, {"show mship-daemon": _fail(stderr="Unit mship-daemon.service could not be found.")})
+    assert sup.query().state == "absent"

--- a/tests/core/daemon/test_supervisor.py
+++ b/tests/core/daemon/test_supervisor.py
@@ -1,0 +1,190 @@
+"""Supervisor adapter: every OS-supervisor invocation goes through this one
+injectable boundary, tested with a recorder fake for run_cmd."""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mship.core.daemon.supervisor import (
+    DaemonSupervisorError,
+    LaunchdSupervisor,
+    SystemdUserSupervisor,
+    pick_supervisor,
+)
+
+
+class Recorder:
+    """Fake subprocess.run: records argv, returns scripted results."""
+
+    def __init__(self, responses=None):
+        self.calls: list[list[str]] = []
+        self.responses = responses or {}
+
+    def __call__(self, argv, **kw):
+        self.calls.append(list(argv))
+        key = " ".join(argv)
+        for pattern, resp in self.responses.items():
+            if pattern in key:
+                if isinstance(resp, Exception):
+                    raise resp
+                return resp
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+
+def _ok(stdout=""):
+    return subprocess.CompletedProcess([], 0, stdout=stdout, stderr="")
+
+
+def _fail(stdout="", stderr="", code=1):
+    return subprocess.CompletedProcess([], code, stdout=stdout, stderr=stderr)
+
+
+def _linux(tmp_path, responses=None):
+    rec = Recorder(responses)
+    sup = SystemdUserSupervisor(home=tmp_path, user="bailey", run_cmd=rec)
+    return sup, rec
+
+
+def test_linux_install_order_and_linger_verify(tmp_path):
+    sup, rec = _linux(
+        tmp_path, {"show-user": _ok("Linger=yes\n"), "is-system-running": _ok("running\n")}
+    )
+    sup.install(["/venv/bin/mshipd"])
+    unit = tmp_path / ".config" / "systemd" / "user" / "mship-daemon.service"
+    assert unit.is_file()
+    cmds = [" ".join(c) for c in rec.calls]
+    reload_i = next(i for i, c in enumerate(cmds) if "daemon-reload" in c)
+    enable_i = next(i for i, c in enumerate(cmds) if " enable " in f" {c} ")
+    linger_i = next(i for i, c in enumerate(cmds) if "enable-linger" in c)
+    verify_i = next(i for i, c in enumerate(cmds) if "show-user" in c)
+    assert reload_i < enable_i < linger_i < verify_i
+
+
+def test_linux_install_fails_loudly_when_linger_does_not_stick(tmp_path):
+    sup, _ = _linux(tmp_path, {"show-user": _ok("Linger=no\n")})
+    with pytest.raises(DaemonSupervisorError, match="[Ll]inger"):
+        sup.install(["/venv/bin/mshipd"])
+
+
+def test_linux_lifecycle_commands(tmp_path):
+    sup, rec = _linux(tmp_path)
+    sup.start()
+    sup.stop()
+    sup.restart()
+    assert [c[2] for c in rec.calls] == ["start", "stop", "restart"]
+    assert all(c[:2] == ["systemctl", "--user"] for c in rec.calls)
+
+
+def test_linux_query_states(tmp_path):
+    sup, _ = _linux(tmp_path, {"show mship-daemon": _ok("ActiveState=active\nSubState=running\n")})
+    assert sup.query().state == "active"
+    sup2, _ = _linux(tmp_path, {"show mship-daemon": _ok("ActiveState=failed\nSubState=failed\n")})
+    assert sup2.query().state == "failed"
+    sup3, _ = _linux(tmp_path, {"show mship-daemon": _ok("ActiveState=inactive\nSubState=dead\n")})
+    assert sup3.query().state == "absent"
+    sup4, _ = _linux(tmp_path, {"show mship-daemon": _fail(stderr="Failed to connect to bus")})
+    assert sup4.query().state == "unreachable"
+    sup5, _ = _linux(tmp_path, {"show mship-daemon": _ok("garbage")})
+    assert sup5.query().state == "absent"  # parse failure → absent-with-warning, never raise
+
+
+def test_linger_state_parses(tmp_path):
+    sup, _ = _linux(tmp_path, {"show-user": _ok("Linger=yes\n")})
+    assert sup.linger_state() == "yes"
+    sup2, _ = _linux(tmp_path, {"show-user": _ok("Linger=no\n")})
+    assert sup2.linger_state() == "no"
+    sup3, _ = _linux(tmp_path, {"show-user": _fail(stderr="boom")})
+    assert sup3.linger_state() == "unknown"
+
+
+def test_available_probes_user_manager_not_binary(tmp_path):
+    # systemctl exists but every --user call dies with a bus error → unavailable.
+    sup, _ = _linux(
+        tmp_path, {"is-system-running": _fail(stderr="Failed to connect to bus: No medium found")}
+    )
+    assert sup.available() is False
+    # Even a degraded manager reply proves reachability.
+    sup2, _ = _linux(tmp_path, {"is-system-running": _fail(stdout="degraded\n")})
+    assert sup2.available() is True
+    sup3, _ = _linux(tmp_path, {"is-system-running": _ok("running\n")})
+    assert sup3.available() is True
+
+
+def test_available_true_but_reload_bus_error_names_fallback(tmp_path):
+    sup, _ = _linux(
+        tmp_path,
+        {
+            "is-system-running": _ok("running\n"),
+            "show-user": _ok("Linger=yes\n"),
+            "daemon-reload": _fail(stderr="Failed to connect to bus"),
+        },
+    )
+    with pytest.raises(DaemonSupervisorError, match="mship daemon run"):
+        sup.install(["/venv/bin/mshipd"])
+
+
+def _mac(tmp_path, responses=None):
+    rec = Recorder(responses)
+    sup = LaunchdSupervisor(home=tmp_path, uid=501, run_cmd=rec)
+    return sup, rec
+
+
+def test_macos_install_uses_user_domain_not_gui(tmp_path):
+    """gui/<uid> bootstrap fails over SSH with no GUI session ('Bootstrap
+    failed: 5: Input/output error') — exactly the headless provisioning
+    scenario #469/#470 describe."""
+    sup, rec = _mac(tmp_path)
+    sup.install(["/venv/bin/mshipd"])
+    plist = tmp_path / "Library" / "LaunchAgents" / "com.mothership.daemon.plist"
+    assert plist.is_file()
+    cmds = [" ".join(c) for c in rec.calls]
+    assert any("bootstrap user/501" in c for c in cmds)
+    assert not any("gui/" in c for c in cmds)
+
+
+def test_macos_bootstrap_failure_is_daemon_error(tmp_path):
+    sup, _ = _mac(tmp_path, {"bootstrap": _fail(stderr="Bootstrap failed: 5: Input/output error")})
+    with pytest.raises(DaemonSupervisorError, match="[Bb]ootstrap"):
+        sup.install(["/venv/bin/mshipd"])
+
+
+def test_macos_lifecycle_commands(tmp_path):
+    sup, rec = _mac(tmp_path)
+    sup.start()
+    sup.stop()
+    sup.restart()
+    cmds = [" ".join(c) for c in rec.calls]
+    assert any("kickstart user/501/com.mothership.daemon" in c for c in cmds)
+    assert any("bootout user/501/com.mothership.daemon" in c for c in cmds)
+
+
+def test_macos_query_unreachable_never_absent(tmp_path):
+    """A running daemon must not render 'absent' just because launchctl can't
+    be reached from this session."""
+    sup, _ = _mac(tmp_path, {"print": OSError("launchctl gone")})
+    assert sup.query().state == "unreachable"
+    sup2, _ = _mac(tmp_path, {"print": _fail(stderr="Could not find service")})
+    assert sup2.query().state == "absent"
+    sup3, _ = _mac(tmp_path, {"print": _ok("state = running\npid = 4242\n")})
+    assert sup3.query().state == "active"
+
+
+def test_macos_linger_not_applicable(tmp_path):
+    sup, _ = _mac(tmp_path)
+    assert sup.linger_state() == "unknown"
+
+
+def test_logs_tail_spans_rotated_siblings(tmp_path):
+    log_dir = tmp_path / ".mothership" / "daemon" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "daemon.log.2").write_text("oldest-1\noldest-2\n")
+    (log_dir / "daemon.log.1").write_text("middle-1\n")
+    (log_dir / "daemon.log").write_text("newest-1\nnewest-2\n")
+    sup, _ = _linux(tmp_path)
+    assert sup.logs_tail(3) == ["middle-1", "newest-1", "newest-2"]
+    assert sup.logs_tail(50) == ["oldest-1", "oldest-2", "middle-1", "newest-1", "newest-2"]
+
+
+def test_pick_supervisor():
+    assert isinstance(pick_supervisor(platform="linux"), SystemdUserSupervisor)
+    assert isinstance(pick_supervisor(platform="darwin"), LaunchdSupervisor)

--- a/tests/core/daemon/test_supervisor.py
+++ b/tests/core/daemon/test_supervisor.py
@@ -227,3 +227,20 @@ def test_linux_query_unit_not_found_is_absent(tmp_path):
     absent, not unreachable (the pre-install `daemon status` case)."""
     sup, _ = _linux(tmp_path, {"show mship-daemon": _fail(stderr="Unit mship-daemon.service could not be found.")})
     assert sup.query().state == "absent"
+
+
+def test_macos_reinstall_unloads_first(tmp_path):
+    """launchd rejects a duplicate bootstrap of a loaded label and the running
+    job would keep the OLD plist — install boots the label out first
+    (tolerated when not loaded), then bootstraps the fresh plist."""
+    sup, rec = _mac(tmp_path)
+    sup.install(["/venv/bin/mshipd"])
+    cmds = [" ".join(c) for c in rec.calls]
+    bootout_i = next(i for i, c in enumerate(cmds) if "bootout" in c)
+    bootstrap_i = next(i for i, c in enumerate(cmds) if "bootstrap" in c)
+    assert bootout_i < bootstrap_i
+
+    # bootout failing (label not loaded — the FIRST install) must not block.
+    sup2, rec2 = _mac(tmp_path, {"launchctl bootout": _fail(stderr="Boot-out failed: 3: No such process")})
+    sup2.install(["/venv/bin/mshipd"])
+    assert any("bootstrap" in " ".join(c) for c in rec2.calls)

--- a/tests/core/daemon/test_units.py
+++ b/tests/core/daemon/test_units.py
@@ -1,0 +1,115 @@
+"""Rendered units are PARSED, not substring-matched: systemd directives are
+section-scoped and a directive in the wrong section is silently ignored (only
+an "Unknown lvalue" journal line), so flat `in` assertions would pass CI while
+the backoff policy is broken on the host."""
+import configparser
+import plistlib
+import sys
+from pathlib import Path
+
+import pytest
+
+from mship.core.daemon.units import (
+    LAUNCHD_LABEL,
+    DaemonExecResolutionError,
+    render_launchd_plist,
+    render_systemd_unit,
+    resolve_mshipd_argv,
+)
+
+ARGV = ["/opt/venv/bin/mshipd"]
+
+
+def _parse_unit(text: str) -> configparser.ConfigParser:
+    cp = configparser.ConfigParser()
+    cp.read_string(text)
+    return cp
+
+
+def test_systemd_unit_sections():
+    cp = _parse_unit(render_systemd_unit(ARGV))
+    assert cp["Service"]["ExecStart"] == "/opt/venv/bin/mshipd"
+    assert cp["Service"]["Restart"] == "on-failure"
+    assert cp["Service"]["RestartSec"] == "5"
+    assert cp["Unit"]["StartLimitIntervalSec"] == "300"
+    assert cp["Unit"]["StartLimitBurst"] == "5"
+    assert cp["Install"]["WantedBy"] == "default.target"
+    # Loser exits 0 (run.py), so no SuccessExitStatus mapping exists — and none
+    # exists for launchd anyway.
+    assert "SuccessExitStatus" not in cp["Service"]
+
+
+def test_systemd_unit_has_no_working_directory():
+    """The workspace-agnostic assumption, made enforceable: a WorkingDirectory
+    would bake one workspace into the one-per-host daemon."""
+    text = render_systemd_unit(ARGV)
+    assert "WorkingDirectory" not in text
+
+
+def test_systemd_multiarg_exec_is_joined():
+    cp = _parse_unit(render_systemd_unit(["/usr/bin/python3", "-m", "mship.core.daemon"]))
+    assert cp["Service"]["ExecStart"] == "/usr/bin/python3 -m mship.core.daemon"
+
+
+def test_launchd_plist_shape(tmp_path: Path):
+    log_dir = tmp_path / "logs"
+    plist = plistlib.loads(render_launchd_plist(ARGV, log_dir).encode())
+    assert plist["Label"] == LAUNCHD_LABEL == "com.mothership.daemon"
+    assert plist["KeepAlive"] == {"SuccessfulExit": False}
+    assert plist["ThrottleInterval"] == 5
+    assert plist["RunAtLoad"] is True
+    assert plist["ProgramArguments"] == ARGV
+    # launchd discards stderr otherwise — the last-resort net for output that
+    # escapes the logging tree.
+    assert plist["StandardOutPath"] == str(log_dir / "launchd.out.log")
+    assert plist["StandardErrorPath"] == str(log_dir / "launchd.err.log")
+
+
+def test_execstart_resolves_sibling_first(tmp_path, monkeypatch):
+    """Same venv bin dir ⇒ provably same dist (the uv-tool-install layout);
+    sibling wins even when PATH has a different mshipd."""
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    exe = bin_dir / "python"
+    exe.touch()
+    sibling = bin_dir / "mshipd"
+    sibling.touch()
+    monkeypatch.setattr(sys, "executable", str(exe))
+    argv = resolve_mshipd_argv(which=lambda name: "/somewhere/else/mshipd")
+    assert argv == [str(sibling)]
+
+
+def test_which_fallback_verified_against_sys_prefix(tmp_path, monkeypatch):
+    prefix = tmp_path / "venv"
+    bin_dir = prefix / "bin"
+    bin_dir.mkdir(parents=True)
+    exe = bin_dir / "python"
+    exe.touch()
+    monkeypatch.setattr(sys, "executable", str(exe))
+    monkeypatch.setattr(sys, "prefix", str(prefix))
+
+    inside = bin_dir / "shims" / "mshipd"
+    inside.parent.mkdir()
+    inside.touch()
+    assert resolve_mshipd_argv(which=lambda name: str(inside)) == [str(inside)]
+
+    # A PATH shim from ANOTHER install (stale uv-tool shim while running
+    # `uv run mship` from a checkout) must refuse, not silently bake a
+    # worktree venv into a persistent unit.
+    outside = tmp_path / "other" / "mshipd"
+    outside.parent.mkdir()
+    outside.touch()
+    with pytest.raises(DaemonExecResolutionError, match="dev tree"):
+        resolve_mshipd_argv(which=lambda name: str(outside))
+
+
+def test_module_fallback_when_nothing_resolvable(tmp_path, monkeypatch):
+    prefix = tmp_path / "venv"
+    bin_dir = prefix / "bin"
+    bin_dir.mkdir(parents=True)
+    exe = bin_dir / "python"
+    exe.touch()
+    monkeypatch.setattr(sys, "executable", str(exe))
+    monkeypatch.setattr(sys, "prefix", str(prefix))
+    argv = resolve_mshipd_argv(which=lambda name: None)
+    assert argv == [str(exe), "-m", "mship.core.daemon"]

--- a/tests/core/daemon/test_units.py
+++ b/tests/core/daemon/test_units.py
@@ -113,3 +113,12 @@ def test_module_fallback_when_nothing_resolvable(tmp_path, monkeypatch):
     monkeypatch.setattr(sys, "prefix", str(prefix))
     argv = resolve_mshipd_argv(which=lambda name: None)
     assert argv == [str(exe), "-m", "mship.core.daemon"]
+
+
+def test_launchd_plist_escapes_xml_special_chars(tmp_path: Path):
+    """A path containing &, <, > must render a plist launchctl can parse."""
+    log_dir = tmp_path / "logs & <special>"
+    argv = [str(tmp_path / "venv & tools" / "bin" / "mshipd")]
+    plist = plistlib.loads(render_launchd_plist(argv, log_dir).encode())
+    assert plist["ProgramArguments"] == argv
+    assert plist["StandardOutPath"] == str(log_dir / "launchd.out.log")

--- a/uv.lock
+++ b/uv.lock
@@ -559,7 +559,7 @@ wheels = [
 
 [[package]]
 name = "mothership"
-version = "0.5.46"
+version = "0.5.52"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Mothership daemon provisioning and supervision (#470): mship daemon install/start/stop/restart/status/logs/run + supervised mshipd

Closes #470
---

## Acceptance criteria

- [x] `ac1` mship daemon install writes a systemd --user unit (Linux) or LaunchAgent plist (macOS) whose exec line resolves the mshipd entrypoint of the same installed distribution as the invoking CLI, sibling-first; an unverifiable resolution (dev-tree CLI, foreign PATH shim) refuses install with guidance to install the tool first — test:test-runs/4.mothership
- [x] `ac2` Install on Linux runs loginctl enable-linger and verifies Linger=yes, failing loudly otherwise; mship daemon status re-warns whenever linger is off — test:test-runs/4.mothership
- [x] `ac3` mship daemon start|stop|restart|status|logs exist and delegate through one injectable supervisor seam; mship daemon run runs mshipd in the foreground with no supervisor — test:test-runs/4.mothership
- [x] `ac4` With no reachable user manager (probed via systemctl --user is-system-running, not binary presence), install fails loudly and names mship daemon run as the fallback - it never pretends persistence exists — test:test-runs/4.mothership
- [x] `ac5` Single-instance guard: the daemon holds a lifetime flock on its lease file; a lease loser with a confirmed-live holder exits 0, a contended-but-dead lease exits nonzero, a stale lease is reclaimed even under pid reuse, concurrent cold starts converge on exactly one daemon (real-multiprocessing test), and no CLI/status path ever acquires the lease flock — test:test-runs/4.mothership
- [x] `ac6` Unit/plist text encodes restart-on-crash with bounded backoff and a visible terminal state (Restart=on-failure + RestartSec + StartLimit on systemd; KeepAlive.SuccessfulExit=false + ThrottleInterval + StandardOut/ErrorPath on launchd), asserted by parsing the rendered files, not substring match; no WorkingDirectory anywhere — test:test-runs/4.mothership
- [x] `ac7` Crash loops are visible in status, computed OS-agnostically from the daemon's durable start-history file counting only unclean starts, so routine operator restarts do not read as a loop — test:test-runs/4.mothership
- [x] `ac8` Logs are durable and rotated under ~/.mothership/daemon/logs/ and capture crashes: uvicorn loggers routed into the rotating handler and uncaught-exception tracebacks logged before exit; mship daemon logs tails them including rotated siblings, no journald dependency — test:test-runs/4.mothership
- [x] `ac9` The daemon reports the version it imported at process start plus a protocol integer over its control socket; status compares against the CLI version and prints a restart-required line on mismatch (exact-match policy) — test:test-runs/4.mothership
- [x] `ac10` mship daemon restart consults a restart_blockers() seam (empty in v1, documented as the #473 recovery handoff) and refuses the restart when non-empty — test:test-runs/4.mothership
- [x] `ac11` Ordinary local mship commands work with no daemon present, and mship daemon status works from a directory with no mothership.yaml (no workspace discovery on any daemon path), both pinned by tests — test:test-runs/4.mothership
- [x] `ac12` docs/daemon.md ships a manual/VM checklist covering the OS-contract items CI cannot exercise: SSH-logout survival via real linger, return after kill -9 and reboot, headless launchd bootstrap over SSH (user/<uid> domain), crash loop tripping start-limit-hit, and upgrade-then-restart moving to the new version — test:test-runs/4.mothership