### PR TITLE
Fix daemon install dev-tree sibling bypass + linger uid resolution + pre-exec failure log coverage

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -15,7 +15,7 @@ mship daemon start
 mship daemon stop
 mship daemon restart   # consults restart blockers first (the #473 recovery seam)
 mship daemon status
-mship daemon logs      # tails rotated logs + launchd pre-exec captures
+mship daemon logs      # tails rotated logs + launchd stderr captures
 mship daemon run       # foreground/debug, no supervisor
 ```
 
@@ -26,12 +26,14 @@ commands never require the daemon.
 
 - State: `~/.mothership/daemon/` (per OS user — the daemon is workspace-agnostic)
 - Lease: `~/.mothership/daemon/daemon.lease` (flock held for the daemon's lifetime)
-- Logs: `~/.mothership/daemon/logs/daemon.log` (rotated, 5MB x 3). Pre-exec
-  failures (missing executable, broken interpreter) never reach Python logging:
-  launchd captures them in `launchd.*.log` in the same dir (included in
-  `mship daemon logs`); on Linux they land in the user journal — check
-  `journalctl --user -u mship-daemon` if `daemon logs` is empty after a failed
-  start.
+- Logs: `~/.mothership/daemon/logs/daemon.log` (rotated, 5MB x 3). Early-exit
+  stderr (interpreter starts but dies before Python logging is configured) is
+  captured by launchd into `launchd.*.log` in the same dir and included in
+  `mship daemon logs`. A true pre-exec failure (missing executable) produces no
+  child process at all, so NOTHING reaches these files: diagnose with
+  `journalctl --user -u mship-daemon` on Linux or
+  `launchctl print user/<uid>/com.mothership.daemon` / the unified log
+  (`log show`) on macOS.
 - Start history: `~/.mothership/daemon/start-history.json` (crash-loop visibility)
 - Control socket: `$XDG_RUNTIME_DIR/mship/daemon.sock`, else
   `~/.mothership/daemon/run/daemon.sock`. Status probes prefer the socket path

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -15,7 +15,7 @@ mship daemon start
 mship daemon stop
 mship daemon restart   # consults restart blockers first (the #473 recovery seam)
 mship daemon status
-mship daemon logs      # tails rotated logs, no journald needed
+mship daemon logs      # tails rotated logs + launchd pre-exec captures
 mship daemon run       # foreground/debug, no supervisor
 ```
 
@@ -26,7 +26,12 @@ commands never require the daemon.
 
 - State: `~/.mothership/daemon/` (per OS user — the daemon is workspace-agnostic)
 - Lease: `~/.mothership/daemon/daemon.lease` (flock held for the daemon's lifetime)
-- Logs: `~/.mothership/daemon/logs/daemon.log` (rotated, 5MB x 3)
+- Logs: `~/.mothership/daemon/logs/daemon.log` (rotated, 5MB x 3). Pre-exec
+  failures (missing executable, broken interpreter) never reach Python logging:
+  launchd captures them in `launchd.*.log` in the same dir (included in
+  `mship daemon logs`); on Linux they land in the user journal — check
+  `journalctl --user -u mship-daemon` if `daemon logs` is empty after a failed
+  start.
 - Start history: `~/.mothership/daemon/start-history.json` (crash-loop visibility)
 - Control socket: `$XDG_RUNTIME_DIR/mship/daemon.sock`, else
   `~/.mothership/daemon/run/daemon.sock`. Status probes prefer the socket path

--- a/src/mship/cli/daemon.py
+++ b/src/mship/cli/daemon.py
@@ -15,8 +15,9 @@ import typer
 
 import mship
 from mship.core.daemon.history import read_history
+from mship.core.daemon.log_capture import rotate_launchd_captures
 from mship.core.daemon.lease import read_lease_record
-from mship.core.daemon.paths import lease_path, start_history_path
+from mship.core.daemon.paths import daemon_log_dir, lease_path, start_history_path
 from mship.core.daemon.status import build_status, probe_daemon, restart_blockers
 from mship.core.daemon.supervisor import DaemonSupervisorError, pick_supervisor
 from mship.core.daemon.units import DaemonExecResolutionError, resolve_mshipd_argv
@@ -96,6 +97,7 @@ def register(parent: typer.Typer, get_container):
     def status():
         out = Output()
         home = Path.home()
+        rotate_launchd_captures(daemon_log_dir(home))
         sup = _supervisor()
         st = build_status(
             supervisor_state=sup.query(),

--- a/src/mship/core/daemon/log_capture.py
+++ b/src/mship/core/daemon/log_capture.py
@@ -13,18 +13,20 @@ too, giving a never-starting daemon's capture a bound whenever an operator
 looks at it.
 """
 from __future__ import annotations
+import os
 
 from pathlib import Path
 
-# Truncate a capture larger than this. In place, never renamed: launchd holds
-# the fd open across relaunches, so a renamed file keeps growing invisibly.
+# Compact a capture larger than this, preserving its newest bytes. In place,
+# never renamed: launchd holds the fd open across relaunches, so a renamed file
+# keeps growing invisibly.
 LAUNCHD_CAPTURE_MAX_BYTES = 5 * 1024 * 1024
 
 
 def trim_launchd_captures(log_dir: Path, max_bytes: int = LAUNCHD_CAPTURE_MAX_BYTES) -> list[str]:
-    """Truncate oversized `launchd.*.log` captures. Returns the names trimmed.
-    Never raises: this runs on the crash path, where failing loudly would
-    replace one problem with a worse one."""
+    """Compact oversized `launchd.*.log` captures to their newest bytes.
+    Returns the names trimmed. Never raises: this runs on the crash path, where
+    failing loudly would replace one problem with a worse one."""
     trimmed: list[str] = []
     try:
         candidates = sorted(Path(log_dir).glob("launchd.*.log"))
@@ -32,10 +34,18 @@ def trim_launchd_captures(log_dir: Path, max_bytes: int = LAUNCHD_CAPTURE_MAX_BY
         return trimmed
     for path in candidates:
         try:
-            if path.stat().st_size <= max_bytes:
+            stat = path.stat()
+            if stat.st_size <= max_bytes:
                 continue
             with open(path, "r+b") as fh:
-                fh.truncate(0)
+                fh.seek(-max_bytes, os.SEEK_END)
+                tail = fh.read(max_bytes)
+                fh.seek(0)
+                fh.write(tail)
+                fh.truncate()
+            # Contents are compacted, not newly produced. Preserve their
+            # timestamp so logs_tail's cross-file chronology remains truthful.
+            os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns))
             trimmed.append(path.name)
         except OSError:
             continue

--- a/src/mship/core/daemon/log_capture.py
+++ b/src/mship/core/daemon/log_capture.py
@@ -1,0 +1,42 @@
+"""launchd stderr-capture trimming (#471-adjacent, #475 review).
+
+launchd has no log rotation: with `KeepAlive.SuccessfulExit=false` a failing
+daemon is relaunched every `ThrottleInterval` and appends to the SAME
+`StandardErrorPath` forever. Nothing else prunes it.
+
+Deliberately stdlib-only and import-light so it can run as the very first
+thing in `mshipd`'s entrypoint — the crash loop this exists for is often a
+BROKEN IMPORT, so anything it depends on is something that might not import.
+Honest limit: if the failure is importing this module (or the package) itself,
+no in-process trim can run — which is why `mship daemon logs`/`status` trim
+too, giving a never-starting daemon's capture a bound whenever an operator
+looks at it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+# Truncate a capture larger than this. In place, never renamed: launchd holds
+# the fd open across relaunches, so a renamed file keeps growing invisibly.
+LAUNCHD_CAPTURE_MAX_BYTES = 5 * 1024 * 1024
+
+
+def trim_launchd_captures(log_dir: Path, max_bytes: int = LAUNCHD_CAPTURE_MAX_BYTES) -> list[str]:
+    """Truncate oversized `launchd.*.log` captures. Returns the names trimmed.
+    Never raises: this runs on the crash path, where failing loudly would
+    replace one problem with a worse one."""
+    trimmed: list[str] = []
+    try:
+        candidates = sorted(Path(log_dir).glob("launchd.*.log"))
+    except OSError:
+        return trimmed
+    for path in candidates:
+        try:
+            if path.stat().st_size <= max_bytes:
+                continue
+            with open(path, "r+b") as fh:
+                fh.truncate(0)
+            trimmed.append(path.name)
+        except OSError:
+            continue
+    return trimmed

--- a/src/mship/core/daemon/log_capture.py
+++ b/src/mship/core/daemon/log_capture.py
@@ -1,4 +1,4 @@
-"""launchd stderr-capture trimming (#471-adjacent, #475 review).
+"""Race-safe launchd stderr-capture rollover (#475 review).
 
 launchd has no log rotation: with `KeepAlive.SuccessfulExit=false` a failing
 daemon is relaunched every `ThrottleInterval` and appends to the SAME
@@ -8,45 +8,61 @@ Deliberately stdlib-only and import-light so it can run as the very first
 thing in `mshipd`'s entrypoint — the crash loop this exists for is often a
 BROKEN IMPORT, so anything it depends on is something that might not import.
 Honest limit: if the failure is importing this module (or the package) itself,
-no in-process trim can run — which is why `mship daemon logs`/`status` trim
-too, giving a never-starting daemon's capture a bound whenever an operator
-looks at it.
+no in-process rollover can run — which is why `mship daemon logs`/`status`
+also perform it when an operator inspects a never-starting daemon.
 """
 from __future__ import annotations
+
 import os
 
 from pathlib import Path
 
-# Compact a capture larger than this, preserving its newest bytes. In place,
-# never renamed: launchd holds the fd open across relaunches, so a renamed file
-# keeps growing invisibly.
+# Retire an active capture larger than this. launchd opens StandardErrorPath
+# with O_APPEND for each job process, so an atomic rename keeps an existing
+# writer on the retired inode while later launches create a fresh active path.
 LAUNCHD_CAPTURE_MAX_BYTES = 5 * 1024 * 1024
 
 
-def trim_launchd_captures(log_dir: Path, max_bytes: int = LAUNCHD_CAPTURE_MAX_BYTES) -> list[str]:
-    """Compact oversized `launchd.*.log` captures to their newest bytes.
-    Returns the names trimmed. Never raises: this runs on the crash path, where
-    failing loudly would replace one problem with a worse one."""
-    trimmed: list[str] = []
+def rotate_launchd_captures(
+    log_dir: Path, max_bytes: int = LAUNCHD_CAPTURE_MAX_BYTES
+) -> list[str]:
+    """Race-safely roll over `launchd.*.log` captures; return changed names.
+
+    An oversized active path is atomically renamed to `.1`, never rewritten,
+    so an O_APPEND writer keeps every concurrent byte. If a later launch has
+    recreated the active path below the cap, the previous `.1` can no longer
+    have that launchd job's writer and is safely compacted in place.
+    """
+    changed: list[str] = []
     try:
-        candidates = sorted(Path(log_dir).glob("launchd.*.log"))
+        active_captures = sorted(Path(log_dir).glob("launchd.*.log"))
     except OSError:
-        return trimmed
-    for path in candidates:
+        return changed
+    for path in active_captures:
         try:
             stat = path.stat()
-            if stat.st_size <= max_bytes:
+            retired = path.with_name(f"{path.name}.1")
+            if stat.st_size > max_bytes:
+                os.replace(path, retired)
+                changed.append(path.name)
                 continue
-            with open(path, "r+b") as fh:
+
+            # The active path can only be recreated by a later launch, after
+            # the process whose O_APPEND fd followed the prior rename exited.
+            retired_stat = retired.stat()
+            if retired_stat.st_size <= max_bytes:
+                continue
+            with open(retired, "r+b") as fh:
                 fh.seek(-max_bytes, os.SEEK_END)
                 tail = fh.read(max_bytes)
                 fh.seek(0)
                 fh.write(tail)
                 fh.truncate()
-            # Contents are compacted, not newly produced. Preserve their
-            # timestamp so logs_tail's cross-file chronology remains truthful.
-            os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns))
-            trimmed.append(path.name)
+            os.utime(
+                retired,
+                ns=(retired_stat.st_atime_ns, retired_stat.st_mtime_ns),
+            )
+            changed.append(retired.name)
         except OSError:
             continue
-    return trimmed
+    return changed

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -77,11 +77,11 @@ def main(home: Path | None = None, env: Mapping[str, str] | None = None) -> int:
     # FIRST, before any heavier import or setup can fail: the crash loop this
     # guards against is frequently a broken import, and every relaunch appends
     # another traceback to the launchd capture. Logged once logging exists, so
-    # the truncation is never silent.
+    # the compaction is never silent.
     trimmed = trim_launchd_captures(paths.daemon_log_dir(home))
     _configure_logging(home)
     for name in trimmed:
-        log.warning("truncated oversized launchd capture %s (>%d bytes)", name, LAUNCHD_CAPTURE_MAX_BYTES)
+        log.warning("trimmed oversized launchd capture %s (>%d bytes)", name, LAUNCHD_CAPTURE_MAX_BYTES)
     try:
         return _run(home, env)
     except Exception:

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -22,7 +22,10 @@ from pathlib import Path
 from typing import Mapping
 
 from mship.core.daemon import history, lease as lease_mod, paths
-from mship.core.daemon.log_capture import LAUNCHD_CAPTURE_MAX_BYTES, trim_launchd_captures
+from mship.core.daemon.log_capture import (
+    LAUNCHD_CAPTURE_MAX_BYTES,
+    rotate_launchd_captures,
+)
 
 log = logging.getLogger(__name__)
 
@@ -77,11 +80,15 @@ def main(home: Path | None = None, env: Mapping[str, str] | None = None) -> int:
     # FIRST, before any heavier import or setup can fail: the crash loop this
     # guards against is frequently a broken import, and every relaunch appends
     # another traceback to the launchd capture. Logged once logging exists, so
-    # the compaction is never silent.
-    trimmed = trim_launchd_captures(paths.daemon_log_dir(home))
+    # the rollover is never silent.
+    changed = rotate_launchd_captures(paths.daemon_log_dir(home))
     _configure_logging(home)
-    for name in trimmed:
-        log.warning("trimmed oversized launchd capture %s (>%d bytes)", name, LAUNCHD_CAPTURE_MAX_BYTES)
+    for name in changed:
+        log.warning(
+            "rolled over oversized launchd capture %s (>%d bytes)",
+            name,
+            LAUNCHD_CAPTURE_MAX_BYTES,
+        )
     try:
         return _run(home, env)
     except Exception:

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Mapping
 
 from mship.core.daemon import history, lease as lease_mod, paths
+from mship.core.daemon.log_capture import LAUNCHD_CAPTURE_MAX_BYTES, trim_launchd_captures
 
 log = logging.getLogger(__name__)
 
@@ -51,32 +52,9 @@ def _import_server_stack():
     return uvicorn, create_control_app
 
 
-# launchd has no log rotation: with KeepAlive.SuccessfulExit=false a
-# crash-looping daemon is relaunched every ThrottleInterval and appends to the
-# SAME StandardErrorPath forever. Nothing else prunes it, so the daemon caps it
-# on each start. Truncate in place rather than rename: launchd holds the fd
-# open across relaunches, so a renamed file would keep growing invisibly.
-_LAUNCHD_CAPTURE_MAX_BYTES = 5 * 1024 * 1024
-
-
-def _trim_launchd_captures(log_dir: Path) -> list[str]:
-    trimmed: list[str] = []
-    for path in sorted(log_dir.glob("launchd.*.log")):
-        try:
-            if path.stat().st_size <= _LAUNCHD_CAPTURE_MAX_BYTES:
-                continue
-            with open(path, "r+b") as fh:
-                fh.truncate(0)
-            trimmed.append(path.name)
-        except OSError:
-            continue
-    return trimmed
-
-
 def _configure_logging(home: Path) -> None:
     log_dir = paths.daemon_log_dir(home)
     log_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-    trimmed = _trim_launchd_captures(log_dir)
     handler = RotatingFileHandler(
         log_dir / "daemon.log", maxBytes=_LOG_MAX_BYTES, backupCount=_LOG_BACKUPS
     )
@@ -90,15 +68,20 @@ def _configure_logging(home: Path) -> None:
         lg = logging.getLogger(name)
         lg.addHandler(handler)
         lg.setLevel(logging.INFO)
-    for name in trimmed:
-        # Recorded in the rotated log so a truncation is never silent.
-        log.warning("truncated oversized launchd capture %s (>%d bytes)", name, _LAUNCHD_CAPTURE_MAX_BYTES)
+
 
 
 def main(home: Path | None = None, env: Mapping[str, str] | None = None) -> int:
     home = home if home is not None else Path.home()
     env = env if env is not None else os.environ
+    # FIRST, before any heavier import or setup can fail: the crash loop this
+    # guards against is frequently a broken import, and every relaunch appends
+    # another traceback to the launchd capture. Logged once logging exists, so
+    # the truncation is never silent.
+    trimmed = trim_launchd_captures(paths.daemon_log_dir(home))
     _configure_logging(home)
+    for name in trimmed:
+        log.warning("truncated oversized launchd capture %s (>%d bytes)", name, LAUNCHD_CAPTURE_MAX_BYTES)
     try:
         return _run(home, env)
     except Exception:

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -51,9 +51,32 @@ def _import_server_stack():
     return uvicorn, create_control_app
 
 
+# launchd has no log rotation: with KeepAlive.SuccessfulExit=false a
+# crash-looping daemon is relaunched every ThrottleInterval and appends to the
+# SAME StandardErrorPath forever. Nothing else prunes it, so the daemon caps it
+# on each start. Truncate in place rather than rename: launchd holds the fd
+# open across relaunches, so a renamed file would keep growing invisibly.
+_LAUNCHD_CAPTURE_MAX_BYTES = 5 * 1024 * 1024
+
+
+def _trim_launchd_captures(log_dir: Path) -> list[str]:
+    trimmed: list[str] = []
+    for path in sorted(log_dir.glob("launchd.*.log")):
+        try:
+            if path.stat().st_size <= _LAUNCHD_CAPTURE_MAX_BYTES:
+                continue
+            with open(path, "r+b") as fh:
+                fh.truncate(0)
+            trimmed.append(path.name)
+        except OSError:
+            continue
+    return trimmed
+
+
 def _configure_logging(home: Path) -> None:
     log_dir = paths.daemon_log_dir(home)
     log_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    trimmed = _trim_launchd_captures(log_dir)
     handler = RotatingFileHandler(
         log_dir / "daemon.log", maxBytes=_LOG_MAX_BYTES, backupCount=_LOG_BACKUPS
     )
@@ -67,6 +90,9 @@ def _configure_logging(home: Path) -> None:
         lg = logging.getLogger(name)
         lg.addHandler(handler)
         lg.setLevel(logging.INFO)
+    for name in trimmed:
+        # Recorded in the rotated log so a truncation is never silent.
+        log.warning("truncated oversized launchd capture %s (>%d bytes)", name, _LAUNCHD_CAPTURE_MAX_BYTES)
 
 
 def main(home: Path | None = None, env: Mapping[str, str] | None = None) -> int:

--- a/src/mship/core/daemon/supervisor.py
+++ b/src/mship/core/daemon/supervisor.py
@@ -44,6 +44,23 @@ class SupervisorState:
     detail: str = ""
 
 
+def _uid_username() -> str | None:
+    """This UID's passwd name, or None.
+
+    pwd first, NOT getpass.getuser(): getuser trusts LOGNAME/USER, so a
+    stale/spoofed env would enable-linger for ANOTHER account while
+    `systemctl --user` still targets this uid — reported success, daemon still
+    dies on logout. But an arbitrary UID with no NSS/passwd entry is normal in
+    containers, and `SystemdUserSupervisor` is constructed for EVERY daemon
+    command: returning None there keeps `status`/`logs` working (linger checks
+    degrade to "unknown"/loud install failure) instead of crashing the CLI.
+    """
+    try:
+        return pwd.getpwuid(os.getuid()).pw_name
+    except KeyError:
+        return None
+
+
 def _default_run(argv: list[str], **kw) -> subprocess.CompletedProcess:
     return subprocess.run(argv, capture_output=True, text=True, **kw)
 
@@ -69,7 +86,18 @@ class _BaseSupervisor:
         # child process and lands only in launchd's unified log / journald;
         # `launchctl print` and `journalctl --user -u mship-daemon` are the
         # diagnostics there (docs/daemon.md).
-        files.extend(sorted(log_dir.glob("launchd.*.log")))
+        # Ordered by MTIME against the daemon logs rather than appended last:
+        # a stale launchd.err.log with >= n lines would otherwise crowd the
+        # current daemon.log out of the `-n` tail.
+        launchd = sorted(log_dir.glob("launchd.*.log"))
+        if launchd:
+            def _mtime(p: Path) -> float:
+                try:
+                    return p.stat().st_mtime
+                except OSError:
+                    return 0.0
+
+            files = sorted(files + launchd, key=_mtime)
         lines: list[str] = []
         for f in files:
             try:
@@ -84,11 +112,7 @@ class SystemdUserSupervisor(_BaseSupervisor):
         self, *, home: Path, user: str | None = None, run_cmd: Callable = _default_run
     ) -> None:
         super().__init__(home=home, run_cmd=run_cmd)
-        # pwd, not getpass.getuser(): getuser trusts LOGNAME/USER env vars, so a
-        # stale/spoofed env would enable-linger for ANOTHER account while
-        # systemctl --user still targets this uid — reported success, daemon
-        # still dies on logout.
-        self._user = user or pwd.getpwuid(os.getuid()).pw_name
+        self._user = user or _uid_username()
 
     def _systemctl(self, *args: str) -> subprocess.CompletedProcess:
         return self._run(["systemctl", "--user", *args])
@@ -124,6 +148,12 @@ class SystemdUserSupervisor(_BaseSupervisor):
         self._checked("enable", SYSTEMD_UNIT_NAME.removesuffix(".service"))
         # Linger is mandatory: without it the user unit is torn down when the
         # last SSH session ends — precisely the moment the daemon is needed.
+        if self._user is None:
+            raise DaemonSupervisorError(
+                f"uid {os.getuid()} has no passwd entry, so `loginctl enable-linger` has no "
+                "user to target — linger is mandatory (without it the daemon dies when your "
+                f"last session ends). Run as a real user, or use `mship daemon run`."
+            )
         try:
             r = self._run(["loginctl", "enable-linger", self._user])
         except OSError as e:
@@ -172,6 +202,8 @@ class SystemdUserSupervisor(_BaseSupervisor):
         return SupervisorState("absent", f"{active}/{props.get('SubState', '')}")
 
     def linger_state(self) -> Literal["yes", "no", "unknown"]:
+        if self._user is None:
+            return "unknown"  # no passwd entry (container UID) — nothing to query
         try:
             r = self._run(["loginctl", "show-user", self._user, "--property=Linger"])
         except OSError:

--- a/src/mship/core/daemon/supervisor.py
+++ b/src/mship/core/daemon/supervisor.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Callable, Literal
 
 from mship.core.daemon.paths import daemon_log_dir
+from mship.core.daemon.log_capture import trim_launchd_captures
 from mship.core.daemon.units import (
     LAUNCHD_LABEL,
     SYSTEMD_UNIT_NAME,
@@ -54,7 +55,9 @@ def _tail_lines(path: Path, n: int) -> list[str]:
         fh.seek(0, os.SEEK_END)
         size = fh.tell()
         fh.seek(max(0, size - _TAIL_READ_BYTES))
-        chunk = fh.read()
+        # Bound the READ too, not just the seek: a concurrent append between
+        # tell() and read() would otherwise hand back the enlarged file.
+        chunk = fh.read(_TAIL_READ_BYTES)
     text = chunk.decode("utf-8", errors="replace")
     if size > _TAIL_READ_BYTES:
         text = text.split("\n", 1)[-1]  # drop the partial first line
@@ -95,6 +98,9 @@ class _BaseSupervisor:
         """Last N lines across daemon.log + rotated siblings — pure Python, no
         journalctl (the phone-only-client case needs OS-independent logs)."""
         log_dir = daemon_log_dir(self._home)
+        # A daemon that dies before main() cannot trim its own capture, so the
+        # operator-facing path trims too (#475 review).
+        trim_launchd_captures(log_dir)
         files = sorted(
             log_dir.glob("daemon.log*"),
             key=lambda p: int(p.suffix[1:]) if p.suffix[1:].isdigit() else 0,

--- a/src/mship/core/daemon/supervisor.py
+++ b/src/mship/core/daemon/supervisor.py
@@ -13,8 +13,8 @@ raw supervisor state.
 """
 from __future__ import annotations
 
-import getpass
 import os
+import pwd
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -62,6 +62,11 @@ class _BaseSupervisor:
             key=lambda p: int(p.suffix[1:]) if p.suffix[1:].isdigit() else 0,
             reverse=True,  # highest numeric suffix = oldest first
         )
+        # Pre-exec failures (missing executable, broken interpreter) never
+        # reach Python logging: launchd captures them in launchd.*.log (wired
+        # in the plist); on Linux they land in journald only. Include the
+        # launchd captures so `daemon logs` still explains a failed start.
+        files.extend(sorted(log_dir.glob("launchd.*.log")))
         lines: list[str] = []
         for f in files:
             try:
@@ -76,7 +81,11 @@ class SystemdUserSupervisor(_BaseSupervisor):
         self, *, home: Path, user: str | None = None, run_cmd: Callable = _default_run
     ) -> None:
         super().__init__(home=home, run_cmd=run_cmd)
-        self._user = user or getpass.getuser()
+        # pwd, not getpass.getuser(): getuser trusts LOGNAME/USER env vars, so a
+        # stale/spoofed env would enable-linger for ANOTHER account while
+        # systemctl --user still targets this uid — reported success, daemon
+        # still dies on logout.
+        self._user = user or pwd.getpwuid(os.getuid()).pw_name
 
     def _systemctl(self, *args: str) -> subprocess.CompletedProcess:
         return self._run(["systemctl", "--user", *args])

--- a/src/mship/core/daemon/supervisor.py
+++ b/src/mship/core/daemon/supervisor.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Callable, Literal
 
 from mship.core.daemon.paths import daemon_log_dir
-from mship.core.daemon.log_capture import trim_launchd_captures
+from mship.core.daemon.log_capture import rotate_launchd_captures
 from mship.core.daemon.units import (
     LAUNCHD_LABEL,
     SYSTEMD_UNIT_NAME,
@@ -98,9 +98,9 @@ class _BaseSupervisor:
         """Last N lines across daemon.log + rotated siblings — pure Python, no
         journalctl (the phone-only-client case needs OS-independent logs)."""
         log_dir = daemon_log_dir(self._home)
-        # A daemon that dies before main() cannot trim its own capture, so the
-        # operator-facing path trims too (#475 review).
-        trim_launchd_captures(log_dir)
+        # A daemon that dies before main() cannot roll over its own capture, so
+        # the operator-facing path does too (#475 review).
+        rotate_launchd_captures(log_dir)
         files = sorted(
             log_dir.glob("daemon.log*"),
             key=lambda p: int(p.suffix[1:]) if p.suffix[1:].isdigit() else 0,
@@ -116,7 +116,7 @@ class _BaseSupervisor:
         # Ordered by MTIME against the daemon logs rather than appended last:
         # a stale launchd.err.log with >= n lines would otherwise crowd the
         # current daemon.log out of the `-n` tail.
-        launchd = sorted(log_dir.glob("launchd.*.log"))
+        launchd = sorted(log_dir.glob("launchd.*.log*"))
         if launchd:
             def _mtime(p: Path) -> float:
                 try:

--- a/src/mship/core/daemon/supervisor.py
+++ b/src/mship/core/daemon/supervisor.py
@@ -43,6 +43,24 @@ class SupervisorState:
     detail: str = ""
 
 
+# Read at most this much from the END of each log file: `logs_tail` must not
+# pull a multi-megabyte launchd capture into memory to print 100 lines.
+_TAIL_READ_BYTES = 256 * 1024
+
+
+def _tail_lines(path: Path, n: int) -> list[str]:
+    """Last-ish `n` lines without reading the whole file."""
+    with open(path, "rb") as fh:
+        fh.seek(0, os.SEEK_END)
+        size = fh.tell()
+        fh.seek(max(0, size - _TAIL_READ_BYTES))
+        chunk = fh.read()
+    text = chunk.decode("utf-8", errors="replace")
+    if size > _TAIL_READ_BYTES:
+        text = text.split("\n", 1)[-1]  # drop the partial first line
+    return text.splitlines()[-n:]
+
+
 def _uid_username() -> str | None:
     """This UID's passwd name, or None.
 
@@ -104,7 +122,7 @@ class _BaseSupervisor:
         lines: list[str] = []
         for f in files:
             try:
-                lines.extend(f.read_text().splitlines())
+                lines.extend(_tail_lines(f, n))
             except OSError:
                 continue
         return lines[-n:]

--- a/src/mship/core/daemon/supervisor.py
+++ b/src/mship/core/daemon/supervisor.py
@@ -14,7 +14,6 @@ raw supervisor state.
 from __future__ import annotations
 
 import os
-import pwd
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -56,8 +55,12 @@ def _uid_username() -> str | None:
     degrade to "unknown"/loud install failure) instead of crashing the CLI.
     """
     try:
+        import pwd  # Unix-only: imported lazily so `mship <anything>` still runs on Windows
+    except ModuleNotFoundError:
+        return None
+    try:
         return pwd.getpwuid(os.getuid()).pw_name
-    except KeyError:
+    except (KeyError, AttributeError):  # no passwd entry / no getuid on this platform
         return None
 
 
@@ -141,6 +144,15 @@ class SystemdUserSupervisor(_BaseSupervisor):
         return False
 
     def install(self, argv: list[str]) -> None:
+        # Validate BEFORE any unit mutation: linger is mandatory, so if we can
+        # never enable it, writing+enabling a unit first would leave an enabled
+        # unit that starts and dies without linger (worse than not installing).
+        if self._user is None:
+            raise DaemonSupervisorError(
+                f"uid {os.getuid()} has no passwd entry, so `loginctl enable-linger` has no "
+                "user to target — linger is mandatory (without it the daemon dies when your "
+                "last session ends). Run as a real user, or use `mship daemon run`."
+            )
         unit_path = systemd_unit_path(self._home)
         unit_path.parent.mkdir(parents=True, exist_ok=True)
         unit_path.write_text(render_systemd_unit(argv))
@@ -148,12 +160,6 @@ class SystemdUserSupervisor(_BaseSupervisor):
         self._checked("enable", SYSTEMD_UNIT_NAME.removesuffix(".service"))
         # Linger is mandatory: without it the user unit is torn down when the
         # last SSH session ends — precisely the moment the daemon is needed.
-        if self._user is None:
-            raise DaemonSupervisorError(
-                f"uid {os.getuid()} has no passwd entry, so `loginctl enable-linger` has no "
-                "user to target — linger is mandatory (without it the daemon dies when your "
-                f"last session ends). Run as a real user, or use `mship daemon run`."
-            )
         try:
             r = self._run(["loginctl", "enable-linger", self._user])
         except OSError as e:

--- a/src/mship/core/daemon/supervisor.py
+++ b/src/mship/core/daemon/supervisor.py
@@ -168,22 +168,14 @@ class SystemdUserSupervisor(_BaseSupervisor):
         return False
 
     def install(self, argv: list[str]) -> None:
-        # Validate BEFORE any unit mutation: linger is mandatory, so if we can
-        # never enable it, writing+enabling a unit first would leave an enabled
-        # unit that starts and dies without linger (worse than not installing).
+        # Validate linger BEFORE any unit mutation: it is mandatory, so a setup
+        # failure must not leave an enabled unit that starts and dies on logout.
         if self._user is None:
             raise DaemonSupervisorError(
                 f"uid {os.getuid()} has no passwd entry, so `loginctl enable-linger` has no "
                 "user to target — linger is mandatory (without it the daemon dies when your "
                 "last session ends). Run as a real user, or use `mship daemon run`."
             )
-        unit_path = systemd_unit_path(self._home)
-        unit_path.parent.mkdir(parents=True, exist_ok=True)
-        unit_path.write_text(render_systemd_unit(argv))
-        self._checked("daemon-reload")
-        self._checked("enable", SYSTEMD_UNIT_NAME.removesuffix(".service"))
-        # Linger is mandatory: without it the user unit is torn down when the
-        # last SSH session ends — precisely the moment the daemon is needed.
         try:
             r = self._run(["loginctl", "enable-linger", self._user])
         except OSError as e:
@@ -195,6 +187,12 @@ class SystemdUserSupervisor(_BaseSupervisor):
                 "loginctl enable-linger did not stick (Linger!=yes) — without linger the "
                 "daemon dies when your last SSH session ends. Check `loginctl show-user`."
             )
+
+        unit_path = systemd_unit_path(self._home)
+        unit_path.parent.mkdir(parents=True, exist_ok=True)
+        unit_path.write_text(render_systemd_unit(argv))
+        self._checked("daemon-reload")
+        self._checked("enable", SYSTEMD_UNIT_NAME.removesuffix(".service"))
 
     def start(self) -> None:
         self._checked("start", SYSTEMD_UNIT_NAME.removesuffix(".service"))

--- a/src/mship/core/daemon/supervisor.py
+++ b/src/mship/core/daemon/supervisor.py
@@ -62,10 +62,13 @@ class _BaseSupervisor:
             key=lambda p: int(p.suffix[1:]) if p.suffix[1:].isdigit() else 0,
             reverse=True,  # highest numeric suffix = oldest first
         )
-        # Pre-exec failures (missing executable, broken interpreter) never
-        # reach Python logging: launchd captures them in launchd.*.log (wired
-        # in the plist); on Linux they land in journald only. Include the
-        # launchd captures so `daemon logs` still explains a failed start.
+        # Early-exit output that never reaches Python logging (interpreter
+        # starts but dies before _configure_logging) goes to stderr, which the
+        # plist wires into launchd.*.log — include those captures. NOTE: a true
+        # pre-exec failure (missing executable → posix_spawn error) produces NO
+        # child process and lands only in launchd's unified log / journald;
+        # `launchctl print` and `journalctl --user -u mship-daemon` are the
+        # diagnostics there (docs/daemon.md).
         files.extend(sorted(log_dir.glob("launchd.*.log")))
         lines: list[str] = []
         for f in files:

--- a/src/mship/core/daemon/units.py
+++ b/src/mship/core/daemon/units.py
@@ -51,9 +51,16 @@ def _running_from_dev_tree() -> str | None:
         return f"mship is imported from {pkg.parent} (editable checkout), not the running venv"
     project = prefix.parent / "pyproject.toml"
     try:
-        if project.is_file() and 'name = "mothership"' in project.read_text():
-            return f"the running venv sits inside a mothership checkout ({prefix.parent})"
-    except OSError:
+        if project.is_file():
+            import tomllib
+
+            data = tomllib.loads(project.read_text(encoding="utf-8"))
+            # Parsed, not substring-matched: `name='mothership'`, extra spaces,
+            # or any other valid TOML spelling must be detected too, or a
+            # checkout venv gets baked into the unit and upgrades deploy nothing.
+            if (data.get("project") or {}).get("name") == "mothership":
+                return f"the running venv sits inside a mothership checkout ({prefix.parent})"
+    except (OSError, ValueError):
         pass
     return None
 

--- a/src/mship/core/daemon/units.py
+++ b/src/mship/core/daemon/units.py
@@ -29,7 +29,42 @@ class DaemonExecResolutionError(RuntimeError):
     pass
 
 
+def _running_from_dev_tree() -> str | None:
+    """A checkout's own venv must never be persisted into a supervisor unit —
+    upgrades (`uv tool install --force` + restart) would silently deploy
+    nothing, or break when the worktree is removed. Two signals, either
+    refuses:
+
+    - the imported mship package resolves OUTSIDE sys.prefix (editable
+      install — exactly what `uv run mship` from a checkout produces);
+    - the venv sits beside a pyproject.toml declaring this same project
+      (a non-editable `.venv` inside the checkout).
+    """
+    import mship
+
+    prefix = Path(sys.prefix).resolve()
+    try:
+        pkg = Path(mship.__file__).resolve()
+    except (TypeError, OSError):
+        return None
+    if not pkg.is_relative_to(prefix):
+        return f"mship is imported from {pkg.parent} (editable checkout), not the running venv"
+    project = prefix.parent / "pyproject.toml"
+    try:
+        if project.is_file() and 'name = "mothership"' in project.read_text():
+            return f"the running venv sits inside a mothership checkout ({prefix.parent})"
+    except OSError:
+        pass
+    return None
+
+
 def resolve_mshipd_argv(which: Callable[[str], str | None] = shutil.which) -> list[str]:
+    dev_reason = _running_from_dev_tree()
+    if dev_reason is not None:
+        raise DaemonExecResolutionError(
+            f"{dev_reason} — you are running mship from a dev tree; install the tool "
+            "first (uv tool install --force <path>) and re-run mship daemon install."
+        )
     exe = Path(sys.executable)
     sibling = exe.parent / "mshipd"
     if sibling.exists():

--- a/tests/cli/test_daemon.py
+++ b/tests/cli/test_daemon.py
@@ -125,6 +125,34 @@ def test_status_renders_skew_and_warnings(cli, monkeypatch):
     assert "outside the supervisor" in res.output
 
 
+def test_status_rotates_oversized_launchd_capture(cli, tmp_path):
+    """Status must bound a pre-main crash loop even when logs is never called."""
+    from mship.core.daemon.log_capture import LAUNCHD_CAPTURE_MAX_BYTES
+    from mship.core.daemon.paths import daemon_log_dir
+
+    app, _ = cli
+    log_dir = daemon_log_dir(tmp_path)
+    log_dir.mkdir(parents=True)
+    capture = log_dir / "launchd.err.log"
+    latest = b"latest startup traceback\n"
+    capture.write_bytes(b"x" * (LAUNCHD_CAPTURE_MAX_BYTES + 1) + latest)
+
+    res = runner.invoke(app, ["daemon", "status"])
+
+    assert res.exit_code == 0, res.output
+    retired = log_dir / "launchd.err.log.1"
+    assert not capture.exists()
+    assert retired.read_bytes().endswith(latest)
+
+    # A later launch recreates the active path only after the retired writer
+    # exits; the next status can then compact that inactive generation safely.
+    capture.write_text("next launch\n")
+    res = runner.invoke(app, ["daemon", "status"])
+    assert res.exit_code == 0, res.output
+    assert retired.stat().st_size == LAUNCHD_CAPTURE_MAX_BYTES
+    assert retired.read_bytes().endswith(latest)
+
+
 def test_logs_prints_tail(cli):
     app, fake = cli
     res = runner.invoke(app, ["daemon", "logs"])

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -178,3 +178,22 @@ def test_entrypoint_registered():
         pyproject = tomllib.load(f)
     assert pyproject["project"]["scripts"]["mshipd"] == "mship.core.daemon.run:main"
     assert callable(run_mod.main)
+
+
+def test_oversized_launchd_capture_is_truncated_on_start(env_home, monkeypatch):
+    """launchd never rotates StandardErrorPath: under KeepAlive relaunch a
+    persistent startup failure would grow it forever, so the daemon caps it."""
+    home, env = env_home
+    _capture_uvicorn(monkeypatch)
+    log_dir = daemon_log_dir(home)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    big = log_dir / "launchd.err.log"
+    big.write_bytes(b"x" * (run_mod._LAUNCHD_CAPTURE_MAX_BYTES + 1024))
+    small = log_dir / "launchd.out.log"
+    small.write_text("keep me\n")
+
+    assert run_mod.main(home=home, env=env) == 0
+
+    assert big.stat().st_size == 0            # capped
+    assert small.read_text() == "keep me\n"   # under the cap: untouched
+    assert "truncated oversized launchd capture" in (log_dir / "daemon.log").read_text()

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -180,23 +180,26 @@ def test_entrypoint_registered():
     assert callable(run_mod.main)
 
 
-def test_oversized_launchd_capture_is_truncated_on_start(env_home, monkeypatch):
-    """launchd never rotates StandardErrorPath: under KeepAlive relaunch a
-    persistent startup failure would grow it forever, so the daemon caps it."""
+def test_oversized_launchd_capture_preserves_latest_evidence_on_start(
+    env_home, monkeypatch
+):
+    """Capping launchd's unrotated capture retains the newest crash evidence."""
     home, env = env_home
     _capture_uvicorn(monkeypatch)
     log_dir = daemon_log_dir(home)
     log_dir.mkdir(parents=True, exist_ok=True)
     big = log_dir / "launchd.err.log"
-    big.write_bytes(b"x" * (run_mod.LAUNCHD_CAPTURE_MAX_BYTES + 1024))
+    latest = b"latest startup traceback\n"
+    big.write_bytes(b"x" * (run_mod.LAUNCHD_CAPTURE_MAX_BYTES + 1024) + latest)
     small = log_dir / "launchd.out.log"
     small.write_text("keep me\n")
 
     assert run_mod.main(home=home, env=env) == 0
 
-    assert big.stat().st_size == 0            # capped
-    assert small.read_text() == "keep me\n"   # under the cap: untouched
-    assert "truncated oversized launchd capture" in (log_dir / "daemon.log").read_text()
+    assert big.stat().st_size == run_mod.LAUNCHD_CAPTURE_MAX_BYTES
+    assert big.read_bytes().endswith(latest)
+    assert small.read_text() == "keep me\n"
+    assert "trimmed oversized launchd capture" in (log_dir / "daemon.log").read_text()
 
 
 def test_capture_trimmed_before_logging_setup(env_home, monkeypatch):

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -183,34 +183,36 @@ def test_entrypoint_registered():
 def test_oversized_launchd_capture_preserves_latest_evidence_on_start(
     env_home, monkeypatch
 ):
-    """Capping launchd's unrotated capture retains the newest crash evidence."""
+    """Atomic rollover caps the active capture without losing crash evidence."""
     home, env = env_home
     _capture_uvicorn(monkeypatch)
     log_dir = daemon_log_dir(home)
     log_dir.mkdir(parents=True, exist_ok=True)
-    big = log_dir / "launchd.err.log"
+    capture = log_dir / "launchd.err.log"
     latest = b"latest startup traceback\n"
-    big.write_bytes(b"x" * (run_mod.LAUNCHD_CAPTURE_MAX_BYTES + 1024) + latest)
+    capture.write_bytes(b"x" * (run_mod.LAUNCHD_CAPTURE_MAX_BYTES + 1024) + latest)
     small = log_dir / "launchd.out.log"
     small.write_text("keep me\n")
 
     assert run_mod.main(home=home, env=env) == 0
 
-    assert big.stat().st_size == run_mod.LAUNCHD_CAPTURE_MAX_BYTES
-    assert big.read_bytes().endswith(latest)
+    assert not capture.exists()
+    assert (log_dir / "launchd.err.log.1").read_bytes().endswith(latest)
     assert small.read_text() == "keep me\n"
-    assert "trimmed oversized launchd capture" in (log_dir / "daemon.log").read_text()
+    assert "rolled over oversized launchd capture" in (
+        log_dir / "daemon.log"
+    ).read_text()
 
 
-def test_capture_trimmed_before_logging_setup(env_home, monkeypatch):
+def test_capture_rotated_before_logging_setup(env_home, monkeypatch):
     """A crash loop is often a BROKEN IMPORT that dies before logging is
-    configured; trimming must happen first, not inside _configure_logging."""
+    configured; rollover must happen first, not inside _configure_logging."""
     home, env = env_home
     order: list[str] = []
-    monkeypatch.setattr(run_mod, "trim_launchd_captures",
-                        lambda d: order.append("trim") or [])
+    monkeypatch.setattr(run_mod, "rotate_launchd_captures",
+                        lambda d: order.append("rotate") or [])
     monkeypatch.setattr(run_mod, "_configure_logging",
                         lambda h: order.append("logging"))
     monkeypatch.setattr(run_mod, "_run", lambda h, e: order.append("run") or 0)
     assert run_mod.main(home=home, env=env) == 0
-    assert order[0] == "trim", order
+    assert order[0] == "rotate", order

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -188,7 +188,7 @@ def test_oversized_launchd_capture_is_truncated_on_start(env_home, monkeypatch):
     log_dir = daemon_log_dir(home)
     log_dir.mkdir(parents=True, exist_ok=True)
     big = log_dir / "launchd.err.log"
-    big.write_bytes(b"x" * (run_mod._LAUNCHD_CAPTURE_MAX_BYTES + 1024))
+    big.write_bytes(b"x" * (run_mod.LAUNCHD_CAPTURE_MAX_BYTES + 1024))
     small = log_dir / "launchd.out.log"
     small.write_text("keep me\n")
 
@@ -197,3 +197,17 @@ def test_oversized_launchd_capture_is_truncated_on_start(env_home, monkeypatch):
     assert big.stat().st_size == 0            # capped
     assert small.read_text() == "keep me\n"   # under the cap: untouched
     assert "truncated oversized launchd capture" in (log_dir / "daemon.log").read_text()
+
+
+def test_capture_trimmed_before_logging_setup(env_home, monkeypatch):
+    """A crash loop is often a BROKEN IMPORT that dies before logging is
+    configured; trimming must happen first, not inside _configure_logging."""
+    home, env = env_home
+    order: list[str] = []
+    monkeypatch.setattr(run_mod, "trim_launchd_captures",
+                        lambda d: order.append("trim") or [])
+    monkeypatch.setattr(run_mod, "_configure_logging",
+                        lambda h: order.append("logging"))
+    monkeypatch.setattr(run_mod, "_run", lambda h, e: order.append("run") or 0)
+    assert run_mod.main(home=home, env=env) == 0
+    assert order[0] == "trim", order

--- a/tests/core/daemon/test_supervisor.py
+++ b/tests/core/daemon/test_supervisor.py
@@ -278,11 +278,9 @@ def test_logs_tail_includes_launchd_stderr_captures(tmp_path):
 def test_uid_without_passwd_entry_does_not_crash_commands(tmp_path, monkeypatch):
     """Arbitrary container UIDs have no NSS entry; the supervisor is built for
     EVERY daemon command, so status/logs must keep working."""
-    import pwd as pwd_mod
+    import pwd
 
-    import mship.core.daemon.supervisor as sup_mod
-
-    monkeypatch.setattr(sup_mod.pwd, "getpwuid", lambda uid: (_ for _ in ()).throw(KeyError(uid)))
+    monkeypatch.setattr(pwd, "getpwuid", lambda uid: (_ for _ in ()).throw(KeyError(uid)))
     rec = Recorder({"show mship-daemon": _ok("ActiveState=active\nSubState=running\n")})
     sup = SystemdUserSupervisor(home=tmp_path, run_cmd=rec)
     assert sup._user is None
@@ -294,12 +292,17 @@ def test_uid_without_passwd_entry_does_not_crash_commands(tmp_path, monkeypatch)
 def test_install_fails_loudly_without_passwd_entry(tmp_path, monkeypatch):
     """Linger is mandatory, so an uninstallable environment must say so, not silently
     install a unit that dies on logout."""
-    import mship.core.daemon.supervisor as sup_mod
+    import pwd
 
-    monkeypatch.setattr(sup_mod.pwd, "getpwuid", lambda uid: (_ for _ in ()).throw(KeyError(uid)))
-    sup = SystemdUserSupervisor(home=tmp_path, run_cmd=Recorder())
+    monkeypatch.setattr(pwd, "getpwuid", lambda uid: (_ for _ in ()).throw(KeyError(uid)))
+    rec = Recorder()
+    sup = SystemdUserSupervisor(home=tmp_path, run_cmd=rec)
     with pytest.raises(DaemonSupervisorError, match="passwd entry"):
         sup.install(["/venv/bin/mshipd"])
+    # Nothing was mutated: no unit written, no daemon-reload, no enable — an
+    # enabled unit without linger would start and die on every login.
+    assert not (tmp_path / ".config" / "systemd" / "user" / "mship-daemon.service").exists()
+    assert rec.calls == []
 
 
 def test_stale_launchd_capture_does_not_hide_fresh_daemon_log(tmp_path):
@@ -320,3 +323,40 @@ def test_stale_launchd_capture_does_not_hide_fresh_daemon_log(tmp_path):
     sup, _ = _linux(tmp_path)
     tail = sup.logs_tail(2)
     assert tail == ["fresh-1", "fresh-2"], tail
+
+
+def test_uid_username_is_none_without_pwd_module(monkeypatch):
+    """Windows has no `pwd`; mship.cli imports this module for EVERY command, so
+    the import must be lazy and failure-tolerant."""
+    import builtins
+
+    import mship.core.daemon.supervisor as sup_mod
+
+    real_import = builtins.__import__
+
+    def no_pwd(name, *a, **kw):
+        if name == "pwd":
+            raise ModuleNotFoundError("No module named 'pwd'")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", no_pwd)
+    assert sup_mod._uid_username() is None
+
+
+def test_supervisor_module_has_no_toplevel_pwd_import():
+    """Static guard for the same class: a top-level `import pwd` would break
+    the whole CLI on Windows at import time, before Typer dispatch."""
+    import ast
+    from pathlib import Path as _P
+
+    src = _P(sup_module_path()).read_text()
+    tree = ast.parse(src)
+    toplevel = [n for n in tree.body if isinstance(n, (ast.Import, ast.ImportFrom))]
+    names = {a.name for n in toplevel if isinstance(n, ast.Import) for a in n.names}
+    assert "pwd" not in names
+
+
+def sup_module_path() -> str:
+    import mship.core.daemon.supervisor as sup_mod
+
+    return sup_mod.__file__

--- a/tests/core/daemon/test_supervisor.py
+++ b/tests/core/daemon/test_supervisor.py
@@ -273,3 +273,50 @@ def test_logs_tail_includes_launchd_stderr_captures(tmp_path):
     lines = sup.logs_tail(10)
     assert "app-line" in lines
     assert "posix_spawn: No such file or directory" in lines
+
+
+def test_uid_without_passwd_entry_does_not_crash_commands(tmp_path, monkeypatch):
+    """Arbitrary container UIDs have no NSS entry; the supervisor is built for
+    EVERY daemon command, so status/logs must keep working."""
+    import pwd as pwd_mod
+
+    import mship.core.daemon.supervisor as sup_mod
+
+    monkeypatch.setattr(sup_mod.pwd, "getpwuid", lambda uid: (_ for _ in ()).throw(KeyError(uid)))
+    rec = Recorder({"show mship-daemon": _ok("ActiveState=active\nSubState=running\n")})
+    sup = SystemdUserSupervisor(home=tmp_path, run_cmd=rec)
+    assert sup._user is None
+    assert sup.query().state == "active"      # status still works
+    assert sup.linger_state() == "unknown"    # nothing to query, no crash
+    assert sup.logs_tail(5) == []
+
+
+def test_install_fails_loudly_without_passwd_entry(tmp_path, monkeypatch):
+    """Linger is mandatory, so an uninstallable environment must say so, not silently
+    install a unit that dies on logout."""
+    import mship.core.daemon.supervisor as sup_mod
+
+    monkeypatch.setattr(sup_mod.pwd, "getpwuid", lambda uid: (_ for _ in ()).throw(KeyError(uid)))
+    sup = SystemdUserSupervisor(home=tmp_path, run_cmd=Recorder())
+    with pytest.raises(DaemonSupervisorError, match="passwd entry"):
+        sup.install(["/venv/bin/mshipd"])
+
+
+def test_stale_launchd_capture_does_not_hide_fresh_daemon_log(tmp_path):
+    """A big stale launchd.err.log must not crowd the current daemon.log out of
+    the -n tail (ordering is by mtime, not 'launchd always last')."""
+    import os
+    import time
+
+    log_dir = tmp_path / ".mothership" / "daemon" / "logs"
+    log_dir.mkdir(parents=True)
+    stale = log_dir / "launchd.err.log"
+    stale.write_text("\n".join(f"stale-{i}" for i in range(10)) + "\n")
+    fresh = log_dir / "daemon.log"
+    fresh.write_text("fresh-1\nfresh-2\n")
+    old = time.time() - 3600
+    os.utime(stale, (old, old))  # stale capture is genuinely older
+
+    sup, _ = _linux(tmp_path)
+    tail = sup.logs_tail(2)
+    assert tail == ["fresh-1", "fresh-2"], tail

--- a/tests/core/daemon/test_supervisor.py
+++ b/tests/core/daemon/test_supervisor.py
@@ -45,7 +45,7 @@ def _linux(tmp_path, responses=None):
     return sup, rec
 
 
-def test_linux_install_order_and_linger_verify(tmp_path):
+def test_linux_install_linger_precedes_unit_mutation(tmp_path):
     sup, rec = _linux(
         tmp_path, {"show-user": _ok("Linger=yes\n"), "is-system-running": _ok("running\n")}
     )
@@ -57,13 +57,32 @@ def test_linux_install_order_and_linger_verify(tmp_path):
     enable_i = next(i for i, c in enumerate(cmds) if " enable " in f" {c} ")
     linger_i = next(i for i, c in enumerate(cmds) if "enable-linger" in c)
     verify_i = next(i for i, c in enumerate(cmds) if "show-user" in c)
-    assert reload_i < enable_i < linger_i < verify_i
+    assert linger_i < verify_i < reload_i < enable_i
 
 
-def test_linux_install_fails_loudly_when_linger_does_not_stick(tmp_path):
-    sup, _ = _linux(tmp_path, {"show-user": _ok("Linger=no\n")})
+def test_linux_install_fails_before_unit_mutation_when_linger_does_not_stick(tmp_path):
+    sup, rec = _linux(tmp_path, {"show-user": _ok("Linger=no\n")})
     with pytest.raises(DaemonSupervisorError, match="[Ll]inger"):
         sup.install(["/venv/bin/mshipd"])
+    unit = tmp_path / ".config" / "systemd" / "user" / "mship-daemon.service"
+    assert not unit.exists()
+    assert all(call[0] == "loginctl" for call in rec.calls)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [_fail(stderr="permission denied"), OSError("loginctl missing")],
+    ids=["nonzero", "os-error"],
+)
+def test_linux_install_fails_before_unit_mutation_when_enable_linger_fails(
+    tmp_path, response
+):
+    sup, rec = _linux(tmp_path, {"enable-linger": response})
+    with pytest.raises(DaemonSupervisorError, match="loginctl enable-linger failed"):
+        sup.install(["/venv/bin/mshipd"])
+    unit = tmp_path / ".config" / "systemd" / "user" / "mship-daemon.service"
+    assert not unit.exists()
+    assert all(call[0] == "loginctl" for call in rec.calls)
 
 
 def test_linux_lifecycle_commands(tmp_path):
@@ -325,6 +344,28 @@ def test_stale_launchd_capture_does_not_hide_fresh_daemon_log(tmp_path):
     assert tail == ["fresh-1", "fresh-2"], tail
 
 
+def test_trimming_oversized_stale_capture_preserves_log_order(tmp_path):
+    """Compaction must not make an old launchd capture look newer than daemon.log."""
+    import os
+    import time
+
+    from mship.core.daemon.log_capture import LAUNCHD_CAPTURE_MAX_BYTES
+
+    log_dir = tmp_path / ".mothership" / "daemon" / "logs"
+    log_dir.mkdir(parents=True)
+    stale = log_dir / "launchd.err.log"
+    stale.write_bytes(
+        b"x" * LAUNCHD_CAPTURE_MAX_BYTES + b"\nstale-1\nstale-2\n"
+    )
+    fresh = log_dir / "daemon.log"
+    fresh.write_text("fresh-1\nfresh-2\n")
+    old = time.time() - 3600
+    os.utime(stale, (old, old))
+
+    sup, _ = _linux(tmp_path)
+    assert sup.logs_tail(2) == ["fresh-1", "fresh-2"]
+
+
 def test_uid_username_is_none_without_pwd_module(monkeypatch):
     """Windows has no `pwd`; mship.cli imports this module for EVERY command, so
     the import must be lazy and failure-tolerant."""
@@ -436,16 +477,17 @@ def test_logs_tail_read_is_bounded_not_just_the_seek(tmp_path):
     assert len("\n".join(lines).encode()) <= sup_mod._TAIL_READ_BYTES
 
 
-def test_logs_tail_trims_oversized_capture(tmp_path):
-    """A daemon that never reaches main() can't trim its own capture, so the
-    operator-facing path does it."""
+def test_logs_tail_preserves_latest_evidence_when_trimming_oversized_capture(tmp_path):
+    """The operator-facing trim must retain the newest crash evidence."""
     from mship.core.daemon.log_capture import LAUNCHD_CAPTURE_MAX_BYTES
 
     log_dir = tmp_path / ".mothership" / "daemon" / "logs"
     log_dir.mkdir(parents=True)
     (log_dir / "daemon.log").write_text("app\n")
     huge = log_dir / "launchd.err.log"
-    huge.write_bytes(b"y" * (LAUNCHD_CAPTURE_MAX_BYTES + 2048))
+    latest = b"latest startup traceback\n"
+    huge.write_bytes(b"y" * (LAUNCHD_CAPTURE_MAX_BYTES + 2048) + b"\n" + latest)
     sup, _ = _linux(tmp_path)
-    sup.logs_tail(5)
-    assert huge.stat().st_size == 0
+    assert sup.logs_tail(5)[-1] == latest.decode().strip()
+    assert huge.stat().st_size == LAUNCHD_CAPTURE_MAX_BYTES
+    assert huge.read_bytes().endswith(latest)

--- a/tests/core/daemon/test_supervisor.py
+++ b/tests/core/daemon/test_supervisor.py
@@ -344,8 +344,8 @@ def test_stale_launchd_capture_does_not_hide_fresh_daemon_log(tmp_path):
     assert tail == ["fresh-1", "fresh-2"], tail
 
 
-def test_trimming_oversized_stale_capture_preserves_log_order(tmp_path):
-    """Compaction must not make an old launchd capture look newer than daemon.log."""
+def test_rotating_oversized_stale_capture_preserves_log_order(tmp_path):
+    """Rollover must not make an old launchd capture look newer than daemon.log."""
     import os
     import time
 
@@ -477,17 +477,45 @@ def test_logs_tail_read_is_bounded_not_just_the_seek(tmp_path):
     assert len("\n".join(lines).encode()) <= sup_mod._TAIL_READ_BYTES
 
 
-def test_logs_tail_preserves_latest_evidence_when_trimming_oversized_capture(tmp_path):
-    """The operator-facing trim must retain the newest crash evidence."""
+def test_logs_tail_preserves_latest_evidence_when_rotating_oversized_capture(tmp_path):
+    """The operator-facing rollover must retain the newest crash evidence."""
     from mship.core.daemon.log_capture import LAUNCHD_CAPTURE_MAX_BYTES
 
     log_dir = tmp_path / ".mothership" / "daemon" / "logs"
     log_dir.mkdir(parents=True)
     (log_dir / "daemon.log").write_text("app\n")
-    huge = log_dir / "launchd.err.log"
+    capture = log_dir / "launchd.err.log"
     latest = b"latest startup traceback\n"
-    huge.write_bytes(b"y" * (LAUNCHD_CAPTURE_MAX_BYTES + 2048) + b"\n" + latest)
+    capture.write_bytes(b"y" * (LAUNCHD_CAPTURE_MAX_BYTES + 2048) + b"\n" + latest)
     sup, _ = _linux(tmp_path)
     assert sup.logs_tail(5)[-1] == latest.decode().strip()
-    assert huge.stat().st_size == LAUNCHD_CAPTURE_MAX_BYTES
-    assert huge.read_bytes().endswith(latest)
+    assert not capture.exists()
+    assert (log_dir / "launchd.err.log.1").read_bytes().endswith(latest)
+
+
+def test_capture_rollover_does_not_discard_open_writer_appends(tmp_path, monkeypatch):
+    """An O_APPEND fd follows the atomic rename, so writes survive rollover."""
+    import os
+
+    import mship.core.daemon.log_capture as capture_mod
+
+    log_dir = tmp_path / ".mothership" / "daemon" / "logs"
+    log_dir.mkdir(parents=True)
+    capture = log_dir / "launchd.err.log"
+    capture.write_bytes(b"x" * (capture_mod.LAUNCHD_CAPTURE_MAX_BYTES + 1))
+    marker = b"concurrent launchd append\n"
+    writer = open(capture, "ab", buffering=0)
+    real_replace = os.replace
+
+    def replace_and_append(src, dst):
+        real_replace(src, dst)
+        writer.write(marker)
+
+    monkeypatch.setattr(capture_mod.os, "replace", replace_and_append)
+    try:
+        capture_mod.rotate_launchd_captures(log_dir)
+    finally:
+        writer.close()
+
+    retired = log_dir / "launchd.err.log.1"
+    assert retired.read_bytes().endswith(marker)

--- a/tests/core/daemon/test_supervisor.py
+++ b/tests/core/daemon/test_supervisor.py
@@ -260,9 +260,11 @@ def test_linux_user_defaults_to_uid_not_env(tmp_path, monkeypatch):
     assert sup._user != "someone-else"
 
 
-def test_logs_tail_includes_launchd_pre_exec_captures(tmp_path):
-    """A pre-exec failure (missing executable) only lands in launchd.err.log —
-    `daemon logs` must surface it, not return nothing on a failed start."""
+def test_logs_tail_includes_launchd_stderr_captures(tmp_path):
+    """Early-exit stderr (process spawned, died before Python logging) lands
+    only in launchd.err.log — `daemon logs` must surface it. (A posix_spawn
+    failure produces no child and lands only in the unified log/journald —
+    documented, not capturable here.)"""
     log_dir = tmp_path / ".mothership" / "daemon" / "logs"
     log_dir.mkdir(parents=True)
     (log_dir / "daemon.log").write_text("app-line\n")

--- a/tests/core/daemon/test_supervisor.py
+++ b/tests/core/daemon/test_supervisor.py
@@ -386,3 +386,66 @@ def test_logs_tail_reads_only_the_tail_of_a_huge_file(tmp_path):
     assert len("\n".join(lines).encode()) <= sup_mod._TAIL_READ_BYTES
     # the partial first line is dropped: every returned line is a WHOLE line
     assert all(len(l) == len(filler) - 1 for l in lines if l.startswith("OLD-"))
+
+
+def test_logs_tail_read_is_bounded_not_just_the_seek(tmp_path):
+    """Concurrent appends between tell() and read() must not enlarge the read:
+    the bound is on read(), not only on the seek offset."""
+    import mship.core.daemon.supervisor as sup_mod
+
+    log_dir = tmp_path / ".mothership" / "daemon" / "logs"
+    log_dir.mkdir(parents=True)
+    f = log_dir / "daemon.log"
+    f.write_text("seed\n")
+
+    real_open = open
+    grown = {"done": False}
+
+    class GrowingFile:
+        """Appends a megabyte between tell() and read(), like a live writer."""
+
+        def __init__(self, fh):
+            self._fh = fh
+
+        def seek(self, *a):
+            return self._fh.seek(*a)
+
+        def tell(self):
+            return self._fh.tell()
+
+        def read(self, *a):
+            if not grown["done"]:
+                grown["done"] = True
+                with real_open(f, "ab") as w:
+                    w.write(b"z" * (2 * sup_mod._TAIL_READ_BYTES))
+            return self._fh.read(*a)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            self._fh.close()
+
+    monkeyed = sup_mod.open if hasattr(sup_mod, "open") else None
+    assert monkeyed is None  # uses builtins; wrap via the module namespace
+    sup_mod.open = lambda p, mode="r", *a, **kw: GrowingFile(real_open(p, mode, *a, **kw))
+    try:
+        lines = sup_mod._tail_lines(f, 10)
+    finally:
+        del sup_mod.open
+    assert len("\n".join(lines).encode()) <= sup_mod._TAIL_READ_BYTES
+
+
+def test_logs_tail_trims_oversized_capture(tmp_path):
+    """A daemon that never reaches main() can't trim its own capture, so the
+    operator-facing path does it."""
+    from mship.core.daemon.log_capture import LAUNCHD_CAPTURE_MAX_BYTES
+
+    log_dir = tmp_path / ".mothership" / "daemon" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "daemon.log").write_text("app\n")
+    huge = log_dir / "launchd.err.log"
+    huge.write_bytes(b"y" * (LAUNCHD_CAPTURE_MAX_BYTES + 2048))
+    sup, _ = _linux(tmp_path)
+    sup.logs_tail(5)
+    assert huge.stat().st_size == 0

--- a/tests/core/daemon/test_supervisor.py
+++ b/tests/core/daemon/test_supervisor.py
@@ -360,3 +360,29 @@ def sup_module_path() -> str:
     import mship.core.daemon.supervisor as sup_mod
 
     return sup_mod.__file__
+
+
+def test_logs_tail_reads_only_the_tail_of_a_huge_file(tmp_path):
+    """A crash-looping macOS daemon can leave a huge launchd capture; printing
+    N lines must not pull the whole file into memory. Proven by content: the
+    early megabytes are simply never returned, and the read is bounded by
+    _TAIL_READ_BYTES (not monkeypatching builtins.open — pytest uses it too)."""
+    import mship.core.daemon.supervisor as sup_mod
+
+    log_dir = tmp_path / ".mothership" / "daemon" / "logs"
+    log_dir.mkdir(parents=True)
+    big = log_dir / "daemon.log"
+    filler = "OLD-" + "x" * 96 + "\n"
+    with open(big, "w") as fh:
+        fh.write(filler * ((sup_mod._TAIL_READ_BYTES // len(filler)) + 500))
+        fh.write("NEW-1\nNEW-2\nNEW-3\n")
+    assert big.stat().st_size > sup_mod._TAIL_READ_BYTES
+
+    sup, _ = _linux(tmp_path)
+    assert sup.logs_tail(3) == ["NEW-1", "NEW-2", "NEW-3"]
+
+    # the bound itself: a full-file read would yield far more than this
+    lines = sup_mod._tail_lines(big, 10**9)
+    assert len("\n".join(lines).encode()) <= sup_mod._TAIL_READ_BYTES
+    # the partial first line is dropped: every returned line is a WHOLE line
+    assert all(len(l) == len(filler) - 1 for l in lines if l.startswith("OLD-"))

--- a/tests/core/daemon/test_supervisor.py
+++ b/tests/core/daemon/test_supervisor.py
@@ -244,3 +244,30 @@ def test_macos_reinstall_unloads_first(tmp_path):
     sup2, rec2 = _mac(tmp_path, {"launchctl bootout": _fail(stderr="Boot-out failed: 3: No such process")})
     sup2.install(["/venv/bin/mshipd"])
     assert any("bootstrap" in " ".join(c) for c in rec2.calls)
+
+
+def test_linux_user_defaults_to_uid_not_env(tmp_path, monkeypatch):
+    """getpass.getuser() trusts LOGNAME/USER; a spoofed env must not make
+    enable-linger target another account while systemctl targets this uid."""
+    import os
+    import pwd
+
+    monkeypatch.setenv("LOGNAME", "someone-else")
+    monkeypatch.setenv("USER", "someone-else")
+    rec = Recorder({"show-user": _ok("Linger=yes\n")})
+    sup = SystemdUserSupervisor(home=tmp_path, run_cmd=rec)
+    assert sup._user == pwd.getpwuid(os.getuid()).pw_name
+    assert sup._user != "someone-else"
+
+
+def test_logs_tail_includes_launchd_pre_exec_captures(tmp_path):
+    """A pre-exec failure (missing executable) only lands in launchd.err.log —
+    `daemon logs` must surface it, not return nothing on a failed start."""
+    log_dir = tmp_path / ".mothership" / "daemon" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "daemon.log").write_text("app-line\n")
+    (log_dir / "launchd.err.log").write_text("posix_spawn: No such file or directory\n")
+    sup, _ = _linux(tmp_path)
+    lines = sup.logs_tail(10)
+    assert "app-line" in lines
+    assert "posix_spawn: No such file or directory" in lines

--- a/tests/core/daemon/test_units.py
+++ b/tests/core/daemon/test_units.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+import mship.core.daemon.units as units_mod
 from mship.core.daemon.units import (
     LAUNCHD_LABEL,
     DaemonExecResolutionError,
@@ -65,7 +66,44 @@ def test_launchd_plist_shape(tmp_path: Path):
     assert plist["StandardErrorPath"] == str(log_dir / "launchd.err.log")
 
 
-def test_execstart_resolves_sibling_first(tmp_path, monkeypatch):
+@pytest.fixture
+def not_dev_tree(monkeypatch):
+    """Resolution-rule tests simulate an installed tool: neutralize the
+    dev-tree refusal (itself covered by test_dev_tree_refuses_install)."""
+    monkeypatch.setattr(units_mod, "_running_from_dev_tree", lambda: None)
+
+
+def test_dev_tree_refuses_install(monkeypatch):
+    """Running from a checkout (editable mship / venv-in-checkout) must refuse
+    BEFORE the sibling shortcut: the checkout venv has its own mshipd sibling,
+    which would otherwise be persisted into the unit and defeat upgrades."""
+    monkeypatch.setattr(units_mod, "_running_from_dev_tree", lambda: "editable checkout at /x")
+    with pytest.raises(DaemonExecResolutionError, match="dev tree"):
+        resolve_mshipd_argv(which=lambda name: None)
+
+
+def test_dev_tree_detector_flags_editable_package(tmp_path, monkeypatch):
+    """The real detector: package resolving outside sys.prefix = editable
+    checkout (`uv run mship`)."""
+    import mship as mship_pkg
+
+    monkeypatch.setattr(sys, "prefix", str(tmp_path / "venv"))
+    assert units_mod._running_from_dev_tree() is not None  # real pkg is outside tmp venv
+
+    # Package inside the prefix and no adjacent checkout: not a dev tree.
+    pkg_dir = tmp_path / "venv" / "lib" / "mship"
+    pkg_dir.mkdir(parents=True)
+    fake_file = pkg_dir / "__init__.py"
+    fake_file.touch()
+    monkeypatch.setattr(mship_pkg, "__file__", str(fake_file))
+    assert units_mod._running_from_dev_tree() is None
+
+    # Adjacent pyproject declaring mothership: venv-in-checkout, refuse.
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "mothership"\n')
+    assert units_mod._running_from_dev_tree() is not None
+
+
+def test_execstart_resolves_sibling_first(tmp_path, monkeypatch, not_dev_tree):
     """Same venv bin dir ⇒ provably same dist (the uv-tool-install layout);
     sibling wins even when PATH has a different mshipd."""
     bin_dir = tmp_path / "venv" / "bin"
@@ -79,7 +117,7 @@ def test_execstart_resolves_sibling_first(tmp_path, monkeypatch):
     assert argv == [str(sibling)]
 
 
-def test_which_fallback_verified_against_sys_prefix(tmp_path, monkeypatch):
+def test_which_fallback_verified_against_sys_prefix(tmp_path, monkeypatch, not_dev_tree):
     prefix = tmp_path / "venv"
     bin_dir = prefix / "bin"
     bin_dir.mkdir(parents=True)
@@ -103,7 +141,7 @@ def test_which_fallback_verified_against_sys_prefix(tmp_path, monkeypatch):
         resolve_mshipd_argv(which=lambda name: str(outside))
 
 
-def test_module_fallback_when_nothing_resolvable(tmp_path, monkeypatch):
+def test_module_fallback_when_nothing_resolvable(tmp_path, monkeypatch, not_dev_tree):
     prefix = tmp_path / "venv"
     bin_dir = prefix / "bin"
     bin_dir.mkdir(parents=True)

--- a/tests/core/daemon/test_units.py
+++ b/tests/core/daemon/test_units.py
@@ -160,3 +160,28 @@ def test_launchd_plist_escapes_xml_special_chars(tmp_path: Path):
     plist = plistlib.loads(render_launchd_plist(argv, log_dir).encode())
     assert plist["ProgramArguments"] == argv
     assert plist["StandardOutPath"] == str(log_dir / "launchd.out.log")
+
+
+def test_dev_tree_detector_parses_toml_not_substrings(tmp_path, monkeypatch):
+    """`name='mothership'` (single quotes / spacing variants) is still a
+    checkout: a substring match would miss it and bake the checkout's mshipd
+    into the unit, so upgrades would deploy nothing."""
+    import mship as mship_pkg
+
+    prefix = tmp_path / "checkout" / ".venv"
+    (prefix / "lib" / "mship").mkdir(parents=True)
+    fake = prefix / "lib" / "mship" / "__init__.py"
+    fake.touch()
+    monkeypatch.setattr(sys, "prefix", str(prefix))
+    monkeypatch.setattr(mship_pkg, "__file__", str(fake))
+
+    for spelling in ("name = \"mothership\"", "name='mothership'", "name   =    'mothership'"):
+        (tmp_path / "checkout" / "pyproject.toml").write_text(f"[project]\n{spelling}\nversion = '1'\n")
+        assert units_mod._running_from_dev_tree() is not None, spelling
+
+    # a DIFFERENT project's checkout is not ours → not a dev-tree refusal
+    (tmp_path / "checkout" / "pyproject.toml").write_text("[project]\nname = 'something-else'\n")
+    assert units_mod._running_from_dev_tree() is None
+    # malformed TOML must not raise
+    (tmp_path / "checkout" / "pyproject.toml").write_text("[project\nname=")
+    assert units_mod._running_from_dev_tree() is None

--- a/uv.lock
+++ b/uv.lock
@@ -559,7 +559,7 @@ wheels = [
 
 [[package]]
 name = "mothership"
-version = "0.5.52"
+version = "0.5.53"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

- Reject daemon executables resolved from a Mothership development checkout, including valid TOML formatting variants.
- Capture and bound launchd startup diagnostics while preserving the newest crash evidence and cross-log chronology.
- Keep daemon status/log commands usable for UIDs without passwd entries.
- Enable and verify systemd linger before mutating or enabling the user unit.

## Test plan

- `mship test` — mothership task suite passed (iteration 10).
- Focused daemon supervisor and startup-capture regressions passed.

Closes #474
