### PR TITLE
Tunnel registration: host reachable from the phone without an address (#471)

### DIFF
--- a/docker/relay/Caddyfile
+++ b/docker/relay/Caddyfile
@@ -18,6 +18,11 @@ enroll.{$RELAY_DOMAIN} {
 		method GET
 		path /status/*
 	}
+	# Host registration + directory (#471). Without this the 404 catch-all below
+	# swallows every /hosts route in production while unit tests stay green.
+	@hosts {
+		path /hosts /hosts/*
+	}
 	handle @enroll {
 		request_body {
 			max_size 4KB
@@ -25,6 +30,12 @@ enroll.{$RELAY_DOMAIN} {
 		reverse_proxy 127.0.0.1:47180
 	}
 	handle @status {
+		reverse_proxy 127.0.0.1:47180
+	}
+	handle @hosts {
+		request_body {
+			max_size 8KB
+		}
 		reverse_proxy 127.0.0.1:47180
 	}
 	handle {

--- a/docs/checklists/host-tunnel-manual.md
+++ b/docs/checklists/host-tunnel-manual.md
@@ -37,7 +37,7 @@ Run this pass on a real host + the live relay before calling #471 done.
    that URL answers `/health` from off-box.
 
 2. **Re-registration after a tunnel flap (AC2 in reality).**
-   `pkill -f 'ssh -R <subdomain>'` → the supervisor respawns the child and the
+   `pkill -f ' -R <subdomain>:80:localhost:'` → the supervisor respawns the child and the
    daemon re-registers *once* (not once per tick): `last_seen` in
    `mship relay hosts` advances within seconds of the respawn, `restarts`
    increments in `mship --json daemon status`, and the public URL serves again.
@@ -45,7 +45,7 @@ Run this pass on a real host + the live relay before calling #471 done.
 3. **No orphan holds the subdomain.** `kill -9 <mshipd pid>` → on the next start
    the daemon reaps the reparented `ssh -R` (it survives the kill;
    `start_new_session=True`) and reaches `online` again on the same subdomain.
-   Confirm with `pgrep -af 'ssh -R'` that exactly one ssh child exists
+   Confirm with `pgrep -af ' -R <subdomain>:80:localhost:'` that exactly one ssh child exists
    afterwards.
 
 4. **Clean shutdown (AC7 shutdown).** `systemctl --user stop mship-daemon` →

--- a/docs/checklists/host-tunnel-manual.md
+++ b/docs/checklists/host-tunnel-manual.md
@@ -19,8 +19,9 @@ Run this pass on a real host + the live relay before calling #471 done.
   would generate a *different* sish host key, so bringing the stack up from a
   worktree breaks every existing tunnel. Always `docker compose -f
   <main checkout>/docker/relay/docker-compose.yml …`.
-- **There is no passwordless sudo here.** Where a step below wants a wedged
-  peer, simulate it with `kill -STOP <pid of the ssh -R>` (and `kill -CONT` to
+- **There is no passwordLESS sudo here** (interactive `sudo` at a terminal is
+  fine — item 8 uses it; what is missing is unattended/scripted sudo). Where a
+  step below wants a wedged peer, simulate it with `kill -STOP <pid of the ssh -R>` (and `kill -CONT` to
   release) rather than iptables/nft rules.
 - Useful throughout: `mship daemon status` (and `mship --json daemon status`) on
   the host, `mship relay hosts --store-dir <relay-dir>/pending-store` on the
@@ -80,12 +81,23 @@ Run this pass on a real host + the live relay before calling #471 done.
    not log in → the daemon is running and its tunnel is `online` again, verified
    from another machine.
 
-8. **Wall-clock step (AC10).** `sudo timedatectl set-time '+1 hour'` (or step
-   the VM's clock) while a phone is paired → already-issued host bearers keep
-   working until their real elapsed TTL, the phone does not have to re-pair, and
-   `mship --json daemon status` reports a non-zero `clock_skew_seconds`
-   (sampled from the enroll server's `Date`, so it is measured against the
-   relay, not against itself). Put the clock back afterwards.
+8. **Wall-clock step (AC10).** `sudo timedatectl set-time '+1 hour'` (interactive
+   sudo is fine here — it is passwordLESS sudo this box does not have), or step
+   the VM's clock, while a phone is paired.
+
+   A *forwards* step past `expires_at + 120s` **rejects** the bearers minted
+   before it — that is the intended behaviour, not a failure: the wall bound and
+   the monotonic bound are ANDed as "earliest wins", and the monotonic floor
+   exists to stop a *backwards* step silently extending a live token, not to
+   keep a stale one alive. What must not happen is the phone falling out of
+   pairing over it.
+
+   **PASS =** the phone keeps working with no re-pairing — it silently re-mints
+   a bearer via `POST /host/token` from its 30-day refresh credential, which a
+   one-hour step cannot expire — **and** `mship --json daemon status` reports a
+   non-zero `clock_skew_seconds` (sampled from the enroll server's `Date`, so it
+   is measured against the relay, not against itself). Put the clock back
+   afterwards.
 
 9. **Worker survives a tunnel outage (AC7).** Start a long-running task on the
    host, then take the tunnel away for ~10 minutes — `kill -STOP` the `ssh -R`

--- a/docs/checklists/host-tunnel-manual.md
+++ b/docs/checklists/host-tunnel-manual.md
@@ -32,7 +32,7 @@ Run this pass on a real host + the live relay before calling #471 done.
 
 1. **Real tunnel over the live relay.** `mship daemon install --serve
    127.0.0.1:47190 --relay mship-relay.atomikpanda.com && mship daemon start`,
-   then one `mship relay approve <id>` on the relay box → `mship daemon status`
+   then one `mship relay approve <id> --store-dir <relay-dir>/pending-store --pubkeys-dir <relay-dir>/pubkeys` on the relay box → `mship daemon status`
    reaches `tunnel: online https://<subdomain>.mship-relay.atomikpanda.com`, and
    that URL answers `/health` from off-box.
 

--- a/docs/checklists/host-tunnel-manual.md
+++ b/docs/checklists/host-tunnel-manual.md
@@ -1,0 +1,110 @@
+# Manual checklist — host tunnel registration (#471)
+
+The unit suite for #471 opens no sockets and takes no real sleeps: every
+collaborator (`post`/`get`/`clock`/`rng`/`reaper`/`verify`/proc factory) is
+injected, which is what makes the loops testable at all. That discipline is also
+the honest boundary of what CI can prove here — everything below needs a real
+`ssh -R`, a real relay, a second VM, a real clock or a real phone, and therefore
+needs a human.
+
+Run this pass on a real host + the live relay before calling #471 done.
+
+## This environment
+
+- **The workspace box IS the relay**: `mship-relay.atomikpanda.com`. There is no
+  separate VPS to SSH into — "on the relay box" means here.
+- **The compose project lives in the MAIN checkout**
+  (`mship-workspace/mothership/docker/relay/`), never a worktree. A worktree's
+  copy of `docker/relay/` has an empty `pubkeys/` (nothing is approved) and
+  would generate a *different* sish host key, so bringing the stack up from a
+  worktree breaks every existing tunnel. Always `docker compose -f
+  <main checkout>/docker/relay/docker-compose.yml …`.
+- **There is no passwordless sudo here.** Where a step below wants a wedged
+  peer, simulate it with `kill -STOP <pid of the ssh -R>` (and `kill -CONT` to
+  release) rather than iptables/nft rules.
+- Useful throughout: `mship daemon status` (and `mship --json daemon status`) on
+  the host, `mship relay hosts --store-dir <relay-dir>/pending-store` on the
+  relay, `~/.mothership/daemon/logs/relay-tunnel.log` for the ssh child's own
+  output.
+
+## Checklist
+
+1. **Real tunnel over the live relay.** `mship daemon install --serve
+   127.0.0.1:47190 --relay mship-relay.atomikpanda.com && mship daemon start`,
+   then one `mship relay approve <id>` on the relay box → `mship daemon status`
+   reaches `tunnel: online https://<subdomain>.mship-relay.atomikpanda.com`, and
+   that URL answers `/health` from off-box.
+
+2. **Re-registration after a tunnel flap (AC2 in reality).**
+   `pkill -f 'ssh -R <subdomain>'` → the supervisor respawns the child and the
+   daemon re-registers *once* (not once per tick): `last_seen` in
+   `mship relay hosts` advances within seconds of the respawn, `restarts`
+   increments in `mship --json daemon status`, and the public URL serves again.
+
+3. **No orphan holds the subdomain.** `kill -9 <mshipd pid>` → on the next start
+   the daemon reaps the reparented `ssh -R` (it survives the kill;
+   `start_new_session=True`) and reaches `online` again on the same subdomain.
+   Confirm with `pgrep -af 'ssh -R'` that exactly one ssh child exists
+   afterwards.
+
+4. **Clean shutdown (AC7 shutdown).** `systemctl --user stop mship-daemon` →
+   the daemon exits within systemd's stop timeout with **no** `SIGKILL` in
+   `journalctl --user -u mship-daemon` ("state 'stop-sigterm' timed out" must
+   not appear), the ssh child is gone, and `start-history.json` gains a
+   `clean_stop` entry (`mship daemon status` then reports no unclean start).
+
+5. **Relay redeploy, no host action (AC3/AC13).** On the relay box,
+   `docker compose … up -d --force-recreate sish` → every host's tunnel drops
+   and every host is back `online` unattended (allow ~90s keepalive detection
+   plus a jittered ≤60s backoff); no command is run on any host. Then
+   `docker compose … up -d --force-recreate caddy` → `GET /hosts` on
+   `https://enroll.mship-relay.atomikpanda.com` is reachable again (with the
+   `Mship-Fleet-Token` header) — this is the check that would catch a lost
+   `@hosts` matcher.
+
+6. **Realistic VM clone (AC4).** `cp -a` a running host's disk and boot the copy
+   **beside** its source **without truncating `/etc/machine-id`**. (Cloning from
+   a prepared image that regenerates the machine id exercises the easy path —
+   the local fingerprint check — and would pass while the real case fails.)
+   Expect: the source stays `online` and keeps the subdomain; the clone reports
+   `tunnel: rejected (duplicate-identity)`, and after 3 consecutive refusals
+   re-identifies itself automatically (new `host_id`, rotated relay key) and
+   re-posts `/enroll`, so it shows up in `mship relay hosts` as a
+   **`pending-approval` row under a new key fingerprint** — with nobody logging
+   into it. (Pending rows come from the enroll store, so their `host_id` is
+   null until the first successful registration.) Approving that new key brings
+   the clone up as its own host on its own subdomain, and the clone's daemon log
+   carries the "re-identified as hst-…" warning.
+
+7. **Reboot + linger survival.** `loginctl enable-linger`, reboot the host, do
+   not log in → the daemon is running and its tunnel is `online` again, verified
+   from another machine.
+
+8. **Wall-clock step (AC10).** `sudo timedatectl set-time '+1 hour'` (or step
+   the VM's clock) while a phone is paired → already-issued host bearers keep
+   working until their real elapsed TTL, the phone does not have to re-pair, and
+   `mship --json daemon status` reports a non-zero `clock_skew_seconds`
+   (sampled from the enroll server's `Date`, so it is measured against the
+   relay, not against itself). Put the clock back afterwards.
+
+9. **Worker survives a tunnel outage (AC7).** Start a long-running task on the
+   host, then take the tunnel away for ~10 minutes — `kill -STOP` the `ssh -R`
+   pid (no sudo needed; do **not** reach for iptables here) or stop sish on the
+   relay. After `kill -CONT` / restarting sish: the task is still running, the
+   daemon reconnects on its own, and its state is visible again from the phone.
+   Nothing about the outage may kill work in progress.
+
+10. **Phone end-to-end from one QR (AC1).** On the relay box,
+    `mship relay fleet-token --label phone --relay-domain
+    mship-relay.atomikpanda.com --store-dir <relay-dir>/pending-store`; scan the
+    printed QR once in Ground Control. **No address is typed anywhere.** A
+    freshly provisioned host appears by itself once approved.
+
+11. **Two hosts at once (AC5).** With a second host registered, both are visible
+    simultaneously in the app from that same single pairing, each addressable
+    on its own subdomain.
+
+12. **Relay down, host up (AC9).** Stop the relay stack (or block it) while a
+    workspace is still reachable on the LAN/tailnet → the phone still opens that
+    workspace over its direct address. The relay is a convenience path, not a
+    dependency for a host you can already reach.

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -179,14 +179,17 @@ mship relay approve <id>
 `--relay` needs a local bind to forward, from this install or an earlier one
 (`--serve HOST:PORT`); like `--serve`, a **changed** relay takes effect on
 `mship daemon restart`. Nothing else is manual: while its key is unapproved the
-daemon posts `/enroll` non-blockingly and re-posts every 600s against the
-relay's 1800s pending TTL, so a VM provisioned at 02:00 is still approvable at
-09:00 with nobody at its terminal. Registration itself is challenge/response —
-fetch a nonce (120s TTL), sign `namespace ‖ nonce ‖ canonical payload` with the
-same ed25519 relay key the tunnel authenticates with (`ssh-keygen -Y sign`,
-namespace `host-registration@mship`), POST it — repeated every 60s, and after a
-failure on a 2s backoff doubling to a 60s cap, jittered **downward** so a fleet
-coming back after a relay redeploy does not retry in lockstep.
+relay refuses challenge allocation, so the daemon posts `/enroll`
+non-blockingly and re-posts every 600s against the relay's 1800s pending TTL.
+A VM provisioned at 02:00 is therefore still approvable at 09:00 with nobody at
+its terminal. Once approved, registration is challenge/response: the daemon
+POSTs its key fingerprint and receives the one live nonce allocated to that
+approved identity (120s TTL), signs
+`namespace ‖ nonce ‖ canonical payload` with the same ed25519 relay key the
+tunnel authenticates with (`ssh-keygen -Y sign`, namespace
+`host-registration@mship`), then POSTs the registration. It repeats every 60s;
+after a failure it backs off from 2s to a 60s cap, jittered **downward** so a
+fleet returning after a relay redeploy does not retry in lockstep.
 
 `mship relay hosts` on the relay box lists the directory; a host that has not
 re-registered within 240s (three intervals plus a worst-case backoff) reads as

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -4,9 +4,10 @@ One supervised daemon process per OS user per host, shipped from the same
 package as the CLI. The daemon makes a host reachable/operable without a
 terminal (#469); v1 (#470) provides provisioning, supervision, singleton-ness,
 logs, and status, while the workspace registry (#472) discovers and serves
-every healthy workspace under configured scan roots. It opens no tunnel (#471)
-and supervises no workers (#473) yet; those remain sibling capabilities behind
-the seams reported by `mship daemon status`.
+every healthy workspace under configured scan roots and the host tunnel (#471)
+registers this machine with a relay and keeps an `ssh -R` up to it. It
+supervises no workers (#473) yet; that remains a sibling capability behind the
+seam reported by `mship daemon status`.
 
 ## Lifecycle
 
@@ -36,6 +37,11 @@ commands never require the daemon.
   `launchctl print user/<uid>/com.mothership.daemon` / the unified log
   (`log show`) on macOS.
 - Start history: `~/.mothership/daemon/start-history.json` (crash-loop visibility)
+- Host identity: `~/.mothership/daemon/host-identity.json` (#471 — see
+  [Tunnel registration](#tunnel-registration-471)), beside the credential stores
+  `host-root-secret`, `host-tokens.json` and `host-refresh.json` (all 0600 in a
+  0700 dir) and the tunnel's captured `ssh -R` output,
+  `~/.mothership/daemon/logs/relay-tunnel.log`.
 - Control socket: `$XDG_RUNTIME_DIR/mship/daemon.sock`, else
   `~/.mothership/daemon/run/daemon.sock`. Status probes prefer the socket path
   recorded in the lease (the daemon's env and your shell can disagree about
@@ -83,6 +89,150 @@ per merge).
 - Reboot-survival on a headless Mac requires a login session (enable
   auto-login); a system-domain LaunchDaemon is out of scope for v1.
 
+## Tunnel registration (#471)
+
+With a relay configured, the daemon does two things beside the servers on the
+same asyncio loop: it keeps an `ssh -R` tunnel to the relay up, and it keeps
+this host's entry in the relay's host directory current. Together they are what
+makes a freshly provisioned VM reachable from the phone with **no address typed
+anywhere** — the phone scans one relay QR and reads the directory.
+
+### Identity
+
+Three distinct things, in `core/daemon/identity.py`:
+
+- **`host_id`** — minted once (`hst-<ts>-<uuid8>`), persisted to
+  `~/.mothership/daemon/host-identity.json`, and the name the relay's directory
+  keys on. Deliberately *not* derived from the relay key: that key is a file,
+  and a cloned VM reproduces it byte-for-byte.
+- **machine fingerprint** — best-effort binding to the machine, read from the
+  first readable of `/etc/machine-id`, `/var/lib/dbus/machine-id`,
+  `/sys/class/dmi/id/product_uuid`, and recorded beside the `host_id`. It
+  catches a *re-imaged* host. It does **not** catch a `cp -a`/snapshot clone,
+  which copies it verbatim. An unreadable fingerprint (containers) reads as
+  unknown, never as a mismatch — no false clone alarms.
+- **`instance_id`** — minted per **process**, in memory, never written to disk.
+  It is the one thing a clone cannot copy, so it is what lets the relay (and the
+  tunnel's own read-back of its public `/health`) tell a restart from a second
+  live claimant.
+
+The relay subdomain is derived from the `host_id`, the relay key's device id and
+the local subdomain secret — the same `<opaque-slug>-<6hex>` shape a serve
+subdomain already has, so it needs no TLS/Caddy cert change.
+
+**Re-identification** mints a new `host_id`, records the old one as
+`cloned_from`, and **rotates the relay key**: the current key pair is moved
+aside to `<name>.pre-reidentify-<UTC timestamp>` and a new one generated. The
+rotation is the point — the clone still holds a copy of the old private key and
+that key is still in the relay's `pubkeys/`, so keeping it would let the twin go
+on authenticating as this host. The new key is unapproved by construction, so
+the host lands back in the enrollment queue and needs one more
+`mship relay approve <id>` on the relay box.
+
+### Tokens
+
+The phone's credential chain has two tiers, both self-issued by the host and
+verified by that same host — nothing is proxied and no shared secret is
+distributed:
+
+- a **refresh credential** per `(host_id, client)`, *derived* (HMAC over the
+  host root secret and a per-record nonce) rather than stored, so a
+  reconnect/re-registration re-publishes the identical string and writes
+  nothing at all. TTL 30 days; only `revoke` and a first mint touch the file.
+  It is the field the directory entry carries.
+- a **short-lived bearer**, `<token_id>.<secret>`, minted by
+  `POST /host/token` in exchange for that refresh credential and good for
+  `HOST_TOKEN_TTL_S` (300s). Only its sha256 is stored; verification is a pure
+  read, so a reconnecting phone never churns the store.
+
+Expiry is owned in one place (`core/relay/token_clock.py`) and is the **earlier**
+of two bounds: an epoch-tagged monotonic deadline and the wall deadline plus a
+120s skew grace. The monotonic floor is what makes an NTP step (or
+`timedatectl set-time`) unable to silently extend a live bearer; the epoch tag
+(the kernel boot id, or a per-process id where there is none) is what keeps a
+floor taken in a previous boot from being compared against this boot's
+`time.monotonic()`. Because the monotonic bound fires first for any ordinary
+token, the skew grace only ever applies where the anchor cannot vouch for
+elapsed time — a check after a restart, or a caller with no anchor.
+
+Clock skew is *reported*, never gating: the link samples the enroll server's
+`Date` header on every call and publishes `clock_skew_seconds`, which
+`mship daemon status` prints once it exceeds a second.
+
+### Provisioning
+
+```bash
+mship daemon install --serve 127.0.0.1:47190 --relay relay.example.com
+mship daemon start
+# then, once, on the relay box:
+mship relay approve <id>
+```
+
+`--relay` needs a local bind to forward, from this install or an earlier one
+(`--serve HOST:PORT`); like `--serve`, a **changed** relay takes effect on
+`mship daemon restart`. Nothing else is manual: while its key is unapproved the
+daemon posts `/enroll` non-blockingly and re-posts every 600s against the
+relay's 1800s pending TTL, so a VM provisioned at 02:00 is still approvable at
+09:00 with nobody at its terminal. Registration itself is challenge/response —
+fetch a nonce (120s TTL), sign `namespace ‖ nonce ‖ canonical payload` with the
+same ed25519 relay key the tunnel authenticates with (`ssh-keygen -Y sign`,
+namespace `host-registration@mship`), POST it — repeated every 60s, and after a
+failure on a 2s backoff doubling to a 60s cap, jittered **downward** so a fleet
+coming back after a relay redeploy does not retry in lockstep.
+
+`mship relay hosts` on the relay box lists the directory; a host that has not
+re-registered within 240s (three intervals plus a worst-case backoff) reads as
+`offline` there rather than disappearing.
+
+### Tunnel state
+
+There is no tunnel state file. The tunnel lives inside the daemon process, so
+its published snapshot on `/health` is the only honest source — with no daemon
+answering, `status` says so rather than guessing:
+
+| state | what `mship daemon status` prints |
+|---|---|
+| `disabled` | `tunnel: disabled (no relay configured)` |
+| `awaiting-enrollment` | `tunnel: awaiting relay approval (run 'mship relay approve <id>' on the relay host)` |
+| `connecting` | `tunnel: connecting <public_url>` |
+| `online` | `tunnel: online <public_url> (<n> restarts)` |
+| `contended` | `tunnel: contended — another host holds <subdomain>` |
+| `duplicate-identity` | `tunnel: rejected (duplicate-identity) — re-identifying automatically; 'mship daemon reidentify' to force` |
+| `error` | `tunnel: error — <last_error>` |
+
+(with no daemon running: `tunnel: unknown (daemon not running)`.)
+
+`mship --json daemon status` carries the `/health` tunnel block verbatim under
+`tunnel` — `state`, `subdomain`, `public_url`, `restarts`, `last_error`,
+`clock_skew_seconds` — plus `clock_skew_seconds` at the top level, so a reader
+never has to re-parse the prose.
+
+`contended` outranks `error` deliberately: a live twin answering on our
+subdomain is a specific, actionable fact, and the two co-occur constantly.
+
+### Clone recovery
+
+A `cp -a` clone booted beside its source publishes the same `host_id` on the
+same subdomain, and the relay arbitrates by probing the incumbent's published
+URL: the claim is refused only when the incumbent is still live and still
+answers with its own `instance_id`. A stale entry is nobody's and is taken over
+without a probe; an identical `(key fp, machine fp, instance_id)` re-post is the
+same daemon reconnecting, not contention. The refused claimant gets
+`409 duplicate-identity` and stops dialing — fighting a live twin for the
+subdomain helps nobody.
+
+- **Automatic.** After 3 consecutive 409s the link re-identifies itself — new
+  `host_id`, rotated key — and drops back to `awaiting-enrollment`, re-posting
+  `/enroll` at once. The clone therefore reappears in `GET /hosts` as
+  `pending-approval` with no SSH session: the machine that needs this recovery
+  is by definition one nobody can log into. It still needs approving.
+- **Manual.** `mship daemon reidentify` forces the same move and prints the new
+  host id and subdomain. `mship daemon reidentify --keep-identity` is the
+  opposite claim — "this *is* the same host" — and adopts the running machine's
+  fingerprint after a re-image or hardware change tripped the check, keeping the
+  `host_id` and the key. After a forced re-identify, approve the new key and
+  `mship daemon restart` to dial with it.
+
 ## Manual/VM verification checklist
 
 The suite fakes the supervisor boundary; these OS-contract behaviors need a
@@ -106,6 +256,10 @@ real VM pass:
    is already active in a shell → exactly one daemon survives; the loser logs
    the holder pid and exits 0.
 
+The tunnel half needs real sockets, a real relay and a second VM, which the
+suite has none of: those items live in
+[`checklists/host-tunnel-manual.md`](checklists/host-tunnel-manual.md).
+
 ## Workspaces (#472)
 
 The daemon discovers workspaces instead of being told about them: at startup
@@ -125,8 +279,9 @@ mship daemon install --scan-root ~/src --scan-root ~/work --serve 127.0.0.1:4719
   last registry state unchanged. A symlink supplied as a root is never traversed.
 - Derived registry state is `~/.mothership/daemon/workspaces.json`.
 - Without `--serve` the daemon is control-socket only: local `mship daemon ...`
-  works, but the phone cannot reach it. Address-less reachability is #471; until
-  then bind a tailnet/LAN address here.
+  works, but the phone cannot reach it — and `--relay` refuses without a bind to
+  forward. Bind a tailnet/LAN address here for direct reachability; the
+  address-less path is [Tunnel registration](#tunnel-registration-471).
 
 ### Addressing
 

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -173,7 +173,9 @@ Clock skew is *reported*, never gating: the link samples the enroll server's
 mship daemon install --serve 127.0.0.1:47190 --relay relay.example.com
 mship daemon start
 # then, once, on the relay box:
-mship relay approve <id>
+mship relay approve <id> \
+  --store-dir /path/to/docker/relay/pending-store \
+  --pubkeys-dir /path/to/docker/relay/pubkeys
 ```
 
 `--relay` needs a local bind to forward, from this install or an earlier one

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -132,14 +132,16 @@ the host lands back in the enrollment queue and needs one more
 ### Tokens
 
 The phone's credential chain has two tiers, both self-issued by the host and
-verified by that same host — nothing is proxied and no shared secret is
-distributed:
+verified by that same host — the exchange is never proxied, and no operator ever
+copies a secret between machines:
 
 - a **refresh credential** per `(host_id, client)`, *derived* (HMAC over the
   host root secret and a per-record nonce) rather than stored, so a
-  reconnect/re-registration re-publishes the identical string and writes
-  nothing at all. TTL 30 days; only `revoke` and a first mint touch the file.
-  It is the field the directory entry carries.
+  reconnect/re-registration re-publishes the identical string and, in steady
+  state, writes nothing at all (a re-issue that finds expired sibling records
+  does pay them off). TTL 30 days. It is the field the host's directory entry
+  carries — so whoever can read the directory can read it: see
+  [Fleet-token exposure](relay-hosting.md#fleet-token-exposure).
 - a **short-lived bearer**, `<token_id>.<secret>`, minted by
   `POST /host/token` in exchange for that refresh credential and good for
   `HOST_TOKEN_TTL_S` (300s). Only its sha256 is stored; verification is a pure
@@ -154,6 +156,12 @@ floor taken in a previous boot from being compared against this boot's
 `time.monotonic()`. Because the monotonic bound fires first for any ordinary
 token, the skew grace only ever applies where the anchor cannot vouch for
 elapsed time — a check after a restart, or a caller with no anchor.
+
+Earliest-wins cuts both ways, deliberately: a *forwards* step past
+`expires_at + 120s` retires the bearers minted before it. That is cheap and
+invisible — the phone re-mints from its refresh credential, which the same step
+cannot expire — whereas the reverse mistake (a backwards step silently
+extending live bearers) is a security hole.
 
 Clock skew is *reported*, never gating: the link samples the enroll server's
 `Date` header on every call and publishes `clock_skew_seconds`, which

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -143,7 +143,7 @@ The enroll-server is not part of the Docker compose stack — it runs as a long-
 ```bash
 mship relay enroll-server \
   --relay-domain relay.example.com \
-  --store-dir /path/to/docker/relay/enroll-store \
+  --store-dir /path/to/docker/relay/pending-store \
   --pubkeys-dir /path/to/docker/relay/pubkeys
 # Binds 127.0.0.1:47180 by default; Caddy proxies public traffic to it.
 # pending requests expire after 30 min.
@@ -232,7 +232,7 @@ mship relay enroll --enroll-url https://enroll.relay.example.com
 ```bash
 mship relay requests                 # id · hostname · key fingerprint
 mship relay approve a1c2 \
-  --store-dir docker/relay/enroll-store \
+  --store-dir docker/relay/pending-store \
   --pubkeys-dir docker/relay/pubkeys
 # writes the key into pubkeys/ → sish picks it up (no restart needed).
 # `mship relay deny <id>` discards it.

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -264,6 +264,94 @@ After the stack is running, verify each layer:
 
 ---
 
+## Host directory + fleet token (#471)
+
+A relay that already serves device enrollment gains two things with #471: a
+**host directory** (`GET /hosts` on the enroll server, where each daemon
+publishes its identity, subdomain and refresh credential) and a **fleet token**
+— the per-device credential a phone carries to read that directory. Together
+they are why a freshly provisioned VM needs no address typed on the phone.
+
+### The exact relay-box delta
+
+Four commands, all on the relay host:
+
+```bash
+# 1. Ship the new enroll-server code, then restart the (supervised) process.
+uv tool install --force --no-cache /path/to/mothership
+systemctl restart mship-relay-enroll.service
+
+# 2. Pick up the ONE new Caddyfile matcher (@hosts).
+cd /path/to/mothership
+docker compose -f docker/relay/docker-compose.yml up -d --force-recreate caddy
+
+# 3. Once per phone: mint its fleet token and show the pairing QR.
+mship relay fleet-token --label phone \
+  --relay-domain relay.example.com \
+  --store-dir /path/to/docker/relay/pending-store
+
+# 4. Per new VM, exactly as before — one approval, then it is done.
+mship relay approve <id> \
+  --store-dir /path/to/docker/relay/pending-store \
+  --pubkeys-dir /path/to/docker/relay/pubkeys
+```
+
+Notes on each:
+
+- **Step 1** is not optional: `/hosts`, `/hosts/challenge` and `/hosts/register`
+  are served by the enroll-server process, and merging does not deploy — the
+  live process keeps running the version it imported.
+- **Step 2** is the only edge change. `docker/relay/Caddyfile` gains one
+  matcher, `@hosts { path /hosts /hosts/* }`, plus its `handle` block
+  (`request_body max_size 8KB` → `127.0.0.1:47180`). Without it the site's
+  `respond "not found" 404` catch-all swallows every `/hosts` route in
+  production while every unit test stays green. A `caddy reload` inside the
+  running container works too; the force-recreate above is the version that
+  needs no exec.
+- **Step 3** prints the token, a `groundcontrol://add-relay?relay=…&token=…`
+  deep link and its QR. Re-running it for the same `--label` reprints the **same
+  token** — showing the QR again never unpairs the device that already scanned
+  it. `--store-dir` must be the directory the enroll-server runs with, or the
+  token is minted into a store nothing verifies against.
+- **Step 4** is unchanged because the signature allowlist *is* the sish
+  `pubkeys/` allowlist, re-read per verification: approving a host's key both
+  admits its tunnel and makes its signed registrations verify, with no restart.
+  `mship relay hosts --store-dir …` lists what the directory holds.
+
+### What does **not** change
+
+- `docker/relay/docker-compose.yml` — no new service, no new mount, no new port.
+- sish's flags — unchanged (including `--idle-connection*`, see above).
+- DNS — the existing wildcard `*.relay.example.com` record already covers both
+  `enroll.<relay>` and every per-host subdomain.
+- Firewall/ports — still 2222/80/443; `:47180` stays loopback-only.
+- `tls_ask.py` — a host subdomain is the same `<opaque-slug>-<6hex>` label shape
+  a serve subdomain already has, so the on-demand-TLS allowlist needs no edit.
+
+The `Caddyfile` is deliberately **not** on that list: it is the one file that
+changes, which is exactly why step 2 exists.
+
+### Fleet-token exposure
+
+A fleet token is a **fleet-wide read credential**. `GET /hosts` returns every
+host's directory entry *including its `refresh` credential* — which is the
+credential that trades for short-lived bearers on that host. So one leaked
+fleet token is read access to the whole fleet, not to one host. Treat it like a
+password:
+
+- one `--label` per physical device, so a lost phone can be cut off by itself;
+- `mship relay fleet-token --label phone --revoke` invalidates that label
+  (`--revoke` is a boolean flag used *with* `--label`, not a value). A later
+  re-mint under the same label derives a **different** token rather than
+  resurrecting the revoked one.
+
+Revocation stops future directory reads, and that is all it does: it does not
+rotate the per-host refresh credentials a paired phone already fetched. Those
+live on the hosts, expire on their own 30-day TTL, and are re-derived from a
+per-record nonce — so to invalidate them *now*, delete
+`~/.mothership/daemon/host-refresh.json` on the host; the daemon's next
+registration (within a minute) publishes freshly derived ones.
+
 ## Configuration Reference
 
 The relay is configured entirely through environment variables passed to `docker compose`. The bootstrap script sets them; you can also export them in a `.env` file alongside `docker-compose.yml`:
@@ -309,5 +397,30 @@ Data directories (`keys/`, `pubkeys/`, `caddy-data/`, `caddy-config/`) are mount
 **sish container exits immediately** — run `docker compose -f docker/relay/docker-compose.yml logs sish` to inspect startup errors. Common causes: port already in use, or missing `RELAY_DOMAIN` environment variable.
 
 **Caddy container exits immediately** — check `docker compose logs caddy`. A malformed `Caddyfile` or a missing `RELAY_DOMAIN`/`ACME_EMAIL` variable is the usual cause.
+
+**Every host went offline right after a relay redeploy** — expected, and it
+fixes itself. `docker compose … up -d --force-recreate sish` drops every open
+tunnel, because sish *is* the SSH endpoint. No host action is needed: each
+daemon's `ssh -R` notices the dead peer through its keepalives
+(`ServerAliveInterval=30` × `ServerAliveCountMax=3`, so roughly 90s worst case),
+respawns, and re-registers. The reconnect backoff is capped at 60s and jittered
+**downward only** — deliberately, so a whole fleet coming back does not
+stampede the relay in lockstep, and so a jittered delay can never exceed the cap
+the directory's staleness window is derived from. Recreating **caddy** does not
+drop tunnels at all (sish owns them); it only interrupts HTTPS for the moment
+the container restarts.
+
+**Phone says the fleet token is invalid** — the token is verified against
+`fleet-tokens.json` in the enroll-server's `--store-dir`. Minting it with a
+different `--store-dir` than the running server uses is the usual cause; a
+revoked label is the other (`mship relay fleet-token --label <device>` re-mints
+a *new* token after a revoke — the device must scan the fresh QR).
+
+**A host never appears in `mship relay hosts`** — check its own view first:
+`mship daemon status` on that host prints a `tunnel:` line naming the state
+(`awaiting-enrollment` means it is waiting for `mship relay approve`;
+`duplicate-identity` means a twin holds the entry). If the host reports
+`online` but `/hosts` 404s from outside, the `@hosts` Caddy matcher is missing —
+see [Host directory + fleet token](#host-directory-fleet-token-471).
 
 **Enroll request times out** — confirm the enroll-server process is running on the relay host (`curl http://127.0.0.1:47180/status/x` from the host should return a JSON status). Also check that Caddy is running and that `enroll.<relay>` resolves to the relay IP.

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -26,6 +26,7 @@ internet
 | A domain you control | Example: `relay.example.com`. You only need a subdomain — the relay does not take over the root domain. |
 | SSH access to the VPS as root (or a sudo user) | To run the bootstrap script and open ports. |
 | OpenSSH client tools on the VPS | `ssh-keygen` verifies signed host registrations. On Debian/Ubuntu: `apt install openssh-client`. |
+| [uv](https://docs.astral.sh/uv/getting-started/installation/) | Installs and upgrades `mship` on the relay host; it automatically provisions the Python version required by `pyproject.toml`. |
 
 ---
 
@@ -80,7 +81,9 @@ Clone (or copy) the mothership repo to your VPS, then run the one-shot bootstrap
 
 ```bash
 git clone https://github.com/your-org/mothership.git
+
 cd mothership
+uv tool install --force --no-cache .
 
 RELAY_DOMAIN=relay.example.com \
 ACME_EMAIL=you@example.com \

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -325,7 +325,8 @@ Notes on each:
 - DNS — the existing wildcard `*.relay.example.com` record already covers both
   `enroll.<relay>` and every per-host subdomain.
 - Firewall/ports — still 2222/80/443; `:47180` stays loopback-only.
-- `tls_ask.py` — a host subdomain is the same `<opaque-slug>-<6hex>` label shape
+- `src/mship/core/relay/tls_ask.py` (in the mship package, not `docker/relay/`)
+  — a host subdomain is the same `<opaque-slug>-<6hex>` label shape
   a serve subdomain already has, so the on-demand-TLS allowlist needs no edit.
 
 The `Caddyfile` is deliberately **not** on that list: it is the one file that

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -25,6 +25,7 @@ internet
 | A VPS (Debian 12 or Ubuntu 22.04+) | 1 CPU / 512 MB RAM is sufficient. A $5/month cloud instance (Hetzner, DigitalOcean, Vultr, etc.) works. |
 | A domain you control | Example: `relay.example.com`. You only need a subdomain — the relay does not take over the root domain. |
 | SSH access to the VPS as root (or a sudo user) | To run the bootstrap script and open ports. |
+| OpenSSH client tools on the VPS | `ssh-keygen` verifies signed host registrations. On Debian/Ubuntu: `apt install openssh-client`. |
 
 ---
 

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -127,7 +127,7 @@ keepalives at all needs either its own keepalive or a longer timeout here.
 
 The `Caddyfile` (`docker/relay/Caddyfile`) wires:
 
-- `enroll.{$RELAY_DOMAIN}` → `127.0.0.1:47180` (enroll-server; only `POST /enroll` and `GET /status/*` are forwarded — everything else returns 404).
+- `enroll.{$RELAY_DOMAIN}` → `127.0.0.1:47180` (enroll-server; only `POST /enroll`, `GET /status/*` and the host-directory routes under `/hosts` are forwarded — everything else returns 404). Adding a route to the enroll app is therefore not enough on its own: it must sit under one of those matchers, or the `respond "not found" 404` catch-all swallows it in production while every unit test passes.
 - `*.{$RELAY_DOMAIN}` → `127.0.0.1:8080` (sish HTTP, `Host` header preserved).
 
 The GitHub token broker is no longer a separate host/route: it's folded into `mship serve`'s `GET /gh-token` and reached over the workspace's own `*.{$RELAY_DOMAIN}` serve tunnel. See [`docs/cloud-agent-auth.md`](cloud-agent-auth.md).

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -155,6 +155,11 @@ mship relay enroll-server \
 
 `--relay-domain` can also be set via the `RELAY_DOMAIN` environment variable. The enroll-server is reached from the internet only through Caddy at `https://enroll.<relay>` — the raw `:47180` port is not accessible externally.
 
+Every owner-side command must receive its applicable `--store-dir` and
+`--pubkeys-dir` explicitly. The examples below use
+`/path/to/docker/relay/pending-store` and `/path/to/docker/relay/pubkeys`;
+substitute the exact values from the running unit's `ExecStart`.
+
 > **Important — keep the enroll-server supervised.** The enroll-server backs Caddy's on-demand TLS `ask` endpoint, which gates cert issuance **and renewal** for every relay subdomain — not just new enrollment requests. If the enroll-server is down, Caddy cannot renew existing certs and will refuse to issue new ones for serve subdomains. Unlike sish and Caddy (which Docker Compose restarts automatically), the enroll-server runs outside the compose stack and **must run under a supervisor so it survives reboots**.
 >
 > The bootstrap script installs a systemd unit automatically when run as root (it runs the service as the user that owns the relay dir, so `mship relay approve` can still read the pending store). To install it manually, set `User=` to the operator who owns `<relay-dir>` and runs `mship relay approve` — not root:
@@ -234,12 +239,15 @@ mship relay enroll --enroll-url https://enroll.relay.example.com
 **Back on the relay host**, review and grant (or deny):
 
 ```bash
-mship relay requests                 # id · hostname · key fingerprint
+mship relay requests \
+  --store-dir /path/to/docker/relay/pending-store
+# id · hostname · key fingerprint
 mship relay approve a1c2 \
-  --store-dir docker/relay/pending-store \
-  --pubkeys-dir docker/relay/pubkeys
+  --store-dir /path/to/docker/relay/pending-store \
+  --pubkeys-dir /path/to/docker/relay/pubkeys
 # writes the key into pubkeys/ → sish picks it up (no restart needed).
-# `mship relay deny <id>` discards it.
+mship relay deny <id> \
+  --store-dir /path/to/docker/relay/pending-store
 ```
 
 A request only ever creates a *pending* entry — nothing reaches the allowlist until you `approve` it, and pending requests auto-expire after 30 minutes. The device can then `mship serve --relay`.
@@ -260,7 +268,14 @@ After the stack is running, verify each layer:
    ```
    It should print a request ID and enter polling. `:47180` should **not** be reachable directly from outside the relay host.
 
-4. **Approve and confirm**: on the relay host, `mship relay approve <id>` — the device should print `approved`.
+4. **Approve and confirm**: on the relay host, use the same store and allowlist
+   paths as the enroll-server:
+   ```bash
+   mship relay approve <id> \
+     --store-dir /path/to/docker/relay/pending-store \
+     --pubkeys-dir /path/to/docker/relay/pubkeys
+   ```
+   The device should print `approved`.
 
 5. **Serve subdomain**: run `mship serve --relay` from an enrolled device and confirm the printed URL (`https://<slug>-<6hex>.relay.example.com`) loads through Caddy (look for a valid TLS certificate issued by Let's Encrypt).
 
@@ -278,10 +293,14 @@ they are why a freshly provisioned VM needs no address typed on the phone.
 
 ### The exact relay-box delta
 
-Four commands, all on the relay host:
+Four steps, all on the relay host:
 
 ```bash
-# 1. Ship the new enroll-server code, then restart the (supervised) process.
+# 1. Keep the unit's existing stores: they contain enrollment history. Inspect
+#    ExecStart, then copy its exact --store-dir and --pubkeys-dir values here.
+systemctl cat mship-relay-enroll.service
+RELAY_STORE=/path/already/configured/in/ExecStart
+RELAY_PUBKEYS=/path/already/configured/in/ExecStart
 uv tool install --force --no-cache /path/to/mothership
 systemctl restart mship-relay-enroll.service
 
@@ -292,19 +311,25 @@ docker compose -f docker/relay/docker-compose.yml up -d --force-recreate caddy
 # 3. Once per phone: mint its fleet token and show the pairing QR.
 mship relay fleet-token --label phone \
   --relay-domain relay.example.com \
-  --store-dir /path/to/docker/relay/pending-store
+  --store-dir "$RELAY_STORE"
 
 # 4. Per new VM, exactly as before — one approval, then it is done.
 mship relay approve <id> \
-  --store-dir /path/to/docker/relay/pending-store \
-  --pubkeys-dir /path/to/docker/relay/pubkeys
+  --store-dir "$RELAY_STORE" \
+  --pubkeys-dir "$RELAY_PUBKEYS"
 ```
 
 Notes on each:
 
-- **Step 1** is not optional: `/hosts`, `/hosts/challenge` and `/hosts/register`
-  are served by the enroll-server process, and merging does not deploy — the
-  live process keeps running the version it imported.
+- **Step 1** deliberately retains the unit's configured store. Older units may
+  call it `<relay-dir>/enroll-store`; current ones use
+  `<relay-dir>/pending-store`. The name does not matter, but changing it during
+  an upgrade loses the existing request/history state unless the entire store
+  is migrated first. Keep `ExecStart`, `$RELAY_STORE`, and every later owner
+  command on that one directory. Likewise, `$RELAY_PUBKEYS` must remain the
+  allowlist sish reads. `/hosts`, `/hosts/challenge` and `/hosts/register` are
+  served by the upgraded process, and merging does not deploy — it keeps
+  running the version it imported.
 - **Step 2** is the only edge change. `docker/relay/Caddyfile` gains one
   matcher, `@hosts { path /hosts /hosts/* }`, plus its `handle` block
   (`request_body max_size 8KB` → `127.0.0.1:47180`). Without it the site's
@@ -320,7 +345,7 @@ Notes on each:
 - **Step 4** is unchanged because the signature allowlist *is* the sish
   `pubkeys/` allowlist, re-read per verification: approving a host's key both
   admits its tunnel and makes its signed registrations verify, with no restart.
-  `mship relay hosts --store-dir …` lists what the directory holds.
+  `mship relay hosts --store-dir "$RELAY_STORE"` lists what the directory holds.
 
 ### What does **not** change
 
@@ -345,10 +370,10 @@ fleet token is read access to the whole fleet, not to one host. Treat it like a
 password:
 
 - one `--label` per physical device, so a lost phone can be cut off by itself;
-- `mship relay fleet-token --label phone --revoke` invalidates that label
-  (`--revoke` is a boolean flag used *with* `--label`, not a value). A later
-  re-mint under the same label derives a **different** token rather than
-  resurrecting the revoked one.
+- `mship relay fleet-token --label phone --revoke --store-dir "$RELAY_STORE"`
+  invalidates that label (`--revoke` is a boolean flag used *with* `--label`,
+  not a value). A later re-mint under the same label derives a **different**
+  token rather than resurrecting the revoked one.
 
 Revocation stops future directory reads, and that is all it does: it does not
 rotate the per-host refresh credentials a paired phone already fetched. Those
@@ -417,15 +442,19 @@ the container restarts.
 
 **Phone says the fleet token is invalid** — the token is verified against
 `fleet-tokens.json` in the enroll-server's `--store-dir`. Minting it with a
-different `--store-dir` than the running server uses is the usual cause; a
-revoked label is the other (`mship relay fleet-token --label <device>` re-mints
-a *new* token after a revoke — the device must scan the fresh QR).
+different store than the running server uses is the usual cause; a revoked
+label is the other. Re-mint from the configured store:
+`mship relay fleet-token --label <device> --relay-domain relay.example.com
+--store-dir "$RELAY_STORE"`. The device must scan the fresh QR.
 
-**A host never appears in `mship relay hosts`** — check its own view first:
-`mship daemon status` on that host prints a `tunnel:` line naming the state
-(`awaiting-enrollment` means it is waiting for `mship relay approve`;
-`duplicate-identity` means a twin holds the entry). If the host reports
-`online` but `/hosts` 404s from outside, the `@hosts` Caddy matcher is missing —
-see [Host directory + fleet token](#host-directory-fleet-token-471).
+**A host never appears in
+`mship relay hosts --store-dir "$RELAY_STORE"`** — check its own view first:
+`mship daemon status` on that host prints a `tunnel:` line naming the state.
+`awaiting-enrollment` means it is waiting for
+`mship relay approve <id> --store-dir "$RELAY_STORE" --pubkeys-dir
+"$RELAY_PUBKEYS"`; `duplicate-identity` means a twin holds the entry. If the
+host reports `online` but `/hosts` 404s from outside, the `@hosts` Caddy matcher
+is missing — see
+[Host directory + fleet token](#host-directory-fleet-token-471).
 
 **Enroll request times out** — confirm the enroll-server process is running on the relay host (`curl http://127.0.0.1:47180/status/x` from the host should return a JSON status). Also check that Caddy is running and that `enroll.<relay>` resolves to the relay IP.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
       - CLI reference: cli.md
       - Configuration: configuration.md
       - Daemon operations: daemon.md
+      - Host tunnel manual checklist: checklists/host-tunnel-manual.md
   - Remote access:
       - Serve over Tailscale: mship-serve-tailscale.md
       - Relay hosting: relay-hosting.md

--- a/scripts/relay-bootstrap.sh
+++ b/scripts/relay-bootstrap.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 : "${RELAY_DOMAIN:?set RELAY_DOMAIN (the wildcard base, e.g. relay.example.com)}"
 : "${ACME_EMAIL:?set ACME_EMAIL (for Lets Encrypt / ACME)}"
 
+if ! command -v ssh-keygen >/dev/null 2>&1; then
+  echo "[bootstrap] ssh-keygen is required; install the openssh-client package." >&2
+  exit 1
+fi
 if ! command -v docker >/dev/null 2>&1; then
   echo "[bootstrap] installing Docker..."
   curl -fsSL https://get.docker.com | sh

--- a/src/mship/cli/daemon.py
+++ b/src/mship/cli/daemon.py
@@ -172,6 +172,10 @@ def register(parent: typer.Typer, get_container):
             None, "--serve", metavar="HOST:PORT",
             help="Also bind the workspace-addressed HTTP API on HOST:PORT (pre-#471 phone reachability). Without it the daemon is control-socket only.",
         ),
+        relay: str = typer.Option(
+            None, "--relay", metavar="HOST",
+            help="Register this host with the relay at HOST and keep an ssh -R tunnel to it up. Needs a --serve bind (here or from an earlier install). Like --serve, a changed relay takes effect on `mship daemon restart`.",
+        ),
     ):
         """Install + enable the OS-user supervisor unit (systemd --user / launchd)."""
         out = Output()
@@ -213,8 +217,9 @@ def register(parent: typer.Typer, get_container):
                 "persisted — use `mship daemon restart` to apply them"
             )
             raise typer.Exit(1)
+        relay_cfg = {"host": relay} if relay is not None else None
         merged = None
-        if roots or serve_cfg is not None:
+        if roots or serve_cfg is not None or relay_cfg is not None:
             from mship.core.daemon.registry import save_daemon_config
 
             merged = DaemonConfig(
@@ -222,7 +227,18 @@ def register(parent: typer.Typer, get_container):
                 ignore_globs=previous_cfg.ignore_globs,
                 max_depth=previous_cfg.max_depth,
                 serve=serve_cfg if serve_cfg is not None else previous_cfg.serve,
+                relay=relay_cfg if relay_cfg is not None else previous_cfg.relay,
             )
+            # The MERGED config, not the flag: `--relay` on a host whose
+            # `serve:` an earlier install already set is the normal
+            # incremental-provisioning path, and validating the flag alone
+            # would reject it.
+            if merged.relay is not None and merged.serve is None:
+                out.error(
+                    "--relay needs a local bind to forward: pass --serve HOST:PORT "
+                    "(here or in an earlier install)"
+                )
+                raise typer.Exit(1)
             _validate_scan_roots(merged, out)
 
             # Launchd's bootstrap starts a RunAtLoad job immediately. Persist
@@ -242,7 +258,11 @@ def register(parent: typer.Typer, get_container):
             out.error(str(e))
             raise typer.Exit(1)
         if merged is not None:
-            out.print(f"daemon config seeded: {len(merged.scan_roots)} scan root(s)" + (", serve bind set" if merged.serve else ""))
+            out.print(
+                f"daemon config seeded: {len(merged.scan_roots)} scan root(s)"
+                + (", serve bind set" if merged.serve else "")
+                + (f", relay {merged.relay['host']}" if merged.relay else "")
+            )
         out.print("daemon installed and enabled — start it with `mship daemon start`")
 
     @daemon_app.command("start")

--- a/src/mship/cli/daemon.py
+++ b/src/mship/cli/daemon.py
@@ -217,7 +217,11 @@ def register(parent: typer.Typer, get_container):
                 "persisted — use `mship daemon restart` to apply them"
             )
             raise typer.Exit(1)
-        relay_cfg = {"host": relay} if relay is not None else None
+        relay_host = relay.strip() if relay is not None else None
+        if relay is not None and not relay_host:
+            out.error(f"--relay expects HOST, got {relay!r}")
+            raise typer.Exit(1)
+        relay_cfg = {"host": relay_host} if relay_host else None
         merged = None
         if roots or serve_cfg is not None or relay_cfg is not None:
             from mship.core.daemon.registry import save_daemon_config

--- a/src/mship/cli/daemon.py
+++ b/src/mship/cli/daemon.py
@@ -402,7 +402,8 @@ def register(parent: typer.Typer, get_container):
             )
             out.print(
                 f"kept host id {ident.host_id}; adopted machine fingerprint "
-                f"{ident.fingerprint}"
+                f"{ident.fingerprint}\n"
+                "run `mship daemon restart` to make a running daemon use it"
             )
             return
         ident = force_reidentify(home)

--- a/src/mship/cli/daemon.py
+++ b/src/mship/cli/daemon.py
@@ -368,11 +368,50 @@ def register(parent: typer.Typer, get_container):
                     "supervisor": {"state": st.supervisor.state, "detail": st.supervisor.detail},
                     "linger": st.linger,
                     "unclean_starts": st.unclean_starts,
+                    "tunnel": st.tunnel,
+                    "clock_skew_seconds": st.clock_skew_seconds,
                     "lines": st.lines,
                 }
             )
         else:
             out.print(st.render())
+
+    @daemon_app.command("reidentify")
+    def reidentify(
+        keep_identity: bool = typer.Option(
+            False, "--keep-identity",
+            help="This IS the same host: adopt the running machine's fingerprint "
+                 "instead of minting a new identity (after a re-image or a "
+                 "hardware change that tripped the clone check).",
+        ),
+    ):
+        """Mint a new host identity + relay key after a clone (or adopt this
+        machine's fingerprint with --keep-identity)."""
+        from mship.core.daemon.identity import (
+            ensure_host_identity,
+            force_reidentify,
+            machine_fingerprint,
+        )
+        from mship.core.daemon.relay_link import host_subdomain_for
+
+        out = Output()
+        home = Path.home()
+        if keep_identity:
+            ident = ensure_host_identity(
+                home, fingerprint=machine_fingerprint(), on_mismatch="keep"
+            )
+            out.print(
+                f"kept host id {ident.host_id}; adopted machine fingerprint "
+                f"{ident.fingerprint}"
+            )
+            return
+        ident = force_reidentify(home)
+        out.print(
+            f"re-identified as {ident.host_id} (was {ident.cloned_from})\n"
+            f"new relay subdomain: {host_subdomain_for(home, ident.host_id)}\n"
+            "the rotated key needs approving again (`mship relay approve <id>` on "
+            "the relay host); run `mship daemon restart` to dial with it"
+        )
 
     @daemon_app.command("logs")
     def logs(n: int = typer.Option(100, "-n", "--lines", help="Lines to show.")):

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -441,6 +441,7 @@ def register(parent: typer.Typer, get_container):
 
         import httpx
 
+        from mship.core.relay import host_contract
         from mship.core.relay.keys import ensure_relay_key, relay_public_key
 
         out = Output()
@@ -455,7 +456,7 @@ def register(parent: typer.Typer, get_container):
         # rather than dumping an httpx traceback.
         try:
             r = httpx.post(
-                f"{base}/enroll",
+                base + host_contract.ENROLL_PATH,
                 json={"pubkey": pub, "hostname": socket.gethostname()},
                 timeout=10,
             )

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -362,9 +362,7 @@ def register(parent: typer.Typer, get_container):
             probe=lambda public_url: None,  # …and never arbitrates
         )
         entries = directory.list_hosts(RequestStore(Path(store_dir)).list_pending())
-        if not entries:
-            out.print("no hosts")
-            return
+        hosts = []
         for entry in entries:
             last_seen = entry.get("last_seen") or entry.get("created_at")
             when = (
@@ -374,12 +372,27 @@ def register(parent: typer.Typer, get_container):
             )
             # Never the entry's `refresh`: that credential goes to the paired
             # phone over GET /hosts, not into a terminal's scrollback.
-            host_id = json.dumps(str(entry.get("host_id") or "-"), ensure_ascii=False)[
-                1:-1
-            ]
-            label = json.dumps(str(entry.get("label") or "-"), ensure_ascii=False)[1:-1]
-            line = f"{host_id}  {label}  {entry['state']}  {when}"
-            out.print(escape(line) if out.human_mode else line)
+            hosts.append(
+                {
+                    "host_id": str(entry.get("host_id") or "-"),
+                    "label": str(entry.get("label") or "-"),
+                    "state": entry["state"],
+                    "last_seen": when,
+                }
+            )
+        if out.json_mode:
+            out.json({"hosts": hosts})
+            return
+        if not hosts:
+            out.print("no hosts")
+            return
+        for host in hosts:
+            host_id = json.dumps(host["host_id"], ensure_ascii=False)[1:-1]
+            label = json.dumps(host["label"], ensure_ascii=False)[1:-1]
+            line = (
+                f"{host_id}  {label}  {host['state']}  {host['last_seen']}"
+            )
+            out.print(escape(line))
 
     # ---- typed grants + per-run tokens (cloud-worker-auth-spine) ----
 

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -18,6 +18,7 @@ import typer
 from rich.markup import escape
 
 from mship.cli.output import Output
+from mship.core.relay.config import canonical_relay_host
 
 
 def enroll_base_url(*, enroll_url, relay_host, config_host):
@@ -59,6 +60,7 @@ def _enroll_server_impl(*, store_dir, pubkeys_dir, port, host, ttl, relay_domain
     from mship.core.relay.host_directory import HostDirectory, probe_instance_id
     from mship.core.relay.ssh_sig import build_allowed_signers
 
+    relay_domain = canonical_relay_host(relay_domain)
     if not relay_domain:
         raise typer.BadParameter(
             "relay domain required: pass --relay-domain or set RELAY_DOMAIN"
@@ -305,6 +307,7 @@ def register(parent: typer.Typer, get_container):
                 raise typer.Exit(1)
             out.success(f"revoked {label} — that device must scan a fresh QR to return")
             return
+        relay_domain = canonical_relay_host(relay_domain)
         if not relay_domain:
             raise typer.BadParameter(
                 "relay domain required: pass --relay-domain or set RELAY_DOMAIN"

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -58,7 +58,7 @@ def _enroll_server_impl(*, store_dir, pubkeys_dir, port, host, ttl, relay_domain
     from mship.core.relay.enroll_app import build_enroll_app
     from mship.core.relay.fleet_token import FleetTokenStore
     from mship.core.relay.host_directory import HostDirectory, probe_instance_id
-    from mship.core.relay.ssh_sig import build_allowed_signers
+    from mship.core.relay.ssh_sig import build_allowed_signers, revoke_allowed_key
 
     relay_domain = canonical_relay_host(relay_domain)
     if not relay_domain:
@@ -69,15 +69,31 @@ def _enroll_server_impl(*, store_dir, pubkeys_dir, port, host, ttl, relay_domain
         raise typer.BadParameter(
             "ssh-keygen is required for host registration; install openssh-client"
         )
-    store = RequestStore(Path(store_dir), ttl_seconds=ttl)
+    pubkeys_path = Path(pubkeys_dir)
+    store = RequestStore(
+        Path(store_dir),
+        ttl_seconds=ttl,
+        is_approved=lambda key_fingerprint: any(
+            line.startswith(f"{key_fingerprint} ")
+            for line in build_allowed_signers(pubkeys_path).splitlines()
+        ),
+    )
+
+    def revoke_signer(identity: str):
+        return store.revoke_approved(
+            identity,
+            lambda approved: revoke_allowed_key(pubkeys_path, approved),
+        )
+
     # The signature allowlist IS the sish `pubkeys/` allowlist, re-read per
     # verification: that is what makes signature-auth and tunnel-auth one
     # identity, and what lets an approval take effect without a restart.
     directory = HostDirectory(
         Path(store_dir),
         relay_domain=relay_domain,
-        allowed_signers=lambda: build_allowed_signers(Path(pubkeys_dir)),
+        allowed_signers=lambda: build_allowed_signers(pubkeys_path),
         probe=probe_instance_id,
+        revoke_signer=revoke_signer,
     )
     Output().print(
         f"enroll-server → http://{host}:{port}  (relay: {relay_domain}, "
@@ -615,7 +631,7 @@ def register(parent: typer.Typer, get_container):
             raise typer.Exit(1)
         try:
             rid = r.json()["id"]
-        except ValueError, KeyError:
+        except (ValueError, KeyError):
             out.error("enroll server returned an unexpected response (no request id)")
             raise typer.Exit(1)
         out.print(
@@ -632,7 +648,7 @@ def register(parent: typer.Typer, get_container):
                 try:
                     resp = httpx.get(f"{base}/status/{rid}", timeout=10)
                     st = resp.json().get("status", "pending")
-                except httpx.RequestError, ValueError:  # ValueError covers JSON decode
+                except (httpx.RequestError, ValueError):  # ValueError covers JSON decode
                     time.sleep(3)
                     continue
                 if st == "approved":

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -8,11 +8,14 @@ host (`docker/relay/pubkeys/`). See plan Task B7 (ac4).
 host; `mship relay requests/approve/deny` manage pending enroll requests
 (owner-side); `mship relay enroll` is the requester path (new device).
 """
+
 from __future__ import annotations
 
 import os
+import json
 
 import typer
+from rich.markup import escape
 
 from mship.cli.output import Output
 
@@ -40,8 +43,9 @@ def _configured_relay_host(get_container):
         return None
 
 
-def _run_uvicorn(app, host, port):   # seam so tests don't boot a server
+def _run_uvicorn(app, host, port):  # seam so tests don't boot a server
     import uvicorn
+
     uvicorn.run(app, host=host, port=port)
 
 
@@ -55,7 +59,9 @@ def _enroll_server_impl(*, store_dir, pubkeys_dir, port, host, ttl, relay_domain
     from mship.core.relay.ssh_sig import build_allowed_signers
 
     if not relay_domain:
-        raise typer.BadParameter("relay domain required: pass --relay-domain or set RELAY_DOMAIN")
+        raise typer.BadParameter(
+            "relay domain required: pass --relay-domain or set RELAY_DOMAIN"
+        )
     store = RequestStore(Path(store_dir), ttl_seconds=ttl)
     # The signature allowlist IS the sish `pubkeys/` allowlist, re-read per
     # verification: that is what makes signature-auth and tunnel-auth one
@@ -66,8 +72,10 @@ def _enroll_server_impl(*, store_dir, pubkeys_dir, port, host, ttl, relay_domain
         allowed_signers=lambda: build_allowed_signers(Path(pubkeys_dir)),
         probe=probe_instance_id,
     )
-    Output().print(f"enroll-server → http://{host}:{port}  (relay: {relay_domain}, "
-                   f"pubkeys: {pubkeys_dir}, store: {store_dir}, ttl: {ttl}s)")
+    Output().print(
+        f"enroll-server → http://{host}:{port}  (relay: {relay_domain}, "
+        f"pubkeys: {pubkeys_dir}, store: {store_dir}, ttl: {ttl}s)"
+    )
     _run_uvicorn(
         build_enroll_app(
             store,
@@ -120,7 +128,7 @@ def register(parent: typer.Typer, get_container):
             f"  • On the relay host itself, just copy it in:\n"
             f"      cp {pub_path} <relay-dir>/docker/relay/pubkeys/{label}\n\n"
             f"  • From another machine, scp it over (the tunnel auths by key, so there is\n"
-            f"    no \"relay user\" — <login> is just your normal SSH account on the relay box):\n"
+            f'    no "relay user" — <login> is just your normal SSH account on the relay box):\n'
             f"      scp {pub_path} <login>@{relay_host}:<relay-dir>/docker/relay/pubkeys/{label}\n\n"
             f"  <relay-dir> = where you deployed the docker/relay/ compose; the filename is "
             f"just a unique label."
@@ -132,23 +140,40 @@ def register(parent: typer.Typer, get_container):
 
     @relay_app.command("enroll-server")
     def enroll_server(
-        pubkeys_dir: str = typer.Option("./pubkeys", "--pubkeys-dir",
-                                        help="Allowlist dir used by 'mship relay approve' "
-                                             "(this server only creates pending requests; "
-                                             "it never writes keys)."),
-        store_dir: str = typer.Option("./pending-store", "--store-dir",
-                                      help="Directory for pending enroll request state."),
+        pubkeys_dir: str = typer.Option(
+            "./pubkeys",
+            "--pubkeys-dir",
+            help="Allowlist dir used by 'mship relay approve' "
+            "(this server only creates pending requests; "
+            "it never writes keys).",
+        ),
+        store_dir: str = typer.Option(
+            "./pending-store",
+            "--store-dir",
+            help="Directory for pending enroll request state.",
+        ),
         port: int = typer.Option(47180, "--port", help="Port to listen on."),
-        host: str = typer.Option("127.0.0.1", "--host",
-                                 help="Interface to bind (loopback; Caddy fronts it)."),
-        ttl: int = typer.Option(1800, "--ttl",
-                                help="Pending request TTL in seconds (default 30 min)."),
-        relay_domain: str = typer.Option(lambda: os.environ.get("RELAY_DOMAIN", ""), "--relay-domain",
-                                         help="Relay domain for the on-demand TLS ask (default $RELAY_DOMAIN)."),
+        host: str = typer.Option(
+            "127.0.0.1", "--host", help="Interface to bind (loopback; Caddy fronts it)."
+        ),
+        ttl: int = typer.Option(
+            1800, "--ttl", help="Pending request TTL in seconds (default 30 min)."
+        ),
+        relay_domain: str = typer.Option(
+            lambda: os.environ.get("RELAY_DOMAIN", ""),
+            "--relay-domain",
+            help="Relay domain for the on-demand TLS ask (default $RELAY_DOMAIN).",
+        ),
     ):
         """Run the public enroll endpoint on the relay host (devices POST their key here)."""
-        _enroll_server_impl(store_dir=store_dir, pubkeys_dir=pubkeys_dir,
-                            port=port, host=host, ttl=ttl, relay_domain=relay_domain)
+        _enroll_server_impl(
+            store_dir=store_dir,
+            pubkeys_dir=pubkeys_dir,
+            port=port,
+            host=host,
+            ttl=ttl,
+            relay_domain=relay_domain,
+        )
 
     # -------------------------------------------------------------------------
     # Owner-side: list / approve / deny
@@ -156,8 +181,11 @@ def register(parent: typer.Typer, get_container):
 
     @relay_app.command("requests")
     def requests_cmd(
-        store_dir: str = typer.Option("./pending-store", "--store-dir",
-                                      help="Directory for pending enroll request state."),
+        store_dir: str = typer.Option(
+            "./pending-store",
+            "--store-dir",
+            help="Directory for pending enroll request state.",
+        ),
     ):
         """List pending enroll requests (id · hostname · fingerprint)."""
         from pathlib import Path
@@ -175,10 +203,16 @@ def register(parent: typer.Typer, get_container):
     @relay_app.command("approve")
     def approve_cmd(
         rid: str = typer.Argument(..., help="Request ID to approve."),
-        store_dir: str = typer.Option("./pending-store", "--store-dir",
-                                      help="Directory for pending enroll request state."),
-        pubkeys_dir: str = typer.Option("./pubkeys", "--pubkeys-dir",
-                                        help="Directory where approved keys are written (sish pubkeys/)."),
+        store_dir: str = typer.Option(
+            "./pending-store",
+            "--store-dir",
+            help="Directory for pending enroll request state.",
+        ),
+        pubkeys_dir: str = typer.Option(
+            "./pubkeys",
+            "--pubkeys-dir",
+            help="Directory where approved keys are written (sish pubkeys/).",
+        ),
     ):
         """Approve a pending request: add its key to the allowlist (sish picks it up, no restart)."""
         from pathlib import Path
@@ -190,14 +224,19 @@ def register(parent: typer.Typer, get_container):
             RequestStore(Path(store_dir)).approve(rid, Path(pubkeys_dir))
             out.success(f"approved {rid} — key enrolled into {pubkeys_dir}")
         except NotPending:
-            out.error(f"no pending request {rid!r} (unknown, already resolved, or expired)")
+            out.error(
+                f"no pending request {rid!r} (unknown, already resolved, or expired)"
+            )
             raise typer.Exit(1)
 
     @relay_app.command("deny")
     def deny_cmd(
         rid: str = typer.Argument(..., help="Request ID to deny."),
-        store_dir: str = typer.Option("./pending-store", "--store-dir",
-                                      help="Directory for pending enroll request state."),
+        store_dir: str = typer.Option(
+            "./pending-store",
+            "--store-dir",
+            help="Directory for pending enroll request state.",
+        ),
     ):
         """Deny a pending request (does not touch the allowlist)."""
         from pathlib import Path
@@ -209,7 +248,9 @@ def register(parent: typer.Typer, get_container):
             RequestStore(Path(store_dir)).deny(rid)
             out.print(f"denied {rid}")
         except NotPending:
-            out.error(f"no pending request {rid!r} (unknown, already resolved, or expired)")
+            out.error(
+                f"no pending request {rid!r} (unknown, already resolved, or expired)"
+            )
             raise typer.Exit(1)
 
     # -------------------------------------------------------------------------
@@ -218,15 +259,26 @@ def register(parent: typer.Typer, get_container):
 
     @relay_app.command("fleet-token")
     def fleet_token_cmd(
-        label: str = typer.Option(..., "--label",
-                                  help="Nickname for the device this token is for (e.g. phone)."),
-        store_dir: str = typer.Option("./pending-store", "--store-dir",
-                                      help="Directory for pending enroll request state."),
-        relay_domain: str = typer.Option(lambda: os.environ.get("RELAY_DOMAIN", ""),
-                                         "--relay-domain",
-                                         help="Relay domain to pair against (default $RELAY_DOMAIN)."),
-        revoke: bool = typer.Option(False, "--revoke",
-                                    help="Invalidate this label's token instead of minting one."),
+        label: str = typer.Option(
+            ...,
+            "--label",
+            help="Nickname for the device this token is for (e.g. phone).",
+        ),
+        store_dir: str = typer.Option(
+            "./pending-store",
+            "--store-dir",
+            help="Directory for pending enroll request state.",
+        ),
+        relay_domain: str = typer.Option(
+            lambda: os.environ.get("RELAY_DOMAIN", ""),
+            "--relay-domain",
+            help="Relay domain to pair against (default $RELAY_DOMAIN).",
+        ),
+        revoke: bool = typer.Option(
+            False,
+            "--revoke",
+            help="Invalidate this label's token instead of minting one.",
+        ),
     ):
         """Mint (or revoke) a device's fleet token and print its pairing QR.
 
@@ -265,8 +317,11 @@ def register(parent: typer.Typer, get_container):
 
     @relay_app.command("hosts")
     def hosts_cmd(
-        store_dir: str = typer.Option("./pending-store", "--store-dir",
-                                      help="Directory for pending enroll request state."),
+        store_dir: str = typer.Option(
+            "./pending-store",
+            "--store-dir",
+            help="Directory for pending enroll request state.",
+        ),
     ):
         """List the relay's host directory (host_id · label · state · last_seen)."""
         import time
@@ -278,9 +333,9 @@ def register(parent: typer.Typer, get_container):
         out = Output()
         directory = HostDirectory(
             Path(store_dir),
-            relay_domain="",                   # read-only: never registers/probes
-            allowed_signers=lambda: "",       # listing verifies nothing…
-            probe=lambda public_url: None,    # …and never arbitrates
+            relay_domain="",  # read-only: never registers/probes
+            allowed_signers=lambda: "",  # listing verifies nothing…
+            probe=lambda public_url: None,  # …and never arbitrates
         )
         entries = directory.list_hosts(RequestStore(Path(store_dir)).list_pending())
         if not entries:
@@ -295,26 +350,48 @@ def register(parent: typer.Typer, get_container):
             )
             # Never the entry's `refresh`: that credential goes to the paired
             # phone over GET /hosts, not into a terminal's scrollback.
-            out.print(f"{entry.get('host_id') or '-'}  {entry.get('label') or '-'}  "
-                      f"{entry['state']}  {when}")
+            host_id = json.dumps(str(entry.get("host_id") or "-"), ensure_ascii=False)[
+                1:-1
+            ]
+            label = json.dumps(str(entry.get("label") or "-"), ensure_ascii=False)[1:-1]
+            line = f"{host_id}  {label}  {entry['state']}  {when}"
+            out.print(escape(line) if out.human_mode else line)
 
     # ---- typed grants + per-run tokens (cloud-worker-auth-spine) ----
 
     @relay_app.command("grant")
     def grant_cmd(
-        rid: str = typer.Argument(..., help="Approved enrollment id to grant repos to."),
-        provider: str = typer.Option("github-app", "--provider", help="Credential provider."),
-        repos: str = typer.Option(..., "--repos", help="Ceiling repos owner/a,owner/b."),
-        store_dir: str = typer.Option("./pending-store", "--store-dir",
-                                      help="Enroll request store (to confirm approval)."),
-        grant_store_dir: str = typer.Option("./grants-store", "--grant-store-dir",
-                                            help="Directory for the typed-grant store."),
+        rid: str = typer.Argument(
+            ..., help="Approved enrollment id to grant repos to."
+        ),
+        provider: str = typer.Option(
+            "github-app", "--provider", help="Credential provider."
+        ),
+        repos: str = typer.Option(
+            ..., "--repos", help="Ceiling repos owner/a,owner/b."
+        ),
+        store_dir: str = typer.Option(
+            "./pending-store",
+            "--store-dir",
+            help="Enroll request store (to confirm approval).",
+        ),
+        grant_store_dir: str = typer.Option(
+            "./grants-store",
+            "--grant-store-dir",
+            help="Directory for the typed-grant store.",
+        ),
     ):
         """Set/update an enrollment's typed grant (the repo CEILING it may ever touch)."""
         from pathlib import Path
 
         from mship.core.relay.enroll import RequestStore
-        from mship.core.relay.grants import Grant, GrantStore, RepoSpecError, Scope, parse_repos
+        from mship.core.relay.grants import (
+            Grant,
+            GrantStore,
+            RepoSpecError,
+            Scope,
+            parse_repos,
+        )
 
         out = Output()
         if RequestStore(Path(store_dir)).get(rid) != "approved":
@@ -333,18 +410,35 @@ def register(parent: typer.Typer, get_container):
     @relay_app.command("issue-run-token")
     def issue_run_token_cmd(
         rid: str = typer.Argument(..., help="Approved+granted enrollment id."),
-        repos: str = typer.Option(..., "--repos", help="Run repos (⊆ the grant ceiling)."),
-        push_branch: str = typer.Option(..., "--push-branch", help="The run's branch, e.g. feat/<slug>."),
-        ttl: int = typer.Option(86400, "--ttl", help="Token TTL in seconds (default 24h)."),
-        grant_store_dir: str = typer.Option("./grants-store", "--grant-store-dir",
-                                            help="Directory for the typed-grant store."),
-        run_token_dir: str = typer.Option("./run-tokens-store", "--run-token-dir",
-                                           help="Directory for per-run token records."),
+        repos: str = typer.Option(
+            ..., "--repos", help="Run repos (⊆ the grant ceiling)."
+        ),
+        push_branch: str = typer.Option(
+            ..., "--push-branch", help="The run's branch, e.g. feat/<slug>."
+        ),
+        ttl: int = typer.Option(
+            86400, "--ttl", help="Token TTL in seconds (default 24h)."
+        ),
+        grant_store_dir: str = typer.Option(
+            "./grants-store",
+            "--grant-store-dir",
+            help="Directory for the typed-grant store.",
+        ),
+        run_token_dir: str = typer.Option(
+            "./run-tokens-store",
+            "--run-token-dir",
+            help="Directory for per-run token records.",
+        ),
     ):
         """Issue a per-run token {repos ⊆ ceiling, push_branch}; prints plaintext ONCE."""
         from pathlib import Path
 
-        from mship.core.relay.grants import GrantStore, RepoSpecError, Scope, parse_repos
+        from mship.core.relay.grants import (
+            GrantStore,
+            RepoSpecError,
+            Scope,
+            parse_repos,
+        )
         from mship.core.relay.run_token import issue_run_token
 
         out = Output()
@@ -354,14 +448,26 @@ def register(parent: typer.Typer, get_container):
         if not push_branch.strip():
             out.error("--push-branch must be a non-empty branch name")
             raise typer.Exit(1)
-        if push_branch.strip().startswith("refs/") and not push_branch.strip().startswith("refs/heads/"):
-            out.error("--push-branch must be a branch (bare name or refs/heads/...), "
-                      "not a tag or other ref")
+        if push_branch.strip().startswith(
+            "refs/"
+        ) and not push_branch.strip().startswith("refs/heads/"):
+            out.error(
+                "--push-branch must be a branch (bare name or refs/heads/...), "
+                "not a tag or other ref"
+            )
             raise typer.Exit(1)
-        ceiling = next((g for g in GrantStore(Path(grant_store_dir)).get_grants(rid)
-                        if g.provider == "github-app"), None)
+        ceiling = next(
+            (
+                g
+                for g in GrantStore(Path(grant_store_dir)).get_grants(rid)
+                if g.provider == "github-app"
+            ),
+            None,
+        )
         if ceiling is None:
-            out.error(f"enrollment {rid!r} has no github-app grant; run `mship relay grant` first")
+            out.error(
+                f"enrollment {rid!r} has no github-app grant; run `mship relay grant` first"
+            )
             raise typer.Exit(1)
         try:
             run_repos = parse_repos(repos)
@@ -370,20 +476,33 @@ def register(parent: typer.Typer, get_container):
             raise typer.Exit(1)
         run_scope = Scope(repos=run_repos, push_branch=push_branch.strip())
         if not ceiling.scope.covers(run_scope):
-            out.error(f"requested repos exceed the grant ceiling {list(ceiling.scope.repos)}")
+            out.error(
+                f"requested repos exceed the grant ceiling {list(ceiling.scope.repos)}"
+            )
             raise typer.Exit(1)
-        token = issue_run_token(Path(run_token_dir), enrollment_id=rid,
-                                scope=run_scope, ttl_seconds=ttl)
+        token = issue_run_token(
+            Path(run_token_dir), enrollment_id=rid, scope=run_scope, ttl_seconds=ttl
+        )
         out.print(f"run token (store on the worker, shown once): {token}")
 
     @relay_app.command("egress-server")
     def egress_server(
-        grant_store_dir: str = typer.Option("./grants-store", "--grant-store-dir",
-                                             help="Directory for the typed-grant store."),
-        run_token_dir: str = typer.Option("./run-tokens-store", "--run-token-dir",
-                                           help="Directory for per-run token records."),
-        port: int = typer.Option(47280, "--port", help="Port to listen on (Caddy fronts it)."),
-        host: str = typer.Option("127.0.0.1", "--host", help="Interface to bind (loopback)."),
+        grant_store_dir: str = typer.Option(
+            "./grants-store",
+            "--grant-store-dir",
+            help="Directory for the typed-grant store.",
+        ),
+        run_token_dir: str = typer.Option(
+            "./run-tokens-store",
+            "--run-token-dir",
+            help="Directory for per-run token records.",
+        ),
+        port: int = typer.Option(
+            47280, "--port", help="Port to listen on (Caddy fronts it)."
+        ),
+        host: str = typer.Option(
+            "127.0.0.1", "--host", help="Interface to bind (loopback)."
+        ),
     ):
         """Run the credential-attaching egress proxy (worker git/API traffic terminates here)."""
         import os
@@ -415,12 +534,15 @@ def register(parent: typer.Typer, get_container):
             provider = GitHubAppProvider(app_id=app_id, private_key=app_key)
             routes = build_default_routes(provider)
         else:
-            out.warning("no App creds (MSHIP_GH_APP_ID/MSHIP_GH_APP_KEY) — egress will "
-                        "refuse to forward (503) until configured.")
+            out.warning(
+                "no App creds (MSHIP_GH_APP_ID/MSHIP_GH_APP_KEY) — egress will "
+                "refuse to forward (503) until configured."
+            )
 
         app = build_egress_app(
             grant_store=GrantStore(Path(grant_store_dir)),
-            run_token_dir=Path(run_token_dir), routes=routes,
+            run_token_dir=Path(run_token_dir),
+            routes=routes,
         )
         out.print(f"egress-server → http://{host}:{port}")
         _run_uvicorn(app, host, port)
@@ -431,12 +553,21 @@ def register(parent: typer.Typer, get_container):
 
     @relay_app.command("enroll")
     def enroll_cmd(
-        enroll_url: str = typer.Option(None, "--enroll-url",
-                                       help="Explicit enroll base URL (overrides --relay-host)."),
-        relay_host: str = typer.Option(None, "--relay-host",
-                                       help="Relay host, e.g. mship-relay.example.com (enroll URL is derived)."),
-        wait: bool = typer.Option(True, "--wait/--no-wait",
-                                  help="Poll until approved/denied (default) or return immediately."),
+        enroll_url: str = typer.Option(
+            None,
+            "--enroll-url",
+            help="Explicit enroll base URL (overrides --relay-host).",
+        ),
+        relay_host: str = typer.Option(
+            None,
+            "--relay-host",
+            help="Relay host, e.g. mship-relay.example.com (enroll URL is derived).",
+        ),
+        wait: bool = typer.Option(
+            True,
+            "--wait/--no-wait",
+            help="Poll until approved/denied (default) or return immediately.",
+        ),
     ):
         """From a NEW device: request relay access; the relay owner approves/denies."""
         import socket
@@ -451,10 +582,14 @@ def register(parent: typer.Typer, get_container):
         out = Output()
         pub = relay_public_key(ensure_relay_key(home=Path.home())).strip()
         try:
-            base = enroll_base_url(enroll_url=enroll_url, relay_host=relay_host,
-                                   config_host=_configured_relay_host(get_container))
+            base = enroll_base_url(
+                enroll_url=enroll_url,
+                relay_host=relay_host,
+                config_host=_configured_relay_host(get_container),
+            )
         except ValueError as e:
-            out.error(str(e)); raise typer.Exit(2)
+            out.error(str(e))
+            raise typer.Exit(2)
         # The requester runs on a remote device hitting a public endpoint, so
         # connection-refused / DNS / timeout are LIKELY: surface them cleanly
         # rather than dumping an httpx traceback.
@@ -472,10 +607,12 @@ def register(parent: typer.Typer, get_container):
             raise typer.Exit(1)
         try:
             rid = r.json()["id"]
-        except (ValueError, KeyError):
+        except ValueError, KeyError:
             out.error("enroll server returned an unexpected response (no request id)")
             raise typer.Exit(1)
-        out.print(f"requested (id {rid}) — ask the relay owner to run: mship relay approve {rid}")
+        out.print(
+            f"requested (id {rid}) — ask the relay owner to run: mship relay approve {rid}"
+        )
         if not wait:
             return
         deadline = time.monotonic() + 1800
@@ -487,7 +624,7 @@ def register(parent: typer.Typer, get_container):
                 try:
                     resp = httpx.get(f"{base}/status/{rid}", timeout=10)
                     st = resp.json().get("status", "pending")
-                except (httpx.RequestError, ValueError):  # ValueError covers JSON decode
+                except httpx.RequestError, ValueError:  # ValueError covers JSON decode
                     time.sleep(3)
                     continue
                 if st == "approved":
@@ -512,7 +649,9 @@ def register(parent: typer.Typer, get_container):
             ..., help="A relay subdomain (or full label <slug>-<devid>, or <sub>.host)."
         ),
         workspace: list[str] = typer.Option(
-            None, "--workspace", "-w",
+            None,
+            "--workspace",
+            "-w",
             help="Candidate workspace name(s) to test. Defaults to the current workspace.",
         ),
     ):

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -48,13 +48,33 @@ def _enroll_server_impl(*, store_dir, pubkeys_dir, port, host, ttl, relay_domain
 
     from mship.core.relay.enroll import RequestStore
     from mship.core.relay.enroll_app import build_enroll_app
+    from mship.core.relay.fleet_token import FleetTokenStore
+    from mship.core.relay.host_directory import HostDirectory, probe_instance_id
+    from mship.core.relay.ssh_sig import build_allowed_signers
 
     if not relay_domain:
         raise typer.BadParameter("relay domain required: pass --relay-domain or set RELAY_DOMAIN")
     store = RequestStore(Path(store_dir), ttl_seconds=ttl)
+    # The signature allowlist IS the sish `pubkeys/` allowlist, re-read per
+    # verification: that is what makes signature-auth and tunnel-auth one
+    # identity, and what lets an approval take effect without a restart.
+    directory = HostDirectory(
+        Path(store_dir),
+        allowed_signers=lambda: build_allowed_signers(Path(pubkeys_dir)),
+        probe=probe_instance_id,
+    )
     Output().print(f"enroll-server → http://{host}:{port}  (relay: {relay_domain}, "
                    f"pubkeys: {pubkeys_dir}, store: {store_dir}, ttl: {ttl}s)")
-    _run_uvicorn(build_enroll_app(store, relay_domain=relay_domain), host=host, port=port)
+    _run_uvicorn(
+        build_enroll_app(
+            store,
+            relay_domain=relay_domain,
+            host_directory=directory,
+            fleet_tokens=FleetTokenStore(Path(store_dir)),
+        ),
+        host=host,
+        port=port,
+    )
 
 
 def register(parent: typer.Typer, get_container):
@@ -188,6 +208,89 @@ def register(parent: typer.Typer, get_container):
         except NotPending:
             out.error(f"no pending request {rid!r} (unknown, already resolved, or expired)")
             raise typer.Exit(1)
+
+    # -------------------------------------------------------------------------
+    # Owner-side: the host directory + the phone's fleet credential (#471)
+    # -------------------------------------------------------------------------
+
+    @relay_app.command("fleet-token")
+    def fleet_token_cmd(
+        label: str = typer.Option(..., "--label",
+                                  help="Nickname for the device this token is for (e.g. phone)."),
+        store_dir: str = typer.Option("./pending-store", "--store-dir",
+                                      help="Directory for pending enroll request state."),
+        relay_domain: str = typer.Option(lambda: os.environ.get("RELAY_DOMAIN", ""),
+                                         "--relay-domain",
+                                         help="Relay domain to pair against (default $RELAY_DOMAIN)."),
+        revoke: bool = typer.Option(False, "--revoke",
+                                    help="Invalidate this label's token instead of minting one."),
+    ):
+        """Mint (or revoke) a device's fleet token and print its pairing QR.
+
+        Re-running for the same label reprints the SAME token, so showing the QR
+        again never unpairs the device that already scanned it.
+        """
+        from pathlib import Path
+
+        import segno
+
+        from mship.core.relay.fleet_token import FleetTokenStore
+        from mship.core.relay.pairing import build_relay_account_link
+
+        out = Output()
+        store = FleetTokenStore(Path(store_dir))
+        if revoke:
+            if not store.revoke(label):
+                out.error(f"no fleet token for label {label!r}")
+                raise typer.Exit(1)
+            out.success(f"revoked {label} — that device must scan a fresh QR to return")
+            return
+        if not relay_domain:
+            raise typer.BadParameter(
+                "relay domain required: pass --relay-domain or set RELAY_DOMAIN"
+            )
+        try:
+            token = store.issue(label)
+        except ValueError as e:
+            raise typer.BadParameter(f"--label {e}")
+        link = build_relay_account_link(relay=relay_domain, token=token)
+        out.print(token)
+        out.print(link)
+        typer.echo(segno.make(link).terminal(compact=True))
+
+    @relay_app.command("hosts")
+    def hosts_cmd(
+        store_dir: str = typer.Option("./pending-store", "--store-dir",
+                                      help="Directory for pending enroll request state."),
+    ):
+        """List the relay's host directory (host_id · label · state · last_seen)."""
+        import time
+        from pathlib import Path
+
+        from mship.core.relay.enroll import RequestStore
+        from mship.core.relay.host_directory import HostDirectory
+
+        out = Output()
+        directory = HostDirectory(
+            Path(store_dir),
+            allowed_signers=lambda: "",       # listing verifies nothing…
+            probe=lambda public_url: None,    # …and never arbitrates
+        )
+        entries = directory.list_hosts(RequestStore(Path(store_dir)).list_pending())
+        if not entries:
+            out.print("no hosts")
+            return
+        for entry in entries:
+            last_seen = entry.get("last_seen") or entry.get("created_at")
+            when = (
+                time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(last_seen))
+                if isinstance(last_seen, (int, float))
+                else "-"
+            )
+            # Never the entry's `refresh`: that credential goes to the paired
+            # phone over GET /hosts, not into a terminal's scrollback.
+            out.print(f"{entry.get('host_id') or '-'}  {entry.get('label') or '-'}  "
+                      f"{entry['state']}  {when}")
 
     # ---- typed grants + per-run tokens (cloud-worker-auth-spine) ----
 

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -51,6 +51,7 @@ def _run_uvicorn(app, host, port):  # seam so tests don't boot a server
 
 def _enroll_server_impl(*, store_dir, pubkeys_dir, port, host, ttl, relay_domain):
     from pathlib import Path
+    import shutil
 
     from mship.core.relay.enroll import RequestStore
     from mship.core.relay.enroll_app import build_enroll_app
@@ -61,6 +62,10 @@ def _enroll_server_impl(*, store_dir, pubkeys_dir, port, host, ttl, relay_domain
     if not relay_domain:
         raise typer.BadParameter(
             "relay domain required: pass --relay-domain or set RELAY_DOMAIN"
+        )
+    if shutil.which("ssh-keygen") is None:
+        raise typer.BadParameter(
+            "ssh-keygen is required for host registration; install openssh-client"
         )
     store = RequestStore(Path(store_dir), ttl_seconds=ttl)
     # The signature allowlist IS the sish `pubkeys/` allowlist, re-read per

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -26,7 +26,9 @@ def enroll_base_url(*, enroll_url, relay_host, config_host):
     host = relay_host or config_host
     if not host:
         raise ValueError("provide --relay-host (or configure relay.host)")
-    return f"https://enroll.{host.strip().rstrip('.')}"
+    from mship.core.relay.host_contract import enroll_base_url as derive
+
+    return derive(host)
 
 
 def _configured_relay_host(get_container):

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -256,8 +256,10 @@ def register(parent: typer.Typer, get_container):
         except ValueError as e:
             raise typer.BadParameter(f"--label {e}")
         link = build_relay_account_link(relay=relay_domain, token=token)
-        out.print(token)
-        out.print(link)
+        # These are command results the operator must transfer, not log lines.
+        # Keep them off Output.print's general-purpose logging path.
+        typer.echo(token)
+        typer.echo(link)
         typer.echo(segno.make(link).terminal(compact=True))
 
     @relay_app.command("hosts")

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -62,6 +62,7 @@ def _enroll_server_impl(*, store_dir, pubkeys_dir, port, host, ttl, relay_domain
     # identity, and what lets an approval take effect without a restart.
     directory = HostDirectory(
         Path(store_dir),
+        relay_domain=relay_domain,
         allowed_signers=lambda: build_allowed_signers(Path(pubkeys_dir)),
         probe=probe_instance_id,
     )
@@ -277,6 +278,7 @@ def register(parent: typer.Typer, get_container):
         out = Output()
         directory = HostDirectory(
             Path(store_dir),
+            relay_domain="",                   # read-only: never registers/probes
             allowed_signers=lambda: "",       # listing verifies nothing…
             probe=lambda public_url: None,    # …and never arbitrates
         )

--- a/src/mship/core/daemon/capabilities.py
+++ b/src/mship/core/daemon/capabilities.py
@@ -8,6 +8,7 @@ the projection lives here — workspace-free, import-light — and both call it.
 
 #473 fills a real runner state in `runner_block` and nowhere else.
 """
+
 from __future__ import annotations
 
 from collections.abc import Mapping
@@ -22,7 +23,7 @@ def runner_block(raw: object | None) -> dict:
     else — absent, disabled, or malformed from a hand-edited registry — reads
     `disabled` rather than failing a request.
     """
-    enabled = bool(raw.get("enabled")) if isinstance(raw, Mapping) else False
+    enabled = isinstance(raw, Mapping) and raw.get("enabled") is True
     return {"enabled": enabled, "state": "unknown" if enabled else "disabled"}
 
 

--- a/src/mship/core/daemon/capabilities.py
+++ b/src/mship/core/daemon/capabilities.py
@@ -1,0 +1,41 @@
+"""What this host publishes about itself (#471 AC6's one owner).
+
+Two surfaces publish the same capability shape and neither can see the other's
+code: the host app's `/health` + `/workspaces` responses (`host_app.py`, which
+lives inside FastAPI) and the registration payload the daemon signs and POSTs
+to the relay (`relay_link.py`, which must import no web framework at all). So
+the projection lives here — workspace-free, import-light — and both call it.
+
+#473 fills a real runner state in `runner_block` and nowhere else.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+def runner_block(raw: object | None) -> dict:
+    """Project the registry's opaque `runner:` passthrough.
+
+    One projection, one shape, everywhere a runner block is published — #473
+    fills `state` in here and nowhere else. Declared-and-enabled reads
+    `unknown` because #471 carries runner state but never observes it; anything
+    else — absent, disabled, or malformed from a hand-edited registry — reads
+    `disabled` rather than failing a request.
+    """
+    enabled = bool(raw.get("enabled")) if isinstance(raw, Mapping) else False
+    return {"enabled": enabled, "state": "unknown" if enabled else "disabled"}
+
+
+def host_capability_payload(runner: object | None = None) -> dict:
+    """The `capabilities` + `runner` pair a registration payload carries.
+
+    Assembled in exactly one function so the flat `capabilities` summary can
+    never disagree with the `runner` block beside it: the summary is *derived*
+    from that block rather than restated. `tunnel` is unconditionally True —
+    only a host that dials the relay ever builds this payload.
+    """
+    block = runner_block(runner)
+    return {
+        "capabilities": {"tunnel": True, "runner": block["enabled"]},
+        "runner": block,
+    }

--- a/src/mship/core/daemon/control.py
+++ b/src/mship/core/daemon/control.py
@@ -21,7 +21,8 @@ from mship.core.daemon.registry import RegistryReadError
 
 # CLI<->daemon control-protocol version; bump on breaking payload changes.
 # 2: capabilities.registry/serve became real + /workspaces endpoints (#472).
-PROTOCOL = 2
+# 3: capabilities.tunnel became real + /health carries a `tunnel` block (#471).
+PROTOCOL = 3
 RESCAN_ERROR_STATUS = 503
 
 _PROBE_TIMEOUT_S = 3.0
@@ -36,6 +37,7 @@ def create_control_app(
     rescan=None,
     after_rescan=None,
     serve_bound: bool = False,
+    tunnel=None,
 ):
     """Tiny closure app factory (the `core/serve.py::create_app` style).
 
@@ -43,7 +45,12 @@ def create_control_app(
     endpoints over the control socket; `rescan()` re-runs discovery+reconcile.
     `after_rescan()` lets the sibling TCP host app stop stale workspace
     lifespans after a control-socket refresh. `serve_bound` reports whether the
-    TCP host app is up (#472).
+    TCP host app is up (#472). `tunnel` is the `HostTunnel` this daemon dials
+    with, or None for a host with no relay (#471).
+
+    Only the tunnel's PUBLISHED SNAPSHOT is ever read here: ticks mutate it on
+    an executor thread (`run.py::_tunnel_loop`) while requests are served on the
+    loop thread, so reading its live fields would be a torn read.
     """
     from fastapi import FastAPI, HTTPException
 
@@ -65,10 +72,13 @@ def create_control_app(
             "socket": socket_path,
             "capabilities": {
                 "serve": serve_state["bound"],  # actual TCP listener lifecycle
-                "tunnel": False,  # #471: relay tunnel registration
+                "tunnel": tunnel is not None,  # #471: relay tunnel registration
                 "registry": store is not None,  # #472: workspace discovery/registry
                 "runner": False,  # #473: unattended worker supervision
             },
+            # State, not capability: `mship daemon status` renders this, and it
+            # is the only reader-visible source — the tunnel lives in-process.
+            "tunnel": tunnel.snapshot() if tunnel is not None else None,
         }
 
     if store is not None:

--- a/src/mship/core/daemon/control.py
+++ b/src/mship/core/daemon/control.py
@@ -8,6 +8,7 @@ the guarded single source of truth (`src/mship/__init__.py`, pinned by
 Filesystem perms on the unix socket are the auth; no bearer token locally.
 Remote traffic stays on the #471 tunnel path.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -38,6 +39,7 @@ def create_control_app(
     after_rescan=None,
     serve_bound: bool = False,
     tunnel=None,
+    tunnel_state=None,
 ):
     """Tiny closure app factory (the `core/serve.py::create_app` style).
 
@@ -45,8 +47,9 @@ def create_control_app(
     endpoints over the control socket; `rescan()` re-runs discovery+reconcile.
     `after_rescan()` lets the sibling TCP host app stop stale workspace
     lifespans after a control-socket refresh. `serve_bound` reports whether the
-    TCP host app is up (#472). `tunnel` is the `HostTunnel` this daemon dials
-    with, or None for a host with no relay (#471).
+    TCP host app is up (#472). `tunnel` is the live `HostTunnel` this daemon
+    dials with, or None when there is no live tunnel lifecycle (#471).
+    `tunnel_state` can independently publish an initialization failure.
 
     Only the tunnel's PUBLISHED SNAPSHOT is ever read here: ticks mutate it on
     an executor thread (`run.py::_tunnel_loop`) while requests are served on the
@@ -57,7 +60,8 @@ def create_control_app(
     app = FastAPI(title="mshipd control", docs_url=None, redoc_url=None)
     serve_state = {"bound": serve_bound}
     app.state.set_serve_bound = lambda bound: serve_state.update(bound=bound)
-
+    if tunnel_state is None and tunnel is not None:
+        tunnel_state = tunnel.snapshot
 
     @app.get("/health")
     def health():
@@ -78,10 +82,11 @@ def create_control_app(
             },
             # State, not capability: `mship daemon status` renders this, and it
             # is the only reader-visible source — the tunnel lives in-process.
-            "tunnel": tunnel.snapshot() if tunnel is not None else None,
+            "tunnel": tunnel_state() if tunnel_state is not None else None,
         }
 
     if store is not None:
+
         @app.get("/workspaces")
         def workspaces():
             return {
@@ -104,9 +109,7 @@ def create_control_app(
         async def refresh(cleanup_only: bool = False):
             if not cleanup_only and rescan is not None:
                 try:
-                    await asyncio.get_running_loop().run_in_executor(
-                        None, rescan
-                    )
+                    await asyncio.get_running_loop().run_in_executor(None, rescan)
                 except (ValueError, RegistryReadError) as exc:
                     raise HTTPException(
                         status_code=RESCAN_ERROR_STATUS, detail=str(exc)

--- a/src/mship/core/daemon/host_app.py
+++ b/src/mship/core/daemon/host_app.py
@@ -37,6 +37,7 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
+from urllib.parse import parse_qs
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
@@ -321,24 +322,51 @@ def _make_host_auth_dependency(
     return require_host_credential
 
 
-# A refresh credential is `<16 hex>.<64 hex>`; the bound is generous slack over
-# that, not a schema. Bounded like the enroll app's `_EnrollBody`, because this
-# route is unauthenticated by design.
+# A refresh credential is `<16 hex>.<64 hex>`; the credential and request-body
+# bounds are generous slack over that shape, not a schema. Both are local
+# because this route is unauthenticated by design.
 _MAX_REFRESH_LEN = 512
+_MAX_REFRESH_BODY_BYTES = _MAX_REFRESH_LEN * 2
 
 
-def _presented_refresh(body: bytes) -> str | None:
+async def _read_refresh_body(request: Request) -> bytes | None:
+    """Read at most the public exchange's hard body cap.
+
+    Returning as soon as a chunk crosses the cap is load-bearing: `Request.body`
+    would continue receiving and buffering an attacker-controlled stream before
+    the credential-length check ever ran.
+    """
+    body = bytearray()
+    async for chunk in request.stream():
+        if len(body) + len(chunk) > _MAX_REFRESH_BODY_BYTES:
+            return None
+        body.extend(chunk)
+    return bytes(body)
+
+
+def _presented_refresh(body: bytes, content_type: str = "") -> str | None:
     """The refresh credential in a `/host/token` body, or None if there isn't
     one. Every malformed shape collapses to None so the route answers a uniform
-    401: a 422 for an over-long or non-JSON body would make the endpoint an
-    oracle that separates "malformed" from "wrong"."""
-    try:
-        payload = json.loads(body)
-    except ValueError:
-        return None
-    if not isinstance(payload, Mapping):
-        return None
-    credential = payload.get("refresh")
+    401 rather than telling an unauthenticated caller which failure occurred."""
+    if content_type.partition(";")[0].strip().lower() == (
+        "application/x-www-form-urlencoded"
+    ):
+        try:
+            fields = parse_qs(
+                body.decode("utf-8"), keep_blank_values=True, max_num_fields=4
+            )
+        except (UnicodeDecodeError, ValueError):
+            return None
+        values = fields.get("refresh", [])
+        credential = values[0] if len(values) == 1 else None
+    else:
+        try:
+            payload = json.loads(body)
+        except ValueError:
+            return None
+        if not isinstance(payload, Mapping):
+            return None
+        credential = payload.get("refresh")
     if not isinstance(credential, str) or not credential:
         return None
     if len(credential) > _MAX_REFRESH_LEN:
@@ -499,7 +527,14 @@ def create_host_app(
             malformed one fails exactly like a wrong credential (401), instead
             of a 422 that tells an unauthenticated caller which it was.
             """
-            credential = _presented_refresh(await request.body())
+            body = await _read_refresh_body(request)
+            credential = (
+                _presented_refresh(
+                    body, request.headers.get("content-type", "")
+                )
+                if body is not None
+                else None
+            )
             granted = exchange_refresh(credential) if credential else None
             if granted is None:
                 raise HTTPException(

--- a/src/mship/core/daemon/host_app.py
+++ b/src/mship/core/daemon/host_app.py
@@ -41,6 +41,7 @@ from typing import Any, Callable
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
+from mship.core.daemon.capabilities import runner_block
 from mship.core.daemon.control import RESCAN_ERROR_STATUS
 from mship.core.daemon.registry import RegistryReadError, RegistryStore, WorkspaceEntry
 from mship.core.workspace_context import ContextError
@@ -248,19 +249,6 @@ _BEARER_PREFIX = "Bearer "
 # stamps are the only honest discriminator. A direct caller who forges one only
 # denies itself the standing-token fallback, so the failure direction is safe.
 _EDGE_HEADERS = ("x-forwarded-for", "x-forwarded-host", "x-forwarded-proto")
-
-
-def runner_block(raw: object | None) -> dict:
-    """Project the registry's opaque `runner:` passthrough (AC6's one owner).
-
-    One projection, one shape, everywhere a runner block is published — #473
-    fills `state` in here and nowhere else. Declared-and-enabled reads
-    `unknown` because #471 carries runner state but never observes it; anything
-    else — absent, disabled, or malformed from a hand-edited registry — reads
-    `disabled` rather than failing a request.
-    """
-    enabled = bool(raw.get("enabled")) if isinstance(raw, Mapping) else False
-    return {"enabled": enabled, "state": "unknown" if enabled else "disabled"}
 
 
 def _is_relay_borne(request: Request) -> bool:

--- a/src/mship/core/daemon/host_app.py
+++ b/src/mship/core/daemon/host_app.py
@@ -251,12 +251,29 @@ _BEARER_PREFIX = "Bearer "
 _EDGE_HEADERS = ("x-forwarded-for", "x-forwarded-host", "x-forwarded-proto")
 
 
-def _is_relay_borne(request: Request) -> bool:
-    return any(name in request.headers for name in _EDGE_HEADERS)
+def _is_relay_borne(request: Request, relay_domain: str | None = None) -> bool:
+    """Two independent witnesses, either of which is enough (fail closed).
+
+    The edge headers are the edge's own testimony, and an edge misconfigured to
+    strip them would silently re-open the standing token to everything that can
+    reach the relay. The `Host` the request was addressed to is the second: our
+    tunnel is only ever addressed under the relay's domain, so a request that
+    names it arrived through the relay whatever the headers say. Matched as a
+    dotted suffix, never a substring — `notrelay.example` is somebody else."""
+    if any(name in request.headers for name in _EDGE_HEADERS):
+        return True
+    if not relay_domain:
+        return False
+    # Host may carry a port, and DNS names are case-insensitive.
+    hostname = request.headers.get("host", "").split(":")[0].strip(".").lower()
+    domain = relay_domain.strip().strip(".").lower()
+    return hostname == domain or hostname.endswith(f".{domain}")
 
 
 def _make_host_auth_dependency(
-    token: str | None, verify_bearer: Callable[[str], bool] | None
+    token: str | None,
+    verify_bearer: Callable[[str], bool] | None,
+    relay_domain: str | None = None,
 ):
     """Accept a short-lived host bearer; fall back to the standing token for
     direct origins only, plus the namespaced UI's token/cookie exchange."""
@@ -277,7 +294,7 @@ def _make_host_auth_dependency(
         if verify_bearer is not None and provided.startswith(_BEARER_PREFIX):
             if verify_bearer(provided[len(_BEARER_PREFIX):]):
                 return
-        if token is None or _is_relay_borne(request):
+        if token is None or _is_relay_borne(request, relay_domain):
             raise HTTPException(
                 status_code=401, detail="missing or invalid bearer token"
             )
@@ -349,6 +366,7 @@ def create_host_app(
     *,
     auth_token: str | None,
     verify_bearer: Callable[[str], bool] | None = None,
+    relay_domain: str | None = None,
     exchange_refresh: Callable[[str], tuple[str, float] | None] | None = None,
     host_id: str | None = None,
     instance_id: str | None = None,
@@ -371,6 +389,9 @@ def create_host_app(
     `(token, expires_in)` for a valid refresh credential (None → 401), which is
     what `POST /host/token` publishes. Without an exchange the route is not
     registered at all — a host with no refresh store has nothing to mint.
+    `relay_domain` is the domain of the relay this host tunnels to; it is the
+    second, edge-independent witness `_is_relay_borne` uses to keep the standing
+    token off relay-borne traffic.
     `host_id`/`instance_id`/`host_state()` are the identity and tunnel state
     `/health` reports for the daemon's read-back and GC's ladder, and
     `runner_config()` is the host-level runner block `/health` projects — the
@@ -404,7 +425,7 @@ def create_host_app(
     # unauthenticated reachability probe the daemon and GC both poll.
     guarded = APIRouter(
         dependencies=(
-            [Depends(_make_host_auth_dependency(auth_token, verify_bearer))]
+            [Depends(_make_host_auth_dependency(auth_token, verify_bearer, relay_domain))]
             if (auth_token or verify_bearer)
             else []
         )

--- a/src/mship/core/daemon/host_app.py
+++ b/src/mship/core/daemon/host_app.py
@@ -222,6 +222,8 @@ def _default_build_subapp(
     pr_watch_interval: float | None,
     gh_app_id: str | None,
     gh_app_key: str | None,
+    host_id,
+    workspace_id: str,
 ):
     from mship.core.serve import create_app
     from mship.core.spec_store import SPECS_DIRNAME
@@ -240,6 +242,8 @@ def _default_build_subapp(
         gh_app_id=gh_app_id,
         gh_app_key=gh_app_key,
         pr_watch_interval=pr_watch_interval,
+        host_id=host_id,
+        workspace_id=workspace_id,
     )
 
 
@@ -481,6 +485,8 @@ def create_host_app(
                         pr_watch_interval=pr_watch_interval,
                         gh_app_id=gh_app_id,
                         gh_app_key=gh_app_key,
+                        host_id=host_id,
+                        workspace_id=entry.id,
                     ),
                     fp,
                 )

--- a/src/mship/core/daemon/host_app.py
+++ b/src/mship/core/daemon/host_app.py
@@ -396,8 +396,8 @@ def create_host_app(
     verify_bearer: Callable[[str], bool] | None = None,
     relay_domain: str | None = None,
     exchange_refresh: Callable[[str], tuple[str, float] | None] | None = None,
-    host_id: str | None = None,
-    instance_id: str | None = None,
+    host_id: str | Callable[[], str | None] | None = None,
+    instance_id: str | Callable[[], str | None] | None = None,
     host_state: Callable[[], Mapping] | None = None,
     runner_config: Callable[[], Any] | None = None,
     build_subapp: Callable = _default_build_subapp,
@@ -501,13 +501,16 @@ def create_host_app(
     # in a sibling ASGI app. Expose only the post-rescan cleanup it must await.
     app.state.drop_stale_subapps = _drop_stale
 
+    def _current_identity(value):
+        return value() if callable(value) else value
+
     @app.get("/health")
     def health():
         entries = _entries()
         return {
             "status": "ok",
-            "host_id": host_id,
-            "instance_id": instance_id,
+            "host_id": _current_identity(host_id),
+            "instance_id": _current_identity(instance_id),
             "workspaces": len([e for e in entries if not e.ignored]),
             "degraded": len([e for e in entries if e.state == "degraded" and not e.ignored]),
             "tunnel": dict(host_state()) if host_state is not None else {"state": "disabled"},

--- a/src/mship/core/daemon/host_app.py
+++ b/src/mship/core/daemon/host_app.py
@@ -29,16 +29,17 @@ reachability, so both stay open.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import secrets
 import tempfile
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Mapping
+from typing import Any, Callable
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
 
 from mship.core.daemon.control import RESCAN_ERROR_STATUS
 from mship.core.daemon.registry import RegistryReadError, RegistryStore, WorkspaceEntry
@@ -315,11 +316,29 @@ def _make_host_auth_dependency(
     return require_host_credential
 
 
-class _TokenExchange(BaseModel):
-    """Bounded like the enroll app's `_EnrollBody`: an unbounded body on an
-    unauthenticated route is free memory for anyone who can reach it."""
+# A refresh credential is `<16 hex>.<64 hex>`; the bound is generous slack over
+# that, not a schema. Bounded like the enroll app's `_EnrollBody`, because this
+# route is unauthenticated by design.
+_MAX_REFRESH_LEN = 512
 
-    refresh: str = Field(max_length=512)
+
+def _presented_refresh(body: bytes) -> str | None:
+    """The refresh credential in a `/host/token` body, or None if there isn't
+    one. Every malformed shape collapses to None so the route answers a uniform
+    401: a 422 for an over-long or non-JSON body would make the endpoint an
+    oracle that separates "malformed" from "wrong"."""
+    try:
+        payload = json.loads(body)
+    except ValueError:
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    credential = payload.get("refresh")
+    if not isinstance(credential, str) or not credential:
+        return None
+    if len(credential) > _MAX_REFRESH_LEN:
+        return None
+    return credential
 
 
 def _with_internal_authorization(
@@ -346,6 +365,7 @@ def create_host_app(
     host_id: str | None = None,
     instance_id: str | None = None,
     host_state: Callable[[], Mapping] | None = None,
+    runner_config: Callable[[], Any] | None = None,
     build_subapp: Callable = _default_build_subapp,
     rescan: Callable | None = None,
     pr_watch_interval: float | None = None,
@@ -364,7 +384,9 @@ def create_host_app(
     what `POST /host/token` publishes. Without an exchange the route is not
     registered at all — a host with no refresh store has nothing to mint.
     `host_id`/`instance_id`/`host_state()` are the identity and tunnel state
-    `/health` reports for the daemon's read-back and GC's ladder.
+    `/health` reports for the daemon's read-back and GC's ladder, and
+    `runner_config()` is the host-level runner block `/health` projects — the
+    seam #473 fills; absent, the host reports no runner.
     """
     from contextlib import asynccontextmanager
 
@@ -452,16 +474,24 @@ def create_host_app(
             "workspaces": len([e for e in entries if not e.ignored]),
             "degraded": len([e for e in entries if e.state == "degraded" and not e.ignored]),
             "tunnel": dict(host_state()) if host_state is not None else {"state": "disabled"},
-            "runner": runner_block(None),
+            "runner": runner_block(
+                runner_config() if runner_config is not None else None
+            ),
         }
 
     if exchange_refresh is not None:
         @app.post("/host/token")
-        def mint_host_token(body: _TokenExchange):
+        async def mint_host_token(request: Request):
             """The bootstrap exchange (AC9): the phone's persisted refresh
             credential in, a short-lived bearer out — from the host that will
-            verify it, never proxied and never published into the directory."""
-            granted = exchange_refresh(body.refresh)
+            verify it, never proxied and never published into the directory.
+
+            The body is read here rather than declared as a model so that a
+            malformed one fails exactly like a wrong credential (401), instead
+            of a 422 that tells an unauthenticated caller which it was.
+            """
+            credential = _presented_refresh(await request.body())
+            granted = exchange_refresh(credential) if credential else None
             if granted is None:
                 raise HTTPException(
                     status_code=401, detail="invalid or expired refresh credential"

--- a/src/mship/core/daemon/host_app.py
+++ b/src/mship/core/daemon/host_app.py
@@ -15,7 +15,16 @@ guarded by a lock.
 Addressing is by ID only — name-in-URL would reintroduce the same-name
 ambiguity the id exists to kill. Degraded/missing ids → 503 with the stored
 reason (matches #471's "workspace unavailable" ladder); unknown ids → 404.
-One host-level token gates everything (the #471 short-lived-token seam).
+
+Auth is tiered (#471): callers present a short-lived host bearer, checked by an
+injected `verify_bearer` — the app never holds the material. The standing
+`ensure_host_token` string survives in two narrow roles: the credential the
+sub-apps verify (rewritten into the forwarded scope, since a sub-app knows
+nothing of host bearers), and a direct/loopback-origin fallback so first-time
+LAN pairing works before any bearer exists (AC9 — never over the relay). The
+guard rides an `APIRouter`, not the app: `POST /host/token` cannot require the
+credential it mints, and `/health` is what the daemon and GC poll to decide
+reachability, so both stay open.
 """
 from __future__ import annotations
 
@@ -27,8 +36,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Mapping
 
-from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
 
 from mship.core.daemon.control import RESCAN_ERROR_STATUS
 from mship.core.daemon.registry import RegistryReadError, RegistryStore, WorkspaceEntry
@@ -230,8 +240,37 @@ def _default_build_subapp(
     )
 
 
-def _make_host_auth_dependency(token: str):
-    """Accept the host bearer, plus the namespaced UI's token/cookie exchange."""
+_BEARER_PREFIX = "Bearer "
+
+# A relay-borne request arrives through Caddy → sish → the ssh -R tunnel, so it
+# hits this app from loopback exactly like a direct one; the headers the edge
+# stamps are the only honest discriminator. A direct caller who forges one only
+# denies itself the standing-token fallback, so the failure direction is safe.
+_EDGE_HEADERS = ("x-forwarded-for", "x-forwarded-host", "x-forwarded-proto")
+
+
+def runner_block(raw: object | None) -> dict:
+    """Project the registry's opaque `runner:` passthrough (AC6's one owner).
+
+    One projection, one shape, everywhere a runner block is published — #473
+    fills `state` in here and nowhere else. Declared-and-enabled reads
+    `unknown` because #471 carries runner state but never observes it; anything
+    else — absent, disabled, or malformed from a hand-edited registry — reads
+    `disabled` rather than failing a request.
+    """
+    enabled = bool(raw.get("enabled")) if isinstance(raw, Mapping) else False
+    return {"enabled": enabled, "state": "unknown" if enabled else "disabled"}
+
+
+def _is_relay_borne(request: Request) -> bool:
+    return any(name in request.headers for name in _EDGE_HEADERS)
+
+
+def _make_host_auth_dependency(
+    token: str | None, verify_bearer: Callable[[str], bool] | None
+):
+    """Accept a short-lived host bearer; fall back to the standing token for
+    direct origins only, plus the namespaced UI's token/cookie exchange."""
     import hmac
     import time
 
@@ -239,14 +278,21 @@ def _make_host_auth_dependency(token: str):
 
     from mship.webui import COOKIE_NAME, _cookie_is_valid
 
-    expected = f"Bearer {token}".encode()
+    expected = f"Bearer {token}".encode() if token is not None else b""
 
-    def require_host_token(
+    def require_host_credential(
         request: Request,
         authorization: str | None = Header(default=None),
     ):
-        provided = (authorization or "").encode()
-        if hmac.compare_digest(provided, expected):
+        provided = authorization or ""
+        if verify_bearer is not None and provided.startswith(_BEARER_PREFIX):
+            if verify_bearer(provided[len(_BEARER_PREFIX):]):
+                return
+        if token is None or _is_relay_borne(request):
+            raise HTTPException(
+                status_code=401, detail="missing or invalid bearer token"
+            )
+        if hmac.compare_digest(provided.encode(), expected):
             return
         segments = request.url.path.split("/")
         is_workspace_ui = any(
@@ -266,13 +312,40 @@ def _make_host_auth_dependency(token: str):
             status_code=401, detail="missing or invalid bearer token"
         )
 
-    return require_host_token
+    return require_host_credential
+
+
+class _TokenExchange(BaseModel):
+    """Bounded like the enroll app's `_EnrollBody`: an unbounded body on an
+    unauthenticated route is free memory for anyone who can reach it."""
+
+    refresh: str = Field(max_length=512)
+
+
+def _with_internal_authorization(
+    headers: list[tuple[bytes, bytes]], token: str | None
+) -> list[tuple[bytes, bytes]]:
+    """Swap the caller's credential for the sub-app's own.
+
+    Sub-apps verify the standing token (`core/serve.py`'s single-string
+    dependency), so forwarding a short-lived host bearer 401s every call — and
+    the caller's credential has no business inside a workspace app anyway.
+    """
+    rewritten = [(k, v) for k, v in headers if k.lower() != b"authorization"]
+    if token is not None:
+        rewritten.append((b"authorization", f"Bearer {token}".encode()))
+    return rewritten
 
 
 def create_host_app(
     store: RegistryStore,
     *,
     auth_token: str | None,
+    verify_bearer: Callable[[str], bool] | None = None,
+    exchange_refresh: Callable[[str], tuple[str, float] | None] | None = None,
+    host_id: str | None = None,
+    instance_id: str | None = None,
+    host_state: Callable[[], Mapping] | None = None,
     build_subapp: Callable = _default_build_subapp,
     rescan: Callable | None = None,
     pr_watch_interval: float | None = None,
@@ -284,6 +357,14 @@ def create_host_app(
     `rescan()` (optional) re-runs discovery+reconcile and returns nothing; the
     refresh route calls it before diffing the registry. `build_subapp` is the
     injectable seam for tests.
+
+    Auth material stays outside: `verify_bearer(presented)` decides whether a
+    short-lived host bearer is live, and `exchange_refresh(credential)` returns
+    `(token, expires_in)` for a valid refresh credential (None → 401), which is
+    what `POST /host/token` publishes. Without an exchange the route is not
+    registered at all — a host with no refresh store has nothing to mint.
+    `host_id`/`instance_id`/`host_state()` are the identity and tunnel state
+    `/health` reports for the daemon's read-back and GC's ladder.
     """
     from contextlib import asynccontextmanager
 
@@ -306,9 +387,18 @@ def create_host_app(
                     await sub.stop()
                 subapps.clear()
 
-    dependencies = [Depends(_make_host_auth_dependency(auth_token))] if auth_token else []
     app = FastAPI(title="mship host", docs_url=None, redoc_url=None,
-                  openapi_url=None, dependencies=dependencies, lifespan=_lifespan)
+                  openapi_url=None, lifespan=_lifespan)
+    # On a router, NOT the app: `POST /host/token` mints the very credential a
+    # blanket app-level dependency would demand of it, and `/health` is the
+    # unauthenticated reachability probe the daemon and GC both poll.
+    guarded = APIRouter(
+        dependencies=(
+            [Depends(_make_host_auth_dependency(auth_token, verify_bearer))]
+            if (auth_token or verify_bearer)
+            else []
+        )
+    )
 
     def _entries() -> list[WorkspaceEntry]:
         return store.load().entries
@@ -357,11 +447,29 @@ def create_host_app(
         entries = _entries()
         return {
             "status": "ok",
+            "host_id": host_id,
+            "instance_id": instance_id,
             "workspaces": len([e for e in entries if not e.ignored]),
             "degraded": len([e for e in entries if e.state == "degraded" and not e.ignored]),
+            "tunnel": dict(host_state()) if host_state is not None else {"state": "disabled"},
+            "runner": runner_block(None),
         }
 
-    @app.get("/workspaces")
+    if exchange_refresh is not None:
+        @app.post("/host/token")
+        def mint_host_token(body: _TokenExchange):
+            """The bootstrap exchange (AC9): the phone's persisted refresh
+            credential in, a short-lived bearer out — from the host that will
+            verify it, never proxied and never published into the directory."""
+            granted = exchange_refresh(body.refresh)
+            if granted is None:
+                raise HTTPException(
+                    status_code=401, detail="invalid or expired refresh credential"
+                )
+            token, expires_in = granted
+            return {"token": token, "expires_in": expires_in}
+
+    @guarded.get("/workspaces")
     def list_workspaces():
         return {
             "workspaces": [
@@ -373,13 +481,14 @@ def create_host_app(
                     "detail": e.detail,
                     "repos": [r.model_dump() for r in e.repos],
                     "runtime": e.runtime.model_dump(),
+                    "runner": runner_block(e.runner),
                 }
                 for e in _entries()
                 if not e.ignored
             ]
         }
 
-    @app.post("/workspaces/refresh")
+    @guarded.post("/workspaces/refresh")
     async def refresh():
         if rescan is not None:
             try:
@@ -391,7 +500,7 @@ def create_host_app(
         await _drop_stale()
         return {"workspaces": len(_entries())}
 
-    @app.api_route(
+    @guarded.api_route(
         "/workspaces/{workspace_id}/{path:path}",
         methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
     )
@@ -422,6 +531,9 @@ def create_host_app(
         scope["root_path"] = workspace_root
         scope["path"] = workspace_root + subapp_path
         scope["raw_path"] = scope["path"].encode()
+        scope["headers"] = _with_internal_authorization(
+            scope.get("headers", []), auth_token
+        )
 
         # STREAMED, not buffered: `POST /exec/{verb}` is consumed with
         # iter_raw() to render task output live, and a client disconnect must
@@ -477,4 +589,5 @@ def create_host_app(
             headers={k.decode(): v.decode() for k, v in started.get("headers", [])},
         )
 
+    app.include_router(guarded)
     return app

--- a/src/mship/core/daemon/host_auth.py
+++ b/src/mship/core/daemon/host_auth.py
@@ -33,7 +33,7 @@ from typing import Callable
 
 from mship.core.daemon.host_token import ensure_host_root_secret
 from mship.core.daemon.paths import host_refresh_path
-from mship.core.relay.token_clock import is_expired
+from mship.core.relay.token_clock import AnchoredClock, Deadline
 
 # Long-lived by design (it is the thing that survives reboots and flaps), but
 # not forever: a phone that has not come back in a month re-pairs.
@@ -94,13 +94,16 @@ class RefreshStore:
         ttl_seconds: float = REFRESH_TTL_S,
         max_clients: int = MAX_REFRESH_CLIENTS,
         clock: Callable[[], float] = time.time,
+        monotonic_clock: Callable[[], float] = time.monotonic,
+        epoch: str | None = None,
     ) -> None:
         self._home = Path(home)
         self._path = host_refresh_path(self._home)
         self._lock = self._path.with_name(self._path.name + ".lock")
         self._ttl = ttl_seconds
         self._max_clients = max_clients
-        self._clock = clock
+        self._wall_clock = clock
+        self._clock = AnchoredClock(wall=clock, mono=monotonic_clock, epoch=epoch)
 
     # -- storage ----------------------------------------------------------
 
@@ -133,11 +136,11 @@ class RefreshStore:
         self._path.chmod(0o600)
 
     def _live(self, clients: dict) -> dict:
-        now = self._clock()
         return {
             cid: rec
             for cid, rec in clients.items()
-            if isinstance(rec, dict) and not is_expired(rec.get("expires_at", 0), now)
+            if isinstance(rec, dict)
+            and not self._clock.is_expired(Deadline.from_record(rec))
         }
 
     # -- credential derivation --------------------------------------------
@@ -160,9 +163,16 @@ class RefreshStore:
             live = self._live(clients)
             existing = live.get(client_id)
             if existing is not None and existing.get("nonce"):
-                if live != clients:  # expired siblings to drop; else touch nothing
+                secret = self._derive(host_id, client, existing["nonce"])
+                needs_save = live != clients
+                if not hmac.compare_digest(
+                    _hash(secret), str(existing.get("secret_hash", ""))
+                ):
+                    live[client_id] = {**existing, "secret_hash": _hash(secret)}
+                    needs_save = True
+                if needs_save:
                     self._save(live)
-                return f"{client_id}.{self._derive(host_id, client, existing['nonce'])}"
+                return f"{client_id}.{secret}"
             # No usable record (absent, expired, or hand-corrupted) → mint one.
             # Evict from the PRE-EXISTING set only, so the credential we are
             # about to hand back can never be the one the cap drops.
@@ -175,7 +185,7 @@ class RefreshStore:
 
             nonce = secrets.token_hex(16)
             secret = self._derive(host_id, client, nonce)
-            now = self._clock()
+            now = self._wall_clock()
             live[client_id] = {
                 "client_id": client_id,
                 "client": client,
@@ -183,7 +193,7 @@ class RefreshStore:
                 "nonce": nonce,
                 "secret_hash": _hash(secret),
                 "created_at": now,
-                "expires_at": now + self._ttl,
+                **self._clock.deadline(self._ttl).as_record(),
             }
             self._save(live)
         return f"{client_id}.{secret}"
@@ -202,7 +212,7 @@ class RefreshStore:
             return None
         if not hmac.compare_digest(_hash(secret), str(rec.get("secret_hash", ""))):
             return None
-        if is_expired(rec.get("expires_at", 0), self._clock()):
+        if self._clock.is_expired(Deadline.from_record(rec)):
             return None
         return RefreshGrant(
             client_id=client_id,

--- a/src/mship/core/daemon/host_auth.py
+++ b/src/mship/core/daemon/host_auth.py
@@ -1,0 +1,196 @@
+"""Refresh credentials (#471): one long-lived, revocable credential per client.
+
+The phone holds one of these and trades it for short-lived bearers
+(`host_token`). Two properties matter and neither is free:
+
+- **Stable per `(host_id, client)` (AC11).** A network flap re-registers, and
+  re-registration must re-publish the *same* credential — otherwise N
+  reconnects mint N credentials, the file grows, and the phone's copy becomes
+  one of many. Since nothing is stored in plaintext, "the same credential"
+  cannot mean "read it back": it is *derived* from the host root secret and a
+  per-record nonce, so a re-issue recomputes it and writes nothing at all.
+- **Revocation is real.** `revoke` drops the record (and its nonce), so a later
+  re-registration of the same client name derives a *different* credential
+  rather than resurrecting the one the operator just killed.
+
+Verification is a pure read; only issue/revoke write.
+"""
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import hmac
+import json
+import re
+import secrets
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from mship.core.daemon.host_token import ensure_host_root_secret
+from mship.core.daemon.paths import host_refresh_path
+from mship.core.relay.token_clock import is_expired
+
+# Long-lived by design (it is the thing that survives reboots and flaps), but
+# not forever: a phone that has not come back in a month re-pairs.
+REFRESH_TTL_S = 30 * 86_400
+
+MAX_REFRESH_CLIENTS = 32
+
+# Client ids are a truncated sha256 hex digest (see `_client_id`).
+_ID_RE = re.compile(r"\A[0-9a-f]{1,64}\Z")
+
+
+@dataclass(frozen=True)
+class RefreshGrant:
+    client_id: str
+    client: str
+    host_id: str
+
+
+@contextmanager
+def _locked(lock_path: Path, mode: int):
+    """Advisory flock (the `registry.py`/`state.py` house pattern)."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    lock_path.touch(exist_ok=True, mode=0o600)
+    with open(lock_path, "r+") as lf:
+        fcntl.flock(lf, mode)
+        try:
+            yield
+        finally:
+            fcntl.flock(lf, fcntl.LOCK_UN)
+
+
+def _client_id(host_id: str, client: str) -> str:
+    """A stable, traversal-proof record key for one client of one host."""
+    return hashlib.sha256(f"{host_id}\x00{client}".encode("utf-8")).hexdigest()[:16]
+
+
+def _hash(secret: str) -> str:
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()
+
+
+class RefreshStore:
+    """Flock'd RMW over one JSON doc of per-client refresh records."""
+
+    def __init__(
+        self,
+        home: Path,
+        *,
+        ttl_seconds: float = REFRESH_TTL_S,
+        max_clients: int = MAX_REFRESH_CLIENTS,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._home = Path(home)
+        self._path = host_refresh_path(self._home)
+        self._lock = self._path.with_name(self._path.name + ".lock")
+        self._ttl = ttl_seconds
+        self._max_clients = max_clients
+        self._clock = clock
+
+    # -- storage ----------------------------------------------------------
+
+    def _load(self) -> dict:
+        """Records by client_id; a corrupt/truncated doc reads as empty (its
+        records are unverifiable anyway — `RegistryStore._load_nolock`)."""
+        try:
+            doc = json.loads(self._path.read_text())
+            clients = doc["clients"]
+            return clients if isinstance(clients, dict) else {}
+        except (OSError, ValueError, KeyError, TypeError):
+            return {}
+
+    def _save(self, clients: dict) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        tmp = self._path.with_name(self._path.name + ".tmp")
+        tmp.write_text(json.dumps({"clients": clients}, indent=2))
+        tmp.chmod(0o600)
+        tmp.replace(self._path)
+
+    def _live(self, clients: dict) -> dict:
+        now = self._clock()
+        return {
+            cid: rec
+            for cid, rec in clients.items()
+            if isinstance(rec, dict) and not is_expired(rec.get("expires_at", 0), now)
+        }
+
+    # -- credential derivation --------------------------------------------
+
+    def _derive(self, host_id: str, client: str, nonce: str) -> str:
+        """The credential secret for one record — recomputable, so a re-issue
+        returns the same string without ever storing the plaintext."""
+        root = ensure_host_root_secret(self._home)
+        msg = f"{host_id}\x00{client}\x00{nonce}".encode("utf-8")
+        return hmac.new(root, msg, hashlib.sha256).hexdigest()
+
+    # -- API ---------------------------------------------------------------
+
+    def issue_refresh(self, *, host_id: str, client: str) -> str:
+        """Return this client's refresh credential, minting it only if it has
+        none. Re-registration is a no-op on disk (AC11)."""
+        client_id = _client_id(host_id, client)
+        with _locked(self._lock, fcntl.LOCK_EX):
+            clients = self._load()
+            live = self._live(clients)
+            existing = live.get(client_id)
+            if existing is not None and existing.get("nonce"):
+                if live != clients:  # expired siblings to drop; else touch nothing
+                    self._save(live)
+                return f"{client_id}.{self._derive(host_id, client, existing['nonce'])}"
+            # No usable record (absent, expired, or hand-corrupted) → mint one.
+
+            nonce = secrets.token_hex(16)
+            secret = self._derive(host_id, client, nonce)
+            now = self._clock()
+            live[client_id] = {
+                "client_id": client_id,
+                "client": client,
+                "host_id": host_id,
+                "nonce": nonce,
+                "secret_hash": _hash(secret),
+                "created_at": now,
+                "expires_at": now + self._ttl,
+            }
+            if len(live) > self._max_clients:
+                keep = sorted(
+                    live.items(), key=lambda kv: kv[1].get("created_at", 0), reverse=True
+                )[: self._max_clients]
+                live = dict(keep)
+            self._save(live)
+        return f"{client_id}.{secret}"
+
+    def verify_refresh(self, presented: str) -> RefreshGrant | None:
+        """Return the grant behind a valid, unrevoked, unexpired credential,
+        else None. Never raises, and never writes."""
+        if "." not in presented:
+            return None
+        client_id, secret = presented.split(".", 1)
+        if not _ID_RE.match(client_id):
+            return None
+        with _locked(self._lock, fcntl.LOCK_SH):
+            rec = self._load().get(client_id)
+        if not isinstance(rec, dict):
+            return None
+        if not hmac.compare_digest(_hash(secret), str(rec.get("secret_hash", ""))):
+            return None
+        if is_expired(rec.get("expires_at", 0), self._clock()):
+            return None
+        return RefreshGrant(
+            client_id=client_id,
+            client=rec.get("client", ""),
+            host_id=rec.get("host_id", ""),
+        )
+
+    def revoke(self, *, host_id: str, client: str) -> bool:
+        """Drop this client's credential. True if one was there to drop."""
+        client_id = _client_id(host_id, client)
+        with _locked(self._lock, fcntl.LOCK_EX):
+            clients = self._load()
+            if client_id not in clients:
+                return False
+            del clients[client_id]
+            self._save(clients)
+        return True

--- a/src/mship/core/daemon/host_auth.py
+++ b/src/mship/core/daemon/host_auth.py
@@ -206,8 +206,7 @@ class RefreshStore:
         client_id, secret = presented.split(".", 1)
         if not _ID_RE.match(client_id):
             return None
-        with _locked(self._lock, fcntl.LOCK_SH):
-            rec = self._load().get(client_id)
+        rec = self._load().get(client_id)
         if not isinstance(rec, dict):
             return None
         if not hmac.compare_digest(_hash(secret), str(rec.get("secret_hash", ""))):

--- a/src/mship/core/daemon/host_auth.py
+++ b/src/mship/core/daemon/host_auth.py
@@ -21,8 +21,10 @@ import fcntl
 import hashlib
 import hmac
 import json
+import os
 import re
 import secrets
+import tempfile
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -39,8 +41,10 @@ REFRESH_TTL_S = 30 * 86_400
 
 MAX_REFRESH_CLIENTS = 32
 
-# Client ids are a truncated sha256 hex digest (see `_client_id`).
-_ID_RE = re.compile(r"\A[0-9a-f]{1,64}\Z")
+# Client ids are exactly the first 16 hex chars of a sha256 digest
+# (`_client_id`); anything else is rejected before it is used as a lookup key.
+_CLIENT_ID_LEN = 16
+_ID_RE = re.compile(r"\A[0-9a-f]{%d}\Z" % _CLIENT_ID_LEN)
 
 
 @dataclass(frozen=True)
@@ -50,10 +54,18 @@ class RefreshGrant:
     host_id: str
 
 
+def _private_dir(path: Path) -> None:
+    """Owner-only parent dir. The corrective chmod is not redundant: mkdir's
+    mode is masked by the umask, and `exist_ok=True` never tightens a dir that
+    already exists too loose (the `registry.py`/`host_app.py` house pattern)."""
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.parent.chmod(0o700)
+
+
 @contextmanager
 def _locked(lock_path: Path, mode: int):
     """Advisory flock (the `registry.py`/`state.py` house pattern)."""
-    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    _private_dir(lock_path)
     lock_path.touch(exist_ok=True, mode=0o600)
     with open(lock_path, "r+") as lf:
         fcntl.flock(lf, mode)
@@ -103,11 +115,22 @@ class RefreshStore:
             return {}
 
     def _save(self, clients: dict) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        tmp = self._path.with_name(self._path.name + ".tmp")
-        tmp.write_text(json.dumps({"clients": clients}, indent=2))
-        tmp.chmod(0o600)
-        tmp.replace(self._path)
+        """Atomic, owner-only write (`host_app._atomic_write_owner_file` shape):
+        mkstemp creates the temp file 0600, so the hashes are never briefly
+        world-readable."""
+        _private_dir(self._path)
+        fd, temp_name = tempfile.mkstemp(
+            prefix=self._path.name + ".", dir=self._path.parent
+        )
+        temp = Path(temp_name)
+        try:
+            with os.fdopen(fd, "w") as stream:
+                stream.write(json.dumps({"clients": clients}, indent=2))
+            os.replace(temp, self._path)
+        except BaseException:
+            temp.unlink(missing_ok=True)
+            raise
+        self._path.chmod(0o600)
 
     def _live(self, clients: dict) -> dict:
         now = self._clock()
@@ -141,6 +164,14 @@ class RefreshStore:
                     self._save(live)
                 return f"{client_id}.{self._derive(host_id, client, existing['nonce'])}"
             # No usable record (absent, expired, or hand-corrupted) → mint one.
+            # Evict from the PRE-EXISTING set only, so the credential we are
+            # about to hand back can never be the one the cap drops.
+            if len(live) >= self._max_clients:
+                live = dict(sorted(
+                    live.items(),
+                    key=lambda kv: kv[1].get("created_at", 0),
+                    reverse=True,
+                )[: max(self._max_clients - 1, 0)])
 
             nonce = secrets.token_hex(16)
             secret = self._derive(host_id, client, nonce)
@@ -154,11 +185,6 @@ class RefreshStore:
                 "created_at": now,
                 "expires_at": now + self._ttl,
             }
-            if len(live) > self._max_clients:
-                keep = sorted(
-                    live.items(), key=lambda kv: kv[1].get("created_at", 0), reverse=True
-                )[: self._max_clients]
-                live = dict(keep)
             self._save(live)
         return f"{client_id}.{secret}"
 
@@ -191,6 +217,9 @@ class RefreshStore:
             clients = self._load()
             if client_id not in clients:
                 return False
-            del clients[client_id]
-            self._save(clients)
+            # Prune here too: this is a write, so pay off the expired records
+            # rather than re-persisting them.
+            remaining = self._live(clients)
+            remaining.pop(client_id, None)
+            self._save(remaining)
         return True

--- a/src/mship/core/daemon/host_token.py
+++ b/src/mship/core/daemon/host_token.py
@@ -1,0 +1,154 @@
+"""Short-lived host bearer tokens (#471): `<token_id>.<secret>`, hash at rest.
+
+Modelled on `core.relay.run_token`, with two deliberate differences:
+
+- **One JSON doc, not a file per token**, because these are minted often and
+  must be prunable/cappable as a set (a per-file store grows unbounded until
+  something sweeps it, and nothing would).
+- **Expiry is delegated to `core.relay.token_clock`**, not re-derived here.
+  These bearers live and die on a long-running VM whose wall clock gets
+  stepped, so the deadline carries an epoch-tagged monotonic floor (AC10).
+
+Verification is a pure read: a reconnecting phone must not churn the store
+(AC11). Only issuance writes, and it prunes and caps while it holds the lock.
+"""
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import hmac
+import json
+import re
+import secrets
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from mship.core.daemon.paths import host_secret_path, host_tokens_path
+from mship.core.relay.keys import ensure_secret_file
+from mship.core.relay.token_clock import AnchoredClock, Deadline
+
+# Deliberately short: a host token is the credential a phone carries, and the
+# only revocation that survives a lost/stolen device is expiry (revocation
+# happens one tier up, on the refresh credential in `host_auth`).
+HOST_TOKEN_TTL_S = 300
+
+# Bounded so the doc cannot grow without limit while every token is still live
+# (many devices, or a client re-minting in a tight loop).
+MAX_HOST_TOKENS = 64
+
+_ROOT_SECRET_LEN = 32
+
+# Token ids are `secrets.token_hex(8)`. Anything else is rejected before it is
+# used as a lookup key — defense in depth against a crafted `../../evil` id.
+_ID_RE = re.compile(r"\A[0-9a-f]{1,32}\Z")
+
+
+@dataclass(frozen=True)
+class HostToken:
+    token_id: str
+    expires_at: float
+
+
+def ensure_host_root_secret(home: Path) -> bytes:
+    """This host's root key material, generated on first use (0600).
+
+    Not used to hash bearer tokens (those are random and stored as a plain
+    sha256) — it exists so `host_auth` can *derive* a stable per-client refresh
+    credential instead of storing one in plaintext (AC11).
+    """
+    return ensure_secret_file(host_secret_path(home), _ROOT_SECRET_LEN)
+
+
+@contextmanager
+def _locked(lock_path: Path, mode: int):
+    """Advisory flock (the `registry.py`/`state.py` house pattern)."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    lock_path.touch(exist_ok=True, mode=0o600)
+    with open(lock_path, "r+") as lf:
+        fcntl.flock(lf, mode)
+        try:
+            yield
+        finally:
+            fcntl.flock(lf, fcntl.LOCK_UN)
+
+
+def _load(path: Path) -> dict:
+    """Records by token_id; a corrupt/truncated doc reads as empty (every token
+    it held is unverifiable anyway — `RegistryStore._load_nolock` precedent)."""
+    try:
+        doc = json.loads(path.read_text())
+        tokens = doc["tokens"]
+        return tokens if isinstance(tokens, dict) else {}
+    except (OSError, ValueError, KeyError, TypeError):
+        return {}
+
+
+def _save(path: Path, tokens: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(json.dumps({"tokens": tokens}, indent=2))
+    tmp.chmod(0o600)
+    tmp.replace(path)
+
+
+def _hash(secret: str) -> str:
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()
+
+
+def _expired(rec: dict, clock: AnchoredClock) -> bool:
+    return clock.is_expired(Deadline.from_record(rec))
+
+
+def issue_host_token(
+    home: Path,
+    *,
+    ttl_seconds: float = HOST_TOKEN_TTL_S,
+    clock: AnchoredClock | None = None,
+    max_tokens: int = MAX_HOST_TOKENS,
+) -> str:
+    """Mint a bearer, persist only its hash and deadline, return the plaintext
+    `<token_id>.<secret>` — handed out once and never re-derivable."""
+    clock = clock or AnchoredClock()
+    path = host_tokens_path(home)
+    token_id = secrets.token_hex(8)
+    secret = secrets.token_urlsafe(32)
+    with _locked(path.with_name(path.name + ".lock"), fcntl.LOCK_EX):
+        tokens = {
+            tid: rec for tid, rec in _load(path).items() if not _expired(rec, clock)
+        }
+        tokens[token_id] = {
+            "token_id": token_id,
+            "secret_hash": _hash(secret),
+            **clock.deadline(ttl_seconds).as_record(),
+        }
+        if len(tokens) > max_tokens:
+            keep = sorted(
+                tokens.items(), key=lambda kv: kv[1]["expires_at"], reverse=True
+            )[:max_tokens]
+            tokens = dict(keep)
+        _save(path, tokens)
+    return f"{token_id}.{secret}"
+
+
+def verify_host_token(
+    home: Path, presented: str, *, clock: AnchoredClock | None = None
+) -> HostToken | None:
+    """Return the HostToken for a valid, unexpired bearer, else None. Never
+    raises, and never writes."""
+    clock = clock or AnchoredClock()
+    if "." not in presented:
+        return None
+    token_id, secret = presented.split(".", 1)
+    if not _ID_RE.match(token_id):
+        return None
+    path = host_tokens_path(home)
+    with _locked(path.with_name(path.name + ".lock"), fcntl.LOCK_SH):
+        rec = _load(path).get(token_id)
+    if not isinstance(rec, dict):
+        return None
+    if not hmac.compare_digest(_hash(secret), str(rec.get("secret_hash", ""))):
+        return None
+    if _expired(rec, clock):
+        return None
+    return HostToken(token_id=token_id, expires_at=float(rec["expires_at"]))

--- a/src/mship/core/daemon/host_token.py
+++ b/src/mship/core/daemon/host_token.py
@@ -18,8 +18,10 @@ import fcntl
 import hashlib
 import hmac
 import json
+import os
 import re
 import secrets
+import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -39,9 +41,10 @@ MAX_HOST_TOKENS = 64
 
 _ROOT_SECRET_LEN = 32
 
-# Token ids are `secrets.token_hex(8)`. Anything else is rejected before it is
-# used as a lookup key — defense in depth against a crafted `../../evil` id.
-_ID_RE = re.compile(r"\A[0-9a-f]{1,32}\Z")
+# Token ids are exactly `secrets.token_hex(8)` — 16 lowercase hex. Anything
+# else is rejected before it is used as a lookup key: defense in depth against
+# a crafted `../../evil` id ever reaching a path or a record.
+_ID_RE = re.compile(r"\A[0-9a-f]{16}\Z")
 
 
 @dataclass(frozen=True)
@@ -60,10 +63,18 @@ def ensure_host_root_secret(home: Path) -> bytes:
     return ensure_secret_file(host_secret_path(home), _ROOT_SECRET_LEN)
 
 
+def _private_dir(path: Path) -> None:
+    """Owner-only parent dir. The corrective chmod is not redundant: mkdir's
+    mode is masked by the umask, and `exist_ok=True` never tightens a dir that
+    already exists too loose (the `registry.py`/`host_app.py` house pattern)."""
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.parent.chmod(0o700)
+
+
 @contextmanager
 def _locked(lock_path: Path, mode: int):
     """Advisory flock (the `registry.py`/`state.py` house pattern)."""
-    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    _private_dir(lock_path)
     lock_path.touch(exist_ok=True, mode=0o600)
     with open(lock_path, "r+") as lf:
         fcntl.flock(lf, mode)
@@ -85,11 +96,20 @@ def _load(path: Path) -> dict:
 
 
 def _save(path: Path, tokens: dict) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    tmp = path.with_name(path.name + ".tmp")
-    tmp.write_text(json.dumps({"tokens": tokens}, indent=2))
-    tmp.chmod(0o600)
-    tmp.replace(path)
+    """Atomic, owner-only write (`host_app._atomic_write_owner_file` shape):
+    mkstemp creates the temp file 0600, so the hashes are never briefly
+    world-readable."""
+    _private_dir(path)
+    fd, temp_name = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    temp = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w") as stream:
+            stream.write(json.dumps({"tokens": tokens}, indent=2))
+        os.replace(temp, path)
+    except BaseException:
+        temp.unlink(missing_ok=True)
+        raise
+    path.chmod(0o600)
 
 
 def _hash(secret: str) -> str:
@@ -117,16 +137,20 @@ def issue_host_token(
         tokens = {
             tid: rec for tid, rec in _load(path).items() if not _expired(rec, clock)
         }
+        # Evict from the PRE-EXISTING set only: the token we are about to hand
+        # back must never be the one the cap drops (a short-TTL mint at the cap
+        # sorts last and would be issued already dead).
+        if len(tokens) >= max_tokens:
+            tokens = dict(sorted(
+                tokens.items(),
+                key=lambda kv: kv[1].get("expires_at", 0),
+                reverse=True,
+            )[: max(max_tokens - 1, 0)])
         tokens[token_id] = {
             "token_id": token_id,
             "secret_hash": _hash(secret),
             **clock.deadline(ttl_seconds).as_record(),
         }
-        if len(tokens) > max_tokens:
-            keep = sorted(
-                tokens.items(), key=lambda kv: kv[1]["expires_at"], reverse=True
-            )[:max_tokens]
-            tokens = dict(keep)
         _save(path, tokens)
     return f"{token_id}.{secret}"
 

--- a/src/mship/core/daemon/host_token.py
+++ b/src/mship/core/daemon/host_token.py
@@ -27,13 +27,15 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from mship.core.daemon.paths import host_secret_path, host_tokens_path
+from mship.core.relay.host_contract import HOST_TOKEN_TTL_S
 from mship.core.relay.keys import ensure_secret_file
 from mship.core.relay.token_clock import AnchoredClock, Deadline
 
-# Deliberately short: a host token is the credential a phone carries, and the
-# only revocation that survives a lost/stolen device is expiry (revocation
-# happens one tier up, on the refresh credential in `host_auth`).
-HOST_TOKEN_TTL_S = 300
+# HOST_TOKEN_TTL_S is deliberately short — a host token is the credential a
+# phone carries, and the only revocation that survives a lost/stolen device is
+# expiry (revocation happens one tier up, on the refresh credential in
+# `host_auth`). It is OWNED by `core.relay.host_contract` because both ends of
+# the wire need it, and re-exported here so the mint site reads as one name.
 
 # Bounded so the doc cannot grow without limit while every token is still live
 # (many devices, or a client re-minting in a tight loop).

--- a/src/mship/core/daemon/host_token.py
+++ b/src/mship/core/daemon/host_token.py
@@ -169,8 +169,7 @@ def verify_host_token(
     if not _ID_RE.match(token_id):
         return None
     path = host_tokens_path(home)
-    with _locked(path.with_name(path.name + ".lock"), fcntl.LOCK_SH):
-        rec = _load(path).get(token_id)
+    rec = _load(path).get(token_id)
     if not isinstance(rec, dict):
         return None
     if not hmac.compare_digest(_hash(secret), str(rec.get("secret_hash", ""))):

--- a/src/mship/core/daemon/host_tunnel.py
+++ b/src/mship/core/daemon/host_tunnel.py
@@ -58,6 +58,10 @@ TICK_INTERVAL_S = 1.0
 # derives its tunnel-join bound from it (`core/daemon/run.py`) — a tick must
 # not be able to outlast the wait that exists to keep it from orphaning ssh.
 PROCESS_LIST_TIMEOUT_S = 10.0
+# Discovery, pre-TERM revalidation, and pre-KILL revalidation. Each phase takes
+# one bounded process-table snapshot regardless of how many orphans it contains.
+MAX_PROCESS_LIST_CALLS_PER_REAP = 3
+
 
 # One shared grace period for every matching orphan: signal all of them, wait
 # together, then escalate survivors. The daemon's shutdown join bound includes
@@ -209,112 +213,98 @@ def reap_orphan_tunnels(
             and _forward_label(current.cmdline) == subdomain
         )
 
-    def signal_atomically(proc: ProcessInfo, sig: int) -> bool:
-        opener = pidfd_open or getattr(os, "pidfd_open", None)
-        native_sender = getattr(signal, "pidfd_send_signal", None)
-        sender = pidfd_signal or (
-            (lambda fd, signal_number: native_sender(fd, signal_number, None, 0))
-            if native_sender is not None
-            else None
+    pidfd_opener = pidfd_open or getattr(os, "pidfd_open", None)
+    native_pidfd_sender = getattr(signal, "pidfd_send_signal", None)
+    pidfd_sender = pidfd_signal or (
+        (lambda fd, sig: native_pidfd_sender(fd, sig, None, 0))
+        if native_pidfd_sender is not None
+        else None
+    )
+
+    def signal_phase(
+        candidates: list[ProcessInfo],
+        sig: int,
+        injected_signal: Callable[[int], None] | None,
+    ) -> list[ProcessInfo]:
+        """Revalidate and signal a whole phase from one bounded snapshot."""
+        if not candidates:
+            return []
+        use_pidfds = (
+            injected_signal is None
+            and pidfd_opener is not None
+            and pidfd_sender is not None
         )
-        if opener is None or sender is None:
-            raise RuntimeError("atomic pidfd signaling is unavailable")
+        opened: dict[int, int] = {}
         try:
-            fd = opener(proc.pid)
-        except ProcessLookupError:
-            return False
-        except Exception as exc:
-            raise RuntimeError("atomic pidfd signaling is unavailable") from exc
-        try:
-            current = {row.pid: row for row in processes()}.get(proc.pid)
-            if not same_process(proc, current):
-                return False
-            try:
-                sender(fd, sig)
-            except ProcessLookupError:
-                return False
-            return True
+            if use_pidfds:
+                for proc in candidates:
+                    try:
+                        opened[proc.pid] = pidfd_opener(proc.pid)
+                    except ProcessLookupError:
+                        continue
+                    except Exception as exc:
+                        raise RuntimeError(
+                            "atomic pidfd signaling is unavailable"
+                        ) from exc
+
+            current_by_pid = {proc.pid: proc for proc in processes()}
+            accepted = []
+            for proc in candidates:
+                if use_pidfds and proc.pid not in opened:
+                    continue
+                current = current_by_pid.get(proc.pid)
+                if current is None:
+                    if process_exists(proc.pid):
+                        raise RuntimeError(
+                            f"could not revalidate orphan tunnel pid {proc.pid}"
+                        )
+                    continue
+                if not same_process(proc, current):
+                    continue
+                try:
+                    if use_pidfds:
+                        pidfd_sender(opened[proc.pid], sig)
+                    elif injected_signal is not None:
+                        injected_signal(proc.pid)
+                    else:
+                        # macOS has no pidfds. The shared phase snapshot narrows
+                        # the unavoidable PID-reuse race before this signal.
+                        os.kill(proc.pid, sig)
+                except ProcessLookupError:
+                    continue
+                except Exception as exc:
+                    if process_exists(proc.pid):
+                        action = "force-kill" if sig == signal.SIGKILL else "signal"
+                        raise RuntimeError(
+                            f"could not {action} orphan tunnel pid {proc.pid}"
+                        ) from exc
+                    continue
+                accepted.append(proc)
+            return accepted
         finally:
-            close_pidfd(fd)
+            for fd in opened.values():
+                close_pidfd(fd)
 
     candidates = [
         proc
         for proc in processes()
         if proc.ppid == 1 and _forward_label(proc.cmdline) == subdomain
     ]
-    refreshed = (
-        {proc.pid: proc for proc in processes()}
-        if candidates and kill is not None
-        else {}
-    )
-    signalled = []
-    identities = []
-    for proc in candidates:
-        if kill is None:
-            accepted = signal_atomically(proc, signal.SIGTERM)
-        else:
-            current = refreshed.get(proc.pid)
-            if current is None:
-                if process_exists(proc.pid):
-                    raise RuntimeError(
-                        f"could not revalidate orphan tunnel pid {proc.pid}"
-                    )
-                continue
-            if not same_process(proc, current):
-                continue
-            try:
-                kill(proc.pid)
-                accepted = True
-            except Exception as exc:
-                if process_exists(proc.pid):
-                    raise RuntimeError(
-                        f"could not signal orphan tunnel pid {proc.pid}"
-                    ) from exc
-                accepted = False
-        if not accepted:
-            continue
+    identities = signal_phase(candidates, signal.SIGTERM, kill)
+    for proc in identities:
         log.warning(
             "signalled orphaned relay tunnel pid=%s holding %s", proc.pid, subdomain
         )
-        signalled.append(proc.pid)
-        identities.append(proc)
+    signalled = [proc.pid for proc in identities]
+
     survivors = wait_for_exit(identities)
-    refreshed = (
-        {proc.pid: proc for proc in processes()}
-        if survivors and force_kill is not None
-        else {}
-    )
-    force_signalled = []
-    for proc in survivors:
-        if force_kill is None:
-            accepted = signal_atomically(proc, signal.SIGKILL)
-        else:
-            current = refreshed.get(proc.pid)
-            if current is None:
-                if process_exists(proc.pid):
-                    raise RuntimeError(
-                        f"could not revalidate orphan tunnel pid {proc.pid}"
-                    )
-                continue
-            if not same_process(proc, current):
-                continue
-            try:
-                force_kill(proc.pid)
-                accepted = True
-            except Exception as exc:
-                if process_exists(proc.pid):
-                    raise RuntimeError(
-                        f"could not force-kill orphan tunnel pid {proc.pid}"
-                    ) from exc
-                accepted = False
-        if not accepted:
-            continue
+    force_signalled = signal_phase(survivors, signal.SIGKILL, force_kill)
+    for proc in force_signalled:
         log.warning(
             "force-killed orphaned relay tunnel pid=%s holding %s",
             proc.pid,
             subdomain,
         )
-        force_signalled.append(proc)
     still_live = wait_for_exit(force_signalled)
     if still_live:
         raise RuntimeError(

--- a/src/mship/core/daemon/host_tunnel.py
+++ b/src/mship/core/daemon/host_tunnel.py
@@ -59,6 +59,12 @@ TICK_INTERVAL_S = 1.0
 # not be able to outlast the wait that exists to keep it from orphaning ssh.
 PROCESS_LIST_TIMEOUT_S = 10.0
 
+# One shared grace period for every matching orphan: signal all of them, wait
+# together, then escalate survivors. The daemon's shutdown join bound includes
+# both this TERM wait and the post-KILL confirmation wait.
+ORPHAN_EXIT_TIMEOUT_S = 2.0
+_ORPHAN_EXIT_POLL_S = 0.05
+
 # What ssh prints when the relay has our key on file but nobody has approved it
 # yet. It is the FIRST evidence of that state — it arrives before any
 # registration verdict does — which is why the log tail is worth reading.
@@ -78,37 +84,43 @@ STATES = (
 
 @dataclass(frozen=True)
 class ProcessInfo:
-    """One row of the process table, as the reaper needs it."""
+    """One process-table row, including its creation identity."""
 
     pid: int
     ppid: int
     cmdline: str
+    started: str
 
 
 def list_processes() -> list[ProcessInfo]:
-    """The process table via `ps`, or empty if it cannot be read.
+    """Read the process table with a stable creation identity per PID.
 
-    Never raises: failing to enumerate processes must degrade to "reaped
-    nothing", not take the daemon's tick down with it."""
+    Failure is loud: dialing without knowing whether an orphan still owns the
+    reverse forward recreates the collision this sweep exists to prevent.
+    """
     try:
         out = subprocess.run(
-            ["ps", "-eo", "pid=,ppid=,args="],
+            ["ps", "-eo", "pid=,ppid=,lstart=,args="],
             capture_output=True,
             text=True,
             timeout=PROCESS_LIST_TIMEOUT_S,
             check=True,
         ).stdout
     except Exception as exc:
-        log.debug("could not list processes for the orphan sweep: %s", exc)
-        return []
+        raise RuntimeError("could not list processes for the orphan sweep") from exc
     rows = []
     for line in out.splitlines():
-        parts = line.split(None, 2)
-        if len(parts) != 3:
+        parts = line.split(None, 7)
+        if len(parts) != 8:
             continue
         try:
             rows.append(
-                ProcessInfo(pid=int(parts[0]), ppid=int(parts[1]), cmdline=parts[2])
+                ProcessInfo(
+                    pid=int(parts[0]),
+                    ppid=int(parts[1]),
+                    started=" ".join(parts[2:7]),
+                    cmdline=parts[7],
+                )
             )
         except ValueError:
             continue
@@ -130,35 +142,120 @@ def _forward_label(cmdline: str) -> str | None:
     return spec.split(":")[0]
 
 
+def _process_exists(pid: int) -> bool:
+    """Whether pid is still live (a zombie has already released its sockets)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    if not os.path.isdir("/proc"):
+        return True
+    try:
+        with open(f"/proc/{pid}/stat") as stat_file:
+            stat = stat_file.read()
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return True
+    closing_paren = stat.rfind(")")
+    return closing_paren < 0 or not stat[closing_paren + 2 :].startswith("Z")
+
+
 def reap_orphan_tunnels(
     subdomain: str,
     *,
     processes: Callable[[], Sequence[ProcessInfo]] = list_processes,
     kill: Callable[[int], None] | None = None,
+    force_kill: Callable[[int], None] | None = None,
+    process_exists: Callable[[int], bool] = _process_exists,
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
 ) -> list[int]:
-    """Signal any `ssh -R <subdomain>:…` reparented to init; return those pids.
+    """Terminate `ssh -R <subdomain>:…` processes reparented to init.
 
     Reparenting to init is the whole test: a tunnel we own has *us* as its
     parent, so PPID 1 means the process that dialed it is gone and nothing will
     ever clean it up. Anything that merely mentions the subdomain (an operator's
     interactive `ssh`, a `grep`, a host whose label ends with ours) is left
     alone — only a live reverse forward of OUR exact label can collide with us.
+
+    Every match receives SIGTERM before one shared bounded wait. Survivors then
+    receive SIGKILL and another bounded wait, so the caller cannot redial while
+    an old process still owns the reverse forward. Returns the pids that
+    accepted the initial signal.
     """
     if kill is None:
         kill = lambda pid: os.kill(pid, signal.SIGTERM)
+    if force_kill is None:
+        force_kill = lambda pid: os.kill(pid, signal.SIGKILL)
+
+    def wait_for_exit(processes: list[ProcessInfo]) -> list[ProcessInfo]:
+        deadline = clock() + ORPHAN_EXIT_TIMEOUT_S
+        live = [process for process in processes if process_exists(process.pid)]
+        while live:
+            remaining = deadline - clock()
+            if remaining <= 0:
+                return live
+            sleep(min(_ORPHAN_EXIT_POLL_S, remaining))
+            live = [process for process in live if process_exists(process.pid)]
+        return []
+
     signalled = []
+    identities = []
     for proc in processes():
         if proc.ppid != 1 or _forward_label(proc.cmdline) != subdomain:
             continue
         try:
             kill(proc.pid)
-        except Exception as exc:  # already gone, or not ours to signal
-            log.debug("could not signal orphan tunnel pid=%s: %s", proc.pid, exc)
+        except Exception as exc:
+            if process_exists(proc.pid):
+                raise RuntimeError(
+                    f"could not signal orphan tunnel pid {proc.pid}"
+                ) from exc
             continue
         log.warning(
             "signalled orphaned relay tunnel pid=%s holding %s", proc.pid, subdomain
         )
         signalled.append(proc.pid)
+        identities.append(proc)
+
+    survivors = wait_for_exit(identities)
+    refreshed = {proc.pid: proc for proc in processes()} if survivors else {}
+    force_signalled = []
+    for proc in survivors:
+        current = refreshed.get(proc.pid)
+        if current is None:
+            if process_exists(proc.pid):
+                raise RuntimeError(f"could not revalidate orphan tunnel pid {proc.pid}")
+            continue
+        if (
+            current.started != proc.started
+            or current.ppid != 1
+            or _forward_label(current.cmdline) != subdomain
+        ):
+            continue
+        try:
+            force_kill(proc.pid)
+        except Exception as exc:
+            if process_exists(proc.pid):
+                raise RuntimeError(
+                    f"could not force-kill orphan tunnel pid {proc.pid}"
+                ) from exc
+            continue
+        log.warning(
+            "force-killed orphaned relay tunnel pid=%s holding %s",
+            proc.pid,
+            subdomain,
+        )
+        force_signalled.append(proc)
+    still_live = wait_for_exit(force_signalled)
+    if still_live:
+        raise RuntimeError(
+            "orphaned relay tunnel pids still live after SIGKILL: "
+            + ", ".join(str(proc.pid) for proc in still_live)
+        )
     return signalled
 
 
@@ -284,8 +381,8 @@ class HostTunnel:
         do it hundreds of times."""
         if self._reaped:
             return
-        self._reaped = True
         self._reaper(self._link.subdomain)
+        self._reaped = True
 
     def _sample_ssh_log(self) -> None:
         """Read the ssh tail while the child is down — the only time it explains

--- a/src/mship/core/daemon/host_tunnel.py
+++ b/src/mship/core/daemon/host_tunnel.py
@@ -182,6 +182,7 @@ class HostTunnel:
         # resets it and `start()` zeroes it, so diffing it would read a *drop*
         # as a respawn and re-register while no child exists at all (AC2).
         self._spawns_seen = supervisor.spawn_count
+        self._publish()
 
     # -- the loop -----------------------------------------------------------
 
@@ -197,6 +198,7 @@ class HostTunnel:
         self._guard("tunnel", self._supervise)
         self._guard("registration", self._link.tick)
         self._guard("tunnel", self._redial)
+        self._publish()
         return self.state()
 
     def stop(self) -> None:
@@ -210,6 +212,7 @@ class HostTunnel:
         self._stopped = True
         self._supervisor.stop(final=True)
         self._online = False
+        self._publish()
 
     def _guard(self, what: str, fn: Callable[[], object]) -> None:
         try:
@@ -369,3 +372,27 @@ class HostTunnel:
     @property
     def restart_count(self) -> int:
         return self._supervisor.restart_count
+
+    def snapshot(self) -> dict:
+        """What `/health` (and through it `mship daemon status`) publishes.
+
+        A PUBLICATION, not a live read: ticks run in the daemon's executor
+        (`run.py::_tunnel_loop`) while requests are served on the loop thread,
+        so a reader assembling this field-by-field could see half of one tick
+        and half of the next. `_publish` builds a fresh dict at the end of every
+        tick and nothing ever mutates a published one, which makes a read a
+        single attribute load."""
+        return self._published
+
+    def _publish(self) -> None:
+        self._published = {
+            "state": self.state(),
+            "subdomain": self._link.subdomain,
+            "public_url": self._link.public_url,
+            "restarts": self._supervisor.restart_count,
+            "last_error": self.last_error,
+            # The ENROLL SERVER's clock, sampled by the link — never the
+            # read-back's, which is this host's own uvicorn (~0 by
+            # construction). Reported only; it gates nothing.
+            "clock_skew_seconds": self._link.clock_skew_seconds,
+        }

--- a/src/mship/core/daemon/host_tunnel.py
+++ b/src/mship/core/daemon/host_tunnel.py
@@ -27,6 +27,7 @@ Like everything it supervises, this class is entirely tick-driven: no threads,
 no sleeps, every collaborator (`clock`, `reaper`, `verify`) injected, so the
 whole loop is unit-testable without a socket.
 """
+
 from __future__ import annotations
 
 import logging
@@ -64,8 +65,15 @@ PROCESS_LIST_TIMEOUT_S = 10.0
 _UNAPPROVED_SSH_MARKER = "permission denied"
 
 # The states this reports, in the order `state()` resolves them.
-STATES = ("disabled", "duplicate-identity", "awaiting-enrollment", "contended",
-          "error", "online", "connecting")
+STATES = (
+    "disabled",
+    "duplicate-identity",
+    "awaiting-enrollment",
+    "contended",
+    "error",
+    "online",
+    "connecting",
+)
 
 
 @dataclass(frozen=True)
@@ -85,7 +93,9 @@ def list_processes() -> list[ProcessInfo]:
     try:
         out = subprocess.run(
             ["ps", "-eo", "pid=,ppid=,args="],
-            capture_output=True, text=True, timeout=PROCESS_LIST_TIMEOUT_S,
+            capture_output=True,
+            text=True,
+            timeout=PROCESS_LIST_TIMEOUT_S,
             check=True,
         ).stdout
     except Exception as exc:
@@ -97,7 +107,9 @@ def list_processes() -> list[ProcessInfo]:
         if len(parts) != 3:
             continue
         try:
-            rows.append(ProcessInfo(pid=int(parts[0]), ppid=int(parts[1]), cmdline=parts[2]))
+            rows.append(
+                ProcessInfo(pid=int(parts[0]), ppid=int(parts[1]), cmdline=parts[2])
+            )
         except ValueError:
             continue
     return rows
@@ -113,7 +125,7 @@ def _forward_label(cmdline: str) -> str | None:
     tokens = cmdline.split()
     try:
         spec = tokens[tokens.index("-R") + 1]
-    except (ValueError, IndexError):
+    except ValueError, IndexError:
         return None
     return spec.split(":")[0]
 
@@ -143,7 +155,9 @@ def reap_orphan_tunnels(
         except Exception as exc:  # already gone, or not ours to signal
             log.debug("could not signal orphan tunnel pid=%s: %s", proc.pid, exc)
             continue
-        log.warning("signalled orphaned relay tunnel pid=%s holding %s", proc.pid, subdomain)
+        log.warning(
+            "signalled orphaned relay tunnel pid=%s holding %s", proc.pid, subdomain
+        )
         signalled.append(proc.pid)
     return signalled
 
@@ -169,14 +183,14 @@ class HostTunnel:
         self._readback_interval = readback_interval
 
         self._stopped = False
-        self._started = False          # True once we have dialed at least once
-        self._reaped = False           # swept during the current downtime
-        self._online = False           # the last read-back was us
+        self._started = False  # True after the first dial attempt
+        self._reaped = False  # swept during the current downtime
+        self._online = False  # the last read-back was us
         self._ever_online = False
-        self._ssh_rejected = False     # the ssh log tail says "not approved yet"
+        self._ssh_rejected = False  # the ssh log tail says "not approved yet"
         self._contended_with: str | None = None
-        self._failure: str | None = None   # this tick's own fault, if any
-        self._detail: str | None = None    # the last read-back's explanation
+        self._failure: str | None = None  # this tick's own fault, if any
+        self._detail: str | None = None  # the last read-back's explanation
         self._last_readback_at: float | None = None
         # Monotonic: `restart_count` is NOT a respawn signal — a healthy run
         # resets it and `start()` zeroes it, so diffing it would read a *drop*
@@ -234,7 +248,7 @@ class HostTunnel:
                 self._online = False
                 self._sample_ssh_log()
                 self._reap()
-                sup.tick()          # gated by the supervisor's own backoff
+                sup.tick()  # gated by the supervisor's own backoff
         if sup.spawn_count != self._spawns_seen:
             self._spawns_seen = sup.spawn_count
             # A new child is up, holding a fresh sish route; re-publish the entry
@@ -256,12 +270,13 @@ class HostTunnel:
                 self._online = False
             return
         if not self._started:
+            # Once start is attempted, every retry belongs to the supervisor's
+            # capped backoff — including failures before a child is returned.
+            self._started = True
             self._supervisor.start()
             # This tick's `link.tick()` already published the entry for this
-            # child, so the initial dial (and the re-dial after a duplicate
-            # identity clears) must not also count as a respawn.
+            # child, so the initial dial must not also count as a respawn.
             self._spawns_seen = self._supervisor.spawn_count
-            self._started = True
 
     def _reap(self) -> None:
         """Sweep orphans once per downtime, not once per tick: this shells out to
@@ -293,8 +308,10 @@ class HostTunnel:
         clone. Same split `health.py` makes between a stale token and a route
         that has not come up yet.
         """
-        if (self._last_readback_at is not None
-                and 0 <= now - self._last_readback_at < self._readback_interval):
+        if (
+            self._last_readback_at is not None
+            and 0 <= now - self._last_readback_at < self._readback_interval
+        ):
             return
         self._last_readback_at = now
         probe = self._verify(self._link.public_url, "")
@@ -309,7 +326,9 @@ class HostTunnel:
         answered = (probe.body or {}).get("instance_id")
         if not answered:
             self._online = False
-            self._detail = f"read-back of {self._link.public_url} carried no instance_id"
+            self._detail = (
+                f"read-back of {self._link.public_url} carried no instance_id"
+            )
             return
         if answered == self._link.instance_id:
             self._online = True

--- a/src/mship/core/daemon/host_tunnel.py
+++ b/src/mship/core/daemon/host_tunnel.py
@@ -1,0 +1,326 @@
+"""The daemon's tunnel half of host registration (#471).
+
+`TunnelSupervisor` already owns "keep an `ssh -R` child alive" and `RelayLink`
+already owns "keep this host's directory entry current". `HostTunnel` is the
+thin object that joins them, and it exists for the three facts neither half can
+know on its own:
+
+- **An orphan must be reaped before we dial.** A `kill -9` (or a SIGKILL after a
+  systemd stop timeout) leaves the `start_new_session=True` ssh child reparented
+  to init, still holding the subdomain; sish then rejects the fresh tunnel and
+  the relay 404s a host that looks perfectly healthy from the daemon's side.
+  `scripts/redeploy-serve.sh` sweeps exactly this class by hand today, which is
+  survivable for an operator running a redeploy and is not survivable for a
+  daemon that restarts unattended.
+- **A respawn must re-register exactly once.** The reconnected child lands on a
+  fresh sish route, so the directory entry has to be re-published — but once per
+  respawn, never once per tick, or a flapping tunnel turns into a registration
+  storm against the relay (AC2).
+- **Only a read-back proves the subdomain is ours.** A live `ssh -R` proves we
+  dialed, not that we won: a `cp -a` twin publishes the *same* `host_id` on the
+  *same* subdomain, so comparing host ids is blind to precisely the clone case.
+  The per-process `instance_id` read back off our own public `/health` is the
+  one thing that differs — and `/health` is unauthenticated (Task 3), so the
+  read-back mints no token and therefore writes nothing (AC11).
+
+Like everything it supervises, this class is entirely tick-driven: no threads,
+no sleeps, every collaborator (`clock`, `reaper`, `verify`) injected, so the
+whole loop is unit-testable without a socket.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+from mship.core.relay.health import probe_health
+
+log = logging.getLogger(__name__)
+
+# How often the tunnel asks its own public URL who is answering. Far cheaper
+# than the registration interval it rides beside, but not free: it is a full
+# round trip out to the relay and back down our own tunnel.
+READBACK_INTERVAL_S = 30.0
+
+# What ssh prints when the relay has our key on file but nobody has approved it
+# yet. It is the FIRST evidence of that state — it arrives before any
+# registration verdict does — which is why the log tail is worth reading.
+_UNAPPROVED_SSH_MARKER = "permission denied"
+
+# The states this reports, in the order `state()` resolves them.
+STATES = ("disabled", "duplicate-identity", "awaiting-enrollment", "contended",
+          "error", "online", "connecting")
+
+
+@dataclass(frozen=True)
+class ProcessInfo:
+    """One row of the process table, as the reaper needs it."""
+
+    pid: int
+    ppid: int
+    cmdline: str
+
+
+def list_processes() -> list[ProcessInfo]:
+    """The process table via `ps`, or empty if it cannot be read.
+
+    Never raises: failing to enumerate processes must degrade to "reaped
+    nothing", not take the daemon's tick down with it."""
+    try:
+        out = subprocess.run(
+            ["ps", "-eo", "pid=,ppid=,args="],
+            capture_output=True, text=True, timeout=10, check=True,
+        ).stdout
+    except Exception as exc:
+        log.debug("could not list processes for the orphan sweep: %s", exc)
+        return []
+    rows = []
+    for line in out.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) != 3:
+            continue
+        try:
+            rows.append(ProcessInfo(pid=int(parts[0]), ppid=int(parts[1]), cmdline=parts[2]))
+        except ValueError:
+            continue
+    return rows
+
+
+def reap_orphan_tunnels(
+    subdomain: str,
+    *,
+    processes: Callable[[], Sequence[ProcessInfo]] = list_processes,
+    kill: Callable[[int], None] | None = None,
+) -> list[int]:
+    """Kill any `ssh -R <subdomain>:…` reparented to init; return the pids killed.
+
+    Reparenting to init is the whole test: a tunnel we own has *us* as its
+    parent, so PPID 1 means the process that dialed it is gone and nothing will
+    ever clean it up. Anything that merely mentions the subdomain (an operator's
+    interactive `ssh`, a `grep`) is left alone — only a live reverse forward of
+    OUR label can collide with us.
+    """
+    if kill is None:
+        kill = lambda pid: os.kill(pid, 15)
+    killed = []
+    for proc in processes():
+        if proc.ppid != 1 or "-R" not in proc.cmdline.split():
+            continue
+        if f"{subdomain}:" not in proc.cmdline:
+            continue
+        try:
+            kill(proc.pid)
+        except Exception as exc:  # already gone, or not ours to signal
+            log.debug("could not kill orphan tunnel pid=%s: %s", proc.pid, exc)
+            continue
+        log.warning("killed orphaned relay tunnel pid=%s holding %s", proc.pid, subdomain)
+        killed.append(proc.pid)
+    return killed
+
+
+class HostTunnel:
+    """Dial the relay, keep the directory entry current, and prove it is ours."""
+
+    def __init__(
+        self,
+        link,
+        supervisor,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        reaper: Callable[[str], list[int]] = reap_orphan_tunnels,
+        verify: Callable[..., object] = probe_health,
+        readback_interval: float = READBACK_INTERVAL_S,
+    ) -> None:
+        self._link = link
+        self._supervisor = supervisor
+        self._clock = clock
+        self._reaper = reaper
+        self._verify = verify
+        self._readback_interval = readback_interval
+
+        self._stopped = False
+        self._started = False          # True once we have dialed at least once
+        self._reaped = False           # swept during the current downtime
+        self._online = False           # the last read-back was us
+        self._ever_online = False
+        self._ssh_rejected = False     # the ssh log tail says "not approved yet"
+        self._contended_with: str | None = None
+        self._failure: str | None = None   # this tick's own fault, if any
+        self._detail: str | None = None    # the last read-back's explanation
+        self._last_readback_at: float | None = None
+        self._restarts_seen = supervisor.restart_count
+
+    # -- the loop -----------------------------------------------------------
+
+    def tick(self) -> str:
+        """One pass: supervise, register, (re)dial. Returns the new state.
+
+        Never raises. The two halves are guarded separately and deliberately: a
+        registration outage must not tear down a working tunnel, and a tunnel
+        that cannot respawn must not silence registration (AC7)."""
+        if self._stopped:
+            return self.state()
+        self._failure = None
+        self._guard("tunnel", self._supervise)
+        self._guard("registration", self._link.tick)
+        self._guard("tunnel", self._redial)
+        return self.state()
+
+    def stop(self) -> None:
+        """Terminate the ssh child and stay down. Idempotent — the second call
+        must not signal a pid the supervisor has already released."""
+        if self._stopped:
+            return
+        self._stopped = True
+        self._supervisor.stop()
+        self._online = False
+
+    def _guard(self, what: str, fn: Callable[[], object]) -> None:
+        try:
+            fn()
+        except Exception as exc:
+            log.exception("%s tick failed", what)
+            self._failure = f"{what}: {exc}"
+
+    def _supervise(self) -> None:
+        """Respawn a dead child, read back a live one, and tell the link when a
+        respawn happened — exactly once per respawn."""
+        sup = self._supervisor
+        if self._started:
+            if sup.is_running():
+                self._reaped = False
+                sup.tick()
+                self._read_back(self._clock())
+            else:
+                self._online = False
+                self._sample_ssh_log()
+                self._reap()
+                sup.tick()          # gated by the supervisor's own backoff
+        if sup.restart_count != self._restarts_seen:
+            self._restarts_seen = sup.restart_count
+            # The new child holds a fresh sish route; re-publish the entry now
+            # rather than waiting out `REGISTER_INTERVAL_S` (AC2).
+            self._link.register_soon()
+
+    def _redial(self) -> None:
+        """Act on the link's verdict: a duplicate identity must not hold a
+        tunnel open (two twins on one subdomain split traffic between them),
+        and everything else dials."""
+        if not self._link.should_dial():
+            if self._started:
+                self._supervisor.stop()
+                self._started = False
+                self._online = False
+            return
+        if not self._started:
+            # First dial only after the link has had its say, so a host the
+            # relay already refuses as a duplicate never spawns ssh at all (AC4).
+            self._reap()
+            self._supervisor.start()
+            self._started = True
+
+    def _reap(self) -> None:
+        """Sweep orphans once per downtime, not once per tick: this shells out to
+        the process table, and a tunnel that is down for an hour would otherwise
+        do it hundreds of times."""
+        if self._reaped:
+            return
+        self._reaped = True
+        self._reaper(self._link.subdomain)
+
+    def _sample_ssh_log(self) -> None:
+        """Read the ssh tail while the child is down — the only time it explains
+        anything. Ignored once a read-back has ever confirmed us: the log is
+        append-only, so an old rejection stays in the tail long after the key
+        was approved, and from then on the relay's own verdict is authoritative.
+        """
+        if self._ever_online:
+            return
+        tail = self._supervisor.recent_output()
+        self._ssh_rejected = _UNAPPROVED_SSH_MARKER in tail.lower()
+
+    def _read_back(self, now: float) -> None:
+        """Ask our own public URL who is answering on it.
+
+        Three outcomes, and the difference between the last two is the whole
+        point: a DIFFERENT `instance_id` is a live twin (terminal — a human has
+        to sort it out), while no answer at all is just an unreachable relay
+        (transient), and conflating them would report every network blip as a
+        clone. Same split `health.py` makes between a stale token and a route
+        that has not come up yet.
+        """
+        if (self._last_readback_at is not None
+                and 0 <= now - self._last_readback_at < self._readback_interval):
+            return
+        self._last_readback_at = now
+        probe = self._verify(self._link.public_url, "")
+        if probe.error is not None:
+            self._online = False
+            self._detail = f"read-back failed: {probe.error}"
+            return
+        if not probe.ok:
+            self._online = False
+            self._detail = f"read-back returned HTTP {probe.status_code}"
+            return
+        answered = (probe.body or {}).get("instance_id")
+        if not answered:
+            self._online = False
+            self._detail = f"read-back of {self._link.public_url} carried no instance_id"
+            return
+        if answered == self._link.instance_id:
+            self._online = True
+            self._ever_online = True
+            self._ssh_rejected = False
+            self._contended_with = None
+            self._detail = None
+            return
+        # Deliberately does NOT tear the tunnel down: we may be the incumbent and
+        # the twin the newcomer, and dropping our own tunnel would hand it the
+        # subdomain outright.
+        self._online = False
+        self._contended_with = str(answered)
+        self._detail = (
+            f"another host answers {self._link.public_url} (instance_id "
+            f"{answered}; ours is {self._link.instance_id})"
+        )
+
+    # -- what the daemon reports --------------------------------------------
+
+    def state(self) -> str:
+        """The tunnel's state, most authoritative verdict first: what the relay
+        decided about our identity, then what our own read-back saw, then how
+        far along the dial is."""
+        if self._stopped:
+            return "disabled"
+        if not self._link.should_dial():
+            return "duplicate-identity"
+        if self._link.state == "awaiting-enrollment" or self._ssh_rejected:
+            return "awaiting-enrollment"
+        if self._contended_with is not None:
+            return "contended"
+        if self._failure is not None or self._link.state == "error":
+            return "error"
+        if self._online:
+            return "online"
+        return "connecting"
+
+    @property
+    def last_error(self) -> str | None:
+        """The most specific explanation available: this tick's own fault, then
+        the read-back's, then whatever the relay last told the link."""
+        return self._failure or self._detail or self._link.last_error
+
+    @property
+    def subdomain(self) -> str:
+        return self._link.subdomain
+
+    @property
+    def public_url(self) -> str:
+        return self._link.public_url
+
+    @property
+    def restart_count(self) -> int:
+        return self._supervisor.restart_count

--- a/src/mship/core/daemon/host_tunnel.py
+++ b/src/mship/core/daemon/host_tunnel.py
@@ -362,6 +362,14 @@ class HostTunnel:
         return self._failure or self._detail or self._link.last_error
 
     @property
+    def host_id(self) -> str:
+        return self._link.host_id
+
+    @property
+    def instance_id(self) -> str:
+        return self._link.instance_id
+
+    @property
     def subdomain(self) -> str:
         return self._link.subdomain
 

--- a/src/mship/core/daemon/host_tunnel.py
+++ b/src/mship/core/daemon/host_tunnel.py
@@ -46,6 +46,13 @@ log = logging.getLogger(__name__)
 # round trip out to the relay and back down our own tunnel.
 READBACK_INTERVAL_S = 30.0
 
+# How often the daemon's loop calls `tick()`. Not a schedule of its own: every
+# collaborator this class drives already owns one (the link's registration
+# interval, the supervisor's respawn backoff, `READBACK_INTERVAL_S`), so this is
+# only the resolution at which they are asked — the "every second" cadence
+# `TunnelSupervisor` documents for its own tick.
+TICK_INTERVAL_S = 1.0
+
 # What ssh prints when the relay has our key on file but nobody has approved it
 # yet. It is the FIRST evidence of that state — it arrives before any
 # registration verdict does — which is why the log tail is worth reading.

--- a/src/mship/core/daemon/host_tunnel.py
+++ b/src/mship/core/daemon/host_tunnel.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import logging
 import os
+import signal
 import subprocess
 import time
 from dataclasses import dataclass
@@ -89,34 +90,47 @@ def list_processes() -> list[ProcessInfo]:
     return rows
 
 
+def _forward_label(cmdline: str) -> str | None:
+    """The subdomain an `ssh … -R <label>:<port>:…` command forwards to.
+
+    Parsed as a token, never matched as a substring: `-R xyz-<oursub>:80:…` is
+    somebody else's label that merely ends with ours, and signalling it would
+    take down an unrelated host's tunnel.
+    """
+    tokens = cmdline.split()
+    try:
+        spec = tokens[tokens.index("-R") + 1]
+    except (ValueError, IndexError):
+        return None
+    return spec.split(":")[0]
+
+
 def reap_orphan_tunnels(
     subdomain: str,
     *,
     processes: Callable[[], Sequence[ProcessInfo]] = list_processes,
     kill: Callable[[int], None] | None = None,
 ) -> list[int]:
-    """Kill any `ssh -R <subdomain>:…` reparented to init; return the pids killed.
+    """Signal any `ssh -R <subdomain>:…` reparented to init; return those pids.
 
     Reparenting to init is the whole test: a tunnel we own has *us* as its
     parent, so PPID 1 means the process that dialed it is gone and nothing will
     ever clean it up. Anything that merely mentions the subdomain (an operator's
-    interactive `ssh`, a `grep`) is left alone — only a live reverse forward of
-    OUR label can collide with us.
+    interactive `ssh`, a `grep`, a host whose label ends with ours) is left
+    alone — only a live reverse forward of OUR exact label can collide with us.
     """
     if kill is None:
-        kill = lambda pid: os.kill(pid, 15)
+        kill = lambda pid: os.kill(pid, signal.SIGTERM)
     killed = []
     for proc in processes():
-        if proc.ppid != 1 or "-R" not in proc.cmdline.split():
-            continue
-        if f"{subdomain}:" not in proc.cmdline:
+        if proc.ppid != 1 or _forward_label(proc.cmdline) != subdomain:
             continue
         try:
             kill(proc.pid)
         except Exception as exc:  # already gone, or not ours to signal
-            log.debug("could not kill orphan tunnel pid=%s: %s", proc.pid, exc)
+            log.debug("could not signal orphan tunnel pid=%s: %s", proc.pid, exc)
             continue
-        log.warning("killed orphaned relay tunnel pid=%s holding %s", proc.pid, subdomain)
+        log.warning("signalled orphaned relay tunnel pid=%s holding %s", proc.pid, subdomain)
         killed.append(proc.pid)
     return killed
 
@@ -151,7 +165,10 @@ class HostTunnel:
         self._failure: str | None = None   # this tick's own fault, if any
         self._detail: str | None = None    # the last read-back's explanation
         self._last_readback_at: float | None = None
-        self._restarts_seen = supervisor.restart_count
+        # Monotonic: `restart_count` is NOT a respawn signal — a healthy run
+        # resets it and `start()` zeroes it, so diffing it would read a *drop*
+        # as a respawn and re-register while no child exists at all (AC2).
+        self._spawns_seen = supervisor.spawn_count
 
     # -- the loop -----------------------------------------------------------
 
@@ -199,10 +216,10 @@ class HostTunnel:
                 self._sample_ssh_log()
                 self._reap()
                 sup.tick()          # gated by the supervisor's own backoff
-        if sup.restart_count != self._restarts_seen:
-            self._restarts_seen = sup.restart_count
-            # The new child holds a fresh sish route; re-publish the entry now
-            # rather than waiting out `REGISTER_INTERVAL_S` (AC2).
+        if sup.spawn_count != self._spawns_seen:
+            self._spawns_seen = sup.spawn_count
+            # A new child is up, holding a fresh sish route; re-publish the entry
+            # now rather than waiting out `REGISTER_INTERVAL_S` (AC2).
             self._link.register_soon()
 
     def _redial(self) -> None:
@@ -220,6 +237,10 @@ class HostTunnel:
             # relay already refuses as a duplicate never spawns ssh at all (AC4).
             self._reap()
             self._supervisor.start()
+            # This tick's `link.tick()` already published the entry for this
+            # child, so the initial dial (and the re-dial after a duplicate
+            # identity clears) must not also count as a respawn.
+            self._spawns_seen = self._supervisor.spawn_count
             self._started = True
 
     def _reap(self) -> None:
@@ -292,7 +313,15 @@ class HostTunnel:
     def state(self) -> str:
         """The tunnel's state, most authoritative verdict first: what the relay
         decided about our identity, then what our own read-back saw, then how
-        far along the dial is."""
+        far along the dial is.
+
+        `contended` deliberately outranks `error`: a live twin answering on our
+        subdomain is a specific, named, operator-actionable fact, while `error`
+        is the catch-all for "a tick faulted or registration is failing" — and
+        the two co-occur constantly (a twin holding the route is exactly what
+        makes our own registrations fail), so the specific verdict has to win or
+        it would never be the one displayed.
+        """
         if self._stopped:
             return "disabled"
         if not self._link.should_dial():

--- a/src/mship/core/daemon/host_tunnel.py
+++ b/src/mship/core/daemon/host_tunnel.py
@@ -121,7 +121,7 @@ def reap_orphan_tunnels(
     """
     if kill is None:
         kill = lambda pid: os.kill(pid, signal.SIGTERM)
-    killed = []
+    signalled = []
     for proc in processes():
         if proc.ppid != 1 or _forward_label(proc.cmdline) != subdomain:
             continue
@@ -131,8 +131,8 @@ def reap_orphan_tunnels(
             log.debug("could not signal orphan tunnel pid=%s: %s", proc.pid, exc)
             continue
         log.warning("signalled orphaned relay tunnel pid=%s holding %s", proc.pid, subdomain)
-        killed.append(proc.pid)
-    return killed
+        signalled.append(proc.pid)
+    return signalled
 
 
 class HostTunnel:

--- a/src/mship/core/daemon/host_tunnel.py
+++ b/src/mship/core/daemon/host_tunnel.py
@@ -137,7 +137,7 @@ def _forward_label(cmdline: str) -> str | None:
     tokens = cmdline.split()
     try:
         spec = tokens[tokens.index("-R") + 1]
-    except ValueError, IndexError:
+    except (ValueError, IndexError):
         return None
     return spec.split(":")[0]
 
@@ -169,6 +169,9 @@ def reap_orphan_tunnels(
     processes: Callable[[], Sequence[ProcessInfo]] = list_processes,
     kill: Callable[[int], None] | None = None,
     force_kill: Callable[[int], None] | None = None,
+    pidfd_open: Callable[[int], int] | None = None,
+    pidfd_signal: Callable[[int, int], None] | None = None,
+    close_pidfd: Callable[[int], None] = os.close,
     process_exists: Callable[[int], bool] = _process_exists,
     clock: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
@@ -186,10 +189,6 @@ def reap_orphan_tunnels(
     an old process still owns the reverse forward. Returns the pids that
     accepted the initial signal.
     """
-    if kill is None:
-        kill = lambda pid: os.kill(pid, signal.SIGTERM)
-    if force_kill is None:
-        force_kill = lambda pid: os.kill(pid, signal.SIGKILL)
 
     def wait_for_exit(processes: list[ProcessInfo]) -> list[ProcessInfo]:
         deadline = clock() + ORPHAN_EXIT_TIMEOUT_S
@@ -202,47 +201,113 @@ def reap_orphan_tunnels(
             live = [process for process in live if process_exists(process.pid)]
         return []
 
+    def same_process(expected: ProcessInfo, current: ProcessInfo | None) -> bool:
+        return (
+            current is not None
+            and current.started == expected.started
+            and current.ppid == 1
+            and _forward_label(current.cmdline) == subdomain
+        )
+
+    def signal_atomically(proc: ProcessInfo, sig: int) -> bool:
+        opener = pidfd_open or getattr(os, "pidfd_open", None)
+        native_sender = getattr(signal, "pidfd_send_signal", None)
+        sender = pidfd_signal or (
+            (lambda fd, signal_number: native_sender(fd, signal_number, None, 0))
+            if native_sender is not None
+            else None
+        )
+        if opener is None or sender is None:
+            raise RuntimeError("atomic pidfd signaling is unavailable")
+        try:
+            fd = opener(proc.pid)
+        except ProcessLookupError:
+            return False
+        except Exception as exc:
+            raise RuntimeError("atomic pidfd signaling is unavailable") from exc
+        try:
+            current = {row.pid: row for row in processes()}.get(proc.pid)
+            if not same_process(proc, current):
+                return False
+            try:
+                sender(fd, sig)
+            except ProcessLookupError:
+                return False
+            return True
+        finally:
+            close_pidfd(fd)
+
+    candidates = [
+        proc
+        for proc in processes()
+        if proc.ppid == 1 and _forward_label(proc.cmdline) == subdomain
+    ]
+    refreshed = (
+        {proc.pid: proc for proc in processes()}
+        if candidates and kill is not None
+        else {}
+    )
     signalled = []
     identities = []
-    for proc in processes():
-        if proc.ppid != 1 or _forward_label(proc.cmdline) != subdomain:
-            continue
-        try:
-            kill(proc.pid)
-        except Exception as exc:
-            if process_exists(proc.pid):
-                raise RuntimeError(
-                    f"could not signal orphan tunnel pid {proc.pid}"
-                ) from exc
+    for proc in candidates:
+        if kill is None:
+            accepted = signal_atomically(proc, signal.SIGTERM)
+        else:
+            current = refreshed.get(proc.pid)
+            if current is None:
+                if process_exists(proc.pid):
+                    raise RuntimeError(
+                        f"could not revalidate orphan tunnel pid {proc.pid}"
+                    )
+                continue
+            if not same_process(proc, current):
+                continue
+            try:
+                kill(proc.pid)
+                accepted = True
+            except Exception as exc:
+                if process_exists(proc.pid):
+                    raise RuntimeError(
+                        f"could not signal orphan tunnel pid {proc.pid}"
+                    ) from exc
+                accepted = False
+        if not accepted:
             continue
         log.warning(
             "signalled orphaned relay tunnel pid=%s holding %s", proc.pid, subdomain
         )
         signalled.append(proc.pid)
         identities.append(proc)
-
     survivors = wait_for_exit(identities)
-    refreshed = {proc.pid: proc for proc in processes()} if survivors else {}
+    refreshed = (
+        {proc.pid: proc for proc in processes()}
+        if survivors and force_kill is not None
+        else {}
+    )
     force_signalled = []
     for proc in survivors:
-        current = refreshed.get(proc.pid)
-        if current is None:
-            if process_exists(proc.pid):
-                raise RuntimeError(f"could not revalidate orphan tunnel pid {proc.pid}")
-            continue
-        if (
-            current.started != proc.started
-            or current.ppid != 1
-            or _forward_label(current.cmdline) != subdomain
-        ):
-            continue
-        try:
-            force_kill(proc.pid)
-        except Exception as exc:
-            if process_exists(proc.pid):
-                raise RuntimeError(
-                    f"could not force-kill orphan tunnel pid {proc.pid}"
-                ) from exc
+        if force_kill is None:
+            accepted = signal_atomically(proc, signal.SIGKILL)
+        else:
+            current = refreshed.get(proc.pid)
+            if current is None:
+                if process_exists(proc.pid):
+                    raise RuntimeError(
+                        f"could not revalidate orphan tunnel pid {proc.pid}"
+                    )
+                continue
+            if not same_process(proc, current):
+                continue
+            try:
+                force_kill(proc.pid)
+                accepted = True
+            except Exception as exc:
+                if process_exists(proc.pid):
+                    raise RuntimeError(
+                        f"could not force-kill orphan tunnel pid {proc.pid}"
+                    ) from exc
+                accepted = False
+        if not accepted:
             continue
         log.warning(
             "force-killed orphaned relay tunnel pid=%s holding %s",
@@ -286,7 +351,7 @@ class HostTunnel:
         self._ever_online = False
         self._ssh_rejected = False  # the ssh log tail says "not approved yet"
         self._contended_with: str | None = None
-        self._failure: str | None = None  # this tick's own fault, if any
+        self._failure: str | None = None  # persists until the failed operation recovers
         self._detail: str | None = None  # the last read-back's explanation
         self._last_readback_at: float | None = None
         # Monotonic: `restart_count` is NOT a respawn signal — a healthy run
@@ -305,7 +370,6 @@ class HostTunnel:
         that cannot respawn must not silence registration (AC7)."""
         if self._stopped:
             return self.state()
-        self._failure = None
         self._guard("tunnel", self._supervise)
         self._guard("registration", self._link.tick)
         self._guard("tunnel", self._redial)
@@ -331,6 +395,13 @@ class HostTunnel:
         except Exception as exc:
             log.exception("%s tick failed", what)
             self._failure = f"{what}: {exc}"
+        else:
+            if (
+                what == "registration"
+                and self._failure is not None
+                and self._failure.startswith("registration:")
+            ):
+                self._failure = None
 
     def _supervise(self) -> None:
         """Respawn a dead child, read back a live one, and tell the link when a
@@ -351,6 +422,12 @@ class HostTunnel:
             # A new child is up, holding a fresh sish route; re-publish the entry
             # now rather than waiting out `REGISTER_INTERVAL_S` (AC2).
             self._link.register_soon()
+        if (
+            sup.is_running()
+            and self._failure is not None
+            and self._failure.startswith("tunnel:")
+        ):
+            self._failure = None
 
     def _redial(self) -> None:
         """Act on the link's verdict: a duplicate identity must not hold a
@@ -374,6 +451,12 @@ class HostTunnel:
             # This tick's `link.tick()` already published the entry for this
             # child, so the initial dial must not also count as a respawn.
             self._spawns_seen = self._supervisor.spawn_count
+            if (
+                self._supervisor.is_running()
+                and self._failure is not None
+                and self._failure.startswith("tunnel:")
+            ):
+                self._failure = None
 
     def _reap(self) -> None:
         """Sweep orphans once per downtime, not once per tick: this shells out to

--- a/src/mship/core/daemon/host_tunnel.py
+++ b/src/mship/core/daemon/host_tunnel.py
@@ -69,10 +69,6 @@ MAX_PROCESS_LIST_CALLS_PER_REAP = 3
 ORPHAN_EXIT_TIMEOUT_S = 2.0
 _ORPHAN_EXIT_POLL_S = 0.05
 
-# What ssh prints when the relay has our key on file but nobody has approved it
-# yet. It is the FIRST evidence of that state — it arrives before any
-# registration verdict does — which is why the log tail is worth reading.
-_UNAPPROVED_SSH_MARKER = "permission denied"
 
 # The states this reports, in the order `state()` resolves them.
 STATES = (
@@ -338,8 +334,6 @@ class HostTunnel:
         self._started = False  # True after the first dial attempt
         self._reaped = False  # swept during the current downtime
         self._online = False  # the last read-back was us
-        self._ever_online = False
-        self._ssh_rejected = False  # the ssh log tail says "not approved yet"
         self._contended_with: str | None = None
         self._failure: str | None = None  # persists until the failed operation recovers
         self._detail: str | None = None  # the last read-back's explanation
@@ -404,7 +398,6 @@ class HostTunnel:
                 self._read_back(self._clock())
             else:
                 self._online = False
-                self._sample_ssh_log()
                 self._reap()
                 sup.tick()  # gated by the supervisor's own backoff
         if sup.spawn_count != self._spawns_seen:
@@ -457,16 +450,6 @@ class HostTunnel:
         self._reaper(self._link.subdomain)
         self._reaped = True
 
-    def _sample_ssh_log(self) -> None:
-        """Read the ssh tail while the child is down — the only time it explains
-        anything. Ignored once a read-back has ever confirmed us: the log is
-        append-only, so an old rejection stays in the tail long after the key
-        was approved, and from then on the relay's own verdict is authoritative.
-        """
-        if self._ever_online:
-            return
-        tail = self._supervisor.recent_output()
-        self._ssh_rejected = _UNAPPROVED_SSH_MARKER in tail.lower()
 
     def _read_back(self, now: float) -> None:
         """Ask our own public URL who is answering on it.
@@ -505,8 +488,6 @@ class HostTunnel:
             return
         if answered == self._link.instance_id:
             self._online = True
-            self._ever_online = True
-            self._ssh_rejected = False
             self._contended_with = None
             self._detail = None
             return
@@ -538,7 +519,7 @@ class HostTunnel:
             return "disabled"
         if not self._link.should_dial():
             return "duplicate-identity"
-        if self._link.state == "awaiting-enrollment" or self._ssh_rejected:
+        if self._link.state == "awaiting-enrollment":
             return "awaiting-enrollment"
         if self._contended_with is not None:
             return "contended"

--- a/src/mship/core/daemon/host_tunnel.py
+++ b/src/mship/core/daemon/host_tunnel.py
@@ -245,6 +245,10 @@ class HostTunnel:
         """Act on the link's verdict: a duplicate identity must not hold a
         tunnel open (two twins on one subdomain split traffic between them),
         and everything else dials."""
+        if not self._started:
+            # Reap before accepting the relay's verdict: an orphan from the
+            # previous daemon can itself be the incumbent that caused a 409.
+            self._reap()
         if not self._link.should_dial():
             if self._started:
                 self._supervisor.stop()
@@ -252,9 +256,6 @@ class HostTunnel:
                 self._online = False
             return
         if not self._started:
-            # First dial only after the link has had its say, so a host the
-            # relay already refuses as a duplicate never spawns ssh at all (AC4).
-            self._reap()
             self._supervisor.start()
             # This tick's `link.tick()` already published the entry for this
             # child, so the initial dial (and the re-dial after a duplicate

--- a/src/mship/core/daemon/host_tunnel.py
+++ b/src/mship/core/daemon/host_tunnel.py
@@ -53,6 +53,11 @@ READBACK_INTERVAL_S = 30.0
 # `TunnelSupervisor` documents for its own tick.
 TICK_INTERVAL_S = 1.0
 
+# Bound on the orphan sweep's shell-out. Named because the daemon's shutdown
+# derives its tunnel-join bound from it (`core/daemon/run.py`) — a tick must
+# not be able to outlast the wait that exists to keep it from orphaning ssh.
+PROCESS_LIST_TIMEOUT_S = 10.0
+
 # What ssh prints when the relay has our key on file but nobody has approved it
 # yet. It is the FIRST evidence of that state — it arrives before any
 # registration verdict does — which is why the log tail is worth reading.
@@ -80,7 +85,8 @@ def list_processes() -> list[ProcessInfo]:
     try:
         out = subprocess.run(
             ["ps", "-eo", "pid=,ppid=,args="],
-            capture_output=True, text=True, timeout=10, check=True,
+            capture_output=True, text=True, timeout=PROCESS_LIST_TIMEOUT_S,
+            check=True,
         ).stdout
     except Exception as exc:
         log.debug("could not list processes for the orphan sweep: %s", exc)
@@ -194,12 +200,15 @@ class HostTunnel:
         return self.state()
 
     def stop(self) -> None:
-        """Terminate the ssh child and stay down. Idempotent — the second call
-        must not signal a pid the supervisor has already released."""
+        """Terminate the ssh child and stay down, for good. Idempotent — the
+        second call must not signal a pid the supervisor has already released.
+
+        `final=True` because this is the shutdown path: a tick still in flight
+        on another thread must not be able to dial a replacement behind us."""
         if self._stopped:
             return
         self._stopped = True
-        self._supervisor.stop()
+        self._supervisor.stop(final=True)
         self._online = False
 
     def _guard(self, what: str, fn: Callable[[], object]) -> None:

--- a/src/mship/core/daemon/host_tunnel.py
+++ b/src/mship/core/daemon/host_tunnel.py
@@ -315,6 +315,9 @@ class HostTunnel:
             return
         self._last_readback_at = now
         probe = self._verify(self._link.public_url, "")
+        # Contention is an observation, not a latch: every completed read-back
+        # supersedes the previous verdict, even when the new result is transient.
+        self._contended_with = None
         if probe.error is not None:
             self._online = False
             self._detail = f"read-back failed: {probe.error}"

--- a/src/mship/core/daemon/identity.py
+++ b/src/mship/core/daemon/identity.py
@@ -97,10 +97,22 @@ def _read(path: Path) -> dict | None:
         return None  # corrupt/truncated → re-mint (RegistryStore._load_nolock precedent)
 
 
+def _revoke_relay_key(home: Path) -> None:
+    """Remove the current key from a configured relay before rotating it."""
+    from mship.core.daemon.registry import load_daemon_config
+    from mship.core.relay.config import RelayConfig
+
+    relay = RelayConfig.from_mapping(load_daemon_config(home).relay)
+    if relay is None:
+        return
+    from mship.core.daemon.relay_link import revoke_relay_key
+
+    revoke_relay_key(home, relay)
+
+
 def _rotate_relay_key(home: Path) -> None:
-    """Move the current relay key aside so a re-identified host presents a NEW
-    key: the clone's copied key is still in the relay's `pubkeys/`, so keeping
-    it would let the clone keep authenticating as this host."""
+    """Move the revoked relay key aside so the re-identified host generates and
+    enrolls fresh local key material."""
     from mship.core.relay.keys import relay_key_path
 
     key = relay_key_path(home)
@@ -114,23 +126,24 @@ def force_reidentify(
     home: Path,
     *,
     fingerprint: str | None = None,
+    revoke_key: Callable[[Path], None] = _revoke_relay_key,
     rotate_key: Callable[[Path], None] = _rotate_relay_key,
     now: datetime | None = None,
 ) -> HostIdentity:
-    """Re-identify unconditionally: mint a new `host_id`, record the old one as
-    `cloned_from`, and rotate the relay key so the twin's copy stops working.
+    """Re-identify unconditionally: revoke the old relay key, mint a new
+    `host_id`, record the old one as `cloned_from`, and rotate local key
+    material.
 
-    The single owner of that move. `ensure_host_identity` delegates here when a
-    changed machine fingerprint is what noticed the clone (passing the running
-    machine's `fingerprint`); the daemon calls it directly after repeated
-    `409 duplicate-identity` answers, when the *relay* is what noticed and the
-    local fingerprint still matches; `mship daemon reidentify` calls it for an
-    operator. A headless VM must be able to recover without anyone SSHing in.
+    The single owner of that transition. `ensure_host_identity` delegates here
+    when a changed machine fingerprint is what noticed the clone; the daemon
+    calls it directly after repeated `409 duplicate-identity` answers, when the
+    relay noticed; `mship daemon reidentify` calls it for an operator.
     """
     from mship.core.daemon.paths import host_identity_path
 
     path = host_identity_path(home)
     previous = _read(path) or {}
+    revoke_key(home)
     rotate_key(home)
     ident = HostIdentity(
         host_id=mint_host_id(now),
@@ -148,6 +161,7 @@ def ensure_host_identity(
     *,
     fingerprint: str | None = None,
     on_mismatch: Literal["reidentify", "keep"] = "reidentify",
+    revoke_key: Callable[[Path], None] = _revoke_relay_key,
     rotate_key: Callable[[Path], None] = _rotate_relay_key,
     now: datetime | None = None,
 ) -> HostIdentity:
@@ -200,5 +214,9 @@ def ensure_host_identity(
         return ident
 
     return force_reidentify(
-        home, fingerprint=fingerprint, rotate_key=rotate_key, now=now
+        home,
+        fingerprint=fingerprint,
+        revoke_key=revoke_key,
+        rotate_key=rotate_key,
+        now=now,
     )

--- a/src/mship/core/daemon/identity.py
+++ b/src/mship/core/daemon/identity.py
@@ -113,17 +113,19 @@ def _rotate_relay_key(home: Path) -> None:
 def force_reidentify(
     home: Path,
     *,
+    fingerprint: str | None = None,
     rotate_key: Callable[[Path], None] = _rotate_relay_key,
     now: datetime | None = None,
 ) -> HostIdentity:
     """Re-identify unconditionally: mint a new `host_id`, record the old one as
-    `cloned_from`, and rotate the relay key — the same two moves
-    `ensure_host_identity` makes on a fingerprint mismatch, for the case where
-    the *relay* (not the local fingerprint) is what noticed the collision.
+    `cloned_from`, and rotate the relay key so the twin's copy stops working.
 
-    The daemon calls this itself after repeated `409 duplicate-identity`
-    answers, and `mship daemon reidentify` calls it for an operator: a headless
-    VM must be able to recover without anyone SSHing into it.
+    The single owner of that move. `ensure_host_identity` delegates here when a
+    changed machine fingerprint is what noticed the clone (passing the running
+    machine's `fingerprint`); the daemon calls it directly after repeated
+    `409 duplicate-identity` answers, when the *relay* is what noticed and the
+    local fingerprint still matches; `mship daemon reidentify` calls it for an
+    operator. A headless VM must be able to recover without anyone SSHing in.
     """
     from mship.core.daemon.paths import host_identity_path
 
@@ -133,7 +135,7 @@ def force_reidentify(
     ident = HostIdentity(
         host_id=mint_host_id(now),
         created_at=(now or datetime.now(timezone.utc)).isoformat(),
-        fingerprint=previous.get("fingerprint") or machine_fingerprint(),
+        fingerprint=fingerprint or previous.get("fingerprint") or machine_fingerprint(),
         cloned_from=previous.get("host_id"),
         reidentified=True,
     )
@@ -197,13 +199,6 @@ def ensure_host_identity(
         _write(path, ident)
         return ident
 
-    rotate_key(home)
-    ident = HostIdentity(
-        host_id=mint_host_id(now),
-        created_at=(now or datetime.now(timezone.utc)).isoformat(),
-        fingerprint=fingerprint,
-        cloned_from=raw["host_id"],
-        reidentified=True,
+    return force_reidentify(
+        home, fingerprint=fingerprint, rotate_key=rotate_key, now=now
     )
-    _write(path, ident)
-    return ident

--- a/src/mship/core/daemon/identity.py
+++ b/src/mship/core/daemon/identity.py
@@ -73,18 +73,34 @@ def machine_fingerprint(readers: Sequence[Path] | None = None) -> str | None:
 
 def _write(path: Path, ident: HostIdentity) -> None:
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    payload = memoryview(
+        json.dumps(
+            {
+                "host_id": ident.host_id,
+                "created_at": ident.created_at,
+                "fingerprint": ident.fingerprint,
+                "cloned_from": ident.cloned_from,
+            }
+        ).encode()
+    )
     tmp = path.with_name(path.name + ".tmp")
     fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
-        os.write(fd, json.dumps({
-            "host_id": ident.host_id,
-            "created_at": ident.created_at,
-            "fingerprint": ident.fingerprint,
-            "cloned_from": ident.cloned_from,
-        }).encode())
+        remaining = payload
+        while remaining:
+            written = os.write(fd, remaining)
+            if written == 0:
+                raise OSError("host identity write made no progress")
+            remaining = remaining[written:]
+        os.fsync(fd)
     finally:
         os.close(fd)
     tmp.replace(path)
+    parent_fd = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
 
 
 def _read(path: Path) -> dict | None:

--- a/src/mship/core/daemon/identity.py
+++ b/src/mship/core/daemon/identity.py
@@ -1,0 +1,178 @@
+"""Host identity (#471): who this machine IS, independent of any workspace.
+
+Three distinct things, deliberately:
+
+- `host_id` — minted once (`hst-<ts>-<uuid8>`), persisted, and the name the
+  relay directory keys on. Never derived from the relay key: that key is a
+  FILE, and a cloned VM reproduces it byte-for-byte.
+- machine fingerprint — a best-effort binding to the physical/virtual machine
+  (`/etc/machine-id`, DMI product uuid). Catches a RE-IMAGED host. It does NOT
+  catch `cp -a`/snapshot clones, which copy the fingerprint verbatim — that is
+  net (b)'s job (the relay arbitrates by probing the incumbent).
+- `instance_id` — minted per PROCESS, in memory, never written to disk. A clone
+  cannot copy what was never persisted, so it is what lets the relay tell a
+  restart from a second live claimant.
+
+Everything here is workspace-free: no config, no cwd, no repos. The daemon is
+one per host and its identity must not depend on which workspaces it serves.
+"""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Literal, Sequence
+
+_FINGERPRINT_SOURCES = (
+    Path("/etc/machine-id"),
+    Path("/var/lib/dbus/machine-id"),
+    Path("/sys/class/dmi/id/product_uuid"),
+)
+
+
+@dataclass(frozen=True)
+class HostIdentity:
+    host_id: str
+    created_at: str
+    fingerprint: str | None = None
+    cloned_from: str | None = None
+    reidentified: bool = False
+    adopted_fingerprint: str | None = None
+
+
+def mint_host_id(now: datetime | None = None) -> str:
+    now = now or datetime.now(timezone.utc)
+    return f"hst-{now.strftime('%Y%m%d%H%M%S')}-{uuid.uuid4().hex[:8]}"
+
+
+def mint_instance_id() -> str:
+    """Per-process, in-memory only. Deliberately NOT persisted: a clone must
+    not be able to reproduce it (see module docstring)."""
+    return secrets.token_hex(8)
+
+
+def machine_fingerprint(readers: Sequence[Path] | None = None) -> str | None:
+    """Best-effort machine binding, or None where unavailable (containers).
+
+    None is NOT a mismatch signal — an unreadable fingerprint must never raise
+    a false clone alarm on a host that simply cannot report one.
+    """
+    for path in (readers if readers is not None else _FINGERPRINT_SOURCES):
+        try:
+            value = Path(path).read_text().strip()
+        except OSError:
+            continue
+        if value:
+            return value
+    return None
+
+
+def _write(path: Path, ident: HostIdentity) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    tmp = path.with_name(path.name + ".tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, json.dumps({
+            "host_id": ident.host_id,
+            "created_at": ident.created_at,
+            "fingerprint": ident.fingerprint,
+            "cloned_from": ident.cloned_from,
+        }).encode())
+    finally:
+        os.close(fd)
+    tmp.replace(path)
+
+
+def _read(path: Path) -> dict | None:
+    try:
+        raw = json.loads(path.read_text())
+        if not isinstance(raw, dict) or not raw.get("host_id"):
+            return None
+        return raw
+    except (OSError, ValueError):
+        return None  # corrupt/truncated → re-mint (RegistryStore._load_nolock precedent)
+
+
+def _rotate_relay_key(home: Path) -> None:
+    """Move the current relay key aside so a re-identified host presents a NEW
+    key: the clone's copied key is still in the relay's `pubkeys/`, so keeping
+    it would let the clone keep authenticating as this host."""
+    from mship.core.relay.keys import relay_key_path
+
+    key = relay_key_path(home)
+    for path in (key, key.with_name(key.name + ".pub")):
+        if path.exists():
+            stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+            path.replace(path.with_name(f"{path.name}.pre-reidentify-{stamp}"))
+
+
+def ensure_host_identity(
+    home: Path,
+    *,
+    fingerprint: str | None = None,
+    on_mismatch: Literal["reidentify", "keep"] = "reidentify",
+    rotate_key: Callable[[Path], None] = _rotate_relay_key,
+    now: datetime | None = None,
+) -> HostIdentity:
+    """Load or mint this host's identity.
+
+    A recorded fingerprint that no longer matches the running machine means the
+    identity file travelled to different hardware (a re-imaged/restored host):
+    with `on_mismatch="reidentify"` (default) a NEW host_id is minted, the old
+    one recorded as `cloned_from`, and the relay key rotated so the twin cannot
+    keep authenticating as us. `on_mismatch="keep"` is the operator's explicit
+    "this is still the same host" adoption.
+
+    Idempotent: a second call returns the same identity, and a re-identified
+    host does not re-identify again on the next call.
+    """
+    from mship.core.daemon.paths import host_identity_path
+
+    path = host_identity_path(home)
+    raw = _read(path)
+    if raw is None:
+        ident = HostIdentity(
+            host_id=mint_host_id(now),
+            created_at=(now or datetime.now(timezone.utc)).isoformat(),
+            fingerprint=fingerprint,
+        )
+        _write(path, ident)
+        return ident
+
+    recorded = raw.get("fingerprint")
+    mismatch = (
+        recorded is not None and fingerprint is not None and recorded != fingerprint
+    )
+    if not mismatch:
+        return HostIdentity(
+            host_id=raw["host_id"],
+            created_at=raw.get("created_at", ""),
+            fingerprint=recorded,
+            cloned_from=raw.get("cloned_from"),
+        )
+
+    if on_mismatch == "keep":
+        ident = HostIdentity(
+            host_id=raw["host_id"],
+            created_at=raw.get("created_at", ""),
+            fingerprint=fingerprint,
+            cloned_from=raw.get("cloned_from"),
+            adopted_fingerprint=fingerprint,
+        )
+        _write(path, ident)
+        return ident
+
+    rotate_key(home)
+    ident = HostIdentity(
+        host_id=mint_host_id(now),
+        created_at=(now or datetime.now(timezone.utc)).isoformat(),
+        fingerprint=fingerprint,
+        cloned_from=raw["host_id"],
+        reidentified=True,
+    )
+    _write(path, ident)
+    return ident

--- a/src/mship/core/daemon/identity.py
+++ b/src/mship/core/daemon/identity.py
@@ -98,20 +98,7 @@ def _read(path: Path) -> dict | None:
 
 
 def _preserve_relay_key(_home: Path) -> None:
-    """Automatic recovery cannot prove a copied key is not still in use."""
-
-
-def _revoke_relay_key(home: Path) -> None:
-    """Remove the current key from a configured relay before rotating it."""
-    from mship.core.daemon.registry import load_daemon_config
-    from mship.core.relay.config import RelayConfig
-
-    relay = RelayConfig.from_mapping(load_daemon_config(home).relay)
-    if relay is None:
-        return
-    from mship.core.daemon.relay_link import revoke_relay_key
-
-    revoke_relay_key(home, relay)
+    """A copied key may still be serving a healthy source host."""
 
 
 def _rotate_relay_key(home: Path) -> None:
@@ -130,18 +117,20 @@ def force_reidentify(
     home: Path,
     *,
     fingerprint: str | None = None,
-    revoke_key: Callable[[Path], None] = _revoke_relay_key,
+    revoke_key: Callable[[Path], None] = _preserve_relay_key,
     rotate_key: Callable[[Path], None] = _rotate_relay_key,
     now: datetime | None = None,
 ) -> HostIdentity:
-    """Re-identify unconditionally: revoke the old relay key, mint a new
-    `host_id`, record the old one as `cloned_from`, and rotate local key
-    material.
+    """Re-identify unconditionally: preserve the old relay approval by default,
+    mint a new `host_id`, record the old one as `cloned_from`, and rotate the
+    local key material.
 
-    The single owner of that transition. `ensure_host_identity` delegates here
-    when a changed machine fingerprint is what noticed the clone; the daemon
-    calls it directly after repeated `409 duplicate-identity` answers, when the
-    relay noticed; `mship daemon reidentify` calls it for an operator.
+    A copied key may still be serving a healthy source host, so no recovery
+    path revokes it implicitly. Callers that can prove sole ownership may inject
+    a revoker. `ensure_host_identity` delegates here when a changed machine
+    fingerprint notices the clone; the daemon calls it after repeated
+    `409 duplicate-identity` answers; `mship daemon reidentify` calls it for an
+    operator.
     """
     from mship.core.daemon.paths import host_identity_path
 
@@ -174,9 +163,10 @@ def ensure_host_identity(
     A recorded fingerprint that no longer matches the running machine means the
     identity file travelled to different hardware (a re-imaged/restored host):
     with `on_mismatch="reidentify"` (default) a NEW host_id is minted, the old
-    one recorded as `cloned_from`, and the relay key rotated so the twin cannot
-    keep authenticating as us. `on_mismatch="keep"` is the operator's explicit
-    "this is still the same host" adoption.
+    one recorded as `cloned_from`, and the local relay key rotated so the new
+    identity enrolls independently without revoking a possibly-live source.
+    `on_mismatch="keep"` is the operator's explicit "this is still the same
+    host" adoption.
 
     Idempotent: a second call returns the same identity, and a re-identified
     host does not re-identify again on the next call.

--- a/src/mship/core/daemon/identity.py
+++ b/src/mship/core/daemon/identity.py
@@ -110,6 +110,37 @@ def _rotate_relay_key(home: Path) -> None:
             path.replace(path.with_name(f"{path.name}.pre-reidentify-{stamp}"))
 
 
+def force_reidentify(
+    home: Path,
+    *,
+    rotate_key: Callable[[Path], None] = _rotate_relay_key,
+    now: datetime | None = None,
+) -> HostIdentity:
+    """Re-identify unconditionally: mint a new `host_id`, record the old one as
+    `cloned_from`, and rotate the relay key — the same two moves
+    `ensure_host_identity` makes on a fingerprint mismatch, for the case where
+    the *relay* (not the local fingerprint) is what noticed the collision.
+
+    The daemon calls this itself after repeated `409 duplicate-identity`
+    answers, and `mship daemon reidentify` calls it for an operator: a headless
+    VM must be able to recover without anyone SSHing into it.
+    """
+    from mship.core.daemon.paths import host_identity_path
+
+    path = host_identity_path(home)
+    previous = _read(path) or {}
+    rotate_key(home)
+    ident = HostIdentity(
+        host_id=mint_host_id(now),
+        created_at=(now or datetime.now(timezone.utc)).isoformat(),
+        fingerprint=previous.get("fingerprint") or machine_fingerprint(),
+        cloned_from=previous.get("host_id"),
+        reidentified=True,
+    )
+    _write(path, ident)
+    return ident
+
+
 def ensure_host_identity(
     home: Path,
     *,

--- a/src/mship/core/daemon/identity.py
+++ b/src/mship/core/daemon/identity.py
@@ -97,6 +97,10 @@ def _read(path: Path) -> dict | None:
         return None  # corrupt/truncated → re-mint (RegistryStore._load_nolock precedent)
 
 
+def _preserve_relay_key(_home: Path) -> None:
+    """Automatic recovery cannot prove a copied key is not still in use."""
+
+
 def _revoke_relay_key(home: Path) -> None:
     """Remove the current key from a configured relay before rotating it."""
     from mship.core.daemon.registry import load_daemon_config
@@ -111,7 +115,7 @@ def _revoke_relay_key(home: Path) -> None:
 
 
 def _rotate_relay_key(home: Path) -> None:
-    """Move the revoked relay key aside so the re-identified host generates and
+    """Move the current relay key aside so the re-identified host generates and
     enrolls fresh local key material."""
     from mship.core.relay.keys import relay_key_path
 
@@ -161,7 +165,7 @@ def ensure_host_identity(
     *,
     fingerprint: str | None = None,
     on_mismatch: Literal["reidentify", "keep"] = "reidentify",
-    revoke_key: Callable[[Path], None] = _revoke_relay_key,
+    revoke_key: Callable[[Path], None] = _preserve_relay_key,
     rotate_key: Callable[[Path], None] = _rotate_relay_key,
     now: datetime | None = None,
 ) -> HostIdentity:

--- a/src/mship/core/daemon/paths.py
+++ b/src/mship/core/daemon/paths.py
@@ -30,6 +30,10 @@ def daemon_config_path(home: Path) -> Path:
     return daemon_state_dir(home) / "config.yaml"
 
 
+def host_identity_path(home: Path) -> Path:
+    return daemon_state_dir(home) / "host-identity.json"
+
+
 def registry_path(home: Path) -> Path:
     return daemon_state_dir(home) / "workspaces.json"
 

--- a/src/mship/core/daemon/paths.py
+++ b/src/mship/core/daemon/paths.py
@@ -58,12 +58,6 @@ def tunnel_log_path(home: Path) -> Path:
     return daemon_log_dir(home) / "relay-tunnel.log"
 
 
-def tunnel_runtime_path(home: Path) -> Path:
-    """Where the live tunnel's subdomain/public URL is recorded for a reader
-    outside the daemon process (`mship daemon status`)."""
-    return daemon_state_dir(home) / "tunnel.json"
-
-
 def registry_path(home: Path) -> Path:
     return daemon_state_dir(home) / "workspaces.json"
 

--- a/src/mship/core/daemon/paths.py
+++ b/src/mship/core/daemon/paths.py
@@ -48,6 +48,22 @@ def host_refresh_path(home: Path) -> Path:
     return daemon_state_dir(home) / "host-refresh.json"
 
 
+def tunnel_log_path(home: Path) -> Path:
+    """Captured `ssh -R` output for the HOST tunnel (#471).
+
+    Daemon-owned and per-OS-user, deliberately NOT the workspace-scoped
+    `.mothership/relay-tunnel.log` that `mship serve --relay` writes: the daemon
+    dials one tunnel for the machine, not one per workspace, and it must not
+    write into a workspace it happens to have discovered."""
+    return daemon_log_dir(home) / "relay-tunnel.log"
+
+
+def tunnel_runtime_path(home: Path) -> Path:
+    """Where the live tunnel's subdomain/public URL is recorded for a reader
+    outside the daemon process (`mship daemon status`)."""
+    return daemon_state_dir(home) / "tunnel.json"
+
+
 def registry_path(home: Path) -> Path:
     return daemon_state_dir(home) / "workspaces.json"
 

--- a/src/mship/core/daemon/paths.py
+++ b/src/mship/core/daemon/paths.py
@@ -34,6 +34,20 @@ def host_identity_path(home: Path) -> Path:
     return daemon_state_dir(home) / "host-identity.json"
 
 
+def host_secret_path(home: Path) -> Path:
+    """The per-host root secret (`core.daemon.host_token`). Read-only — creates
+    nothing, so a reporter can check for it without minting one."""
+    return daemon_state_dir(home) / "host-root-secret"
+
+
+def host_tokens_path(home: Path) -> Path:
+    return daemon_state_dir(home) / "host-tokens.json"
+
+
+def host_refresh_path(home: Path) -> Path:
+    return daemon_state_dir(home) / "host-refresh.json"
+
+
 def registry_path(home: Path) -> Path:
     return daemon_state_dir(home) / "workspaces.json"
 

--- a/src/mship/core/daemon/registry.py
+++ b/src/mship/core/daemon/registry.py
@@ -140,16 +140,17 @@ class RegistryStore:
 
 
 class DaemonConfig(BaseModel):
-    """The daemon's own scan/serve configuration (`~/.mothership/daemon/config.yaml`).
+    """The daemon's own scan/serve/relay configuration (`~/.mothership/daemon/config.yaml`).
 
-    Missing file → empty scan roots (scan NOTHING — bounded by construction)
-    and no TCP bind (control-UDS only)."""
+    Missing file → empty scan roots (scan NOTHING — bounded by construction),
+    no TCP bind (control-UDS only) and no relay tunnel."""
 
     model_config = ConfigDict(extra="ignore")
     scan_roots: list[str] = []
     ignore_globs: list[str] = []
     max_depth: int = 6
     serve: Optional[dict] = None  # {"host": str, "port": int}
+    relay: Optional[dict] = None  # {"host": str, "ssh_port": int?, "user": str?}
 
     @field_validator("max_depth")
     @classmethod
@@ -173,6 +174,26 @@ class DaemonConfig(BaseModel):
         if isinstance(port, bool) or not isinstance(port, int) or not 1 <= port <= 65535:
             raise ValueError("daemon serve.port must be an integer from 1 to 65535")
         return {"host": host, "port": port}
+
+    @field_validator("relay", mode="before")
+    @classmethod
+    def _validate_relay(cls, value):
+        """Validated THROUGH `RelayConfig.from_mapping` — the tunnel's own
+        constructor — so the config boundary and the dialer can never disagree
+        about what a usable relay block is. An empty block is rejected rather
+        than read as "no relay": `from_mapping` treats falsy input as absent,
+        which is right for a caller that never wrote one and wrong for an
+        operator who wrote `relay:` and forgot the host."""
+        from mship.core.relay.config import RELAY_HOST_REQUIRED, RelayConfig
+
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise ValueError("daemon relay must be a host/ssh_port/user mapping")
+        if not value:
+            raise ValueError(RELAY_HOST_REQUIRED)
+        RelayConfig.from_mapping(value)
+        return value
 
 
 class DaemonConfigReadError(ValueError):

--- a/src/mship/core/daemon/relay_link.py
+++ b/src/mship/core/daemon/relay_link.py
@@ -84,6 +84,68 @@ HTTP_TIMEOUT_S = 10.0
 _STICKY_STATES = ("awaiting-enrollment", "duplicate-identity")
 
 
+def revoke_relay_key(
+    home: Path,
+    relay_cfg,
+    *,
+    post: Callable | None = None,
+    signer: Callable[[bytes], str] | None = None,
+    timeout: float = HTTP_TIMEOUT_S,
+) -> None:
+    """Prove possession of the current key, then remove it from the relay."""
+    key_path = keys.relay_key_path(home)
+    public_path = key_path.with_name(key_path.name + ".pub")
+    if not key_path.exists():
+        if public_path.exists():
+            raise RuntimeError(
+                "cannot revoke relay key: private key is missing while the old "
+                "public key may still be authorized"
+            )
+        return
+    identity = fingerprint(keys.relay_public_key(key_path).strip())
+    send = post if post is not None else _default_post
+    sign = (
+        signer
+        if signer is not None
+        else lambda blob: ssh_sig.sign_blob(
+            blob, key_path=key_path, namespace=host_contract.NAMESPACE
+        )
+    )
+    base = host_contract.enroll_base_url(relay_cfg.host)
+    challenge = send(
+        base + host_contract.CHALLENGE_PATH,
+        json={"key_fingerprint": identity},
+        timeout=timeout,
+    )
+    body = _body(challenge)
+    nonce = body.get("nonce") if body is not None else None
+    if (
+        challenge.status_code == 401
+        and _detail(challenge) == host_contract.UNAPPROVED_KEY_DETAIL
+    ):
+        return
+    if challenge.status_code != 200 or not isinstance(nonce, str) or not nonce:
+        raise RuntimeError(
+            _detail(challenge)
+            or f"relay key revocation challenge failed: HTTP {challenge.status_code}"
+        )
+    payload = host_contract.key_revocation_payload(identity)
+    response = send(
+        base + host_contract.REVOKE_PATH,
+        json={
+            "key_fingerprint": identity,
+            "nonce": nonce,
+            "signature": sign(host_contract.signing_blob(nonce, payload)),
+        },
+        timeout=timeout,
+    )
+    if not 200 <= response.status_code < 300:
+        raise RuntimeError(
+            _detail(response)
+            or f"relay key revocation failed: HTTP {response.status_code}"
+        )
+
+
 def host_subdomain_for(home: Path, host_id: str) -> str:
     """The relay subdomain this host publishes on, derived in ONE place.
 
@@ -143,7 +205,11 @@ class RelayLink:
         self._reidentify = (
             reidentify
             if reidentify is not None
-            else (lambda: force_reidentify(self._home))
+            else (
+                lambda: force_reidentify(
+                    self._home, revoke_key=self._revoke_current_key
+                )
+            )
         )
 
         self.instance_id = mint_instance_id()
@@ -158,9 +224,24 @@ class RelayLink:
         self._last_enroll_at: float | None = None
         self._enroll_repost_interval = host_contract.ENROLL_REPOST_INTERVAL_S
         self._delay = 0.0
-        self._adopt(ensure_host_identity(self._home, fingerprint=machine_fingerprint()))
+        self._adopt(
+            ensure_host_identity(
+                self._home,
+                fingerprint=machine_fingerprint(),
+                revoke_key=self._revoke_current_key,
+            )
+        )
 
     # -- identity + key material -------------------------------------------
+
+    def _revoke_current_key(self, home: Path) -> None:
+        revoke_relay_key(
+            home,
+            self._relay,
+            post=self._post,
+            signer=self._signer,
+            timeout=self._timeout,
+        )
 
     def _adopt(self, ident: HostIdentity) -> None:
         """Take on an identity and everything derived from it. Called again
@@ -280,7 +361,7 @@ class RelayLink:
             self.clock_skew_seconds = (
                 self._clock() - parsedate_to_datetime(raw).timestamp()
             )
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return
 
     # -- the loop -----------------------------------------------------------
@@ -353,7 +434,13 @@ class RelayLink:
             self._duplicate_streak,
             self.last_error,
         )
-        self._adopt(self._reidentify())
+        try:
+            ident = self._reidentify()
+        except Exception as exc:
+            log.exception("automatic re-identification failed")
+            self.last_error = f"automatic re-identification failed: {exc}"
+            return
+        self._adopt(ident)
         log.warning("re-identified as %s (subdomain %s)", self.host_id, self.subdomain)
         self._duplicate_streak = 0
         self.state = "awaiting-enrollment"
@@ -390,9 +477,18 @@ class RelayLink:
         if not body or not isinstance(body.get("id"), str) or not body["id"]:
             self.last_error = "enroll post failed: invalid response"
             return
+        if body.get("status") == "approved":
+            # The registration refusal is the relay's current allowlist verdict.
+            # An approved enrollment id can be historical if revocation won
+            # after create's locked dedupe read but before this response arrived.
+            # Do not suppress the next re-post: it must create the pending row.
+            self.last_error = (
+                "enroll response referenced a historical approval; retrying"
+            )
+            return
         try:
             ttl = float(body.get("expires_in"))
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             ttl = 0
         if math.isfinite(ttl) and ttl > 0:
             self._enroll_repost_interval = ttl / 3

--- a/src/mship/core/daemon/relay_link.py
+++ b/src/mship/core/daemon/relay_link.py
@@ -290,13 +290,14 @@ class RelayLink:
         now = self._clock()
         if not self._due(now):
             return None
-        self._last_attempt_at = now
         try:
             outcome = self.register_once()
         except Exception as exc:  # a bug here must not kill the daemon's loop
             log.exception("registration attempt failed unexpectedly")
             outcome = RegistrationOutcome(False, "error", detail=str(exc))
-        self._apply(outcome, now)
+        completed_at = self._clock()
+        self._apply(outcome, completed_at)
+        self._last_attempt_at = self._clock()
         return outcome
 
     def _due(self, now: float) -> bool:

--- a/src/mship/core/daemon/relay_link.py
+++ b/src/mship/core/daemon/relay_link.py
@@ -73,7 +73,10 @@ JITTER = tunnel.BACKOFF_JITTER
 # daemon does.
 _MAX_EXPONENT = math.ceil(math.log2(host_contract.MAX_BACKOFF_S / RETRY_BASE_S))
 
-_HTTP_TIMEOUT_S = 10.0
+# Per-call bound on every relay HTTP call this link makes. Public: the daemon's
+# shutdown derives its tunnel-join bound from it (`core/daemon/run.py`), so a
+# worst-case tick cannot outlast the wait that exists to prevent an orphan.
+HTTP_TIMEOUT_S = 10.0
 
 # States that describe what the RELAY decided about us. A transport blip must
 # not erase them: "the relay is unreachable" is not "the relay approved us".
@@ -109,7 +112,7 @@ class RelayLink:
         signer: Callable[[bytes], str] | None = None,
         issue_refresh: Callable[[str], str] | None = None,
         reidentify: Callable[[], HostIdentity] | None = None,
-        timeout: float = _HTTP_TIMEOUT_S,
+        timeout: float = HTTP_TIMEOUT_S,
     ) -> None:
         self._home = Path(home)
         self._relay = relay_cfg

--- a/src/mship/core/daemon/relay_link.py
+++ b/src/mship/core/daemon/relay_link.py
@@ -380,6 +380,11 @@ class RelayLink:
             # Leaves `_last_enroll_at` alone, so the next tick retries.
             self.last_error = f"enroll post failed: {exc}"
             return
+        if not 200 <= response.status_code < 300:
+            self.last_error = (
+                _detail(response) or f"enroll post failed: HTTP {response.status_code}"
+            )
+            return
         try:
             ttl = float((_body(response) or {}).get("expires_in"))
         except TypeError, ValueError:

--- a/src/mship/core/daemon/relay_link.py
+++ b/src/mship/core/daemon/relay_link.py
@@ -206,8 +206,11 @@ class RelayLink:
             reidentify
             if reidentify is not None
             else (
+                # A snapshot clone shares the incumbent's old private key.
+                # Rotating our copy is required; revoking the shared relay key
+                # would take the healthy source host offline too.
                 lambda: force_reidentify(
-                    self._home, revoke_key=self._revoke_current_key
+                    self._home, revoke_key=lambda _home: None
                 )
             )
         )
@@ -228,20 +231,13 @@ class RelayLink:
             ensure_host_identity(
                 self._home,
                 fingerprint=machine_fingerprint(),
-                revoke_key=self._revoke_current_key,
+                # A fingerprint-changing clone can still share the incumbent's
+                # copied key. Rotate our copy without revoking the shared key.
+                revoke_key=lambda _home: None,
             )
         )
 
     # -- identity + key material -------------------------------------------
-
-    def _revoke_current_key(self, home: Path) -> None:
-        revoke_relay_key(
-            home,
-            self._relay,
-            post=self._post,
-            signer=self._signer,
-            timeout=self._timeout,
-        )
 
     def _adopt(self, ident: HostIdentity) -> None:
         """Take on an identity and everything derived from it. Called again

--- a/src/mship/core/daemon/relay_link.py
+++ b/src/mship/core/daemon/relay_link.py
@@ -1,0 +1,383 @@
+"""The daemon's side of host registration (#471).
+
+One tick-driven object: fetch a challenge, sign the canonical payload with the
+same ed25519 key the tunnel authenticates with, POST it, and keep doing that
+forever. Every collaborator is injected (`post`/`get`/`clock`/`rng`/`signer`/
+`issue_refresh`/`reidentify`) so the whole loop is testable with no sockets and
+no sleeps, exactly like `core/relay/health.py`.
+
+Three properties are the reason this is a class and not a function:
+
+- **It never blocks and never prompts.** An unapproved key POSTs `/enroll`
+  non-blockingly and re-posts on `ENROLL_REPOST_INTERVAL_S`, rather than
+  running `mship relay enroll --wait`'s 1800s polling loop: a VM provisioned at
+  02:00 must still be approvable at 09:00, and nobody is at its terminal (AC1,
+  AC8). The relay's per-fingerprint dedupe collapses those re-posts to exactly
+  one pending record.
+- **It backs off without a ceiling.** `TunnelSupervisor`'s
+  `backoff_delay * 2 ** restart_count` raises `OverflowError` at 1024 restarts
+  — unreachable for a CLI, ~17h for an immortal daemon — so the exponent is
+  clamped here, and the delay is jittered from an injected RNG so a fleet
+  coming back after a relay redeploy does not retry in lockstep (AC2, AC3).
+- **It self-heals from a 409.** A duplicate identity stops the dial; after a
+  few consecutive refusals the link re-identifies itself (new `host_id`,
+  rotated key) and drops back to awaiting-enrollment, so a cloned VM recovers
+  into `GET /hosts` as `pending-approval` without an SSH session (AC4b).
+
+Reconnects write nothing: the refresh credential is *derived*, so re-issuing it
+re-publishes the same string and leaves `~/.mothership/daemon/` byte-identical
+(AC11).
+"""
+from __future__ import annotations
+
+import logging
+import math
+import random
+import socket
+import time
+from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+from typing import Callable
+
+from mship import __version__
+from mship.core.daemon.capabilities import host_capability_payload
+from mship.core.daemon.identity import (
+    HostIdentity,
+    ensure_host_identity,
+    force_reidentify,
+    machine_fingerprint,
+    mint_instance_id,
+)
+from mship.core.relay import host_contract, keys, ssh_sig, tunnel
+from mship.core.relay.enroll import fingerprint
+
+log = logging.getLogger(__name__)
+
+# The client name the host's own refresh credential is issued under. It is
+# published in the directory for whichever phone reads it, so it names the
+# channel, not a device.
+DIRECTORY_CLIENT = "relay-directory"
+
+# First retry delay; doubles per consecutive failure up to MAX_BACKOFF_S.
+RETRY_BASE_S = 2.0
+
+# ±20%: enough to de-phase a fleet that all lost the relay in the same second,
+# small enough that the cap still means roughly what it says.
+JITTER = 0.2
+
+# DERIVED, not picked: the first exponent at which the delay already exceeds
+# the cap. Clamping here is what keeps `2 ** n` from overflowing a float after
+# ~17h of failures (assumption 5) — a bound a CLI never reaches and an immortal
+# daemon does.
+_MAX_EXPONENT = math.ceil(math.log2(host_contract.MAX_BACKOFF_S / RETRY_BASE_S))
+
+_HTTP_TIMEOUT_S = 10.0
+
+# States that describe what the RELAY decided about us. A transport blip must
+# not erase them: "the relay is unreachable" is not "the relay approved us".
+_STICKY_STATES = ("awaiting-enrollment", "duplicate-identity")
+
+
+@dataclass(frozen=True)
+class RegistrationOutcome:
+    """One registration attempt, as data. Never an exception: the caller is a
+    loop that must keep ticking, and `kind` is what the ladder reads."""
+
+    ok: bool
+    kind: str          # registered|unapproved|duplicate-identity|refused|transport|signing|error
+    detail: str = ""
+    refresh: str | None = None
+    status_code: int | None = None
+
+
+class RelayLink:
+    """Keeps this host's entry in the relay's directory current."""
+
+    DUPLICATE_REIDENTIFY_AFTER = 3
+
+    def __init__(
+        self,
+        home: Path,
+        relay_cfg,
+        *,
+        post: Callable | None = None,
+        get: Callable | None = None,
+        clock: Callable[[], float] = time.time,
+        rng: Callable[[], float] = random.random,
+        signer: Callable[[bytes], str] | None = None,
+        issue_refresh: Callable[[str], str] | None = None,
+        reidentify: Callable[[], HostIdentity] | None = None,
+        timeout: float = _HTTP_TIMEOUT_S,
+    ) -> None:
+        self._home = Path(home)
+        self._relay = relay_cfg
+        self._base = host_contract.enroll_base_url(relay_cfg.host)
+        self._timeout = timeout
+        self._clock = clock          # wall clock: it also dates the skew sample
+        self._rng = rng
+        self._post = post if post is not None else _default_post
+        self._get = get if get is not None else _default_get
+        self._signer = signer if signer is not None else self._sign_with_relay_key
+        self._issue_refresh = (
+            issue_refresh if issue_refresh is not None else self._issue_from_store
+        )
+        self._reidentify = (
+            reidentify if reidentify is not None else (lambda: force_reidentify(self._home))
+        )
+
+        self.instance_id = mint_instance_id()
+        self.state = "unregistered"
+        self.last_error: str | None = None
+        self.clock_skew_seconds: float | None = None
+        self.refresh: str | None = None
+        self.failure_count = 0
+
+        self._duplicate_streak = 0
+        self._last_attempt_at: float | None = None
+        self._last_enroll_at: float | None = None
+        self._delay = 0.0
+        self._adopt(
+            ensure_host_identity(self._home, fingerprint=machine_fingerprint())
+        )
+
+    # -- identity + key material -------------------------------------------
+
+    def _adopt(self, ident: HostIdentity) -> None:
+        """Take on an identity and everything derived from it. Called again
+        after a re-identify, when both the host_id AND the key have changed."""
+        self._identity = ident
+        self.host_id = ident.host_id
+        key_path = keys.ensure_relay_key(self._home)
+        self._pubkey = keys.relay_public_key(key_path).strip()
+        self.key_fingerprint = fingerprint(self._pubkey)
+        self.subdomain = tunnel.host_subdomain(
+            ident.host_id,
+            tunnel.device_id(self._pubkey),
+            keys.ensure_subdomain_secret(self._home),
+        )
+        self.public_url = f"https://{self.subdomain}.{self._relay.host}"
+
+    def _sign_with_relay_key(self, blob: bytes) -> str:
+        return ssh_sig.sign_blob(
+            blob,
+            key_path=keys.relay_key_path(self._home),
+            namespace=host_contract.NAMESPACE,
+        )
+
+    def _issue_from_store(self, host_id: str) -> str:
+        from mship.core.daemon.host_auth import RefreshStore
+
+        return RefreshStore(self._home).issue_refresh(
+            host_id=host_id, client=DIRECTORY_CLIENT
+        )
+
+    # -- the payload --------------------------------------------------------
+
+    def _payload(self) -> dict:
+        """Identity + capability metadata, and nothing else: a registration is
+        published to every paired phone, and it is re-sent on every reconnect,
+        so anything expensive or private here would be both a leak and a cost."""
+        return {
+            "host_id": self.host_id,
+            "instance_id": self.instance_id,
+            "label": socket.gethostname(),
+            "machine_fingerprint": self._identity.fingerprint,
+            "key_fingerprint": self.key_fingerprint,
+            "subdomain": self.subdomain,
+            "public_url": self.public_url,
+            "mship_version": __version__,
+            "refresh": self._issue_refresh(self.host_id),
+            **host_capability_payload(),
+        }
+
+    # -- one attempt --------------------------------------------------------
+
+    def register_once(self) -> RegistrationOutcome:
+        """Challenge → sign → register, as one typed outcome. Never raises for
+        anything the relay or the network can do."""
+        try:
+            challenge = self._get(
+                self._base + host_contract.CHALLENGE_PATH, timeout=self._timeout
+            )
+        except Exception as exc:
+            return RegistrationOutcome(False, "transport", detail=str(exc))
+        self._sample_skew(challenge)
+        if challenge.status_code != 200:
+            return RegistrationOutcome(
+                False, "refused", detail=_detail(challenge),
+                status_code=challenge.status_code,
+            )
+        nonce = str((challenge.json() or {}).get("nonce", ""))
+
+        payload = self._payload()
+        try:
+            signature = self._signer(host_contract.signing_blob(nonce, payload))
+        except Exception as exc:
+            return RegistrationOutcome(False, "signing", detail=str(exc))
+
+        try:
+            resp = self._post(
+                self._base + host_contract.REGISTER_PATH,
+                json={"nonce": nonce, "signature": signature, "payload": payload},
+                timeout=self._timeout,
+            )
+        except Exception as exc:
+            return RegistrationOutcome(False, "transport", detail=str(exc))
+        self._sample_skew(resp)
+        if resp.status_code == 200:
+            return RegistrationOutcome(
+                True, "registered", refresh=payload["refresh"], status_code=200
+            )
+        kind = {401: "unapproved", 409: "duplicate-identity"}.get(
+            resp.status_code, "refused"
+        )
+        return RegistrationOutcome(
+            False, kind, detail=_detail(resp), status_code=resp.status_code
+        )
+
+    def _sample_skew(self, resp) -> None:
+        """The enroll server's `Date` is the only header in this loop written by
+        a different clock (the read-back's is our own uvicorn's), so it is where
+        `mship daemon status` gets `clock_skew_seconds` from. Unparseable or
+        absent leaves it unknown rather than guessing zero."""
+        raw = (getattr(resp, "headers", None) or {}).get("Date")
+        if not raw:
+            return
+        try:
+            self.clock_skew_seconds = self._clock() - parsedate_to_datetime(raw).timestamp()
+        except (TypeError, ValueError):
+            return
+
+    # -- the loop -----------------------------------------------------------
+
+    def tick(self) -> RegistrationOutcome | None:
+        """Attempt a registration if one is due, else None. Never raises."""
+        now = self._clock()
+        if not self._due(now):
+            return None
+        self._last_attempt_at = now
+        try:
+            outcome = self.register_once()
+        except Exception as exc:  # a bug here must not kill the daemon's loop
+            log.exception("registration attempt failed unexpectedly")
+            outcome = RegistrationOutcome(False, "error", detail=str(exc))
+        self._apply(outcome, now)
+        return outcome
+
+    def _due(self, now: float) -> bool:
+        if self._last_attempt_at is None:
+            return True
+        elapsed = now - self._last_attempt_at
+        # A backwards wall-clock step (ntp correction, `timedatectl set-time`)
+        # must not park the link until the clock catches up.
+        return elapsed < 0 or elapsed >= self._delay
+
+    def _apply(self, outcome: RegistrationOutcome, now: float) -> None:
+        if outcome.ok:
+            self.state = "registered"
+            self.refresh = outcome.refresh
+            self.last_error = None
+            self.failure_count = 0
+            self._duplicate_streak = 0
+            self._delay = self._jittered(host_contract.REGISTER_INTERVAL_S)
+            return
+
+        self.failure_count += 1
+        self.last_error = outcome.detail or outcome.kind
+        if outcome.kind == "unapproved":
+            self.state = "awaiting-enrollment"
+            self._duplicate_streak = 0
+            self._post_enroll_if_due(now)
+        elif outcome.kind == "duplicate-identity":
+            self.state = "duplicate-identity"
+            self._duplicate_streak += 1
+            if self._duplicate_streak >= self.DUPLICATE_REIDENTIFY_AFTER:
+                self._auto_reidentify(now)
+        elif self.state not in _STICKY_STATES:
+            self.state = "error"
+        self._delay = self._jittered(
+            min(RETRY_BASE_S * 2 ** min(self.failure_count - 1, _MAX_EXPONENT),
+                host_contract.MAX_BACKOFF_S)
+        )
+
+    def _jittered(self, delay: float) -> float:
+        return delay * (1 + JITTER * (2 * self._rng() - 1))
+
+    def _auto_reidentify(self, now: float) -> None:
+        """The relay says someone else holds this identity and we cannot talk it
+        out of that. Mint a new one and go back to the enrollment queue — the
+        machine that needs this recovery is by definition one nobody can log
+        into."""
+        log.warning(
+            "relay refused %s consecutive registrations as a duplicate identity "
+            "(%s); re-identifying automatically — this host will reappear in the "
+            "relay's host list as pending-approval and needs approving again",
+            self._duplicate_streak, self.last_error,
+        )
+        self._adopt(self._reidentify())
+        log.warning("re-identified as %s (subdomain %s)", self.host_id, self.subdomain)
+        self._duplicate_streak = 0
+        self.state = "awaiting-enrollment"
+        self._last_enroll_at = None      # the new key needs approving at once
+        self._post_enroll_if_due(now)
+
+    def _post_enroll_if_due(self, now: float) -> None:
+        """Keep exactly one live enrollment request in the relay's store.
+
+        Non-blocking and fire-and-forget: no `/status/{rid}` polling, no wait
+        loop, no prompt. The relay dedupes by key fingerprint, so re-posting
+        refreshes the record's TTL instead of filling the pending cap."""
+        if (
+            self._last_enroll_at is not None
+            and 0 <= now - self._last_enroll_at < host_contract.ENROLL_REPOST_INTERVAL_S
+        ):
+            return
+        try:
+            self._post(
+                self._base + "/enroll",
+                json={"pubkey": self._pubkey, "hostname": socket.gethostname()},
+                timeout=self._timeout,
+            )
+        except Exception as exc:
+            # Leaves `_last_enroll_at` alone, so the next tick retries.
+            self.last_error = f"enroll post failed: {exc}"
+            return
+        self._last_enroll_at = now
+
+    # -- what the tunnel asks ------------------------------------------------
+
+    def should_dial(self) -> bool:
+        """False only while the relay says another host holds this identity:
+        dialing then would fight a live twin for the subdomain. An unapproved
+        key still dials — ssh's refusal is how Task 7 classifies it."""
+        return self.state != "duplicate-identity"
+
+    def next_attempt_delay(self) -> float:
+        """Seconds from the last attempt until the next one is due."""
+        return self._delay
+
+
+def _detail(resp) -> str:
+    """The relay's own explanation, which is what the operator must read (a 409
+    carries the `mship daemon reidentify` hint). Never raises on a proxy's HTML
+    error page."""
+    try:
+        body = resp.json()
+    except Exception:
+        return ""
+    if isinstance(body, dict):
+        return str(body.get("detail", ""))
+    return ""
+
+
+def _default_get(url, **kw):
+    import httpx
+
+    return httpx.get(url, **kw)
+
+
+def _default_post(url, **kw):
+    import httpx
+
+    return httpx.post(url, **kw)

--- a/src/mship/core/daemon/relay_link.py
+++ b/src/mship/core/daemon/relay_link.py
@@ -62,8 +62,9 @@ DIRECTORY_CLIENT = "relay-directory"
 # First retry delay; doubles per consecutive failure up to MAX_BACKOFF_S.
 RETRY_BASE_S = 2.0
 
-# ±20%: enough to de-phase a fleet that all lost the relay in the same second,
-# small enough that the cap still means roughly what it says.
+# Up to 20% OFF the scheduled delay (never added — see `_jittered`): enough to
+# de-phase a fleet that all lost the relay in the same second, small enough that
+# the delay still means roughly what it says.
 JITTER = 0.2
 
 # DERIVED, not picked: the first exponent at which the delay already exceeds
@@ -168,7 +169,7 @@ class RelayLink:
     def _issue_from_store(self, host_id: str) -> str:
         from mship.core.daemon.host_auth import RefreshStore
 
-        return RefreshStore(self._home).issue_refresh(
+        return RefreshStore(self._home, clock=self._clock).issue_refresh(
             host_id=host_id, client=DIRECTORY_CLIENT
         )
 
@@ -208,7 +209,16 @@ class RelayLink:
                 False, "refused", detail=_detail(challenge),
                 status_code=challenge.status_code,
             )
-        nonce = str((challenge.json() or {}).get("nonce", ""))
+        # A 200 is not a promise of JSON: a captive portal, a misrouted vhost or
+        # a proxy's error page all answer 200 with HTML, and a `.json()` raising
+        # here would break this function's never-raises contract.
+        nonce = str((_body(challenge) or {}).get("nonce", ""))
+        if not nonce:
+            return RegistrationOutcome(
+                False, "refused", status_code=challenge.status_code,
+                detail="challenge response carried no nonce "
+                       f"(is {self._base} really the relay's enroll server?)",
+            )
 
         payload = self._payload()
         try:
@@ -229,11 +239,10 @@ class RelayLink:
             return RegistrationOutcome(
                 True, "registered", refresh=payload["refresh"], status_code=200
             )
-        kind = {401: "unapproved", 409: "duplicate-identity"}.get(
-            resp.status_code, "refused"
-        )
+        detail = _detail(resp)
         return RegistrationOutcome(
-            False, kind, detail=_detail(resp), status_code=resp.status_code
+            False, _classify(resp.status_code, detail),
+            detail=detail, status_code=resp.status_code,
         )
 
     def _sample_skew(self, resp) -> None:
@@ -302,7 +311,10 @@ class RelayLink:
         )
 
     def _jittered(self, delay: float) -> float:
-        return delay * (1 + JITTER * (2 * self._rng() - 1))
+        """De-phase DOWNWARD only. `DIRECTORY_STALE_S` is derived from
+        `MAX_BACKOFF_S`, so a delay jittered *above* the cap would let a healthy
+        reconnecting host read as stale in the directory."""
+        return delay * (1 - JITTER * self._rng())
 
     def _auto_reidentify(self, now: float) -> None:
         """The relay says someone else holds this identity and we cannot talk it
@@ -335,7 +347,7 @@ class RelayLink:
             return
         try:
             self._post(
-                self._base + "/enroll",
+                self._base + host_contract.ENROLL_PATH,
                 json={"pubkey": self._pubkey, "hostname": socket.gethostname()},
                 timeout=self._timeout,
             )
@@ -358,17 +370,41 @@ class RelayLink:
         return self._delay
 
 
-def _detail(resp) -> str:
-    """The relay's own explanation, which is what the operator must read (a 409
-    carries the `mship daemon reidentify` hint). Never raises on a proxy's HTML
-    error page."""
+def _classify(status_code: int, detail: str) -> str:
+    """Which failure a refused registration actually is.
+
+    `/hosts/register` answers 401 for two unrelated things: an unapproved key,
+    and a challenge the relay would not accept — a nonce that expired, raced
+    another attempt, or was already spent, on a `CHALLENGE_TTL_S` window. Only
+    the first means "wait for a human". Reading the second as unapproved would
+    make an approved host on a slow link report `awaiting-enrollment` and
+    re-post `/enroll` for a key that is already in `pubkeys/`, so the two are
+    told apart by the `detail` both ends read from `host_contract`. An
+    unrecognised 401 falls back to `unapproved`: enrolling once too often is
+    recoverable, never enrolling at all is not.
+    """
+    if status_code == 409:
+        return "duplicate-identity"
+    if status_code != 401:
+        return "refused"
+    return "refused" if detail in host_contract.CHALLENGE_REFUSAL_DETAILS else "unapproved"
+
+
+def _body(resp) -> dict | None:
+    """The response's JSON object, or None for anything else — HTML error page,
+    truncated body, a bare list. Never raises (the `health.py` discipline)."""
     try:
         body = resp.json()
     except Exception:
-        return ""
-    if isinstance(body, dict):
-        return str(body.get("detail", ""))
-    return ""
+        return None
+    return body if isinstance(body, dict) else None
+
+
+def _detail(resp) -> str:
+    """The relay's own explanation, which is what the operator must read (a 409
+    carries the `mship daemon reidentify` hint) and what `_classify` reads to
+    tell the two flavors of 401 apart."""
+    return str((_body(resp) or {}).get("detail", ""))
 
 
 def _default_get(url, **kw):

--- a/src/mship/core/daemon/relay_link.py
+++ b/src/mship/core/daemon/relay_link.py
@@ -153,6 +153,7 @@ class RelayLink:
         self._duplicate_streak = 0
         self._last_attempt_at: float | None = None
         self._last_enroll_at: float | None = None
+        self._enroll_repost_interval = host_contract.ENROLL_REPOST_INTERVAL_S
         self._delay = 0.0
         self._adopt(
             ensure_host_identity(self._home, fingerprint=machine_fingerprint())
@@ -351,11 +352,11 @@ class RelayLink:
         refreshes the record's TTL instead of filling the pending cap."""
         if (
             self._last_enroll_at is not None
-            and 0 <= now - self._last_enroll_at < host_contract.ENROLL_REPOST_INTERVAL_S
+            and 0 <= now - self._last_enroll_at < self._enroll_repost_interval
         ):
             return
         try:
-            self._post(
+            response = self._post(
                 self._base + host_contract.ENROLL_PATH,
                 json={"pubkey": self._pubkey, "hostname": socket.gethostname()},
                 timeout=self._timeout,
@@ -364,6 +365,12 @@ class RelayLink:
             # Leaves `_last_enroll_at` alone, so the next tick retries.
             self.last_error = f"enroll post failed: {exc}"
             return
+        try:
+            ttl = float((_body(response) or {}).get("expires_in"))
+        except (TypeError, ValueError):
+            ttl = 0
+        if math.isfinite(ttl) and ttl > 0:
+            self._enroll_repost_interval = ttl / 3
         self._last_enroll_at = now
 
     # -- what the tunnel asks ------------------------------------------------

--- a/src/mship/core/daemon/relay_link.py
+++ b/src/mship/core/daemon/relay_link.py
@@ -1,10 +1,10 @@
 """The daemon's side of host registration (#471).
 
-One tick-driven object: fetch a challenge, sign the canonical payload with the
-same ed25519 key the tunnel authenticates with, POST it, and keep doing that
-forever. Every collaborator is injected (`post`/`get`/`clock`/`rng`/`signer`/
-`issue_refresh`/`reidentify`) so the whole loop is testable with no sockets and
-no sleeps, exactly like `core/relay/health.py`.
+One tick-driven object: request an identity-scoped challenge, sign the canonical
+payload with the same ed25519 key the tunnel authenticates with, POST it, and
+keep doing that forever. Every collaborator is injected (`post`/`clock`/`rng`/
+`signer`/`issue_refresh`/`reidentify`) so the whole loop is testable with no
+sockets and no sleeps, exactly like `core/relay/health.py`.
 
 Three properties are the reason this is a class and not a function:
 
@@ -28,6 +28,7 @@ Reconnects write nothing: the refresh credential is *derived*, so re-issuing it
 re-publishes the same string and leaves `~/.mothership/daemon/` byte-identical
 (AC11).
 """
+
 from __future__ import annotations
 
 import logging
@@ -102,7 +103,9 @@ class RegistrationOutcome:
     loop that must keep ticking, and `kind` is what the ladder reads."""
 
     ok: bool
-    kind: str          # registered|unapproved|duplicate-identity|refused|transport|signing|error
+    kind: (
+        str  # registered|unapproved|duplicate-identity|refused|transport|signing|error
+    )
     detail: str = ""
     refresh: str | None = None
     status_code: int | None = None
@@ -119,7 +122,6 @@ class RelayLink:
         relay_cfg,
         *,
         post: Callable | None = None,
-        get: Callable | None = None,
         clock: Callable[[], float] = time.time,
         rng: Callable[[], float] = random.random,
         signer: Callable[[bytes], str] | None = None,
@@ -131,16 +133,17 @@ class RelayLink:
         self._relay = relay_cfg
         self._base = host_contract.enroll_base_url(relay_cfg.host)
         self._timeout = timeout
-        self._clock = clock          # wall clock: it also dates the skew sample
+        self._clock = clock  # wall clock: it also dates the skew sample
         self._rng = rng
         self._post = post if post is not None else _default_post
-        self._get = get if get is not None else _default_get
         self._signer = signer if signer is not None else self._sign_with_relay_key
         self._issue_refresh = (
             issue_refresh if issue_refresh is not None else self._issue_from_store
         )
         self._reidentify = (
-            reidentify if reidentify is not None else (lambda: force_reidentify(self._home))
+            reidentify
+            if reidentify is not None
+            else (lambda: force_reidentify(self._home))
         )
 
         self.instance_id = mint_instance_id()
@@ -155,9 +158,7 @@ class RelayLink:
         self._last_enroll_at: float | None = None
         self._enroll_repost_interval = host_contract.ENROLL_REPOST_INTERVAL_S
         self._delay = 0.0
-        self._adopt(
-            ensure_host_identity(self._home, fingerprint=machine_fingerprint())
-        )
+        self._adopt(ensure_host_identity(self._home, fingerprint=machine_fingerprint()))
 
     # -- identity + key material -------------------------------------------
 
@@ -211,15 +212,20 @@ class RelayLink:
         """Challenge → sign → register, as one typed outcome. Never raises for
         anything the relay or the network can do."""
         try:
-            challenge = self._get(
-                self._base + host_contract.CHALLENGE_PATH, timeout=self._timeout
+            challenge = self._post(
+                self._base + host_contract.CHALLENGE_PATH,
+                json={"key_fingerprint": self.key_fingerprint},
+                timeout=self._timeout,
             )
         except Exception as exc:
             return RegistrationOutcome(False, "transport", detail=str(exc))
         self._sample_skew(challenge)
         if challenge.status_code != 200:
+            detail = _detail(challenge)
             return RegistrationOutcome(
-                False, "refused", detail=_detail(challenge),
+                False,
+                _classify(challenge.status_code, detail),
+                detail=detail,
                 status_code=challenge.status_code,
             )
         # A 200 is not a promise of JSON: a captive portal, a misrouted vhost or
@@ -228,9 +234,11 @@ class RelayLink:
         nonce = str((_body(challenge) or {}).get("nonce", ""))
         if not nonce:
             return RegistrationOutcome(
-                False, "refused", status_code=challenge.status_code,
+                False,
+                "refused",
+                status_code=challenge.status_code,
                 detail="challenge response carried no nonce "
-                       f"(is {self._base} really the relay's enroll server?)",
+                f"(is {self._base} really the relay's enroll server?)",
             )
 
         payload = self._payload()
@@ -254,8 +262,10 @@ class RelayLink:
             )
         detail = _detail(resp)
         return RegistrationOutcome(
-            False, _classify(resp.status_code, detail),
-            detail=detail, status_code=resp.status_code,
+            False,
+            _classify(resp.status_code, detail),
+            detail=detail,
+            status_code=resp.status_code,
         )
 
     def _sample_skew(self, resp) -> None:
@@ -267,8 +277,10 @@ class RelayLink:
         if not raw:
             return
         try:
-            self.clock_skew_seconds = self._clock() - parsedate_to_datetime(raw).timestamp()
-        except (TypeError, ValueError):
+            self.clock_skew_seconds = (
+                self._clock() - parsedate_to_datetime(raw).timestamp()
+            )
+        except TypeError, ValueError:
             return
 
     # -- the loop -----------------------------------------------------------
@@ -319,8 +331,10 @@ class RelayLink:
         elif self.state not in _STICKY_STATES:
             self.state = "error"
         self._delay = self._jittered(
-            min(RETRY_BASE_S * 2 ** min(self.failure_count - 1, _MAX_EXPONENT),
-                host_contract.MAX_BACKOFF_S)
+            min(
+                RETRY_BASE_S * 2 ** min(self.failure_count - 1, _MAX_EXPONENT),
+                host_contract.MAX_BACKOFF_S,
+            )
         )
 
     def _jittered(self, delay: float) -> float:
@@ -335,13 +349,14 @@ class RelayLink:
             "relay refused %s consecutive registrations as a duplicate identity "
             "(%s); re-identifying automatically — this host will reappear in the "
             "relay's host list as pending-approval and needs approving again",
-            self._duplicate_streak, self.last_error,
+            self._duplicate_streak,
+            self.last_error,
         )
         self._adopt(self._reidentify())
         log.warning("re-identified as %s (subdomain %s)", self.host_id, self.subdomain)
         self._duplicate_streak = 0
         self.state = "awaiting-enrollment"
-        self._last_enroll_at = None      # the new key needs approving at once
+        self._last_enroll_at = None  # the new key needs approving at once
         self._post_enroll_if_due(now)
 
     def _post_enroll_if_due(self, now: float) -> None:
@@ -367,7 +382,7 @@ class RelayLink:
             return
         try:
             ttl = float((_body(response) or {}).get("expires_in"))
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             ttl = 0
         if math.isfinite(ttl) and ttl > 0:
             self._enroll_repost_interval = ttl / 3
@@ -396,23 +411,23 @@ class RelayLink:
 
 
 def _classify(status_code: int, detail: str) -> str:
-    """Which failure a refused registration actually is.
+    """Classify a challenge or registration refusal for the retry loop.
 
-    `/hosts/register` answers 401 for two unrelated things: an unapproved key,
-    and a challenge the relay would not accept — a nonce that expired, raced
-    another attempt, or was already spent, on a `CHALLENGE_TTL_S` window. Only
-    the first means "wait for a human". Reading the second as unapproved would
-    make an approved host on a slow link report `awaiting-enrollment` and
-    re-post `/enroll` for a key that is already in `pubkeys/`, so the two are
-    told apart by the `detail` both ends read from `host_contract`. An
-    unrecognised 401 falls back to `unapproved`: enrolling once too often is
-    recoverable, never enrolling at all is not.
+    Both host-registration routes can reject an unapproved key; registration
+    can also reject a nonce that expired, raced another attempt, or was already
+    spent. Only the former means "wait for a human". Reading the latter as
+    unapproved would make an approved host on a slow link re-post `/enroll`.
+    The exact details come from `host_contract`; an unrecognised 401 falls back
+    to `unapproved` because enrolling once too often is recoverable while never
+    enrolling at all is not.
     """
     if status_code == 409:
         return "duplicate-identity"
     if status_code != 401:
         return "refused"
-    return "refused" if detail in host_contract.CHALLENGE_REFUSAL_DETAILS else "unapproved"
+    return (
+        "refused" if detail in host_contract.CHALLENGE_REFUSAL_DETAILS else "unapproved"
+    )
 
 
 def _body(resp) -> dict | None:
@@ -430,12 +445,6 @@ def _detail(resp) -> str:
     carries the `mship daemon reidentify` hint) and what `_classify` reads to
     tell the two flavors of 401 apart."""
     return str((_body(resp) or {}).get("detail", ""))
-
-
-def _default_get(url, **kw):
-    import httpx
-
-    return httpx.get(url, **kw)
 
 
 def _default_post(url, **kw):

--- a/src/mship/core/daemon/relay_link.py
+++ b/src/mship/core/daemon/relay_link.py
@@ -83,6 +83,19 @@ HTTP_TIMEOUT_S = 10.0
 _STICKY_STATES = ("awaiting-enrollment", "duplicate-identity")
 
 
+def host_subdomain_for(home: Path, host_id: str) -> str:
+    """The relay subdomain this host publishes on, derived in ONE place.
+
+    Two callers must agree exactly or an operator approves a key for a name the
+    daemon never dials: the link derives it on every identity adoption, and
+    `mship daemon reidentify` prints it after minting a new identity.
+    """
+    pubkey = keys.relay_public_key(keys.ensure_relay_key(home)).strip()
+    return tunnel.host_subdomain(
+        host_id, tunnel.device_id(pubkey), keys.ensure_subdomain_secret(home)
+    )
+
+
 @dataclass(frozen=True)
 class RegistrationOutcome:
     """One registration attempt, as data. Never an exception: the caller is a
@@ -155,11 +168,7 @@ class RelayLink:
         key_path = keys.ensure_relay_key(self._home)
         self._pubkey = keys.relay_public_key(key_path).strip()
         self.key_fingerprint = fingerprint(self._pubkey)
-        self.subdomain = tunnel.host_subdomain(
-            ident.host_id,
-            tunnel.device_id(self._pubkey),
-            keys.ensure_subdomain_secret(self._home),
-        )
+        self.subdomain = host_subdomain_for(self._home, ident.host_id)
         self.public_url = f"https://{self.subdomain}.{self._relay.host}"
 
     def _sign_with_relay_key(self, blob: bytes) -> str:

--- a/src/mship/core/daemon/relay_link.py
+++ b/src/mship/core/daemon/relay_link.py
@@ -62,10 +62,10 @@ DIRECTORY_CLIENT = "relay-directory"
 # First retry delay; doubles per consecutive failure up to MAX_BACKOFF_S.
 RETRY_BASE_S = 2.0
 
-# Up to 20% OFF the scheduled delay (never added — see `_jittered`): enough to
-# de-phase a fleet that all lost the relay in the same second, small enough that
-# the delay still means roughly what it says.
-JITTER = 0.2
+# The de-phasing fraction, re-exported under this module's name: the tunnel
+# supervisor jitters its respawn backoff with the same constant and the same
+# downward-only formula, so both live in `core/relay/tunnel.py`.
+JITTER = tunnel.BACKOFF_JITTER
 
 # DERIVED, not picked: the first exponent at which the delay already exceeds
 # the cap. Clamping here is what keeps `2 ** n` from overflowing a float after
@@ -311,10 +311,7 @@ class RelayLink:
         )
 
     def _jittered(self, delay: float) -> float:
-        """De-phase DOWNWARD only. `DIRECTORY_STALE_S` is derived from
-        `MAX_BACKOFF_S`, so a delay jittered *above* the cap would let a healthy
-        reconnecting host read as stale in the directory."""
-        return delay * (1 - JITTER * self._rng())
+        return tunnel.jittered(delay, self._rng)
 
     def _auto_reidentify(self, now: float) -> None:
         """The relay says someone else holds this identity and we cannot talk it
@@ -368,6 +365,15 @@ class RelayLink:
     def next_attempt_delay(self) -> float:
         """Seconds from the last attempt until the next one is due."""
         return self._delay
+
+    def register_soon(self) -> None:
+        """Make the next `tick()` register instead of waiting out the schedule.
+
+        The tunnel calls this once per respawn (AC2): a reconnected `ssh -R`
+        lands on a fresh sish route, so the directory entry must be re-published
+        without waiting up to `REGISTER_INTERVAL_S` for it. It only clears the
+        schedule — one extra registration per call, never a re-register storm."""
+        self._last_attempt_at = None
 
 
 def _classify(status_code: int, detail: str) -> str:

--- a/src/mship/core/daemon/relay_link.py
+++ b/src/mship/core/daemon/relay_link.py
@@ -406,8 +406,10 @@ class RelayLink:
             self._duplicate_streak += 1
             if self._duplicate_streak >= self.DUPLICATE_REIDENTIFY_AFTER:
                 self._auto_reidentify(now)
-        elif self.state not in _STICKY_STATES:
-            self.state = "error"
+        else:
+            self._duplicate_streak = 0
+            if self.state not in _STICKY_STATES:
+                self.state = "error"
         self._delay = self._jittered(
             min(
                 RETRY_BASE_S * 2 ** min(self.failure_count - 1, _MAX_EXPONENT),

--- a/src/mship/core/daemon/relay_link.py
+++ b/src/mship/core/daemon/relay_link.py
@@ -386,8 +386,12 @@ class RelayLink:
                 _detail(response) or f"enroll post failed: HTTP {response.status_code}"
             )
             return
+        body = _body(response)
+        if not body or not isinstance(body.get("id"), str) or not body["id"]:
+            self.last_error = "enroll post failed: invalid response"
+            return
         try:
-            ttl = float((_body(response) or {}).get("expires_in"))
+            ttl = float(body.get("expires_in"))
         except TypeError, ValueError:
             ttl = 0
         if math.isfinite(ttl) and ttl > 0:

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -6,10 +6,17 @@ append so a broken-upgrade ImportError still lands in history and the rotating
 log (`test_broken_import_still_appends_history`).
 
 Sequence: rotating logs → lease → loser path (probe holder; live → exit 0,
-dead → exit 1) → history start → unlink stale socket → uvicorn over the unix
-socket → clean-stop entry on normal return. SIGTERM relies on uvicorn's default
-graceful shutdown — no bespoke signal code. The OS supervisor owns
-restart/backoff; there is deliberately no retry loop here.
+dead → exit 1) → history start → unlink stale socket → servers (and, when a
+relay is configured, the tunnel) over one asyncio loop → clean-stop entry on
+normal return. The OS supervisor owns restart/backoff; there is deliberately no
+retry loop here.
+
+SIGTERM is no longer uvicorn's business alone (#471): its handlers only set
+`should_exit` on the server that installed them, so a tunnel loop beside them
+would never learn a stop was requested, the daemon would outlive
+`TimeoutStopSec`, be SIGKILLed, and leave its `start_new_session=True` ssh child
+orphaned on the subdomain — where it blocks the next start from claiming it. One
+shared `asyncio.Event` is the stop condition for everything.
 """
 from __future__ import annotations
 
@@ -124,69 +131,208 @@ def _build_registry(home: Path):
     return store, rescan, cfg.serve
 
 
-def _serve_forever(control_app, socket_path, host_app, serve_cfg) -> None:
-    """Control app on the unix socket; when a TCP bind is configured, the
-    workspace-addressed host app runs beside it under one asyncio loop."""
-    import uvicorn
+def _relay_config(home: Path):
+    """This host's `relay:` block as a `RelayConfig`, or None for no relay.
 
-    if host_app is None or serve_cfg is None:
-        uvicorn.run(control_app, uds=str(socket_path), log_config=None)
-        return
+    Never raises, for the same reason `_build_tunnel` does not: a relay we
+    cannot read is a host without a tunnel, never a host that refuses to start
+    — the workspaces it serves on the LAN do not depend on one."""
+    from mship.core.daemon.registry import load_daemon_config
+    from mship.core.relay.config import RelayConfig
 
+    try:
+        return RelayConfig.from_mapping(load_daemon_config(home).relay)
+    except Exception:
+        log.exception("relay config unusable — daemon continues without a tunnel")
+        return None
+
+
+def _build_tunnel(home: Path, relay_cfg, serve_cfg):
+    """The relay tunnel + registration link (#471), or None when either half of
+    what it needs — a relay to dial or a local bind to forward — is absent.
+
+    Same never-raise contract and deferred-import seam as `_build_registry`.
+    """
+    if relay_cfg is None or serve_cfg is None:
+        return None
+    try:
+        from mship.core.daemon.host_tunnel import HostTunnel
+        from mship.core.daemon.relay_link import RelayLink
+        from mship.core.relay import keys
+        from mship.core.relay.tunnel import TunnelSupervisor, build_tunnel_argv
+
+        link = RelayLink(home, relay_cfg)
+        supervisor = TunnelSupervisor(
+            # A callable, not a frozen list: an auto-reidentify moves the link
+            # onto a NEW subdomain mid-run (AC4), and argv frozen at startup
+            # would keep re-dialing the one this host no longer owns.
+            argv=lambda: build_tunnel_argv(
+                relay_cfg,
+                subdomain=link.subdomain,
+                local_port=int(serve_cfg["port"]),
+                key_path=keys.relay_key_path(home),
+            ),
+            log_path=paths.tunnel_log_path(home),
+        )
+        return HostTunnel(link, supervisor)
+    except Exception:
+        log.exception("relay tunnel unavailable — daemon continues without one")
+        return None
+
+
+# How long a shutdown waits for the tunnel loop's in-flight tick before it
+# cancels: bounded because that tick can be inside a 10s HTTP timeout, and
+# systemd's TimeoutStopSec ends in SIGKILL — which is precisely how an ssh child
+# orphans onto the subdomain.
+_TUNNEL_JOIN_TIMEOUT_S = 5.0
+
+
+def _serve_forever(control_app, socket_path, host_app, serve_cfg, tunnel=None) -> None:
+    """Run every long-lived part of the daemon on ONE asyncio loop.
+
+    Always asyncio, even control-only: `uvicorn.run` owns the loop and returns
+    only once the server is done, which leaves no seam to run a tunnel beside —
+    and one startup/shutdown shape for all three configurations is one shutdown
+    path to keep correct rather than three.
+    """
     import asyncio
 
-    async def _both():
-        control = uvicorn.Server(uvicorn.Config(control_app, uds=str(socket_path), log_config=None))
-        host = uvicorn.Server(uvicorn.Config(
-            host_app, host=serve_cfg["host"], port=int(serve_cfg["port"]), log_config=None,
-        ))
-        control_app.state.set_serve_bound(False)
-        control_task = asyncio.create_task(control.serve())
-        host_task = asyncio.create_task(host.serve())
-        try:
-            while not host.started:
-                if host_task.done():
-                    control.should_exit = True
-                    await asyncio.gather(control_task, return_exceptions=True)
-                    failure = host_task.exception()
-                    if failure is not None:
-                        raise RuntimeError("TCP server failed to bind") from failure
-                    raise RuntimeError("TCP server failed to bind")
-                if control_task.done():
-                    host.should_exit = True
-                    await asyncio.gather(host_task, return_exceptions=True)
-                    failure = control_task.exception()
-                    if failure is not None:
-                        raise RuntimeError("control server stopped before TCP bind") from failure
-                    raise RuntimeError("control server stopped before TCP bind")
-                await asyncio.sleep(0)
+    asyncio.run(_serve(control_app, socket_path, host_app, serve_cfg, tunnel))
 
+
+async def _serve(control_app, socket_path, host_app, serve_cfg, tunnel) -> None:
+    import asyncio
+
+    import uvicorn
+
+    control = uvicorn.Server(
+        uvicorn.Config(control_app, uds=str(socket_path), log_config=None)
+    )
+    servers = [control]
+    tasks = [asyncio.create_task(control.serve())]
+    control_app.state.set_serve_bound(False)
+    stop = asyncio.Event()
+    tunnel_task = None
+    try:
+        if host_app is not None and serve_cfg is not None:
+            host = uvicorn.Server(uvicorn.Config(
+                host_app, host=serve_cfg["host"], port=int(serve_cfg["port"]),
+                log_config=None,
+            ))
+            servers.append(host)
+            tasks.append(asyncio.create_task(host.serve()))
+            await _await_tcp_bind(control, tasks[0], host, tasks[1])
             control_app.state.set_serve_bound(True)
-            done, _pending = await asyncio.wait(
-                {control_task, host_task}, return_when=asyncio.FIRST_COMPLETED
-            )
-            unexpected = (
-                control_task in done and not control.should_exit
-            ) or (
-                host_task in done and not host.should_exit
-            )
-            control.should_exit = True
-            host.should_exit = True
-            results = await asyncio.gather(
-                control_task, host_task, return_exceptions=True
-            )
-            failure = next(
-                (result for result in results if isinstance(result, BaseException)),
-                None,
-            )
-            if failure is not None:
-                raise RuntimeError("daemon server failed") from failure
-            if unexpected:
-                raise RuntimeError("daemon server stopped unexpectedly")
-        finally:
-            control_app.state.set_serve_bound(False)
+        _install_stop_handlers(stop, servers)
+        if tunnel is not None:
+            tunnel_task = asyncio.create_task(_tunnel_loop(tunnel, stop))
 
-    asyncio.run(_both())
+        done, _pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        unexpected = any(
+            task in done and not server.should_exit
+            for task, server in zip(tasks, servers)
+        )
+        for server in servers:
+            server.should_exit = True
+        stop.set()
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        failure = next(
+            (result for result in results if isinstance(result, BaseException)), None
+        )
+        if failure is not None:
+            raise RuntimeError("daemon server failed") from failure
+        if unexpected:
+            raise RuntimeError("daemon server stopped unexpectedly")
+    finally:
+        control_app.state.set_serve_bound(False)
+        # Joined BEFORE the tunnel is torn down, and torn down before `_run`
+        # writes its clean-stop entry: a tick still running while `stop()`
+        # signals the ssh child could spawn a replacement nothing then owns,
+        # and that orphan holds the subdomain against the next start.
+        stop.set()
+        await _join_tunnel(tunnel_task)
+        if tunnel is not None:
+            tunnel.stop()
+
+
+async def _await_tcp_bind(control, control_task, host, host_task) -> None:
+    """Block until the TCP host app is listening, or fail loudly if either
+    server gives up first — a half-bound daemon must not advertise itself."""
+    import asyncio
+
+    while not host.started:
+        if host_task.done():
+            control.should_exit = True
+            await asyncio.gather(control_task, return_exceptions=True)
+            raise RuntimeError("TCP server failed to bind") from host_task.exception()
+        if control_task.done():
+            host.should_exit = True
+            await asyncio.gather(host_task, return_exceptions=True)
+            raise RuntimeError(
+                "control server stopped before TCP bind"
+            ) from control_task.exception()
+        await asyncio.sleep(0)
+
+
+def _install_stop_handlers(stop, servers) -> None:
+    """One Event for the whole process, set by SIGTERM/SIGINT.
+
+    Uvicorn's own handlers only set `should_exit` on the server that installed
+    them, so nothing else in the process would ever learn a stop was requested;
+    the shutdown path below sets this Event too, making the handlers the fast
+    path rather than the only one."""
+    import asyncio
+    import signal
+
+    loop = asyncio.get_running_loop()
+
+    def _request_stop() -> None:
+        stop.set()
+        for server in servers:
+            server.should_exit = True
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, _request_stop)
+        except (NotImplementedError, RuntimeError, ValueError):
+            # Non-POSIX, or not the main thread (tests). Uvicorn's own handlers
+            # plus the shutdown path still stop everything.
+            log.debug("no asyncio signal handler available for %s", sig)
+
+
+async def _tunnel_loop(tunnel, stop) -> None:
+    """`tick(); sleep(interval)` until the shared stop Event says otherwise.
+
+    The tick runs in the default executor because it BLOCKS: a registration
+    waits out an HTTP timeout, an auto-reidentify shells out to `ssh-keygen`,
+    the orphan sweep to `ps`, and a respawn opens a `Popen` — any of them on the
+    loop thread would stall both HTTP servers. A tick never raises by contract;
+    if one ever does it must not end the loop, because the tunnel is the half of
+    the daemon that recovers by retrying."""
+    import asyncio
+
+    from mship.core.daemon.host_tunnel import TICK_INTERVAL_S
+
+    loop = asyncio.get_running_loop()
+    while not stop.is_set():
+        try:
+            await loop.run_in_executor(None, tunnel.tick)
+        except Exception:
+            log.exception("tunnel tick failed")
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=TICK_INTERVAL_S)
+        except TimeoutError:
+            pass
+
+
+async def _join_tunnel(task) -> None:
+    import asyncio
+
+    if task is None:
+        return
+    await asyncio.wait({task}, timeout=_TUNNEL_JOIN_TIMEOUT_S)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
 
 
 def _configure_logging(home: Path) -> None:
@@ -273,6 +419,7 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
         "mshipd %s starting on %s (pid %s) — %d workspace(s) discovered",
         version, socket_path, os.getpid(), len(entries),
     )
+    relay_cfg = _relay_config(home)
     host_app = None
     if serve_cfg is not None:
         from mship.core.daemon.host_app import (
@@ -285,6 +432,7 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
         host_app = create_host_app(
             store,
             auth_token=ensure_host_token(home, env=env),
+            relay_domain=relay_cfg.host if relay_cfg is not None else None,
             rescan=rescan,
             gh_app_id=gh_app_id,
             gh_app_key=gh_app_key,
@@ -296,7 +444,13 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
             host_app.state.drop_stale_subapps if host_app is not None else None
         ),
     )
-    _serve_forever(app, socket_path, host_app, serve_cfg)
+    # AFTER the lease is won and the apps are built: a tunnel dialed by a
+    # process that then stands down for the incumbent would fork an ssh child
+    # onto a subdomain it is about to abandon.
+    tunnel = _build_tunnel(home, relay_cfg, serve_cfg)
+    if tunnel is not None:
+        log.info("relay tunnel enabled — dialing %s", tunnel.public_url)
+    _serve_forever(app, socket_path, host_app, serve_cfg, tunnel)
     history.append_clean_stop(paths.start_history_path(home), datetime.now(timezone.utc))
     log.info("mshipd stopped cleanly")
     return 0

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -464,8 +464,12 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
         from mship.core.relay.host_contract import HOST_TOKEN_TTL_S
 
         if tunnel is not None:
-            host_id = tunnel.host_id
-            instance_id = tunnel.instance_id
+            def current_host_id():
+                return tunnel.host_id
+
+            def current_instance_id():
+                return tunnel.instance_id
+
             host_state = tunnel.snapshot
         else:
             from mship.core.daemon.identity import (
@@ -474,17 +478,24 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
                 mint_instance_id,
             )
 
-            host_id = ensure_host_identity(
+            identity = ensure_host_identity(
                 home, fingerprint=machine_fingerprint()
-            ).host_id
-            instance_id = mint_instance_id()
+            )
+            process_instance_id = mint_instance_id()
+
+            def current_host_id():
+                return identity.host_id
+
+            def current_instance_id():
+                return process_instance_id
+
             host_state = None
 
         refresh_store = RefreshStore(home)
 
         def exchange_refresh(credential: str):
             grant = refresh_store.verify_refresh(credential)
-            if grant is None or grant.host_id != host_id:
+            if grant is None or grant.host_id != current_host_id():
                 return None
             return issue_host_token(home), HOST_TOKEN_TTL_S
 
@@ -497,8 +508,8 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
             ),
             relay_domain=relay_cfg.host if relay_cfg is not None else None,
             exchange_refresh=exchange_refresh,
-            host_id=host_id,
-            instance_id=instance_id,
+            host_id=current_host_id,
+            instance_id=current_instance_id,
             host_state=host_state,
             rescan=rescan,
             gh_app_id=gh_app_id,

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -180,11 +180,21 @@ def _build_tunnel(home: Path, relay_cfg, serve_cfg):
         return None
 
 
-# How long a shutdown waits for the tunnel loop's in-flight tick before it
-# cancels: bounded because that tick can be inside a 10s HTTP timeout, and
-# systemd's TimeoutStopSec ends in SIGKILL — which is precisely how an ssh child
-# orphans onto the subdomain.
-_TUNNEL_JOIN_TIMEOUT_S = 5.0
+def _tunnel_join_timeout() -> float:
+    """How long a shutdown waits for the tunnel loop's in-flight tick.
+
+    DERIVED, never picked: cancelling the loop cannot interrupt the tick already
+    running in the executor, so a bound shorter than a worst-case tick would
+    routinely give up while one is still in flight. That worst case is the three
+    relay calls a single tick can make (challenge, register, enroll) plus the
+    orphan sweep's `ps`, each bounded by its own timeout. Still bounded, because
+    a daemon that never returns is SIGKILLed by systemd — which is itself how an
+    ssh child orphans onto the subdomain (#471 AC7).
+    """
+    from mship.core.daemon.host_tunnel import PROCESS_LIST_TIMEOUT_S
+    from mship.core.daemon.relay_link import HTTP_TIMEOUT_S
+
+    return 3 * HTTP_TIMEOUT_S + PROCESS_LIST_TIMEOUT_S
 
 
 def _serve_forever(control_app, socket_path, host_app, serve_cfg, tunnel=None) -> None:
@@ -278,9 +288,17 @@ def _install_stop_handlers(stop, servers) -> None:
     """One Event for the whole process, set by SIGTERM/SIGINT.
 
     Uvicorn's own handlers only set `should_exit` on the server that installed
-    them, so nothing else in the process would ever learn a stop was requested;
-    the shutdown path below sets this Event too, making the handlers the fast
-    path rather than the only one."""
+    them, so nothing else in the process would ever learn a stop was requested.
+
+    ORDERING, deliberately not relied upon: uvicorn captures signals with
+    `signal.signal` from inside `serve()`, and so does `add_signal_handler` —
+    last install wins. Ours goes in after the TCP bind wait, which is after both
+    servers have started (so ours wins) in the host shape, but before the
+    control server's first await in the control-only shape (so uvicorn's wins
+    there). Both outcomes are correct, and that is the point: uvicorn's handler
+    ends its server's task, and the shutdown path below sets this Event the
+    moment ANY server task completes. The handler here is the fast path, never
+    the only one."""
     import asyncio
     import signal
 
@@ -330,9 +348,15 @@ async def _join_tunnel(task) -> None:
 
     if task is None:
         return
-    await asyncio.wait({task}, timeout=_TUNNEL_JOIN_TIMEOUT_S)
+    await asyncio.wait({task}, timeout=_tunnel_join_timeout())
     task.cancel()
-    await asyncio.gather(task, return_exceptions=True)
+    for result in await asyncio.gather(task, return_exceptions=True):
+        # `return_exceptions` keeps a shutdown going; it must not also make a
+        # crashed tunnel loop invisible.
+        if isinstance(result, BaseException) and not isinstance(
+            result, asyncio.CancelledError
+        ):
+            log.error("tunnel loop stopped on an error: %r", result)
 
 
 def _configure_logging(home: Path) -> None:

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -131,9 +131,9 @@ def _build_registry(home: Path):
 def _relay_config(home: Path):
     """This host's `relay:` block as a `RelayConfig`, or None for no relay.
 
-    Never raises, for the same reason `_build_tunnel` does not: a relay we
-    cannot read is a host without a tunnel, never a host that refuses to start
-    — the workspaces it serves on the LAN do not depend on one."""
+    This loader never raises: an unreadable relay is a host without a tunnel,
+    never a host that refuses to start — the workspaces it serves on the LAN
+    do not depend on one."""
     from mship.core.daemon.registry import load_daemon_config
     from mship.core.relay.config import RelayConfig
 
@@ -145,14 +145,16 @@ def _relay_config(home: Path):
 
 
 def _build_tunnel(home: Path, relay_cfg, serve_cfg):
-    """The relay tunnel + registration link (#471), or None when either half of
-    what it needs — a relay to dial or a local bind to forward — is absent.
+    """The relay tunnel + registration link (#471), or None without a relay.
 
-    Construction failures propagate to `_run`, which keeps local service alive
-    while publishing the failure separately from the live tunnel lifecycle.
+    A configured relay without a local bind is invalid: there is nowhere for
+    the reverse tunnel to forward. Construction failures propagate to `_run`,
+    which keeps local service alive while publishing the tunnel error.
     """
-    if relay_cfg is None or serve_cfg is None:
+    if relay_cfg is None:
         return None
+    if serve_cfg is None:
+        raise ValueError("relay needs a local serve bind")
     from mship.core.daemon.host_tunnel import HostTunnel
     from mship.core.daemon.relay_link import RelayLink
     from mship.core.relay import keys

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -179,20 +179,27 @@ def _tunnel_join_timeout() -> float:
     DERIVED, never picked: cancelling the loop cannot interrupt the tick already
     running in the executor, so a bound shorter than a worst-case tick would
     routinely give up while one is still in flight. That worst case is the three
-    relay calls a single tick can make (challenge, register, enroll), the two
-    process-table reads needed to identify and revalidate orphans, and the
-    shared TERM/KILL exit waits, each bounded by its own timeout. Still bounded,
+    relay calls a single tick can make (challenge, register, enroll); automatic
+    clone recovery rotates its local key without revoking the incumbent's shared
+    key, so it adds no relay calls. The tick can also make three fixed, bounded
+    process-table snapshots (discovery, pre-TERM, pre-KILL) and the shared
+    TERM/KILL exit waits. Still bounded,
     because a daemon that never returns is
     SIGKILLed by systemd — which is itself how an ssh child orphans onto the
     subdomain (#471 AC7).
     """
     from mship.core.daemon.host_tunnel import (
+        MAX_PROCESS_LIST_CALLS_PER_REAP,
         ORPHAN_EXIT_TIMEOUT_S,
         PROCESS_LIST_TIMEOUT_S,
     )
     from mship.core.daemon.relay_link import HTTP_TIMEOUT_S
 
-    return 3 * HTTP_TIMEOUT_S + 2 * PROCESS_LIST_TIMEOUT_S + 2 * ORPHAN_EXIT_TIMEOUT_S
+    return (
+        3 * HTTP_TIMEOUT_S
+        + MAX_PROCESS_LIST_CALLS_PER_REAP * PROCESS_LIST_TIMEOUT_S
+        + 2 * ORPHAN_EXIT_TIMEOUT_S
+    )
 
 
 def _serve_forever(control_app, socket_path, host_app, serve_cfg, tunnel=None) -> None:

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -180,15 +180,20 @@ def _tunnel_join_timeout() -> float:
     DERIVED, never picked: cancelling the loop cannot interrupt the tick already
     running in the executor, so a bound shorter than a worst-case tick would
     routinely give up while one is still in flight. That worst case is the three
-    relay calls a single tick can make (challenge, register, enroll) plus the
-    orphan sweep's `ps`, each bounded by its own timeout. Still bounded, because
-    a daemon that never returns is SIGKILLed by systemd — which is itself how an
-    ssh child orphans onto the subdomain (#471 AC7).
+    relay calls a single tick can make (challenge, register, enroll), the two
+    process-table reads needed to identify and revalidate orphans, and the
+    shared TERM/KILL exit waits, each bounded by its own timeout. Still bounded,
+    because a daemon that never returns is
+    SIGKILLed by systemd — which is itself how an ssh child orphans onto the
+    subdomain (#471 AC7).
     """
-    from mship.core.daemon.host_tunnel import PROCESS_LIST_TIMEOUT_S
+    from mship.core.daemon.host_tunnel import (
+        ORPHAN_EXIT_TIMEOUT_S,
+        PROCESS_LIST_TIMEOUT_S,
+    )
     from mship.core.daemon.relay_link import HTTP_TIMEOUT_S
 
-    return 3 * HTTP_TIMEOUT_S + PROCESS_LIST_TIMEOUT_S
+    return 3 * HTTP_TIMEOUT_S + 2 * PROCESS_LIST_TIMEOUT_S + 2 * ORPHAN_EXIT_TIMEOUT_S
 
 
 def _serve_forever(control_app, socket_path, host_app, serve_cfg, tunnel=None) -> None:

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -18,6 +18,7 @@ would never learn a stop was requested, the daemon would outlive
 orphaned on the subdomain — where it blocks the next start from claiming it. One
 shared `asyncio.Event` is the stop condition for everything.
 """
+
 from __future__ import annotations
 
 import logging
@@ -102,14 +103,10 @@ def _build_registry(home: Path):
         try:
             current = load_daemon_config(home)
         except DaemonConfigReadError:
-            log.exception(
-                "daemon config unreadable on refresh — registry unchanged"
-            )
+            log.exception("daemon config unreadable on refresh — registry unchanged")
             raise
         except ValueError:
-            log.exception(
-                "daemon config invalid on refresh — registry unchanged"
-            )
+            log.exception("daemon config invalid on refresh — registry unchanged")
             raise
         reconcile(store, scan_roots(current), datetime.now(timezone.utc))
 
@@ -151,33 +148,30 @@ def _build_tunnel(home: Path, relay_cfg, serve_cfg):
     """The relay tunnel + registration link (#471), or None when either half of
     what it needs — a relay to dial or a local bind to forward — is absent.
 
-    Same never-raise contract and deferred-import seam as `_build_registry`.
+    Construction failures propagate to `_run`, which keeps local service alive
+    while publishing the failure separately from the live tunnel lifecycle.
     """
     if relay_cfg is None or serve_cfg is None:
         return None
-    try:
-        from mship.core.daemon.host_tunnel import HostTunnel
-        from mship.core.daemon.relay_link import RelayLink
-        from mship.core.relay import keys
-        from mship.core.relay.tunnel import TunnelSupervisor, build_tunnel_argv
+    from mship.core.daemon.host_tunnel import HostTunnel
+    from mship.core.daemon.relay_link import RelayLink
+    from mship.core.relay import keys
+    from mship.core.relay.tunnel import TunnelSupervisor, build_tunnel_argv
 
-        link = RelayLink(home, relay_cfg)
-        supervisor = TunnelSupervisor(
-            # A callable, not a frozen list: an auto-reidentify moves the link
-            # onto a NEW subdomain mid-run (AC4), and argv frozen at startup
-            # would keep re-dialing the one this host no longer owns.
-            argv=lambda: build_tunnel_argv(
-                relay_cfg,
-                subdomain=link.subdomain,
-                local_port=int(serve_cfg["port"]),
-                key_path=keys.relay_key_path(home),
-            ),
-            log_path=paths.tunnel_log_path(home),
-        )
-        return HostTunnel(link, supervisor)
-    except Exception:
-        log.exception("relay tunnel unavailable — daemon continues without one")
-        return None
+    link = RelayLink(home, relay_cfg)
+    supervisor = TunnelSupervisor(
+        # A callable, not a frozen list: an auto-reidentify moves the link
+        # onto a NEW subdomain mid-run (AC4), and argv frozen at startup
+        # would keep re-dialing the one this host no longer owns.
+        argv=lambda: build_tunnel_argv(
+            relay_cfg,
+            subdomain=link.subdomain,
+            local_port=int(serve_cfg["port"]),
+            key_path=keys.relay_key_path(home),
+        ),
+        log_path=paths.tunnel_log_path(home),
+    )
+    return HostTunnel(link, supervisor)
 
 
 def _tunnel_join_timeout() -> float:
@@ -225,10 +219,14 @@ async def _serve(control_app, socket_path, host_app, serve_cfg, tunnel) -> None:
     tunnel_task = None
     try:
         if host_app is not None and serve_cfg is not None:
-            host = uvicorn.Server(uvicorn.Config(
-                host_app, host=serve_cfg["host"], port=int(serve_cfg["port"]),
-                log_config=None,
-            ))
+            host = uvicorn.Server(
+                uvicorn.Config(
+                    host_app,
+                    host=serve_cfg["host"],
+                    port=int(serve_cfg["port"]),
+                    log_config=None,
+                )
+            )
             servers.append(host)
             tasks.append(asyncio.create_task(host.serve()))
             await _await_tcp_bind(control, tasks[0], host, tasks[1])
@@ -312,7 +310,7 @@ def _install_stop_handlers(stop, servers) -> None:
     for sig in (signal.SIGTERM, signal.SIGINT):
         try:
             loop.add_signal_handler(sig, _request_stop)
-        except (NotImplementedError, RuntimeError, ValueError):
+        except NotImplementedError, RuntimeError, ValueError:
             # Non-POSIX, or not the main thread (tests). Uvicorn's own handlers
             # plus the shutdown path still stop everything.
             log.debug("no asyncio signal handler available for %s", sig)
@@ -365,7 +363,9 @@ def _configure_logging(home: Path) -> None:
     handler = RotatingFileHandler(
         log_dir / "daemon.log", maxBytes=_LOG_MAX_BYTES, backupCount=_LOG_BACKUPS
     )
-    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+    )
     root = logging.getLogger()
     root.setLevel(logging.INFO)
     root.addHandler(handler)
@@ -375,7 +375,6 @@ def _configure_logging(home: Path) -> None:
         lg = logging.getLogger(name)
         lg.addHandler(handler)
         lg.setLevel(logging.INFO)
-
 
 
 def main(home: Path | None = None, env: Mapping[str, str] | None = None) -> int:
@@ -441,16 +440,37 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
     entries = store.load().entries
     log.info(
         "mshipd %s starting on %s (pid %s) — %d workspace(s) discovered",
-        version, socket_path, os.getpid(), len(entries),
+        version,
+        socket_path,
+        os.getpid(),
+        len(entries),
     )
     relay_cfg = _relay_config(home)
     # AFTER the lease is won: a tunnel dialed by a process that then stands down
     # for the incumbent would fork an ssh child onto a subdomain it is about to
     # abandon. Constructing one dials nothing — only `tick()` does — so it is
     # safe to build here, and both HTTP apps need its runtime identity/state.
-    tunnel = _build_tunnel(home, relay_cfg, serve_cfg)
-    if tunnel is not None:
-        log.info("relay tunnel enabled — dialing %s", tunnel.public_url)
+    tunnel_state = None
+    try:
+        tunnel = _build_tunnel(home, relay_cfg, serve_cfg)
+    except Exception as exc:
+        log.exception("relay tunnel unavailable — daemon continues without one")
+        tunnel = None
+        failed_tunnel_state = {
+            "state": "error",
+            "subdomain": None,
+            "public_url": None,
+            "restarts": 0,
+            "last_error": f"relay tunnel initialization failed: {exc}",
+            "clock_skew_seconds": None,
+        }
+
+        def tunnel_state():
+            return failed_tunnel_state.copy()
+    else:
+        if tunnel is not None:
+            log.info("relay tunnel enabled — dialing %s", tunnel.public_url)
+            tunnel_state = tunnel.snapshot
 
     host_app = None
     if serve_cfg is not None:
@@ -464,13 +484,13 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
         from mship.core.relay.host_contract import HOST_TOKEN_TTL_S
 
         if tunnel is not None:
+
             def current_host_id():
                 return tunnel.host_id
 
             def current_instance_id():
                 return tunnel.instance_id
 
-            host_state = tunnel.snapshot
         else:
             from mship.core.daemon.identity import (
                 ensure_host_identity,
@@ -478,9 +498,7 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
                 mint_instance_id,
             )
 
-            identity = ensure_host_identity(
-                home, fingerprint=machine_fingerprint()
-            )
+            identity = ensure_host_identity(home, fingerprint=machine_fingerprint())
             process_instance_id = mint_instance_id()
 
             def current_host_id():
@@ -488,8 +506,6 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
 
             def current_instance_id():
                 return process_instance_id
-
-            host_state = None
 
         refresh_store = RefreshStore(home)
 
@@ -510,21 +526,28 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
             exchange_refresh=exchange_refresh,
             host_id=current_host_id,
             instance_id=current_instance_id,
-            host_state=host_state,
+            host_state=tunnel_state,
             rescan=rescan,
             gh_app_id=gh_app_id,
             gh_app_key=gh_app_key,
         )
     app = create_control_app(
-        started_at=started_at, version=version, socket_path=str(socket_path),
-        store=store, rescan=rescan, serve_bound=host_app is not None,
+        started_at=started_at,
+        version=version,
+        socket_path=str(socket_path),
+        store=store,
+        rescan=rescan,
+        serve_bound=host_app is not None,
         tunnel=tunnel,
+        tunnel_state=tunnel_state,
         after_rescan=(
             host_app.state.drop_stale_subapps if host_app is not None else None
         ),
     )
     _serve_forever(app, socket_path, host_app, serve_cfg, tunnel)
-    history.append_clean_stop(paths.start_history_path(home), datetime.now(timezone.utc))
+    history.append_clean_stop(
+        paths.start_history_path(home), datetime.now(timezone.utc)
+    )
     log.info("mshipd stopped cleanly")
     return 0
 

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -131,17 +131,14 @@ def _build_registry(home: Path):
 def _relay_config(home: Path):
     """This host's `relay:` block as a `RelayConfig`, or None for no relay.
 
-    This loader never raises: an unreadable relay is a host without a tunnel,
-    never a host that refuses to start — the workspaces it serves on the LAN
-    do not depend on one."""
+    Invalid configuration raises instead of impersonating an absent `relay:`
+    block. A configured-but-broken tunnel must be visible as an error or stop
+    startup, never be reported as deliberately disabled.
+    """
     from mship.core.daemon.registry import load_daemon_config
     from mship.core.relay.config import RelayConfig
 
-    try:
-        return RelayConfig.from_mapping(load_daemon_config(home).relay)
-    except Exception:
-        log.exception("relay config unusable — daemon continues without a tunnel")
-        return None
+    return RelayConfig.from_mapping(load_daemon_config(home).relay)
 
 
 def _build_tunnel(home: Path, relay_cfg, serve_cfg):
@@ -317,7 +314,7 @@ def _install_stop_handlers(stop, servers) -> None:
     for sig in (signal.SIGTERM, signal.SIGINT):
         try:
             loop.add_signal_handler(sig, _request_stop)
-        except NotImplementedError, RuntimeError, ValueError:
+        except (NotImplementedError, RuntimeError, ValueError):
             # Non-POSIX, or not the main thread (tests). Uvicorn's own handlers
             # plus the shutdown path still stop everything.
             log.debug("no asyncio signal handler available for %s", sig)

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -444,6 +444,14 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
         version, socket_path, os.getpid(), len(entries),
     )
     relay_cfg = _relay_config(home)
+    # AFTER the lease is won: a tunnel dialed by a process that then stands down
+    # for the incumbent would fork an ssh child onto a subdomain it is about to
+    # abandon. Constructing one dials nothing — only `tick()` does — so it is
+    # safe to build here, and both HTTP apps need its runtime identity/state.
+    tunnel = _build_tunnel(home, relay_cfg, serve_cfg)
+    if tunnel is not None:
+        log.info("relay tunnel enabled — dialing %s", tunnel.public_url)
+
     host_app = None
     if serve_cfg is not None:
         from mship.core.daemon.host_app import (
@@ -451,23 +459,51 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
             ensure_host_token,
             load_gh_app_credentials,
         )
+        from mship.core.daemon.host_auth import RefreshStore
+        from mship.core.daemon.host_token import issue_host_token, verify_host_token
+        from mship.core.relay.host_contract import HOST_TOKEN_TTL_S
+
+        if tunnel is not None:
+            host_id = tunnel.host_id
+            instance_id = tunnel.instance_id
+            host_state = tunnel.snapshot
+        else:
+            from mship.core.daemon.identity import (
+                ensure_host_identity,
+                machine_fingerprint,
+                mint_instance_id,
+            )
+
+            host_id = ensure_host_identity(
+                home, fingerprint=machine_fingerprint()
+            ).host_id
+            instance_id = mint_instance_id()
+            host_state = None
+
+        refresh_store = RefreshStore(home)
+
+        def exchange_refresh(credential: str):
+            grant = refresh_store.verify_refresh(credential)
+            if grant is None or grant.host_id != host_id:
+                return None
+            return issue_host_token(home), HOST_TOKEN_TTL_S
 
         gh_app_id, gh_app_key = load_gh_app_credentials(home, env=env)
         host_app = create_host_app(
             store,
             auth_token=ensure_host_token(home, env=env),
+            verify_bearer=lambda presented: (
+                verify_host_token(home, presented) is not None
+            ),
             relay_domain=relay_cfg.host if relay_cfg is not None else None,
+            exchange_refresh=exchange_refresh,
+            host_id=host_id,
+            instance_id=instance_id,
+            host_state=host_state,
             rescan=rescan,
             gh_app_id=gh_app_id,
             gh_app_key=gh_app_key,
         )
-    # AFTER the lease is won: a tunnel dialed by a process that then stands down
-    # for the incumbent would fork an ssh child onto a subdomain it is about to
-    # abandon. Constructing one dials nothing — only `tick()` does — so it is
-    # safe to build here, and the control app needs it to publish its state.
-    tunnel = _build_tunnel(home, relay_cfg, serve_cfg)
-    if tunnel is not None:
-        log.info("relay tunnel enabled — dialing %s", tunnel.public_url)
     app = create_control_app(
         started_at=started_at, version=version, socket_path=str(socket_path),
         store=store, rescan=rescan, serve_bound=host_app is not None,

--- a/src/mship/core/daemon/run.py
+++ b/src/mship/core/daemon/run.py
@@ -461,19 +461,21 @@ def _run(home: Path, env: Mapping[str, str]) -> int:
             gh_app_id=gh_app_id,
             gh_app_key=gh_app_key,
         )
+    # AFTER the lease is won: a tunnel dialed by a process that then stands down
+    # for the incumbent would fork an ssh child onto a subdomain it is about to
+    # abandon. Constructing one dials nothing — only `tick()` does — so it is
+    # safe to build here, and the control app needs it to publish its state.
+    tunnel = _build_tunnel(home, relay_cfg, serve_cfg)
+    if tunnel is not None:
+        log.info("relay tunnel enabled — dialing %s", tunnel.public_url)
     app = create_control_app(
         started_at=started_at, version=version, socket_path=str(socket_path),
         store=store, rescan=rescan, serve_bound=host_app is not None,
+        tunnel=tunnel,
         after_rescan=(
             host_app.state.drop_stale_subapps if host_app is not None else None
         ),
     )
-    # AFTER the lease is won and the apps are built: a tunnel dialed by a
-    # process that then stands down for the incumbent would fork an ssh child
-    # onto a subdomain it is about to abandon.
-    tunnel = _build_tunnel(home, relay_cfg, serve_cfg)
-    if tunnel is not None:
-        log.info("relay tunnel enabled — dialing %s", tunnel.public_url)
     _serve_forever(app, socket_path, host_app, serve_cfg, tunnel)
     history.append_clean_stop(paths.start_history_path(home), datetime.now(timezone.utc))
     log.info("mshipd stopped cleanly")

--- a/src/mship/core/daemon/status.py
+++ b/src/mship/core/daemon/status.py
@@ -40,6 +40,60 @@ def probe_daemon(*, home: Path, env: Mapping[str, str]) -> dict | None:
 
 _LOOP_WINDOW_S = 600
 
+# One line per tunnel state (`host_tunnel.STATES`), keyed by the state the
+# daemon published — the states themselves have exactly one owner
+# (`HostTunnel.state()`), so this table only ever says how to phrase one.
+_TUNNEL_LINES = {
+    "disabled": "tunnel: disabled (no relay configured)",
+    "awaiting-enrollment": (
+        "tunnel: awaiting relay approval "
+        "(run 'mship relay approve <id>' on the relay host)"
+    ),
+    "connecting": "tunnel: connecting {public_url}",
+    "online": "tunnel: online {public_url} ({restarts} restarts)",
+    "contended": "tunnel: contended — another host holds {subdomain}",
+    "duplicate-identity": (
+        "tunnel: rejected (duplicate-identity) — re-identifying automatically; "
+        "'mship daemon reidentify' to force"
+    ),
+    "error": "tunnel: error — {last_error}",
+}
+
+# Below this the sample is measurement noise (one HTTP round trip), not a clock
+# an operator should go looking at.
+_SKEW_REPORT_S = 1.0
+
+
+def _tunnel_lines(health: dict | None, tunnel: dict | None) -> list[str]:
+    """The tunnel's line(s), from the block `/health` published.
+
+    The tunnel lives inside the daemon process, so `/health` is its only
+    reader-visible source: with no answering daemon there is no state to report
+    and `disabled` would be a guess.
+    """
+    if health is None:
+        return ["tunnel: unknown (daemon not running)"]
+    if tunnel is None:
+        return [_TUNNEL_LINES["disabled"]]
+    state = str(tunnel.get("state") or "")
+    template = _TUNNEL_LINES.get(state)
+    lines = [
+        f"tunnel: {state or 'unknown'}"
+        if template is None
+        else template.format(
+            public_url=tunnel.get("public_url") or "?",
+            subdomain=tunnel.get("subdomain") or "?",
+            restarts=tunnel.get("restarts", 0),
+            last_error=tunnel.get("last_error") or "unknown",
+        )
+    ]
+    skew = tunnel.get("clock_skew_seconds")
+    if isinstance(skew, (int, float)) and abs(skew) >= _SKEW_REPORT_S:
+        # Reported, never gating: host tokens are self-issued and
+        # skew-tolerant, so this explains a symptom rather than causing one.
+        lines.append(f"clock skew: {skew}s vs the relay's enroll server")
+    return lines
+
 
 @dataclass(frozen=True)
 class DaemonStatus:
@@ -55,6 +109,10 @@ class DaemonStatus:
     linger: Literal["yes", "no", "unknown"]
     unclean_starts: int
     lease_info: LeaseInfo | None
+    # The `/health` tunnel block verbatim (#471 AC12), so `mship --json daemon
+    # status` carries the tunnel as data rather than as prose to re-parse.
+    tunnel: dict | None = None
+    clock_skew_seconds: float | None = None
     lines: list[str] = field(default_factory=list)
 
     def render(self) -> str:
@@ -106,7 +164,9 @@ def build_status(
         lines.append("warning: linger is OFF — the daemon dies when your last SSH session ends; run `loginctl enable-linger`")
     elif linger == "unknown":
         lines.append("linger: unknown")
-    lines.append("tunnel: not configured (#471)")
+    tunnel = health.get("tunnel") if health else None
+    tunnel = tunnel if isinstance(tunnel, dict) else None
+    lines.extend(_tunnel_lines(health, tunnel))
     if workspaces is None:
         lines.append("workspaces: registry not loaded")
     else:
@@ -127,5 +187,7 @@ def build_status(
         linger=linger,
         unclean_starts=unclean,
         lease_info=lease_info,
+        tunnel=tunnel,
+        clock_skew_seconds=(tunnel or {}).get("clock_skew_seconds"),
         lines=lines,
     )

--- a/src/mship/core/relay/config.py
+++ b/src/mship/core/relay/config.py
@@ -8,6 +8,11 @@ RELAY_HOST_REQUIRED = "relay.host is required when a `relay:` block is present"
 RELAY_SSH_PORT_INVALID = "relay.ssh_port must be an integer from 1 to 65535"
 
 
+def canonical_relay_host(host: str) -> str:
+    """The DNS spelling shared by config, directory validation, and pairing."""
+    return host.strip().lower().rstrip(".")
+
+
 @dataclass(frozen=True)
 class RelayConfig:
     host: str
@@ -15,7 +20,7 @@ class RelayConfig:
     user: str | None = None  # ssh user; None → ssh default
 
     def __post_init__(self) -> None:
-        canonical_host = self.host.strip().lower().rstrip(".")
+        canonical_host = canonical_relay_host(self.host)
         if not canonical_host:
             raise ValueError(RELAY_HOST_REQUIRED)
         if (

--- a/src/mship/core/relay/config.py
+++ b/src/mship/core/relay/config.py
@@ -13,6 +13,12 @@ class RelayConfig:
     ssh_port: int = 2222
     user: str | None = None       # ssh user; None → ssh default
 
+    def __post_init__(self) -> None:
+        canonical_host = self.host.strip().lower().rstrip(".")
+        if not canonical_host:
+            raise ValueError(RELAY_HOST_REQUIRED)
+        object.__setattr__(self, "host", canonical_host)
+
     @staticmethod
     def from_mapping(data: dict | None) -> "RelayConfig | None":
         if not data:

--- a/src/mship/core/relay/config.py
+++ b/src/mship/core/relay/config.py
@@ -18,10 +18,10 @@ class RelayConfig:
         if not data:
             return None
         host = data.get("host")
-        if not host:
+        if not isinstance(host, str) or not host.strip():
             raise ValueError(RELAY_HOST_REQUIRED)
         return RelayConfig(
-            host=host,
+            host=host.strip(),
             ssh_port=int(data.get("ssh_port", 2222)),
             user=data.get("user"),
         )

--- a/src/mship/core/relay/config.py
+++ b/src/mship/core/relay/config.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 from dataclasses import dataclass
 
+# Spelled once: `from_mapping` raises it, and the daemon config's `relay:`
+# validator (`core/daemon/registry.py`) rejects an empty block with the same
+# sentence, so an operator sees one message whichever end catches the typo.
+RELAY_HOST_REQUIRED = "relay.host is required when a `relay:` block is present"
+
+
 @dataclass(frozen=True)
 class RelayConfig:
     host: str
@@ -13,7 +19,7 @@ class RelayConfig:
             return None
         host = data.get("host")
         if not host:
-            raise ValueError("relay.host is required when a `relay:` block is present")
+            raise ValueError(RELAY_HOST_REQUIRED)
         return RelayConfig(
             host=host,
             ssh_port=int(data.get("ssh_port", 2222)),

--- a/src/mship/core/relay/config.py
+++ b/src/mship/core/relay/config.py
@@ -5,18 +5,25 @@ from dataclasses import dataclass
 # validator (`core/daemon/registry.py`) rejects an empty block with the same
 # sentence, so an operator sees one message whichever end catches the typo.
 RELAY_HOST_REQUIRED = "relay.host is required when a `relay:` block is present"
+RELAY_SSH_PORT_INVALID = "relay.ssh_port must be an integer from 1 to 65535"
 
 
 @dataclass(frozen=True)
 class RelayConfig:
     host: str
     ssh_port: int = 2222
-    user: str | None = None       # ssh user; None → ssh default
+    user: str | None = None  # ssh user; None → ssh default
 
     def __post_init__(self) -> None:
         canonical_host = self.host.strip().lower().rstrip(".")
         if not canonical_host:
             raise ValueError(RELAY_HOST_REQUIRED)
+        if (
+            isinstance(self.ssh_port, bool)
+            or not isinstance(self.ssh_port, int)
+            or not 1 <= self.ssh_port <= 65535
+        ):
+            raise ValueError(RELAY_SSH_PORT_INVALID)
         object.__setattr__(self, "host", canonical_host)
 
     @staticmethod
@@ -28,6 +35,6 @@ class RelayConfig:
             raise ValueError(RELAY_HOST_REQUIRED)
         return RelayConfig(
             host=host.strip(),
-            ssh_port=int(data.get("ssh_port", 2222)),
+            ssh_port=data.get("ssh_port", 2222),
             user=data.get("user"),
         )

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -113,6 +113,7 @@ class RequestStore:
         ttl_seconds: int = ENROLL_TTL_S,
         max_pending: int = 50,
         clock: Callable[[], float] = time.time,
+        is_approved: Callable[[str], bool] | None = None,
     ) -> None:
         self._pending = Path(base_dir) / "pending"
         self._resolved = Path(base_dir) / "resolved"
@@ -122,6 +123,7 @@ class RequestStore:
         self._ttl = ttl_seconds
         self._max_pending = max_pending
         self._clock = clock
+        self._is_approved = is_approved
 
     @property
     def ttl_seconds(self) -> int:
@@ -149,7 +151,7 @@ class RequestStore:
             if "created_at" not in rec:
                 raise ValueError("missing created_at")
             return rec
-        except json.JSONDecodeError, OSError, ValueError:
+        except (json.JSONDecodeError, OSError, ValueError):
             try:
                 p.replace(p.with_suffix(".json.corrupt"))
             except OSError:
@@ -164,11 +166,11 @@ class RequestStore:
                 continue
             try:
                 deadline = float(rec["expires_at"])
-            except KeyError, TypeError, ValueError:
+            except (KeyError, TypeError, ValueError):
                 # Records created before per-request deadlines used the store TTL.
                 try:
                     deadline = float(rec["created_at"]) + self._ttl
-                except KeyError, TypeError, ValueError:
+                except (KeyError, TypeError, ValueError):
                     deadline = math.nan
             expired = not math.isfinite(deadline) or now >= deadline
             if expired:
@@ -214,6 +216,10 @@ class RequestStore:
                     rec is not None
                     and rec.get("status") == "approved"
                     and rec.get("fingerprint") == fp
+                    and (
+                        self._is_approved is None
+                        or self._is_approved(fp)
+                    )
                 ):
                     return rec["id"]
             if len(pending) >= self._max_pending:
@@ -233,6 +239,15 @@ class RequestStore:
                 },
             )
         return rid
+
+    def revoke_approved(
+        self,
+        identity: str,
+        revoke: Callable[[str], object],
+    ) -> object:
+        """Mutate the allowlist under the same lock as enrollment dedupe."""
+        with _locked(self._lock_path):
+            return revoke(identity)
 
     def list_pending(self) -> list[dict]:
         with _locked(self._lock_path):

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -3,6 +3,7 @@ import base64
 import fcntl
 import hashlib
 import json
+import math
 import os
 import re
 import secrets
@@ -161,7 +162,13 @@ class RequestStore:
             rec = self._read_rec(p)
             if rec is None:
                 continue
-            if now - rec["created_at"] >= self._ttl:
+            try:
+                expires_at = float(rec["expires_at"])
+                expired = not math.isfinite(expires_at) or now >= expires_at
+            except (KeyError, TypeError, ValueError):
+                # Records created before per-request deadlines used the store TTL.
+                expired = now - rec["created_at"] >= self._ttl
+            if expired:
                 self._resolve(p, rec, "expired")
 
     def _list_pending_unlocked(self) -> list[dict]:
@@ -190,7 +197,9 @@ class RequestStore:
             for rec in pending:
                 if rec.get("fingerprint") == fp:
                     renewed = dict(rec)
-                    renewed["created_at"] = self._clock()
+                    renewed_at = self._clock()
+                    renewed["created_at"] = renewed_at
+                    renewed["expires_at"] = renewed_at + self._ttl
                     self._write_atomic(
                         self._pending / f"{rec['id']}.json", renewed
                     )
@@ -208,6 +217,7 @@ class RequestStore:
                     return rec["id"]
             if len(pending) >= self._max_pending:
                 raise PendingCapReached()
+            created_at = self._clock()
             rid = secrets.token_hex(16)
             self._write_atomic(
                 self._pending / f"{rid}.json",
@@ -216,7 +226,8 @@ class RequestStore:
                     "pubkey": pubkey.strip(),
                     "hostname": hostname,
                     "fingerprint": fp,
-                    "created_at": self._clock(),
+                    "created_at": created_at,
+                    "expires_at": created_at + self._ttl,
                     "status": "pending",
                 },
             )

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 import base64
+import fcntl
 import hashlib
 import json
 import os
 import re
 import secrets
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Callable
 
@@ -63,6 +65,23 @@ def sanitize_label(hostname: str) -> str:
 # ---------------------------------------------------------------------------
 # Exceptions
 # ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _locked(lock_path: Path):
+    """Exclusive advisory flock (the `host_auth`/`registry` house pattern).
+
+    flock is per open-file-description, so it serializes threads within the
+    enroll server's request threadpool as well as separate processes.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.touch(exist_ok=True, mode=0o600)
+    with open(lock_path, "r+") as lf:
+        fcntl.flock(lf, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lf, fcntl.LOCK_UN)
 
 
 class PendingCapReached(Exception):
@@ -146,31 +165,39 @@ class RequestStore:
         # be smuggled in here and later written into the pubkeys allowlist on approve.
         if not validate_pubkey(pubkey):
             raise ValueError("invalid pubkey")
-        pending = self.list_pending()          # sweeps expired records first
-        # Idempotent per key: the daemon re-posts its request on a schedule while
-        # it waits for approval, so without dedupe one unapproved host would fill
-        # the pending cap by itself and 429 enrollment for the whole fleet. A
-        # re-post is a pure read — `created_at` is NOT refreshed, or an
-        # unapproved request would never expire and the TTL would stop bounding
-        # the store.
-        fp = fingerprint(pubkey)
-        for rec in pending:
-            if rec.get("fingerprint") == fp:
-                return rec["id"]
-        if len(pending) >= self._max_pending:
-            raise PendingCapReached()
-        rid = secrets.token_hex(16)
-        self._write_atomic(
-            self._pending / f"{rid}.json",
-            {
-                "id": rid,
-                "pubkey": pubkey.strip(),
-                "hostname": hostname,
-                "fingerprint": fingerprint(pubkey),
-                "created_at": self._clock(),
-                "status": "pending",
-            },
-        )
+        # Scan-then-write under an exclusive flock (the `host_auth`/`registry`
+        # house pattern). The dedupe below and the cap check are both read-then-
+        # write, and the enroll app serves sync endpoints on a threadpool, so two
+        # re-posts of one key can interleave in a single process — the same class
+        # `_consume_nonce` is hardened against. The lock is the linearization
+        # point; every other method is unaffected because only `create` adds a
+        # pending record.
+        with _locked(self._pending.parent / "create.lock"):
+            pending = self.list_pending()      # sweeps expired records first
+            # Idempotent per key: the daemon re-posts its request on a schedule
+            # while it waits for approval, so without dedupe one unapproved host
+            # would fill the pending cap by itself and 429 enrollment for the
+            # whole fleet. A re-post is a pure read — `created_at` is NOT
+            # refreshed, or an unapproved request would never expire and the TTL
+            # would stop bounding the store.
+            fp = fingerprint(pubkey)
+            for rec in pending:
+                if rec.get("fingerprint") == fp:
+                    return rec["id"]
+            if len(pending) >= self._max_pending:
+                raise PendingCapReached()
+            rid = secrets.token_hex(16)
+            self._write_atomic(
+                self._pending / f"{rid}.json",
+                {
+                    "id": rid,
+                    "pubkey": pubkey.strip(),
+                    "hostname": hostname,
+                    "fingerprint": fp,
+                    "created_at": self._clock(),
+                    "status": "pending",
+                },
+            )
         return rid
 
     def list_pending(self) -> list[dict]:

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -9,6 +9,8 @@ import time
 from pathlib import Path
 from typing import Callable
 
+from mship.core.relay.host_contract import ENROLL_TTL_S
+
 
 def _b64decode_strict(body: str) -> bytes:
     """Decode base64, adding padding if needed, rejecting non-base64 characters."""
@@ -88,7 +90,7 @@ class RequestStore:
     def __init__(
         self,
         base_dir,
-        ttl_seconds: int = 1800,
+        ttl_seconds: int = ENROLL_TTL_S,
         max_pending: int = 50,
         clock: Callable[[], float] = time.time,
     ) -> None:

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -115,6 +115,7 @@ class RequestStore:
     ) -> None:
         self._pending = Path(base_dir) / "pending"
         self._resolved = Path(base_dir) / "resolved"
+        self._lock_path = Path(base_dir) / "create.lock"
         self._pending.mkdir(parents=True, exist_ok=True)
         self._resolved.mkdir(parents=True, exist_ok=True)
         self._ttl = ttl_seconds
@@ -163,27 +164,28 @@ class RequestStore:
             if now - rec["created_at"] >= self._ttl:
                 self._resolve(p, rec, "expired")
 
+    def _list_pending_unlocked(self) -> list[dict]:
+        self._sweep()
+        out = []
+        for p in sorted(self._pending.glob("*.json")):
+            rec = self._read_rec(p)
+            if rec is not None:
+                out.append(rec)
+        return out
+
     def create(self, pubkey: str, hostname: str) -> str:
         # The store is the security boundary, not just the HTTP layer: self-protect.
         # validate_pubkey rejects multi-line/CRLF input, so a crafted second line can't
         # be smuggled in here and later written into the pubkeys allowlist on approve.
         if not validate_pubkey(pubkey):
             raise ValueError("invalid pubkey")
-        # Scan-then-write under an exclusive flock (the `host_auth`/`registry`
-        # house pattern). The dedupe below and the cap check are both read-then-
-        # write, and the enroll app serves sync endpoints on a threadpool, so two
-        # re-posts of one key can interleave in a single process — the same class
-        # `_consume_nonce` is hardened against. The lock is the linearization
-        # point; every other method is unaffected because only `create` adds a
-        # pending record.
-        with _locked(self._pending.parent / "create.lock"):
-            pending = self.list_pending()      # sweeps expired records first
+        # Every pending-state transition shares this lock. The enrollment app
+        # serves sync endpoints on a threadpool, so create/approve and two
+        # creates can otherwise interleave their scan-then-write operations.
+        with _locked(self._lock_path):
+            pending = self._list_pending_unlocked()
             # Idempotent per key: keep one request id while the daemon is alive
-            # and renew its relay-stamped TTL on each scheduled re-post. The TTL
-            # still bounds abandoned records because renewal stops with the
-            # daemon. This atomic replace happens inside the same create lock as
-            # the dedupe scan, so concurrent re-posts cannot fork ids or lose a
-            # newer timestamp.
+            # and renew its relay-stamped TTL on each scheduled re-post.
             fp = fingerprint(pubkey)
             for rec in pending:
                 if rec.get("fingerprint") == fp:
@@ -192,6 +194,17 @@ class RequestStore:
                     self._write_atomic(
                         self._pending / f"{rec['id']}.json", renewed
                     )
+                    return rec["id"]
+            # An approval can win the lock immediately before an in-flight
+            # daemon re-post. Return that approved request so the daemon
+            # observes its terminal state instead of recreating it as pending.
+            for p in sorted(self._resolved.glob("*.json")):
+                rec = self._read_rec(p)
+                if (
+                    rec is not None
+                    and rec.get("status") == "approved"
+                    and rec.get("fingerprint") == fp
+                ):
                     return rec["id"]
             if len(pending) >= self._max_pending:
                 raise PendingCapReached()
@@ -210,54 +223,52 @@ class RequestStore:
         return rid
 
     def list_pending(self) -> list[dict]:
-        self._sweep()
-        out = []
-        for p in sorted(self._pending.glob("*.json")):
-            rec = self._read_rec(p)
-            if rec is not None:
-                out.append(rec)
-        return out
+        with _locked(self._lock_path):
+            return self._list_pending_unlocked()
 
     def get(self, rid: str) -> str:
         if not _RID_RE.match(rid):
             return "unknown"
-        self._sweep()
-        if (self._pending / f"{rid}.json").exists():
-            return "pending"
-        rec = self._read_rec(self._resolved / f"{rid}.json")
-        return rec.get("status", "unknown") if rec else "unknown"
+        with _locked(self._lock_path):
+            self._sweep()
+            if (self._pending / f"{rid}.json").exists():
+                return "pending"
+            rec = self._read_rec(self._resolved / f"{rid}.json")
+            return rec.get("status", "unknown") if rec else "unknown"
 
     def approve(self, rid: str, pubkeys_dir) -> None:
         if not _RID_RE.match(rid):
             raise NotPending(rid)
-        self._sweep()
-        p = self._pending / f"{rid}.json"
-        if not p.exists():
-            raise NotPending(rid)
-        rec = self._read_rec(p)
-        if rec is None:                       # corrupt/truncated → quarantined, treat as gone
-            raise NotPending(rid)
-        dest = _unique_pub_path(Path(pubkeys_dir), sanitize_label(rec["hostname"]))
-        # Atomic key write: sish re-reads pubkeys/ per connection and must never observe
-        # a half-written key file mid-write.
-        tmp = dest.with_suffix(".pub.tmp")
-        tmp.write_text(rec["pubkey"] + "\n")
-        tmp.replace(dest)
-        self._resolve(p, rec, "approved")
+        with _locked(self._lock_path):
+            self._sweep()
+            p = self._pending / f"{rid}.json"
+            if not p.exists():
+                raise NotPending(rid)
+            rec = self._read_rec(p)
+            if rec is None:
+                raise NotPending(rid)
+            dest = _unique_pub_path(Path(pubkeys_dir), sanitize_label(rec["hostname"]))
+            # Atomic key write: sish re-reads pubkeys/ per connection and must never
+            # observe a half-written key file mid-write.
+            tmp = dest.with_suffix(".pub.tmp")
+            tmp.write_text(rec["pubkey"] + "\n")
+            tmp.replace(dest)
+            self._resolve(p, rec, "approved")
 
     def deny(self, rid: str) -> None:
         if not _RID_RE.match(rid):
             raise NotPending(rid)
-        # Sweep first so denying an already-expired request resolves it as `expired`,
-        # consistent with the other methods.
-        self._sweep()
-        p = self._pending / f"{rid}.json"
-        if not p.exists():
-            raise NotPending(rid)
-        rec = self._read_rec(p)
-        if rec is None:                       # corrupt/truncated → quarantined, treat as gone
-            raise NotPending(rid)
-        self._resolve(p, rec, "denied")
+        with _locked(self._lock_path):
+            # Sweep first so denying an already-expired request resolves it as
+            # `expired`, consistent with the other methods.
+            self._sweep()
+            p = self._pending / f"{rid}.json"
+            if not p.exists():
+                raise NotPending(rid)
+            rec = self._read_rec(p)
+            if rec is None:
+                raise NotPending(rid)
+            self._resolve(p, rec, "denied")
 
 
 # ---------------------------------------------------------------------------

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -165,15 +165,18 @@ class RequestStore:
             if rec is None:
                 continue
             try:
+                created_at = float(rec["created_at"])
+            except (KeyError, TypeError, ValueError, OverflowError):
+                created_at = math.nan
+            if not math.isfinite(created_at):
+                self._resolve(p, rec, "expired")
+                continue
+            try:
                 deadline = float(rec["expires_at"])
-            except (KeyError, TypeError, ValueError):
+            except (KeyError, TypeError, ValueError, OverflowError):
                 # Records created before per-request deadlines used the store TTL.
-                try:
-                    deadline = float(rec["created_at"]) + self._ttl
-                except (KeyError, TypeError, ValueError):
-                    deadline = math.nan
-            expired = not math.isfinite(deadline) or now >= deadline
-            if expired:
+                deadline = created_at + self._ttl
+            if not math.isfinite(deadline) or now >= deadline:
                 self._resolve(p, rec, "expired")
 
     def _list_pending_unlocked(self) -> list[dict]:

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -120,6 +120,10 @@ class RequestStore:
         self._ttl = ttl_seconds
         self._max_pending = max_pending
         self._clock = clock
+    @property
+    def ttl_seconds(self) -> int:
+        return self._ttl
+
 
     def _write_atomic(self, path: Path, rec: dict) -> None:
         tmp = path.with_suffix(".json.tmp")

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -174,15 +174,20 @@ class RequestStore:
         # pending record.
         with _locked(self._pending.parent / "create.lock"):
             pending = self.list_pending()      # sweeps expired records first
-            # Idempotent per key: the daemon re-posts its request on a schedule
-            # while it waits for approval, so without dedupe one unapproved host
-            # would fill the pending cap by itself and 429 enrollment for the
-            # whole fleet. A re-post is a pure read — `created_at` is NOT
-            # refreshed, or an unapproved request would never expire and the TTL
-            # would stop bounding the store.
+            # Idempotent per key: keep one request id while the daemon is alive
+            # and renew its relay-stamped TTL on each scheduled re-post. The TTL
+            # still bounds abandoned records because renewal stops with the
+            # daemon. This atomic replace happens inside the same create lock as
+            # the dedupe scan, so concurrent re-posts cannot fork ids or lose a
+            # newer timestamp.
             fp = fingerprint(pubkey)
             for rec in pending:
                 if rec.get("fingerprint") == fp:
+                    renewed = dict(rec)
+                    renewed["created_at"] = self._clock()
+                    self._write_atomic(
+                        self._pending / f"{rec['id']}.json", renewed
+                    )
                     return rec["id"]
             if len(pending) >= self._max_pending:
                 raise PendingCapReached()

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -122,10 +122,10 @@ class RequestStore:
         self._ttl = ttl_seconds
         self._max_pending = max_pending
         self._clock = clock
+
     @property
     def ttl_seconds(self) -> int:
         return self._ttl
-
 
     def _write_atomic(self, path: Path, rec: dict) -> None:
         tmp = path.with_suffix(".json.tmp")
@@ -149,7 +149,7 @@ class RequestStore:
             if "created_at" not in rec:
                 raise ValueError("missing created_at")
             return rec
-        except (json.JSONDecodeError, OSError, ValueError):
+        except json.JSONDecodeError, OSError, ValueError:
             try:
                 p.replace(p.with_suffix(".json.corrupt"))
             except OSError:
@@ -163,11 +163,14 @@ class RequestStore:
             if rec is None:
                 continue
             try:
-                expires_at = float(rec["expires_at"])
-                expired = not math.isfinite(expires_at) or now >= expires_at
-            except (KeyError, TypeError, ValueError):
+                deadline = float(rec["expires_at"])
+            except KeyError, TypeError, ValueError:
                 # Records created before per-request deadlines used the store TTL.
-                expired = now - rec["created_at"] >= self._ttl
+                try:
+                    deadline = float(rec["created_at"]) + self._ttl
+                except KeyError, TypeError, ValueError:
+                    deadline = math.nan
+            expired = not math.isfinite(deadline) or now >= deadline
             if expired:
                 self._resolve(p, rec, "expired")
 
@@ -200,9 +203,7 @@ class RequestStore:
                     renewed_at = self._clock()
                     renewed["created_at"] = renewed_at
                     renewed["expires_at"] = renewed_at + self._ttl
-                    self._write_atomic(
-                        self._pending / f"{rec['id']}.json", renewed
-                    )
+                    self._write_atomic(self._pending / f"{rec['id']}.json", renewed)
                     return rec["id"]
             # An approval can win the lock immediately before an in-flight
             # daemon re-post. Return that approved request so the daemon

--- a/src/mship/core/relay/enroll.py
+++ b/src/mship/core/relay/enroll.py
@@ -146,8 +146,18 @@ class RequestStore:
         # be smuggled in here and later written into the pubkeys allowlist on approve.
         if not validate_pubkey(pubkey):
             raise ValueError("invalid pubkey")
-        self._sweep()
-        if len(list(self._pending.glob("*.json"))) >= self._max_pending:
+        pending = self.list_pending()          # sweeps expired records first
+        # Idempotent per key: the daemon re-posts its request on a schedule while
+        # it waits for approval, so without dedupe one unapproved host would fill
+        # the pending cap by itself and 429 enrollment for the whole fleet. A
+        # re-post is a pure read — `created_at` is NOT refreshed, or an
+        # unapproved request would never expire and the TTL would stop bounding
+        # the store.
+        fp = fingerprint(pubkey)
+        for rec in pending:
+            if rec.get("fingerprint") == fp:
+                return rec["id"]
+        if len(pending) >= self._max_pending:
             raise PendingCapReached()
         rid = secrets.token_hex(16)
         self._write_atomic(

--- a/src/mship/core/relay/enroll_app.py
+++ b/src/mship/core/relay/enroll_app.py
@@ -83,7 +83,7 @@ def build_enroll_app(
 ) -> FastAPI:
     app = FastAPI(title="mship relay enroll")
 
-    @app.post("/enroll")
+    @app.post(host_contract.ENROLL_PATH)
     def enroll(body: _EnrollBody):
         if not validate_pubkey(body.pubkey):
             raise HTTPException(status_code=400, detail="invalid ssh public key")

--- a/src/mship/core/relay/enroll_app.py
+++ b/src/mship/core/relay/enroll_app.py
@@ -55,6 +55,12 @@ class _RegisterBody(BaseModel):
     payload: dict[_Key, _PayloadValue] = Field(max_length=_MAX_PAYLOAD_FIELDS)
 
 
+class _RevokeBody(BaseModel):
+    key_fingerprint: str = Field(max_length=_MAX_STR)
+    nonce: str = Field(max_length=128)
+    signature: str = Field(max_length=8192)
+
+
 # The directory is a PUBLISHED surface: a field added to a stored entry must not
 # auto-appear on every paired phone. `refresh` is here deliberately — fetching it
 # is why the phone reads this route at all — and appears on no other response.
@@ -122,6 +128,24 @@ def build_enroll_app(
         except SignatureRefused as exc:
             raise HTTPException(status_code=401, detail=str(exc))
         return {"nonce": challenge["nonce"], "expires_at": challenge["expires_at"]}
+
+    @app.post(host_contract.REVOKE_PATH)
+    def hosts_revoke(body: _RevokeBody):
+        try:
+            host_directory.revoke_key(
+                body.key_fingerprint,
+                nonce=body.nonce,
+                signature=body.signature,
+            )
+        except (ChallengeRefused, SignatureRefused) as exc:
+            raise HTTPException(status_code=401, detail=str(exc))
+        except VerificationBusy:
+            raise HTTPException(
+                status_code=429,
+                detail="signature verification busy; try later",
+                headers={"Retry-After": "1"},
+            )
+        return {"status": "revoked"}
 
     @app.post(host_contract.REGISTER_PATH)
     def hosts_register(body: _RegisterBody):

--- a/src/mship/core/relay/enroll_app.py
+++ b/src/mship/core/relay/enroll_app.py
@@ -33,19 +33,21 @@ class _EnrollBody(BaseModel):
 # would fail. `capabilities`/`runner` are the one nested level the contract
 # defines, so a value is a scalar or a flat map of scalars.
 _MAX_STR = 512
+_MAX_KEY = 128
 _MAX_PAYLOAD_FIELDS = 64
 _MAX_NESTED_FIELDS = 32
 
+_Key = Annotated[str, Field(max_length=_MAX_KEY)]
 _Scalar = Union[Annotated[str, Field(max_length=_MAX_STR)], bool, int, float, None]
 _PayloadValue = Union[
-    _Scalar, Annotated[dict[str, _Scalar], Field(max_length=_MAX_NESTED_FIELDS)]
+    _Scalar, Annotated[dict[_Key, _Scalar], Field(max_length=_MAX_NESTED_FIELDS)]
 ]
 
 
 class _RegisterBody(BaseModel):
     nonce: str = Field(max_length=128)
     signature: str = Field(max_length=8192)      # an armored SSHSIG, ~600B for ed25519
-    payload: dict[str, _PayloadValue] = Field(max_length=_MAX_PAYLOAD_FIELDS)
+    payload: dict[_Key, _PayloadValue] = Field(max_length=_MAX_PAYLOAD_FIELDS)
 
 
 # The directory is a PUBLISHED surface: a field added to a stored entry must not

--- a/src/mship/core/relay/enroll_app.py
+++ b/src/mship/core/relay/enroll_app.py
@@ -132,6 +132,10 @@ def build_enroll_app(
             raise HTTPException(status_code=400, detail="malformed host_id")
         except InvalidPublicUrl as exc:
             raise HTTPException(status_code=400, detail=str(exc))
+        except ValueError:
+            raise HTTPException(
+                status_code=400, detail="malformed registration payload"
+            )
         except (ChallengeRefused, SignatureRefused) as exc:
             raise HTTPException(status_code=401, detail=str(exc))
         except DuplicateIdentity as exc:

--- a/src/mship/core/relay/enroll_app.py
+++ b/src/mship/core/relay/enroll_app.py
@@ -8,7 +8,6 @@ from mship.core.relay import host_contract
 from mship.core.relay.enroll import RequestStore, PendingCapReached, validate_pubkey
 from mship.core.relay.fleet_token import FleetTokenStore
 from mship.core.relay.host_directory import (
-    ChallengeCapReached,
     ChallengeRefused,
     DuplicateIdentity,
     HostDirectory,
@@ -45,9 +44,13 @@ _PayloadValue = Union[
 ]
 
 
+class _ChallengeBody(BaseModel):
+    key_fingerprint: str = Field(max_length=_MAX_STR)
+
+
 class _RegisterBody(BaseModel):
     nonce: str = Field(max_length=128)
-    signature: str = Field(max_length=8192)      # an armored SSHSIG, ~600B for ed25519
+    signature: str = Field(max_length=8192)  # an armored SSHSIG, ~600B for ed25519
     payload: dict[_Key, _PayloadValue] = Field(max_length=_MAX_PAYLOAD_FIELDS)
 
 
@@ -91,7 +94,9 @@ def build_enroll_app(
         try:
             rid = store.create(body.pubkey, body.hostname)
         except PendingCapReached:
-            raise HTTPException(status_code=429, detail="too many pending requests; try later")
+            raise HTTPException(
+                status_code=429, detail="too many pending requests; try later"
+            )
         except ValueError:
             # Store self-validates (belt-and-suspenders); surface its rejection
             # as a clean 400 rather than letting it bubble up as a 500.
@@ -109,13 +114,12 @@ def build_enroll_app(
             raise HTTPException(status_code=403, detail="host not allowed")
         return Response(status_code=200)
 
-    @app.get(host_contract.CHALLENGE_PATH)
-    def hosts_challenge():
+    @app.post(host_contract.CHALLENGE_PATH)
+    def hosts_challenge(body: _ChallengeBody):
         try:
-            challenge = host_directory.issue_challenge()
-        except ChallengeCapReached as exc:
-            # Public and unauthenticated: a flood is refused, never a 500.
-            raise HTTPException(status_code=429, detail=str(exc))
+            challenge = host_directory.issue_challenge(body.key_fingerprint)
+        except SignatureRefused as exc:
+            raise HTTPException(status_code=401, detail=str(exc))
         return {"nonce": challenge["nonce"], "expires_at": challenge["expires_at"]}
 
     @app.post(host_contract.REGISTER_PATH)
@@ -140,11 +144,14 @@ def build_enroll_app(
     def hosts_list(request: Request):
         presented = request.headers.get(host_contract.FLEET_TOKEN_HEADER, "")
         if fleet_tokens.verify(presented) is None:
-            raise HTTPException(status_code=401, detail="invalid or revoked fleet token")
+            raise HTTPException(
+                status_code=401, detail="invalid or revoked fleet token"
+            )
         entries = host_directory.list_hosts(store.list_pending())
         return {
             "hosts": [
-                {f: entry[f] for f in _DIRECTORY_FIELDS if f in entry} for entry in entries
+                {f: entry[f] for f in _DIRECTORY_FIELDS if f in entry}
+                for entry in entries
             ]
         }
 

--- a/src/mship/core/relay/enroll_app.py
+++ b/src/mship/core/relay/enroll_app.py
@@ -13,6 +13,7 @@ from mship.core.relay.host_directory import (
     DuplicateIdentity,
     HostDirectory,
     InvalidHostId,
+    InvalidPublicUrl,
     SignatureRefused,
 )
 from mship.core.relay.tls_ask import tls_ask_allowed
@@ -125,6 +126,8 @@ def build_enroll_app(
             )
         except InvalidHostId:
             raise HTTPException(status_code=400, detail="malformed host_id")
+        except InvalidPublicUrl as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
         except (ChallengeRefused, SignatureRefused) as exc:
             raise HTTPException(status_code=401, detail=str(exc))
         except DuplicateIdentity as exc:

--- a/src/mship/core/relay/enroll_app.py
+++ b/src/mship/core/relay/enroll_app.py
@@ -14,6 +14,7 @@ from mship.core.relay.host_directory import (
     InvalidHostId,
     InvalidPublicUrl,
     SignatureRefused,
+    VerificationBusy,
 )
 from mship.core.relay.tls_ask import tls_ask_allowed
 
@@ -138,6 +139,12 @@ def build_enroll_app(
             )
         except (ChallengeRefused, SignatureRefused) as exc:
             raise HTTPException(status_code=401, detail=str(exc))
+        except VerificationBusy:
+            raise HTTPException(
+                status_code=429,
+                detail="signature verification busy; try later",
+                headers={"Retry-After": "1"},
+            )
         except DuplicateIdentity as exc:
             raise HTTPException(status_code=409, detail=str(exc))
         # Echoes identity only: the entry carries the host's refresh credential,

--- a/src/mship/core/relay/enroll_app.py
+++ b/src/mship/core/relay/enroll_app.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
-from fastapi import FastAPI, HTTPException, Query, Response
+from typing import Annotated, Union
+
+from fastapi import FastAPI, HTTPException, Query, Request, Response
 from pydantic import BaseModel, Field
 
+from mship.core.relay import host_contract
 from mship.core.relay.enroll import RequestStore, PendingCapReached, validate_pubkey
+from mship.core.relay.fleet_token import FleetTokenStore
+from mship.core.relay.host_directory import (
+    ChallengeCapReached,
+    ChallengeRefused,
+    DuplicateIdentity,
+    HostDirectory,
+    InvalidHostId,
+    SignatureRefused,
+)
 from mship.core.relay.tls_ask import tls_ask_allowed
 
 
@@ -14,7 +26,59 @@ class _EnrollBody(BaseModel):
     hostname: str = Field(default="", max_length=253)
 
 
-def build_enroll_app(store: RequestStore, *, relay_domain: str) -> FastAPI:
+# `/hosts/register` is public too (the signature, not the transport, is the
+# gate), and its payload is verified as the bytes the client sent — so it is
+# accepted as a bounded dict rather than a field-by-field model: a model with
+# defaults would re-serialize keys the client never sent and every signature
+# would fail. `capabilities`/`runner` are the one nested level the contract
+# defines, so a value is a scalar or a flat map of scalars.
+_MAX_STR = 512
+_MAX_PAYLOAD_FIELDS = 64
+_MAX_NESTED_FIELDS = 32
+
+_Scalar = Union[Annotated[str, Field(max_length=_MAX_STR)], bool, int, float, None]
+_PayloadValue = Union[
+    _Scalar, Annotated[dict[str, _Scalar], Field(max_length=_MAX_NESTED_FIELDS)]
+]
+
+
+class _RegisterBody(BaseModel):
+    nonce: str = Field(max_length=128)
+    signature: str = Field(max_length=8192)      # an armored SSHSIG, ~600B for ed25519
+    payload: dict[str, _PayloadValue] = Field(max_length=_MAX_PAYLOAD_FIELDS)
+
+
+# The directory is a PUBLISHED surface: a field added to a stored entry must not
+# auto-appear on every paired phone. `refresh` is here deliberately — fetching it
+# is why the phone reads this route at all — and appears on no other response.
+_DIRECTORY_FIELDS = (
+    "host_id",
+    "state",
+    "label",
+    "instance_id",
+    "key_fingerprint",
+    "machine_fingerprint",
+    "subdomain",
+    "public_url",
+    "mship_version",
+    "capabilities",
+    "runner",
+    "refresh",
+    "first_seen",
+    "last_seen",
+    "previous_instance_id",
+    "request_id",
+    "created_at",
+)
+
+
+def build_enroll_app(
+    store: RequestStore,
+    *,
+    relay_domain: str,
+    host_directory: HostDirectory,
+    fleet_tokens: FleetTokenStore,
+) -> FastAPI:
     app = FastAPI(title="mship relay enroll")
 
     @app.post("/enroll")
@@ -41,5 +105,42 @@ def build_enroll_app(store: RequestStore, *, relay_domain: str) -> FastAPI:
         if not tls_ask_allowed(domain, relay_domain):
             raise HTTPException(status_code=403, detail="host not allowed")
         return Response(status_code=200)
+
+    @app.get(host_contract.CHALLENGE_PATH)
+    def hosts_challenge():
+        try:
+            challenge = host_directory.issue_challenge()
+        except ChallengeCapReached as exc:
+            # Public and unauthenticated: a flood is refused, never a 500.
+            raise HTTPException(status_code=429, detail=str(exc))
+        return {"nonce": challenge["nonce"], "expires_at": challenge["expires_at"]}
+
+    @app.post(host_contract.REGISTER_PATH)
+    def hosts_register(body: _RegisterBody):
+        try:
+            entry = host_directory.register(
+                body.payload, nonce=body.nonce, signature=body.signature
+            )
+        except InvalidHostId:
+            raise HTTPException(status_code=400, detail="malformed host_id")
+        except (ChallengeRefused, SignatureRefused) as exc:
+            raise HTTPException(status_code=401, detail=str(exc))
+        except DuplicateIdentity as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+        # Echoes identity only: the entry carries the host's refresh credential,
+        # which is published on `GET /hosts` and nowhere else.
+        return {"status": "registered", "host_id": entry["host_id"]}
+
+    @app.get(host_contract.LIST_PATH)
+    def hosts_list(request: Request):
+        presented = request.headers.get(host_contract.FLEET_TOKEN_HEADER, "")
+        if fleet_tokens.verify(presented) is None:
+            raise HTTPException(status_code=401, detail="invalid or revoked fleet token")
+        entries = host_directory.list_hosts(store.list_pending())
+        return {
+            "hosts": [
+                {f: entry[f] for f in _DIRECTORY_FIELDS if f in entry} for entry in entries
+            ]
+        }
 
     return app

--- a/src/mship/core/relay/enroll_app.py
+++ b/src/mship/core/relay/enroll_app.py
@@ -96,7 +96,7 @@ def build_enroll_app(
             # Store self-validates (belt-and-suspenders); surface its rejection
             # as a clean 400 rather than letting it bubble up as a 500.
             raise HTTPException(status_code=400, detail="invalid ssh public key")
-        return {"id": rid, "status": "pending", "expires_in": store.ttl_seconds}
+        return {"id": rid, "status": store.get(rid), "expires_in": store.ttl_seconds}
 
     @app.get("/status/{rid}")
     def status(rid: str):

--- a/src/mship/core/relay/enroll_app.py
+++ b/src/mship/core/relay/enroll_app.py
@@ -96,7 +96,7 @@ def build_enroll_app(
             # Store self-validates (belt-and-suspenders); surface its rejection
             # as a clean 400 rather than letting it bubble up as a 500.
             raise HTTPException(status_code=400, detail="invalid ssh public key")
-        return {"id": rid, "status": "pending"}
+        return {"id": rid, "status": "pending", "expires_in": store.ttl_seconds}
 
     @app.get("/status/{rid}")
     def status(rid: str):

--- a/src/mship/core/relay/fleet_token.py
+++ b/src/mship/core/relay/fleet_token.py
@@ -16,6 +16,7 @@ Nothing is stored in plaintext: only a sha256 of the derived secret, which is
 what `verify` compares against. Verification is a pure read — a phone polling
 the directory must not churn the store.
 """
+
 from __future__ import annotations
 
 import fcntl
@@ -96,14 +97,16 @@ class FleetTokenStore:
             doc = json.loads(self.path.read_text())
             labels = doc["labels"]
             return labels if isinstance(labels, dict) else {}
-        except (OSError, ValueError, KeyError, TypeError):
+        except OSError, ValueError, KeyError, TypeError:
             return {}
 
     def _save(self, labels: dict) -> None:
         """Atomic, owner-only write: mkstemp creates the temp file 0600, so the
         hashes are never briefly world-readable."""
         _private_dir(self.path)
-        fd, temp_name = tempfile.mkstemp(prefix=self.path.name + ".", dir=self.path.parent)
+        fd, temp_name = tempfile.mkstemp(
+            prefix=self.path.name + ".", dir=self.path.parent
+        )
         temp = Path(temp_name)
         try:
             with os.fdopen(fd, "w") as stream:
@@ -118,8 +121,9 @@ class FleetTokenStore:
         """The secret for one record — recomputable, so a re-mint returns the
         same string without ever storing the plaintext."""
         root = ensure_secret_file(self._secret_path, _ROOT_SECRET_LEN)
-        return hmac.new(root, f"{label}\x00{nonce}".encode("utf-8"),
-                        hashlib.sha256).hexdigest()
+        return hmac.new(
+            root, f"{label}\x00{nonce}".encode("utf-8"), hashlib.sha256
+        ).hexdigest()
 
     # -- API ---------------------------------------------------------------
 
@@ -133,16 +137,26 @@ class FleetTokenStore:
         with _locked(self._lock, fcntl.LOCK_EX):
             labels = self._load()
             existing = labels.get(label_id)
-            if isinstance(existing, dict) and existing.get("nonce"):
-                return f"{label_id}.{self._derive(label, existing['nonce'])}"
+            replacing = isinstance(existing, dict) and bool(existing.get("nonce"))
+            if replacing:
+                secret = self._derive(label, existing["nonce"])
+                if hmac.compare_digest(
+                    _hash(secret), str(existing.get("secret_hash", ""))
+                ):
+                    return f"{label_id}.{secret}"
             # Evict from the PRE-EXISTING set only, so the credential we are
-            # about to hand back can never be the one the cap drops.
-            if len(labels) >= self._max_labels:
-                labels = dict(sorted(
-                    labels.items(),
-                    key=lambda kv: kv[1].get("created_at", 0) if isinstance(kv[1], dict) else 0,
-                    reverse=True,
-                )[: max(self._max_labels - 1, 0)])
+            # about to hand back can never be the one the cap drops. Replacing
+            # a record whose root-derived secret no longer matches needs no slot.
+            if not replacing and len(labels) >= self._max_labels:
+                labels = dict(
+                    sorted(
+                        labels.items(),
+                        key=lambda kv: (
+                            kv[1].get("created_at", 0) if isinstance(kv[1], dict) else 0
+                        ),
+                        reverse=True,
+                    )[: max(self._max_labels - 1, 0)]
+                )
             nonce = secrets.token_hex(16)
             secret = self._derive(label, nonce)
             labels[label_id] = {

--- a/src/mship/core/relay/fleet_token.py
+++ b/src/mship/core/relay/fleet_token.py
@@ -97,7 +97,7 @@ class FleetTokenStore:
             doc = json.loads(self.path.read_text())
             labels = doc["labels"]
             return labels if isinstance(labels, dict) else {}
-        except OSError, ValueError, KeyError, TypeError:
+        except (OSError, ValueError, KeyError, TypeError):
             return {}
 
     def _save(self, labels: dict) -> None:

--- a/src/mship/core/relay/fleet_token.py
+++ b/src/mship/core/relay/fleet_token.py
@@ -1,0 +1,182 @@
+"""Per-device fleet tokens (#471): the credential a phone carries to read the
+relay's host directory (`GET /hosts`).
+
+The `core.daemon.host_auth.RefreshStore` shape, for the same two reasons:
+
+- **Stable per label.** `mship relay fleet-token --label phone` is the command
+  that prints the QR, and an operator will run it again just to re-display it.
+  A fresh secret on every run would silently unpair the phone that already
+  scanned the last one — so the secret is *derived* from a relay root secret
+  plus a per-label nonce, and a re-mint recomputes it and writes nothing.
+- **Revocation is real.** `revoke` drops the record *and its nonce*, so a later
+  re-mint under the same label derives a different credential rather than
+  resurrecting the one the operator just killed.
+
+Nothing is stored in plaintext: only a sha256 of the derived secret, which is
+what `verify` compares against. Verification is a pure read — a phone polling
+the directory must not churn the store.
+"""
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import tempfile
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+from mship.core.relay.keys import ensure_secret_file
+
+# Bounded so the document cannot grow without limit; far above any real fleet
+# (this counts *devices the owner paired*, not hosts).
+MAX_FLEET_LABELS = 32
+
+_ROOT_SECRET_LEN = 32
+
+# Record keys are the first 16 hex of a sha256 over the label, so a label is
+# never a path component and never a lookup key verbatim.
+_LABEL_ID_LEN = 16
+_ID_RE = re.compile(r"\A[0-9a-f]{%d}\Z" % _LABEL_ID_LEN)
+
+# A label is an operator-typed nickname ("phone"); bounded so it cannot be used
+# to bloat the document.
+MAX_LABEL_LEN = 64
+
+
+def _label_id(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()[:_LABEL_ID_LEN]
+
+
+def _hash(secret: str) -> str:
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()
+
+
+def _private_dir(path: Path) -> None:
+    """Owner-only parent dir. The corrective chmod is not redundant: mkdir's
+    mode is masked by the umask, and `exist_ok=True` never tightens a dir that
+    already exists too loose (the `registry.py`/`host_token.py` house pattern)."""
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.parent.chmod(0o700)
+
+
+@contextmanager
+def _locked(lock_path: Path, mode: int):
+    """Advisory flock (the `registry.py`/`host_auth.py` house pattern)."""
+    _private_dir(lock_path)
+    lock_path.touch(exist_ok=True, mode=0o600)
+    with open(lock_path, "r+") as lf:
+        fcntl.flock(lf, mode)
+        try:
+            yield
+        finally:
+            fcntl.flock(lf, fcntl.LOCK_UN)
+
+
+class FleetTokenStore:
+    """Flock'd RMW over one JSON doc of per-label fleet-token records."""
+
+    def __init__(self, store_dir, *, max_labels: int = MAX_FLEET_LABELS) -> None:
+        self._dir = Path(store_dir)
+        self.path = self._dir / "fleet-tokens.json"
+        self._lock = self.path.with_name(self.path.name + ".lock")
+        self._secret_path = self._dir / "fleet-secret"
+        self._max_labels = max_labels
+
+    # -- storage -----------------------------------------------------------
+
+    def _load(self) -> dict:
+        """Records by label_id; a corrupt/truncated doc reads as empty (every
+        token it held is unverifiable anyway — `RegistryStore._load_nolock`)."""
+        try:
+            doc = json.loads(self.path.read_text())
+            labels = doc["labels"]
+            return labels if isinstance(labels, dict) else {}
+        except (OSError, ValueError, KeyError, TypeError):
+            return {}
+
+    def _save(self, labels: dict) -> None:
+        """Atomic, owner-only write: mkstemp creates the temp file 0600, so the
+        hashes are never briefly world-readable."""
+        _private_dir(self.path)
+        fd, temp_name = tempfile.mkstemp(prefix=self.path.name + ".", dir=self.path.parent)
+        temp = Path(temp_name)
+        try:
+            with os.fdopen(fd, "w") as stream:
+                stream.write(json.dumps({"labels": labels}, indent=2))
+            os.replace(temp, self.path)
+        except BaseException:
+            temp.unlink(missing_ok=True)
+            raise
+        self.path.chmod(0o600)
+
+    def _derive(self, label: str, nonce: str) -> str:
+        """The secret for one record — recomputable, so a re-mint returns the
+        same string without ever storing the plaintext."""
+        root = ensure_secret_file(self._secret_path, _ROOT_SECRET_LEN)
+        return hmac.new(root, f"{label}\x00{nonce}".encode("utf-8"),
+                        hashlib.sha256).hexdigest()
+
+    # -- API ---------------------------------------------------------------
+
+    def issue(self, label: str) -> str:
+        """This label's fleet token (`<label_id>.<secret>`), minted only if it
+        has none. Re-running the mint command is a no-op on disk."""
+        label = (label or "").strip()
+        if not label or len(label) > MAX_LABEL_LEN:
+            raise ValueError(f"label must be 1..{MAX_LABEL_LEN} characters")
+        label_id = _label_id(label)
+        with _locked(self._lock, fcntl.LOCK_EX):
+            labels = self._load()
+            existing = labels.get(label_id)
+            if isinstance(existing, dict) and existing.get("nonce"):
+                return f"{label_id}.{self._derive(label, existing['nonce'])}"
+            # Evict from the PRE-EXISTING set only, so the credential we are
+            # about to hand back can never be the one the cap drops.
+            if len(labels) >= self._max_labels:
+                labels = dict(sorted(
+                    labels.items(),
+                    key=lambda kv: kv[1].get("created_at", 0) if isinstance(kv[1], dict) else 0,
+                    reverse=True,
+                )[: max(self._max_labels - 1, 0)])
+            nonce = secrets.token_hex(16)
+            secret = self._derive(label, nonce)
+            labels[label_id] = {
+                "label_id": label_id,
+                "label": label,
+                "nonce": nonce,
+                "secret_hash": _hash(secret),
+                "created_at": time.time(),
+            }
+            self._save(labels)
+        return f"{label_id}.{secret}"
+
+    def verify(self, presented: str) -> str | None:
+        """The label behind a live token, else None. Never raises, never writes."""
+        if not presented or "." not in presented:
+            return None
+        label_id, secret = presented.split(".", 1)
+        if not _ID_RE.match(label_id):
+            return None
+        with _locked(self._lock, fcntl.LOCK_SH):
+            rec = self._load().get(label_id)
+        if not isinstance(rec, dict):
+            return None
+        if not hmac.compare_digest(_hash(secret), str(rec.get("secret_hash", ""))):
+            return None
+        return str(rec.get("label", ""))
+
+    def revoke(self, label: str) -> bool:
+        """Drop this label's credential. True if one was there to drop."""
+        label_id = _label_id((label or "").strip())
+        with _locked(self._lock, fcntl.LOCK_EX):
+            labels = self._load()
+            if label_id not in labels:
+                return False
+            labels.pop(label_id)
+            self._save(labels)
+        return True

--- a/src/mship/core/relay/fleet_token.py
+++ b/src/mship/core/relay/fleet_token.py
@@ -176,8 +176,7 @@ class FleetTokenStore:
         label_id, secret = presented.split(".", 1)
         if not _ID_RE.match(label_id):
             return None
-        with _locked(self._lock, fcntl.LOCK_SH):
-            rec = self._load().get(label_id)
+        rec = self._load().get(label_id)
         if not isinstance(rec, dict):
             return None
         if not hmac.compare_digest(_hash(secret), str(rec.get("secret_hash", ""))):

--- a/src/mship/core/relay/health.py
+++ b/src/mship/core/relay/health.py
@@ -28,6 +28,8 @@ def probe_health(public_url: str, token: str, *, get: Callable | None = None,
     renders its prose from this, and `mship.core.topology` maps the status code
     to a per-edge status + fix hint (a run-host 401 and a phone-pairing 401 need
     different advice, so that mapping belongs with the caller, not here).
+    Redirects are reported, never followed: the relay-owned URL must not become
+    an attacker-selected request from inside the host.
     """
     if get is None:
         import httpx
@@ -35,7 +37,7 @@ def probe_health(public_url: str, token: str, *, get: Callable | None = None,
     url = public_url.rstrip("/") + "/health"
     try:
         r = get(url, headers={"Authorization": f"Bearer {token}"},
-                timeout=timeout, follow_redirects=True)
+                timeout=timeout, follow_redirects=False)
     except Exception as e:  # transport/DNS/TLS error
         return HealthProbe(ok=False, error=str(e))
     code = r.status_code

--- a/src/mship/core/relay/health.py
+++ b/src/mship/core/relay/health.py
@@ -6,10 +6,18 @@ from typing import Callable
 @dataclass(frozen=True)
 class HealthProbe:
     """Outcome of one `/health` request. Exactly one of `status_code` (a
-    response arrived) or `error` (transport/DNS/TLS failure) is set."""
+    response arrived) or `error` (transport/DNS/TLS failure) is set.
+
+    `body`/`date_header` exist for the daemon's tunnel read-back (#471): it asks
+    *which* host is answering on its own subdomain, which is a fact only the
+    body carries. They are additive — every other caller reads `ok`,
+    `status_code` and `error` only.
+    """
     ok: bool
     status_code: int | None = None
     error: str | None = None
+    body: dict | None = None
+    date_header: str | None = None
 
 
 def probe_health(public_url: str, token: str, *, get: Callable | None = None,
@@ -31,7 +39,23 @@ def probe_health(public_url: str, token: str, *, get: Callable | None = None,
     except Exception as e:  # transport/DNS/TLS error
         return HealthProbe(ok=False, error=str(e))
     code = r.status_code
-    return HealthProbe(ok=200 <= code < 300, status_code=code)
+    return HealthProbe(ok=200 <= code < 300, status_code=code,
+                       body=_json_object(r), date_header=_date_header(r))
+
+
+def _json_object(resp) -> dict | None:
+    """The response's JSON object, or None for anything else — an HTML error
+    page, a truncated body, a bare list. Never raises: a probe that blew up on a
+    captive portal's 200 would turn a reachability check into a crash."""
+    try:
+        body = resp.json()
+    except Exception:
+        return None
+    return body if isinstance(body, dict) else None
+
+
+def _date_header(resp) -> str | None:
+    return (getattr(resp, "headers", None) or {}).get("Date")
 
 
 def verify_relay_reachable(public_url: str, token: str, *, get: Callable | None = None,

--- a/src/mship/core/relay/host_contract.py
+++ b/src/mship/core/relay/host_contract.py
@@ -41,7 +41,13 @@ ENROLL_SUBDOMAIN = "enroll"
 LIST_PATH = HOSTS_PREFIX
 CHALLENGE_PATH = f"{HOSTS_PREFIX}/challenge"
 REGISTER_PATH = f"{HOSTS_PREFIX}/register"
-ROUTE_PATHS: tuple[str, ...] = (LIST_PATH, CHALLENGE_PATH, REGISTER_PATH)
+REVOKE_PATH = f"{HOSTS_PREFIX}/revoke"
+ROUTE_PATHS: tuple[str, ...] = (
+    LIST_PATH,
+    CHALLENGE_PATH,
+    REGISTER_PATH,
+    REVOKE_PATH,
+)
 
 # The pre-existing enrollment route, spelled once: the daemon's relay link, the
 # `mship relay enroll` CLI and the app that serves it must all name it the same.
@@ -110,6 +116,11 @@ def canonical_payload(payload: dict) -> bytes:
         ensure_ascii=False,
         allow_nan=False,
     ).encode("utf-8")
+
+
+def key_revocation_payload(key_fingerprint: str) -> dict:
+    """The exact signed request that authorizes removal of the old relay key."""
+    return {"action": "revoke-key", "key_fingerprint": key_fingerprint}
 
 
 def signing_blob(nonce: str, payload: dict) -> bytes:

--- a/src/mship/core/relay/host_contract.py
+++ b/src/mship/core/relay/host_contract.py
@@ -15,6 +15,7 @@ escaping are free parameters of `json.dumps`: two ends that pick differently
 verify fine in one interpreter and 401 on every registration in production, so
 the bytes are pinned here and golden-tested, never re-derived at a call site.
 """
+
 from __future__ import annotations
 
 import json
@@ -46,12 +47,10 @@ ROUTE_PATHS: tuple[str, ...] = (LIST_PATH, CHALLENGE_PATH, REGISTER_PATH)
 # `mship relay enroll` CLI and the app that serves it must all name it the same.
 ENROLL_PATH = "/enroll"
 
-# The two ways `/hosts/register` answers 401, as the exact `detail` each carries.
-# The status code cannot tell them apart, and they need opposite handling: an
-# unapproved key must (re-)enroll and wait for a human, while a stale nonce is a
-# lost race on a 120s window that the next attempt fixes by itself. So the
-# strings ARE the contract — the daemon discriminates on them — and both ends
-# read them from here rather than restating a literal.
+# Challenge issuance and registration both use 401. The exact detail tells the
+# daemon whether the key is unapproved (enroll and wait for a human) or the
+# signed registration lost a race on its 120s nonce (retry). The strings are
+# therefore wire-contract values read by both ends, not presentation text.
 UNAPPROVED_KEY_DETAIL = "registration is not signed by an approved key"
 MALFORMED_NONCE_DETAIL = "malformed nonce"
 UNKNOWN_NONCE_DETAIL = "unknown or already-used nonce"

--- a/src/mship/core/relay/host_contract.py
+++ b/src/mship/core/relay/host_contract.py
@@ -1,0 +1,94 @@
+"""Single source of truth for the host-registration contract (#471).
+
+Three ends must agree, and none of them can see the others' code:
+
+- the daemon's relay link (`core/daemon/relay_link.py`) SIGNS a payload and
+  POSTs it,
+- the relay's enroll app (`core/relay/enroll_app.py`) VERIFIES the same bytes
+  and serves the directory,
+- Ground Control READS the directory over the same routes.
+
+Everything they must agree on lives here — the ssh signature namespace, the
+header the phone carries its fleet token in, the route paths, the TTLs, and
+above all `canonical_payload`/`signing_blob`. Key order, separators and
+escaping are free parameters of `json.dumps`: two ends that pick differently
+verify fine in one interpreter and 401 on every registration in production, so
+the bytes are pinned here and golden-tested, never re-derived at a call site.
+"""
+from __future__ import annotations
+
+import json
+
+# `ssh-keygen -Y sign -n <namespace>`: binds a signature to THIS use, so a
+# signature made for anything else cannot be replayed as a registration.
+NAMESPACE = "host-registration@mship"
+
+# The phone's per-device fleet credential (relay-issued, revocable per label).
+FLEET_TOKEN_HEADER = "Mship-Fleet-Token"
+
+# AC13: the enroll site is hardened to POST /enroll + GET /status/* with a 404
+# catch-all, so every route below must sit under ONE prefix — that is what
+# keeps a single `@hosts { path /hosts /hosts/* }` Caddy matcher sufficient.
+HOSTS_PREFIX = "/hosts"
+LIST_PATH = HOSTS_PREFIX
+CHALLENGE_PATH = f"{HOSTS_PREFIX}/challenge"
+REGISTER_PATH = f"{HOSTS_PREFIX}/register"
+ROUTE_PATHS: tuple[str, ...] = (LIST_PATH, CHALLENGE_PATH, REGISTER_PATH)
+
+# A nonce only has to survive one round trip; short because it is single-use
+# and a replay window is the whole point of issuing one.
+CHALLENGE_TTL_S = 120
+
+# The bearer the phone carries. Owned here (published to both ends), minted by
+# `core/daemon/host_token.py`, which imports it rather than restating it.
+HOST_TOKEN_TTL_S = 300
+
+# How often a healthy daemon re-registers, and the cap on its reconnect
+# backoff (mirrors `TunnelSupervisor(max_backoff_delay=...)`, pinned by test).
+REGISTER_INTERVAL_S = 60.0
+MAX_BACKOFF_S = 60.0
+
+# DERIVED, never a hand-picked number: a host that misses beats and reconnects
+# on the worst-case backoff must still be inside the window, or healthy hosts
+# flap to `offline` on every reconnect (AC10).
+DIRECTORY_STALE_S = 3 * REGISTER_INTERVAL_S + MAX_BACKOFF_S
+
+# How long the relay's enroll store keeps an unapproved request (the store's
+# default TTL — `enroll.RequestStore` imports this).
+ENROLL_TTL_S = 1800
+
+# The daemon re-posts its enroll request on this schedule while awaiting
+# approval. Strictly shorter than the store's TTL, so a VM provisioned at 02:00
+# is still approvable at 09:00 (AC1/AC8).
+ENROLL_REPOST_INTERVAL_S = ENROLL_TTL_S // 3
+
+
+def canonical_payload(payload: dict) -> bytes:
+    """The exact bytes both ends sign and verify.
+
+    `sort_keys` removes insertion order, the compact separators remove
+    whitespace, `ensure_ascii=False` + explicit utf-8 keeps a non-ASCII
+    hostname one stable encoding rather than two (`\\u00f4` vs the raw bytes),
+    and `allow_nan=False` fails loud instead of emitting `NaN`, which is not
+    JSON and which the other end could not parse back.
+    """
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def signing_blob(nonce: str, payload: dict) -> bytes:
+    """`namespace ‖ nonce ‖ canonical_payload(payload)`, NUL-separated.
+
+    The nonce is inside the signed bytes, so a captured signature cannot be
+    replayed against a fresh challenge, and the payload is inside them, so a
+    signature cannot be lifted onto a different payload. NUL is the separator
+    because it can appear in neither the namespace nor the nonce.
+    """
+    return b"\x00".join(
+        (NAMESPACE.encode("utf-8"), nonce.encode("utf-8"), canonical_payload(payload))
+    )

--- a/src/mship/core/relay/host_contract.py
+++ b/src/mship/core/relay/host_contract.py
@@ -42,6 +42,26 @@ CHALLENGE_PATH = f"{HOSTS_PREFIX}/challenge"
 REGISTER_PATH = f"{HOSTS_PREFIX}/register"
 ROUTE_PATHS: tuple[str, ...] = (LIST_PATH, CHALLENGE_PATH, REGISTER_PATH)
 
+# The pre-existing enrollment route, spelled once: the daemon's relay link, the
+# `mship relay enroll` CLI and the app that serves it must all name it the same.
+ENROLL_PATH = "/enroll"
+
+# The two ways `/hosts/register` answers 401, as the exact `detail` each carries.
+# The status code cannot tell them apart, and they need opposite handling: an
+# unapproved key must (re-)enroll and wait for a human, while a stale nonce is a
+# lost race on a 120s window that the next attempt fixes by itself. So the
+# strings ARE the contract — the daemon discriminates on them — and both ends
+# read them from here rather than restating a literal.
+UNAPPROVED_KEY_DETAIL = "registration is not signed by an approved key"
+MALFORMED_NONCE_DETAIL = "malformed nonce"
+UNKNOWN_NONCE_DETAIL = "unknown or already-used nonce"
+EXPIRED_CHALLENGE_DETAIL = "challenge expired"
+CHALLENGE_REFUSAL_DETAILS: tuple[str, ...] = (
+    MALFORMED_NONCE_DETAIL,
+    UNKNOWN_NONCE_DETAIL,
+    EXPIRED_CHALLENGE_DETAIL,
+)
+
 # A nonce only has to survive one round trip; short because it is single-use
 # and a replay window is the whole point of issuing one.
 CHALLENGE_TTL_S = 120

--- a/src/mship/core/relay/host_contract.py
+++ b/src/mship/core/relay/host_contract.py
@@ -30,6 +30,13 @@ FLEET_TOKEN_HEADER = "Mship-Fleet-Token"
 # catch-all, so every route below must sit under ONE prefix — that is what
 # keeps a single `@hosts { path /hosts /hosts/* }` Caddy matcher sufficient.
 HOSTS_PREFIX = "/hosts"
+
+# The enroll site's public name, derived from the relay domain. One spelling:
+# `mship relay enroll` (a human on a new device) and the daemon's relay link (a
+# headless host) must reach the SAME server, or a host enrolls where nobody is
+# looking for it.
+ENROLL_SUBDOMAIN = "enroll"
+
 LIST_PATH = HOSTS_PREFIX
 CHALLENGE_PATH = f"{HOSTS_PREFIX}/challenge"
 REGISTER_PATH = f"{HOSTS_PREFIX}/register"
@@ -61,6 +68,11 @@ ENROLL_TTL_S = 1800
 # approval. Strictly shorter than the store's TTL, so a VM provisioned at 02:00
 # is still approvable at 09:00 (AC1/AC8).
 ENROLL_REPOST_INTERVAL_S = ENROLL_TTL_S // 3
+
+
+def enroll_base_url(relay_host: str) -> str:
+    """`https://enroll.<relay domain>` — the base every route above hangs off."""
+    return f"https://{ENROLL_SUBDOMAIN}.{relay_host.strip().rstrip('.')}"
 
 
 def canonical_payload(payload: dict) -> bytes:

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -34,6 +34,8 @@ from pathlib import Path
 from typing import Callable, Sequence
 
 from mship.core.relay import host_contract, ssh_sig
+from mship.core.relay.enroll import _locked
+from mship.core.relay.tls_ask import tls_ask_allowed
 
 # host_ids are `hst-<timestamp>-<hex>` (`core.daemon.identity.mint_host_id`).
 # Anything else is rejected before it is used as a path component — the
@@ -104,7 +106,7 @@ def probe_instance_id(public_url: str, *, get: Callable | None = None,
 
         get = httpx.get
     response = get(public_url.rstrip("/") + "/health", timeout=timeout,
-                   follow_redirects=True)
+                   follow_redirects=False)
     if response.status_code != 200:
         return None
     body = response.json()
@@ -131,6 +133,10 @@ class InvalidHostId(ValueError):
     """The host_id is not a well-formed host id (400)."""
 
 
+class InvalidPublicUrl(ValueError):
+    """The signed registration does not name its relay-owned HTTPS route (400)."""
+
+
 class HostDirectory:
     """Filesystem-backed host directory with signature-gated writes."""
 
@@ -138,6 +144,7 @@ class HostDirectory:
         self,
         base_dir,
         *,
+        relay_domain: str,
         allowed_signers: Callable[[], str],
         probe: Callable[[str], str | None],
         verify: Callable[..., bool] = ssh_sig.verify_blob,
@@ -168,6 +175,7 @@ class HostDirectory:
         self._challenge_ttl = challenge_ttl_s
         self._stale_after = stale_after_s
         self._max_challenges = max_challenges
+        self._relay_domain = relay_domain.strip().lower().rstrip(".")
 
     # --- storage primitives -------------------------------------------------
 
@@ -246,16 +254,17 @@ class HostDirectory:
         (`RequestStore.create`'s `max_pending` precedent). The cap is per *live*
         challenge, so it only ever bites on a flood inside one TTL window.
         """
-        if len(self._sweep_challenges()) >= self._max_challenges:
-            raise ChallengeCapReached("too many outstanding challenges; try later")
-        now = self._clock()
-        rec = {
-            "nonce": secrets.token_hex(16),
-            "issued_at": now,
-            "expires_at": now + self._challenge_ttl,
-        }
-        self._write_atomic(self._challenges / f"{rec['nonce']}.json", rec)
-        return rec
+        with _locked(self._challenges / ".issue.lock"):
+            if len(self._sweep_challenges()) >= self._max_challenges:
+                raise ChallengeCapReached("too many outstanding challenges; try later")
+            now = self._clock()
+            rec = {
+                "nonce": secrets.token_hex(16),
+                "issued_at": now,
+                "expires_at": now + self._challenge_ttl,
+            }
+            self._write_atomic(self._challenges / f"{rec['nonce']}.json", rec)
+            return rec
 
     def _consume_nonce(self, nonce: str) -> None:
         """Spend a nonce, or refuse.
@@ -313,29 +322,35 @@ class HostDirectory:
         ):
             raise SignatureRefused(host_contract.UNAPPROVED_KEY_DETAIL)
 
-        now = self._clock()
-        incumbent = self._read_rec(path) if path.exists() else None
-        previous_instance_id = None
-        if incumbent is not None and not self._same_identity(incumbent, payload):
-            self._arbitrate(incumbent, payload, now)
-            previous_instance_id = incumbent.get("instance_id")
+        public_url = self._trusted_public_url(payload)
+        if public_url is None:
+            raise InvalidPublicUrl("public_url must be the signed relay-owned HTTPS route")
 
-        entry = {
-            "host_id": host_id,
-            **{f: payload.get(f) for f in _PAYLOAD_FIELDS},
-            "first_seen": incumbent.get("first_seen", now) if incumbent else now,
-            "last_seen": now,                       # relay clock, never the payload's
-            # Carried forward on a heartbeat: the takeover is a fact about the
-            # entry, and the next re-registration must not erase the audit of
-            # who used to hold it.
-            "previous_instance_id": (
-                previous_instance_id
-                if incumbent is None or previous_instance_id is not None
-                else incumbent.get("previous_instance_id")
-            ),
-        }
-        self._write_atomic(path, entry)
-        return entry
+        with _locked(self._hosts / f".{host_id}.lock"):
+            now = self._clock()
+            incumbent = self._read_rec(path) if path.exists() else None
+            previous_instance_id = None
+            if incumbent is not None and not self._same_identity(incumbent, payload):
+                self._arbitrate(incumbent, payload, now)
+                previous_instance_id = incumbent.get("instance_id")
+
+            entry = {
+                "host_id": host_id,
+                **{f: payload.get(f) for f in _PAYLOAD_FIELDS},
+                "public_url": public_url,
+                "first_seen": incumbent.get("first_seen", now) if incumbent else now,
+                "last_seen": now,                       # relay clock, never the payload's
+                # Carried forward on a heartbeat: the takeover is a fact about the
+                # entry, and the next re-registration must not erase the audit of
+                # who used to hold it.
+                "previous_instance_id": (
+                    previous_instance_id
+                    if incumbent is None or previous_instance_id is not None
+                    else incumbent.get("previous_instance_id")
+                ),
+            }
+            self._write_atomic(path, entry)
+            return entry
 
     @staticmethod
     def _same_identity(incumbent: dict, payload: dict) -> bool:
@@ -345,6 +360,18 @@ class HostDirectory:
             incumbent.get(f) == payload.get(f)
             for f in ("key_fingerprint", "machine_fingerprint", "instance_id")
         )
+
+    def _trusted_public_url(self, entry: dict) -> str | None:
+        """Canonical relay-owned route, or None for an attacker-controlled URL."""
+        subdomain = entry.get("subdomain")
+        public_url = entry.get("public_url")
+        if not isinstance(subdomain, str) or not isinstance(public_url, str):
+            return None
+        hostname = f"{subdomain}.{self._relay_domain}"
+        canonical = f"https://{hostname}"
+        if not tls_ask_allowed(hostname, self._relay_domain) or public_url != canonical:
+            return None
+        return canonical
 
     def _arbitrate(self, incumbent: dict, payload: dict, now: float) -> None:
         """Refuse the claim iff the incumbent is still live and still itself.
@@ -357,7 +384,7 @@ class HostDirectory:
         """
         if now - _as_float(incumbent.get("last_seen")) >= self._stale_after:
             return
-        public_url = incumbent.get("public_url") or ""
+        public_url = self._trusted_public_url(incumbent)
         try:
             answered = self._probe(public_url) if public_url else None
         except Exception:                            # timeout, DNS, TLS, refused

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -86,7 +86,7 @@ def _as_float(value, default: float = 0.0) -> float:
     """
     try:
         parsed = float(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return default
     return parsed if math.isfinite(parsed) else default
 
@@ -510,6 +510,7 @@ class HostDirectory:
             hosts.append(
                 {
                     **rec,
+                    "first_seen": _as_float(rec.get("first_seen")),
                     "last_seen": _as_float(rec.get("last_seen")),
                     "state": "offline" if stale else "online",
                 }

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -24,6 +24,7 @@ probe decides which instance currently holds it.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 import os
@@ -67,6 +68,10 @@ _PAYLOAD_FIELDS = (
 _REIDENTIFY_HINT = (
     "another approved key or live host already claims this host_id; "
     "run `mship daemon reidentify` on the new machine"
+)
+_KEY_BOUND_HINT = (
+    "approved key is already bound to another host_id; "
+    "run `mship daemon reidentify` to rotate the key"
 )
 
 
@@ -211,10 +216,18 @@ class HostDirectory:
             temp.unlink(missing_ok=True)
             raise
 
-    def _read_rec(self, path: Path) -> dict | None:
+    def _read_rec(self, path: Path, *, host_locked: bool = False) -> dict | None:
         """Load a record, quarantining a corrupt/truncated file instead of
         raising: one hand-edited file must not brick the whole directory
-        (`RequestStore._read_rec` precedent)."""
+        (`RequestStore._read_rec` precedent).
+
+        Quarantine is a mutation, so readers take the same per-host lock as
+        registration. Callers already holding that lock opt out of re-locking;
+        flock is not reentrant across distinct file descriptors.
+        """
+        if not host_locked:
+            with _locked(self._hosts / f".{path.stem}.lock"):
+                return self._read_rec(path, host_locked=True)
         try:
             rec = json.loads(path.read_text())
             if not isinstance(rec, dict):
@@ -327,9 +340,9 @@ class HostDirectory:
         """Verify and publish one host's registration.
 
         Order is security-sensitive: id shape → challenge identity → signature
-        → atomic claim → arbitration → write. A bad signature cannot burn the
-        approved identity's shared challenge, while two valid replays still
-        serialize at the atomic claim.
+        → atomic claim → key/host ownership → arbitration → write. A bad
+        signature cannot burn the approved identity's shared challenge, while
+        two valid replays still serialize at the atomic claim.
         """
         host_id = str(payload.get("host_id", ""))
         path = self._entry_path(host_id)
@@ -359,36 +372,55 @@ class HostDirectory:
                 "public_url must be the signed relay-owned HTTPS route"
             )
 
-        with _locked(self._hosts / f".{host_id}.lock"):
-            now = self._clock()
-            incumbent = self._read_rec(path) if path.exists() else None
-            previous_instance_id = None
-            if incumbent is not None:
-                # Staleness transfers a copied identity between instances; it
-                # never transfers the host-id slot to a different approved key.
-                if incumbent.get("key_fingerprint") != identity:
-                    raise DuplicateIdentity(_REIDENTIFY_HINT)
-                if not self._same_identity(incumbent, payload):
-                    self._arbitrate(incumbent, payload, now)
-                    previous_instance_id = incumbent.get("instance_id")
+        # One approved key is one host identity. The per-identity lock makes
+        # scan → claim atomic without making an unrelated host wait behind an
+        # incumbent's network arbitration probe.
+        identity_key = hashlib.sha256(identity.encode()).hexdigest()
+        with _locked(self._hosts / f".identity-{identity_key}.lock"):
+            for candidate in sorted(self._hosts.glob("*.json")):
+                if candidate == path:
+                    continue
+                candidate_rec = self._read_rec(candidate)
+                if (
+                    candidate_rec is not None
+                    and candidate_rec.get("key_fingerprint") == identity
+                ):
+                    raise DuplicateIdentity(_KEY_BOUND_HINT)
 
-            entry = {
-                "host_id": host_id,
-                **{f: payload.get(f) for f in _PAYLOAD_FIELDS},
-                "public_url": public_url,
-                "first_seen": incumbent.get("first_seen", now) if incumbent else now,
-                "last_seen": now,  # relay clock, never the payload's
-                # Carried forward on a heartbeat: the takeover is a fact about the
-                # entry, and the next re-registration must not erase the audit of
-                # who used to hold it.
-                "previous_instance_id": (
-                    previous_instance_id
-                    if incumbent is None or previous_instance_id is not None
-                    else incumbent.get("previous_instance_id")
-                ),
-            }
-            self._write_atomic(path, entry)
-            return entry
+            with _locked(self._hosts / f".{host_id}.lock"):
+                now = self._clock()
+                incumbent = (
+                    self._read_rec(path, host_locked=True) if path.exists() else None
+                )
+                previous_instance_id = None
+                if incumbent is not None:
+                    # Staleness transfers a copied identity between instances; it
+                    # never transfers the host-id slot to a different approved key.
+                    if incumbent.get("key_fingerprint") != identity:
+                        raise DuplicateIdentity(_REIDENTIFY_HINT)
+                    if not self._same_identity(incumbent, payload):
+                        self._arbitrate(incumbent, payload, now)
+                        previous_instance_id = incumbent.get("instance_id")
+
+                entry = {
+                    "host_id": host_id,
+                    **{f: payload.get(f) for f in _PAYLOAD_FIELDS},
+                    "public_url": public_url,
+                    "first_seen": incumbent.get("first_seen", now)
+                    if incumbent
+                    else now,
+                    "last_seen": now,  # relay clock, never the payload's
+                    # Carried forward on a heartbeat: the takeover is a fact about
+                    # the entry, and the next re-registration must not erase the
+                    # audit of who used to hold it.
+                    "previous_instance_id": (
+                        previous_instance_id
+                        if incumbent is None or previous_instance_id is not None
+                        else incumbent.get("previous_instance_id")
+                    ),
+                }
+                self._write_atomic(path, entry)
+                return entry
 
     @staticmethod
     def _same_identity(incumbent: dict, payload: dict) -> bool:

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -21,6 +21,7 @@ fingerprints: `cp -a` copies the machine fingerprint verbatim, so a
 fingerprint-keyed check would read the clone as an idempotent re-registration
 and silently overwrite the incumbent's URL and credential (decision f).
 """
+
 from __future__ import annotations
 
 import json
@@ -59,10 +60,6 @@ _PAYLOAD_FIELDS = (
     "refresh",
 )
 
-# Bounded so a public, unauthenticated route cannot fill the relay's disk. Sized
-# far above any real fleet: every host asks for at most one challenge per
-# registration, and a challenge lives CHALLENGE_TTL_S.
-MAX_CHALLENGES = 1000
 
 _REIDENTIFY_HINT = (
     "another live host already claims this host_id; "
@@ -81,13 +78,25 @@ def _as_float(value, default: float = 0.0) -> float:
     """
     try:
         parsed = float(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return default
     return parsed if math.isfinite(parsed) else default
 
 
-def probe_instance_id(public_url: str, *, get: Callable | None = None,
-                      timeout: float = 5.0) -> str | None:
+def _principal_allowed(identity: str, allowed_signers: str) -> bool:
+    """Exact membership in the canonical allowed-signers principal column."""
+    if not identity:
+        return False
+    for line in allowed_signers.splitlines():
+        fields = line.strip().split(None, 1)
+        if fields and identity in fields[0].split(","):
+            return True
+    return False
+
+
+def probe_instance_id(
+    public_url: str, *, get: Callable | None = None, timeout: float = 5.0
+) -> str | None:
     """Ask an incumbent's published URL who it is: `GET <url>/health` →
     `instance_id`, or None if it does not answer recognisably.
 
@@ -105,8 +114,9 @@ def probe_instance_id(public_url: str, *, get: Callable | None = None,
         import httpx
 
         get = httpx.get
-    response = get(public_url.rstrip("/") + "/health", timeout=timeout,
-                   follow_redirects=False)
+    response = get(
+        public_url.rstrip("/") + "/health", timeout=timeout, follow_redirects=False
+    )
     if response.status_code != 200:
         return None
     body = response.json()
@@ -115,10 +125,6 @@ def probe_instance_id(public_url: str, *, get: Callable | None = None,
 
 class ChallengeRefused(Exception):
     """The nonce is unknown, already used, or expired (401)."""
-
-
-class ChallengeCapReached(Exception):
-    """Too many outstanding challenges to mint another (429)."""
 
 
 class SignatureRefused(Exception):
@@ -151,7 +157,6 @@ class HostDirectory:
         clock: Callable[[], float] = time.time,
         challenge_ttl_s: float = host_contract.CHALLENGE_TTL_S,
         stale_after_s: float = host_contract.DIRECTORY_STALE_S,
-        max_challenges: int = MAX_CHALLENGES,
     ) -> None:
         """`allowed_signers` is re-read per verification (an approval between
         two registrations must take effect without restarting the server), and
@@ -174,7 +179,6 @@ class HostDirectory:
         self._clock = clock
         self._challenge_ttl = challenge_ttl_s
         self._stale_after = stale_after_s
-        self._max_challenges = max_challenges
         self._relay_domain = relay_domain.strip().lower().rstrip(".")
 
     # --- storage primitives -------------------------------------------------
@@ -184,8 +188,9 @@ class HostDirectory:
         the file 0600, so an entry's refresh credential is never briefly
         world-readable, and the unique temp name means two writers to the same
         entry cannot scribble over each other's half-written temp file."""
-        fd, temp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp",
-                                         dir=path.parent)
+        fd, temp_name = tempfile.mkstemp(
+            prefix=path.name + ".", suffix=".tmp", dir=path.parent
+        )
         temp = Path(temp_name)
         try:
             with os.fdopen(fd, "w") as stream:
@@ -204,7 +209,7 @@ class HostDirectory:
             if not isinstance(rec, dict):
                 raise ValueError("not an object")
             return rec
-        except (json.JSONDecodeError, OSError, ValueError):
+        except json.JSONDecodeError, OSError, ValueError:
             try:
                 path.replace(path.with_suffix(".json.corrupt"))
             except OSError:
@@ -222,7 +227,7 @@ class HostDirectory:
             if not isinstance(rec, dict):
                 raise ValueError("not an object")
             return rec
-        except (json.JSONDecodeError, OSError, ValueError):
+        except json.JSONDecodeError, OSError, ValueError:
             path.unlink(missing_ok=True)
             return None
 
@@ -243,41 +248,48 @@ class HostDirectory:
             if rec is None or now >= _as_float(rec.get("expires_at")):
                 path.unlink(missing_ok=True)
             elif path.suffix == ".json":
-                live.append(path)                    # a claim is already spent
+                live.append(path)  # a claim is already spent
         return live
 
-    def issue_challenge(self) -> dict:
-        """Mint a single-use nonce, stamped and expiring on the relay clock.
+    def issue_challenge(self, identity: str) -> dict:
+        """Return the one live challenge allocated to an approved identity.
 
-        Capped: this route is public and unauthenticated, and each call writes a
-        file, so the store — not the HTTP layer — is the security boundary
-        (`RequestStore.create`'s `max_pending` precedent). The cap is per *live*
-        challenge, so it only ever bites on a flood inside one TTL window.
+        The allowlist is the storage bound: an unauthenticated caller cannot
+        allocate a file for an unapproved identity, and repeatedly naming an
+        approved identity returns its existing nonce rather than consuming
+        another slot. Verification stays out of this public path so a request
+        flood cannot turn into unbounded ``ssh-keygen`` subprocesses.
         """
+        allowed_signers = self._allowed_signers()
+        if not _principal_allowed(identity, allowed_signers):
+            raise SignatureRefused(host_contract.UNAPPROVED_KEY_DETAIL)
         with _locked(self._challenges / ".issue.lock"):
-            if len(self._sweep_challenges()) >= self._max_challenges:
-                raise ChallengeCapReached("too many outstanding challenges; try later")
+            for path in self._sweep_challenges():
+                rec = self._read_challenge(path)
+                if rec is not None and rec.get("identity") == identity:
+                    return rec
             now = self._clock()
             rec = {
                 "nonce": secrets.token_hex(16),
+                "identity": identity,
                 "issued_at": now,
                 "expires_at": now + self._challenge_ttl,
             }
             self._write_atomic(self._challenges / f"{rec['nonce']}.json", rec)
             return rec
 
-    def _consume_nonce(self, nonce: str) -> None:
-        """Spend a nonce, or refuse.
-
-        Single use is enforced by *claiming* the file with `os.rename` before
-        reading it: rename is atomic and fails with FileNotFoundError for every
-        loser, so two concurrent registrations quoting one nonce cannot both
-        proceed (an exists()-read-unlink sequence would let both through — the
-        enroll app serves sync endpoints on a threadpool, so this is reachable
-        in one process).
-        """
+    def _peek_nonce(self, nonce: str, identity: str) -> None:
+        """Validate a challenge without spending the shared identity slot."""
         if not _NONCE_RE.match(nonce or ""):
             raise ChallengeRefused(host_contract.MALFORMED_NONCE_DETAIL)
+        rec = self._read_challenge(self._challenges / f"{nonce}.json")
+        if rec is None or rec.get("identity") != identity:
+            raise ChallengeRefused(host_contract.UNKNOWN_NONCE_DETAIL)
+        if self._clock() >= _as_float(rec.get("expires_at")):
+            raise ChallengeRefused(host_contract.EXPIRED_CHALLENGE_DETAIL)
+
+    def _consume_nonce(self, nonce: str, identity: str) -> None:
+        """Atomically spend a verified challenge, or refuse a racing replay."""
         path = self._challenges / f"{nonce}.json"
         claim = self._challenges / f"{nonce}.{secrets.token_hex(8)}.claim"
         try:
@@ -288,7 +300,7 @@ class HostDirectory:
             rec = self._read_challenge(claim)
         finally:
             claim.unlink(missing_ok=True)
-        if rec is None:
+        if rec is None or rec.get("identity") != identity:
             raise ChallengeRefused(host_contract.UNKNOWN_NONCE_DETAIL)
         if self._clock() >= _as_float(rec.get("expires_at")):
             raise ChallengeRefused(host_contract.EXPIRED_CHALLENGE_DETAIL)
@@ -303,15 +315,16 @@ class HostDirectory:
     def register(self, payload: dict, *, nonce: str, signature: str) -> dict:
         """Verify and publish one host's registration.
 
-        Order matters and is the invariant: id shape → nonce → signature →
-        arbitration → write. Nothing below the signature check can be reached
-        by an unsigned request, and nothing writes before arbitration.
+        Order is security-sensitive: id shape → challenge identity → signature
+        → atomic claim → arbitration → write. A bad signature cannot burn the
+        approved identity's shared challenge, while two valid replays still
+        serialize at the atomic claim.
         """
         host_id = str(payload.get("host_id", ""))
-        path = self._entry_path(host_id)           # traversal dies here
-        self._consume_nonce(nonce)
-
+        path = self._entry_path(host_id)
         identity = str(payload.get("key_fingerprint", ""))
+        self._peek_nonce(nonce, identity)
+
         blob = host_contract.signing_blob(nonce, payload)
         if not self._verify(
             blob,
@@ -321,10 +334,13 @@ class HostDirectory:
             namespace=host_contract.NAMESPACE,
         ):
             raise SignatureRefused(host_contract.UNAPPROVED_KEY_DETAIL)
+        self._consume_nonce(nonce, identity)
 
         public_url = self._trusted_public_url(payload)
         if public_url is None:
-            raise InvalidPublicUrl("public_url must be the signed relay-owned HTTPS route")
+            raise InvalidPublicUrl(
+                "public_url must be the signed relay-owned HTTPS route"
+            )
 
         with _locked(self._hosts / f".{host_id}.lock"):
             now = self._clock()
@@ -339,7 +355,7 @@ class HostDirectory:
                 **{f: payload.get(f) for f in _PAYLOAD_FIELDS},
                 "public_url": public_url,
                 "first_seen": incumbent.get("first_seen", now) if incumbent else now,
-                "last_seen": now,                       # relay clock, never the payload's
+                "last_seen": now,  # relay clock, never the payload's
                 # Carried forward on a heartbeat: the takeover is a fact about the
                 # entry, and the next re-registration must not erase the audit of
                 # who used to hold it.
@@ -387,7 +403,7 @@ class HostDirectory:
         public_url = self._trusted_public_url(incumbent)
         try:
             answered = self._probe(public_url) if public_url else None
-        except Exception:                            # timeout, DNS, TLS, refused
+        except Exception:  # timeout, DNS, TLS, refused
             answered = None
         if answered is not None and answered == incumbent.get("instance_id"):
             raise DuplicateIdentity(_REIDENTIFY_HINT)
@@ -423,13 +439,15 @@ class HostDirectory:
             hosts.append({**rec, "state": "offline" if stale else "online"})
         for req in pending:
             if req.get("fingerprint") in known_keys:
-                continue                             # already registered
-            hosts.append({
-                "host_id": None,
-                "state": "pending-approval",
-                "label": req.get("hostname") or "",
-                "key_fingerprint": req.get("fingerprint"),
-                "request_id": req.get("id"),
-                "created_at": req.get("created_at"),
-            })
+                continue  # already registered
+            hosts.append(
+                {
+                    "host_id": None,
+                    "state": "pending-approval",
+                    "label": req.get("hostname") or "",
+                    "key_fingerprint": req.get("fingerprint"),
+                    "request_id": req.get("id"),
+                    "created_at": req.get("created_at"),
+                }
+            )
         return hosts

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -268,21 +268,21 @@ class HostDirectory:
         in one process).
         """
         if not _NONCE_RE.match(nonce or ""):
-            raise ChallengeRefused("malformed nonce")
+            raise ChallengeRefused(host_contract.MALFORMED_NONCE_DETAIL)
         path = self._challenges / f"{nonce}.json"
         claim = self._challenges / f"{nonce}.{secrets.token_hex(8)}.claim"
         try:
             os.rename(path, claim)
         except OSError:
-            raise ChallengeRefused("unknown or already-used nonce") from None
+            raise ChallengeRefused(host_contract.UNKNOWN_NONCE_DETAIL) from None
         try:
             rec = self._read_challenge(claim)
         finally:
             claim.unlink(missing_ok=True)
         if rec is None:
-            raise ChallengeRefused("unknown or already-used nonce")
+            raise ChallengeRefused(host_contract.UNKNOWN_NONCE_DETAIL)
         if self._clock() >= _as_float(rec.get("expires_at")):
-            raise ChallengeRefused("challenge expired")
+            raise ChallengeRefused(host_contract.EXPIRED_CHALLENGE_DETAIL)
 
     # --- registration -------------------------------------------------------
 
@@ -311,7 +311,7 @@ class HostDirectory:
             allowed_signers=self._allowed_signers(),
             namespace=host_contract.NAMESPACE,
         ):
-            raise SignatureRefused("registration is not signed by an approved key")
+            raise SignatureRefused(host_contract.UNAPPROVED_KEY_DETAIL)
 
         now = self._clock()
         incumbent = self._read_rec(path) if path.exists() else None

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -1,0 +1,287 @@
+"""The relay's host directory (#471): who is out there, and who may claim it.
+
+`<store-dir>/hosts/<host_id>.json` + `<store-dir>/challenges/<nonce>.json`,
+atomic tmp-replace writes and a lazy TTL sweep — the `enroll.RequestStore`
+shape, for the same reason: the enroll server restarts and the fleet must
+survive it.
+
+Two invariants carry the security of this module:
+
+- **The relay never asserts identity.** Every write is gated on a signature it
+  verified against the `pubkeys/` allowlist sish itself authenticates against.
+  There is exactly one write path (`_write_entry`) and `register` is the only
+  caller.
+- **Only the relay's clock decides freshness.** `last_seen`, challenge issue
+  and expiry, staleness and takeover eligibility are stamped from the injected
+  clock, never from a payload field — a VM whose wall clock stepped an hour
+  must not be able to render itself offline or become hijackable (AC10).
+
+Restart vs clone is arbitrated by PROBING the incumbent, not by comparing
+fingerprints: `cp -a` copies the machine fingerprint verbatim, so a
+fingerprint-keyed check would read the clone as an idempotent re-registration
+and silently overwrite the incumbent's URL and credential (decision f).
+"""
+from __future__ import annotations
+
+import json
+import re
+import secrets
+import time
+from pathlib import Path
+from typing import Callable, Sequence
+
+from mship.core.relay import host_contract, ssh_sig
+
+# host_ids are `hst-<timestamp>-<hex>` (`core.daemon.identity.mint_host_id`).
+# Anything else is rejected before it is used as a path component — the
+# `enroll._RID_RE` precedent, and the reason a traversal-shaped id never
+# reaches the filesystem.
+_HOST_ID_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9_-]{0,63}\Z")
+_NONCE_RE = re.compile(r"\A[0-9a-f]{1,64}\Z")
+
+# Copied from the payload onto the entry. Anything else a future daemon sends
+# is ignored rather than stored: the directory is a published surface.
+_PAYLOAD_FIELDS = (
+    "instance_id",
+    "label",
+    "key_fingerprint",
+    "machine_fingerprint",
+    "subdomain",
+    "public_url",
+    "mship_version",
+    "capabilities",
+    "runner",
+    "refresh",
+)
+
+_REIDENTIFY_HINT = (
+    "another live host already claims this host_id; "
+    "run `mship daemon reidentify` on the new machine"
+)
+
+
+class ChallengeRefused(Exception):
+    """The nonce is unknown, already used, or expired (401)."""
+
+
+class SignatureRefused(Exception):
+    """The payload was not signed by the approved key it names (401)."""
+
+
+class DuplicateIdentity(Exception):
+    """A different live instance already holds this host_id (409)."""
+
+
+class InvalidHostId(ValueError):
+    """The host_id is not a well-formed host id (400)."""
+
+
+class HostDirectory:
+    """Filesystem-backed host directory with signature-gated writes."""
+
+    def __init__(
+        self,
+        base_dir,
+        *,
+        allowed_signers: Callable[[], str],
+        probe: Callable[[str], str | None],
+        verify: Callable[..., bool] = ssh_sig.verify_blob,
+        clock: Callable[[], float] = time.time,
+        challenge_ttl_s: float = host_contract.CHALLENGE_TTL_S,
+        stale_after_s: float = host_contract.DIRECTORY_STALE_S,
+    ) -> None:
+        """`allowed_signers` is re-read per verification (an approval between
+        two registrations must take effect without restarting the server), and
+        `probe(public_url) -> instance_id | None` is the arbitration probe —
+        required, not defaulted, because a directory that cannot probe cannot
+        tell a restart from a clone."""
+        base = Path(base_dir)
+        self._hosts = base / "hosts"
+        self._challenges = base / "challenges"
+        for directory in (self._hosts, self._challenges):
+            # Owner-only: an entry carries the phone's refresh credential. The
+            # corrective chmod is not redundant — mkdir's mode is masked by the
+            # umask and `exist_ok=True` never tightens an already-loose dir
+            # (the `registry.py`/`host_token.py` house pattern).
+            directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+            directory.chmod(0o700)
+        self._allowed_signers = allowed_signers
+        self._probe = probe
+        self._verify = verify
+        self._clock = clock
+        self._challenge_ttl = challenge_ttl_s
+        self._stale_after = stale_after_s
+
+    # --- storage primitives -------------------------------------------------
+
+    def _write_atomic(self, path: Path, rec: dict) -> None:
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(rec, sort_keys=True))
+        tmp.chmod(0o600)          # an entry carries a refresh credential
+        tmp.replace(path)
+
+    def _read_rec(self, path: Path) -> dict | None:
+        """Load a record, quarantining a corrupt/truncated file instead of
+        raising: one hand-edited file must not brick the whole directory
+        (`RequestStore._read_rec` precedent)."""
+        try:
+            rec = json.loads(path.read_text())
+            if not isinstance(rec, dict):
+                raise ValueError("not an object")
+            return rec
+        except (json.JSONDecodeError, OSError, ValueError):
+            try:
+                path.replace(path.with_suffix(".json.corrupt"))
+            except OSError:
+                path.unlink(missing_ok=True)
+            return None
+
+    # --- challenges ---------------------------------------------------------
+
+    def _sweep_challenges(self) -> None:
+        now = self._clock()
+        for path in list(self._challenges.glob("*.json")):
+            rec = self._read_rec(path)
+            if rec is None or now >= float(rec.get("expires_at", 0)):
+                path.unlink(missing_ok=True)
+
+    def issue_challenge(self) -> dict:
+        """Mint a single-use nonce, stamped and expiring on the relay clock."""
+        self._sweep_challenges()
+        now = self._clock()
+        rec = {
+            "nonce": secrets.token_hex(16),
+            "issued_at": now,
+            "expires_at": now + self._challenge_ttl,
+        }
+        self._write_atomic(self._challenges / f"{rec['nonce']}.json", rec)
+        return rec
+
+    def _consume_nonce(self, nonce: str) -> None:
+        """Spend a nonce, or refuse. Single use: the record is unlinked before
+        anything else happens, so a replay loses even if it races."""
+        if not _NONCE_RE.match(nonce or ""):
+            raise ChallengeRefused("malformed nonce")
+        path = self._challenges / f"{nonce}.json"
+        rec = self._read_rec(path) if path.exists() else None
+        path.unlink(missing_ok=True)
+        if rec is None:
+            raise ChallengeRefused("unknown or already-used nonce")
+        if self._clock() >= float(rec.get("expires_at", 0)):
+            raise ChallengeRefused("challenge expired")
+
+    # --- registration -------------------------------------------------------
+
+    def _entry_path(self, host_id: str) -> Path:
+        if not _HOST_ID_RE.match(host_id or ""):
+            raise InvalidHostId(host_id)
+        return self._hosts / f"{host_id}.json"
+
+    def register(self, payload: dict, *, nonce: str, signature: str) -> dict:
+        """Verify and publish one host's registration.
+
+        Order matters and is the invariant: id shape → nonce → signature →
+        arbitration → write. Nothing below the signature check can be reached
+        by an unsigned request, and nothing writes before arbitration.
+        """
+        host_id = str(payload.get("host_id", ""))
+        path = self._entry_path(host_id)           # traversal dies here
+        self._consume_nonce(nonce)
+
+        identity = str(payload.get("key_fingerprint", ""))
+        blob = host_contract.signing_blob(nonce, payload)
+        if not self._verify(
+            blob,
+            signature=signature,
+            identity=identity,
+            allowed_signers=self._allowed_signers(),
+            namespace=host_contract.NAMESPACE,
+        ):
+            raise SignatureRefused("registration is not signed by an approved key")
+
+        now = self._clock()
+        incumbent = self._read_rec(path) if path.exists() else None
+        previous_instance_id = None
+        if incumbent is not None and not self._same_identity(incumbent, payload):
+            self._arbitrate(incumbent, payload, now)
+            previous_instance_id = incumbent.get("instance_id")
+
+        entry = {
+            "host_id": host_id,
+            **{f: payload.get(f) for f in _PAYLOAD_FIELDS},
+            "first_seen": incumbent.get("first_seen", now) if incumbent else now,
+            "last_seen": now,                       # relay clock, never the payload's
+            "previous_instance_id": previous_instance_id,
+        }
+        self._write_atomic(path, entry)
+        return entry
+
+    @staticmethod
+    def _same_identity(incumbent: dict, payload: dict) -> bool:
+        """AC11: an identical `(key fp, machine fp, instance_id)` re-post is the
+        same daemon reconnecting — idempotent, not contention."""
+        return all(
+            incumbent.get(f) == payload.get(f)
+            for f in ("key_fingerprint", "machine_fingerprint", "instance_id")
+        )
+
+    def _arbitrate(self, incumbent: dict, payload: dict, now: float) -> None:
+        """Refuse the claim iff the incumbent is still live and still itself.
+
+        A stale entry is nobody's: no probe, straight takeover. Otherwise ask
+        the incumbent's published URL who it is — the only answer that can
+        refuse a claimant is the incumbent's own `instance_id`. An unreachable
+        or unrecognisable incumbent, or one already answering as the claimant
+        (a restart whose old tunnel is gone), yields the entry.
+        """
+        if now - float(incumbent.get("last_seen", 0)) >= self._stale_after:
+            return
+        public_url = incumbent.get("public_url") or ""
+        try:
+            answered = self._probe(public_url) if public_url else None
+        except Exception:                            # timeout, DNS, TLS, refused
+            answered = None
+        if answered is not None and answered == incumbent.get("instance_id"):
+            raise DuplicateIdentity(_REIDENTIFY_HINT)
+
+    # --- reads --------------------------------------------------------------
+
+    def get_host(self, host_id: str) -> dict | None:
+        try:
+            path = self._entry_path(host_id)
+        except InvalidHostId:
+            return None
+        return self._read_rec(path) if path.exists() else None
+
+    def _entries(self) -> list[dict]:
+        out = []
+        for path in sorted(self._hosts.glob("*.json")):
+            rec = self._read_rec(path)
+            if rec is not None:
+                out.append(rec)
+        return out
+
+    def list_hosts(self, pending: Sequence[dict] = ()) -> list[dict]:
+        """Registered hosts (`online`/`offline` by the relay clock) followed by
+        unapproved enroll requests as `pending-approval`, so a freshly
+        provisioned VM is visible on the phone before anyone approves it (AC1).
+        """
+        now = self._clock()
+        hosts = []
+        known_keys = set()
+        for rec in self._entries():
+            known_keys.add(rec.get("key_fingerprint"))
+            stale = now - float(rec.get("last_seen", 0)) >= self._stale_after
+            hosts.append({**rec, "state": "offline" if stale else "online"})
+        for req in pending:
+            if req.get("fingerprint") in known_keys:
+                continue                             # already registered
+            hosts.append({
+                "host_id": None,
+                "state": "pending-approval",
+                "label": req.get("hostname") or "",
+                "key_fingerprint": req.get("fingerprint"),
+                "request_id": req.get("id"),
+                "created_at": req.get("created_at"),
+            })
+        return hosts

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -86,7 +86,7 @@ def _as_float(value, default: float = 0.0) -> float:
     """
     try:
         parsed = float(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return default
     return parsed if math.isfinite(parsed) else default
 
@@ -165,6 +165,7 @@ class HostDirectory:
         relay_domain: str,
         allowed_signers: Callable[[], str],
         probe: Callable[[str], str | None],
+        revoke_signer: Callable[[str], object] | None = None,
         verify: Callable[..., bool] = ssh_sig.verify_blob,
         clock: Callable[[], float] = time.time,
         challenge_ttl_s: float = host_contract.CHALLENGE_TTL_S,
@@ -188,6 +189,7 @@ class HostDirectory:
             directory.chmod(0o700)
         self._allowed_signers = allowed_signers
         self._probe = probe
+        self._revoke_signer = revoke_signer
         self._verify = verify
         self._clock = clock
         self._challenge_ttl = challenge_ttl_s
@@ -233,7 +235,7 @@ class HostDirectory:
             if not isinstance(rec, dict):
                 raise ValueError("not an object")
             return rec
-        except json.JSONDecodeError, OSError, ValueError:
+        except (json.JSONDecodeError, OSError, ValueError):
             try:
                 path.replace(path.with_suffix(".json.corrupt"))
             except OSError:
@@ -251,7 +253,7 @@ class HostDirectory:
             if not isinstance(rec, dict):
                 raise ValueError("not an object")
             return rec
-        except json.JSONDecodeError, OSError, ValueError:
+        except (json.JSONDecodeError, OSError, ValueError):
             path.unlink(missing_ok=True)
             return None
 
@@ -329,6 +331,37 @@ class HostDirectory:
         if self._clock() >= _as_float(rec.get("expires_at")):
             raise ChallengeRefused(host_contract.EXPIRED_CHALLENGE_DETAIL)
 
+    def _verify_signed_payload(
+        self, payload: dict, *, nonce: str, signature: str
+    ) -> str:
+        identity = str(payload.get("key_fingerprint", ""))
+        self._peek_nonce(nonce, identity)
+        blob = host_contract.signing_blob(nonce, payload)
+        if not self._verification_slots.acquire(blocking=False):
+            raise VerificationBusy
+        try:
+            verified = self._verify(
+                blob,
+                signature=signature,
+                identity=identity,
+                allowed_signers=self._allowed_signers(),
+                namespace=host_contract.NAMESPACE,
+            )
+        finally:
+            self._verification_slots.release()
+        if not verified:
+            raise SignatureRefused(host_contract.UNAPPROVED_KEY_DETAIL)
+        self._consume_nonce(nonce, identity)
+        return identity
+
+    def revoke_key(self, identity: str, *, nonce: str, signature: str) -> None:
+        """Revoke an allowlisted key after it signs its own removal request."""
+        payload = host_contract.key_revocation_payload(identity)
+        self._verify_signed_payload(payload, nonce=nonce, signature=signature)
+        if self._revoke_signer is None:
+            raise RuntimeError("relay key revocation is not configured")
+        self._revoke_signer(identity)
+
     # --- registration -------------------------------------------------------
 
     def _entry_path(self, host_id: str) -> Path:
@@ -346,25 +379,9 @@ class HostDirectory:
         """
         host_id = str(payload.get("host_id", ""))
         path = self._entry_path(host_id)
-        identity = str(payload.get("key_fingerprint", ""))
-        self._peek_nonce(nonce, identity)
-
-        blob = host_contract.signing_blob(nonce, payload)
-        if not self._verification_slots.acquire(blocking=False):
-            raise VerificationBusy
-        try:
-            verified = self._verify(
-                blob,
-                signature=signature,
-                identity=identity,
-                allowed_signers=self._allowed_signers(),
-                namespace=host_contract.NAMESPACE,
-            )
-        finally:
-            self._verification_slots.release()
-        if not verified:
-            raise SignatureRefused(host_contract.UNAPPROVED_KEY_DETAIL)
-        self._consume_nonce(nonce, identity)
+        identity = self._verify_signed_payload(
+            payload, nonce=nonce, signature=signature
+        )
 
         public_url = self._trusted_public_url(payload)
         if public_url is None:
@@ -490,7 +507,13 @@ class HostDirectory:
         for rec in self._entries():
             known_keys.add(rec.get("key_fingerprint"))
             stale = now - _as_float(rec.get("last_seen")) >= self._stale_after
-            hosts.append({**rec, "state": "offline" if stale else "online"})
+            hosts.append(
+                {
+                    **rec,
+                    "last_seen": _as_float(rec.get("last_seen")),
+                    "state": "offline" if stale else "online",
+                }
+            )
         for req in pending:
             if req.get("fingerprint") in known_keys:
                 continue  # already registered

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -16,10 +16,10 @@ Two invariants carry the security of this module:
   clock, never from a payload field — a VM whose wall clock stepped an hour
   must not be able to render itself offline or become hijackable (AC10).
 
-Restart vs clone is arbitrated by PROBING the incumbent, not by comparing
-fingerprints: `cp -a` copies the machine fingerprint verbatim, so a
-fingerprint-keyed check would read the clone as an idempotent re-registration
-and silently overwrite the incumbent's URL and credential (decision f).
+Restart vs clone is arbitrated by probing the incumbent after key ownership is
+confirmed: `cp -a` copies the key and machine fingerprint verbatim, so neither
+can distinguish two instances. The approved key owns the host-id slot; the
+probe decides which instance currently holds it.
 """
 
 from __future__ import annotations
@@ -62,7 +62,7 @@ _PAYLOAD_FIELDS = (
 
 
 _REIDENTIFY_HINT = (
-    "another live host already claims this host_id; "
+    "another approved key or live host already claims this host_id; "
     "run `mship daemon reidentify` on the new machine"
 )
 
@@ -346,9 +346,14 @@ class HostDirectory:
             now = self._clock()
             incumbent = self._read_rec(path) if path.exists() else None
             previous_instance_id = None
-            if incumbent is not None and not self._same_identity(incumbent, payload):
-                self._arbitrate(incumbent, payload, now)
-                previous_instance_id = incumbent.get("instance_id")
+            if incumbent is not None:
+                # Staleness transfers a copied identity between instances; it
+                # never transfers the host-id slot to a different approved key.
+                if incumbent.get("key_fingerprint") != identity:
+                    raise DuplicateIdentity(_REIDENTIFY_HINT)
+                if not self._same_identity(incumbent, payload):
+                    self._arbitrate(incumbent, payload, now)
+                    previous_instance_id = incumbent.get("instance_id")
 
             entry = {
                 "host_id": host_id,

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -9,8 +9,8 @@ Two invariants carry the security of this module:
 
 - **The relay never asserts identity.** Every write is gated on a signature it
   verified against the `pubkeys/` allowlist sish itself authenticates against.
-  There is exactly one write path (`_write_entry`) and `register` is the only
-  caller.
+  There is exactly one entry-write call site (in `register`, after the
+  signature check) and it is the only caller of `_write_atomic` for `hosts/`.
 - **Only the relay's clock decides freshness.** `last_seen`, challenge issue
   and expiry, staleness and takeover eligibility are stamped from the injected
   clock, never from a payload field — a VM whose wall clock stepped an hour
@@ -24,8 +24,10 @@ and silently overwrite the incumbent's URL and credential (decision f).
 from __future__ import annotations
 
 import json
+import os
 import re
 import secrets
+import tempfile
 import time
 from pathlib import Path
 from typing import Callable, Sequence
@@ -54,14 +56,34 @@ _PAYLOAD_FIELDS = (
     "refresh",
 )
 
+# Bounded so a public, unauthenticated route cannot fill the relay's disk. Sized
+# far above any real fleet: every host asks for at most one challenge per
+# registration, and a challenge lives CHALLENGE_TTL_S.
+MAX_CHALLENGES = 1000
+
 _REIDENTIFY_HINT = (
     "another live host already claims this host_id; "
     "run `mship daemon reidentify` on the new machine"
 )
 
 
+def _as_float(value, default: float = 0.0) -> float:
+    """A timestamp read back from disk, or `default` if it is not a number.
+
+    A hand-edited entry must degrade to "very old" (→ offline, takeover-
+    eligible) rather than raise and brick every listing."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 class ChallengeRefused(Exception):
     """The nonce is unknown, already used, or expired (401)."""
+
+
+class ChallengeCapReached(Exception):
+    """Too many outstanding challenges to mint another (429)."""
 
 
 class SignatureRefused(Exception):
@@ -89,6 +111,7 @@ class HostDirectory:
         clock: Callable[[], float] = time.time,
         challenge_ttl_s: float = host_contract.CHALLENGE_TTL_S,
         stale_after_s: float = host_contract.DIRECTORY_STALE_S,
+        max_challenges: int = MAX_CHALLENGES,
     ) -> None:
         """`allowed_signers` is re-read per verification (an approval between
         two registrations must take effect without restarting the server), and
@@ -111,14 +134,25 @@ class HostDirectory:
         self._clock = clock
         self._challenge_ttl = challenge_ttl_s
         self._stale_after = stale_after_s
+        self._max_challenges = max_challenges
 
     # --- storage primitives -------------------------------------------------
 
     def _write_atomic(self, path: Path, rec: dict) -> None:
-        tmp = path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(rec, sort_keys=True))
-        tmp.chmod(0o600)          # an entry carries a refresh credential
-        tmp.replace(path)
+        """Owner-only atomic write (`host_token._save` shape): mkstemp creates
+        the file 0600, so an entry's refresh credential is never briefly
+        world-readable, and the unique temp name means two writers to the same
+        entry cannot scribble over each other's half-written temp file."""
+        fd, temp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp",
+                                         dir=path.parent)
+        temp = Path(temp_name)
+        try:
+            with os.fdopen(fd, "w") as stream:
+                stream.write(json.dumps(rec, sort_keys=True))
+            os.replace(temp, path)
+        except BaseException:
+            temp.unlink(missing_ok=True)
+            raise
 
     def _read_rec(self, path: Path) -> dict | None:
         """Load a record, quarantining a corrupt/truncated file instead of
@@ -138,16 +172,41 @@ class HostDirectory:
 
     # --- challenges ---------------------------------------------------------
 
-    def _sweep_challenges(self) -> None:
+    def _read_challenge(self, path: Path) -> dict | None:
+        """Load a challenge, DELETING a corrupt one rather than quarantining
+        it: unlike a host entry it carries nothing recoverable, and a `.corrupt`
+        file nothing ever reaps is just litter on a public write path."""
+        try:
+            rec = json.loads(path.read_text())
+            if not isinstance(rec, dict):
+                raise ValueError("not an object")
+            return rec
+        except (json.JSONDecodeError, OSError, ValueError):
+            path.unlink(missing_ok=True)
+            return None
+
+    def _sweep_challenges(self) -> list[Path]:
+        """Drop expired/corrupt challenges; return what is still live."""
         now = self._clock()
-        for path in list(self._challenges.glob("*.json")):
-            rec = self._read_rec(path)
-            if rec is None or now >= float(rec.get("expires_at", 0)):
+        live = []
+        for path in sorted(self._challenges.glob("*.json")):
+            rec = self._read_challenge(path)
+            if rec is None or now >= _as_float(rec.get("expires_at")):
                 path.unlink(missing_ok=True)
+            else:
+                live.append(path)
+        return live
 
     def issue_challenge(self) -> dict:
-        """Mint a single-use nonce, stamped and expiring on the relay clock."""
-        self._sweep_challenges()
+        """Mint a single-use nonce, stamped and expiring on the relay clock.
+
+        Capped: this route is public and unauthenticated, and each call writes a
+        file, so the store — not the HTTP layer — is the security boundary
+        (`RequestStore.create`'s `max_pending` precedent). The cap is per *live*
+        challenge, so it only ever bites on a flood inside one TTL window.
+        """
+        if len(self._sweep_challenges()) >= self._max_challenges:
+            raise ChallengeCapReached("too many outstanding challenges; try later")
         now = self._clock()
         rec = {
             "nonce": secrets.token_hex(16),
@@ -158,16 +217,30 @@ class HostDirectory:
         return rec
 
     def _consume_nonce(self, nonce: str) -> None:
-        """Spend a nonce, or refuse. Single use: the record is unlinked before
-        anything else happens, so a replay loses even if it races."""
+        """Spend a nonce, or refuse.
+
+        Single use is enforced by *claiming* the file with `os.rename` before
+        reading it: rename is atomic and fails with FileNotFoundError for every
+        loser, so two concurrent registrations quoting one nonce cannot both
+        proceed (an exists()-read-unlink sequence would let both through — the
+        enroll app serves sync endpoints on a threadpool, so this is reachable
+        in one process).
+        """
         if not _NONCE_RE.match(nonce or ""):
             raise ChallengeRefused("malformed nonce")
         path = self._challenges / f"{nonce}.json"
-        rec = self._read_rec(path) if path.exists() else None
-        path.unlink(missing_ok=True)
+        claim = self._challenges / f"{nonce}.{secrets.token_hex(8)}.claim"
+        try:
+            os.rename(path, claim)
+        except OSError:
+            raise ChallengeRefused("unknown or already-used nonce") from None
+        try:
+            rec = self._read_challenge(claim)
+        finally:
+            claim.unlink(missing_ok=True)
         if rec is None:
             raise ChallengeRefused("unknown or already-used nonce")
-        if self._clock() >= float(rec.get("expires_at", 0)):
+        if self._clock() >= _as_float(rec.get("expires_at")):
             raise ChallengeRefused("challenge expired")
 
     # --- registration -------------------------------------------------------
@@ -211,7 +284,14 @@ class HostDirectory:
             **{f: payload.get(f) for f in _PAYLOAD_FIELDS},
             "first_seen": incumbent.get("first_seen", now) if incumbent else now,
             "last_seen": now,                       # relay clock, never the payload's
-            "previous_instance_id": previous_instance_id,
+            # Carried forward on a heartbeat: the takeover is a fact about the
+            # entry, and the next re-registration must not erase the audit of
+            # who used to hold it.
+            "previous_instance_id": (
+                previous_instance_id
+                if incumbent is None or previous_instance_id is not None
+                else incumbent.get("previous_instance_id")
+            ),
         }
         self._write_atomic(path, entry)
         return entry
@@ -234,7 +314,7 @@ class HostDirectory:
         or unrecognisable incumbent, or one already answering as the claimant
         (a restart whose old tunnel is gone), yields the entry.
         """
-        if now - float(incumbent.get("last_seen", 0)) >= self._stale_after:
+        if now - _as_float(incumbent.get("last_seen")) >= self._stale_after:
             return
         public_url = incumbent.get("public_url") or ""
         try:
@@ -271,7 +351,7 @@ class HostDirectory:
         known_keys = set()
         for rec in self._entries():
             known_keys.add(rec.get("key_fingerprint"))
-            stale = now - float(rec.get("last_seen", 0)) >= self._stale_after
+            stale = now - _as_float(rec.get("last_seen")) >= self._stale_after
             hosts.append({**rec, "state": "offline" if stale else "online"})
         for req in pending:
             if req.get("fingerprint") in known_keys:

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -73,6 +73,7 @@ _KEY_BOUND_HINT = (
     "approved key is already bound to another host_id; "
     "run `mship daemon reidentify` to rotate the key"
 )
+_SUBDOMAIN_BOUND_HINT = "relay subdomain is already bound to another host_id"
 
 
 def _as_float(value, default: float = 0.0) -> float:
@@ -389,55 +390,65 @@ class HostDirectory:
                 "public_url must be the signed relay-owned HTTPS route"
             )
 
-        # One approved key is one host identity. The per-identity lock makes
-        # scan → claim atomic without making an unrelated host wait behind an
-        # incumbent's network arbitration probe.
+        # One approved key is one host identity, and one relay subdomain is one
+        # host route. The per-claim locks make both scans atomic without making
+        # unrelated hosts wait behind an incumbent's network arbitration probe.
         identity_key = hashlib.sha256(identity.encode()).hexdigest()
+        subdomain_key = hashlib.sha256(
+            str(payload.get("subdomain", "")).encode()
+        ).hexdigest()
         with _locked(self._hosts / f".identity-{identity_key}.lock"):
-            for candidate in sorted(self._hosts.glob("*.json")):
-                if candidate == path:
-                    continue
-                candidate_rec = self._read_rec(candidate)
-                if (
-                    candidate_rec is not None
-                    and candidate_rec.get("key_fingerprint") == identity
-                ):
-                    raise DuplicateIdentity(_KEY_BOUND_HINT)
+            with _locked(self._hosts / f".subdomain-{subdomain_key}.lock"):
+                for candidate in sorted(self._hosts.glob("*.json")):
+                    if candidate == path:
+                        continue
+                    candidate_rec = self._read_rec(candidate)
+                    if candidate_rec is None:
+                        continue
+                    if candidate_rec.get("key_fingerprint") == identity:
+                        raise DuplicateIdentity(_KEY_BOUND_HINT)
+                    if candidate_rec.get("subdomain") == payload.get("subdomain"):
+                        raise DuplicateIdentity(_SUBDOMAIN_BOUND_HINT)
 
-            with _locked(self._hosts / f".{host_id}.lock"):
-                now = self._clock()
-                incumbent = (
-                    self._read_rec(path, host_locked=True) if path.exists() else None
-                )
-                previous_instance_id = None
-                if incumbent is not None:
-                    # Staleness transfers a copied identity between instances; it
-                    # never transfers the host-id slot to a different approved key.
-                    if incumbent.get("key_fingerprint") != identity:
-                        raise DuplicateIdentity(_REIDENTIFY_HINT)
-                    if not self._same_identity(incumbent, payload):
-                        self._arbitrate(incumbent, payload, now)
-                        previous_instance_id = incumbent.get("instance_id")
+                with _locked(self._hosts / f".{host_id}.lock"):
+                    now = self._clock()
+                    incumbent = (
+                        self._read_rec(path, host_locked=True)
+                        if path.exists()
+                        else None
+                    )
+                    previous_instance_id = None
+                    if incumbent is not None:
+                        # Staleness transfers a copied identity between instances;
+                        # it never transfers the host-id slot to a different key or
+                        # lets an existing host identity move to another route.
+                        if incumbent.get("key_fingerprint") != identity:
+                            raise DuplicateIdentity(_REIDENTIFY_HINT)
+                        if incumbent.get("subdomain") != payload.get("subdomain"):
+                            raise DuplicateIdentity(_SUBDOMAIN_BOUND_HINT)
+                        if not self._same_identity(incumbent, payload):
+                            self._arbitrate(incumbent, payload, now)
+                            previous_instance_id = incumbent.get("instance_id")
 
-                entry = {
-                    "host_id": host_id,
-                    **{f: payload.get(f) for f in _PAYLOAD_FIELDS},
-                    "public_url": public_url,
-                    "first_seen": incumbent.get("first_seen", now)
-                    if incumbent
-                    else now,
-                    "last_seen": now,  # relay clock, never the payload's
-                    # Carried forward on a heartbeat: the takeover is a fact about
-                    # the entry, and the next re-registration must not erase the
-                    # audit of who used to hold it.
-                    "previous_instance_id": (
-                        previous_instance_id
-                        if incumbent is None or previous_instance_id is not None
-                        else incumbent.get("previous_instance_id")
-                    ),
-                }
-                self._write_atomic(path, entry)
-                return entry
+                    entry = {
+                        "host_id": host_id,
+                        **{f: payload.get(f) for f in _PAYLOAD_FIELDS},
+                        "public_url": public_url,
+                        "first_seen": incumbent.get("first_seen", now)
+                        if incumbent
+                        else now,
+                        "last_seen": now,  # relay clock, never the payload's
+                        # Carried forward on a heartbeat: the takeover is a fact
+                        # about the entry, and the next re-registration must not
+                        # erase the audit of who used to hold it.
+                        "previous_instance_id": (
+                            previous_instance_id
+                            if incumbent is None or previous_instance_id is not None
+                            else incumbent.get("previous_instance_id")
+                        ),
+                    }
+                    self._write_atomic(path, entry)
+                    return entry
 
     @staticmethod
     def _same_identity(incumbent: dict, payload: dict) -> bool:

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -35,7 +35,7 @@ from typing import Callable, Sequence
 
 from mship.core.relay import host_contract, ssh_sig
 from mship.core.relay.enroll import _locked
-from mship.core.relay.tls_ask import tls_ask_allowed
+from mship.core.relay.tls_ask import host_subdomain_allowed
 
 # host_ids are `hst-<timestamp>-<hex>` (`core.daemon.identity.mint_host_id`).
 # Anything else is rejected before it is used as a path component — the
@@ -369,7 +369,7 @@ class HostDirectory:
             return None
         hostname = f"{subdomain}.{self._relay_domain}"
         canonical = f"https://{hostname}"
-        if not tls_ask_allowed(hostname, self._relay_domain) or public_url != canonical:
+        if not host_subdomain_allowed(subdomain) or public_url != canonical:
             return None
         return canonical
 

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from typing import Callable, Sequence
 
 from mship.core.relay import host_contract, ssh_sig
+from mship.core.relay.config import canonical_relay_host
 from mship.core.relay.enroll import _locked
 from mship.core.relay.tls_ask import host_subdomain_allowed
 
@@ -189,7 +190,7 @@ class HostDirectory:
         self._verification_slots = threading.BoundedSemaphore(
             max_concurrent_verifications
         )
-        self._relay_domain = relay_domain.strip().lower().rstrip(".")
+        self._relay_domain = canonical_relay_host(relay_domain)
 
     # --- storage primitives -------------------------------------------------
 

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -24,6 +24,7 @@ and silently overwrite the incumbent's URL and credential (decision f).
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import secrets
@@ -68,14 +69,19 @@ _REIDENTIFY_HINT = (
 
 
 def _as_float(value, default: float = 0.0) -> float:
-    """A timestamp read back from disk, or `default` if it is not a number.
+    """A finite timestamp read back from disk, or `default` if it is not one.
 
     A hand-edited entry must degrade to "very old" (→ offline, takeover-
-    eligible) rather than raise and brick every listing."""
+    eligible) rather than raise and brick every listing. NaN and infinities are
+    rejected for the same reason and not merely for tidiness: `now - nan >=
+    stale` is False, so a NaN `last_seen` would read as permanently ONLINE and
+    un-takeoverable — the exact opposite of the intended degradation.
+    """
     try:
-        return float(value)
+        parsed = float(value)
     except (TypeError, ValueError):
         return default
+    return parsed if math.isfinite(parsed) else default
 
 
 class ChallengeRefused(Exception):
@@ -186,15 +192,23 @@ class HostDirectory:
             return None
 
     def _sweep_challenges(self) -> list[Path]:
-        """Drop expired/corrupt challenges; return what is still live."""
+        """Drop expired/corrupt challenges; return what is still live.
+
+        `*.claim` files are swept on the same rule: a crash between the rename
+        that claims a nonce and the unlink that spends it would otherwise
+        strand one forever, and a claim past its own expiry can never be
+        spent by anyone.
+        """
         now = self._clock()
         live = []
-        for path in sorted(self._challenges.glob("*.json")):
+        for path in sorted(self._challenges.glob("*")):
+            if path.suffix not in (".json", ".claim"):
+                continue
             rec = self._read_challenge(path)
             if rec is None or now >= _as_float(rec.get("expires_at")):
                 path.unlink(missing_ok=True)
-            else:
-                live.append(path)
+            elif path.suffix == ".json":
+                live.append(path)                    # a claim is already spent
         return live
 
     def issue_challenge(self) -> dict:

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -84,6 +84,33 @@ def _as_float(value, default: float = 0.0) -> float:
     return parsed if math.isfinite(parsed) else default
 
 
+def probe_instance_id(public_url: str, *, get: Callable | None = None,
+                      timeout: float = 5.0) -> str | None:
+    """Ask an incumbent's published URL who it is: `GET <url>/health` →
+    `instance_id`, or None if it does not answer recognisably.
+
+    The production `probe` for `HostDirectory`, kept a free function (and
+    injectable via `get`) because the directory takes its prober as a required
+    argument — a directory that cannot probe cannot tell a restart from a clone,
+    so it must never quietly default to one. Unauthenticated on purpose:
+    `/health` needs no bearer (it exposes only ids and counts), and the relay
+    holds no credential for a host it is arbitrating.
+
+    Transport failures propagate; `_arbitrate` already treats an unreachable
+    incumbent as "yields the entry" and is the only caller.
+    """
+    if get is None:
+        import httpx
+
+        get = httpx.get
+    response = get(public_url.rstrip("/") + "/health", timeout=timeout,
+                   follow_redirects=True)
+    if response.status_code != 200:
+        return None
+    body = response.json()
+    return body.get("instance_id") if isinstance(body, dict) else None
+
+
 class ChallengeRefused(Exception):
     """The nonce is unknown, already used, or expired (401)."""
 

--- a/src/mship/core/relay/host_directory.py
+++ b/src/mship/core/relay/host_directory.py
@@ -31,6 +31,7 @@ import re
 import secrets
 import tempfile
 import time
+import threading
 from pathlib import Path
 from typing import Callable, Sequence
 
@@ -45,6 +46,7 @@ from mship.core.relay.tls_ask import host_subdomain_allowed
 _HOST_ID_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9_-]{0,63}\Z")
 _NONCE_RE = re.compile(r"\A[0-9a-f]{1,64}\Z")
 
+_MAX_CONCURRENT_SIGNATURE_VERIFICATIONS = 4
 # Copied from the payload onto the entry. Anything else a future daemon sends
 # is ignored rather than stored: the directory is a published surface.
 _PAYLOAD_FIELDS = (
@@ -131,6 +133,10 @@ class SignatureRefused(Exception):
     """The payload was not signed by the approved key it names (401)."""
 
 
+class VerificationBusy(Exception):
+    """Every bounded signature-verification slot is occupied (429)."""
+
+
 class DuplicateIdentity(Exception):
     """A different live instance already holds this host_id (409)."""
 
@@ -157,6 +163,7 @@ class HostDirectory:
         clock: Callable[[], float] = time.time,
         challenge_ttl_s: float = host_contract.CHALLENGE_TTL_S,
         stale_after_s: float = host_contract.DIRECTORY_STALE_S,
+        max_concurrent_verifications: int = _MAX_CONCURRENT_SIGNATURE_VERIFICATIONS,
     ) -> None:
         """`allowed_signers` is re-read per verification (an approval between
         two registrations must take effect without restarting the server), and
@@ -179,6 +186,9 @@ class HostDirectory:
         self._clock = clock
         self._challenge_ttl = challenge_ttl_s
         self._stale_after = stale_after_s
+        self._verification_slots = threading.BoundedSemaphore(
+            max_concurrent_verifications
+        )
         self._relay_domain = relay_domain.strip().lower().rstrip(".")
 
     # --- storage primitives -------------------------------------------------
@@ -326,13 +336,19 @@ class HostDirectory:
         self._peek_nonce(nonce, identity)
 
         blob = host_contract.signing_blob(nonce, payload)
-        if not self._verify(
-            blob,
-            signature=signature,
-            identity=identity,
-            allowed_signers=self._allowed_signers(),
-            namespace=host_contract.NAMESPACE,
-        ):
+        if not self._verification_slots.acquire(blocking=False):
+            raise VerificationBusy
+        try:
+            verified = self._verify(
+                blob,
+                signature=signature,
+                identity=identity,
+                allowed_signers=self._allowed_signers(),
+                namespace=host_contract.NAMESPACE,
+            )
+        finally:
+            self._verification_slots.release()
+        if not verified:
             raise SignatureRefused(host_contract.UNAPPROVED_KEY_DETAIL)
         self._consume_nonce(nonce, identity)
 

--- a/src/mship/core/relay/keys.py
+++ b/src/mship/core/relay/keys.py
@@ -4,6 +4,8 @@ import subprocess
 import time
 from pathlib import Path
 
+from mship.core.relay.enroll import _locked
+
 _SUBDOMAIN_SECRET_LEN = 32
 
 
@@ -44,37 +46,42 @@ def ensure_secret_file(path: Path, length: int = _SUBDOMAIN_SECRET_LEN) -> bytes
     dir, so the corrective chmod is what actually makes it owner-only (the
     `registry.py`/`host_app.py` house pattern).
 
-    Concurrency-safe: if two callers race to create it, the loser adopts the
-    winner's secret (so both derive the same values from it) rather than
-    crashing or overwriting. A truncated/corrupt persisted file self-heals by
-    regenerating.
+    Concurrency-safe across threads and processes: the adjacent flock covers
+    read/repair/create/write, so every caller returns the same persisted bytes.
+    A truncated/corrupt persisted file self-heals by regenerating.
     """
-    existing = _read_secret_if_valid(path, length)
-    if existing is not None:
-        return existing
-    if path.exists():
-        # Present but too short → corrupt/truncated; discard and regenerate.
-        path.unlink(missing_ok=True)
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     path.parent.chmod(0o700)
-    secret = os.urandom(length)
-    try:
-        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    except FileExistsError:
-        # Lost a concurrent-creation race — adopt the winner's secret so both
-        # callers agree. Briefly retry in case it was O_EXCL-created but the
-        # bytes haven't landed yet.
-        for _ in range(100):
-            adopted = _read_secret_if_valid(path, length)
-            if adopted is not None:
-                return adopted
-            time.sleep(0.01)
-        raise RuntimeError(f"secret at {path} exists but is unreadable/too short")
-    try:
-        os.write(fd, secret)
-    finally:
-        os.close(fd)
-    return secret
+    with _locked(path.with_name(f".{path.name}.lock")):
+        existing = _read_secret_if_valid(path, length)
+        if existing is not None:
+            path.chmod(0o600)
+            return existing
+        if path.exists():
+            # Present but too short → corrupt/truncated; discard and regenerate.
+            path.unlink(missing_ok=True)
+
+        secret = os.urandom(length)
+        try:
+            fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            # A non-cooperating/older process may not take our lock. Adopt its
+            # completed file rather than returning a divergent secret.
+            for _ in range(100):
+                adopted = _read_secret_if_valid(path, length)
+                if adopted is not None:
+                    path.chmod(0o600)
+                    return adopted
+                time.sleep(0.01)
+            raise RuntimeError(f"secret at {path} exists but is unreadable/too short")
+        try:
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(secret)
+            path.chmod(0o600)
+        except BaseException:
+            path.unlink(missing_ok=True)
+            raise
+        return secret
 
 
 def ensure_subdomain_secret(home: Path) -> bytes:
@@ -94,13 +101,19 @@ def ensure_relay_key(home: Path, runner=_default_runner) -> Path:
     if path.exists():
         return path
     path.parent.mkdir(parents=True, exist_ok=True)
-    runner([
-        "ssh-keygen",
-        "-t", "ed25519",
-        "-f", str(path),
-        "-N", "",
-        "-C", "mship-relay",
-    ])
+    runner(
+        [
+            "ssh-keygen",
+            "-t",
+            "ed25519",
+            "-f",
+            str(path),
+            "-N",
+            "",
+            "-C",
+            "mship-relay",
+        ]
+    )
     return path
 
 

--- a/src/mship/core/relay/keys.py
+++ b/src/mship/core/relay/keys.py
@@ -39,7 +39,10 @@ def ensure_secret_file(path: Path, length: int = _SUBDOMAIN_SECRET_LEN) -> bytes
     """Return the random secret stored at `path`, generating it if absent.
 
     `length` random bytes with mode 0600, created O_EXCL so there is no
-    world-readable window.
+    world-readable window. The parent dir is forced to 0700 — mkdir's mode is
+    masked by the umask and `exist_ok=True` never tightens an existing loose
+    dir, so the corrective chmod is what actually makes it owner-only (the
+    `registry.py`/`host_app.py` house pattern).
 
     Concurrency-safe: if two callers race to create it, the loser adopts the
     winner's secret (so both derive the same values from it) rather than
@@ -52,7 +55,8 @@ def ensure_secret_file(path: Path, length: int = _SUBDOMAIN_SECRET_LEN) -> bytes
     if path.exists():
         # Present but too short → corrupt/truncated; discard and regenerate.
         path.unlink(missing_ok=True)
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.parent.chmod(0o700)
     secret = os.urandom(length)
     try:
         fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)

--- a/src/mship/core/relay/keys.py
+++ b/src/mship/core/relay/keys.py
@@ -11,7 +11,7 @@ def _default_runner(argv: list[str]) -> int:
     return subprocess.run(argv, check=True).returncode
 
 
-def _read_secret_if_valid(path: Path) -> bytes | None:
+def _read_secret_if_valid(path: Path, length: int) -> bytes | None:
     """Return the stored secret iff it's present and at least the expected
     length; None if absent, truncated, or still mid-write (a concurrent creator
     that O_EXCL-created the file but hasn't written its bytes yet)."""
@@ -19,7 +19,7 @@ def _read_secret_if_valid(path: Path) -> bytes | None:
         data = path.read_bytes()
     except FileNotFoundError:
         return None
-    return data if len(data) >= _SUBDOMAIN_SECRET_LEN else None
+    return data if len(data) >= length else None
 
 
 def subdomain_secret_path(home: Path) -> Path:
@@ -35,47 +35,53 @@ def relay_key_path(home: Path) -> Path:
     return home / ".mothership" / "relay_ed25519"
 
 
-def ensure_subdomain_secret(home: Path) -> bytes:
-    """Return the per-machine relay-subdomain HMAC secret, generating it if absent.
+def ensure_secret_file(path: Path, length: int = _SUBDOMAIN_SECRET_LEN) -> bytes:
+    """Return the random secret stored at `path`, generating it if absent.
 
-    Stored at home/.mothership/relay-subdomain-secret as 32 random bytes with
-    mode 0600 (created O_EXCL so there's no world-readable window). This secret
-    keys `opaque_slug`, so it must be identical for the two subdomain callers
-    (`serve --relay` and `pair`) on the same machine. Losing it re-randomizes
-    this machine's subdomains — a one-time re-pair, which is acceptable.
+    `length` random bytes with mode 0600, created O_EXCL so there is no
+    world-readable window.
 
     Concurrency-safe: if two callers race to create it, the loser adopts the
-    winner's secret (so both derive the same subdomain) rather than crashing.
-    A truncated/corrupt persisted file self-heals by regenerating.
+    winner's secret (so both derive the same values from it) rather than
+    crashing or overwriting. A truncated/corrupt persisted file self-heals by
+    regenerating.
     """
-    path = subdomain_secret_path(home)
-    existing = _read_secret_if_valid(path)
+    existing = _read_secret_if_valid(path, length)
     if existing is not None:
         return existing
     if path.exists():
         # Present but too short → corrupt/truncated; discard and regenerate.
         path.unlink(missing_ok=True)
     path.parent.mkdir(parents=True, exist_ok=True)
-    secret = os.urandom(_SUBDOMAIN_SECRET_LEN)
+    secret = os.urandom(length)
     try:
         fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError:
         # Lost a concurrent-creation race — adopt the winner's secret so both
-        # subdomain callers agree. Briefly retry in case it was O_EXCL-created
-        # but the 32 bytes haven't landed yet.
+        # callers agree. Briefly retry in case it was O_EXCL-created but the
+        # bytes haven't landed yet.
         for _ in range(100):
-            adopted = _read_secret_if_valid(path)
+            adopted = _read_secret_if_valid(path, length)
             if adopted is not None:
                 return adopted
             time.sleep(0.01)
-        raise RuntimeError(
-            f"relay subdomain secret at {path} exists but is unreadable/too short"
-        )
+        raise RuntimeError(f"secret at {path} exists but is unreadable/too short")
     try:
         os.write(fd, secret)
     finally:
         os.close(fd)
     return secret
+
+
+def ensure_subdomain_secret(home: Path) -> bytes:
+    """Return the per-machine relay-subdomain HMAC secret, generating it if absent.
+
+    This secret keys `opaque_slug`, so it must be identical for the two
+    subdomain callers (`serve --relay` and `pair`) on the same machine. Losing
+    it re-randomizes this machine's subdomains — a one-time re-pair, which is
+    acceptable.
+    """
+    return ensure_secret_file(subdomain_secret_path(home))
 
 
 def ensure_relay_key(home: Path, runner=_default_runner) -> Path:

--- a/src/mship/core/relay/pairing.py
+++ b/src/mship/core/relay/pairing.py
@@ -16,6 +16,21 @@ def build_pair_link(*, url: str, token: str, workspace: str) -> str:
     return f"groundcontrol://add?{query}"
 
 
+def build_relay_account_link(*, relay: str, token: str) -> str:
+    """Build the `groundcontrol://add-relay?…` deep-link the phone scans once.
+
+    Pairs the app with a whole RELAY rather than one workspace: the app derives
+    `https://enroll.<relay>` and reads the host directory from there with the
+    fleet token, so a freshly provisioned host needs no address typed (AC1).
+    Same `quote` encoding as `build_pair_link` — the token round-trips exactly.
+    """
+    query = urllib.parse.urlencode(
+        {"relay": relay, "token": token},
+        quote_via=urllib.parse.quote,
+    )
+    return f"groundcontrol://add-relay?{query}"
+
+
 def parse_pair_link(link: str) -> dict:
     """Parse a groundcontrol://add? deep-link, returning {url, token, workspace}.
 

--- a/src/mship/core/relay/run_token.py
+++ b/src/mship/core/relay/run_token.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Callable
 
 from mship.core.relay.grants import Scope
+from mship.core.relay.token_clock import is_expired
 
 _ID_RE = re.compile(r"\A[0-9a-f]{1,32}\Z")
 
@@ -72,7 +73,10 @@ def verify_run_token(
         return None
     if not hmac.compare_digest(_hash(secret), rec.get("secret_hash", "")):
         return None
-    if clock() >= rec.get("expires_at", 0):
+    # Expiry semantics (incl. the skew grace) belong to token_clock, not here:
+    # this token is minted on one machine and presented on another, so a bare
+    # `clock() >= expires_at` 401s a live run over a few seconds of NTP drift.
+    if is_expired(rec.get("expires_at", 0), clock()):
         return None
     return RunToken(
         token_id=token_id,

--- a/src/mship/core/relay/ssh_sig.py
+++ b/src/mship/core/relay/ssh_sig.py
@@ -1,0 +1,125 @@
+"""The ssh-keygen signature boundary (#471).
+
+The daemon proves its identity with the SAME ed25519 key sish authenticates its
+tunnel with, verified against the SAME `pubkeys/` allowlist — so signature-auth
+and tunnel-auth are one identity and the relay never has to assert on the
+daemon's behalf. `ssh-keygen -Y sign` / `-Y verify` do the crypto; this module
+is only the subprocess boundary, with an injected `runner` (the
+`keys._default_runner` pattern) so every caller is testable without a shell.
+"""
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Callable
+
+from mship.core.relay.enroll import fingerprint, validate_pubkey
+
+
+class SignatureError(Exception):
+    """Signing failed, or verification could not be carried out at all.
+
+    Deliberately typed: callers map this to a 5xx/"cannot sign" state, which is
+    a different thing from `verify_blob` returning False (a bad signature =
+    401). A bare `CalledProcessError` escaping here would leak the argv, which
+    contains the private key path, into an HTTP error surface.
+    """
+
+
+def _default_runner(argv: list[str], input_bytes: bytes) -> subprocess.CompletedProcess:
+    """Run ssh-keygen with the blob on stdin. No `check=True`: a non-zero exit
+    is data here (a bad signature), not an exception."""
+    return subprocess.run(argv, input=input_bytes, capture_output=True)
+
+
+def _run(argv: list[str], input_bytes: bytes, runner: Callable) -> subprocess.CompletedProcess:
+    try:
+        return runner(argv, input_bytes)
+    except Exception as e:  # missing ssh-keygen, CalledProcessError, OSError…
+        raise SignatureError(f"ssh-keygen could not be run: {e}") from e
+
+
+def _stderr(proc: subprocess.CompletedProcess) -> str:
+    err = proc.stderr or b""
+    return err.decode("utf-8", "replace").strip() if isinstance(err, bytes) else str(err).strip()
+
+
+def sign_blob(
+    blob: bytes,
+    *,
+    key_path: Path,
+    namespace: str,
+    runner: Callable = _default_runner,
+) -> str:
+    """Return the armored SSHSIG over `blob`, signed with the private key at
+    `key_path`. Raises `SignatureError` if ssh-keygen refuses."""
+    argv = [
+        "ssh-keygen", "-Y", "sign",
+        "-f", str(key_path),
+        "-n", namespace,
+        "-q",
+        "-",                      # read the blob from stdin, always last
+    ]
+    proc = _run(argv, blob, runner)
+    if proc.returncode != 0:
+        raise SignatureError(f"ssh-keygen sign failed: {_stderr(proc)}")
+    out = proc.stdout or b""
+    return (out.decode("utf-8") if isinstance(out, bytes) else out).strip()
+
+
+def verify_blob(
+    blob: bytes,
+    *,
+    signature: str,
+    identity: str,
+    allowed_signers: str,
+    namespace: str,
+    runner: Callable = _default_runner,
+) -> bool:
+    """True iff `signature` is a valid SSHSIG over `blob` for `namespace`, made
+    by the key `allowed_signers` lists under principal `identity`.
+
+    False is the ordinary "not signed by an approved key" answer; only an
+    inability to *run* the check raises.
+    """
+    if not signature.strip() or not allowed_signers.strip():
+        # No approved key could have signed it — refuse without spawning.
+        return False
+    with tempfile.TemporaryDirectory(prefix="mship-sshsig.") as td:
+        signers = Path(td) / "allowed_signers"
+        sig = Path(td) / "signature"
+        signers.write_text(allowed_signers if allowed_signers.endswith("\n")
+                           else allowed_signers + "\n")
+        sig.write_text(signature if signature.endswith("\n") else signature + "\n")
+        argv = [
+            "ssh-keygen", "-Y", "verify",
+            "-f", str(signers),
+            "-I", identity,
+            "-n", namespace,
+            "-s", str(sig),
+        ]
+        return _run(argv, blob, runner).returncode == 0
+
+
+def build_allowed_signers(pubkeys_dir) -> str:
+    """The `pubkeys/` allowlist rendered as an ssh allowed_signers file.
+
+    One line per approved key, principal = that key's fingerprint (which is
+    what a registration payload claims, so the relay verifies against exactly
+    the key the payload names). Anything `validate_pubkey` rejects is skipped —
+    the same guard that keeps a smuggled second line out of `authorized_keys`
+    keeps it out of the signer allowlist.
+    """
+    directory = Path(pubkeys_dir)
+    lines: list[str] = []
+    for path in sorted(directory.glob("*.pub")) if directory.is_dir() else []:
+        try:
+            key = path.read_text().strip()
+        except OSError:
+            continue
+        if not validate_pubkey(key):
+            continue
+        ktype, body = key.split()[:2]
+        lines.append(f"{fingerprint(key)} {ktype} {body}")
+    return "".join(f"{line}\n" for line in lines)

--- a/src/mship/core/relay/ssh_sig.py
+++ b/src/mship/core/relay/ssh_sig.py
@@ -59,7 +59,6 @@ def sign_blob(
         "-f", str(key_path),
         "-n", namespace,
         "-q",
-        "-",                      # read the blob from stdin, always last
     ]
     proc = _run(argv, blob, runner)
     if proc.returncode != 0:

--- a/src/mship/core/relay/ssh_sig.py
+++ b/src/mship/core/relay/ssh_sig.py
@@ -107,13 +107,14 @@ def build_allowed_signers(pubkeys_dir) -> str:
 
     One line per approved key, principal = that key's fingerprint (which is
     what a registration payload claims, so the relay verifies against exactly
-    the key the payload names). Anything `validate_pubkey` rejects is skipped —
-    the same guard that keeps a smuggled second line out of `authorized_keys`
-    keeps it out of the signer allowlist.
+    the key the payload names). Filenames and subdirectories are ignored,
+    matching sish's recursive directory loader. Anything `validate_pubkey`
+    rejects is skipped — the same guard that keeps a smuggled second line out
+    of both allowlists.
     """
     directory = Path(pubkeys_dir)
     lines: list[str] = []
-    for path in sorted(directory.glob("*.pub")) if directory.is_dir() else []:
+    for path in sorted(directory.rglob("*")) if directory.is_dir() else []:
         try:
             key = path.read_text().strip()
         except OSError:

--- a/src/mship/core/relay/ssh_sig.py
+++ b/src/mship/core/relay/ssh_sig.py
@@ -117,7 +117,7 @@ def build_allowed_signers(pubkeys_dir) -> str:
     for path in sorted(directory.rglob("*")) if directory.is_dir() else []:
         try:
             key = path.read_text().strip()
-        except OSError:
+        except (OSError, UnicodeError):
             continue
         if not validate_pubkey(key):
             continue

--- a/src/mship/core/relay/ssh_sig.py
+++ b/src/mship/core/relay/ssh_sig.py
@@ -124,3 +124,19 @@ def build_allowed_signers(pubkeys_dir) -> str:
         ktype, body = key.split()[:2]
         lines.append(f"{fingerprint(key)} {ktype} {body}")
     return "".join(f"{line}\n" for line in lines)
+
+
+def revoke_allowed_key(pubkeys_dir, identity: str) -> int:
+    """Remove every allowlist file containing `identity`; return the count."""
+    directory = Path(pubkeys_dir)
+    removed = 0
+    for path in sorted(directory.rglob("*")) if directory.is_dir() else []:
+        try:
+            key = path.read_text().strip()
+        except (OSError, UnicodeError):
+            continue
+        if not validate_pubkey(key) or fingerprint(key) != identity:
+            continue
+        path.unlink()
+        removed += 1
+    return removed

--- a/src/mship/core/relay/tls_ask.py
+++ b/src/mship/core/relay/tls_ask.py
@@ -1,17 +1,26 @@
 from __future__ import annotations
-import re
 
 # A serve per-device subdomain LABEL: <base>-<6 hex>, where base is now an
 # opaque per-workspace slug (base32, [a-z2-7]) — the workspace name is no longer
-# present. Mirrors device_subdomain() in tunnel.py; base32 ⊂ [a-z0-9] so the
-# existing pattern still matches.
-_SERVE_LABEL = re.compile(r"[a-z0-9][a-z0-9-]*-[0-9a-f]{6}")
+# present. Mirrors device_subdomain() in tunnel.py; base32 ⊂ [a-z0-9].
+_LABEL_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789-")
+_HEX_CHARS = frozenset("0123456789abcdef")
 
 
 def host_subdomain_allowed(label: str) -> bool:
     """Whether a label is a tunnel-served host route, excluding relay services."""
     label = (label or "").strip().lower()
-    return len(label) <= 63 and _SERVE_LABEL.fullmatch(label) is not None
+    if not 8 <= len(label) <= 63:
+        return False
+    base, separator, suffix = label.rpartition("-")
+    return bool(
+        separator
+        and base
+        and base[0] != "-"
+        and all(char in _LABEL_CHARS for char in base)
+        and len(suffix) == 6
+        and all(char in _HEX_CHARS for char in suffix)
+    )
 
 
 def tls_ask_allowed(domain: str, relay_domain: str) -> bool:

--- a/src/mship/core/relay/tls_ask.py
+++ b/src/mship/core/relay/tls_ask.py
@@ -8,6 +8,12 @@ import re
 _SERVE_LABEL = re.compile(r"[a-z0-9][a-z0-9-]*-[0-9a-f]{6}")
 
 
+def host_subdomain_allowed(label: str) -> bool:
+    """Whether a label is a tunnel-served host route, excluding relay services."""
+    label = (label or "").strip().lower()
+    return len(label) <= 63 and _SERVE_LABEL.fullmatch(label) is not None
+
+
 def tls_ask_allowed(domain: str, relay_domain: str) -> bool:
     """Whether Caddy may provision an on-demand TLS cert for `domain`.
 
@@ -30,4 +36,4 @@ def tls_ask_allowed(domain: str, relay_domain: str) -> bool:
         return False
     if label in ("enroll", "egress"):
         return True
-    return len(label) <= 63 and _SERVE_LABEL.fullmatch(label) is not None
+    return host_subdomain_allowed(label)

--- a/src/mship/core/relay/token_clock.py
+++ b/src/mship/core/relay/token_clock.py
@@ -102,7 +102,9 @@ class Deadline:
         try:
             expires_at = float(rec["expires_at"])
             mono_deadline = float(rec.get("mono_deadline", 0.0))
-        except (KeyError, TypeError, ValueError):
+        except (KeyError, TypeError, ValueError, OverflowError):
+            return None
+        if not math.isfinite(expires_at) or not math.isfinite(mono_deadline):
             return None
         epoch = rec.get("epoch")
         return cls(

--- a/src/mship/core/relay/token_clock.py
+++ b/src/mship/core/relay/token_clock.py
@@ -1,0 +1,149 @@
+"""The single owner of "is this credential still expired?" (#471, AC10).
+
+Two callers justify it: the relay's run tokens (`run_token.verify_run_token`)
+and the daemon's host bearers (`core.daemon.host_token`). Both used to be — or
+would have been — a bare `clock() >= expires_at`, which gets two things wrong:
+
+- **A wall-clock step.** A long-lived VM's clock is corrected by NTP, sometimes
+  by an hour. Stepped *backwards*, `clock() >= expires_at` silently extends
+  every live bearer by that hour. The fix is a monotonic floor: real elapsed
+  time, immune to corrections.
+- **A monotonic floor without an epoch is worse than none.** `time.monotonic()`
+  is only comparable within one boot (CPython's is boot-relative on Linux), and
+  the daemon restarts routinely (#470 supervises it; #473's upgrades restart
+  it). A floor persisted across a reboot compares two different origins and
+  either expires everything or nothing. So each floor is stamped with the
+  epoch it was taken in, and a floor from another epoch is simply not used.
+
+Expiry is therefore the **earlier** of two bounds: the monotonic deadline (when
+its epoch still matches) and the wall deadline plus a skew grace. The grace
+never lengthens an ordinary token — the monotonic bound always fires first —
+so it only takes effect where the anchor cannot vouch for elapsed time: a
+cross-epoch (post-restart) check, or a caller with no anchor at all.
+"""
+from __future__ import annotations
+
+import secrets
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping
+
+# Tolerance for wall-clock disagreement: an NTP step correction, or the offset
+# between the machine that issued a token and the one presenting it. Kept well
+# under the host bearer's TTL so that even the anchorless fallback path cannot
+# come close to doubling a token's life.
+SKEW_SECONDS = 120.0
+
+_BOOT_ID_PATH = Path("/proc/sys/kernel/random/boot_id")
+
+# Per-process anchor for platforms with no kernel boot id: it is stable for the
+# life of this process (so same-process checks still use the monotonic bound)
+# and unguessably different in the next one (so a restart cannot mistake
+# another process's floor for its own).
+_PROCESS_EPOCH = f"proc:{secrets.token_hex(8)}"
+
+_epoch_cache: str | None = None
+
+
+def _read_boot_id() -> str:
+    return _BOOT_ID_PATH.read_text()
+
+
+def boot_epoch(reader: Callable[[], str] = _read_boot_id) -> str:
+    """An id for the epoch the current `time.monotonic()` origin belongs to."""
+    try:
+        value = reader().strip()
+    except OSError:
+        value = ""
+    return f"boot:{value}" if value else _PROCESS_EPOCH
+
+
+def current_epoch() -> str:
+    """This process's epoch, resolved once (it cannot change while we run)."""
+    global _epoch_cache
+    if _epoch_cache is None:
+        _epoch_cache = boot_epoch()
+    return _epoch_cache
+
+
+def is_expired(expires_at: float, now: float, *, skew: float = SKEW_SECONDS) -> bool:
+    """Wall-clock expiry with a skew grace — the bound for callers with no
+    monotonic anchor to appeal to."""
+    return now >= expires_at + skew
+
+
+@dataclass(frozen=True)
+class Deadline:
+    """When a credential dies, stated in both clocks plus the epoch that makes
+    the monotonic half meaningful."""
+
+    expires_at: float       # wall clock (what a human/API sees)
+    mono_deadline: float    # monotonic, valid only within `epoch`
+    epoch: str
+
+    def as_record(self) -> dict:
+        return {
+            "expires_at": self.expires_at,
+            "mono_deadline": self.mono_deadline,
+            "epoch": self.epoch,
+        }
+
+    @classmethod
+    def from_record(cls, rec: Mapping) -> "Deadline | None":
+        """Read a persisted deadline, or None if it is unusable. An untagged or
+        malformed floor is never guessed at — a missing epoch reads as "not
+        ours", which falls back to the wall-clock bound."""
+        try:
+            expires_at = float(rec["expires_at"])
+            mono_deadline = float(rec.get("mono_deadline", 0.0))
+        except (KeyError, TypeError, ValueError):
+            return None
+        epoch = rec.get("epoch")
+        return cls(
+            expires_at=expires_at,
+            mono_deadline=mono_deadline,
+            epoch=epoch if isinstance(epoch, str) else "",
+        )
+
+
+class AnchoredClock:
+    """Wall time anchored to `time.monotonic()`, tagged with its epoch.
+
+    Injectable in whole (`wall`, `mono`, `epoch`) so tests can step either hand
+    independently and simulate a reboot without sleeping or rebooting.
+    """
+
+    def __init__(
+        self,
+        *,
+        wall: Callable[[], float] = time.time,
+        mono: Callable[[], float] = time.monotonic,
+        epoch: str | None = None,
+    ) -> None:
+        self._wall = wall
+        self._mono = mono
+        self._epoch = current_epoch() if epoch is None else epoch
+
+    @property
+    def epoch(self) -> str:
+        return self._epoch
+
+    def now(self) -> float:
+        return self._wall()
+
+    def deadline(self, ttl_seconds: float) -> Deadline:
+        return Deadline(
+            expires_at=self._wall() + ttl_seconds,
+            mono_deadline=self._mono() + ttl_seconds,
+            epoch=self._epoch,
+        )
+
+    def is_expired(self, deadline: Deadline | None) -> bool:
+        """True if `deadline` has passed on either bound (fail closed: an
+        unreadable deadline is expired)."""
+        if deadline is None:
+            return True
+        if deadline.epoch == self._epoch and self._mono() >= deadline.mono_deadline:
+            return True
+        return is_expired(deadline.expires_at, self._wall())

--- a/src/mship/core/relay/token_clock.py
+++ b/src/mship/core/relay/token_clock.py
@@ -71,6 +71,10 @@ def current_epoch() -> str:
 def is_expired(expires_at: float, now: float, *, skew: float = SKEW_SECONDS) -> bool:
     """Wall-clock expiry with a skew grace — the bound for callers with no
     monotonic anchor to appeal to. Invalid persisted deadlines fail closed."""
+    try:
+        expires_at = float(expires_at)
+    except (TypeError, ValueError, OverflowError):
+        return True
     return not math.isfinite(expires_at) or now >= expires_at + skew
 
 

--- a/src/mship/core/relay/token_clock.py
+++ b/src/mship/core/relay/token_clock.py
@@ -23,6 +23,7 @@ cross-epoch (post-restart) check, or a caller with no anchor at all.
 """
 from __future__ import annotations
 
+import math
 import secrets
 import time
 from dataclasses import dataclass
@@ -69,8 +70,8 @@ def current_epoch() -> str:
 
 def is_expired(expires_at: float, now: float, *, skew: float = SKEW_SECONDS) -> bool:
     """Wall-clock expiry with a skew grace — the bound for callers with no
-    monotonic anchor to appeal to."""
-    return now >= expires_at + skew
+    monotonic anchor to appeal to. Invalid persisted deadlines fail closed."""
+    return not math.isfinite(expires_at) or now >= expires_at + skew
 
 
 @dataclass(frozen=True)

--- a/src/mship/core/relay/token_clock.py
+++ b/src/mship/core/relay/token_clock.py
@@ -129,9 +129,6 @@ class AnchoredClock:
     def epoch(self) -> str:
         return self._epoch
 
-    def now(self) -> float:
-        return self._wall()
-
     def deadline(self, ttl_seconds: float) -> Deadline:
         return Deadline(
             expires_at=self._wall() + ttl_seconds,

--- a/src/mship/core/relay/tunnel.py
+++ b/src/mship/core/relay/tunnel.py
@@ -167,8 +167,14 @@ class TunnelSupervisor:
         self._proc = None
         self._stopped = False          # True once stop() has been called
         self._restart_count = 0
+        # Every process this supervisor has successfully launched. Unlike
+        # `_restart_count` it only ever increases — `start()` zeroes the restart
+        # counter and a healthy run resets it, so a caller that wants to know
+        # "did a NEW child appear?" must ask this instead (#471 AC2).
+        self._spawn_count = 0
         # Monotonic time (seconds) the current process was spawned at; a run
-        # longer than the backoff cap is what ends a failure streak.
+        # longer than the backoff cap is what ends a failure streak. None while
+        # no process is known to be up, INCLUDING after a spawn that raised.
         self._spawned_at: float | None = None
         # Monotonic time (seconds) an exit was first detected at, and the delay
         # frozen for it. None while a process is (believed) alive.
@@ -249,6 +255,12 @@ class TunnelSupervisor:
         """Number of times the supervised process has been restarted."""
         return self._restart_count
 
+    @property
+    def spawn_count(self) -> int:
+        """Processes successfully launched, monotonically. The signal for "a new
+        child exists" — `restart_count` is not, it resets."""
+        return self._spawn_count
+
     def next_delay(self) -> float:
         """Seconds from the detected exit until the respawn is due (0 while the
         process is believed alive) — the jittered value actually being waited."""
@@ -278,8 +290,15 @@ class TunnelSupervisor:
         )
 
     def _spawn(self) -> None:
-        self._spawned_at = self._clock()
+        # Cleared FIRST and stamped only once the factory has actually returned:
+        # a spawn that raises (log file EACCES, `ssh` not on PATH) started no
+        # run at all, and recording one would let the next exit-detection read a
+        # never-started process as a healthy run and wipe the failure streak —
+        # sawtoothing the escalation the clamp exists to reach.
+        self._spawned_at = None
         self._proc = self._proc_factory(self._argv)
+        self._spawned_at = self._clock()
+        self._spawn_count += 1
 
 
 def host_subdomain(host_id: str, dev_id: str, secret: bytes) -> str:

--- a/src/mship/core/relay/tunnel.py
+++ b/src/mship/core/relay/tunnel.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import math
 import os
+import random
 import re
 import subprocess
 import time
@@ -10,6 +12,20 @@ from pathlib import Path
 from typing import Callable
 
 from mship.core.relay.config import RelayConfig
+
+# Up to 20% OFF a scheduled delay (never added — see `jittered`): enough to
+# de-phase a fleet that all lost the relay in the same second, small enough that
+# the delay still means roughly what it says. Owned here because both retry
+# loops in the reconnect path jitter with it — this supervisor and the daemon's
+# `core/daemon/relay_link.py`.
+BACKOFF_JITTER = 0.2
+
+
+def jittered(delay: float, rng: Callable[[], float]) -> float:
+    """De-phase DOWNWARD only. `host_contract.DIRECTORY_STALE_S` is derived from
+    `MAX_BACKOFF_S`, so a delay jittered *above* the cap would let a healthy
+    reconnecting host read as stale in the relay's directory."""
+    return delay * (1 - BACKOFF_JITTER * rng())
 
 
 def subdomain_for(workspace: str) -> str:
@@ -115,7 +131,9 @@ class TunnelSupervisor:
             tests.
         backoff_delay: Minimum seconds between restart attempts (injectable so
             tests can set it to 0 for instant respawn checks).
-        max_backoff_delay: Cap for the backoff counter.
+        max_backoff_delay: Cap for the backoff counter. A run that outlives it
+            counts as healthy and clears the failure streak.
+        rng: Source of the downward backoff jitter (injectable for tests).
     """
 
     def __init__(
@@ -126,6 +144,7 @@ class TunnelSupervisor:
         max_backoff_delay: float = 60.0,
         clock: Callable[[], float] | None = None,
         log_path: Path | None = None,
+        rng: Callable[[], float] | None = None,
     ) -> None:
         self._argv = argv
         self._log_path = log_path
@@ -134,12 +153,27 @@ class TunnelSupervisor:
         self._backoff_delay = backoff_delay
         self._max_backoff_delay = max_backoff_delay
         self._clock = clock if clock is not None else time.monotonic
+        self._rng = rng if rng is not None else random.random
+        # DERIVED, not picked: the first exponent whose delay already exceeds the
+        # cap. Clamping there is what keeps `2 ** n` from overflowing a float
+        # after ~1024 restarts — a bound a CLI never reaches and an immortal
+        # daemon (#471) does, at roughly 17h of flapping.
+        self._max_exponent = (
+            max(0, math.ceil(math.log2(max_backoff_delay / backoff_delay)))
+            if backoff_delay > 0 and max_backoff_delay > 0
+            else 0
+        )
 
         self._proc = None
         self._stopped = False          # True once stop() has been called
         self._restart_count = 0
-        # Monotonic time (seconds) of the last restart attempt; None on first start.
+        # Monotonic time (seconds) the current process was spawned at; a run
+        # longer than the backoff cap is what ends a failure streak.
+        self._spawned_at: float | None = None
+        # Monotonic time (seconds) an exit was first detected at, and the delay
+        # frozen for it. None while a process is (believed) alive.
         self._last_restart_at: float | None = None
+        self._delay = 0.0
 
     # ------------------------------------------------------------------
     # Public API
@@ -149,6 +183,8 @@ class TunnelSupervisor:
         """Spawn the process for the first time."""
         self._stopped = False
         self._restart_count = 0
+        self._last_restart_at = None
+        self._delay = 0.0
         self._spawn()
 
     def tick(self) -> None:
@@ -166,18 +202,21 @@ class TunnelSupervisor:
             return
         # Process has exited unexpectedly.  Check whether the backoff delay has
         # elapsed before respawning.
-        delay = min(
-            self._backoff_delay * (2 ** self._restart_count),
-            self._max_backoff_delay,
-        )
         now = self._clock()
         if self._last_restart_at is None:
-            # First detected exit: record the time and wait for the backoff.
+            # First detected exit: freeze one delay for it (re-jittering it on
+            # every tick would resample the gate instead of honouring it) and
+            # wait the backoff out.
+            if self._spawned_at is not None and now - self._spawned_at >= self._max_backoff_delay:
+                # The tunnel held for longer than the worst case we would ever
+                # wait, so whatever streak preceded it is over.
+                self._restart_count = 0
+            self._delay = jittered(self._backoff(), self._rng)
             self._last_restart_at = now
-        if now - self._last_restart_at < delay:
+        if now - self._last_restart_at < self._delay:
             return
-        self._last_restart_at = now
         self._restart_count += 1
+        self._last_restart_at = None
         self._spawn()
 
     def stop(self) -> None:
@@ -210,6 +249,11 @@ class TunnelSupervisor:
         """Number of times the supervised process has been restarted."""
         return self._restart_count
 
+    def next_delay(self) -> float:
+        """Seconds from the detected exit until the respawn is due (0 while the
+        process is believed alive) — the jittered value actually being waited."""
+        return self._delay if self._last_restart_at is not None else 0.0
+
     def recent_output(self, limit: int = 4000) -> str:
         """Tail of the captured ssh output (empty if no log or file not yet written)."""
         if self._log_path is None:
@@ -224,7 +268,17 @@ class TunnelSupervisor:
     # Internal helpers
     # ------------------------------------------------------------------
 
+    def _backoff(self) -> float:
+        """Capped exponential delay for the current failure streak. The exponent
+        is clamped as well as the product, so the multiplication itself cannot
+        overflow (`5.0 * 2 ** 1024` raises `OverflowError`)."""
+        return min(
+            self._backoff_delay * (2 ** min(self._restart_count, self._max_exponent)),
+            self._max_backoff_delay,
+        )
+
     def _spawn(self) -> None:
+        self._spawned_at = self._clock()
         self._proc = self._proc_factory(self._argv)
 
 

--- a/src/mship/core/relay/tunnel.py
+++ b/src/mship/core/relay/tunnel.py
@@ -9,6 +9,7 @@ import random
 import re
 import subprocess
 import time
+from threading import Lock
 from pathlib import Path
 from typing import Callable
 
@@ -161,6 +162,7 @@ class TunnelSupervisor:
         self._max_backoff_delay = max_backoff_delay
         self._clock = clock if clock is not None else time.monotonic
         self._rng = rng if rng is not None else random.random
+        self._proc_lock = Lock()
         # DERIVED, not picked: the first exponent whose delay already exceeds the
         # cap. Clamping there is what keeps `2 ** n` from overflowing a float
         # after ~1024 restarts — a bound a CLI never reaches and an immortal
@@ -253,18 +255,20 @@ class TunnelSupervisor:
         fork a fresh `start_new_session=True` ssh that nothing then owns — an
         orphan holding the subdomain against the next boot (#471 AC7).
         """
-        self._stopped = True
-        self._final = self._final or final
-        if self._proc is not None:
-            try:
-                self._proc.terminate()
-            except Exception:
-                pass
-            try:
-                self._proc.wait(timeout=5)
-            except Exception:
-                pass
+        with self._proc_lock:
+            self._stopped = True
+            self._final = self._final or final
+            proc = self._proc
             self._proc = None
+        if proc is not None:
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                pass
 
     def is_running(self) -> bool:
         """Return True if a live process is being supervised."""
@@ -320,14 +324,28 @@ class TunnelSupervisor:
         # never-started process as a healthy run and wipe the failure streak —
         # sawtoothing the escalation the clamp exists to reach.
         self._spawned_at = None
-        if self._final:
-            # Checked at the LAST moment, not only in start(): the caller may
-            # have passed its own check before the latch closed.
-            return
+        with self._proc_lock:
+            if self._final:
+                # Checked at the LAST moment, not only in start(): the caller
+                # may have passed its own check before the latch closed.
+                return
         argv = self._argv() if callable(self._argv) else self._argv
-        self._proc = self._proc_factory(argv)
-        self._spawned_at = self._clock()
-        self._spawn_count += 1
+        proc = self._proc_factory(argv)
+        with self._proc_lock:
+            stopped_during_spawn = self._stopped
+            if not stopped_during_spawn:
+                self._proc = proc
+                self._spawned_at = self._clock()
+                self._spawn_count += 1
+        if stopped_during_spawn:
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                pass
 
 
 def host_subdomain(host_id: str, dev_id: str, secret: bytes) -> str:

--- a/src/mship/core/relay/tunnel.py
+++ b/src/mship/core/relay/tunnel.py
@@ -267,6 +267,12 @@ class TunnelSupervisor:
                 pass
             try:
                 proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                try:
+                    proc.kill()
+                    proc.wait(timeout=5)
+                except Exception:
+                    pass
             except Exception:
                 pass
 
@@ -344,6 +350,12 @@ class TunnelSupervisor:
                 pass
             try:
                 proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                try:
+                    proc.kill()
+                    proc.wait(timeout=5)
+                except Exception:
+                    pass
             except Exception:
                 pass
 

--- a/src/mship/core/relay/tunnel.py
+++ b/src/mship/core/relay/tunnel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import logging
 import math
 import os
 import random
@@ -12,6 +13,8 @@ from pathlib import Path
 from typing import Callable
 
 from mship.core.relay.config import RelayConfig
+
+log = logging.getLogger(__name__)
 
 # Up to 20% OFF a scheduled delay (never added — see `jittered`): enough to
 # de-phase a fleet that all lost the relay in the same second, small enough that
@@ -170,6 +173,7 @@ class TunnelSupervisor:
 
         self._proc = None
         self._stopped = False          # True once stop() has been called
+        self._final = False            # ... and stopped for good: never spawn again
         self._restart_count = 0
         # Every process this supervisor has successfully launched. Unlike
         # `_restart_count` it only ever increases — `start()` zeroes the restart
@@ -190,7 +194,13 @@ class TunnelSupervisor:
     # ------------------------------------------------------------------
 
     def start(self) -> None:
-        """Spawn the process for the first time."""
+        """Spawn the process for the first time.
+
+        Refused after a FINAL stop, and deliberately not re-armable: the caller
+        that wants a tunnel again after a shutdown is a new process."""
+        if self._final:
+            log.warning("refusing to dial: this tunnel supervisor was stopped for good")
+            return
         self._stopped = False
         self._restart_count = 0
         self._last_restart_at = None
@@ -229,12 +239,22 @@ class TunnelSupervisor:
         self._last_restart_at = None
         self._spawn()
 
-    def stop(self) -> None:
+    def stop(self, *, final: bool = False) -> None:
         """Terminate the supervised process and mark as intentionally stopped.
 
-        After stop(), tick() will not respawn the process.
+        After stop(), tick() will not respawn the process — but `start()` still
+        may, which is what the duplicate-identity recovery in `HostTunnel`
+        depends on.
+
+        `final=True` LATCHES that shut, and nothing re-arms it. It is for
+        process shutdown, where a caller already past its own checks (a tick
+        running on the executor thread while this runs on the loop thread) could
+        otherwise reach `start()` a moment after the child was signalled and
+        fork a fresh `start_new_session=True` ssh that nothing then owns — an
+        orphan holding the subdomain against the next boot (#471 AC7).
         """
         self._stopped = True
+        self._final = self._final or final
         if self._proc is not None:
             try:
                 self._proc.terminate()
@@ -300,6 +320,10 @@ class TunnelSupervisor:
         # never-started process as a healthy run and wipe the failure streak —
         # sawtoothing the escalation the clamp exists to reach.
         self._spawned_at = None
+        if self._final:
+            # Checked at the LAST moment, not only in start(): the caller may
+            # have passed its own check before the latch closed.
+            return
         argv = self._argv() if callable(self._argv) else self._argv
         self._proc = self._proc_factory(argv)
         self._spawned_at = self._clock()

--- a/src/mship/core/relay/tunnel.py
+++ b/src/mship/core/relay/tunnel.py
@@ -125,7 +125,11 @@ class TunnelSupervisor:
     with a fake proc factory.
 
     Args:
-        argv: The command + arguments to launch (e.g. from build_tunnel_argv).
+        argv: The command + arguments to launch (e.g. from build_tunnel_argv),
+            or a zero-argument callable returning them. Pass the callable when
+            any part of the command can change between spawns: the daemon's
+            subdomain moves with its host identity (#471 AC4), and a frozen
+            argv would re-dial a subdomain the host no longer owns.
         proc_factory: Callable(argv) → proc-like object.  Defaults to
             subprocess.Popen with process-group isolation.  Inject a fake for
             tests.
@@ -138,7 +142,7 @@ class TunnelSupervisor:
 
     def __init__(
         self,
-        argv: list[str],
+        argv: list[str] | Callable[[], list[str]],
         proc_factory: Callable | None = None,
         backoff_delay: float = 5.0,
         max_backoff_delay: float = 60.0,
@@ -296,7 +300,8 @@ class TunnelSupervisor:
         # never-started process as a healthy run and wipe the failure streak —
         # sawtoothing the escalation the clamp exists to reach.
         self._spawned_at = None
-        self._proc = self._proc_factory(self._argv)
+        argv = self._argv() if callable(self._argv) else self._argv
+        self._proc = self._proc_factory(argv)
         self._spawned_at = self._clock()
         self._spawn_count += 1
 

--- a/src/mship/core/relay/tunnel.py
+++ b/src/mship/core/relay/tunnel.py
@@ -83,18 +83,27 @@ def device_subdomain(workspace: str, dev_id: str, secret: bytes) -> str:
     return f"{base}{suffix}"
 
 
-def build_tunnel_argv(rc: RelayConfig, *, subdomain: str, local_port: int, key_path: Path) -> list[str]:
+def build_tunnel_argv(
+    rc: RelayConfig, *, subdomain: str, local_port: int, key_path: Path
+) -> list[str]:
     target = f"{rc.user}@{rc.host}" if rc.user else rc.host
     return [
         "ssh",
-        "-p", str(rc.ssh_port),
-        "-i", str(key_path),
-        "-o", "ExitOnForwardFailure=yes",
-        "-o", "ServerAliveInterval=30",
-        "-o", "ServerAliveCountMax=3",
-        "-o", "StrictHostKeyChecking=accept-new",
+        "-p",
+        str(rc.ssh_port),
+        "-i",
+        str(key_path),
+        "-o",
+        "ExitOnForwardFailure=yes",
+        "-o",
+        "ServerAliveInterval=30",
+        "-o",
+        "ServerAliveCountMax=3",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
         "-N",
-        "-R", f"{subdomain}:80:localhost:{local_port}",
+        "-R",
+        f"{subdomain}:80:localhost:{local_port}",
         target,
     ]
 
@@ -156,8 +165,11 @@ class TunnelSupervisor:
     ) -> None:
         self._argv = argv
         self._log_path = log_path
-        self._proc_factory = proc_factory if proc_factory is not None \
+        self._proc_factory = (
+            proc_factory
+            if proc_factory is not None
             else (lambda a: _default_proc_factory(a, self._log_path))
+        )
         self._backoff_delay = backoff_delay
         self._max_backoff_delay = max_backoff_delay
         self._clock = clock if clock is not None else time.monotonic
@@ -174,8 +186,8 @@ class TunnelSupervisor:
         )
 
         self._proc = None
-        self._stopped = False          # True once stop() has been called
-        self._final = False            # ... and stopped for good: never spawn again
+        self._stopped = False  # True once stop() has been called
+        self._final = False  # ... and stopped for good: never spawn again
         self._restart_count = 0
         # Every process this supervisor has successfully launched. Unlike
         # `_restart_count` it only ever increases — `start()` zeroes the restart
@@ -217,19 +229,21 @@ class TunnelSupervisor:
         """
         if self._stopped:
             return
-        if self._proc is None:
-            return
-        if self._proc.poll() is None:
+        if self._proc is not None and self._proc.poll() is None:
             # Still alive — nothing to do.
             return
-        # Process has exited unexpectedly.  Check whether the backoff delay has
-        # elapsed before respawning.
+        # A process exit or a failed spawn both enter the same retry gate.
         now = self._clock()
         if self._last_restart_at is None:
+            if self._proc is None:
+                return
             # First detected exit: freeze one delay for it (re-jittering it on
             # every tick would resample the gate instead of honouring it) and
             # wait the backoff out.
-            if self._spawned_at is not None and now - self._spawned_at >= self._max_backoff_delay:
+            if (
+                self._spawned_at is not None
+                and now - self._spawned_at >= self._max_backoff_delay
+            ):
                 # The tunnel held for longer than the worst case we would ever
                 # wait, so whatever streak preceded it is over.
                 self._restart_count = 0
@@ -301,13 +315,13 @@ class TunnelSupervisor:
         return self._delay if self._last_restart_at is not None else 0.0
 
     def recent_output(self, limit: int = 4000) -> str:
-        """Tail of the captured ssh output (empty if no log or file not yet written)."""
+        """Tail of captured ssh output, or empty when the log is unreadable."""
         if self._log_path is None:
             return ""
         try:
             data = Path(self._log_path).read_bytes()[-limit:]
             return data.decode(errors="replace")
-        except FileNotFoundError:
+        except OSError:
             return ""
 
     # ------------------------------------------------------------------
@@ -336,7 +350,12 @@ class TunnelSupervisor:
                 # may have passed its own check before the latch closed.
                 return
         argv = self._argv() if callable(self._argv) else self._argv
-        proc = self._proc_factory(argv)
+        try:
+            proc = self._proc_factory(argv)
+        except Exception:
+            self._delay = jittered(self._backoff(), self._rng)
+            self._last_restart_at = self._clock()
+            raise
         with self._proc_lock:
             stopped_during_spawn = self._stopped
             if not stopped_during_spawn:

--- a/src/mship/core/relay/tunnel.py
+++ b/src/mship/core/relay/tunnel.py
@@ -226,3 +226,10 @@ class TunnelSupervisor:
 
     def _spawn(self) -> None:
         self._proc = self._proc_factory(self._argv)
+
+
+def host_subdomain(host_id: str, dev_id: str, secret: bytes) -> str:
+    """Per-HOST relay subdomain (#471), same shape as `device_subdomain` with
+    the host id in the workspace slot — so it satisfies the existing
+    `tls_ask_allowed` pattern and needs no TLS/Caddy cert change."""
+    return device_subdomain(host_id, dev_id, secret)

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -287,6 +287,8 @@ def create_app(
     gh_app_key: str | None = None,
     pair_link: str | None = None,
     pr_watch_interval: float | None = None,
+    host_id=None,
+    workspace_id: str | None = None,
 ):
     """Build the mship serve FastAPI app (read + review/approve write endpoints).
     Sync handlers call the core directly; FastAPI serializes the returns.
@@ -391,7 +393,13 @@ def create_app(
 
     @app.get("/health")
     def health():
-        return {"status": "ok", "workspace": workspace_name}
+        identity = host_id() if callable(host_id) else host_id
+        payload = {"status": "ok", "workspace": workspace_name}
+        if identity is not None:
+            payload["host_id"] = identity
+        if workspace_id is not None:
+            payload["workspace_id"] = workspace_id
+        return payload
 
     def _topology_payload() -> dict:
         """The topology payload. ONE builder, two surfaces: `GET /net/topology`

--- a/tests/cli/test_daemon.py
+++ b/tests/cli/test_daemon.py
@@ -1048,3 +1048,4 @@ def test_reidentify_keep_identity_adopts_the_fingerprint_without_reminting(
     assert kept["fingerprint"] == "fp-new"
     assert relay_key_path(tmp_path).read_text() == original_key
     assert "fp-new" in res.output
+    assert "restart" in res.output.lower()

--- a/tests/cli/test_daemon.py
+++ b/tests/cli/test_daemon.py
@@ -663,11 +663,40 @@ def test_install_rejects_relay_when_merged_config_has_no_serve_bind(cli, tmp_pat
     assert not any(call.startswith("install:") for call in fake.calls)
 
 
+@pytest.mark.parametrize("relay", ["", "   "])
+def test_install_rejects_an_empty_relay_host(cli, tmp_path, relay):
+    from mship.core.daemon.registry import load_daemon_config
+
+    app, fake = cli
+    res = runner.invoke(app, [
+        "daemon", "install", "--serve", "127.0.0.1:47190", "--relay", relay,
+    ])
+    assert res.exit_code == 1
+    assert "HOST" in res.output
+    assert load_daemon_config(tmp_path).relay is None
+    assert not any(call.startswith("install:") for call in fake.calls)
+
+
+def test_install_strips_surrounding_whitespace_from_the_relay_host(cli, tmp_path):
+    from mship.core.daemon.registry import load_daemon_config
+
+    app, _fake = cli
+    res = runner.invoke(app, [
+        "daemon", "install", "--serve", "127.0.0.1:47190",
+        "--relay", "  relay.example.com  ",
+    ])
+    assert res.exit_code == 0, res.output
+    assert load_daemon_config(tmp_path).relay == {"host": "relay.example.com"}
+
+
 def test_install_help_documents_that_relay_needs_a_restart(cli):
     app, _fake = cli
     res = runner.invoke(app, ["daemon", "install", "--help"])
     assert res.exit_code == 0
-    assert "restart" in res.output
+    # Rich wraps option help across lines inside a box; strip the frame and
+    # collapse the wrapping before matching the sentence.
+    text = " ".join(res.output.replace("│", " ").split())
+    assert "a changed relay takes effect on `mship daemon restart`" in text
 
 
 @pytest.mark.parametrize("serve", ["nonsense", "127.0.0.1:0", "127.0.0.1:65536"])

--- a/tests/cli/test_daemon.py
+++ b/tests/cli/test_daemon.py
@@ -898,3 +898,151 @@ def test_daemon_command_reports_persisted_github_app_read_error(
     assert res.exit_code == 1
     assert str(app_key_path) in res.output
     assert not any(call.startswith(command) for call in fake.calls)
+
+
+# --- tunnel state + identity recovery on the CLI (#471 Task 9) --------------
+
+TUNNEL_HEALTH = {
+    "status": "ok",
+    "pid": 7,
+    "mship_version": mship.__version__,
+    "protocol": 3,
+    "uptime_s": 5.0,
+    "socket": "/s.sock",
+    "tunnel": {
+        "state": "online",
+        "subdomain": "hst-abc",
+        "public_url": "https://hst-abc.relay.example",
+        "restarts": 0,
+        "last_error": None,
+        "clock_skew_seconds": 3600.0,
+    },
+}
+
+
+def test_status_renders_the_tunnel_block(cli, monkeypatch):
+    app, _ = cli
+    monkeypatch.setattr(daemon_mod, "probe_daemon", lambda **kw: TUNNEL_HEALTH)
+    res = runner.invoke(app, ["daemon", "status"])
+    assert res.exit_code == 0, res.output
+    assert "tunnel: online https://hst-abc.relay.example (0 restarts)" in res.output
+
+
+def test_status_json_carries_the_tunnel_and_skew_first_class(cli, monkeypatch):
+    """AC12: `mship --json daemon status` is what the manual checklist reads a
+    non-zero `clock_skew_seconds` out of — the rendered text is not parseable."""
+    import json as _json
+
+    from mship.cli.output import configure_output, reset_output_settings
+
+    app, _ = cli
+    monkeypatch.setattr(daemon_mod, "probe_daemon", lambda **kw: TUNNEL_HEALTH)
+    configure_output(json=True)
+    try:
+        res = runner.invoke(app, ["daemon", "status"])
+    finally:
+        reset_output_settings()
+    assert res.exit_code == 0, res.output
+    payload = _json.loads(res.output)
+    assert payload["tunnel"] == TUNNEL_HEALTH["tunnel"]
+    assert payload["clock_skew_seconds"] == 3600.0
+
+
+@pytest.fixture
+def no_keygen(monkeypatch, tmp_path):
+    """A relay keypair that appears on demand, so nothing here spawns
+    ssh-keygen (the `test_relay_link.py::_seed_key` discipline)."""
+    from itertools import count
+
+    from mship.core.relay import keys
+
+    minted = count()
+
+    def fake_ensure(home, runner=None):
+        path = keys.relay_key_path(home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if not path.exists():
+            # A DIFFERENT key each time, like ssh-keygen: a rotation that
+            # reproduced the same bytes would leave the twin's copy working.
+            nth = next(minted)
+            path.write_text(f"PRIVATE-{nth}")
+            path.with_name(path.name + ".pub").write_text(
+                "ssh-ed25519 " + f"{nth}".rjust(68, "A") + " mship-relay\n"
+            )
+        return path
+
+    monkeypatch.setattr(keys, "ensure_relay_key", fake_ensure)
+    return fake_ensure
+
+
+def _identity(home: Path) -> dict:
+    import json as _json
+
+    from mship.core.daemon.paths import host_identity_path
+
+    return _json.loads(host_identity_path(home).read_text())
+
+
+def test_reidentify_mints_a_new_id_rotates_the_key_and_asks_for_a_restart(
+    cli, tmp_path, no_keygen
+):
+    """The cloned-VM recovery an operator forces by hand: the twin's copy of the
+    relay key must stop working, so a new id alone is not enough."""
+    from mship.core.daemon.identity import ensure_host_identity
+    from mship.core.relay.keys import relay_key_path
+
+    app, _ = cli
+    no_keygen(tmp_path)
+    original = ensure_host_identity(tmp_path, fingerprint="fp-1")
+    original_key = relay_key_path(tmp_path).read_text()
+
+    res = runner.invoke(app, ["daemon", "reidentify"])
+
+    assert res.exit_code == 0, res.output
+    fresh = _identity(tmp_path)
+    assert fresh["host_id"] != original.host_id
+    assert fresh["cloned_from"] == original.host_id
+    assert relay_key_path(tmp_path).read_text() != original_key
+    assert any(
+        p.name.startswith("relay_ed25519.pre-reidentify-")
+        for p in relay_key_path(tmp_path).parent.iterdir()
+    )
+    assert "restart" in res.output.lower()
+
+
+def test_reidentify_prints_the_new_subdomain(cli, tmp_path, no_keygen):
+    """The operator's next move is `mship relay approve` on the relay host, and
+    the subdomain is how they recognise this host there."""
+    from mship.core.daemon.relay_link import host_subdomain_for
+
+    app, _ = cli
+    no_keygen(tmp_path)
+    res = runner.invoke(app, ["daemon", "reidentify"])
+
+    assert res.exit_code == 0, res.output
+    assert host_subdomain_for(tmp_path, _identity(tmp_path)["host_id"]) in res.output
+
+
+def test_reidentify_keep_identity_adopts_the_fingerprint_without_reminting(
+    cli, tmp_path, no_keygen, monkeypatch
+):
+    """AC4a: the operator asserting 'this IS still the same host' after a
+    re-image — `on_mismatch="keep"`, which nothing else in the product calls."""
+    from mship.core.daemon import identity as identity_mod
+    from mship.core.daemon.identity import ensure_host_identity
+    from mship.core.relay.keys import relay_key_path
+
+    app, _ = cli
+    no_keygen(tmp_path)
+    original = ensure_host_identity(tmp_path, fingerprint="fp-old")
+    original_key = relay_key_path(tmp_path).read_text()
+    monkeypatch.setattr(identity_mod, "machine_fingerprint", lambda *a, **kw: "fp-new")
+
+    res = runner.invoke(app, ["daemon", "reidentify", "--keep-identity"])
+
+    assert res.exit_code == 0, res.output
+    kept = _identity(tmp_path)
+    assert kept["host_id"] == original.host_id
+    assert kept["fingerprint"] == "fp-new"
+    assert relay_key_path(tmp_path).read_text() == original_key
+    assert "fp-new" in res.output

--- a/tests/cli/test_daemon.py
+++ b/tests/cli/test_daemon.py
@@ -611,6 +611,65 @@ def test_install_without_serve_leaves_null_bind(cli, tmp_path):
     assert load_daemon_config(tmp_path).serve is None
 
 
+def test_install_seeds_relay_beside_scan_roots_and_serve(cli, tmp_path):
+    from mship.core.daemon.registry import load_daemon_config
+
+    app, fake = cli
+    src = tmp_path / "src"
+    src.mkdir()
+    res = runner.invoke(app, [
+        "daemon", "install",
+        "--scan-root", str(src),
+        "--serve", "127.0.0.1:47190",
+        "--relay", "relay.example.com",
+    ])
+    assert res.exit_code == 0, res.output
+    cfg = load_daemon_config(tmp_path)
+    assert cfg.scan_roots == [str(src)]
+    assert cfg.serve == {"host": "127.0.0.1", "port": 47190}
+    assert cfg.relay == {"host": "relay.example.com"}
+
+
+def test_bare_relay_install_succeeds_when_serve_was_set_earlier(cli, tmp_path):
+    """Incremental provisioning: `--serve` yesterday, `--relay` today. The
+    config MERGES, so validating the flag instead of the merged result would
+    reject the normal path."""
+    from mship.core.daemon.registry import load_daemon_config
+
+    app, fake = cli
+    assert runner.invoke(
+        app, ["daemon", "install", "--serve", "127.0.0.1:47190"]
+    ).exit_code == 0
+
+    res = runner.invoke(app, ["daemon", "install", "--relay", "relay.example.com"])
+
+    assert res.exit_code == 0, res.output
+    cfg = load_daemon_config(tmp_path)
+    assert cfg.relay == {"host": "relay.example.com"}
+    assert cfg.serve == {"host": "127.0.0.1", "port": 47190}
+
+
+def test_install_rejects_relay_when_merged_config_has_no_serve_bind(cli, tmp_path):
+    """A tunnel forwards a local port; with no bind there is nothing to
+    forward, and the host would register itself as reachable and 502."""
+    from mship.core.daemon.registry import load_daemon_config
+
+    app, fake = cli
+    res = runner.invoke(app, ["daemon", "install", "--relay", "relay.example.com"])
+
+    assert res.exit_code == 1
+    assert "--serve" in res.output
+    assert load_daemon_config(tmp_path).relay is None
+    assert not any(call.startswith("install:") for call in fake.calls)
+
+
+def test_install_help_documents_that_relay_needs_a_restart(cli):
+    app, _fake = cli
+    res = runner.invoke(app, ["daemon", "install", "--help"])
+    assert res.exit_code == 0
+    assert "restart" in res.output
+
+
 @pytest.mark.parametrize("serve", ["nonsense", "127.0.0.1:0", "127.0.0.1:65536"])
 def test_install_rejects_malformed_serve(cli, serve):
     app, fake = cli

--- a/tests/cli/test_daemon.py
+++ b/tests/cli/test_daemon.py
@@ -2,6 +2,8 @@
 interaction is monkeypatched (`pick_supervisor` → recording fake, the
 `tests/cli/test_relay_enroll_server.py` seam style)."""
 from pathlib import Path
+from click import unstyle
+
 
 import pytest
 import typer
@@ -693,9 +695,9 @@ def test_install_help_documents_that_relay_needs_a_restart(cli):
     app, _fake = cli
     res = runner.invoke(app, ["daemon", "install", "--help"])
     assert res.exit_code == 0
-    # Rich wraps option help across lines inside a box; strip the frame and
-    # collapse the wrapping before matching the sentence.
-    text = " ".join(res.output.replace("│", " ").split())
+    # Rich wraps option help across lines inside a box and may emit ANSI
+    # between words on newer Python/Rich combinations.
+    text = " ".join(unstyle(res.output).replace("│", " ").split())
     assert "a changed relay takes effect on `mship daemon restart`" in text
 
 

--- a/tests/cli/test_relay_enroll_server.py
+++ b/tests/cli/test_relay_enroll_server.py
@@ -8,6 +8,7 @@ Verifies:
 These tests use module-level monkeypatching seams (_run_uvicorn, build_enroll_app)
 so no real server is started.
 """
+
 from __future__ import annotations
 
 import typer
@@ -19,10 +20,14 @@ import mship.core.relay.enroll_app as ea
 
 def _app(monkeypatch):
     captured = {}
-    monkeypatch.setattr(relay_mod, "_run_uvicorn",
-                        lambda app, host, port: captured.update(host=host, port=port, app=app))
-    monkeypatch.setattr(ea, "build_enroll_app",
-                        lambda store, **kw: captured.update(kw) or "APP")
+    monkeypatch.setattr(
+        relay_mod,
+        "_run_uvicorn",
+        lambda app, host, port: captured.update(host=host, port=port, app=app),
+    )
+    monkeypatch.setattr(
+        ea, "build_enroll_app", lambda store, **kw: captured.update(kw) or "APP"
+    )
     app = typer.Typer()
     relay_mod.register(app, lambda: None)
     return app, captured
@@ -30,23 +35,79 @@ def _app(monkeypatch):
 
 def test_enroll_server_defaults_to_loopback(monkeypatch, tmp_path):
     app, captured = _app(monkeypatch)
-    res = CliRunner().invoke(app, ["relay", "enroll-server",
-                                   "--store-dir", str(tmp_path / "s"),
-                                   "--pubkeys-dir", str(tmp_path / "p"),
-                                   "--relay-domain", "r.example.com"])
+    res = CliRunner().invoke(
+        app,
+        [
+            "relay",
+            "enroll-server",
+            "--store-dir",
+            str(tmp_path / "s"),
+            "--pubkeys-dir",
+            str(tmp_path / "p"),
+            "--relay-domain",
+            "r.example.com",
+        ],
+    )
     assert res.exit_code == 0, res.output
-    assert captured["host"] == "127.0.0.1"          # loopback default (ac5)
+    assert captured["host"] == "127.0.0.1"  # loopback default (ac5)
     assert captured["relay_domain"] == "r.example.com"
 
 
 def test_enroll_server_relay_domain_defaults_from_env(monkeypatch, tmp_path):
     monkeypatch.setenv("RELAY_DOMAIN", "env.example.com")
     app, captured = _app(monkeypatch)
-    res = CliRunner().invoke(app, ["relay", "enroll-server",
-                                   "--store-dir", str(tmp_path / "s"),
-                                   "--pubkeys-dir", str(tmp_path / "p")])
+    res = CliRunner().invoke(
+        app,
+        [
+            "relay",
+            "enroll-server",
+            "--store-dir",
+            str(tmp_path / "s"),
+            "--pubkeys-dir",
+            str(tmp_path / "p"),
+        ],
+    )
     assert res.exit_code == 0, res.output
     assert captured["relay_domain"] == "env.example.com"
+
+
+def test_enroll_server_canonicalizes_the_relay_domain(monkeypatch, tmp_path):
+    app, captured = _app(monkeypatch)
+    res = CliRunner().invoke(
+        app,
+        [
+            "relay",
+            "enroll-server",
+            "--store-dir",
+            str(tmp_path / "s"),
+            "--pubkeys-dir",
+            str(tmp_path / "p"),
+            "--relay-domain",
+            "  Relay.Example.COM.  ",
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    assert captured["relay_domain"] == "relay.example.com"
+
+
+def test_enroll_server_rejects_a_whitespace_relay_domain(monkeypatch, tmp_path):
+    app, captured = _app(monkeypatch)
+    res = CliRunner().invoke(
+        app,
+        [
+            "relay",
+            "enroll-server",
+            "--store-dir",
+            str(tmp_path / "s"),
+            "--pubkeys-dir",
+            str(tmp_path / "p"),
+            "--relay-domain",
+            "   ",
+        ],
+    )
+    assert res.exit_code != 0
+    assert "app" not in captured
+
 
 def test_enroll_server_requires_ssh_keygen(monkeypatch, tmp_path):
     monkeypatch.setattr("shutil.which", lambda _name: None)

--- a/tests/cli/test_relay_enroll_server.py
+++ b/tests/cli/test_relay_enroll_server.py
@@ -22,7 +22,7 @@ def _app(monkeypatch):
     monkeypatch.setattr(relay_mod, "_run_uvicorn",
                         lambda app, host, port: captured.update(host=host, port=port, app=app))
     monkeypatch.setattr(ea, "build_enroll_app",
-                        lambda store, *, relay_domain: captured.update(relay_domain=relay_domain) or "APP")
+                        lambda store, **kw: captured.update(kw) or "APP")
     app = typer.Typer()
     relay_mod.register(app, lambda: None)
     return app, captured

--- a/tests/cli/test_relay_enroll_server.py
+++ b/tests/cli/test_relay_enroll_server.py
@@ -47,3 +47,25 @@ def test_enroll_server_relay_domain_defaults_from_env(monkeypatch, tmp_path):
                                    "--pubkeys-dir", str(tmp_path / "p")])
     assert res.exit_code == 0, res.output
     assert captured["relay_domain"] == "env.example.com"
+
+def test_enroll_server_requires_ssh_keygen(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    app, _captured = _app(monkeypatch)
+
+    res = CliRunner().invoke(
+        app,
+        [
+            "relay",
+            "enroll-server",
+            "--store-dir",
+            str(tmp_path / "s"),
+            "--pubkeys-dir",
+            str(tmp_path / "p"),
+            "--relay-domain",
+            "r.example.com",
+        ],
+    )
+
+    assert res.exit_code != 0
+    assert "ssh-keygen" in res.output
+    assert "openssh-client" in res.output

--- a/tests/cli/test_relay_hosts.py
+++ b/tests/cli/test_relay_hosts.py
@@ -10,6 +10,7 @@ authenticates against is what makes signature-auth and tunnel-auth one identity.
 
 from __future__ import annotations
 
+import json
 import re
 import time
 
@@ -18,6 +19,8 @@ from typer.testing import CliRunner
 
 import mship.cli.relay as relay_mod
 import mship.core.relay.enroll_app as ea
+from mship.cli import app as mship_app
+from mship.cli.output import reset_output_settings
 from mship.core.relay.fleet_token import FleetTokenStore
 from mship.core.relay.host_directory import HostDirectory
 
@@ -169,6 +172,35 @@ def _seed(store_dir, clock, **over):
     return payload
 
 
+def test_hosts_json_mode_returns_one_structured_document_without_credentials(tmp_path):
+    store_dir = tmp_path / "s"
+    now = time.time()
+    _seed(store_dir, lambda: now)
+
+    reset_output_settings()
+    try:
+        res = CliRunner().invoke(
+            mship_app,
+            ["--json", "relay", "hosts", "--store-dir", str(store_dir)],
+        )
+    finally:
+        reset_output_settings()
+
+    assert res.exit_code == 0, res.output
+    assert json.loads(res.output) == {
+        "hosts": [
+            {
+                "host_id": "hst-20260818120000-aaaaaaaa",
+                "label": "vm-alpha",
+                "state": "online",
+                "last_seen": time.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ", time.gmtime(now)
+                ),
+            }
+        ]
+    }
+
+
 def test_hosts_lists_id_label_state_and_last_seen(tmp_path):
     store_dir = tmp_path / "s"
     now = time.time()
@@ -227,10 +259,10 @@ def test_hosts_never_prints_the_refresh_credential(tmp_path):
     assert "refresh-credential-1" not in res.output
 
 
-def test_hosts_on_an_empty_relay_says_so(tmp_path):
+def test_hosts_on_an_empty_relay_returns_an_empty_json_list(tmp_path):
     res = _run("hosts", "--store-dir", str(tmp_path / "s"))
     assert res.exit_code == 0
-    assert "no hosts" in res.output
+    assert json.loads(res.output) == {"hosts": []}
 
 
 # --- enroll-server wiring ---------------------------------------------------

--- a/tests/cli/test_relay_hosts.py
+++ b/tests/cli/test_relay_hosts.py
@@ -107,6 +107,37 @@ def test_fleet_token_requires_a_relay_domain(monkeypatch, tmp_path):
     assert res.exit_code != 0
 
 
+def test_fleet_token_canonicalizes_the_relay_domain(tmp_path):
+    res = _run(
+        "fleet-token",
+        "--store-dir",
+        str(tmp_path / "s"),
+        "--label",
+        "phone",
+        "--relay-domain",
+        "  Relay.Example.COM.  ",
+    )
+    assert res.exit_code == 0, res.output
+    assert "groundcontrol://add-relay?relay=relay.example.com&token=" in res.output
+    assert "%20" not in res.output
+
+
+def test_fleet_token_rejects_whitespace_before_writing_a_credential(tmp_path):
+    store_dir = tmp_path / "s"
+    res = _run(
+        "fleet-token",
+        "--store-dir",
+        str(store_dir),
+        "--label",
+        "phone",
+        "--relay-domain",
+        "   ",
+    )
+    assert res.exit_code != 0
+    assert not (store_dir / "fleet-tokens.json").exists()
+    assert not (store_dir / "fleet-secret").exists()
+
+
 # --- hosts ------------------------------------------------------------------
 
 

--- a/tests/cli/test_relay_hosts.py
+++ b/tests/cli/test_relay_hosts.py
@@ -1,0 +1,249 @@
+"""Relay-owner CLI for the host directory (#471 Task 5).
+
+`mship relay fleet-token` mints the phone's credential and prints the QR that
+carries it; `mship relay hosts` is the owner's view of the same directory the
+phone reads. Both default `--store-dir`/`--pubkeys-dir` exactly as the shipped
+`requests`/`approve` commands do, and `enroll-server` wires the directory from
+those same two directories — the `pubkeys/` allowlist being the one sish
+authenticates against is what makes signature-auth and tunnel-auth one identity.
+"""
+from __future__ import annotations
+
+import re
+import time
+
+import typer
+from typer.testing import CliRunner
+
+import mship.cli.relay as relay_mod
+import mship.core.relay.enroll_app as ea
+from mship.core.relay.fleet_token import FleetTokenStore
+from mship.core.relay.host_directory import HostDirectory
+
+FP = "SHA256:keyA"
+
+
+def _app():
+    app = typer.Typer()
+    relay_mod.register(app, lambda: None)
+    return app
+
+
+def _run(*args):
+    return CliRunner().invoke(_app(), ["relay", *args])
+
+
+def _fleet_token(store_dir, *extra):
+    return _run("fleet-token", "--store-dir", str(store_dir),
+                "--relay-domain", "relay.example.com", *extra)
+
+
+def _token_line(result):
+    """The bare `<label_id>.<secret>` the command printed."""
+    lines = (ln.strip() for ln in result.output.splitlines())
+    return next(ln for ln in lines if re.fullmatch(r"[0-9a-f]{16}\.[0-9a-f]{64}", ln))
+
+
+# --- fleet-token ------------------------------------------------------------
+
+
+def test_fleet_token_mints_and_prints_the_pairing_link(tmp_path):
+    res = _fleet_token(tmp_path / "s", "--label", "phone")
+    assert res.exit_code == 0, res.output
+    token = _token_line(res)
+    assert FleetTokenStore(tmp_path / "s").verify(token) == "phone"
+    assert "groundcontrol://add-relay?relay=relay.example.com&token=" in res.output
+
+
+def test_fleet_token_is_stable_across_runs_for_one_label(tmp_path):
+    # Re-printing the QR must not invalidate the phone that already scanned it.
+    first = _fleet_token(tmp_path / "s", "--label", "phone")
+    second = _fleet_token(tmp_path / "s", "--label", "phone")
+    assert _token_line(first) == _token_line(second)
+
+
+def test_fleet_token_mints_a_distinct_token_per_label(tmp_path):
+    phone = _token_line(_fleet_token(tmp_path / "s", "--label", "phone"))
+    tablet = _token_line(_fleet_token(tmp_path / "s", "--label", "tablet"))
+    assert phone != tablet
+    store = FleetTokenStore(tmp_path / "s")
+    assert (store.verify(phone), store.verify(tablet)) == ("phone", "tablet")
+
+
+def test_fleet_token_revoke_invalidates_only_that_label(tmp_path):
+    phone = _token_line(_fleet_token(tmp_path / "s", "--label", "phone"))
+    tablet = _token_line(_fleet_token(tmp_path / "s", "--label", "tablet"))
+    res = _fleet_token(tmp_path / "s", "--label", "phone", "--revoke")
+    assert res.exit_code == 0, res.output
+    store = FleetTokenStore(tmp_path / "s")
+    assert store.verify(phone) is None
+    assert store.verify(tablet) == "tablet"
+    assert "groundcontrol://" not in res.output      # nothing to re-scan
+
+
+def test_fleet_token_revoking_an_unknown_label_reports_it(tmp_path):
+    res = _fleet_token(tmp_path / "s", "--label", "ghost", "--revoke")
+    assert res.exit_code == 1
+    assert "ghost" in res.output
+
+
+def test_fleet_token_relay_domain_defaults_from_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("RELAY_DOMAIN", "env.example.com")
+    res = _run("fleet-token", "--store-dir", str(tmp_path / "s"), "--label", "phone")
+    assert res.exit_code == 0, res.output
+    assert "groundcontrol://add-relay?relay=env.example.com&token=" in res.output
+
+
+def test_fleet_token_requires_a_relay_domain(monkeypatch, tmp_path):
+    monkeypatch.delenv("RELAY_DOMAIN", raising=False)
+    res = _run("fleet-token", "--store-dir", str(tmp_path / "s"), "--label", "phone")
+    assert res.exit_code != 0
+
+
+# --- hosts ------------------------------------------------------------------
+
+
+def _seed(store_dir, clock, **over):
+    """Land one registered entry through the real directory (no on-disk layout
+    knowledge in the test)."""
+    directory = HostDirectory(
+        store_dir,
+        allowed_signers=lambda: FP,
+        probe=lambda url: None,
+        verify=lambda *a, **kw: True,
+        clock=clock,
+    )
+    payload = {
+        "host_id": "hst-20260818120000-aaaaaaaa",
+        "instance_id": "inst-1",
+        "label": "vm-alpha",
+        "key_fingerprint": FP,
+        "machine_fingerprint": "mf",
+        "subdomain": "abc123",
+        "public_url": "https://abc123.relay.example",
+        "refresh": "refresh-credential-1",
+    }
+    payload.update(over)
+    directory.register(payload, nonce=directory.issue_challenge()["nonce"], signature="s")
+    return payload
+
+
+def test_hosts_lists_id_label_state_and_last_seen(tmp_path):
+    store_dir = tmp_path / "s"
+    now = time.time()
+    _seed(store_dir, lambda: now)
+    res = _run("hosts", "--store-dir", str(store_dir))
+    assert res.exit_code == 0, res.output
+    assert "hst-20260818120000-aaaaaaaa" in res.output
+    assert "vm-alpha" in res.output
+    assert "online" in res.output                     # freshness on the real clock
+    assert time.strftime("%Y-%m-%d", time.gmtime(now)) in res.output
+
+
+def test_hosts_marks_a_host_offline_once_it_stops_beating(tmp_path):
+    store_dir = tmp_path / "s"
+    _seed(store_dir, lambda: 1_000.0)
+    res = _run("hosts", "--store-dir", str(store_dir))
+    assert "offline" in res.output
+
+
+def test_hosts_shows_pending_enrollments_alongside_registered_ones(tmp_path):
+    from mship.core.relay.enroll import RequestStore
+
+    store_dir = tmp_path / "s"
+    _seed(store_dir, time.time)
+    RequestStore(store_dir).create(
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAISecondKeyBodyBBBBBBBBBBBBBBBBBBBBBBBB two",
+        "fresh-vm",
+    )
+    res = _run("hosts", "--store-dir", str(store_dir))
+    assert "pending-approval" in res.output
+    assert "fresh-vm" in res.output
+
+
+def test_hosts_never_prints_the_refresh_credential(tmp_path):
+    # The phone fetches it over `GET /hosts`; the owner's terminal (and its
+    # scrollback) is not a place to widen it to.
+    store_dir = tmp_path / "s"
+    _seed(store_dir, time.time)
+    res = _run("hosts", "--store-dir", str(store_dir))
+    assert "refresh-credential-1" not in res.output
+
+
+def test_hosts_on_an_empty_relay_says_so(tmp_path):
+    res = _run("hosts", "--store-dir", str(tmp_path / "s"))
+    assert res.exit_code == 0
+    assert "no hosts" in res.output
+
+
+# --- enroll-server wiring ---------------------------------------------------
+
+
+def test_enroll_server_wires_the_directory_and_the_pubkeys_allowlist(monkeypatch, tmp_path):
+    captured = {}
+    monkeypatch.setattr(relay_mod, "_run_uvicorn", lambda app, host, port: None)
+    monkeypatch.setattr(ea, "build_enroll_app", lambda store, **kw: captured.update(kw))
+
+    pubkeys = tmp_path / "p"
+    pubkeys.mkdir()
+    (pubkeys / "vm.pub").write_text(
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host\n"
+    )
+    res = _run("enroll-server", "--store-dir", str(tmp_path / "s"),
+               "--pubkeys-dir", str(pubkeys), "--relay-domain", "relay.example.com")
+    assert res.exit_code == 0, res.output
+
+    assert isinstance(captured["host_directory"], HostDirectory)
+    assert isinstance(captured["fleet_tokens"], FleetTokenStore)
+    # The allowed-signers callable is re-read per verification and renders the
+    # SAME pubkeys/ dir sish authenticates against.
+    signers = captured["host_directory"]._allowed_signers()      # noqa: SLF001
+    assert signers.startswith("SHA256:")
+    assert "ssh-ed25519" in signers
+
+
+def test_enroll_server_fleet_tokens_share_the_store_dir(monkeypatch, tmp_path):
+    captured = {}
+    monkeypatch.setattr(relay_mod, "_run_uvicorn", lambda app, host, port: None)
+    monkeypatch.setattr(ea, "build_enroll_app", lambda store, **kw: captured.update(kw))
+    store_dir = tmp_path / "s"
+    token = FleetTokenStore(store_dir).issue("phone")
+
+    res = _run("enroll-server", "--store-dir", str(store_dir),
+               "--pubkeys-dir", str(tmp_path / "p"), "--relay-domain", "relay.example.com")
+    assert res.exit_code == 0, res.output
+    # A token minted by the CLI must verify inside the running server.
+    assert captured["fleet_tokens"].verify(token) == "phone"
+
+
+def test_the_registration_probe_reads_the_incumbents_instance_id():
+    from mship.core.relay.host_directory import probe_instance_id
+
+    class Resp:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"instance_id": "inst-9"}
+
+    seen = {}
+
+    def get(url, **kw):
+        seen["url"] = url
+        return Resp()
+
+    assert probe_instance_id("https://abc123.relay.example", get=get) == "inst-9"
+    assert seen["url"] == "https://abc123.relay.example/health"
+
+
+def test_the_registration_probe_has_no_answer_for_an_unhealthy_incumbent():
+    from mship.core.relay.host_directory import probe_instance_id
+
+    class Resp:
+        status_code = 502
+
+        @staticmethod
+        def json():
+            raise AssertionError("must not parse a non-200 body")
+
+    assert probe_instance_id("https://x", get=lambda url, **kw: Resp()) is None

--- a/tests/cli/test_relay_hosts.py
+++ b/tests/cli/test_relay_hosts.py
@@ -108,6 +108,7 @@ def _seed(store_dir, clock, **over):
     knowledge in the test)."""
     directory = HostDirectory(
         store_dir,
+        relay_domain="relay.example",
         allowed_signers=lambda: FP,
         probe=lambda url: None,
         verify=lambda *a, **kw: True,
@@ -119,8 +120,8 @@ def _seed(store_dir, clock, **over):
         "label": "vm-alpha",
         "key_fingerprint": FP,
         "machine_fingerprint": "mf",
-        "subdomain": "abc123",
-        "public_url": "https://abc123.relay.example",
+        "subdomain": "abc123-a1b2c3",
+        "public_url": "https://abc123-a1b2c3.relay.example",
         "refresh": "refresh-credential-1",
     }
     payload.update(over)

--- a/tests/cli/test_relay_hosts.py
+++ b/tests/cli/test_relay_hosts.py
@@ -171,6 +171,22 @@ def test_hosts_shows_pending_enrollments_alongside_registered_ones(tmp_path):
     assert "fresh-vm" in res.output
 
 
+def test_hosts_renders_untrusted_labels_as_one_literal_line(tmp_path):
+    from mship.core.relay.enroll import RequestStore
+
+    label = "[bold red]trusted[/]\nspoof\x1b[2J"
+    RequestStore(tmp_path).create(
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAISecondKeyBodyBBBBBBBBBBBBBBBBBBBBBBBB two",
+        label,
+    )
+
+    res = _run("hosts", "--store-dir", str(tmp_path))
+
+    assert res.exit_code == 0, res.output
+    assert "[bold red]trusted[/]\\nspoof\\u001b[2J" in res.output
+    assert "\x1b" not in res.output
+
+
 def test_hosts_never_prints_the_refresh_credential(tmp_path):
     # The phone fetches it over `GET /hosts`; the owner's terminal (and its
     # scrollback) is not a place to widen it to.

--- a/tests/cli/test_relay_hosts.py
+++ b/tests/cli/test_relay_hosts.py
@@ -7,6 +7,7 @@ phone reads. Both default `--store-dir`/`--pubkeys-dir` exactly as the shipped
 those same two directories — the `pubkeys/` allowlist being the one sish
 authenticates against is what makes signature-auth and tunnel-auth one identity.
 """
+
 from __future__ import annotations
 
 import re
@@ -34,8 +35,14 @@ def _run(*args):
 
 
 def _fleet_token(store_dir, *extra):
-    return _run("fleet-token", "--store-dir", str(store_dir),
-                "--relay-domain", "relay.example.com", *extra)
+    return _run(
+        "fleet-token",
+        "--store-dir",
+        str(store_dir),
+        "--relay-domain",
+        "relay.example.com",
+        *extra,
+    )
 
 
 def _token_line(result):
@@ -78,7 +85,7 @@ def test_fleet_token_revoke_invalidates_only_that_label(tmp_path):
     store = FleetTokenStore(tmp_path / "s")
     assert store.verify(phone) is None
     assert store.verify(tablet) == "tablet"
-    assert "groundcontrol://" not in res.output      # nothing to re-scan
+    assert "groundcontrol://" not in res.output  # nothing to re-scan
 
 
 def test_fleet_token_revoking_an_unknown_label_reports_it(tmp_path):
@@ -125,7 +132,9 @@ def _seed(store_dir, clock, **over):
         "refresh": "refresh-credential-1",
     }
     payload.update(over)
-    directory.register(payload, nonce=directory.issue_challenge()["nonce"], signature="s")
+    directory.register(
+        payload, nonce=directory.issue_challenge(FP)["nonce"], signature="s"
+    )
     return payload
 
 
@@ -137,7 +146,7 @@ def test_hosts_lists_id_label_state_and_last_seen(tmp_path):
     assert res.exit_code == 0, res.output
     assert "hst-20260818120000-aaaaaaaa" in res.output
     assert "vm-alpha" in res.output
-    assert "online" in res.output                     # freshness on the real clock
+    assert "online" in res.output  # freshness on the real clock
     assert time.strftime("%Y-%m-%d", time.gmtime(now)) in res.output
 
 
@@ -180,7 +189,9 @@ def test_hosts_on_an_empty_relay_says_so(tmp_path):
 # --- enroll-server wiring ---------------------------------------------------
 
 
-def test_enroll_server_wires_the_directory_and_the_pubkeys_allowlist(monkeypatch, tmp_path):
+def test_enroll_server_wires_the_directory_and_the_pubkeys_allowlist(
+    monkeypatch, tmp_path
+):
     captured = {}
     monkeypatch.setattr(relay_mod, "_run_uvicorn", lambda app, host, port: None)
     monkeypatch.setattr(ea, "build_enroll_app", lambda store, **kw: captured.update(kw))
@@ -190,15 +201,22 @@ def test_enroll_server_wires_the_directory_and_the_pubkeys_allowlist(monkeypatch
     (pubkeys / "vm.pub").write_text(
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host\n"
     )
-    res = _run("enroll-server", "--store-dir", str(tmp_path / "s"),
-               "--pubkeys-dir", str(pubkeys), "--relay-domain", "relay.example.com")
+    res = _run(
+        "enroll-server",
+        "--store-dir",
+        str(tmp_path / "s"),
+        "--pubkeys-dir",
+        str(pubkeys),
+        "--relay-domain",
+        "relay.example.com",
+    )
     assert res.exit_code == 0, res.output
 
     assert isinstance(captured["host_directory"], HostDirectory)
     assert isinstance(captured["fleet_tokens"], FleetTokenStore)
     # The allowed-signers callable is re-read per verification and renders the
     # SAME pubkeys/ dir sish authenticates against.
-    signers = captured["host_directory"]._allowed_signers()      # noqa: SLF001
+    signers = captured["host_directory"]._allowed_signers()  # noqa: SLF001
     assert signers.startswith("SHA256:")
     assert "ssh-ed25519" in signers
 
@@ -210,8 +228,15 @@ def test_enroll_server_fleet_tokens_share_the_store_dir(monkeypatch, tmp_path):
     store_dir = tmp_path / "s"
     token = FleetTokenStore(store_dir).issue("phone")
 
-    res = _run("enroll-server", "--store-dir", str(store_dir),
-               "--pubkeys-dir", str(tmp_path / "p"), "--relay-domain", "relay.example.com")
+    res = _run(
+        "enroll-server",
+        "--store-dir",
+        str(store_dir),
+        "--pubkeys-dir",
+        str(tmp_path / "p"),
+        "--relay-domain",
+        "relay.example.com",
+    )
     assert res.exit_code == 0, res.output
     # A token minted by the CLI must verify inside the running server.
     assert captured["fleet_tokens"].verify(token) == "phone"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,15 +57,38 @@ def _disable_git_signing_for_tests():
 def _isolate_runtime_dir(monkeypatch, tmp_path: Path):
     """No test may reach the real user's daemon control socket.
 
-    `daemon_socket_path` resolves `$XDG_RUNTIME_DIR/mship/daemon.sock`, and
-    `probe_daemon` falls back to that computed path whenever the (tmp) home has
-    no lease. On a box where a real `mship daemon` is running, that probe
-    answers from the LIVE daemon — so a test asserting "daemon: not running"
-    fails for reasons that have nothing to do with the code under test.
-    Pointing the variable at a per-test dir isolates the probe; production
-    socket resolution is untouched (it reads whatever env it is given).
+    `probe_daemon` has TWO ways to find a live daemon, and isolating one is not
+    enough (a full-suite run of `test_status_reports_registry_read_error_...`
+    answered from the live mshipd, pid and all, while passing in isolation):
+
+    - the COMPUTED path, `$XDG_RUNTIME_DIR/mship/daemon.sock` — closed by
+      pointing the variable at a per-test dir;
+    - the LEASE-recorded path, read from `Path.home()/.mothership/daemon/` and
+      PREFERRED over the computed one whenever a lease exists — so a test whose
+      `Path.home` patch does not cover every caller reads the REAL user's lease
+      and probes the socket it names, whatever XDG_RUNTIME_DIR says. Closed by
+      refusing, in the probe seam itself, any socket outside the test's own
+      tmp dir: the guard is about *which socket* is reachable, which is the
+      actual invariant, and unlike moving `$HOME` it disturbs nothing else.
+
+    Production resolution is untouched — both paths read whatever env they are
+    given, and a test that patches `probe_control_socket` itself still wins
+    (its patch is applied after this one). Pinned by
+    `tests/core/daemon/test_paths.py`.
     """
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "xdg-runtime"))
+
+    from mship.core.daemon import control, status
+
+    real_probe = control.probe_control_socket
+
+    def sandboxed_probe(socket_path, **kw):
+        if not str(socket_path).startswith(str(tmp_path)):
+            return None                     # the real user's daemon: unreachable
+        return real_probe(socket_path, **kw)
+
+    monkeypatch.setattr(control, "probe_control_socket", sandboxed_probe)
+    monkeypatch.setattr(status, "probe_control_socket", sandboxed_probe)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,21 @@ def _disable_git_signing_for_tests():
                 os.environ[k] = v
 
 
+@pytest.fixture(autouse=True)
+def _isolate_runtime_dir(monkeypatch, tmp_path: Path):
+    """No test may reach the real user's daemon control socket.
+
+    `daemon_socket_path` resolves `$XDG_RUNTIME_DIR/mship/daemon.sock`, and
+    `probe_daemon` falls back to that computed path whenever the (tmp) home has
+    no lease. On a box where a real `mship daemon` is running, that probe
+    answers from the LIVE daemon — so a test asserting "daemon: not running"
+    fails for reasons that have nothing to do with the code under test.
+    Pointing the variable at a per-test dir isolates the probe; production
+    socket resolution is untouched (it reads whatever env it is given).
+    """
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "xdg-runtime"))
+
+
 @pytest.fixture
 def workspace(tmp_path: Path) -> Path:
     """Create a minimal workspace with repos that have Taskfile.yml files."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def _isolate_runtime_dir(monkeypatch, tmp_path: Path):
     real_probe = control.probe_control_socket
 
     def sandboxed_probe(socket_path, **kw):
-        if not str(socket_path).startswith(str(tmp_path)):
+        if not Path(socket_path).resolve().is_relative_to(tmp_path.resolve()):
             return None                     # the real user's daemon: unreachable
         return real_probe(socket_path, **kw)
 

--- a/tests/core/daemon/test_control.py
+++ b/tests/core/daemon/test_control.py
@@ -1,6 +1,7 @@
 """Control app: the daemon's local identity surface. Version is captured at
 process start (the upgrade-in-place lie #470 calls out), capabilities are the
 #471/#472/#473 seams."""
+
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -15,7 +16,9 @@ STARTED = datetime(2026, 8, 16, 11, 0, 0, tzinfo=timezone.utc)
 
 
 def _client(version: str = "0.5.52") -> TestClient:
-    app = create_control_app(started_at=STARTED, version=version, socket_path="/run/mship/daemon.sock")
+    app = create_control_app(
+        started_at=STARTED, version=version, socket_path="/run/mship/daemon.sock"
+    )
     return TestClient(app)
 
 
@@ -73,12 +76,36 @@ SNAPSHOT = {
 
 def test_tunnel_capability_is_the_injected_value_and_health_carries_the_snapshot():
     app = create_control_app(
-        started_at=STARTED, version="1", socket_path="/s",
+        started_at=STARTED,
+        version="1",
+        socket_path="/s",
         tunnel=_FakeTunnel(SNAPSHOT),
     )
     body = TestClient(app).get("/health").json()
     assert body["capabilities"]["tunnel"] is True
     assert body["tunnel"] == SNAPSHOT
+
+
+def test_tunnel_initialization_error_is_state_not_a_live_capability():
+    error = {
+        "state": "error",
+        "subdomain": None,
+        "public_url": None,
+        "restarts": 0,
+        "last_error": "relay tunnel initialization failed: boom",
+        "clock_skew_seconds": None,
+    }
+    app = create_control_app(
+        started_at=STARTED,
+        version="1",
+        socket_path="/s",
+        tunnel_state=lambda: error,
+    )
+
+    body = TestClient(app).get("/health").json()
+
+    assert body["capabilities"]["tunnel"] is False
+    assert body["tunnel"] == error
 
 
 def test_version_is_captured_at_start_not_reread(monkeypatch):
@@ -138,16 +165,29 @@ def _registry_store(tmp_path):
 
     store = RegistryStore(tmp_path / "workspaces.json")
     now = datetime(2026, 8, 17, tzinfo=tz.utc)
-    store.mutate(lambda s: s.entries.append(WorkspaceEntry(
-        id="ws-1", name="a", path="/w/a", config_path="/w/a/mothership.yaml",
-        first_seen=now, last_seen=now,
-    )))
+    store.mutate(
+        lambda s: s.entries.append(
+            WorkspaceEntry(
+                id="ws-1",
+                name="a",
+                path="/w/a",
+                config_path="/w/a/mothership.yaml",
+                first_seen=now,
+                last_seen=now,
+            )
+        )
+    )
     return store
 
 
 def test_registry_capability_flips_with_store(tmp_path):
-    app = create_control_app(started_at=STARTED, version="1", socket_path="/s",
-                             store=_registry_store(tmp_path), serve_bound=True)
+    app = create_control_app(
+        started_at=STARTED,
+        version="1",
+        socket_path="/s",
+        store=_registry_store(tmp_path),
+        serve_bound=True,
+    )
     caps = TestClient(app).get("/health").json()["capabilities"]
     assert caps["registry"] is True
     assert caps["serve"] is True
@@ -156,8 +196,13 @@ def test_registry_capability_flips_with_store(tmp_path):
 
 def test_control_workspaces_endpoints(tmp_path):
     calls = []
-    app = create_control_app(started_at=STARTED, version="1", socket_path="/s",
-                             store=_registry_store(tmp_path), rescan=lambda: calls.append(1))
+    app = create_control_app(
+        started_at=STARTED,
+        version="1",
+        socket_path="/s",
+        store=_registry_store(tmp_path),
+        rescan=lambda: calls.append(1),
+    )
     client = TestClient(app)
     ws = client.get("/workspaces").json()["workspaces"]
     assert [w["id"] for w in ws] == ["ws-1"]
@@ -188,9 +233,7 @@ def test_control_refresh_runs_host_cleanup_after_rescan(tmp_path):
     assert events == ["rescan", "cleanup"]
 
     events.clear()
-    response = TestClient(app).post(
-        "/workspaces/refresh?cleanup_only=true"
-    )
+    response = TestClient(app).post("/workspaces/refresh?cleanup_only=true")
 
     assert response.status_code == 200
     assert events == ["cleanup"]

--- a/tests/core/daemon/test_control.py
+++ b/tests/core/daemon/test_control.py
@@ -37,6 +37,48 @@ def test_health_payload_shape():
         "registry": False,
         "runner": False,
     }
+    assert body["tunnel"] is None
+
+
+def test_protocol_is_3_now_that_health_carries_a_tunnel_block():
+    """A payload change the CLI reads (`daemon status`) is a protocol bump —
+    the version-skew line is what tells an operator to restart."""
+    assert PROTOCOL == 3
+
+
+class _FakeTunnel:
+    """What the control app is allowed to touch: a published snapshot, nothing
+    else. Ticks run on an executor thread (`run.py::_tunnel_loop`), so anything
+    read live from the request thread would be a torn read."""
+
+    def __init__(self, snapshot: dict):
+        self._snapshot = snapshot
+
+    def snapshot(self) -> dict:
+        return self._snapshot
+
+    def state(self):  # pragma: no cover - failure path
+        raise AssertionError("/health read live tunnel state instead of a snapshot")
+
+
+SNAPSHOT = {
+    "state": "online",
+    "subdomain": "hst-abc",
+    "public_url": "https://hst-abc.relay.example",
+    "restarts": 0,
+    "last_error": None,
+    "clock_skew_seconds": 1.5,
+}
+
+
+def test_tunnel_capability_is_the_injected_value_and_health_carries_the_snapshot():
+    app = create_control_app(
+        started_at=STARTED, version="1", socket_path="/s",
+        tunnel=_FakeTunnel(SNAPSHOT),
+    )
+    body = TestClient(app).get("/health").json()
+    assert body["capabilities"]["tunnel"] is True
+    assert body["tunnel"] == SNAPSHOT
 
 
 def test_version_is_captured_at_start_not_reread(monkeypatch):

--- a/tests/core/daemon/test_daemon_e2e.py
+++ b/tests/core/daemon/test_daemon_e2e.py
@@ -61,7 +61,7 @@ def test_install_scan_serve_end_to_end(tmp_path, monkeypatch):
     captured = {}
     monkeypatch.setattr(
         run_mod, "_serve_forever",
-        lambda control_app, socket_path, host_app, serve_cfg: captured.update(
+        lambda control_app, socket_path, host_app, serve_cfg, tunnel: captured.update(
             control=control_app, host=host_app, serve=serve_cfg,
         ),
     )
@@ -109,7 +109,7 @@ def test_refresh_rereads_daemon_config(tmp_path, monkeypatch):
     captured = {}
     monkeypatch.setattr(
         run_mod, "_serve_forever",
-        lambda control_app, socket_path, host_app, serve_cfg: captured.update(rescan=True),
+        lambda control_app, socket_path, host_app, serve_cfg, tunnel: captured.update(rescan=True),
     )
     store, rescan, _serve = run_mod._build_registry(home)
     assert sorted(e.name for e in store.load().entries) == ["first"]

--- a/tests/core/daemon/test_daemon_e2e.py
+++ b/tests/core/daemon/test_daemon_e2e.py
@@ -80,12 +80,16 @@ def test_install_scan_serve_end_to_end(tmp_path, monkeypatch):
     token = ensure_host_token(home, env={})
     with TestClient(captured["host"]) as client:
         hdrs = {"Authorization": f"Bearer {token}"}
+        host_id = client.get("/health").json()["host_id"]
         ws = client.get("/workspaces", headers=hdrs).json()["workspaces"]
         assert sorted(w["name"] for w in ws) == ["ws-one", "ws-two"]
         for w in ws:
             r = client.get(f"/workspaces/{w['id']}/health", headers=hdrs)
             assert r.status_code == 200
-            assert r.json()["workspace"] == w["name"]
+            body = r.json()
+            assert body["workspace"] == w["name"]
+            assert body["host_id"] == host_id
+            assert body["workspace_id"] == w["id"]
 
     # 4) control app reports the flipped capabilities.
     with TestClient(captured["control"]) as client:

--- a/tests/core/daemon/test_host_app.py
+++ b/tests/core/daemon/test_host_app.py
@@ -800,6 +800,47 @@ def test_standing_token_works_direct_but_never_over_the_relay(
     assert relay_borne.status_code == 401
 
 
+@pytest.fixture
+def relay_domain_app(tmp_path):
+    """The same shape as `bearer_app`, but told which domain the relay serves."""
+    home = tmp_path / "home"
+    store = _seed(home, [_entry("ws-a", "a", tmp_path / "a")])
+    return create_host_app(
+        store,
+        auth_token="standing",
+        verify_bearer=lambda presented: presented == LIVE_BEARER,
+        relay_domain="relay.example",
+        build_subapp=lambda entry, **_kwargs: FakeSubApp(entry.name),
+    )
+
+
+@pytest.mark.parametrize(
+    ("host_header", "expected"),
+    [
+        ("hst-abc.relay.example", 401),      # our subdomain, headers stripped
+        ("HST-ABC.Relay.Example:443", 401),  # DNS is case-insensitive; so is this
+        ("relay.example", 401),              # the relay's own name
+        ("notrelay.example", 200),           # merely ends with the same letters
+        ("192.168.1.5:47190", 200),          # the LAN pairing path (AC9)
+    ],
+)
+def test_relay_host_header_is_relay_borne_even_with_edge_headers_stripped(
+    relay_domain_app, host_header, expected
+):
+    """Defense in depth for AC9: `_EDGE_HEADERS` is the edge's own testimony, so
+    a proxy misconfigured to strip them would silently re-open the standing
+    token to the whole internet. The `Host` the request was addressed to is the
+    second, independent witness — nothing on the LAN reaches this app under the
+    relay's domain."""
+    with TestClient(relay_domain_app) as client:
+        response = client.get(
+            "/workspaces",
+            headers={"Authorization": "Bearer standing", "Host": host_header},
+        )
+
+    assert response.status_code == expected
+
+
 def test_every_guarded_route_401s_without_a_credential(bearer_app):
     app, _built = bearer_app
     with TestClient(app) as client:

--- a/tests/core/daemon/test_host_app.py
+++ b/tests/core/daemon/test_host_app.py
@@ -753,7 +753,13 @@ def test_real_token_stores_compose_through_the_exchange(tmp_path):
     )
 
     with TestClient(app) as client:
-        tampered = client.post("/host/token", json={"refresh": refresh[:-1] + "0"})
+        # Flip the last character to one it CANNOT already be: appending a fixed
+        # hex digit leaves the credential unchanged 1 run in 16, and that run
+        # asserts 401 against the genuine credential.
+        tampered = client.post(
+            "/host/token",
+            json={"refresh": refresh[:-1] + ("1" if refresh[-1] == "0" else "0")},
+        )
         minted = client.post("/host/token", json={"refresh": refresh}).json()
         auth = {"Authorization": f"Bearer {minted['token']}"}
         live = client.get("/workspaces", headers=auth)

--- a/tests/core/daemon/test_host_app.py
+++ b/tests/core/daemon/test_host_app.py
@@ -768,16 +768,27 @@ def test_real_token_stores_compose_through_the_exchange(tmp_path):
     assert revoked.status_code == 401
 
 
-def test_standing_token_works_direct_but_never_over_the_relay(bearer_app):
+@pytest.mark.parametrize(
+    ("edge_header", "value"),
+    [
+        ("X-Forwarded-For", "203.0.113.7"),
+        ("X-Forwarded-Host", "hst-abc.relay.example"),
+        ("X-Forwarded-Proto", "https"),
+    ],
+)
+def test_standing_token_works_direct_but_never_over_the_relay(
+    bearer_app, edge_header, value
+):
     """AC9: no standing credential authorizes relay-borne traffic, while
-    first-time LAN/loopback pairing still works."""
+    first-time LAN/loopback pairing still works. Every header the edge may
+    stamp counts — Caddy sets all three, but only one is needed to give the
+    request away."""
     app, _built = bearer_app
     standing = {"Authorization": "Bearer standing"}
     with TestClient(app) as client:
         assert client.get("/workspaces", headers=standing).status_code == 200
         relay_borne = client.get(
-            "/workspaces",
-            headers={**standing, "X-Forwarded-For": "203.0.113.7"},
+            "/workspaces", headers={**standing, edge_header: value}
         )
 
     assert relay_borne.status_code == 401
@@ -801,6 +812,41 @@ def test_host_token_exchange_needs_no_bearer(bearer_app):
     assert minted.status_code == 200
     assert minted.json() == {"token": "0123456789abcdef.minted", "expires_in": 300}
     assert rejected.status_code == 401
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"refresh": "x" * 4096},   # over the bound
+        {"refresh": ""},           # empty
+        {"refresh": 17},           # wrong type
+        {},                        # missing the field
+        [],                        # not an object
+    ],
+)
+def test_host_token_answers_401_for_every_malformed_body(bearer_app, body):
+    """A 422 here would make the unauthenticated route an oracle separating
+    "malformed" from "wrong" — every failure reads the same."""
+    app, _built = bearer_app
+    with TestClient(app) as client:
+        assert client.post("/host/token", json=body).status_code == 401
+        assert client.post("/host/token", content=b"not json").status_code == 401
+
+
+def test_host_token_route_is_absent_without_an_exchange(tmp_path):
+    """No refresh store means nothing to mint: the route does not exist rather
+    than 401ing on a credential this host could never honour."""
+    home = tmp_path / "home"
+    store = _seed(home, [_entry("ws-a", "a", tmp_path / "a")])
+    app = create_host_app(
+        store,
+        auth_token="standing",
+        verify_bearer=lambda _presented: False,
+        build_subapp=lambda e, **kw: FakeSubApp(e.name),
+    )
+
+    with TestClient(app) as client:
+        assert client.post("/host/token", json={"refresh": "x"}).status_code == 404
 
 
 def test_health_needs_no_bearer_and_reports_identity(tmp_path):
@@ -847,6 +893,25 @@ def test_health_reports_disabled_tunnel_when_no_relay_is_configured(tmp_path):
     assert health["host_id"] is None and health["instance_id"] is None
 
 
+def test_health_runner_reads_the_injected_host_runner_config(tmp_path):
+    """The host-level runner rides the same projection as a workspace's — this
+    is the seam #473 fills; unwired, the host reports no runner."""
+    home = tmp_path / "home"
+    store = _seed(home, [_entry("ws-a", "a", tmp_path / "a")])
+    app = create_host_app(
+        store,
+        auth_token=None,
+        runner_config=lambda: {"enabled": True, "max_concurrency": 1},
+        build_subapp=lambda e, **kw: FakeSubApp(e.name),
+    )
+
+    with TestClient(app) as client:
+        assert client.get("/health").json()["runner"] == {
+            "enabled": True,
+            "state": "unknown",
+        }
+
+
 @pytest.mark.parametrize(
     ("raw_runner", "projected"),
     [
@@ -879,14 +944,14 @@ def test_workspaces_project_runner_and_pass_metarepo_repos_through(
         (listed,) = client.get("/workspaces").json()["workspaces"]
 
     assert listed["runner"] == projected
-    assert [r["name"] for r in listed["repos"]] == ["alpha", "beta"]
-    assert [r["git_root"] for r in listed["repos"]] == [None, None]
+    assert listed["repos"] == [r.model_dump() for r in candidate.repos]
 
 
 def test_workspaces_runner_projection_degrades_a_malformed_block(tmp_path):
     """A non-dict `runner:` must read as disabled, never 500. Driven off an
-    in-memory state: a persisted malformed block never survives
-    `RegistryStore.load`'s validation, so only this seam can carry it."""
+    in-memory state because a persisted one cannot reach the projection at all:
+    `RegistryStore._load_nolock` answers a failed `model_validate` with an
+    EMPTY `RegistryState`, dropping the whole registry rather than one entry."""
     from mship.core.daemon.registry import RegistryState
 
     entry = _entry("ws-a", "a", tmp_path / "a")

--- a/tests/core/daemon/test_host_app.py
+++ b/tests/core/daemon/test_host_app.py
@@ -34,10 +34,15 @@ class FakeSubApp:
         self.name = name
         self.lifespan_started = False
         self.lifespan_stopped = False
+        self.seen_authorization = None
 
     async def __call__(self, scope, receive, send):
         if scope["type"] == "lifespan":  # pragma: no cover - not used via router hack
             return
+        self.seen_authorization = next(
+            (v.decode() for k, v in scope["headers"] if k.lower() == b"authorization"),
+            None,
+        )
         body = f'{{"workspace": "{self.name}", "path": "{scope["path"]}"}}'.encode()
         await send({"type": "http.response.start", "status": 200,
                     "headers": [(b"content-type", b"application/json")]})
@@ -125,11 +130,12 @@ def test_health_count_and_list_distinguish_degraded_from_missing(tmp_path):
     )
 
     with TestClient(app) as client:
-        assert client.get("/health").json() == {
-            "status": "ok",
-            "workspaces": 3,
-            "degraded": 1,
-        }
+        health = client.get("/health").json()
+        assert (health["status"], health["workspaces"], health["degraded"]) == (
+            "ok",
+            3,
+            1,
+        )
         workspaces = client.get("/workspaces").json()["workspaces"]
 
     assert {workspace["state"] for workspace in workspaces} == {
@@ -661,6 +667,247 @@ def test_workspace_config_edit_rebuilds_subapp(tmp_path):
         client.get("/workspaces/ws-e/specs")
 
     assert built == [str(workspace), str(workspace)]
+
+
+### #471 Task 3 — tiered auth, forwarded-header rewrite, identity + runner ###
+
+LIVE_BEARER = "0123456789abcdef.live-secret"
+
+
+@pytest.fixture
+def bearer_app(tmp_path):
+    """Host app in its #471 shape: a short-lived bearer verifier for callers,
+    the standing token repurposed as the internal sub-app credential."""
+    home = tmp_path / "home"
+    store = _seed(home, [_entry("ws-a", "a", tmp_path / "a")])
+    built: dict[str, FakeSubApp] = {}
+
+    def build(entry, **_kwargs):
+        sub = FakeSubApp(entry.name)
+        built[entry.id] = sub
+        return sub
+
+    app = create_host_app(
+        store,
+        auth_token="standing",
+        verify_bearer=lambda presented: presented == LIVE_BEARER,
+        exchange_refresh=lambda refresh: (
+            ("0123456789abcdef.minted", 300) if refresh == "good-refresh" else None
+        ),
+        build_subapp=build,
+    )
+    return app, built
+
+
+def test_short_lived_bearer_authorizes_list_and_forwarded_call(bearer_app):
+    """The forward must rewrite Authorization: the sub-app knows only the
+    standing token, so passing the caller's bearer through 401s every call."""
+    app, built = bearer_app
+    auth = {"Authorization": f"Bearer {LIVE_BEARER}"}
+    with TestClient(app) as client:
+        assert client.get("/workspaces", headers=auth).status_code == 200
+        forwarded = client.get("/workspaces/ws-a/specs", headers=auth)
+
+    assert forwarded.status_code == 200
+    assert built["ws-a"].seen_authorization == "Bearer standing"
+
+
+def test_foreign_bearer_is_rejected_on_the_list_and_the_forward(bearer_app):
+    app, _built = bearer_app
+    auth = {"Authorization": "Bearer 0123456789abcdef.minted-elsewhere"}
+    with TestClient(app) as client:
+        assert client.get("/workspaces", headers=auth).status_code == 401
+        assert client.get("/workspaces/ws-a/specs", headers=auth).status_code == 401
+
+
+def test_real_token_stores_compose_through_the_exchange(tmp_path):
+    """The whole loop over the shipped stores, on a stepped clock: refresh in,
+    bearer out, bearer authorizes, bearer expires, revoked refresh mints no
+    more. Nothing here is stubbed but the wall clock."""
+    from mship.core.daemon.host_auth import RefreshStore
+    from mship.core.daemon.host_token import issue_host_token, verify_host_token
+    from mship.core.relay.token_clock import AnchoredClock
+
+    home = tmp_path / "home"
+    now = {"t": 1_000.0}
+    clock = AnchoredClock(
+        wall=lambda: now["t"], mono=lambda: now["t"], epoch="test-epoch"
+    )
+    refresh_store = RefreshStore(home, clock=lambda: now["t"])
+    refresh = refresh_store.issue_refresh(host_id="hst-1", client="phone")
+
+    def exchange(credential):
+        if refresh_store.verify_refresh(credential) is None:
+            return None
+        return issue_host_token(home, ttl_seconds=300, clock=clock), 300
+
+    store = _seed(home, [_entry("ws-a", "a", tmp_path / "a")])
+    app = create_host_app(
+        store,
+        auth_token="standing",
+        verify_bearer=lambda presented: (
+            verify_host_token(home, presented, clock=clock) is not None
+        ),
+        exchange_refresh=exchange,
+        build_subapp=lambda e, **kw: FakeSubApp(e.name),
+    )
+
+    with TestClient(app) as client:
+        tampered = client.post("/host/token", json={"refresh": refresh[:-1] + "0"})
+        minted = client.post("/host/token", json={"refresh": refresh}).json()
+        auth = {"Authorization": f"Bearer {minted['token']}"}
+        live = client.get("/workspaces", headers=auth)
+        now["t"] += minted["expires_in"] + 1
+        after_expiry = client.get("/workspaces", headers=auth)
+        refresh_store.revoke(host_id="hst-1", client="phone")
+        revoked = client.post("/host/token", json={"refresh": refresh})
+
+    assert tampered.status_code == 401
+    assert live.status_code == 200
+    assert after_expiry.status_code == 401
+    assert revoked.status_code == 401
+
+
+def test_standing_token_works_direct_but_never_over_the_relay(bearer_app):
+    """AC9: no standing credential authorizes relay-borne traffic, while
+    first-time LAN/loopback pairing still works."""
+    app, _built = bearer_app
+    standing = {"Authorization": "Bearer standing"}
+    with TestClient(app) as client:
+        assert client.get("/workspaces", headers=standing).status_code == 200
+        relay_borne = client.get(
+            "/workspaces",
+            headers={**standing, "X-Forwarded-For": "203.0.113.7"},
+        )
+
+    assert relay_borne.status_code == 401
+
+
+def test_every_guarded_route_401s_without_a_credential(bearer_app):
+    app, _built = bearer_app
+    with TestClient(app) as client:
+        assert client.get("/workspaces").status_code == 401
+        assert client.post("/workspaces/refresh").status_code == 401
+        assert client.get("/workspaces/ws-a/specs").status_code == 401
+
+
+def test_host_token_exchange_needs_no_bearer(bearer_app):
+    """The bootstrap route cannot require the credential it exists to mint."""
+    app, _built = bearer_app
+    with TestClient(app) as client:
+        minted = client.post("/host/token", json={"refresh": "good-refresh"})
+        rejected = client.post("/host/token", json={"refresh": "revoked-refresh"})
+
+    assert minted.status_code == 200
+    assert minted.json() == {"token": "0123456789abcdef.minted", "expires_in": 300}
+    assert rejected.status_code == 401
+
+
+def test_health_needs_no_bearer_and_reports_identity(tmp_path):
+    """The daemon's own read-back and GC's ladder both poll /health, so it
+    stays unauthenticated (and writes nothing — AC11)."""
+    home = tmp_path / "home"
+    store = _seed(home, [_entry("ws-a", "a", tmp_path / "a")])
+    app = create_host_app(
+        store,
+        auth_token="standing",
+        verify_bearer=lambda _presented: False,
+        host_id="hst-20260817-abcd1234",
+        instance_id="0123456789abcdef",
+        host_state=lambda: {"state": "online", "subdomain": "hst-abc"},
+        build_subapp=lambda e, **kw: FakeSubApp(e.name),
+    )
+
+    with TestClient(app) as client:
+        health = client.get("/health")
+
+    assert health.status_code == 200
+    assert health.json() == {
+        "status": "ok",
+        "host_id": "hst-20260817-abcd1234",
+        "instance_id": "0123456789abcdef",
+        "workspaces": 1,
+        "degraded": 0,
+        "tunnel": {"state": "online", "subdomain": "hst-abc"},
+        "runner": {"enabled": False, "state": "disabled"},
+    }
+
+
+def test_health_reports_disabled_tunnel_when_no_relay_is_configured(tmp_path):
+    home = tmp_path / "home"
+    store = _seed(home, [_entry("ws-a", "a", tmp_path / "a")])
+    app = create_host_app(
+        store, auth_token=None, build_subapp=lambda e, **kw: FakeSubApp(e.name)
+    )
+
+    with TestClient(app) as client:
+        health = client.get("/health").json()
+
+    assert health["tunnel"] == {"state": "disabled"}
+    assert health["host_id"] is None and health["instance_id"] is None
+
+
+@pytest.mark.parametrize(
+    ("raw_runner", "projected"),
+    [
+        ({"enabled": True, "max_concurrency": 2}, {"enabled": True, "state": "unknown"}),
+        ({"enabled": False}, {"enabled": False, "state": "disabled"}),
+        (None, {"enabled": False, "state": "disabled"}),
+    ],
+)
+def test_workspaces_project_runner_and_pass_metarepo_repos_through(
+    tmp_path, raw_runner, projected
+):
+    """AC6: #473's opaque `runner:` block rides this projection (#471 reports
+    unknown, never a state it cannot know). Assumption 1: the metarepo shape
+    passes through the same projection untouched."""
+    from mship.core.daemon.discovery import scan_roots
+    from mship.core.daemon.registry import DaemonConfig
+    from tests.core.daemon.test_discovery import _mk_metarepo
+
+    home = tmp_path / "home"
+    roots = tmp_path / "roots"
+    workspace = _mk_metarepo(roots, "meta")
+    (candidate,) = scan_roots(DaemonConfig(scan_roots=[str(roots)]))
+    entry = _entry("ws-meta", "meta", workspace, repos=candidate.repos, runner=raw_runner)
+    store = _seed(home, [entry])
+    app = create_host_app(
+        store, auth_token=None, build_subapp=lambda e, **kw: FakeSubApp(e.name)
+    )
+
+    with TestClient(app) as client:
+        (listed,) = client.get("/workspaces").json()["workspaces"]
+
+    assert listed["runner"] == projected
+    assert [r["name"] for r in listed["repos"]] == ["alpha", "beta"]
+    assert [r["git_root"] for r in listed["repos"]] == [None, None]
+
+
+def test_workspaces_runner_projection_degrades_a_malformed_block(tmp_path):
+    """A non-dict `runner:` must read as disabled, never 500. Driven off an
+    in-memory state: a persisted malformed block never survives
+    `RegistryStore.load`'s validation, so only this seam can carry it."""
+    from mship.core.daemon.registry import RegistryState
+
+    entry = _entry("ws-a", "a", tmp_path / "a")
+    entry.runner = "not-a-block"  # assignment: the constructor would reject it
+
+    class _MemoryStore:
+        def load(self):
+            return RegistryState(entries=[entry])
+
+    app = create_host_app(
+        _MemoryStore(), auth_token=None, build_subapp=lambda e, **kw: FakeSubApp(e.name)
+    )
+
+    with TestClient(app) as client:
+        listed = client.get("/workspaces")
+
+    assert listed.status_code == 200
+    assert listed.json()["workspaces"][0]["runner"] == {
+        "enabled": False,
+        "state": "disabled",
+    }
 
 
 def test_unbuildable_workspace_is_503_not_500(tmp_path):

--- a/tests/core/daemon/test_host_app.py
+++ b/tests/core/daemon/test_host_app.py
@@ -854,10 +854,15 @@ def test_host_token_exchange_needs_no_bearer(bearer_app):
     app, _built = bearer_app
     with TestClient(app) as client:
         minted = client.post("/host/token", json={"refresh": "good-refresh"})
+        form_minted = client.post(
+            "/host/token", data={"refresh": "good-refresh"}
+        )
         rejected = client.post("/host/token", json={"refresh": "revoked-refresh"})
 
     assert minted.status_code == 200
     assert minted.json() == {"token": "0123456789abcdef.minted", "expires_in": 300}
+    assert form_minted.status_code == 200
+    assert form_minted.json() == minted.json()
     assert rejected.status_code == 401
 
 
@@ -878,6 +883,59 @@ def test_host_token_answers_401_for_every_malformed_body(bearer_app, body):
     with TestClient(app) as client:
         assert client.post("/host/token", json=body).status_code == 401
         assert client.post("/host/token", content=b"not json").status_code == 401
+
+
+def test_host_token_stops_reading_as_soon_as_the_body_limit_is_exceeded(
+    bearer_app,
+):
+    """The public exchange must reject the first oversized chunk without
+    requesting the unbounded remainder from the ASGI receive channel."""
+    import asyncio
+
+    app, _built = bearer_app
+
+    async def drive():
+        receive_calls = 0
+        sent = []
+
+        async def receive():
+            nonlocal receive_calls
+            receive_calls += 1
+            if receive_calls > 1:
+                raise AssertionError("oversized request body was still being buffered")
+            return {
+                "type": "http.request",
+                "body": b"x" * 2048,
+                "more_body": True,
+            }
+
+        async def send(message):
+            sent.append(message)
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "POST",
+            "path": "/host/token",
+            "raw_path": b"/host/token",
+            "root_path": "",
+            "scheme": "http",
+            "query_string": b"",
+            "headers": [(b"content-type", b"application/json")],
+            "client": ("test", 1),
+            "server": ("test", 80),
+        }
+        async with app.router.lifespan_context(app):
+            await asyncio.wait_for(app(scope, receive, send), timeout=5)
+        return receive_calls, sent
+
+    receive_calls, sent = asyncio.run(drive())
+    response_start = next(
+        message for message in sent if message["type"] == "http.response.start"
+    )
+    assert receive_calls == 1
+    assert response_start["status"] == 401
 
 
 def test_host_token_route_is_absent_without_an_exchange(tmp_path):

--- a/tests/core/daemon/test_host_auth.py
+++ b/tests/core/daemon/test_host_auth.py
@@ -151,10 +151,15 @@ def test_verify_never_raises_on_a_corrupt_store(tmp_path: Path):
 def test_verify_writes_nothing(tmp_path: Path):
     store = _store(tmp_path)
     cred = store.issue_refresh(host_id=HOST, client="phone-a")
-    before = host_refresh_path(tmp_path).read_bytes()
+    data_path = host_refresh_path(tmp_path)
+    lock_path = data_path.with_name(data_path.name + ".lock")
+    before = data_path.read_bytes()
+    os.utime(lock_path, ns=(1_000_000_000, 1_000_000_000))
+    lock_mtime = lock_path.stat().st_mtime_ns
     for _ in range(5):
         assert store.verify_refresh(cred) is not None
-    assert host_refresh_path(tmp_path).read_bytes() == before
+    assert data_path.read_bytes() == before
+    assert lock_path.stat().st_mtime_ns == lock_mtime
 
 
 def test_expired_credentials_are_rejected_and_pruned_on_issue(tmp_path: Path):

--- a/tests/core/daemon/test_host_auth.py
+++ b/tests/core/daemon/test_host_auth.py
@@ -1,0 +1,176 @@
+"""Refresh credentials (#471 Task 2): stable per client, revocable, hash-at-rest.
+
+AC11's bound lives here: a network flap re-registers, and re-registration must
+re-publish the SAME credential rather than mint a second one — otherwise N
+reconnects leave N rows in `~/.mothership/daemon/` and the phone's stored
+credential silently becomes one of many.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mship.core.daemon.host_auth import (
+    MAX_REFRESH_CLIENTS,
+    REFRESH_TTL_S,
+    RefreshStore,
+)
+from mship.core.daemon.paths import host_refresh_path
+
+HOST = "hst-20260817120000-abcd1234"
+
+
+class _Wall:
+    """Fake wall clock; refresh credentials are long-lived, so wall time (with
+    the shared skew grace) is the right bound for them."""
+
+    def __init__(self, t: float = 1_700_000_000.0):
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+def _store(home: Path, clock=None, **kw) -> RefreshStore:
+    return RefreshStore(home, clock=clock or _Wall(), **kw)
+
+
+def _records(home: Path) -> dict:
+    return json.loads(host_refresh_path(home).read_text())["clients"]
+
+
+def test_issue_verify_roundtrip(tmp_path: Path):
+    store = _store(tmp_path)
+    cred = store.issue_refresh(host_id=HOST, client="phone-a")
+    grant = store.verify_refresh(cred)
+    assert grant is not None
+    assert grant.client == "phone-a"
+    assert grant.host_id == HOST
+
+
+def test_only_the_hash_is_persisted(tmp_path: Path):
+    store = _store(tmp_path)
+    cred = store.issue_refresh(host_id=HOST, client="phone-a")
+    _cid, secret = cred.split(".", 1)
+    assert secret not in host_refresh_path(tmp_path).read_text()
+
+
+def test_reissue_returns_the_same_credential_and_writes_nothing(tmp_path: Path):
+    """AC11: N re-registrations leave the file byte-identical and produce
+    exactly one entry."""
+    store = _store(tmp_path)
+    first = store.issue_refresh(host_id=HOST, client="phone-a")
+    after_first = host_refresh_path(tmp_path).read_bytes()
+
+    for _ in range(5):
+        assert store.issue_refresh(host_id=HOST, client="phone-a") == first
+
+    assert host_refresh_path(tmp_path).read_bytes() == after_first
+    assert len(_records(tmp_path)) == 1
+
+
+def test_reissue_is_stable_across_store_instances(tmp_path: Path):
+    """A daemon restart between registrations must not re-mint either."""
+    first = _store(tmp_path).issue_refresh(host_id=HOST, client="phone-a")
+    after_first = host_refresh_path(tmp_path).read_bytes()
+    assert _store(tmp_path).issue_refresh(host_id=HOST, client="phone-a") == first
+    assert host_refresh_path(tmp_path).read_bytes() == after_first
+
+
+def test_distinct_clients_get_distinct_credentials(tmp_path: Path):
+    store = _store(tmp_path)
+    a = store.issue_refresh(host_id=HOST, client="phone-a")
+    b = store.issue_refresh(host_id=HOST, client="phone-b")
+    assert a != b
+    assert store.verify_refresh(a).client == "phone-a"
+    assert store.verify_refresh(b).client == "phone-b"
+    assert len(_records(tmp_path)) == 2
+
+
+def test_revoke_kills_one_client_and_leaves_its_sibling_working(tmp_path: Path):
+    store = _store(tmp_path)
+    a = store.issue_refresh(host_id=HOST, client="phone-a")
+    b = store.issue_refresh(host_id=HOST, client="phone-b")
+
+    assert store.revoke(host_id=HOST, client="phone-a") is True
+    assert store.verify_refresh(a) is None
+    assert store.verify_refresh(b) is not None
+    assert store.revoke(host_id=HOST, client="phone-a") is False  # already gone
+
+
+def test_reissue_after_revoke_mints_a_new_credential(tmp_path: Path):
+    """Revocation must be real: re-registering the same client name cannot
+    resurrect the credential the operator just killed."""
+    store = _store(tmp_path)
+    a = store.issue_refresh(host_id=HOST, client="phone-a")
+    store.revoke(host_id=HOST, client="phone-a")
+    again = store.issue_refresh(host_id=HOST, client="phone-a")
+    assert again != a
+    assert store.verify_refresh(a) is None
+    assert store.verify_refresh(again) is not None
+
+
+def test_a_credential_is_scoped_to_its_host(tmp_path: Path):
+    store = _store(tmp_path)
+    a = store.issue_refresh(host_id=HOST, client="phone-a")
+    other = store.issue_refresh(host_id="hst-other", client="phone-a")
+    assert a != other
+    assert store.verify_refresh(a).host_id == HOST
+    assert store.verify_refresh(other).host_id == "hst-other"
+
+
+def test_verify_rejects_a_wrong_secret(tmp_path: Path):
+    store = _store(tmp_path)
+    cred = store.issue_refresh(host_id=HOST, client="phone-a")
+    cid = cred.split(".", 1)[0]
+    assert store.verify_refresh(f"{cid}.wrong") is None
+
+
+@pytest.mark.parametrize("presented", [
+    "", "no-dot", ".", "abc.", "../../../etc/passwd.x", "NOTHEX.s", "deadbeef.s",
+])
+def test_verify_never_raises_on_hostile_input(tmp_path: Path, presented: str):
+    store = _store(tmp_path)
+    store.issue_refresh(host_id=HOST, client="phone-a")
+    assert store.verify_refresh(presented) is None
+
+
+def test_verify_never_raises_on_a_corrupt_store(tmp_path: Path):
+    store = _store(tmp_path)
+    cred = store.issue_refresh(host_id=HOST, client="phone-a")
+    host_refresh_path(tmp_path).write_text("{not json")
+    assert store.verify_refresh(cred) is None
+
+
+def test_verify_writes_nothing(tmp_path: Path):
+    store = _store(tmp_path)
+    cred = store.issue_refresh(host_id=HOST, client="phone-a")
+    before = host_refresh_path(tmp_path).read_bytes()
+    for _ in range(5):
+        assert store.verify_refresh(cred) is not None
+    assert host_refresh_path(tmp_path).read_bytes() == before
+
+
+def test_expired_credentials_are_rejected_and_pruned_on_issue(tmp_path: Path):
+    clock = _Wall()
+    store = _store(tmp_path, clock=clock)
+    stale = store.issue_refresh(host_id=HOST, client="phone-a")
+    clock.advance(REFRESH_TTL_S + 86_400)
+    assert store.verify_refresh(stale) is None
+
+    store.issue_refresh(host_id=HOST, client="phone-b")
+    assert set(r["client"] for r in _records(tmp_path).values()) == {"phone-b"}
+
+
+def test_the_store_is_capped(tmp_path: Path):
+    clock = _Wall()
+    store = _store(tmp_path, clock=clock)
+    for i in range(MAX_REFRESH_CLIENTS + 3):
+        store.issue_refresh(host_id=HOST, client=f"phone-{i}")
+        clock.advance(1)  # distinct created_at, so "drop the oldest" is defined
+    assert len(_records(tmp_path)) == MAX_REFRESH_CLIENTS

--- a/tests/core/daemon/test_host_auth.py
+++ b/tests/core/daemon/test_host_auth.py
@@ -8,6 +8,7 @@ credential silently becomes one of many.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -17,7 +18,7 @@ from mship.core.daemon.host_auth import (
     REFRESH_TTL_S,
     RefreshStore,
 )
-from mship.core.daemon.paths import host_refresh_path
+from mship.core.daemon.paths import daemon_state_dir, host_refresh_path
 
 HOST = "hst-20260817120000-abcd1234"
 
@@ -174,3 +175,63 @@ def test_the_store_is_capped(tmp_path: Path):
         store.issue_refresh(host_id=HOST, client=f"phone-{i}")
         clock.advance(1)  # distinct created_at, so "drop the oldest" is defined
     assert len(_records(tmp_path)) == MAX_REFRESH_CLIENTS
+
+
+def test_every_issued_credential_verifies_while_the_cap_churns(tmp_path: Path):
+    """The cap must never evict the credential it is handing back — including
+    the pathological case where the new record is the oldest by tie-break."""
+    clock = _Wall()
+    store = _store(tmp_path, clock=clock)
+    for i in range(MAX_REFRESH_CLIENTS + 5):
+        cred = store.issue_refresh(host_id=HOST, client=f"phone-{i}")
+        assert store.verify_refresh(cred) is not None, f"evicted its own mint at {i}"
+
+
+def test_revoke_prunes_expired_siblings(tmp_path: Path):
+    clock = _Wall()
+    store = _store(tmp_path, clock=clock)
+    store.issue_refresh(host_id=HOST, client="stale")
+    clock.advance(REFRESH_TTL_S + 86_400)
+    store.issue_refresh(host_id=HOST, client="live")
+    store.issue_refresh(host_id=HOST, client="doomed")
+
+    assert store.revoke(host_id=HOST, client="doomed") is True
+    assert set(r["client"] for r in _records(tmp_path).values()) == {"live"}
+
+
+# --- the state dir is owner-only, whatever the umask -----------------------
+
+
+@pytest.fixture
+def loose_umask():
+    """A permissive umask, so these assertions test the corrective chmod rather
+    than the ambient umask (mkdir's mode argument is umask-masked)."""
+    previous = os.umask(0o002)
+    try:
+        yield
+    finally:
+        os.umask(previous)
+
+
+def _mode(path: Path) -> str:
+    return oct(path.stat().st_mode & 0o777)
+
+
+def test_state_dir_and_store_are_owner_only(tmp_path: Path, loose_umask):
+    store = _store(tmp_path)
+    cred = store.issue_refresh(host_id=HOST, client="phone-a")
+    assert _mode(daemon_state_dir(tmp_path)) == "0o700"
+    assert _mode(host_refresh_path(tmp_path)) == "0o600"
+
+    store.verify_refresh(cred)
+    store.revoke(host_id=HOST, client="phone-a")
+    assert _mode(daemon_state_dir(tmp_path)) == "0o700"
+    assert _mode(host_refresh_path(tmp_path)) == "0o600"
+
+
+def test_a_pre_existing_loose_state_dir_is_tightened(tmp_path: Path, loose_umask):
+    state_dir = daemon_state_dir(tmp_path)
+    state_dir.mkdir(parents=True)
+    state_dir.chmod(0o755)
+    _store(tmp_path).issue_refresh(host_id=HOST, client="phone-a")
+    assert _mode(state_dir) == "0o700"

--- a/tests/core/daemon/test_host_auth.py
+++ b/tests/core/daemon/test_host_auth.py
@@ -18,7 +18,7 @@ from mship.core.daemon.host_auth import (
     REFRESH_TTL_S,
     RefreshStore,
 )
-from mship.core.daemon.paths import daemon_state_dir, host_refresh_path
+from mship.core.daemon.paths import daemon_state_dir, host_refresh_path, host_secret_path
 
 HOST = "hst-20260817120000-abcd1234"
 
@@ -166,6 +166,35 @@ def test_expired_credentials_are_rejected_and_pruned_on_issue(tmp_path: Path):
 
     store.issue_refresh(host_id=HOST, client="phone-b")
     assert set(r["client"] for r in _records(tmp_path).values()) == {"phone-b"}
+
+
+def test_wall_clock_step_back_does_not_extend_a_refresh_credential(tmp_path: Path):
+    wall = _Wall()
+    mono = _Wall(0)
+    store = _store(
+        tmp_path,
+        clock=wall,
+        monotonic_clock=mono,
+        epoch="boot-a",
+    )
+    credential = store.issue_refresh(host_id=HOST, client="phone-a")
+
+    wall.advance(-86_400)
+    mono.advance(REFRESH_TTL_S)
+
+    assert store.verify_refresh(credential) is None
+
+
+def test_reissue_repairs_the_hash_after_root_secret_regeneration(tmp_path: Path):
+    store = _store(tmp_path)
+    original = store.issue_refresh(host_id=HOST, client="phone-a")
+    host_secret_path(tmp_path).unlink()
+
+    replacement = store.issue_refresh(host_id=HOST, client="phone-a")
+
+    assert replacement != original
+    assert store.verify_refresh(original) is None
+    assert store.verify_refresh(replacement) is not None
 
 
 def test_the_store_is_capped(tmp_path: Path):

--- a/tests/core/daemon/test_host_identity.py
+++ b/tests/core/daemon/test_host_identity.py
@@ -1,0 +1,159 @@
+"""Host identity (#471 Task 1): minted, machine-bound, workspace-free.
+
+The three-net clone story lives here in part: net (a) — this file — catches a
+RE-IMAGED host (fingerprint changed). A `cp -a` clone copies the fingerprint
+verbatim, so net (a) deliberately does NOT fire for it; that is the relay's job
+(net (b), Task 4). Both are asserted below so the boundary is explicit.
+"""
+import ast
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from mship.core.daemon.identity import (
+    ensure_host_identity,
+    machine_fingerprint,
+    mint_host_id,
+    mint_instance_id,
+)
+from mship.core.daemon.paths import host_identity_path
+from mship.core.relay.tls_ask import tls_ask_allowed
+from mship.core.relay.tunnel import device_subdomain, host_subdomain
+
+NOW = datetime(2026, 8, 17, 18, 0, tzinfo=timezone.utc)
+
+
+def _noop_rotate(home):
+    pass
+
+
+def test_mint_on_empty_home(tmp_path: Path):
+    ident = ensure_host_identity(tmp_path, fingerprint="fp-A", now=NOW, rotate_key=_noop_rotate)
+    assert ident.host_id.startswith("hst-20260817")
+    assert ident.fingerprint == "fp-A"
+    path = host_identity_path(tmp_path)
+    assert (path.stat().st_mode & 0o777) == 0o600
+    assert json.loads(path.read_text())["host_id"] == ident.host_id
+
+
+def test_idempotent_and_per_home(tmp_path: Path):
+    a1 = ensure_host_identity(tmp_path / "a", fingerprint="fp", rotate_key=_noop_rotate)
+    a2 = ensure_host_identity(tmp_path / "a", fingerprint="fp", rotate_key=_noop_rotate)
+    b = ensure_host_identity(tmp_path / "b", fingerprint="fp", rotate_key=_noop_rotate)
+    assert a1.host_id == a2.host_id
+    assert b.host_id != a1.host_id  # AC5 at the identity layer
+
+
+def test_reimage_reidentifies_once_and_rotates_key(tmp_path: Path):
+    rotated = []
+    first = ensure_host_identity(tmp_path, fingerprint="A", rotate_key=lambda h: rotated.append(h))
+    second = ensure_host_identity(tmp_path, fingerprint="B", rotate_key=lambda h: rotated.append(h))
+    assert second.host_id != first.host_id
+    assert second.cloned_from == first.host_id
+    assert second.reidentified is True
+    assert rotated == [tmp_path]  # the clone's copied key must stop working
+    third = ensure_host_identity(tmp_path, fingerprint="B", rotate_key=lambda h: rotated.append(h))
+    assert third.host_id == second.host_id  # stable; no re-identify loop
+    assert third.reidentified is False
+    assert rotated == [tmp_path]
+
+
+def test_real_key_rotation_moves_key_aside(tmp_path: Path):
+    from mship.core.relay.keys import relay_key_path
+
+    key = relay_key_path(tmp_path)
+    key.parent.mkdir(parents=True, exist_ok=True)
+    key.write_text("PRIVATE")
+    key.with_name(key.name + ".pub").write_text("ssh-ed25519 AAAAC3Nz mship-relay")
+    ensure_host_identity(tmp_path, fingerprint="A")
+    ensure_host_identity(tmp_path, fingerprint="B")
+    assert not key.exists()
+    assert any(p.name.startswith("relay_ed25519.pre-reidentify-") for p in key.parent.iterdir())
+
+
+def test_keep_adopts_without_rotating(tmp_path: Path):
+    rotated = []
+    first = ensure_host_identity(tmp_path, fingerprint="A", rotate_key=lambda h: rotated.append(h))
+    kept = ensure_host_identity(
+        tmp_path, fingerprint="B", on_mismatch="keep", rotate_key=lambda h: rotated.append(h)
+    )
+    assert kept.host_id == first.host_id
+    assert kept.adopted_fingerprint == "B"
+    assert rotated == []
+    # the adoption persisted: B is now the recorded fingerprint
+    assert ensure_host_identity(tmp_path, fingerprint="B", rotate_key=_noop_rotate).host_id == first.host_id
+
+
+def test_absent_fingerprint_is_never_a_mismatch(tmp_path: Path):
+    """Containers report no machine-id; that must not raise a clone alarm."""
+    first = ensure_host_identity(tmp_path, fingerprint=None, rotate_key=_noop_rotate)
+    again = ensure_host_identity(tmp_path, fingerprint=None, rotate_key=_noop_rotate)
+    assert again.host_id == first.host_id
+    assert again.reidentified is False
+    # and a host that starts reporting one later is not treated as a clone
+    later = ensure_host_identity(tmp_path, fingerprint="A", rotate_key=_noop_rotate)
+    assert later.host_id == first.host_id
+
+
+def test_fingerprint_identical_clone_does_not_fire_net_a(tmp_path: Path):
+    """`cp -a` copies /etc/machine-id verbatim: net (a) deliberately cannot see
+    it, which is precisely why the relay's live-claimant arbitration exists."""
+    src = tmp_path / "src"
+    ensure_host_identity(src, fingerprint="same", rotate_key=_noop_rotate)
+    clone = tmp_path / "clone"
+    clone.mkdir()
+    (clone / ".mothership" / "daemon").mkdir(parents=True)
+    host_identity_path(clone).write_bytes(host_identity_path(src).read_bytes())
+    cloned = ensure_host_identity(clone, fingerprint="same", rotate_key=_noop_rotate)
+    assert cloned.reidentified is False
+    assert cloned.host_id == ensure_host_identity(src, fingerprint="same", rotate_key=_noop_rotate).host_id
+
+
+def test_corrupt_file_remints(tmp_path: Path):
+    path = host_identity_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text("{truncated")
+    ident = ensure_host_identity(tmp_path, fingerprint="A", rotate_key=_noop_rotate)
+    assert ident.host_id.startswith("hst-")
+
+
+def test_instance_id_is_per_process_and_never_persisted(tmp_path: Path):
+    a, b = mint_instance_id(), mint_instance_id()
+    assert a != b and len(a) == 16
+    ensure_host_identity(tmp_path, fingerprint="A", rotate_key=_noop_rotate)
+    raw = host_identity_path(tmp_path).read_text()
+    assert a not in raw and "instance" not in raw  # a clone must not be able to copy it
+
+
+def test_machine_fingerprint_reads_first_available(tmp_path: Path):
+    empty, good = tmp_path / "empty", tmp_path / "good"
+    empty.write_text("   \n")
+    good.write_text("abc123\n")
+    assert machine_fingerprint([tmp_path / "absent", empty, good]) == "abc123"
+    assert machine_fingerprint([tmp_path / "absent"]) is None
+
+
+def test_host_subdomain_shape_and_tls(tmp_path: Path):
+    secret = b"x" * 32
+    host_id = mint_host_id(NOW)
+    sub = host_subdomain(host_id, "abc123", secret)
+    assert len(sub) <= 63
+    assert sub != device_subdomain("some-workspace", "abc123", secret)
+    # AC3: the existing cert allowlist already admits this shape — no TLS change
+    assert tls_ask_allowed(f"{sub}.relay.example.com", "relay.example.com")
+
+
+def test_host_modules_are_workspace_free():
+    """Assumption-header invariant: host identity must not depend on which
+    workspaces this daemon serves."""
+    src = Path(__file__).resolve().parents[3] / "src" / "mship" / "core" / "daemon" / "identity.py"
+    tree = ast.parse(src.read_text())
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+    assert not any(m in imported for m in ("mship.core.config", "mship.core.workspace_context"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            args = {a.arg for a in node.args.args + node.args.kwonlyargs}
+            assert not (args & {"workspace", "repos", "config", "workspace_root"}), node.name

--- a/tests/core/daemon/test_host_identity.py
+++ b/tests/core/daemon/test_host_identity.py
@@ -53,6 +53,11 @@ def test_reimage_reidentifies_once_and_rotates_key(tmp_path: Path):
     assert second.host_id != first.host_id
     assert second.cloned_from == first.host_id
     assert second.reidentified is True
+    # The RUNNING machine's fingerprint is what gets recorded — the branch now
+    # delegates to force_reidentify, whose fallback would otherwise carry the
+    # stale one forward and re-fire the mismatch on every call.
+    assert second.fingerprint == "B"
+    assert json.loads(host_identity_path(tmp_path).read_text())["fingerprint"] == "B"
     assert rotated == [tmp_path]  # the clone's copied key must stop working
     third = ensure_host_identity(tmp_path, fingerprint="B", rotate_key=lambda h: rotated.append(h))
     assert third.host_id == second.host_id  # stable; no re-identify loop

--- a/tests/core/daemon/test_host_identity.py
+++ b/tests/core/daemon/test_host_identity.py
@@ -39,6 +39,35 @@ def test_mint_on_empty_home(tmp_path: Path):
     assert json.loads(path.read_text())["host_id"] == ident.host_id
 
 
+def test_identity_write_retries_short_writes_and_syncs_file_and_directory(
+    tmp_path: Path, monkeypatch
+):
+    from mship.core.daemon import identity as identity_mod
+
+    real_write = identity_mod.os.write
+    write_sizes = []
+    fsynced = []
+
+    def short_write(fd, data):
+        chunk = bytes(data[:3])
+        write_sizes.append(len(chunk))
+        return real_write(fd, chunk)
+
+    monkeypatch.setattr(identity_mod.os, "write", short_write)
+    monkeypatch.setattr(identity_mod.os, "fsync", lambda fd: fsynced.append(fd))
+
+    ident = ensure_host_identity(
+        tmp_path, fingerprint="fp-A", now=NOW, rotate_key=_noop_rotate
+    )
+
+    assert len(write_sizes) > 1
+    assert (
+        json.loads(host_identity_path(tmp_path).read_text())["host_id"]
+        == ident.host_id
+    )
+    assert len(fsynced) == 2
+
+
 def test_idempotent_and_per_home(tmp_path: Path):
     a1 = ensure_host_identity(tmp_path / "a", fingerprint="fp", rotate_key=_noop_rotate)
     a2 = ensure_host_identity(tmp_path / "a", fingerprint="fp", rotate_key=_noop_rotate)

--- a/tests/core/daemon/test_host_identity.py
+++ b/tests/core/daemon/test_host_identity.py
@@ -151,6 +151,8 @@ WORKSPACE_FREE_MODULES = (
     "identity.py",
     "host_token.py",
     "host_auth.py",
+    "capabilities.py",
+    "relay_link.py",
 )
 
 _FORBIDDEN_IMPORTS = ("mship.core.config", "mship.core.workspace_context")

--- a/tests/core/daemon/test_host_identity.py
+++ b/tests/core/daemon/test_host_identity.py
@@ -10,6 +10,8 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 from mship.core.daemon.identity import (
     ensure_host_identity,
     machine_fingerprint,
@@ -143,17 +145,33 @@ def test_host_subdomain_shape_and_tls(tmp_path: Path):
     assert tls_ask_allowed(f"{sub}.relay.example.com", "relay.example.com")
 
 
-def test_host_modules_are_workspace_free():
-    """Assumption-header invariant: host identity must not depend on which
+# Every host-level module #471 adds. Extend this list as tasks 3+ land — the
+# invariant is the point, not the one file it started on.
+WORKSPACE_FREE_MODULES = (
+    "identity.py",
+    "host_token.py",
+    "host_auth.py",
+)
+
+_FORBIDDEN_IMPORTS = ("mship.core.config", "mship.core.workspace_context")
+_FORBIDDEN_ARGS = {"workspace", "repos", "config", "workspace_root"}
+
+
+@pytest.mark.parametrize("module_name", WORKSPACE_FREE_MODULES)
+def test_host_modules_are_workspace_free(module_name):
+    """Assumption-header invariant: the host tier must not depend on which
     workspaces this daemon serves."""
-    src = Path(__file__).resolve().parents[3] / "src" / "mship" / "core" / "daemon" / "identity.py"
+    src = (
+        Path(__file__).resolve().parents[3]
+        / "src" / "mship" / "core" / "daemon" / module_name
+    )
     tree = ast.parse(src.read_text())
     imported = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.module:
             imported.add(node.module)
-    assert not any(m in imported for m in ("mship.core.config", "mship.core.workspace_context"))
+    assert not any(m in imported for m in _FORBIDDEN_IMPORTS), module_name
     for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             args = {a.arg for a in node.args.args + node.args.kwonlyargs}
-            assert not (args & {"workspace", "repos", "config", "workspace_root"}), node.name
+            assert not (args & _FORBIDDEN_ARGS), f"{module_name}:{node.name}"

--- a/tests/core/daemon/test_host_identity.py
+++ b/tests/core/daemon/test_host_identity.py
@@ -158,6 +158,7 @@ WORKSPACE_FREE_MODULES = (
     "host_auth.py",
     "capabilities.py",
     "relay_link.py",
+    "host_tunnel.py",
 )
 
 _FORBIDDEN_IMPORTS = ("mship.core.config", "mship.core.workspace_context")

--- a/tests/core/daemon/test_host_identity.py
+++ b/tests/core/daemon/test_host_identity.py
@@ -14,6 +14,7 @@ import pytest
 
 from mship.core.daemon.identity import (
     ensure_host_identity,
+    force_reidentify,
     machine_fingerprint,
     mint_host_id,
     mint_instance_id,
@@ -58,11 +59,31 @@ def test_reimage_reidentifies_once_and_rotates_key(tmp_path: Path):
     # stale one forward and re-fire the mismatch on every call.
     assert second.fingerprint == "B"
     assert json.loads(host_identity_path(tmp_path).read_text())["fingerprint"] == "B"
-    assert rotated == [tmp_path]  # the clone's copied key must stop working
+    assert rotated == [tmp_path]  # this host must enroll under independent key material
     third = ensure_host_identity(tmp_path, fingerprint="B", rotate_key=lambda h: rotated.append(h))
     assert third.host_id == second.host_id  # stable; no re-identify loop
     assert third.reidentified is False
     assert rotated == [tmp_path]
+
+
+def test_forced_reidentify_preserves_a_possibly_shared_relay_key_approval(
+    tmp_path: Path, monkeypatch
+):
+    from mship.core.daemon import relay_link
+    from mship.core.daemon.registry import DaemonConfig, save_daemon_config
+
+    ensure_host_identity(tmp_path, fingerprint="same", rotate_key=_noop_rotate)
+    save_daemon_config(tmp_path, DaemonConfig(relay={"host": "relay.example"}))
+    revoked = []
+    monkeypatch.setattr(
+        relay_link,
+        "revoke_relay_key",
+        lambda home, relay: revoked.append((home, relay)),
+    )
+
+    force_reidentify(tmp_path, rotate_key=_noop_rotate, now=NOW)
+
+    assert revoked == []
 
 
 def test_real_key_rotation_moves_key_aside(tmp_path: Path):

--- a/tests/core/daemon/test_host_token.py
+++ b/tests/core/daemon/test_host_token.py
@@ -300,10 +300,25 @@ def test_verify_writes_nothing(tmp_path: Path):
     pure read, so a flapping phone cannot churn the store."""
     clk = _Clock()
     token = issue_host_token(tmp_path, ttl_seconds=300, clock=clk.anchored())
-    before = host_tokens_path(tmp_path).read_bytes()
+    data_path = host_tokens_path(tmp_path)
+    lock_path = data_path.with_name(data_path.name + ".lock")
+    before = data_path.read_bytes()
+    os.utime(lock_path, ns=(1_000_000_000, 1_000_000_000))
+    lock_mtime = lock_path.stat().st_mtime_ns
     for _ in range(5):
         assert verify_host_token(tmp_path, token, clock=clk.anchored()) is not None
-    assert host_tokens_path(tmp_path).read_bytes() == before
+    assert data_path.read_bytes() == before
+    assert lock_path.stat().st_mtime_ns == lock_mtime
+
+
+def test_verify_of_missing_store_creates_no_state_directory(tmp_path: Path):
+    assert (
+        verify_host_token(
+            tmp_path, "deadbeefdeadbeef.s", clock=_Clock().anchored()
+        )
+        is None
+    )
+    assert not daemon_state_dir(tmp_path).exists()
 
 
 # --- the state dir is owner-only, whatever the umask -----------------------
@@ -329,12 +344,9 @@ def _mode(path: Path) -> str:
     [
         lambda home: ensure_host_root_secret(home),
         lambda home: issue_host_token(home, clock=_Clock().anchored()),
-        lambda home: verify_host_token(
-            home, "deadbeefdeadbeef.s", clock=_Clock().anchored()
-        ),
     ],
 )
-def test_state_dir_is_owner_only_after_any_entry_point(
+def test_state_dir_is_owner_only_after_any_mutating_entry_point(
     tmp_path: Path, loose_umask, entry_point
 ):
     entry_point(tmp_path)

--- a/tests/core/daemon/test_host_token.py
+++ b/tests/core/daemon/test_host_token.py
@@ -1,0 +1,259 @@
+"""Short-lived host bearer tokens (#471 Task 2) and the single expiry owner.
+
+The host mints these and the host verifies them, so the only clock in the
+bearer loop is this machine's — which makes a *wall-clock step on this VM* the
+one residual hazard (AC10). Every test here pins a behavior that a bare
+`clock() >= expires_at` predicate would get wrong.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mship.core.daemon.host_token import (
+    HOST_TOKEN_TTL_S,
+    MAX_HOST_TOKENS,
+    ensure_host_root_secret,
+    issue_host_token,
+    verify_host_token,
+)
+from mship.core.daemon.paths import host_secret_path, host_tokens_path
+from mship.core.relay import keys as relay_keys
+from mship.core.relay.token_clock import SKEW_SECONDS, AnchoredClock, boot_epoch
+
+
+class _Clock:
+    """A fake wall+monotonic pair (the `test_health.py` fake-clock style).
+
+    `advance` is real time passing (both hands move); `step` is a wall-clock
+    jump (an NTP correction — the monotonic hand does not move).
+    """
+
+    def __init__(self, wall: float = 1_700_000_000.0, mono: float = 10.0,
+                 epoch: str = "boot:aaaa"):
+        self.wall = wall
+        self.mono = mono
+        self.epoch = epoch
+
+    def anchored(self) -> AnchoredClock:
+        return AnchoredClock(
+            wall=lambda: self.wall, mono=lambda: self.mono, epoch=self.epoch
+        )
+
+    def advance(self, dt: float) -> None:
+        self.wall += dt
+        self.mono += dt
+
+    def step(self, dt: float) -> None:
+        self.wall += dt
+
+
+def _records(home: Path) -> dict:
+    return json.loads(host_tokens_path(home).read_text())["tokens"]
+
+
+# --- the per-host root secret (mirrors keys.ensure_subdomain_secret) --------
+
+
+def test_root_secret_is_32_bytes_0600_and_stable(tmp_path: Path):
+    s1 = ensure_host_root_secret(tmp_path)
+    assert isinstance(s1, bytes) and len(s1) == 32
+    path = host_secret_path(tmp_path)
+    assert oct(path.stat().st_mode & 0o777) == "0o600"
+    assert ensure_host_root_secret(tmp_path) == s1  # idempotent
+
+
+def test_root_secret_regenerates_truncated_file(tmp_path: Path):
+    path = host_secret_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"short")
+    s = ensure_host_root_secret(tmp_path)
+    assert len(s) == 32
+    assert path.read_bytes() == s
+    assert ensure_host_root_secret(tmp_path) == s  # now stable
+
+
+def test_root_secret_adopts_the_winner_of_a_creation_race(tmp_path: Path, monkeypatch):
+    """Two daemons racing to create it must end up with the SAME secret: the
+    loser adopts the winner's bytes rather than crashing or overwriting."""
+    path = host_secret_path(tmp_path)
+    winner = b"W" * 32
+    real_open = relay_keys.os.open
+
+    def racing_open(target, flags, mode=0o777):
+        # The winner lands its bytes between our unlink and our O_EXCL create.
+        Path(target).parent.mkdir(parents=True, exist_ok=True)
+        Path(target).write_bytes(winner)
+        monkeypatch.setattr(relay_keys.os, "open", real_open)
+        raise FileExistsError()
+
+    monkeypatch.setattr(relay_keys.os, "open", racing_open)
+    assert ensure_host_root_secret(tmp_path) == winner
+    assert path.read_bytes() == winner
+
+
+# --- issuance: hash-at-rest plus an epoch-tagged monotonic floor -----------
+
+
+def test_issue_persists_only_the_hash_expiry_and_epoch_tagged_floor(tmp_path: Path):
+    clk = _Clock()
+    token = issue_host_token(tmp_path, ttl_seconds=300, clock=clk.anchored())
+    token_id, secret = token.split(".", 1)
+
+    raw = host_tokens_path(tmp_path).read_text()
+    assert secret not in raw  # plaintext is never re-derivable from disk
+
+    rec = _records(tmp_path)[token_id]
+    assert set(rec) == {"token_id", "secret_hash", "expires_at", "mono_deadline", "epoch"}
+    assert rec["expires_at"] == clk.wall + 300
+    assert rec["mono_deadline"] == clk.mono + 300
+    assert rec["epoch"] == clk.epoch  # the floor is useless untagged
+
+
+def test_default_ttl_is_short(tmp_path: Path):
+    assert HOST_TOKEN_TTL_S <= 900
+    clk = _Clock()
+    issue_host_token(tmp_path, clock=clk.anchored())
+    rec = next(iter(_records(tmp_path).values()))
+    assert rec["expires_at"] == clk.wall + HOST_TOKEN_TTL_S
+
+
+def test_verify_accepts_before_expiry(tmp_path: Path):
+    clk = _Clock()
+    token = issue_host_token(tmp_path, ttl_seconds=300, clock=clk.anchored())
+    clk.advance(299)
+    ht = verify_host_token(tmp_path, token, clock=clk.anchored())
+    assert ht is not None
+    assert ht.token_id == token.split(".", 1)[0]
+
+
+def test_verify_rejects_a_wrong_secret(tmp_path: Path):
+    clk = _Clock()
+    token = issue_host_token(tmp_path, ttl_seconds=300, clock=clk.anchored())
+    token_id = token.split(".", 1)[0]
+    assert verify_host_token(tmp_path, f"{token_id}.wrong", clock=clk.anchored()) is None
+
+
+@pytest.mark.parametrize("presented", [
+    "", "no-dot", ".", "abc.", "../../../etc/passwd.x", "..%2f..%2fx.y",
+    "DEADBEEF.s", "z" * 40 + ".s", "deadbeef.secret",
+])
+def test_verify_never_raises_on_hostile_input(tmp_path: Path, presented: str):
+    issue_host_token(tmp_path, clock=_Clock().anchored())
+    assert verify_host_token(tmp_path, presented, clock=_Clock().anchored()) is None
+
+
+def test_verify_never_raises_on_a_corrupt_store(tmp_path: Path):
+    clk = _Clock()
+    token = issue_host_token(tmp_path, clock=clk.anchored())
+    host_tokens_path(tmp_path).write_text("{not json")
+    assert verify_host_token(tmp_path, token, clock=clk.anchored()) is None
+
+
+# --- restart safety: a persisted monotonic floor must carry its epoch ------
+
+
+def test_survives_a_restart_under_a_new_monotonic_origin_and_epoch(tmp_path: Path):
+    """#470 supervises the daemon and #473's upgrades restart it, so a restart
+    is the NORMAL case. A bare persisted `time.monotonic()` floor would compare
+    two boot epochs and either expire everything or nothing."""
+    minted = _Clock(wall=1_700_000_000.0, mono=10.0, epoch="boot:aaaa")
+    token = issue_host_token(tmp_path, ttl_seconds=300, clock=minted.anchored())
+
+    # Rebooted: monotonic restarted from a wildly different origin, new epoch.
+    fresh = _Clock(wall=minted.wall + 100, mono=500_000.0, epoch="boot:bbbb")
+    assert verify_host_token(tmp_path, token, clock=fresh.anchored()) is not None
+
+    stale = _Clock(wall=minted.wall + 300 + SKEW_SECONDS + 1, mono=1.0,
+                   epoch="boot:bbbb")
+    assert verify_host_token(tmp_path, token, clock=stale.anchored()) is None
+
+
+# --- AC10: a wall-clock step must not extend (or silently lengthen) a token -
+
+
+def test_backwards_wall_step_does_not_extend_a_token(tmp_path: Path):
+    """AC10, the real bound: after a one-hour BACKWARDS step the token still
+    dies once 300s of monotonic time have elapsed. `clock() >= expires_at`
+    would have handed the bearer another hour of life."""
+    clk = _Clock()
+    token = issue_host_token(tmp_path, ttl_seconds=300, clock=clk.anchored())
+
+    clk.step(-3600)
+    clk.advance(299)
+    assert verify_host_token(tmp_path, token, clock=clk.anchored()) is not None
+    clk.advance(1)
+    assert verify_host_token(tmp_path, token, clock=clk.anchored()) is None
+
+
+def test_forwards_wall_step_past_expiry_plus_skew_rejects(tmp_path: Path):
+    clk = _Clock()
+    token = issue_host_token(tmp_path, ttl_seconds=300, clock=clk.anchored())
+    clk.step(300 + SKEW_SECONDS + 1)
+    assert verify_host_token(tmp_path, token, clock=clk.anchored()) is None
+
+
+def test_skew_grace_does_not_lengthen_an_ordinary_token(tmp_path: Path):
+    """The grace is for a DETECTED discontinuity only — with both hands moving
+    together the token dies exactly at its TTL, not at TTL + skew."""
+    clk = _Clock()
+    token = issue_host_token(tmp_path, ttl_seconds=300, clock=clk.anchored())
+    clk.advance(300)
+    assert verify_host_token(tmp_path, token, clock=clk.anchored()) is None
+
+
+# --- the store cannot grow without bound -----------------------------------
+
+
+def test_issuing_prunes_expired_records(tmp_path: Path):
+    clk = _Clock()
+    for _ in range(5):
+        issue_host_token(tmp_path, ttl_seconds=10, clock=clk.anchored())
+    assert len(_records(tmp_path)) == 5
+    clk.advance(10 + SKEW_SECONDS + 1)
+    issue_host_token(tmp_path, ttl_seconds=10, clock=clk.anchored())
+    assert len(_records(tmp_path)) == 1
+
+
+def test_issuing_caps_the_number_of_live_records(tmp_path: Path):
+    clk = _Clock()
+    for _ in range(MAX_HOST_TOKENS + 3):
+        issue_host_token(tmp_path, ttl_seconds=10_000, clock=clk.anchored())
+        clk.advance(1)  # distinct expiries, so "drop the oldest" is well defined
+    assert len(_records(tmp_path)) == MAX_HOST_TOKENS
+
+
+def test_verify_writes_nothing(tmp_path: Path):
+    """AC11's "reconnect performs no writes" starts here: verification is a
+    pure read, so a flapping phone cannot churn the store."""
+    clk = _Clock()
+    token = issue_host_token(tmp_path, ttl_seconds=300, clock=clk.anchored())
+    before = host_tokens_path(tmp_path).read_bytes()
+    for _ in range(5):
+        assert verify_host_token(tmp_path, token, clock=clk.anchored()) is not None
+    assert host_tokens_path(tmp_path).read_bytes() == before
+
+
+# --- the epoch tag itself --------------------------------------------------
+
+
+def test_boot_epoch_prefers_the_kernel_boot_id():
+    assert boot_epoch(reader=lambda: "c0ffee-1234\n") == "boot:c0ffee-1234"
+
+
+def test_boot_epoch_falls_back_when_no_boot_id_is_readable():
+    def missing():
+        raise OSError("no /proc")
+
+    fallback = boot_epoch(reader=missing)
+    assert fallback and not fallback.startswith("boot:")
+    # Stable within a process (so a same-process check still uses monotonic)…
+    assert boot_epoch(reader=missing) == fallback
+    # …and it is a process anchor, so a restart cannot reuse another boot's floor.
+    assert boot_epoch(reader=lambda: "") == fallback
+
+
+def test_boot_epoch_of_two_boots_differ():
+    assert boot_epoch(reader=lambda: "aaa") != boot_epoch(reader=lambda: "bbb")

--- a/tests/core/daemon/test_host_token.py
+++ b/tests/core/daemon/test_host_token.py
@@ -182,6 +182,20 @@ def test_verify_never_raises_on_a_corrupt_store(tmp_path: Path):
     assert verify_host_token(tmp_path, token, clock=clk.anchored()) is None
 
 
+@pytest.mark.parametrize("field", ["expires_at", "mono_deadline"])
+def test_verify_rejects_an_oversized_persisted_deadline(
+    tmp_path: Path, field: str
+):
+    clk = _Clock()
+    token = issue_host_token(tmp_path, clock=clk.anchored())
+    path = host_tokens_path(tmp_path)
+    doc = json.loads(path.read_text())
+    next(iter(doc["tokens"].values()))[field] = 10**400
+    path.write_text(json.dumps(doc))
+
+    assert verify_host_token(tmp_path, token, clock=clk.anchored()) is None
+
+
 # --- restart safety: a persisted monotonic floor must carry its epoch ------
 
 

--- a/tests/core/daemon/test_host_token.py
+++ b/tests/core/daemon/test_host_token.py
@@ -5,6 +5,7 @@ bearer loop is this machine's — which makes a *wall-clock step on this VM* the
 one residual hazard (AC10). Every test here pins a behavior that a bare
 `clock() >= expires_at` predicate would get wrong.
 """
+
 from __future__ import annotations
 
 import json
@@ -36,8 +37,12 @@ class _Clock:
     jump (an NTP correction — the monotonic hand does not move).
     """
 
-    def __init__(self, wall: float = 1_700_000_000.0, mono: float = 10.0,
-                 epoch: str = "boot:aaaa"):
+    def __init__(
+        self,
+        wall: float = 1_700_000_000.0,
+        mono: float = 10.0,
+        epoch: str = "boot:aaaa",
+    ):
         self.wall = wall
         self.mono = mono
         self.epoch = epoch
@@ -88,6 +93,8 @@ def test_root_secret_adopts_the_winner_of_a_creation_race(tmp_path: Path, monkey
     real_open = relay_keys.os.open
 
     def racing_open(target, flags, mode=0o777):
+        if Path(target) != path:
+            return real_open(target, flags, mode)
         # The winner lands its bytes between our unlink and our O_EXCL create.
         Path(target).parent.mkdir(parents=True, exist_ok=True)
         Path(target).write_bytes(winner)
@@ -111,7 +118,13 @@ def test_issue_persists_only_the_hash_expiry_and_epoch_tagged_floor(tmp_path: Pa
     assert secret not in raw  # plaintext is never re-derivable from disk
 
     rec = _records(tmp_path)[token_id]
-    assert set(rec) == {"token_id", "secret_hash", "expires_at", "mono_deadline", "epoch"}
+    assert set(rec) == {
+        "token_id",
+        "secret_hash",
+        "expires_at",
+        "mono_deadline",
+        "epoch",
+    }
     assert rec["expires_at"] == clk.wall + 300
     assert rec["mono_deadline"] == clk.mono + 300
     assert rec["epoch"] == clk.epoch  # the floor is useless untagged
@@ -138,13 +151,25 @@ def test_verify_rejects_a_wrong_secret(tmp_path: Path):
     clk = _Clock()
     token = issue_host_token(tmp_path, ttl_seconds=300, clock=clk.anchored())
     token_id = token.split(".", 1)[0]
-    assert verify_host_token(tmp_path, f"{token_id}.wrong", clock=clk.anchored()) is None
+    assert (
+        verify_host_token(tmp_path, f"{token_id}.wrong", clock=clk.anchored()) is None
+    )
 
 
-@pytest.mark.parametrize("presented", [
-    "", "no-dot", ".", "abc.", "../../../etc/passwd.x", "..%2f..%2fx.y",
-    "DEADBEEF.s", "z" * 40 + ".s", "deadbeef.secret",
-])
+@pytest.mark.parametrize(
+    "presented",
+    [
+        "",
+        "no-dot",
+        ".",
+        "abc.",
+        "../../../etc/passwd.x",
+        "..%2f..%2fx.y",
+        "DEADBEEF.s",
+        "z" * 40 + ".s",
+        "deadbeef.secret",
+    ],
+)
 def test_verify_never_raises_on_hostile_input(tmp_path: Path, presented: str):
     issue_host_token(tmp_path, clock=_Clock().anchored())
     assert verify_host_token(tmp_path, presented, clock=_Clock().anchored()) is None
@@ -171,8 +196,9 @@ def test_survives_a_restart_under_a_new_monotonic_origin_and_epoch(tmp_path: Pat
     fresh = _Clock(wall=minted.wall + 100, mono=500_000.0, epoch="boot:bbbb")
     assert verify_host_token(tmp_path, token, clock=fresh.anchored()) is not None
 
-    stale = _Clock(wall=minted.wall + 300 + SKEW_SECONDS + 1, mono=1.0,
-                   epoch="boot:bbbb")
+    stale = _Clock(
+        wall=minted.wall + 300 + SKEW_SECONDS + 1, mono=1.0, epoch="boot:bbbb"
+    )
     assert verify_host_token(tmp_path, token, clock=stale.anchored()) is None
 
 
@@ -284,11 +310,16 @@ def _mode(path: Path) -> str:
     return oct(path.stat().st_mode & 0o777)
 
 
-@pytest.mark.parametrize("entry_point", [
-    lambda home: ensure_host_root_secret(home),
-    lambda home: issue_host_token(home, clock=_Clock().anchored()),
-    lambda home: verify_host_token(home, "deadbeefdeadbeef.s", clock=_Clock().anchored()),
-])
+@pytest.mark.parametrize(
+    "entry_point",
+    [
+        lambda home: ensure_host_root_secret(home),
+        lambda home: issue_host_token(home, clock=_Clock().anchored()),
+        lambda home: verify_host_token(
+            home, "deadbeefdeadbeef.s", clock=_Clock().anchored()
+        ),
+    ],
+)
 def test_state_dir_is_owner_only_after_any_entry_point(
     tmp_path: Path, loose_umask, entry_point
 ):

--- a/tests/core/daemon/test_host_token.py
+++ b/tests/core/daemon/test_host_token.py
@@ -8,6 +8,7 @@ one residual hazard (AC10). Every test here pins a behavior that a bare
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -19,7 +20,11 @@ from mship.core.daemon.host_token import (
     issue_host_token,
     verify_host_token,
 )
-from mship.core.daemon.paths import host_secret_path, host_tokens_path
+from mship.core.daemon.paths import (
+    daemon_state_dir,
+    host_secret_path,
+    host_tokens_path,
+)
 from mship.core.relay import keys as relay_keys
 from mship.core.relay.token_clock import SKEW_SECONDS, AnchoredClock, boot_epoch
 
@@ -225,6 +230,31 @@ def test_issuing_caps_the_number_of_live_records(tmp_path: Path):
     assert len(_records(tmp_path)) == MAX_HOST_TOKENS
 
 
+def test_a_shorter_lived_token_minted_at_the_cap_still_verifies(tmp_path: Path):
+    """The cap must never evict the credential it is handing back. Evicting
+    'the soonest to expire' AFTER inserting picks the new token whenever it has
+    the shorter TTL — it would be issued already dead."""
+    clk = _Clock()
+    for _ in range(MAX_HOST_TOKENS):
+        issue_host_token(tmp_path, ttl_seconds=10_000, clock=clk.anchored())
+    short = issue_host_token(tmp_path, ttl_seconds=60, clock=clk.anchored())
+
+    assert verify_host_token(tmp_path, short, clock=clk.anchored()) is not None
+    assert len(_records(tmp_path)) == MAX_HOST_TOKENS
+    assert short.split(".", 1)[0] in _records(tmp_path)
+
+
+def test_every_issued_token_verifies_while_the_cap_churns(tmp_path: Path):
+    clk = _Clock()
+    for i in range(MAX_HOST_TOKENS + 10):
+        # Alternate long and short TTLs so the new record lands on both sides
+        # of the eviction ordering.
+        token = issue_host_token(
+            tmp_path, ttl_seconds=60 if i % 2 else 10_000, clock=clk.anchored()
+        )
+        assert verify_host_token(tmp_path, token, clock=clk.anchored()) is not None
+
+
 def test_verify_writes_nothing(tmp_path: Path):
     """AC11's "reconnect performs no writes" starts here: verification is a
     pure read, so a flapping phone cannot churn the store."""
@@ -234,6 +264,51 @@ def test_verify_writes_nothing(tmp_path: Path):
     for _ in range(5):
         assert verify_host_token(tmp_path, token, clock=clk.anchored()) is not None
     assert host_tokens_path(tmp_path).read_bytes() == before
+
+
+# --- the state dir is owner-only, whatever the umask -----------------------
+
+
+@pytest.fixture
+def loose_umask():
+    """A permissive umask, so these assertions test the corrective chmod rather
+    than the ambient umask (mkdir's mode argument is umask-masked)."""
+    previous = os.umask(0o002)
+    try:
+        yield
+    finally:
+        os.umask(previous)
+
+
+def _mode(path: Path) -> str:
+    return oct(path.stat().st_mode & 0o777)
+
+
+@pytest.mark.parametrize("entry_point", [
+    lambda home: ensure_host_root_secret(home),
+    lambda home: issue_host_token(home, clock=_Clock().anchored()),
+    lambda home: verify_host_token(home, "deadbeefdeadbeef.s", clock=_Clock().anchored()),
+])
+def test_state_dir_is_owner_only_after_any_entry_point(
+    tmp_path: Path, loose_umask, entry_point
+):
+    entry_point(tmp_path)
+    assert _mode(daemon_state_dir(tmp_path)) == "0o700"
+
+
+def test_a_pre_existing_loose_state_dir_is_tightened(tmp_path: Path, loose_umask):
+    """`exist_ok=True` never fixes a dir that is already too loose — only the
+    corrective chmod does."""
+    state_dir = daemon_state_dir(tmp_path)
+    state_dir.mkdir(parents=True)
+    state_dir.chmod(0o755)
+    ensure_host_root_secret(tmp_path)
+    assert _mode(state_dir) == "0o700"
+
+
+def test_the_token_file_is_owner_only(tmp_path: Path, loose_umask):
+    issue_host_token(tmp_path, clock=_Clock().anchored())
+    assert _mode(host_tokens_path(tmp_path)) == "0o600"
 
 
 # --- the epoch tag itself --------------------------------------------------

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -10,6 +10,7 @@ Seams are injected exactly like `tests/core/relay/test_tunnel_supervisor.py`
 (`FakeProc` + a list clock) and `tests/core/daemon/test_relay_link.py`
 (scripted `post`/`get`): no sockets, no sleeps, no ssh-keygen.
 """
+
 import base64
 import hashlib
 import os
@@ -53,17 +54,33 @@ UNAPPROVED = host_contract.UNAPPROVED_KEY_DETAIL
 
 # --- the seams -------------------------------------------------------------
 
+
 class _Clock:
-    def __init__(self, t: float = 1_000_000.0): self.t = t
-    def __call__(self) -> float: return self.t
-    def advance(self, dt: float) -> None: self.t += dt
+    def __init__(self, t: float = 1_000_000.0):
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
 
 
 class FakeProc:
-    def __init__(self): self._alive = True; self.terminated = 0
-    def poll(self): return None if self._alive else 0
-    def terminate(self): self.terminated += 1; self._alive = False
-    def wait(self, timeout=None): self._alive = False; return 0
+    def __init__(self):
+        self._alive = True
+        self.terminated = 0
+
+    def poll(self):
+        return None if self._alive else 0
+
+    def terminate(self):
+        self.terminated += 1
+        self._alive = False
+
+    def wait(self, timeout=None):
+        self._alive = False
+        return 0
 
 
 class _Resp:
@@ -72,7 +89,8 @@ class _Resp:
         self._body = {} if body is None else body
         self.headers = {}
 
-    def json(self): return self._body
+    def json(self):
+        return self._body
 
 
 class _Relay:
@@ -84,14 +102,11 @@ class _Relay:
         self.enrollments: list[dict] = []
         self.transport_error: str | None = None
 
-    def get(self, url, **kw):
-        if self.transport_error:
-            raise RuntimeError(self.transport_error)
-        return _Resp(200, {"nonce": "nonce-1"})
-
     def post(self, url, json=None, **kw):
         if self.transport_error:
             raise RuntimeError(self.transport_error)
+        if url.endswith(host_contract.CHALLENGE_PATH):
+            return _Resp(200, {"nonce": "nonce-1"})
         if url.endswith(host_contract.ENROLL_PATH):
             self.enrollments.append(json)
             return _Resp(200, {"id": "req-1", "status": "pending"})
@@ -114,27 +129,46 @@ def _seed_key(home: Path) -> None:
 def _link(home: Path, relay: _Relay, clock: _Clock) -> RelayLink:
     _seed_key(home)
     return RelayLink(
-        home, RELAY, post=relay.post, get=relay.get, clock=clock, rng=lambda: 0.0,
+        home,
+        RELAY,
+        post=relay.post,
+        clock=clock,
+        rng=lambda: 0.0,
         signer=lambda blob: "SIG:" + hashlib.sha256(blob).hexdigest(),
         issue_refresh=lambda host_id: f"refresh-for-{host_id}",
         reidentify=lambda: HostIdentity(host_id="hst-new", created_at=""),
     )
 
 
-def _health_get(instance_id: str | None, *, error: str | None = None, status: int = 200):
+def _health_get(
+    instance_id: str | None, *, error: str | None = None, status: int = 200
+):
     def get(url, **kw):
         if error is not None:
             raise RuntimeError(error)
-        body = {"status": "ok"} if instance_id is None else {"status": "ok", "instance_id": instance_id}
+        body = (
+            {"status": "ok"}
+            if instance_id is None
+            else {"status": "ok", "instance_id": instance_id}
+        )
         return _Resp(status, body)
+
     return get
 
 
 class _Fixture:
     """One wired-up tunnel: link + supervisor + the argv a daemon would build."""
 
-    def __init__(self, home: Path, relay: _Relay, clock: _Clock, *,
-                 backoff: float = 0.0, max_backoff: float = 60.0, **kw):
+    def __init__(
+        self,
+        home: Path,
+        relay: _Relay,
+        clock: _Clock,
+        *,
+        backoff: float = 0.0,
+        max_backoff: float = 60.0,
+        **kw,
+    ):
         self.home, self.relay, self.clock = home, relay, clock
         self.procs: list[FakeProc] = []
         self.argvs: list[list[str]] = []
@@ -142,17 +176,25 @@ class _Fixture:
         self.link = _link(home, relay, clock)
         self.argv = self._argv()
         self.sup = TunnelSupervisor(
-            argv=self._argv, proc_factory=self._factory, backoff_delay=backoff,
-            max_backoff_delay=max_backoff, clock=clock,
-            log_path=tunnel_log_path(home), rng=lambda: 0.0,
+            argv=self._argv,
+            proc_factory=self._factory,
+            backoff_delay=backoff,
+            max_backoff_delay=max_backoff,
+            clock=clock,
+            log_path=tunnel_log_path(home),
+            rng=lambda: 0.0,
         )
-        kw.setdefault("verify", partial(probe_health, get=_health_get(self.link.instance_id)))
+        kw.setdefault(
+            "verify", partial(probe_health, get=_health_get(self.link.instance_id))
+        )
         kw.setdefault("reaper", self._reaper)
         self.tunnel = HostTunnel(self.link, self.sup, clock=clock, **kw)
 
     def _argv(self):
         return build_tunnel_argv(
-            RELAY, subdomain=self.link.subdomain, local_port=BIND_PORT,
+            RELAY,
+            subdomain=self.link.subdomain,
+            local_port=BIND_PORT,
             key_path=relay_key_path(self.home),
         )
 
@@ -206,6 +248,7 @@ def fx(tmp_path: Path):
 
 # --- dialing ----------------------------------------------------------------
 
+
 def test_tick_dials_the_host_subdomain_on_the_daemons_bind_port(fx):
     fx.tunnel.tick()
 
@@ -251,7 +294,9 @@ def test_no_ssh_process_is_ever_spawned_while_the_link_says_not_to_dial(tmp_path
     assert fx.link.subdomain in " ".join(fx.argvs[-1])
 
 
-def test_duplicate_identity_still_reaps_a_local_orphan_before_refusing_to_dial(tmp_path):
+def test_duplicate_identity_still_reaps_a_local_orphan_before_refusing_to_dial(
+    tmp_path,
+):
     fx = _Fixture(
         tmp_path,
         _Relay(register=(409, "identity already registered")),
@@ -277,24 +322,29 @@ def test_a_tunnel_already_up_is_torn_down_when_the_identity_goes_duplicate(fx):
 
 # --- AC2: respawn re-registers exactly once ---------------------------------
 
+
 def test_a_respawn_triggers_exactly_one_additional_registration(fx):
     fx.connect()
     assert len(fx.relay.registrations) == 1
 
     fx.kill_child()
     fx.clock.advance(1)
-    fx.tunnel.tick()                       # respawn + the one extra registration
+    fx.tunnel.tick()  # respawn + the one extra registration
 
     assert len(fx.procs) == 2
     assert len(fx.relay.registrations) == 2
 
-    for _ in range(20):                    # a re-register storm is the wrong shape
+    for _ in range(20):  # a re-register storm is the wrong shape
         fx.clock.advance(1)
         fx.tunnel.tick()
-    assert len(fx.relay.registrations) == 2, "re-registered once per tick, not once per respawn"
+    assert len(fx.relay.registrations) == 2, (
+        "re-registered once per tick, not once per respawn"
+    )
 
 
-def test_a_drop_after_a_healthy_run_registers_once_and_never_while_the_child_is_gone(tmp_path):
+def test_a_drop_after_a_healthy_run_registers_once_and_never_while_the_child_is_gone(
+    tmp_path,
+):
     """The regression the zero-backoff fixture cannot see: `restart_count` is
     reset by a healthy run, so diffing it reads the DROP as a respawn and
     re-registers while no child exists, then registers again on the respawn."""
@@ -302,15 +352,15 @@ def test_a_drop_after_a_healthy_run_registers_once_and_never_while_the_child_is_
     started = fx.clock.t
     fx.connect()
 
-    for _ in range(3):                     # a flap streak builds the count up
+    for _ in range(3):  # a flap streak builds the count up
         fx.drop_and_wait()
-    fx.clock.advance(9.0)                  # ...then a run outliving the cap
+    fx.clock.advance(9.0)  # ...then a run outliving the cap
     fx.tunnel.tick()
     assert fx.sup.is_running() and fx.sup.restart_count == 3
 
     before = len(fx.relay.registrations)
     fx.kill_child()
-    fx.tunnel.tick()                       # the drop is detected; nothing is up
+    fx.tunnel.tick()  # the drop is detected; nothing is up
     assert fx.sup.restart_count == 0, "the healthy run should have reset the streak"
     assert len(fx.relay.registrations) == before, "registered while no child existed"
 
@@ -323,8 +373,9 @@ def test_a_drop_after_a_healthy_run_registers_once_and_never_while_the_child_is_
         fx.clock.advance(0.5)
         fx.tunnel.tick()
     assert len(fx.relay.registrations) == before + 1
-    assert fx.clock.t - started < host_contract.REGISTER_INTERVAL_S, \
+    assert fx.clock.t - started < host_contract.REGISTER_INTERVAL_S, (
         "the link's own schedule came due — the counts above stopped meaning anything"
+    )
 
 
 def test_redialing_after_a_duplicate_identity_clears_does_not_register_twice(tmp_path):
@@ -347,7 +398,7 @@ def test_redialing_after_a_duplicate_identity_clears_does_not_register_twice(tmp
 
     fx.relay.refuse(200)
     fx.clock.advance(120)
-    fx.tunnel.tick()                       # re-dials, and registers once, here
+    fx.tunnel.tick()  # re-dials, and registers once, here
     assert len(fx.procs) == 5 and fx.sup.restart_count == 0
     after_redial = len(fx.relay.registrations)
 
@@ -374,9 +425,10 @@ def test_tunnel_failure_does_not_stop_registration_retries(fx):
     before = len(fx.relay.registrations)
     fx.kill_child()
 
-    fx.procs.clear()                       # the ssh child now refuses to come back
+    fx.procs.clear()  # the ssh child now refuses to come back
     fx.tunnel._supervisor._proc_factory = lambda argv: (_ for _ in ()).throw(
-        OSError("ssh: command not found"))
+        OSError("ssh: command not found")
+    )
 
     for _ in range(5):
         fx.clock.advance(120)
@@ -387,15 +439,19 @@ def test_tunnel_failure_does_not_stop_registration_retries(fx):
 
 # --- AC7: the tunnel shares no lifetime with the registry or the host app ---
 
+
 def test_fifty_failing_ticks_leave_the_registry_and_host_app_untouched(fx):
     store = RegistryStore(registry_path(fx.home))
-    store.mutate(lambda s: s)              # materialise the file
-    app = create_host_app(store, auth_token="tok", host_id="hst-1", instance_id="inst-1")
+    store.mutate(lambda s: s)  # materialise the file
+    app = create_host_app(
+        store, auth_token="tok", host_id="hst-1", instance_id="inst-1"
+    )
     before = registry_path(fx.home).read_bytes()
 
     fx.relay.transport_error = "network is unreachable"
     fx.tunnel._supervisor._proc_factory = lambda argv: (_ for _ in ()).throw(
-        OSError("ssh: connect failed"))
+        OSError("ssh: connect failed")
+    )
     for _ in range(50):
         fx.clock.advance(120)
         fx.tunnel.tick()
@@ -406,13 +462,15 @@ def test_fifty_failing_ticks_leave_the_registry_and_host_app_untouched(fx):
 
 
 def test_an_exception_from_a_tick_lands_in_last_error_and_the_loop_keeps_running(fx):
-    def boom(subdomain): raise RuntimeError("ps: no such process table")
+    def boom(subdomain):
+        raise RuntimeError("ps: no such process table")
+
     fx.tunnel._reaper = boom
 
     assert fx.tunnel.tick() == "error"
     assert "no such process table" in fx.tunnel.last_error
 
-    fx.tunnel._reaper = fx._reaper         # the fault clears
+    fx.tunnel._reaper = fx._reaper  # the fault clears
     fx.clock.advance(120)
     assert fx.connect() == "online"
     assert fx.tunnel.last_error is None
@@ -436,7 +494,10 @@ def test_stop_terminates_the_child_exactly_once_and_is_idempotent(fx):
 
 # --- AC11: reconnecting writes nothing --------------------------------------
 
-def test_twenty_failure_respawn_cycles_leave_the_registry_and_journal_byte_identical(fx):
+
+def test_twenty_failure_respawn_cycles_leave_the_registry_and_journal_byte_identical(
+    fx,
+):
     store = RegistryStore(registry_path(fx.home))
     store.mutate(lambda s: s)
     journal = start_history_path(fx.home)
@@ -453,10 +514,13 @@ def test_twenty_failure_respawn_cycles_leave_the_registry_and_journal_byte_ident
     assert (registry_path(fx.home).read_bytes(), journal.read_bytes()) == before
     # ...and one directory entry, re-published rather than re-minted
     assert {r["host_id"] for r in fx.relay.registrations} == {fx.link.host_id}
-    assert {r["refresh"] for r in fx.relay.registrations} == {f"refresh-for-{fx.link.host_id}"}
+    assert {r["refresh"] for r in fx.relay.registrations} == {
+        f"refresh-for-{fx.link.host_id}"
+    }
 
 
 # --- the orphan reaper ------------------------------------------------------
+
 
 def _proc(pid, ppid, cmdline):
     return ProcessInfo(pid=pid, ppid=ppid, cmdline=cmdline)
@@ -466,12 +530,17 @@ def test_reaper_kills_an_orphaned_tunnel_on_our_subdomain(fx):
     """The collision class `scripts/redeploy-serve.sh` sweeps by hand: a `kill -9`
     leaves the `start_new_session` ssh child reparented to init, still holding
     the subdomain, so sish rejects the fresh tunnel and the relay 404s."""
-    ours = _proc(200, 42, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example")
-    orphan = _proc(100, 1, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example")
+    ours = _proc(
+        200, 42, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example"
+    )
+    orphan = _proc(
+        100, 1, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example"
+    )
     killed = []
 
     reaped = reap_orphan_tunnels(
-        fx.link.subdomain, processes=lambda: [ours, orphan],
+        fx.link.subdomain,
+        processes=lambda: [ours, orphan],
         kill=lambda pid: killed.append(pid),
     )
 
@@ -484,7 +553,8 @@ def test_reaper_leaves_other_hosts_tunnels_and_non_tunnels_alone(fx):
     killed = []
 
     reaped = reap_orphan_tunnels(
-        fx.link.subdomain, processes=lambda: [other, shell],
+        fx.link.subdomain,
+        processes=lambda: [other, shell],
         kill=lambda pid: killed.append(pid),
     )
 
@@ -495,12 +565,17 @@ def test_reaper_spares_a_label_that_merely_ends_with_ours(fx):
     """A substring match would take down an unrelated host: its own opaque slug
     can end with the whole of ours, and it is orphaned-looking to us either way.
     The label is a token, so it is compared as one."""
-    collider = _proc(103, 1, f"ssh -N -R xyz-{fx.link.subdomain}:80:localhost:9000 relay.example")
-    prefix = _proc(104, 1, f"ssh -N -R {fx.link.subdomain}-extra:80:localhost:9000 relay.example")
+    collider = _proc(
+        103, 1, f"ssh -N -R xyz-{fx.link.subdomain}:80:localhost:9000 relay.example"
+    )
+    prefix = _proc(
+        104, 1, f"ssh -N -R {fx.link.subdomain}-extra:80:localhost:9000 relay.example"
+    )
     killed = []
 
     reaped = reap_orphan_tunnels(
-        fx.link.subdomain, processes=lambda: [collider, prefix],
+        fx.link.subdomain,
+        processes=lambda: [collider, prefix],
         kill=lambda pid: killed.append(pid),
     )
 
@@ -509,15 +584,28 @@ def test_reaper_spares_a_label_that_merely_ends_with_ours(fx):
 
 def test_reaper_tolerates_a_trailing_dash_r_with_no_forward_spec(fx):
     dangling = _proc(105, 1, "ssh -N relay.example -R")
-    assert reap_orphan_tunnels(fx.link.subdomain, processes=lambda: [dangling],
-                               kill=lambda pid: pytest.fail("signalled a malformed row")) == []
+    assert (
+        reap_orphan_tunnels(
+            fx.link.subdomain,
+            processes=lambda: [dangling],
+            kill=lambda pid: pytest.fail("signalled a malformed row"),
+        )
+        == []
+    )
 
 
 def test_reaper_survives_a_process_that_vanished_between_list_and_kill(fx):
-    def kill(pid): raise ProcessLookupError(pid)
-    orphan = _proc(100, 1, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example")
+    def kill(pid):
+        raise ProcessLookupError(pid)
 
-    assert reap_orphan_tunnels(fx.link.subdomain, processes=lambda: [orphan], kill=kill) == []
+    orphan = _proc(
+        100, 1, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example"
+    )
+
+    assert (
+        reap_orphan_tunnels(fx.link.subdomain, processes=lambda: [orphan], kill=kill)
+        == []
+    )
 
 
 def test_the_default_lister_parses_the_real_process_table():
@@ -535,7 +623,7 @@ def test_orphans_are_reaped_before_dialing_and_before_each_respawn(fx):
     fx.tunnel.tick()
     assert fx.reaped == [fx.link.subdomain], "dialed without sweeping orphans first"
 
-    for _ in range(5):                     # not once per tick while the child holds
+    for _ in range(5):  # not once per tick while the child holds
         fx.clock.advance(1)
         fx.tunnel.tick()
     assert len(fx.reaped) == 1
@@ -547,6 +635,7 @@ def test_orphans_are_reaped_before_dialing_and_before_each_respawn(fx):
 
 
 # --- the state ladder -------------------------------------------------------
+
 
 def test_awaiting_enrollment_is_classified_from_the_ssh_log_tail(fx):
     """ssh's own refusal is the first evidence that the relay has the key but
@@ -580,8 +669,12 @@ def test_a_foreign_instance_id_is_contended_and_does_not_tear_the_tunnel_down(tm
     """Comparing host_id would be blind to exactly this case: a `cp -a` twin
     publishes the SAME host_id on the SAME subdomain. Only the per-process
     instance_id tells the two apart."""
-    fx = _Fixture(tmp_path, _Relay(), _Clock(),
-                  verify=partial(probe_health, get=_health_get("inst-of-the-twin")))
+    fx = _Fixture(
+        tmp_path,
+        _Relay(),
+        _Clock(),
+        verify=partial(probe_health, get=_health_get("inst-of-the-twin")),
+    )
 
     state = fx.connect()
 
@@ -593,8 +686,12 @@ def test_a_foreign_instance_id_is_contended_and_does_not_tear_the_tunnel_down(tm
 def test_a_transport_failure_on_the_read_back_stays_connecting(tmp_path):
     """Unreachable is not contended — the same terminal-vs-transient split
     `health.py` makes for a stale token vs a route that has not come up yet."""
-    fx = _Fixture(tmp_path, _Relay(), _Clock(),
-                  verify=partial(probe_health, get=_health_get(None, error="connection refused")))
+    fx = _Fixture(
+        tmp_path,
+        _Relay(),
+        _Clock(),
+        verify=partial(probe_health, get=_health_get(None, error="connection refused")),
+    )
 
     for _ in range(5):
         fx.clock.advance(120)
@@ -603,8 +700,12 @@ def test_a_transport_failure_on_the_read_back_stays_connecting(tmp_path):
 
 
 def test_a_read_back_without_an_instance_id_stays_connecting(tmp_path):
-    fx = _Fixture(tmp_path, _Relay(), _Clock(),
-                  verify=partial(probe_health, get=_health_get(None)))
+    fx = _Fixture(
+        tmp_path,
+        _Relay(),
+        _Clock(),
+        verify=partial(probe_health, get=_health_get(None)),
+    )
     assert fx.connect() == "connecting"
 
 
@@ -622,19 +723,25 @@ def test_state_covers_the_whole_vocabulary(tmp_path):
     seen = set()
 
     fx = _Fixture(tmp_path / "a", _Relay(), _Clock())
-    seen.add(fx.tunnel.state())                          # connecting (nothing ticked yet)
-    seen.add(fx.connect())                               # online
+    seen.add(fx.tunnel.state())  # connecting (nothing ticked yet)
+    seen.add(fx.connect())  # online
     fx.tunnel.stop()
-    seen.add(fx.tunnel.state())                          # disabled
+    seen.add(fx.tunnel.state())  # disabled
 
-    contended = _Fixture(tmp_path / "b", _Relay(), _Clock(),
-                         verify=partial(probe_health, get=_health_get("inst-twin")))
+    contended = _Fixture(
+        tmp_path / "b",
+        _Relay(),
+        _Clock(),
+        verify=partial(probe_health, get=_health_get("inst-twin")),
+    )
     seen.add(contended.connect())
 
     unapproved = _Fixture(tmp_path / "c", _Relay(register=(401, UNAPPROVED)), _Clock())
     seen.add(unapproved.connect())
 
-    dup = _Fixture(tmp_path / "d", _Relay(register=(409, "already registered")), _Clock())
+    dup = _Fixture(
+        tmp_path / "d", _Relay(register=(409, "already registered")), _Clock()
+    )
     seen.add(dup.connect())
 
     broken = _Fixture(tmp_path / "e", _Relay(), _Clock())
@@ -676,7 +783,7 @@ def test_a_child_respawned_in_the_same_tick_as_the_stop_is_still_terminated(
     fixture = _Fixture(tmp_path, _Relay(), clock)
     fixture.connect()
     fixture.kill_child()
-    clock.advance(120)                      # any backoff has long since elapsed
+    clock.advance(120)  # any backoff has long since elapsed
     real_link_tick = fixture.link.tick
 
     def shutdown_lands_mid_tick():
@@ -696,6 +803,7 @@ def test_a_child_respawned_in_the_same_tick_as_the_stop_is_still_terminated(
 
 
 # --- the snapshot the daemon publishes (#471 Task 9) ------------------------
+
 
 def test_snapshot_is_published_per_tick_not_read_live(fx):
     """`/health` serves this from the request thread while ticks mutate the
@@ -719,7 +827,9 @@ def test_snapshot_is_published_per_tick_not_read_live(fx):
 
 
 def test_snapshot_reports_the_states_and_reasons_the_operator_acts_on(tmp_path):
-    dup = _Fixture(tmp_path / "dup", _Relay(register=(409, "held by hst-other")), _Clock())
+    dup = _Fixture(
+        tmp_path / "dup", _Relay(register=(409, "held by hst-other")), _Clock()
+    )
     dup.connect()
     assert dup.tunnel.snapshot()["state"] == "duplicate-identity"
     assert "held by hst-other" in dup.tunnel.snapshot()["last_error"]

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -140,18 +140,21 @@ class _Fixture:
         self.argvs: list[list[str]] = []
         self.reaped: list[str] = []
         self.link = _link(home, relay, clock)
-        self.argv = build_tunnel_argv(
-            RELAY, subdomain=self.link.subdomain, local_port=BIND_PORT,
-            key_path=relay_key_path(home),
-        )
+        self.argv = self._argv()
         self.sup = TunnelSupervisor(
-            argv=self.argv, proc_factory=self._factory, backoff_delay=backoff,
+            argv=self._argv, proc_factory=self._factory, backoff_delay=backoff,
             max_backoff_delay=max_backoff, clock=clock,
             log_path=tunnel_log_path(home), rng=lambda: 0.0,
         )
         kw.setdefault("verify", partial(probe_health, get=_health_get(self.link.instance_id)))
         kw.setdefault("reaper", self._reaper)
         self.tunnel = HostTunnel(self.link, self.sup, clock=clock, **kw)
+
+    def _argv(self):
+        return build_tunnel_argv(
+            RELAY, subdomain=self.link.subdomain, local_port=BIND_PORT,
+            key_path=relay_key_path(self.home),
+        )
 
     def _factory(self, argv):
         self.argvs.append(list(argv))
@@ -238,14 +241,14 @@ def test_no_ssh_process_is_ever_spawned_while_the_link_says_not_to_dial(tmp_path
     assert fx.procs == [], "dialed while the relay says another host holds our identity"
     assert fx.tunnel.state() == "duplicate-identity"
 
-    # ...and the recovery path un-blocks the dial: the link re-identifies itself,
-    # lands in the enrollment queue, and stops refusing to dial. (The argv the
-    # supervisor holds still carries the OLD subdomain — a re-identify rotates
-    # the key too, so the tunnel only really comes back after the restart
-    # `mship daemon reidentify` tells the operator to perform.)
+    # ...and the recovery path un-blocks the dial on the newly minted identity:
+    # the old key/subdomain cannot serve the new directory entry.
+    old_subdomain = fx.link.subdomain
     fx.tunnel.tick()
     assert fx.tunnel.state() == "awaiting-enrollment"
     assert len(fx.procs) == 1
+    assert old_subdomain not in " ".join(fx.argvs[-1])
+    assert fx.link.subdomain in " ".join(fx.argvs[-1])
 
 
 def test_duplicate_identity_still_reaps_a_local_orphan_before_refusing_to_dial(tmp_path):

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -361,6 +361,23 @@ def test_a_tunnel_already_up_is_torn_down_when_the_identity_goes_duplicate(fx):
     assert fx.child.terminated == 1
 
 
+def test_active_tunnel_redials_the_new_identity_after_auto_reidentification(fx):
+    assert fx.connect() == "online"
+    old_child = fx.child
+    old_subdomain = fx.link.subdomain
+
+    fx.relay.refuse(409, "identity already registered")
+    for _ in range(RelayLink.DUPLICATE_REIDENTIFY_AFTER):
+        fx.clock.advance(120)
+        fx.tunnel.tick()
+
+    assert old_child.terminated == 1
+    assert len(fx.procs) == 2
+    assert fx.sup.is_running()
+    assert old_subdomain not in " ".join(fx.argvs[-1])
+    assert fx.link.subdomain in " ".join(fx.argvs[-1])
+
+
 # --- AC2: respawn re-registers exactly once ---------------------------------
 
 

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -1,0 +1,529 @@
+"""The daemon's tunnel + registration loop (#471 Task 7).
+
+`HostTunnel` joins two things that already exist — `TunnelSupervisor` (the ssh
+child) and `RelayLink` (the directory entry) — and adds the three facts neither
+can know alone: an orphaned `ssh -R` must be reaped before we dial, a respawn
+must re-register exactly once, and the only proof that *we* hold our subdomain
+is reading our own `instance_id` back off it.
+
+Seams are injected exactly like `tests/core/relay/test_tunnel_supervisor.py`
+(`FakeProc` + a list clock) and `tests/core/daemon/test_relay_link.py`
+(scripted `post`/`get`): no sockets, no sleeps, no ssh-keygen.
+"""
+import base64
+import hashlib
+import os
+from datetime import datetime, timezone
+from functools import partial
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mship.core.daemon import history
+from mship.core.daemon.host_app import create_host_app
+from mship.core.daemon.host_tunnel import (
+    STATES,
+    HostTunnel,
+    ProcessInfo,
+    list_processes,
+    reap_orphan_tunnels,
+)
+from mship.core.daemon.identity import HostIdentity
+from mship.core.daemon.paths import registry_path, start_history_path, tunnel_log_path
+from mship.core.daemon.registry import RegistryStore
+from mship.core.daemon.relay_link import RelayLink
+from mship.core.relay import host_contract
+from mship.core.relay.config import RelayConfig
+from mship.core.relay.health import probe_health
+from mship.core.relay.keys import ensure_subdomain_secret, relay_key_path
+from mship.core.relay.tunnel import (
+    TunnelSupervisor,
+    build_tunnel_argv,
+    device_id,
+    host_subdomain,
+)
+
+RELAY = RelayConfig(host="relay.example")
+BASE = host_contract.enroll_base_url(RELAY.host)
+PUBKEY = "ssh-ed25519 " + base64.b64encode(b"k" * 51).decode() + " mship-relay\n"
+BIND_PORT = 8765
+UNAPPROVED = host_contract.UNAPPROVED_KEY_DETAIL
+
+
+# --- the seams -------------------------------------------------------------
+
+class _Clock:
+    def __init__(self, t: float = 1_000_000.0): self.t = t
+    def __call__(self) -> float: return self.t
+    def advance(self, dt: float) -> None: self.t += dt
+
+
+class FakeProc:
+    def __init__(self): self._alive = True; self.terminated = 0
+    def poll(self): return None if self._alive else 0
+    def terminate(self): self.terminated += 1; self._alive = False
+    def wait(self, timeout=None): self._alive = False; return 0
+
+
+class _Resp:
+    def __init__(self, status: int, body: dict | None = None):
+        self.status_code = status
+        self._body = {} if body is None else body
+        self.headers = {}
+
+    def json(self): return self._body
+
+
+class _Relay:
+    """Scriptable stand-in for the enroll app's `/hosts/*` + `/enroll` routes."""
+
+    def __init__(self, register=(200, None)):
+        self.register_status, self.register_detail = register
+        self.registrations: list[dict] = []
+        self.enrollments: list[dict] = []
+        self.transport_error: str | None = None
+
+    def get(self, url, **kw):
+        if self.transport_error:
+            raise RuntimeError(self.transport_error)
+        return _Resp(200, {"nonce": "nonce-1"})
+
+    def post(self, url, json=None, **kw):
+        if self.transport_error:
+            raise RuntimeError(self.transport_error)
+        if url.endswith(host_contract.ENROLL_PATH):
+            self.enrollments.append(json)
+            return _Resp(200, {"id": "req-1", "status": "pending"})
+        self.registrations.append(json["payload"])
+        if self.register_status == 200:
+            return _Resp(200, {"status": "registered"})
+        return _Resp(self.register_status, {"detail": self.register_detail})
+
+    def refuse(self, status: int, detail: str | None = None) -> None:
+        self.register_status, self.register_detail = status, detail
+
+
+def _seed_key(home: Path) -> None:
+    key = relay_key_path(home)
+    key.parent.mkdir(parents=True, exist_ok=True)
+    key.write_text("PRIVATE")
+    key.with_name(key.name + ".pub").write_text(PUBKEY)
+
+
+def _link(home: Path, relay: _Relay, clock: _Clock) -> RelayLink:
+    _seed_key(home)
+    return RelayLink(
+        home, RELAY, post=relay.post, get=relay.get, clock=clock, rng=lambda: 0.0,
+        signer=lambda blob: "SIG:" + hashlib.sha256(blob).hexdigest(),
+        issue_refresh=lambda host_id: f"refresh-for-{host_id}",
+        reidentify=lambda: HostIdentity(host_id="hst-new", created_at=""),
+    )
+
+
+def _health_get(instance_id: str | None, *, error: str | None = None, status: int = 200):
+    def get(url, **kw):
+        if error is not None:
+            raise RuntimeError(error)
+        body = {"status": "ok"} if instance_id is None else {"status": "ok", "instance_id": instance_id}
+        return _Resp(status, body)
+    return get
+
+
+class _Fixture:
+    """One wired-up tunnel: link + supervisor + the argv a daemon would build."""
+
+    def __init__(self, home: Path, relay: _Relay, clock: _Clock, **kw):
+        self.home, self.relay, self.clock = home, relay, clock
+        self.procs: list[FakeProc] = []
+        self.argvs: list[list[str]] = []
+        self.reaped: list[str] = []
+        self.link = _link(home, relay, clock)
+        self.argv = build_tunnel_argv(
+            RELAY, subdomain=self.link.subdomain, local_port=BIND_PORT,
+            key_path=relay_key_path(home),
+        )
+        self.sup = TunnelSupervisor(
+            argv=self.argv, proc_factory=self._factory, backoff_delay=0.0,
+            clock=clock, log_path=tunnel_log_path(home), rng=lambda: 0.0,
+        )
+        kw.setdefault("verify", partial(probe_health, get=_health_get(self.link.instance_id)))
+        kw.setdefault("reaper", self._reaper)
+        self.tunnel = HostTunnel(self.link, self.sup, clock=clock, **kw)
+
+    def _factory(self, argv):
+        self.argvs.append(list(argv))
+        p = FakeProc()
+        self.procs.append(p)
+        return p
+
+    def _reaper(self, subdomain):
+        self.reaped.append(subdomain)
+        return []
+
+    @property
+    def child(self) -> FakeProc:
+        return self.procs[-1]
+
+    def kill_child(self) -> None:
+        """The ssh child exits on its own (a dropped relay), not via stop()."""
+        self.procs[-1]._alive = False
+
+    def connect(self) -> str:
+        """Two ticks: the first dials (only after the link has had its say), the
+        second reads back off the now-live tunnel."""
+        self.tunnel.tick()
+        self.clock.advance(1)
+        return self.tunnel.tick()
+
+    def write_ssh_log(self, text: str) -> None:
+        path = tunnel_log_path(self.home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+
+
+@pytest.fixture
+def fx(tmp_path: Path):
+    return _Fixture(tmp_path, _Relay(), _Clock())
+
+
+# --- dialing ----------------------------------------------------------------
+
+def test_tick_dials_the_host_subdomain_on_the_daemons_bind_port(fx):
+    fx.tunnel.tick()
+
+    assert len(fx.procs) == 1
+    assert fx.argvs[0] == fx.argv
+    assert "-R" in fx.argvs[0]
+    assert f"{fx.link.subdomain}:80:localhost:{BIND_PORT}" in fx.argvs[0]
+    # the label is the HOST subdomain — derived from the host id, never from a
+    # workspace name (assumption 1: nothing here takes a workspace as input)
+    label = fx.argvs[0][fx.argvs[0].index("-R") + 1].split(":")[0]
+    assert label == host_subdomain(
+        fx.link.host_id, device_id(PUBKEY), ensure_subdomain_secret(fx.home)
+    )
+
+
+def test_tick_registers_and_reads_back_to_go_online(fx):
+    assert fx.connect() == "online"
+
+    assert len(fx.relay.registrations) == 1
+    assert fx.tunnel.last_error is None
+
+
+def test_no_ssh_process_is_ever_spawned_while_the_link_says_not_to_dial(tmp_path):
+    """AC4: a 409 means a live twin holds the subdomain; dialing would fight it
+    for the route and split traffic between the two of us."""
+    relay = _Relay(register=(409, "identity already registered"))
+    fx = _Fixture(tmp_path, relay, _Clock())
+
+    for _ in range(RelayLink.DUPLICATE_REIDENTIFY_AFTER - 1):
+        fx.tunnel.tick()
+        fx.clock.advance(120)
+
+    assert fx.procs == [], "dialed while the relay says another host holds our identity"
+    assert fx.tunnel.state() == "duplicate-identity"
+
+    # ...and the recovery path un-blocks the dial: the link re-identifies itself,
+    # lands in the enrollment queue, and stops refusing to dial. (The argv the
+    # supervisor holds still carries the OLD subdomain — a re-identify rotates
+    # the key too, so the tunnel only really comes back after the restart
+    # `mship daemon reidentify` tells the operator to perform.)
+    fx.tunnel.tick()
+    assert fx.tunnel.state() == "awaiting-enrollment"
+    assert len(fx.procs) == 1
+
+
+def test_a_tunnel_already_up_is_torn_down_when_the_identity_goes_duplicate(fx):
+    assert fx.connect() == "online"
+
+    fx.relay.refuse(409, "identity already registered")
+    fx.clock.advance(120)
+    fx.tunnel.tick()
+
+    assert fx.tunnel.state() == "duplicate-identity"
+    assert fx.child.terminated == 1
+
+
+# --- AC2: respawn re-registers exactly once ---------------------------------
+
+def test_a_respawn_triggers_exactly_one_additional_registration(fx):
+    fx.connect()
+    assert len(fx.relay.registrations) == 1
+
+    fx.kill_child()
+    fx.clock.advance(1)
+    fx.tunnel.tick()                       # respawn + the one extra registration
+
+    assert len(fx.procs) == 2
+    assert len(fx.relay.registrations) == 2
+
+    for _ in range(20):                    # a re-register storm is the wrong shape
+        fx.clock.advance(1)
+        fx.tunnel.tick()
+    assert len(fx.relay.registrations) == 2, "re-registered once per tick, not once per respawn"
+
+
+def test_registration_failure_does_not_kill_the_tunnel(fx):
+    fx.connect()
+    fx.relay.transport_error = "connection refused"
+
+    for _ in range(30):
+        fx.clock.advance(120)
+        fx.tunnel.tick()
+
+    assert fx.sup.is_running(), "a registration outage tore down a healthy tunnel"
+    assert fx.child.terminated == 0
+
+
+def test_tunnel_failure_does_not_stop_registration_retries(fx):
+    fx.connect()
+    before = len(fx.relay.registrations)
+    fx.kill_child()
+
+    fx.procs.clear()                       # the ssh child now refuses to come back
+    fx.tunnel._supervisor._proc_factory = lambda argv: (_ for _ in ()).throw(
+        OSError("ssh: command not found"))
+
+    for _ in range(5):
+        fx.clock.advance(120)
+        fx.tunnel.tick()
+
+    assert len(fx.relay.registrations) > before, "a dead tunnel silenced registration"
+
+
+# --- AC7: the tunnel shares no lifetime with the registry or the host app ---
+
+def test_fifty_failing_ticks_leave_the_registry_and_host_app_untouched(fx):
+    store = RegistryStore(registry_path(fx.home))
+    store.mutate(lambda s: s)              # materialise the file
+    app = create_host_app(store, auth_token="tok", host_id="hst-1", instance_id="inst-1")
+    before = registry_path(fx.home).read_bytes()
+
+    fx.relay.transport_error = "network is unreachable"
+    fx.tunnel._supervisor._proc_factory = lambda argv: (_ for _ in ()).throw(
+        OSError("ssh: connect failed"))
+    for _ in range(50):
+        fx.clock.advance(120)
+        fx.tunnel.tick()
+
+    assert registry_path(fx.home).read_bytes() == before
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+
+
+def test_an_exception_from_a_tick_lands_in_last_error_and_the_loop_keeps_running(fx):
+    def boom(subdomain): raise RuntimeError("ps: no such process table")
+    fx.tunnel._reaper = boom
+
+    assert fx.tunnel.tick() == "error"
+    assert "no such process table" in fx.tunnel.last_error
+
+    fx.tunnel._reaper = fx._reaper         # the fault clears
+    fx.clock.advance(120)
+    assert fx.connect() == "online"
+    assert fx.tunnel.last_error is None
+
+
+def test_stop_terminates_the_child_exactly_once_and_is_idempotent(fx):
+    fx.connect()
+    child = fx.child
+
+    fx.tunnel.stop()
+    fx.tunnel.stop()
+    fx.tunnel.stop()
+
+    assert child.terminated == 1
+    assert fx.tunnel.state() == "disabled"
+
+    fx.clock.advance(120)
+    fx.tunnel.tick()
+    assert len(fx.procs) == 1, "ticking after stop() re-dialed the relay"
+
+
+# --- AC11: reconnecting writes nothing --------------------------------------
+
+def test_twenty_failure_respawn_cycles_leave_the_registry_and_journal_byte_identical(fx):
+    store = RegistryStore(registry_path(fx.home))
+    store.mutate(lambda s: s)
+    journal = start_history_path(fx.home)
+    history.append_start(journal, datetime(2026, 8, 18, tzinfo=timezone.utc))
+    before = (registry_path(fx.home).read_bytes(), journal.read_bytes())
+
+    fx.connect()
+    for _ in range(20):
+        fx.kill_child()
+        fx.clock.advance(1)
+        fx.tunnel.tick()
+
+    assert len(fx.procs) == 21
+    assert (registry_path(fx.home).read_bytes(), journal.read_bytes()) == before
+    # ...and one directory entry, re-published rather than re-minted
+    assert {r["host_id"] for r in fx.relay.registrations} == {fx.link.host_id}
+    assert {r["refresh"] for r in fx.relay.registrations} == {f"refresh-for-{fx.link.host_id}"}
+
+
+# --- the orphan reaper ------------------------------------------------------
+
+def _proc(pid, ppid, cmdline):
+    return ProcessInfo(pid=pid, ppid=ppid, cmdline=cmdline)
+
+
+def test_reaper_kills_an_orphaned_tunnel_on_our_subdomain(fx):
+    """The collision class `scripts/redeploy-serve.sh` sweeps by hand: a `kill -9`
+    leaves the `start_new_session` ssh child reparented to init, still holding
+    the subdomain, so sish rejects the fresh tunnel and the relay 404s."""
+    ours = _proc(200, 42, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example")
+    orphan = _proc(100, 1, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example")
+    killed = []
+
+    reaped = reap_orphan_tunnels(
+        fx.link.subdomain, processes=lambda: [ours, orphan],
+        kill=lambda pid: killed.append(pid),
+    )
+
+    assert reaped == [100] and killed == [100]
+
+
+def test_reaper_leaves_other_hosts_tunnels_and_non_tunnels_alone(fx):
+    other = _proc(101, 1, "ssh -N -R someone-else:80:localhost:8765 relay.example")
+    shell = _proc(102, 1, f"ssh relay.example  # mentions {fx.link.subdomain}")
+    killed = []
+
+    reaped = reap_orphan_tunnels(
+        fx.link.subdomain, processes=lambda: [other, shell],
+        kill=lambda pid: killed.append(pid),
+    )
+
+    assert reaped == [] and killed == []
+
+
+def test_reaper_survives_a_process_that_vanished_between_list_and_kill(fx):
+    def kill(pid): raise ProcessLookupError(pid)
+    orphan = _proc(100, 1, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example")
+
+    assert reap_orphan_tunnels(fx.link.subdomain, processes=lambda: [orphan], kill=kill) == []
+
+
+def test_the_default_lister_parses_the_real_process_table():
+    """The sweep is silently a no-op if the `ps` parsing is wrong, so pin it
+    against the real table rather than only against hand-built rows."""
+    rows = list_processes()
+
+    assert rows, "could not read the process table at all"
+    me = next(r for r in rows if r.pid == os.getpid())
+    assert me.ppid == os.getppid()
+    assert me.cmdline, "the command line is what the subdomain is matched in"
+
+
+def test_orphans_are_reaped_before_dialing_and_before_each_respawn(fx):
+    fx.tunnel.tick()
+    assert fx.reaped == [fx.link.subdomain], "dialed without sweeping orphans first"
+
+    for _ in range(5):                     # not once per tick while the child holds
+        fx.clock.advance(1)
+        fx.tunnel.tick()
+    assert len(fx.reaped) == 1
+
+    fx.kill_child()
+    fx.clock.advance(1)
+    fx.tunnel.tick()
+    assert len(fx.reaped) == 2 and len(fx.procs) == 2
+
+
+# --- the state ladder -------------------------------------------------------
+
+def test_awaiting_enrollment_is_classified_from_the_ssh_log_tail(fx):
+    """ssh's own refusal is the first evidence that the relay has the key but
+    nobody has approved it — it arrives before any registration verdict."""
+    fx.write_ssh_log("Permission denied (publickey).\n")
+    fx.relay.transport_error = "connection refused"
+
+    fx.tunnel.tick()
+    fx.kill_child()
+    fx.clock.advance(120)
+    fx.tunnel.tick()
+
+    assert fx.tunnel.state() == "awaiting-enrollment"
+
+
+def test_awaiting_enrollment_is_classified_from_the_relays_verdict(tmp_path):
+    relay = _Relay(register=(401, UNAPPROVED))
+    fx = _Fixture(tmp_path, relay, _Clock())
+
+    fx.tunnel.tick()
+
+    assert fx.tunnel.state() == "awaiting-enrollment"
+    assert fx.relay.enrollments, "did not (re-)post the key for approval"
+
+
+def test_read_back_of_our_own_instance_id_is_online(fx):
+    assert fx.connect() == "online"
+
+
+def test_a_foreign_instance_id_is_contended_and_does_not_tear_the_tunnel_down(tmp_path):
+    """Comparing host_id would be blind to exactly this case: a `cp -a` twin
+    publishes the SAME host_id on the SAME subdomain. Only the per-process
+    instance_id tells the two apart."""
+    fx = _Fixture(tmp_path, _Relay(), _Clock(),
+                  verify=partial(probe_health, get=_health_get("inst-of-the-twin")))
+
+    state = fx.connect()
+
+    assert state == "contended"
+    assert "inst-of-the-twin" in fx.tunnel.last_error
+    assert fx.sup.is_running() and fx.child.terminated == 0
+
+
+def test_a_transport_failure_on_the_read_back_stays_connecting(tmp_path):
+    """Unreachable is not contended — the same terminal-vs-transient split
+    `health.py` makes for a stale token vs a route that has not come up yet."""
+    fx = _Fixture(tmp_path, _Relay(), _Clock(),
+                  verify=partial(probe_health, get=_health_get(None, error="connection refused")))
+
+    for _ in range(5):
+        fx.clock.advance(120)
+        assert fx.tunnel.tick() == "connecting"
+    assert "connection refused" in fx.tunnel.last_error
+
+
+def test_a_read_back_without_an_instance_id_stays_connecting(tmp_path):
+    fx = _Fixture(tmp_path, _Relay(), _Clock(),
+                  verify=partial(probe_health, get=_health_get(None)))
+    assert fx.connect() == "connecting"
+
+
+def test_a_registration_that_keeps_failing_is_error_not_online(fx):
+    fx.connect()
+    fx.relay.refuse(500, "boom")
+
+    fx.clock.advance(120)
+    assert fx.tunnel.tick() == "error"
+    assert fx.sup.is_running(), "a directory failure tore down a working tunnel"
+
+
+def test_state_covers_the_whole_vocabulary(tmp_path):
+    """Every state `mship daemon status` renders must be reachable from here."""
+    seen = set()
+
+    fx = _Fixture(tmp_path / "a", _Relay(), _Clock())
+    seen.add(fx.tunnel.state())                          # connecting (nothing ticked yet)
+    seen.add(fx.connect())                               # online
+    fx.tunnel.stop()
+    seen.add(fx.tunnel.state())                          # disabled
+
+    contended = _Fixture(tmp_path / "b", _Relay(), _Clock(),
+                         verify=partial(probe_health, get=_health_get("inst-twin")))
+    seen.add(contended.connect())
+
+    unapproved = _Fixture(tmp_path / "c", _Relay(register=(401, UNAPPROVED)), _Clock())
+    seen.add(unapproved.connect())
+
+    dup = _Fixture(tmp_path / "d", _Relay(register=(409, "already registered")), _Clock())
+    seen.add(dup.connect())
+
+    broken = _Fixture(tmp_path / "e", _Relay(), _Clock())
+    broken.tunnel._reaper = lambda subdomain: 1 / 0
+    seen.add(broken.tunnel.tick())
+
+    assert seen == set(STATES)

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -264,6 +264,42 @@ def test_tick_dials_the_host_subdomain_on_the_daemons_bind_port(fx):
     )
 
 
+def test_initial_spawn_failure_uses_the_supervisor_backoff(tmp_path):
+    clock = _Clock()
+    link = _link(tmp_path, _Relay(), clock)
+    attempts = []
+
+    def fail_to_spawn(_argv):
+        attempts.append(clock())
+        raise FileNotFoundError("ssh")
+
+    supervisor = TunnelSupervisor(
+        argv=["ssh"],
+        proc_factory=fail_to_spawn,
+        backoff_delay=5,
+        max_backoff_delay=60,
+        clock=clock,
+        rng=lambda: 0.0,
+        log_path=tmp_path,
+    )
+    tunnel = HostTunnel(
+        link,
+        supervisor,
+        clock=clock,
+        reaper=lambda _subdomain: [],
+    )
+
+    assert tunnel.tick() == "error"
+    for _ in range(4):
+        clock.advance(1)
+        tunnel.tick()
+    assert attempts == [1_000_000.0]
+
+    clock.advance(1)
+    tunnel.tick()
+    assert attempts == [1_000_000.0, 1_000_005.0]
+
+
 def test_tick_registers_and_reads_back_to_go_online(fx):
     assert fx.connect() == "online"
 

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -248,6 +248,19 @@ def test_no_ssh_process_is_ever_spawned_while_the_link_says_not_to_dial(tmp_path
     assert len(fx.procs) == 1
 
 
+def test_duplicate_identity_still_reaps_a_local_orphan_before_refusing_to_dial(tmp_path):
+    fx = _Fixture(
+        tmp_path,
+        _Relay(register=(409, "identity already registered")),
+        _Clock(),
+    )
+
+    fx.tunnel.tick()
+
+    assert fx.reaped == [fx.link.subdomain]
+    assert fx.procs == []
+
+
 def test_a_tunnel_already_up_is_torn_down_when_the_identity_goes_duplicate(fx):
     assert fx.connect() == "online"
 

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -853,10 +853,18 @@ def test_orphans_are_reaped_before_dialing_and_before_each_respawn(fx):
 # --- the state ladder -------------------------------------------------------
 
 
-def test_awaiting_enrollment_is_classified_from_the_ssh_log_tail(fx):
-    """ssh's own refusal is the first evidence that the relay has the key but
-    nobody has approved it — it arrives before any registration verdict."""
-    fx.write_ssh_log("Permission denied (publickey).\n")
+@pytest.mark.parametrize(
+    "ssh_log",
+    [
+        "Permission denied (publickey).\n",
+        "Permissions 0644 for 'relay_ed25519' are too open.\n"
+        "Load key \"relay_ed25519\": bad permissions\n",
+    ],
+)
+def test_ssh_permission_errors_do_not_override_the_signed_registration_verdict(
+    fx, ssh_log
+):
+    fx.write_ssh_log(ssh_log)
     fx.relay.transport_error = "connection refused"
 
     fx.tunnel.tick()
@@ -864,7 +872,7 @@ def test_awaiting_enrollment_is_classified_from_the_ssh_log_tail(fx):
     fx.clock.advance(120)
     fx.tunnel.tick()
 
-    assert fx.tunnel.state() == "awaiting-enrollment"
+    assert fx.tunnel.state() == "error"
 
 
 def test_awaiting_enrollment_is_classified_from_the_relays_verdict(tmp_path):

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -311,10 +311,19 @@ def test_a_drop_after_a_healthy_run_registers_once_and_never_while_the_child_is_
         "the link's own schedule came due — the counts above stopped meaning anything"
 
 
-def test_redialing_after_a_duplicate_identity_clears_does_not_register_twice(fx):
+def test_redialing_after_a_duplicate_identity_clears_does_not_register_twice(tmp_path):
     """`TunnelSupervisor.start()` zeroes `restart_count`, so the teardown +
-    re-dial cycle looks like a respawn to anything that diffs it."""
+    re-dial cycle looks like a respawn to anything that diffs it.
+
+    The flap streak is load-bearing: with a counter sitting at 0 on both sides of
+    the teardown there is no difference to observe, and this test would pass
+    against the very implementation it exists to rule out."""
+    fx = _Fixture(tmp_path, _Relay(), _Clock(), backoff=1.0, max_backoff=8.0)
     fx.connect()
+    for _ in range(3):
+        fx.drop_and_wait()
+    assert fx.sup.restart_count == 3
+
     fx.relay.refuse(409, "identity already registered")
     fx.clock.advance(120)
     fx.tunnel.tick()
@@ -323,7 +332,7 @@ def test_redialing_after_a_duplicate_identity_clears_does_not_register_twice(fx)
     fx.relay.refuse(200)
     fx.clock.advance(120)
     fx.tunnel.tick()                       # re-dials, and registers once, here
-    assert len(fx.procs) == 2
+    assert len(fx.procs) == 5 and fx.sup.restart_count == 0
     after_redial = len(fx.relay.registrations)
 
     for _ in range(5):

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -626,3 +626,54 @@ def test_state_covers_the_whole_vocabulary(tmp_path):
     seen.add(broken.tunnel.tick())
 
     assert seen == set(STATES)
+
+
+def test_stop_landing_inside_a_tick_spawns_nothing_afterwards(tmp_path):
+    """AC7's orphan window: `stop()` runs on the daemon's loop thread while a
+    tick runs in the executor. A tick already past its own stopped-check goes on
+    to `_redial`, and without a latch that call would fork a fresh
+    `start_new_session=True` ssh AFTER the child was signalled — an orphan
+    holding the subdomain that nothing in this process owns any more."""
+    clock = _Clock()
+    fixture = _Fixture(tmp_path, _Relay(), clock)
+    real_link_tick = fixture.link.tick
+
+    def shutdown_lands_mid_tick():
+        fixture.tunnel.stop()
+        return real_link_tick()
+
+    fixture.link.tick = shutdown_lands_mid_tick
+
+    fixture.tunnel.tick()
+
+    assert fixture.procs == [], "dialed a tunnel after the daemon stopped it"
+    assert fixture.tunnel.state() == "disabled"
+
+
+def test_a_child_respawned_in_the_same_tick_as_the_stop_is_still_terminated(
+    tmp_path,
+):
+    """The same window one layer in: the respawn happens earlier in the very
+    tick the shutdown lands in. That child must be signalled and must be the
+    last one — the danger is not the spawn, it is a spawn nothing then owns."""
+    clock = _Clock()
+    fixture = _Fixture(tmp_path, _Relay(), clock)
+    fixture.connect()
+    fixture.kill_child()
+    clock.advance(120)                      # any backoff has long since elapsed
+    real_link_tick = fixture.link.tick
+
+    def shutdown_lands_mid_tick():
+        fixture.tunnel.stop()
+        return real_link_tick()
+
+    fixture.link.tick = shutdown_lands_mid_tick
+
+    fixture.tunnel.tick()
+    spawned_by_shutdown_tick = len(fixture.procs)
+    fixture.tunnel.tick()
+    clock.advance(120)
+    fixture.tunnel.tick()
+
+    assert fixture.child.terminated, "the respawned child outlived the stop"
+    assert len(fixture.procs) == spawned_by_shutdown_tick

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -677,3 +677,46 @@ def test_a_child_respawned_in_the_same_tick_as_the_stop_is_still_terminated(
 
     assert fixture.child.terminated, "the respawned child outlived the stop"
     assert len(fixture.procs) == spawned_by_shutdown_tick
+
+
+# --- the snapshot the daemon publishes (#471 Task 9) ------------------------
+
+def test_snapshot_is_published_per_tick_not_read_live(fx):
+    """`/health` serves this from the request thread while ticks mutate the
+    tunnel on the executor thread (`run.py::_tunnel_loop`), so a snapshot must
+    be an immutable per-tick publication: the dict a reader already holds can
+    never change under it, and a later tick publishes a NEW one."""
+    before = fx.tunnel.snapshot()
+    assert before["state"] == "connecting"
+
+    fx.connect()
+    after = fx.tunnel.snapshot()
+
+    assert before["state"] == "connecting", "a published snapshot mutated"
+    assert after is not before
+    assert after["state"] == "online"
+    assert after["subdomain"] == fx.link.subdomain
+    assert after["public_url"] == fx.link.public_url
+    assert after["restarts"] == 0
+    assert after["last_error"] is None
+    assert after["clock_skew_seconds"] is None  # the fake relay sends no Date
+
+
+def test_snapshot_reports_the_states_and_reasons_the_operator_acts_on(tmp_path):
+    dup = _Fixture(tmp_path / "dup", _Relay(register=(409, "held by hst-other")), _Clock())
+    dup.connect()
+    assert dup.tunnel.snapshot()["state"] == "duplicate-identity"
+    assert "held by hst-other" in dup.tunnel.snapshot()["last_error"]
+
+    fx = _Fixture(tmp_path / "up", _Relay(), _Clock())
+    fx.connect()
+    fx.tunnel.stop()
+    assert fx.tunnel.snapshot()["state"] == "disabled"
+
+
+def test_snapshot_carries_the_links_clock_skew(fx):
+    """Sourced from the ENROLL SERVER's `Date` (Task 6), never the read-back's:
+    that one is emitted by this host's own uvicorn and is ~0 by construction."""
+    fx.link.clock_skew_seconds = -3600.0
+    fx.tunnel.tick()
+    assert fx.tunnel.snapshot()["clock_skew_seconds"] == -3600.0

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -718,6 +718,36 @@ def test_a_foreign_instance_id_is_contended_and_does_not_tear_the_tunnel_down(tm
     assert "inst-of-the-twin" in fx.tunnel.last_error
     assert fx.sup.is_running() and fx.child.terminated == 0
 
+@pytest.mark.parametrize(
+    "next_get",
+    (
+        _health_get(None, error="connection refused"),
+        _health_get(None, status=503),
+        _health_get(None),
+    ),
+    ids=("transport-error", "non-2xx", "missing-instance-id"),
+)
+def test_a_transient_readback_replaces_an_obsolete_contention_verdict(
+    tmp_path, next_get
+):
+    responses = iter((_health_get("inst-of-the-twin"), next_get))
+
+    def get(*args, **kwargs):
+        return next(responses)(*args, **kwargs)
+
+    fx = _Fixture(
+        tmp_path,
+        _Relay(),
+        _Clock(),
+        verify=partial(probe_health, get=get),
+    )
+    assert fx.connect() == "contended"
+
+    fx.clock.advance(120)
+
+    assert fx.tunnel.tick() == "connecting"
+
+
 
 def test_a_transport_failure_on_the_read_back_stays_connecting(tmp_path):
     """Unreachable is not contended — the same terminal-vs-transient split

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -295,6 +295,8 @@ def test_initial_spawn_failure_uses_the_supervisor_backoff(tmp_path):
     for _ in range(4):
         clock.advance(1)
         tunnel.tick()
+        assert tunnel.state() == "error"
+        assert "ssh" in tunnel.last_error
     assert attempts == [1_000_000.0]
 
     clock.advance(1)
@@ -654,6 +656,51 @@ def test_reaper_does_not_force_kill_a_reused_pid(fx):
     )
 
     assert signals == [(orphan.pid, signal.SIGTERM)]
+
+
+def test_reaper_does_not_term_a_pid_reused_before_the_first_signal(fx):
+    orphan = _proc(
+        100, 1, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example"
+    )
+    replacement = _proc(
+        orphan.pid,
+        1,
+        f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example",
+        started="replacement",
+    )
+    snapshots = iter(([orphan], [replacement]))
+    opened = []
+    closed = []
+    signals = []
+
+    reaped = reap_orphan_tunnels(
+        fx.link.subdomain,
+        processes=lambda: next(snapshots),
+        pidfd_open=lambda pid: (opened.append(pid), 77)[1],
+        pidfd_signal=lambda fd, sig: signals.append((fd, sig)),
+        close_pidfd=closed.append,
+        process_exists=lambda _pid: True,
+    )
+
+    assert reaped == []
+    assert opened == [orphan.pid]
+    assert closed == [77]
+    assert signals == []
+
+
+def test_reaper_refuses_to_signal_without_atomic_pidfd_support(fx):
+    orphan = _proc(
+        100, 1, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example"
+    )
+
+    with pytest.raises(RuntimeError, match="atomic pidfd signaling"):
+        reap_orphan_tunnels(
+            fx.link.subdomain,
+            processes=lambda: [orphan],
+            pidfd_open=lambda _pid: (_ for _ in ()).throw(
+                NotImplementedError("pidfd unavailable")
+            ),
+        )
 
 
 def test_reaper_leaves_other_hosts_tunnels_and_non_tunnels_alone(fx):

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -25,6 +25,7 @@ from fastapi.testclient import TestClient
 from mship.core.daemon import history
 from mship.core.daemon.host_app import create_host_app
 from mship.core.daemon.host_tunnel import (
+    MAX_PROCESS_LIST_CALLS_PER_REAP,
     ORPHAN_EXIT_TIMEOUT_S,
     STATES,
     HostTunnel,
@@ -688,19 +689,78 @@ def test_reaper_does_not_term_a_pid_reused_before_the_first_signal(fx):
     assert signals == []
 
 
-def test_reaper_refuses_to_signal_without_atomic_pidfd_support(fx):
+def test_reaper_uses_revalidated_kill_when_pidfds_are_unavailable(
+    fx, monkeypatch
+):
     orphan = _proc(
         100, 1, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example"
     )
+    alive = {orphan.pid}
+    signals = []
 
-    with pytest.raises(RuntimeError, match="atomic pidfd signaling"):
-        reap_orphan_tunnels(
-            fx.link.subdomain,
-            processes=lambda: [orphan],
-            pidfd_open=lambda _pid: (_ for _ in ()).throw(
-                NotImplementedError("pidfd unavailable")
-            ),
+    def portable_kill(pid, sig):
+        signals.append((pid, sig))
+        alive.remove(pid)
+
+    monkeypatch.delattr(os, "pidfd_open", raising=False)
+    monkeypatch.delattr(signal, "pidfd_send_signal", raising=False)
+    monkeypatch.setattr(os, "kill", portable_kill)
+
+    reaped = reap_orphan_tunnels(
+        fx.link.subdomain,
+        processes=lambda: [orphan],
+        process_exists=lambda pid: pid in alive,
+    )
+
+    assert reaped == [orphan.pid]
+    assert signals == [(orphan.pid, signal.SIGTERM)]
+
+
+def test_portable_reaper_uses_fixed_process_snapshots_for_many_stubborn_orphans(
+    fx, monkeypatch
+):
+    orphans = [
+        _proc(
+            pid,
+            1,
+            f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example",
         )
+        for pid in range(100, 110)
+    ]
+    alive = {proc.pid for proc in orphans}
+    scans = []
+    signals = []
+    now = [0.0]
+
+    def process_snapshot():
+        scans.append(1)
+        return orphans
+
+    def portable_kill(pid, sig):
+        signals.append((pid, sig))
+        if sig == signal.SIGKILL:
+            alive.remove(pid)
+
+    monkeypatch.delattr(os, "pidfd_open", raising=False)
+    monkeypatch.delattr(signal, "pidfd_send_signal", raising=False)
+    monkeypatch.setattr(os, "kill", portable_kill)
+
+    reap_orphan_tunnels(
+        fx.link.subdomain,
+        processes=process_snapshot,
+        process_exists=lambda pid: pid in alive,
+        clock=lambda: now[0],
+        sleep=lambda seconds: now.__setitem__(0, now[0] + seconds),
+    )
+
+    assert len(scans) == MAX_PROCESS_LIST_CALLS_PER_REAP
+    assert signals == [
+        (proc.pid, signal.SIGTERM) for proc in orphans
+    ] + [
+        (proc.pid, signal.SIGKILL) for proc in orphans
+    ]
+
+
 
 
 def test_reaper_leaves_other_hosts_tunnels_and_non_tunnels_alone(fx):

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -14,6 +14,7 @@ Seams are injected exactly like `tests/core/relay/test_tunnel_supervisor.py`
 import base64
 import hashlib
 import os
+import signal
 from datetime import datetime, timezone
 from functools import partial
 from pathlib import Path
@@ -24,6 +25,7 @@ from fastapi.testclient import TestClient
 from mship.core.daemon import history
 from mship.core.daemon.host_app import create_host_app
 from mship.core.daemon.host_tunnel import (
+    ORPHAN_EXIT_TIMEOUT_S,
     STATES,
     HostTunnel,
     ProcessInfo,
@@ -498,12 +500,18 @@ def test_fifty_failing_ticks_leave_the_registry_and_host_app_untouched(fx):
 
 
 def test_an_exception_from_a_tick_lands_in_last_error_and_the_loop_keeps_running(fx):
+    attempts = []
+
     def boom(subdomain):
+        attempts.append(subdomain)
         raise RuntimeError("ps: no such process table")
 
     fx.tunnel._reaper = boom
 
     assert fx.tunnel.tick() == "error"
+    assert fx.tunnel.tick() == "error"
+    assert attempts == [fx.link.subdomain, fx.link.subdomain]
+    assert fx.procs == []
     assert "no such process table" in fx.tunnel.last_error
 
     fx.tunnel._reaper = fx._reaper  # the fault clears
@@ -558,8 +566,10 @@ def test_twenty_failure_respawn_cycles_leave_the_registry_and_journal_byte_ident
 # --- the orphan reaper ------------------------------------------------------
 
 
-def _proc(pid, ppid, cmdline):
-    return ProcessInfo(pid=pid, ppid=ppid, cmdline=cmdline)
+def _proc(pid, ppid, cmdline, started=None):
+    return ProcessInfo(
+        pid=pid, ppid=ppid, cmdline=cmdline, started=started or f"start-{pid}"
+    )
 
 
 def test_reaper_kills_an_orphaned_tunnel_on_our_subdomain(fx):
@@ -573,14 +583,77 @@ def test_reaper_kills_an_orphaned_tunnel_on_our_subdomain(fx):
         100, 1, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example"
     )
     killed = []
+    alive = {orphan.pid}
+
+    def terminate(pid):
+        killed.append(pid)
+        alive.remove(pid)
 
     reaped = reap_orphan_tunnels(
         fx.link.subdomain,
         processes=lambda: [ours, orphan],
-        kill=lambda pid: killed.append(pid),
+        kill=terminate,
+        process_exists=lambda pid: pid in alive,
     )
 
     assert reaped == [100] and killed == [100]
+
+
+def test_reaper_waits_then_force_kills_a_stubborn_orphan(fx):
+    orphan = _proc(
+        100, 1, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example"
+    )
+    now = [0.0]
+    alive = {orphan.pid}
+    signals = []
+
+    def force_kill(pid):
+        signals.append((pid, signal.SIGKILL))
+        alive.remove(pid)
+
+    reap_orphan_tunnels(
+        fx.link.subdomain,
+        processes=lambda: [orphan],
+        kill=lambda pid: signals.append((pid, signal.SIGTERM)),
+        force_kill=force_kill,
+        process_exists=lambda pid: pid in alive,
+        clock=lambda: now[0],
+        sleep=lambda seconds: now.__setitem__(0, now[0] + seconds),
+    )
+
+    assert signals == [(orphan.pid, signal.SIGTERM), (orphan.pid, signal.SIGKILL)]
+    assert now[0] >= ORPHAN_EXIT_TIMEOUT_S
+
+
+def test_reaper_does_not_force_kill_a_reused_pid(fx):
+    orphan = _proc(
+        100, 1, f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example"
+    )
+    replacement = _proc(
+        orphan.pid,
+        1,
+        f"ssh -N -R {fx.link.subdomain}:80:localhost:8765 relay.example",
+        started="replacement",
+    )
+    rows = [orphan]
+    now = [0.0]
+    signals = []
+
+    def terminate(pid):
+        signals.append((pid, signal.SIGTERM))
+        rows[0] = replacement
+
+    reap_orphan_tunnels(
+        fx.link.subdomain,
+        processes=lambda: list(rows),
+        kill=terminate,
+        force_kill=lambda pid: pytest.fail(f"force-killed reused pid {pid}"),
+        process_exists=lambda _pid: True,
+        clock=lambda: now[0],
+        sleep=lambda seconds: now.__setitem__(0, now[0] + seconds),
+    )
+
+    assert signals == [(orphan.pid, signal.SIGTERM)]
 
 
 def test_reaper_leaves_other_hosts_tunnels_and_non_tunnels_alone(fx):
@@ -718,6 +791,7 @@ def test_a_foreign_instance_id_is_contended_and_does_not_tear_the_tunnel_down(tm
     assert "inst-of-the-twin" in fx.tunnel.last_error
     assert fx.sup.is_running() and fx.child.terminated == 0
 
+
 @pytest.mark.parametrize(
     "next_get",
     (
@@ -746,7 +820,6 @@ def test_a_transient_readback_replaces_an_obsolete_contention_verdict(
     fx.clock.advance(120)
 
     assert fx.tunnel.tick() == "connecting"
-
 
 
 def test_a_transport_failure_on_the_read_back_stays_connecting(tmp_path):

--- a/tests/core/daemon/test_host_tunnel.py
+++ b/tests/core/daemon/test_host_tunnel.py
@@ -133,7 +133,8 @@ def _health_get(instance_id: str | None, *, error: str | None = None, status: in
 class _Fixture:
     """One wired-up tunnel: link + supervisor + the argv a daemon would build."""
 
-    def __init__(self, home: Path, relay: _Relay, clock: _Clock, **kw):
+    def __init__(self, home: Path, relay: _Relay, clock: _Clock, *,
+                 backoff: float = 0.0, max_backoff: float = 60.0, **kw):
         self.home, self.relay, self.clock = home, relay, clock
         self.procs: list[FakeProc] = []
         self.argvs: list[list[str]] = []
@@ -144,8 +145,9 @@ class _Fixture:
             key_path=relay_key_path(home),
         )
         self.sup = TunnelSupervisor(
-            argv=self.argv, proc_factory=self._factory, backoff_delay=0.0,
-            clock=clock, log_path=tunnel_log_path(home), rng=lambda: 0.0,
+            argv=self.argv, proc_factory=self._factory, backoff_delay=backoff,
+            max_backoff_delay=max_backoff, clock=clock,
+            log_path=tunnel_log_path(home), rng=lambda: 0.0,
         )
         kw.setdefault("verify", partial(probe_health, get=_health_get(self.link.instance_id)))
         kw.setdefault("reaper", self._reaper)
@@ -175,6 +177,18 @@ class _Fixture:
         self.tunnel.tick()
         self.clock.advance(1)
         return self.tunnel.tick()
+
+    def drop_and_wait(self, step: float = 0.5, limit: int = 40) -> None:
+        """Kill the child, then tick until the supervisor's backoff lets a
+        replacement through — the real shape, rather than a zero backoff."""
+        before = len(self.procs)
+        self.kill_child()
+        for _ in range(limit):
+            self.tunnel.tick()
+            if len(self.procs) > before:
+                return
+            self.clock.advance(step)
+        raise AssertionError("supervisor never respawned within the tick budget")
 
     def write_ssh_log(self, text: str) -> None:
         path = tunnel_log_path(self.home)
@@ -262,6 +276,60 @@ def test_a_respawn_triggers_exactly_one_additional_registration(fx):
         fx.clock.advance(1)
         fx.tunnel.tick()
     assert len(fx.relay.registrations) == 2, "re-registered once per tick, not once per respawn"
+
+
+def test_a_drop_after_a_healthy_run_registers_once_and_never_while_the_child_is_gone(tmp_path):
+    """The regression the zero-backoff fixture cannot see: `restart_count` is
+    reset by a healthy run, so diffing it reads the DROP as a respawn and
+    re-registers while no child exists, then registers again on the respawn."""
+    fx = _Fixture(tmp_path, _Relay(), _Clock(), backoff=1.0, max_backoff=8.0)
+    started = fx.clock.t
+    fx.connect()
+
+    for _ in range(3):                     # a flap streak builds the count up
+        fx.drop_and_wait()
+    fx.clock.advance(9.0)                  # ...then a run outliving the cap
+    fx.tunnel.tick()
+    assert fx.sup.is_running() and fx.sup.restart_count == 3
+
+    before = len(fx.relay.registrations)
+    fx.kill_child()
+    fx.tunnel.tick()                       # the drop is detected; nothing is up
+    assert fx.sup.restart_count == 0, "the healthy run should have reset the streak"
+    assert len(fx.relay.registrations) == before, "registered while no child existed"
+
+    fx.clock.advance(1.0)
+    fx.tunnel.tick()
+    assert len(fx.procs) == 5
+    assert len(fx.relay.registrations) == before + 1
+
+    for _ in range(5):
+        fx.clock.advance(0.5)
+        fx.tunnel.tick()
+    assert len(fx.relay.registrations) == before + 1
+    assert fx.clock.t - started < host_contract.REGISTER_INTERVAL_S, \
+        "the link's own schedule came due — the counts above stopped meaning anything"
+
+
+def test_redialing_after_a_duplicate_identity_clears_does_not_register_twice(fx):
+    """`TunnelSupervisor.start()` zeroes `restart_count`, so the teardown +
+    re-dial cycle looks like a respawn to anything that diffs it."""
+    fx.connect()
+    fx.relay.refuse(409, "identity already registered")
+    fx.clock.advance(120)
+    fx.tunnel.tick()
+    assert fx.tunnel.state() == "duplicate-identity" and not fx.sup.is_running()
+
+    fx.relay.refuse(200)
+    fx.clock.advance(120)
+    fx.tunnel.tick()                       # re-dials, and registers once, here
+    assert len(fx.procs) == 2
+    after_redial = len(fx.relay.registrations)
+
+    for _ in range(5):
+        fx.clock.advance(1)
+        fx.tunnel.tick()
+    assert len(fx.relay.registrations) == after_redial
 
 
 def test_registration_failure_does_not_kill_the_tunnel(fx):
@@ -396,6 +464,28 @@ def test_reaper_leaves_other_hosts_tunnels_and_non_tunnels_alone(fx):
     )
 
     assert reaped == [] and killed == []
+
+
+def test_reaper_spares_a_label_that_merely_ends_with_ours(fx):
+    """A substring match would take down an unrelated host: its own opaque slug
+    can end with the whole of ours, and it is orphaned-looking to us either way.
+    The label is a token, so it is compared as one."""
+    collider = _proc(103, 1, f"ssh -N -R xyz-{fx.link.subdomain}:80:localhost:9000 relay.example")
+    prefix = _proc(104, 1, f"ssh -N -R {fx.link.subdomain}-extra:80:localhost:9000 relay.example")
+    killed = []
+
+    reaped = reap_orphan_tunnels(
+        fx.link.subdomain, processes=lambda: [collider, prefix],
+        kill=lambda pid: killed.append(pid),
+    )
+
+    assert reaped == [] and killed == []
+
+
+def test_reaper_tolerates_a_trailing_dash_r_with_no_forward_spec(fx):
+    dangling = _proc(105, 1, "ssh -N relay.example -R")
+    assert reap_orphan_tunnels(fx.link.subdomain, processes=lambda: [dangling],
+                               kill=lambda pid: pytest.fail("signalled a malformed row")) == []
 
 
 def test_reaper_survives_a_process_that_vanished_between_list_and_kill(fx):

--- a/tests/core/daemon/test_paths.py
+++ b/tests/core/daemon/test_paths.py
@@ -8,6 +8,8 @@ from mship.core.daemon.paths import (
     daemon_state_dir,
     lease_path,
     start_history_path,
+    tunnel_log_path,
+    tunnel_runtime_path,
 )
 
 
@@ -18,6 +20,16 @@ def test_state_dir_and_derivatives(tmp_path: Path):
     assert daemon_log_dir(home) == state / "logs"
     assert lease_path(home) == state / "daemon.lease"
     assert start_history_path(home) == state / "start-history.json"
+    assert tunnel_log_path(home) == state / "logs" / "relay-tunnel.log"
+    assert tunnel_runtime_path(home) == state / "tunnel.json"
+
+
+def test_tunnel_paths_are_never_workspace_scoped(tmp_path: Path):
+    """`mship serve --relay` logs to `<workspace>/.mothership/relay-tunnel.log`;
+    the daemon's tunnel is per-machine and must not write into a workspace it
+    merely discovered."""
+    for path in (tunnel_log_path(tmp_path), tunnel_runtime_path(tmp_path)):
+        assert daemon_state_dir(tmp_path) in path.parents
 
 
 def test_the_suite_cannot_reach_the_real_daemon_socket(tmp_path: Path):

--- a/tests/core/daemon/test_paths.py
+++ b/tests/core/daemon/test_paths.py
@@ -54,6 +54,20 @@ def test_the_suite_cannot_reach_the_real_daemon_through_the_lease_either(tmp_pat
     assert probe_daemon(home=tmp_path, env=os.environ) is None
 
 
+def test_daemon_probe_sandbox_rejects_a_path_with_only_the_tmp_prefix(tmp_path: Path):
+    from mship.core.daemon import control
+
+    contacted = []
+    outside = tmp_path.parent / f"{tmp_path.name}-live" / "daemon.sock"
+
+    def client_factory(**_kwargs):
+        contacted.append(outside)
+        raise AssertionError("probe escaped the per-test sandbox")
+
+    assert control.probe_control_socket(outside, client_factory=client_factory) is None
+    assert contacted == []
+
+
 def test_socket_prefers_xdg_runtime_dir(tmp_path: Path):
     runtime = tmp_path / "runtime"
     sock = daemon_socket_path({"XDG_RUNTIME_DIR": str(runtime)}, tmp_path / "home", create=True)

--- a/tests/core/daemon/test_paths.py
+++ b/tests/core/daemon/test_paths.py
@@ -1,4 +1,5 @@
 """Daemon path derivation is pure: explicit `home` + `env`, no ambient reads."""
+import os
 from pathlib import Path
 
 from mship.core.daemon.paths import (
@@ -17,6 +18,15 @@ def test_state_dir_and_derivatives(tmp_path: Path):
     assert daemon_log_dir(home) == state / "logs"
     assert lease_path(home) == state / "daemon.lease"
     assert start_history_path(home) == state / "start-history.json"
+
+
+def test_the_suite_cannot_reach_the_real_daemon_socket(tmp_path: Path):
+    """Guard for the autouse `_isolate_runtime_dir` fixture (tests/conftest.py):
+    without it, any test that computes the socket path from the ambient env
+    probes the operator's LIVE daemon on a box where one is running, and
+    'daemon: not running' assertions fail for unrelated reasons."""
+    assert str(tmp_path) in os.environ["XDG_RUNTIME_DIR"]
+    assert not daemon_socket_path(os.environ, tmp_path).exists()
 
 
 def test_socket_prefers_xdg_runtime_dir(tmp_path: Path):

--- a/tests/core/daemon/test_paths.py
+++ b/tests/core/daemon/test_paths.py
@@ -9,7 +9,6 @@ from mship.core.daemon.paths import (
     lease_path,
     start_history_path,
     tunnel_log_path,
-    tunnel_runtime_path,
 )
 
 
@@ -21,15 +20,13 @@ def test_state_dir_and_derivatives(tmp_path: Path):
     assert lease_path(home) == state / "daemon.lease"
     assert start_history_path(home) == state / "start-history.json"
     assert tunnel_log_path(home) == state / "logs" / "relay-tunnel.log"
-    assert tunnel_runtime_path(home) == state / "tunnel.json"
 
 
-def test_tunnel_paths_are_never_workspace_scoped(tmp_path: Path):
+def test_tunnel_log_is_never_workspace_scoped(tmp_path: Path):
     """`mship serve --relay` logs to `<workspace>/.mothership/relay-tunnel.log`;
     the daemon's tunnel is per-machine and must not write into a workspace it
     merely discovered."""
-    for path in (tunnel_log_path(tmp_path), tunnel_runtime_path(tmp_path)):
-        assert daemon_state_dir(tmp_path) in path.parents
+    assert daemon_state_dir(tmp_path) in tunnel_log_path(tmp_path).parents
 
 
 def test_the_suite_cannot_reach_the_real_daemon_socket(tmp_path: Path):

--- a/tests/core/daemon/test_paths.py
+++ b/tests/core/daemon/test_paths.py
@@ -29,6 +29,22 @@ def test_the_suite_cannot_reach_the_real_daemon_socket(tmp_path: Path):
     assert not daemon_socket_path(os.environ, tmp_path).exists()
 
 
+def test_the_suite_cannot_reach_the_real_daemon_through_the_lease_either(tmp_path: Path):
+    """The second escape hatch: `probe_daemon` PREFERS the socket recorded in
+    `Path.home()/.mothership/daemon/daemon.lease`, so isolating XDG_RUNTIME_DIR
+    alone still lets a test that reaches the REAL home answer from the
+    operator's live daemon (that is how `test_status_reports_registry_read_
+    error_...` once reported `running: true` with the live pid). Probe the real
+    home for real: on a box with a running mshipd this returns None only
+    because the autouse sandbox refuses sockets outside the test tmp dir."""
+    from pathlib import Path as _Path
+
+    from mship.core.daemon.status import probe_daemon
+
+    assert probe_daemon(home=_Path.home(), env=os.environ) is None
+    assert probe_daemon(home=tmp_path, env=os.environ) is None
+
+
 def test_socket_prefers_xdg_runtime_dir(tmp_path: Path):
     runtime = tmp_path / "runtime"
     sock = daemon_socket_path({"XDG_RUNTIME_DIR": str(runtime)}, tmp_path / "home", create=True)

--- a/tests/core/daemon/test_registry_store.py
+++ b/tests/core/daemon/test_registry_store.py
@@ -184,7 +184,7 @@ def test_daemon_config_relay_roundtrip(tmp_path: Path):
 
 @pytest.mark.parametrize(
     "relay",
-    [{}, {"ssh_port": 2222}, {"host": ""}, {"user": "mship"}, "relay.example.com"],
+    [{}, {"ssh_port": 2222}, {"host": ""}, {"host": 123}, {"user": "mship"}, "relay.example.com"],
 )
 def test_daemon_config_rejects_relay_block_without_host(relay):
     """A present-but-hostless block is a typo, never a quiet "tunnel off": the

--- a/tests/core/daemon/test_registry_store.py
+++ b/tests/core/daemon/test_registry_store.py
@@ -1,6 +1,7 @@
 """Registry model + flock'd store (#472 Task 1). The two-hosts test is the
 behavioral pin for "no exclusive cross-host ownership": arbitration belongs to
 #473's claims (see WorkspaceEntry docstring), not to registry state."""
+
 import multiprocessing
 import os
 import threading
@@ -26,28 +27,45 @@ NOW = datetime(2026, 8, 17, 1, 0, tzinfo=timezone.utc)
 
 def _entry(id="ws-x", path="/w/a", **kw):
     defaults = dict(
-        id=id, name="a", path=path, config_path=f"{path}/mothership.yaml",
-        first_seen=NOW, last_seen=NOW,
+        id=id,
+        name="a",
+        path=path,
+        config_path=f"{path}/mothership.yaml",
+        first_seen=NOW,
+        last_seen=NOW,
     )
     defaults.update(kw)
     return WorkspaceEntry(**defaults)
 
 
 def test_paths_are_pure(tmp_path: Path):
-    assert daemon_config_path(tmp_path) == tmp_path / ".mothership" / "daemon" / "config.yaml"
-    assert registry_path(tmp_path) == tmp_path / ".mothership" / "daemon" / "workspaces.json"
+    assert (
+        daemon_config_path(tmp_path)
+        == tmp_path / ".mothership" / "daemon" / "config.yaml"
+    )
+    assert (
+        registry_path(tmp_path)
+        == tmp_path / ".mothership" / "daemon" / "workspaces.json"
+    )
 
 
 def test_entry_roundtrip_and_skew_tolerance(tmp_path: Path):
     store = RegistryStore(registry_path(tmp_path))
-    e = _entry(repos=[RepoInfo(name="app", path="app", git_root="root")], runner={"enabled": True})
+    e = _entry(
+        repos=[RepoInfo(name="app", path="app", git_root="root")],
+        runner={"enabled": True},
+    )
     store.mutate(lambda s: s.entries.append(e))
     loaded = store.load()
     assert loaded.entries[0].id == "ws-x"
     assert loaded.entries[0].repos[0].git_root == "root"
     assert loaded.entries[0].runner == {"enabled": True}
     # forward-skew: unknown fields ignored
-    raw = registry_path(tmp_path).read_text().replace('"entries":', '"future_field": 1, "entries":')
+    raw = (
+        registry_path(tmp_path)
+        .read_text()
+        .replace('"entries":', '"future_field": 1, "entries":')
+    )
     registry_path(tmp_path).write_text(raw)
     assert store.load().entries[0].id == "ws-x"
 
@@ -63,8 +81,10 @@ def test_id_is_minted_never_dirname():
 def _mutate_worker(path_str: str, worker: int, rounds: int) -> None:
     store = RegistryStore(Path(path_str))
     for j in range(rounds):
+
         def add(s, worker=worker, j=j):
             s.entries.append(_entry(id=f"ws-{worker}-{j}", path=f"/w/{worker}/{j}"))
+
         store.mutate(add)
 
 
@@ -107,7 +127,10 @@ def test_daemon_config_missing_file_scans_nothing(tmp_path: Path):
 
 
 def test_daemon_config_roundtrip(tmp_path: Path):
-    save_daemon_config(tmp_path, DaemonConfig(scan_roots=["/src"], serve={"host": "127.0.0.1", "port": 47190}))
+    save_daemon_config(
+        tmp_path,
+        DaemonConfig(scan_roots=["/src"], serve={"host": "127.0.0.1", "port": 47190}),
+    )
     cfg = load_daemon_config(tmp_path)
     assert cfg.scan_roots == ["/src"]
     assert cfg.serve == {"host": "127.0.0.1", "port": 47190}
@@ -130,9 +153,7 @@ def test_daemon_config_malformed_yaml_is_a_value_error(tmp_path: Path):
         load_daemon_config(tmp_path)
 
 
-def test_daemon_config_read_error_is_not_treated_as_absent(
-    tmp_path: Path, monkeypatch
-):
+def test_daemon_config_read_error_is_not_treated_as_absent(tmp_path: Path, monkeypatch):
     path = daemon_config_path(tmp_path)
     path.parent.mkdir(parents=True)
     original = b"scan_roots: []\n"
@@ -166,7 +187,6 @@ def test_daemon_config_rejects_invalid_serve_bind(serve):
         DaemonConfig(serve=serve)
 
 
-
 def test_daemon_config_missing_relay_block_is_tunnel_disabled(tmp_path: Path):
     """No `relay:` is the ordinary LAN/tailnet host, not a misconfiguration."""
     assert load_daemon_config(tmp_path).relay is None
@@ -178,19 +198,33 @@ def test_daemon_config_relay_roundtrip(tmp_path: Path):
         DaemonConfig(relay={"host": "relay.example.com", "ssh_port": 2222}),
     )
     assert load_daemon_config(tmp_path).relay == {
-        "host": "relay.example.com", "ssh_port": 2222,
+        "host": "relay.example.com",
+        "ssh_port": 2222,
     }
 
 
 @pytest.mark.parametrize(
     "relay",
-    [{}, {"ssh_port": 2222}, {"host": ""}, {"host": 123}, {"user": "mship"}, "relay.example.com"],
+    [
+        {},
+        {"ssh_port": 2222},
+        {"host": ""},
+        {"host": 123},
+        {"user": "mship"},
+        "relay.example.com",
+    ],
 )
 def test_daemon_config_rejects_relay_block_without_host(relay):
     """A present-but-hostless block is a typo, never a quiet "tunnel off": the
     host it was meant to reach would silently never be dialed."""
     with pytest.raises(ValueError, match="relay"):
         DaemonConfig(relay=relay)
+
+
+@pytest.mark.parametrize("port", [0, 65536, True, "2222"])
+def test_daemon_config_rejects_invalid_relay_ssh_port(port):
+    with pytest.raises(ValueError, match="relay.ssh_port"):
+        DaemonConfig(relay={"host": "relay.example.com", "ssh_port": port})
 
 
 def test_daemon_config_rejects_negative_max_depth():
@@ -287,9 +321,7 @@ def test_daemon_config_save_is_atomically_visible(tmp_path, monkeypatch):
     assert path.stat().st_mode & 0o777 == 0o600
 
 
-def test_daemon_config_replace_failure_preserves_previous_bytes(
-    tmp_path, monkeypatch
-):
+def test_daemon_config_replace_failure_preserves_previous_bytes(tmp_path, monkeypatch):
     previous = DaemonConfig(scan_roots=["/previous"])
     save_daemon_config(tmp_path, previous)
     path = daemon_config_path(tmp_path)
@@ -300,9 +332,7 @@ def test_daemon_config_replace_failure_preserves_previous_bytes(
 
     monkeypatch.setattr(os, "replace", fail_replace)
     with pytest.raises(OSError, match="replace failed"):
-        save_daemon_config(
-            tmp_path, DaemonConfig(scan_roots=["/replacement"])
-        )
+        save_daemon_config(tmp_path, DaemonConfig(scan_roots=["/replacement"]))
 
     assert path.read_bytes() == previous_bytes
     assert list(path.parent.glob(path.name + ".*")) == []

--- a/tests/core/daemon/test_registry_store.py
+++ b/tests/core/daemon/test_registry_store.py
@@ -167,6 +167,32 @@ def test_daemon_config_rejects_invalid_serve_bind(serve):
 
 
 
+def test_daemon_config_missing_relay_block_is_tunnel_disabled(tmp_path: Path):
+    """No `relay:` is the ordinary LAN/tailnet host, not a misconfiguration."""
+    assert load_daemon_config(tmp_path).relay is None
+
+
+def test_daemon_config_relay_roundtrip(tmp_path: Path):
+    save_daemon_config(
+        tmp_path,
+        DaemonConfig(relay={"host": "relay.example.com", "ssh_port": 2222}),
+    )
+    assert load_daemon_config(tmp_path).relay == {
+        "host": "relay.example.com", "ssh_port": 2222,
+    }
+
+
+@pytest.mark.parametrize(
+    "relay",
+    [{}, {"ssh_port": 2222}, {"host": ""}, {"user": "mship"}, "relay.example.com"],
+)
+def test_daemon_config_rejects_relay_block_without_host(relay):
+    """A present-but-hostless block is a typo, never a quiet "tunnel off": the
+    host it was meant to reach would silently never be dialed."""
+    with pytest.raises(ValueError, match="relay"):
+        DaemonConfig(relay=relay)
+
+
 def test_daemon_config_rejects_negative_max_depth():
     with pytest.raises(ValueError, match="max_depth"):
         DaemonConfig(max_depth=-1)

--- a/tests/core/daemon/test_relay_link.py
+++ b/tests/core/daemon/test_relay_link.py
@@ -1,0 +1,450 @@
+"""The daemon's registration client (#471 Task 6).
+
+Everything the daemon does against the relay's host directory happens here, and
+none of it may block, prompt, raise out of a tick, or write to disk on a
+reconnect. The seams (`post`/`get`/`clock`/`rng`/`signer`/`issue_refresh`/
+`reidentify`) are injected exactly like `tests/core/relay/test_health.py`, so
+these tests use no sockets, no sleeps and no ssh-keygen.
+"""
+import base64
+import hashlib
+import json
+import logging
+import socket
+from pathlib import Path
+
+import pytest
+
+from mship.core.daemon.capabilities import host_capability_payload, runner_block
+from mship.core.daemon.identity import HostIdentity, force_reidentify
+from mship.core.daemon.relay_link import RelayLink
+from mship.core.relay import host_contract
+from mship.core.relay.config import RelayConfig
+from mship.core.relay.enroll import fingerprint
+from mship.core.relay.keys import relay_key_path
+
+RELAY = RelayConfig(host="relay.example")
+BASE = host_contract.enroll_base_url(RELAY.host)
+PUBKEY = "ssh-ed25519 " + base64.b64encode(b"k" * 51).decode() + " mship-relay\n"
+
+
+class _Resp:
+    def __init__(self, status: int, body: dict | None = None, headers: dict | None = None):
+        self.status_code = status
+        self._body = {} if body is None else body
+        self.headers = headers or {}
+
+    def json(self):
+        return self._body
+
+
+class _Clock:
+    """Fake wall clock: never sleeps, only advances when a test says so."""
+
+    def __init__(self, t: float = 1_000_000.0):
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+def _advance_past(clock: "_Clock", link) -> None:
+    """Advance just past the link's scheduled delay (a float sum landing a hair
+    under the boundary would silently skip an attempt and weaken the test)."""
+    clock.advance(link.next_attempt_delay() + 0.001)
+
+
+class _Relay:
+    """Scriptable stand-in for the enroll app's `/hosts/*` + `/enroll` routes."""
+
+    def __init__(self, register=(200, None)):
+        self.register_status, self.register_detail = register
+        self.calls: list[tuple[str, str, dict | None]] = []
+        self.nonce = "nonce-1"
+        self.date_header: str | None = None
+        self.transport_error: str | None = None
+
+    def get(self, url, **kw):
+        self.calls.append(("GET", url, None))
+        if self.transport_error:
+            raise RuntimeError(self.transport_error)
+        headers = {"Date": self.date_header} if self.date_header else {}
+        return _Resp(200, {"nonce": self.nonce, "expires_at": 0}, headers)
+
+    def post(self, url, json=None, **kw):
+        self.calls.append(("POST", url, json))
+        if self.transport_error:
+            raise RuntimeError(self.transport_error)
+        if url.endswith("/enroll"):
+            return _Resp(200, {"id": "req-1", "status": "pending"})
+        body = (
+            {"status": "registered", "host_id": json["payload"]["host_id"]}
+            if self.register_status == 200
+            else {"detail": self.register_detail}
+        )
+        headers = {"Date": self.date_header} if self.date_header else {}
+        return _Resp(self.register_status, body, headers)
+
+    def posts_to(self, path: str) -> list[dict]:
+        return [body for verb, url, body in self.calls
+                if verb == "POST" and url.endswith(path)]
+
+
+def _seed_key(home: Path) -> None:
+    """Write a relay keypair so nothing in these tests spawns ssh-keygen."""
+    key = relay_key_path(home)
+    key.parent.mkdir(parents=True, exist_ok=True)
+    key.write_text("PRIVATE")
+    key.with_name(key.name + ".pub").write_text(PUBKEY)
+
+
+def _sign(blob: bytes) -> str:
+    return "SIG:" + hashlib.sha256(blob).hexdigest()
+
+
+def _link(home: Path, relay: _Relay, clock: _Clock, *, rng=lambda: 0.5, **kw) -> RelayLink:
+    _seed_key(home)
+    kw.setdefault("issue_refresh", lambda host_id: f"refresh-for-{host_id}")
+    kw.setdefault("reidentify", lambda: HostIdentity(host_id="hst-new", created_at=""))
+    return RelayLink(
+        home,
+        RELAY,
+        post=relay.post,
+        get=relay.get,
+        clock=clock,
+        rng=rng,
+        signer=_sign,
+        **kw,
+    )
+
+
+# --- register_once: challenge → sign → register ----------------------------
+
+def test_register_once_signs_the_posted_payload_and_returns_the_refresh(tmp_path: Path):
+    relay = _Relay()
+    link = _link(tmp_path, relay, _Clock())
+
+    outcome = link.register_once()
+
+    assert outcome.ok and outcome.kind == "registered"
+    assert outcome.refresh == f"refresh-for-{link.host_id}"
+    assert relay.calls[0][:2] == ("GET", BASE + host_contract.CHALLENGE_PATH)
+    body = relay.posts_to(host_contract.REGISTER_PATH)[0]
+    payload = body["payload"]
+    assert payload["host_id"] == link.host_id
+    assert payload["instance_id"] == link.instance_id
+    assert payload["label"] == socket.gethostname()
+    assert payload["key_fingerprint"] == fingerprint(PUBKEY)
+    assert payload["subdomain"] == link.subdomain
+    assert payload["public_url"] == f"https://{link.subdomain}.{RELAY.host}"
+    assert payload["refresh"] == outcome.refresh
+    assert payload["runner"] == {"enabled": False, "state": "disabled"}
+    assert payload["capabilities"] == host_capability_payload()["capabilities"]
+    # Signed over EXACTLY the bytes posted, with the challenge nonce inside.
+    assert body["nonce"] == relay.nonce
+    assert body["signature"] == _sign(host_contract.signing_blob(relay.nonce, payload))
+
+
+def test_payload_survives_a_canonical_round_trip(tmp_path: Path):
+    """What the relay re-serializes must be what we signed (contract bytes)."""
+    relay = _Relay()
+    _link(tmp_path, relay, _Clock()).register_once()
+    payload = relay.posts_to(host_contract.REGISTER_PATH)[0]["payload"]
+    assert host_contract.canonical_payload(
+        json.loads(json.dumps(payload))
+    ) == host_contract.canonical_payload(payload)
+
+
+@pytest.mark.parametrize(
+    "status, detail, kind",
+    [
+        (401, "registration is not signed by an approved key", "unapproved"),
+        (409, "another host holds this subdomain", "duplicate-identity"),
+        (429, "too many outstanding challenges; try later", "refused"),
+    ],
+)
+def test_typed_failures_never_raise(tmp_path: Path, status, detail, kind):
+    relay = _Relay(register=(status, detail))
+    outcome = _link(tmp_path, relay, _Clock()).register_once()
+    assert outcome.ok is False
+    assert outcome.kind == kind
+    assert outcome.status_code == status
+    assert detail in outcome.detail
+
+
+def test_transport_failure_is_typed_not_raised(tmp_path: Path):
+    relay = _Relay()
+    relay.transport_error = "connect timeout"
+    outcome = _link(tmp_path, relay, _Clock()).register_once()
+    assert outcome.ok is False and outcome.kind == "transport"
+    assert "connect timeout" in outcome.detail
+
+
+def test_relay_date_header_samples_clock_skew(tmp_path: Path):
+    """Task 9 reads this: the enroll server is the only different clock here."""
+    relay = _Relay()
+    clock = _Clock(t=1_755_003_600.0)                     # 2025-08-12T13:00:00Z
+    relay.date_header = "Tue, 12 Aug 2025 12:00:00 GMT"   # an hour behind us
+    link = _link(tmp_path, relay, clock)
+    assert link.clock_skew_seconds is None
+    link.register_once()
+    assert link.clock_skew_seconds == pytest.approx(3600, abs=1)
+
+
+def test_unparseable_date_header_leaves_skew_unknown(tmp_path: Path):
+    relay = _Relay()
+    relay.date_header = "not a date"
+    link = _link(tmp_path, relay, _Clock())
+    link.register_once()
+    assert link.clock_skew_seconds is None
+
+
+# --- tick(): jittered, capped, ceiling-free backoff (AC2/AC3) --------------
+
+def _fail(relay: _Relay, why: str = "boom") -> None:
+    relay.transport_error = why
+
+
+def test_tick_backs_off_and_a_success_resets_the_delay(tmp_path: Path):
+    relay = _Relay()
+    clock = _Clock()
+    link = _link(tmp_path, relay, clock, rng=lambda: 0.5)   # no jitter offset
+
+    _fail(relay)
+    assert link.tick() is not None                          # first tick is due
+    first = link.next_attempt_delay()
+    assert link.tick() is None                              # not due yet
+    clock.advance(first)
+    assert link.tick() is not None
+    assert link.next_attempt_delay() > first                # exponential growth
+
+    relay.transport_error = None
+    _advance_past(clock, link)
+    assert link.tick().ok is True
+    assert link.failure_count == 0
+    # A healthy link heartbeats on the register interval, not the backoff.
+    assert link.next_attempt_delay() == pytest.approx(host_contract.REGISTER_INTERVAL_S)
+
+
+def test_backoff_has_no_ceiling_past_1024_failures(tmp_path: Path):
+    """`float * 2**n` raises OverflowError at n == 1024 (assumption 5): the
+    daemon is immortal, so that count is reachable — the delay must clamp."""
+    relay = _Relay()
+    clock = _Clock()
+    link = _link(tmp_path, relay, clock)
+    _fail(relay)
+    for _ in range(1100):
+        link.tick()
+        _advance_past(clock, link)
+    assert link.failure_count > 1024
+    assert link.next_attempt_delay() == pytest.approx(host_contract.MAX_BACKOFF_S)
+
+
+def test_two_links_do_not_retry_on_the_same_tick(tmp_path: Path):
+    """A fleet reconnecting after a relay redeploy must not stampede (AC3)."""
+    early, late = _Relay(), _Relay()
+    clock = _Clock()
+    a = _link(tmp_path / "a", early, clock, rng=lambda: 0.0)
+    b = _link(tmp_path / "b", late, clock, rng=lambda: 1.0)
+    _fail(early)
+    _fail(late)
+    a.tick()
+    b.tick()
+    assert a.next_attempt_delay() != b.next_attempt_delay()
+
+    _advance_past(clock, a)
+    before = (len(early.calls), len(late.calls))
+    a.tick()
+    b.tick()
+    assert len(early.calls) > before[0] and len(late.calls) == before[1]
+
+
+# --- AC1/AC8: enrollment that stays alive, non-blocking, self-healing ------
+
+def test_unapproved_key_posts_enroll_without_polling(tmp_path: Path):
+    relay = _Relay(register=(401, "not signed by an approved key"))
+    link = _link(tmp_path, relay, _Clock())
+
+    link.tick()
+
+    assert link.state == "awaiting-enrollment"
+    assert link.should_dial() is True        # ssh may still try; the log classifies
+    assert relay.posts_to("/enroll") == [
+        {"pubkey": PUBKEY.strip(), "hostname": socket.gethostname()}
+    ]
+    # Never the 1800s wait loop: nothing polls /status/{rid}.
+    assert not any("/status/" in url for _verb, url, _body in relay.calls)
+
+
+def test_enroll_is_reposted_on_a_schedule_shorter_than_the_store_ttl(tmp_path: Path):
+    """A VM provisioned at 02:00 must still be approvable at 09:00 (AC1)."""
+    assert host_contract.ENROLL_REPOST_INTERVAL_S < host_contract.ENROLL_TTL_S
+    relay = _Relay(register=(401, "not signed by an approved key"))
+    clock = _Clock()
+    link = _link(tmp_path, relay, clock)
+
+    link.tick()
+    assert len(relay.posts_to("/enroll")) == 1
+    # Ticking through the backoff does NOT re-post: one pending record, not one
+    # per tick (the relay's 50-slot pending cap would 429 the whole fleet).
+    for _ in range(6):
+        _advance_past(clock, link)
+        link.tick()
+    assert len(relay.posts_to("/enroll")) == 1
+
+    clock.advance(host_contract.ENROLL_REPOST_INTERVAL_S)
+    link.tick()
+    assert len(relay.posts_to("/enroll")) == 2
+
+    # Seven hours of ticking keeps the request alive across the store's TTL.
+    elapsed = 0.0
+    while elapsed < 7 * 3600:
+        clock.advance(60.0)
+        elapsed += 60.0
+        link.tick()
+    assert (
+        len(relay.posts_to("/enroll"))
+        >= 7 * 3600 // host_contract.ENROLL_REPOST_INTERVAL_S - 1
+    )
+    assert link.state == "awaiting-enrollment"
+
+
+def test_approval_self_heals_with_no_prompt(tmp_path: Path):
+    relay = _Relay(register=(401, "not signed by an approved key"))
+    clock = _Clock()
+    link = _link(tmp_path, relay, clock)
+    link.tick()
+    assert link.state == "awaiting-enrollment"
+
+    relay.register_status, relay.register_detail = 200, None    # owner approved
+    _advance_past(clock, link)
+    outcome = link.tick()
+
+    assert outcome.ok and link.state == "registered"
+    assert link.refresh == f"refresh-for-{link.host_id}"
+
+
+# --- AC4b: a 409 is self-healing, and never needs a terminal ---------------
+
+def test_duplicate_identity_stops_dialling_and_reports_the_relay_detail(tmp_path: Path):
+    relay = _Relay(register=(409, "duplicate identity; run mship daemon reidentify"))
+    link = _link(tmp_path, relay, _Clock())
+    link.tick()
+    assert link.state == "duplicate-identity"
+    assert "mship daemon reidentify" in (link.last_error or "")
+    assert link.should_dial() is False
+
+
+def test_consecutive_409s_auto_reidentify_loudly_and_return_to_enrollment(
+    tmp_path: Path, caplog
+):
+    relay = _Relay(register=(409, "duplicate identity"))
+    clock = _Clock()
+    reidentified: list[int] = []
+
+    def reidentify():
+        reidentified.append(1)
+        return HostIdentity(host_id="hst-fresh", created_at="")
+
+    link = _link(tmp_path, relay, clock, reidentify=reidentify)
+    original, original_subdomain = link.host_id, link.subdomain
+    with caplog.at_level(logging.WARNING):
+        for _ in range(RelayLink.DUPLICATE_REIDENTIFY_AFTER):
+            link.tick()
+            _advance_past(clock, link)
+
+    assert reidentified == [1]
+    assert link.host_id == "hst-fresh" != original
+    assert link.subdomain != original_subdomain             # a new subdomain
+    assert link.state == "awaiting-enrollment"
+    assert link.should_dial() is True
+    assert any("re-identif" in r.getMessage() for r in caplog.records)
+    # The fresh key needs approving again, so the host reappears as pending.
+    assert relay.posts_to("/enroll")
+
+
+def test_a_success_clears_the_duplicate_counter(tmp_path: Path):
+    relay = _Relay(register=(409, "duplicate identity"))
+    clock = _Clock()
+    calls: list[int] = []
+
+    def reidentify():
+        calls.append(1)
+        return HostIdentity(host_id="hst-unexpected", created_at="")
+
+    link = _link(tmp_path, relay, clock, reidentify=reidentify)
+    for _ in range(RelayLink.DUPLICATE_REIDENTIFY_AFTER - 1):
+        link.tick()
+        _advance_past(clock, link)
+    relay.register_status, relay.register_detail = 200, None
+    link.tick()
+    _advance_past(clock, link)
+    relay.register_status, relay.register_detail = 409, "duplicate identity"
+    link.tick()
+    assert calls == []                       # the streak restarted at the success
+
+
+# --- AC11: a reconnect writes nothing ---------------------------------------
+
+def _snapshot(directory: Path) -> dict[str, bytes]:
+    return {
+        str(p.relative_to(directory)): p.read_bytes()
+        for p in sorted(directory.rglob("*")) if p.is_file()
+    }
+
+
+def test_n_registrations_leave_the_daemon_state_dir_byte_identical(tmp_path: Path):
+    from mship.core.daemon.host_auth import RefreshStore
+    from mship.core.daemon.paths import daemon_state_dir
+
+    relay = _Relay()
+    clock = _Clock()
+    store = RefreshStore(tmp_path, clock=clock)
+    link = _link(
+        tmp_path, relay, clock,
+        issue_refresh=lambda host_id: store.issue_refresh(
+            host_id=host_id, client="relay-directory"
+        ),
+    )
+    assert link.register_once().ok                     # first run mints state
+
+    before = _snapshot(daemon_state_dir(tmp_path))
+    assert "host-refresh.json" in before               # the file that could churn
+    for _ in range(20):
+        clock.advance(host_contract.REGISTER_INTERVAL_S * 2)
+        assert link.tick().ok
+    assert _snapshot(daemon_state_dir(tmp_path)) == before
+    # Idempotent per host: the same credential is re-published, never re-minted.
+    assert {b["payload"]["refresh"] for b in relay.posts_to(host_contract.REGISTER_PATH)} == {
+        link.refresh
+    }
+
+
+# --- the capability seam + the default re-identify --------------------------
+
+def test_capability_payload_has_one_assembler():
+    payload = host_capability_payload()
+    assert payload["runner"] == runner_block(None)
+    assert payload["capabilities"]["runner"] is False
+    assert payload["capabilities"]["tunnel"] is True
+    enabled = host_capability_payload({"enabled": True})
+    assert enabled["runner"] == {"enabled": True, "state": "unknown"}
+    assert enabled["capabilities"]["runner"] is True
+
+
+def test_force_reidentify_mints_a_new_id_and_rotates_the_key(tmp_path: Path):
+    from mship.core.daemon.identity import ensure_host_identity
+
+    rotated: list[Path] = []
+    first = ensure_host_identity(tmp_path, fingerprint="fp", rotate_key=lambda h: None)
+    fresh = force_reidentify(tmp_path, rotate_key=rotated.append)
+
+    assert fresh.host_id != first.host_id
+    assert fresh.cloned_from == first.host_id
+    assert fresh.reidentified is True
+    assert rotated == [tmp_path]
+    # Persisted, so a restart does not fall back to the shadowed identity.
+    assert ensure_host_identity(tmp_path, fingerprint="fp").host_id == fresh.host_id

--- a/tests/core/daemon/test_relay_link.py
+++ b/tests/core/daemon/test_relay_link.py
@@ -29,12 +29,16 @@ PUBKEY = "ssh-ed25519 " + base64.b64encode(b"k" * 51).decode() + " mship-relay\n
 
 
 class _Resp:
-    def __init__(self, status: int, body: dict | None = None, headers: dict | None = None):
+    def __init__(self, status: int, body: dict | None = None, headers: dict | None = None,
+                 html: str | None = None):
         self.status_code = status
         self._body = {} if body is None else body
+        self._html = html
         self.headers = headers or {}
 
     def json(self):
+        if self._html is not None:      # what httpx does with a proxy error page
+            raise ValueError("Expecting value: line 1 column 1 (char 0)")
         return self._body
 
 
@@ -66,12 +70,15 @@ class _Relay:
         self.nonce = "nonce-1"
         self.date_header: str | None = None
         self.transport_error: str | None = None
+        self.challenge_html: str | None = None
 
     def get(self, url, **kw):
         self.calls.append(("GET", url, None))
         if self.transport_error:
             raise RuntimeError(self.transport_error)
         headers = {"Date": self.date_header} if self.date_header else {}
+        if self.challenge_html is not None:
+            return _Resp(200, headers=headers, html=self.challenge_html)
         return _Resp(200, {"nonce": self.nonce, "expires_at": 0}, headers)
 
     def post(self, url, json=None, **kw):
@@ -161,7 +168,7 @@ def test_payload_survives_a_canonical_round_trip(tmp_path: Path):
 @pytest.mark.parametrize(
     "status, detail, kind",
     [
-        (401, "registration is not signed by an approved key", "unapproved"),
+        (401, host_contract.UNAPPROVED_KEY_DETAIL, "unapproved"),
         (409, "another host holds this subdomain", "duplicate-identity"),
         (429, "too many outstanding challenges; try later", "refused"),
     ],
@@ -202,6 +209,29 @@ def test_unparseable_date_header_leaves_skew_unknown(tmp_path: Path):
     assert link.clock_skew_seconds is None
 
 
+def test_a_200_that_is_not_json_is_typed_not_raised(tmp_path: Path):
+    """A captive portal, a misrouted vhost and a proxy error page all answer 200
+    with HTML; `register_once` must not raise on `.json()`."""
+    relay = _Relay()
+    relay.challenge_html = "<html>Sign in to continue</html>"
+    outcome = _link(tmp_path, relay, _Clock()).register_once()
+    assert outcome.ok is False and outcome.kind == "refused"
+    assert "nonce" in outcome.detail
+    assert relay.posts_to(host_contract.REGISTER_PATH) == []   # nothing signed blind
+
+
+def test_a_stale_challenge_401_is_transient_not_unapproved(tmp_path: Path):
+    """The relay 401s a lost nonce race the same way it 401s an unapproved key
+    (CHALLENGE_TTL_S is 120s). An approved host on a slow link must not report
+    awaiting-enrollment or re-post /enroll for a key already in `pubkeys/`."""
+    for detail in host_contract.CHALLENGE_REFUSAL_DETAILS:
+        relay = _Relay(register=(401, detail))
+        link = _link(tmp_path / detail.replace(" ", "-"), relay, _Clock())
+        link.tick()
+        assert link.state != "awaiting-enrollment"
+        assert relay.posts_to(host_contract.ENROLL_PATH) == []
+
+
 # --- tick(): jittered, capped, ceiling-free backoff (AC2/AC3) --------------
 
 def _fail(relay: _Relay, why: str = "boom") -> None:
@@ -211,7 +241,7 @@ def _fail(relay: _Relay, why: str = "boom") -> None:
 def test_tick_backs_off_and_a_success_resets_the_delay(tmp_path: Path):
     relay = _Relay()
     clock = _Clock()
-    link = _link(tmp_path, relay, clock, rng=lambda: 0.5)   # no jitter offset
+    link = _link(tmp_path, relay, clock, rng=lambda: 0.0)   # no jitter subtracted
 
     _fail(relay)
     assert link.tick() is not None                          # first tick is due
@@ -234,7 +264,7 @@ def test_backoff_has_no_ceiling_past_1024_failures(tmp_path: Path):
     daemon is immortal, so that count is reachable — the delay must clamp."""
     relay = _Relay()
     clock = _Clock()
-    link = _link(tmp_path, relay, clock)
+    link = _link(tmp_path, relay, clock, rng=lambda: 0.0)
     _fail(relay)
     for _ in range(1100):
         link.tick()
@@ -243,29 +273,44 @@ def test_backoff_has_no_ceiling_past_1024_failures(tmp_path: Path):
     assert link.next_attempt_delay() == pytest.approx(host_contract.MAX_BACKOFF_S)
 
 
+def test_jitter_never_schedules_past_the_cap(tmp_path: Path):
+    """DIRECTORY_STALE_S is derived from MAX_BACKOFF_S, so a delay jittered
+    ABOVE the cap would let a healthy reconnecting host read as stale."""
+    for value in (0.0, 0.5, 1.0):
+        relay = _Relay()
+        clock = _Clock()
+        link = _link(tmp_path / str(value), relay, clock, rng=lambda v=value: v)
+        _fail(relay)
+        for _ in range(12):
+            link.tick()
+            _advance_past(clock, link)
+        assert 0 < link.next_attempt_delay() <= host_contract.MAX_BACKOFF_S
+        assert link.next_attempt_delay() >= host_contract.MAX_BACKOFF_S * (1 - 0.2)
+
+
 def test_two_links_do_not_retry_on_the_same_tick(tmp_path: Path):
     """A fleet reconnecting after a relay redeploy must not stampede (AC3)."""
-    early, late = _Relay(), _Relay()
+    unlucky, lucky = _Relay(), _Relay()
     clock = _Clock()
-    a = _link(tmp_path / "a", early, clock, rng=lambda: 0.0)
-    b = _link(tmp_path / "b", late, clock, rng=lambda: 1.0)
-    _fail(early)
-    _fail(late)
-    a.tick()
-    b.tick()
-    assert a.next_attempt_delay() != b.next_attempt_delay()
+    slow = _link(tmp_path / "a", unlucky, clock, rng=lambda: 0.0)   # full delay
+    fast = _link(tmp_path / "b", lucky, clock, rng=lambda: 1.0)     # 20% off it
+    _fail(unlucky)
+    _fail(lucky)
+    slow.tick()
+    fast.tick()
+    assert fast.next_attempt_delay() < slow.next_attempt_delay()
 
-    _advance_past(clock, a)
-    before = (len(early.calls), len(late.calls))
-    a.tick()
-    b.tick()
-    assert len(early.calls) > before[0] and len(late.calls) == before[1]
+    _advance_past(clock, fast)
+    before = (len(unlucky.calls), len(lucky.calls))
+    slow.tick()
+    fast.tick()
+    assert len(lucky.calls) > before[1] and len(unlucky.calls) == before[0]
 
 
 # --- AC1/AC8: enrollment that stays alive, non-blocking, self-healing ------
 
 def test_unapproved_key_posts_enroll_without_polling(tmp_path: Path):
-    relay = _Relay(register=(401, "not signed by an approved key"))
+    relay = _Relay(register=(401, host_contract.UNAPPROVED_KEY_DETAIL))
     link = _link(tmp_path, relay, _Clock())
 
     link.tick()
@@ -282,7 +327,7 @@ def test_unapproved_key_posts_enroll_without_polling(tmp_path: Path):
 def test_enroll_is_reposted_on_a_schedule_shorter_than_the_store_ttl(tmp_path: Path):
     """A VM provisioned at 02:00 must still be approvable at 09:00 (AC1)."""
     assert host_contract.ENROLL_REPOST_INTERVAL_S < host_contract.ENROLL_TTL_S
-    relay = _Relay(register=(401, "not signed by an approved key"))
+    relay = _Relay(register=(401, host_contract.UNAPPROVED_KEY_DETAIL))
     clock = _Clock()
     link = _link(tmp_path, relay, clock)
 
@@ -313,7 +358,7 @@ def test_enroll_is_reposted_on_a_schedule_shorter_than_the_store_ttl(tmp_path: P
 
 
 def test_approval_self_heals_with_no_prompt(tmp_path: Path):
-    relay = _Relay(register=(401, "not signed by an approved key"))
+    relay = _Relay(register=(401, host_contract.UNAPPROVED_KEY_DETAIL))
     clock = _Clock()
     link = _link(tmp_path, relay, clock)
     link.tick()
@@ -424,6 +469,22 @@ def test_n_registrations_leave_the_daemon_state_dir_byte_identical(tmp_path: Pat
 
 
 # --- the capability seam + the default re-identify --------------------------
+
+def test_the_default_refresh_store_runs_on_the_links_clock(tmp_path: Path):
+    """Two clocks in one daemon is how a credential expires early (or never):
+    the store the link builds for itself must date records by the same clock the
+    link schedules on."""
+    from mship.core.daemon.host_auth import REFRESH_TTL_S
+    from mship.core.daemon.paths import host_refresh_path
+
+    relay = _Relay()
+    clock = _Clock(t=4_000_000_000.0)          # far from time.time()
+    assert _link(tmp_path, relay, clock, issue_refresh=None).register_once().ok
+    doc = json.loads(host_refresh_path(tmp_path).read_text())
+    record = next(iter(doc["clients"].values()))
+    assert record["created_at"] == clock.t
+    assert record["expires_at"] == clock.t + REFRESH_TTL_S
+
 
 def test_capability_payload_has_one_assembler():
     payload = host_capability_payload()

--- a/tests/core/daemon/test_relay_link.py
+++ b/tests/core/daemon/test_relay_link.py
@@ -780,6 +780,32 @@ def test_failed_auto_reidentify_keeps_identity_and_uses_registration_backoff(
     assert attempts == [clock()]
 
 
+
+def test_non_duplicate_failure_breaks_the_duplicate_identity_streak(tmp_path: Path):
+    relay = _Relay(register=(409, "duplicate identity"))
+    clock = _Clock()
+    reidentified: list[int] = []
+
+    def reidentify():
+        reidentified.append(1)
+        return HostIdentity(host_id="hst-unexpected", created_at="")
+
+    link = _link(tmp_path, relay, clock, reidentify=reidentify)
+
+    for _ in range(RelayLink.DUPLICATE_REIDENTIFY_AFTER - 1):
+        link.tick()
+        _advance_past(clock, link)
+        relay.transport_error = "relay unreachable"
+        link.tick()
+        relay.transport_error = None
+        _advance_past(clock, link)
+
+    link.tick()
+
+    assert reidentified == []
+    assert link.state == "duplicate-identity"
+
+
 def test_a_success_clears_the_duplicate_counter(tmp_path: Path):
     relay = _Relay(register=(409, "duplicate identity"))
     clock = _Clock()

--- a/tests/core/daemon/test_relay_link.py
+++ b/tests/core/daemon/test_relay_link.py
@@ -2,10 +2,11 @@
 
 Everything the daemon does against the relay's host directory happens here, and
 none of it may block, prompt, raise out of a tick, or write to disk on a
-reconnect. The seams (`post`/`get`/`clock`/`rng`/`signer`/`issue_refresh`/
+reconnect. The seams (`post`/`clock`/`rng`/`signer`/`issue_refresh`/
 `reidentify`) are injected exactly like `tests/core/relay/test_health.py`, so
 these tests use no sockets, no sleeps and no ssh-keygen.
 """
+
 import base64
 import hashlib
 import json
@@ -30,15 +31,20 @@ PUBKEY = "ssh-ed25519 " + base64.b64encode(b"k" * 51).decode() + " mship-relay\n
 
 
 class _Resp:
-    def __init__(self, status: int, body: dict | None = None, headers: dict | None = None,
-                 html: str | None = None):
+    def __init__(
+        self,
+        status: int,
+        body: dict | None = None,
+        headers: dict | None = None,
+        html: str | None = None,
+    ):
         self.status_code = status
         self._body = {} if body is None else body
         self._html = html
         self.headers = headers or {}
 
     def json(self):
-        if self._html is not None:      # what httpx does with a proxy error page
+        if self._html is not None:  # what httpx does with a proxy error page
             raise ValueError("Expecting value: line 1 column 1 (char 0)")
         return self._body
 
@@ -65,27 +71,35 @@ def _advance_past(clock: "_Clock", link) -> None:
 class _Relay:
     """Scriptable stand-in for the enroll app's `/hosts/*` + `/enroll` routes."""
 
-    def __init__(self, register=(200, None), enroll_ttl=host_contract.ENROLL_TTL_S):
+    def __init__(
+        self,
+        register=(200, None),
+        challenge=(200, None),
+        enroll_ttl=host_contract.ENROLL_TTL_S,
+    ):
         self.register_status, self.register_detail = register
+        self.challenge_status, self.challenge_detail = challenge
         self.enroll_ttl = enroll_ttl
         self.calls: list[tuple[str, str, dict | None]] = []
         self.nonce = "nonce-1"
         self.date_header: str | None = None
         self.transport_error: str | None = None
         self.challenge_html: str | None = None
-    def get(self, url, **kw):
-        self.calls.append(("GET", url, None))
-        if self.transport_error:
-            raise RuntimeError(self.transport_error)
-        headers = {"Date": self.date_header} if self.date_header else {}
-        if self.challenge_html is not None:
-            return _Resp(200, headers=headers, html=self.challenge_html)
-        return _Resp(200, {"nonce": self.nonce, "expires_at": 0}, headers)
 
     def post(self, url, json=None, **kw):
         self.calls.append(("POST", url, json))
         if self.transport_error:
             raise RuntimeError(self.transport_error)
+        if url.endswith(host_contract.CHALLENGE_PATH):
+            headers = {"Date": self.date_header} if self.date_header else {}
+            if self.challenge_html is not None:
+                return _Resp(200, headers=headers, html=self.challenge_html)
+            body = (
+                {"nonce": self.nonce, "expires_at": 0}
+                if self.challenge_status == 200
+                else {"detail": self.challenge_detail}
+            )
+            return _Resp(self.challenge_status, body, headers)
         if url.endswith("/enroll"):
             return _Resp(
                 200,
@@ -100,8 +114,11 @@ class _Relay:
         return _Resp(self.register_status, body, headers)
 
     def posts_to(self, path: str) -> list[dict]:
-        return [body for verb, url, body in self.calls
-                if verb == "POST" and url.endswith(path)]
+        return [
+            body
+            for verb, url, body in self.calls
+            if verb == "POST" and url.endswith(path)
+        ]
 
 
 def _seed_key(home: Path) -> None:
@@ -116,7 +133,9 @@ def _sign(blob: bytes) -> str:
     return "SIG:" + hashlib.sha256(blob).hexdigest()
 
 
-def _link(home: Path, relay: _Relay, clock: _Clock, *, rng=lambda: 0.5, **kw) -> RelayLink:
+def _link(
+    home: Path, relay: _Relay, clock: _Clock, *, rng=lambda: 0.5, **kw
+) -> RelayLink:
     _seed_key(home)
     kw.setdefault("issue_refresh", lambda host_id: f"refresh-for-{host_id}")
     kw.setdefault("reidentify", lambda: HostIdentity(host_id="hst-new", created_at=""))
@@ -124,7 +143,6 @@ def _link(home: Path, relay: _Relay, clock: _Clock, *, rng=lambda: 0.5, **kw) ->
         home,
         RELAY,
         post=relay.post,
-        get=relay.get,
         clock=clock,
         rng=rng,
         signer=_sign,
@@ -134,6 +152,7 @@ def _link(home: Path, relay: _Relay, clock: _Clock, *, rng=lambda: 0.5, **kw) ->
 
 # --- register_once: challenge → sign → register ----------------------------
 
+
 def test_register_once_signs_the_posted_payload_and_returns_the_refresh(tmp_path: Path):
     relay = _Relay()
     link = _link(tmp_path, relay, _Clock())
@@ -142,7 +161,11 @@ def test_register_once_signs_the_posted_payload_and_returns_the_refresh(tmp_path
 
     assert outcome.ok and outcome.kind == "registered"
     assert outcome.refresh == f"refresh-for-{link.host_id}"
-    assert relay.calls[0][:2] == ("GET", BASE + host_contract.CHALLENGE_PATH)
+    assert relay.calls[0] == (
+        "POST",
+        BASE + host_contract.CHALLENGE_PATH,
+        {"key_fingerprint": link.key_fingerprint},
+    )
     body = relay.posts_to(host_contract.REGISTER_PATH)[0]
     payload = body["payload"]
     assert payload["host_id"] == link.host_id
@@ -197,8 +220,8 @@ def test_transport_failure_is_typed_not_raised(tmp_path: Path):
 def test_relay_date_header_samples_clock_skew(tmp_path: Path):
     """Task 9 reads this: the enroll server is the only different clock here."""
     relay = _Relay()
-    clock = _Clock(t=1_755_003_600.0)                     # 2025-08-12T13:00:00Z
-    relay.date_header = "Tue, 12 Aug 2025 12:00:00 GMT"   # an hour behind us
+    clock = _Clock(t=1_755_003_600.0)  # 2025-08-12T13:00:00Z
+    relay.date_header = "Tue, 12 Aug 2025 12:00:00 GMT"  # an hour behind us
     link = _link(tmp_path, relay, clock)
     assert link.clock_skew_seconds is None
     link.register_once()
@@ -207,16 +230,19 @@ def test_relay_date_header_samples_clock_skew(tmp_path: Path):
 
 def test_register_post_date_alone_samples_skew(tmp_path: Path):
     """Both relay calls carry the enroll server's clock; a challenge without a
-    `Date` (a proxy that strips it on GETs) must not leave the skew unknown —
-    `mship daemon status` reports it from whichever answer carried one."""
-    class _NoDateOnGet(_Relay):
-        def get(self, url, **kw):
-            self.calls.append(("GET", url, None))
-            return _Resp(200, {"nonce": self.nonce, "expires_at": 0})
+    `Date` must not leave the skew unknown — `mship daemon status` reports it
+    from whichever answer carried one."""
 
-    relay = _NoDateOnGet()
-    clock = _Clock(t=1_755_003_600.0)                     # 2025-08-12T13:00:00Z
-    relay.date_header = "Tue, 12 Aug 2025 12:00:00 GMT"   # an hour behind us
+    class _NoDateOnChallenge(_Relay):
+        def post(self, url, json=None, **kw):
+            if url.endswith(host_contract.CHALLENGE_PATH):
+                self.calls.append(("POST", url, json))
+                return _Resp(200, {"nonce": self.nonce, "expires_at": 0})
+            return super().post(url, json=json, **kw)
+
+    relay = _NoDateOnChallenge()
+    clock = _Clock(t=1_755_003_600.0)  # 2025-08-12T13:00:00Z
+    relay.date_header = "Tue, 12 Aug 2025 12:00:00 GMT"  # an hour behind us
     link = _link(tmp_path, relay, clock)
 
     link.register_once()
@@ -240,7 +266,7 @@ def test_a_200_that_is_not_json_is_typed_not_raised(tmp_path: Path):
     outcome = _link(tmp_path, relay, _Clock()).register_once()
     assert outcome.ok is False and outcome.kind == "refused"
     assert "nonce" in outcome.detail
-    assert relay.posts_to(host_contract.REGISTER_PATH) == []   # nothing signed blind
+    assert relay.posts_to(host_contract.REGISTER_PATH) == []  # nothing signed blind
 
 
 def test_a_stale_challenge_401_is_transient_not_unapproved(tmp_path: Path):
@@ -270,6 +296,7 @@ def test_an_unrecognised_401_still_enrolls(tmp_path: Path):
 
 # --- tick(): jittered, capped, ceiling-free backoff (AC2/AC3) --------------
 
+
 def _fail(relay: _Relay, why: str = "boom") -> None:
     relay.transport_error = why
 
@@ -277,15 +304,15 @@ def _fail(relay: _Relay, why: str = "boom") -> None:
 def test_tick_backs_off_and_a_success_resets_the_delay(tmp_path: Path):
     relay = _Relay()
     clock = _Clock()
-    link = _link(tmp_path, relay, clock, rng=lambda: 0.0)   # no jitter subtracted
+    link = _link(tmp_path, relay, clock, rng=lambda: 0.0)  # no jitter subtracted
 
     _fail(relay)
-    assert link.tick() is not None                          # first tick is due
+    assert link.tick() is not None  # first tick is due
     first = link.next_attempt_delay()
-    assert link.tick() is None                              # not due yet
+    assert link.tick() is None  # not due yet
     clock.advance(first)
     assert link.tick() is not None
-    assert link.next_attempt_delay() > first                # exponential growth
+    assert link.next_attempt_delay() > first  # exponential growth
 
     relay.transport_error = None
     _advance_past(clock, link)
@@ -330,8 +357,8 @@ def test_two_links_do_not_retry_on_the_same_tick(tmp_path: Path):
     """A fleet reconnecting after a relay redeploy must not stampede (AC3)."""
     unlucky, lucky = _Relay(), _Relay()
     clock = _Clock()
-    slow = _link(tmp_path / "a", unlucky, clock, rng=lambda: 0.0)   # full delay
-    fast = _link(tmp_path / "b", lucky, clock, rng=lambda: 1.0)     # 20% off it
+    slow = _link(tmp_path / "a", unlucky, clock, rng=lambda: 0.0)  # full delay
+    fast = _link(tmp_path / "b", lucky, clock, rng=lambda: 1.0)  # 20% off it
     _fail(unlucky)
     _fail(lucky)
     slow.tick()
@@ -347,6 +374,7 @@ def test_two_links_do_not_retry_on_the_same_tick(tmp_path: Path):
 
 # --- AC1/AC8: enrollment that stays alive, non-blocking, self-healing ------
 
+
 def test_unapproved_key_posts_enroll_without_polling(tmp_path: Path):
     relay = _Relay(register=(401, host_contract.UNAPPROVED_KEY_DETAIL))
     link = _link(tmp_path, relay, _Clock())
@@ -354,7 +382,7 @@ def test_unapproved_key_posts_enroll_without_polling(tmp_path: Path):
     link.tick()
 
     assert link.state == "awaiting-enrollment"
-    assert link.should_dial() is True        # ssh may still try; the log classifies
+    assert link.should_dial() is True  # ssh may still try; the log classifies
     assert relay.posts_to("/enroll") == [
         {"pubkey": PUBKEY.strip(), "hostname": socket.gethostname()}
     ]
@@ -413,14 +441,17 @@ def test_enroll_repost_follows_the_servers_advertised_ttl(tmp_path: Path):
     assert clock() - started_at < 60
 
 
-def test_approval_self_heals_with_no_prompt(tmp_path: Path):
-    relay = _Relay(register=(401, host_contract.UNAPPROVED_KEY_DETAIL))
+def test_challenge_stage_unapproved_self_heals_with_no_prompt(tmp_path: Path):
+    relay = _Relay(challenge=(401, host_contract.UNAPPROVED_KEY_DETAIL))
     clock = _Clock()
     link = _link(tmp_path, relay, clock)
-    link.tick()
-    assert link.state == "awaiting-enrollment"
 
-    relay.register_status, relay.register_detail = 200, None    # owner approved
+    link.tick()
+
+    assert link.state == "awaiting-enrollment"
+    assert len(relay.posts_to(host_contract.ENROLL_PATH)) == 1
+
+    relay.challenge_status, relay.challenge_detail = 200, None  # owner approved
     _advance_past(clock, link)
     outcome = link.tick()
 
@@ -429,6 +460,7 @@ def test_approval_self_heals_with_no_prompt(tmp_path: Path):
 
 
 # --- AC4b: a 409 is self-healing, and never needs a terminal ---------------
+
 
 def test_duplicate_identity_stops_dialling_and_reports_the_relay_detail(tmp_path: Path):
     relay = _Relay(register=(409, "duplicate identity; run mship daemon reidentify"))
@@ -459,7 +491,7 @@ def test_consecutive_409s_auto_reidentify_loudly_and_return_to_enrollment(
 
     assert reidentified == [1]
     assert link.host_id == "hst-fresh" != original
-    assert link.subdomain != original_subdomain             # a new subdomain
+    assert link.subdomain != original_subdomain  # a new subdomain
     assert link.state == "awaiting-enrollment"
     assert link.should_dial() is True
     assert any("re-identif" in r.getMessage() for r in caplog.records)
@@ -485,15 +517,17 @@ def test_a_success_clears_the_duplicate_counter(tmp_path: Path):
     _advance_past(clock, link)
     relay.register_status, relay.register_detail = 409, "duplicate identity"
     link.tick()
-    assert calls == []                       # the streak restarted at the success
+    assert calls == []  # the streak restarted at the success
 
 
 # --- AC11: a reconnect writes nothing ---------------------------------------
 
+
 def _snapshot(directory: Path) -> dict[str, bytes]:
     return {
         str(p.relative_to(directory)): p.read_bytes()
-        for p in sorted(directory.rglob("*")) if p.is_file()
+        for p in sorted(directory.rglob("*"))
+        if p.is_file()
     }
 
 
@@ -505,26 +539,29 @@ def test_n_registrations_leave_the_daemon_state_dir_byte_identical(tmp_path: Pat
     clock = _Clock()
     store = RefreshStore(tmp_path, clock=clock)
     link = _link(
-        tmp_path, relay, clock,
+        tmp_path,
+        relay,
+        clock,
         issue_refresh=lambda host_id: store.issue_refresh(
             host_id=host_id, client="relay-directory"
         ),
     )
-    assert link.register_once().ok                     # first run mints state
+    assert link.register_once().ok  # first run mints state
 
     before = _snapshot(daemon_state_dir(tmp_path))
-    assert "host-refresh.json" in before               # the file that could churn
+    assert "host-refresh.json" in before  # the file that could churn
     for _ in range(20):
         clock.advance(host_contract.REGISTER_INTERVAL_S * 2)
         assert link.tick().ok
     assert _snapshot(daemon_state_dir(tmp_path)) == before
     # Idempotent per host: the same credential is re-published, never re-minted.
-    assert {b["payload"]["refresh"] for b in relay.posts_to(host_contract.REGISTER_PATH)} == {
-        link.refresh
-    }
+    assert {
+        b["payload"]["refresh"] for b in relay.posts_to(host_contract.REGISTER_PATH)
+    } == {link.refresh}
 
 
 # --- the capability seam + the default re-identify --------------------------
+
 
 def test_the_default_refresh_store_runs_on_the_links_clock(tmp_path: Path):
     """Two clocks in one daemon is how a credential expires early (or never):
@@ -534,7 +571,7 @@ def test_the_default_refresh_store_runs_on_the_links_clock(tmp_path: Path):
     from mship.core.daemon.paths import host_refresh_path
 
     relay = _Relay()
-    clock = _Clock(t=4_000_000_000.0)          # far from time.time()
+    clock = _Clock(t=4_000_000_000.0)  # far from time.time()
     assert _link(tmp_path, relay, clock, issue_refresh=None).register_once().ok
     doc = json.loads(host_refresh_path(tmp_path).read_text())
     record = next(iter(doc["clients"].values()))

--- a/tests/core/daemon/test_relay_link.py
+++ b/tests/core/daemon/test_relay_link.py
@@ -612,6 +612,9 @@ def test_capability_payload_has_one_assembler():
     enabled = host_capability_payload({"enabled": True})
     assert enabled["runner"] == {"enabled": True, "state": "unknown"}
     assert enabled["capabilities"]["runner"] is True
+    malformed = host_capability_payload({"enabled": "false"})
+    assert malformed["runner"] == {"enabled": False, "state": "disabled"}
+    assert malformed["capabilities"]["runner"] is False
 
 
 def test_force_reidentify_mints_a_new_id_and_rotates_the_key(tmp_path: Path):

--- a/tests/core/daemon/test_relay_link.py
+++ b/tests/core/daemon/test_relay_link.py
@@ -65,14 +65,14 @@ def _advance_past(clock: "_Clock", link) -> None:
 class _Relay:
     """Scriptable stand-in for the enroll app's `/hosts/*` + `/enroll` routes."""
 
-    def __init__(self, register=(200, None)):
+    def __init__(self, register=(200, None), enroll_ttl=host_contract.ENROLL_TTL_S):
         self.register_status, self.register_detail = register
+        self.enroll_ttl = enroll_ttl
         self.calls: list[tuple[str, str, dict | None]] = []
         self.nonce = "nonce-1"
         self.date_header: str | None = None
         self.transport_error: str | None = None
         self.challenge_html: str | None = None
-
     def get(self, url, **kw):
         self.calls.append(("GET", url, None))
         if self.transport_error:
@@ -87,7 +87,10 @@ class _Relay:
         if self.transport_error:
             raise RuntimeError(self.transport_error)
         if url.endswith("/enroll"):
-            return _Resp(200, {"id": "req-1", "status": "pending"})
+            return _Resp(
+                200,
+                {"id": "req-1", "status": "pending", "expires_in": self.enroll_ttl},
+            )
         body = (
             {"status": "registered", "host_id": json["payload"]["host_id"]}
             if self.register_status == 200
@@ -390,6 +393,24 @@ def test_enroll_is_reposted_on_a_schedule_shorter_than_the_store_ttl(tmp_path: P
         >= 7 * 3600 // host_contract.ENROLL_REPOST_INTERVAL_S - 1
     )
     assert link.state == "awaiting-enrollment"
+
+
+def test_enroll_repost_follows_the_servers_advertised_ttl(tmp_path: Path):
+    relay = _Relay(
+        register=(401, host_contract.UNAPPROVED_KEY_DETAIL),
+        enroll_ttl=60,
+    )
+    clock = _Clock()
+    link = _link(tmp_path, relay, clock)
+
+    started_at = clock()
+    link.tick()
+    while len(relay.posts_to("/enroll")) == 1 and clock() - started_at < 60:
+        _advance_past(clock, link)
+        link.tick()
+
+    assert len(relay.posts_to("/enroll")) == 2
+    assert clock() - started_at < 60
 
 
 def test_approval_self_heals_with_no_prompt(tmp_path: Path):

--- a/tests/core/daemon/test_relay_link.py
+++ b/tests/core/daemon/test_relay_link.py
@@ -696,6 +696,63 @@ def test_consecutive_409s_auto_reidentify_loudly_and_return_to_enrollment(
     assert relay.posts_to("/enroll")
 
 
+def test_startup_fingerprint_recovery_does_not_revoke_a_clones_shared_key(
+    tmp_path: Path, monkeypatch
+):
+    relay = _Relay()
+
+    def fake_ensure_identity(home, *, fingerprint, revoke_key):
+        revoke_key(home)
+        return HostIdentity(host_id="hst-fresh", created_at="")
+
+    monkeypatch.setattr(relay_link, "ensure_host_identity", fake_ensure_identity)
+    _seed_key(tmp_path)
+    link = RelayLink(
+        tmp_path,
+        RELAY,
+        post=relay.post,
+        clock=_Clock(),
+        signer=_sign,
+        issue_refresh=lambda host_id: f"refresh-for-{host_id}",
+    )
+
+    assert relay.posts_to(host_contract.REVOKE_PATH) == []
+    assert link.host_id == "hst-fresh"
+
+
+def test_auto_reidentify_does_not_revoke_the_source_hosts_shared_key(
+    tmp_path: Path, monkeypatch
+):
+    relay = _Relay(register=(409, "duplicate identity"))
+    clock = _Clock()
+
+    def fake_reidentify(home, *, revoke_key):
+        revoke_key(home)
+        return HostIdentity(host_id="hst-fresh", created_at="")
+
+    monkeypatch.setattr(relay_link, "force_reidentify", fake_reidentify)
+    _seed_key(tmp_path)
+    link = RelayLink(
+        tmp_path,
+        RELAY,
+        post=relay.post,
+        clock=clock,
+        rng=lambda: 0.5,
+        signer=_sign,
+        issue_refresh=lambda host_id: f"refresh-for-{host_id}",
+    )
+    for _ in range(RelayLink.DUPLICATE_REIDENTIFY_AFTER - 1):
+        link.tick()
+        _advance_past(clock, link)
+
+    calls_before_recovery = len(relay.calls)
+    link.tick()
+
+    assert relay.posts_to(host_contract.REVOKE_PATH) == []
+    assert len(relay.calls) - calls_before_recovery == 3
+    assert link.host_id == "hst-fresh"
+
+
 def test_failed_auto_reidentify_keeps_identity_and_uses_registration_backoff(
     tmp_path: Path,
 ):

--- a/tests/core/daemon/test_relay_link.py
+++ b/tests/core/daemon/test_relay_link.py
@@ -202,6 +202,25 @@ def test_relay_date_header_samples_clock_skew(tmp_path: Path):
     assert link.clock_skew_seconds == pytest.approx(3600, abs=1)
 
 
+def test_register_post_date_alone_samples_skew(tmp_path: Path):
+    """Both relay calls carry the enroll server's clock; a challenge without a
+    `Date` (a proxy that strips it on GETs) must not leave the skew unknown —
+    `mship daemon status` reports it from whichever answer carried one."""
+    class _NoDateOnGet(_Relay):
+        def get(self, url, **kw):
+            self.calls.append(("GET", url, None))
+            return _Resp(200, {"nonce": self.nonce, "expires_at": 0})
+
+    relay = _NoDateOnGet()
+    clock = _Clock(t=1_755_003_600.0)                     # 2025-08-12T13:00:00Z
+    relay.date_header = "Tue, 12 Aug 2025 12:00:00 GMT"   # an hour behind us
+    link = _link(tmp_path, relay, clock)
+
+    link.register_once()
+
+    assert link.clock_skew_seconds == pytest.approx(3600, abs=1)
+
+
 def test_unparseable_date_header_leaves_skew_unknown(tmp_path: Path):
     relay = _Relay()
     relay.date_header = "not a date"

--- a/tests/core/daemon/test_relay_link.py
+++ b/tests/core/daemon/test_relay_link.py
@@ -326,6 +326,24 @@ def test_tick_backs_off_and_a_success_resets_the_delay(tmp_path: Path):
     assert link.next_attempt_delay() == pytest.approx(host_contract.REGISTER_INTERVAL_S)
 
 
+def test_retry_delay_starts_after_a_slow_registration_finishes(tmp_path: Path):
+    clock = _Clock()
+    link = _link(tmp_path, _Relay(), clock, rng=lambda: 0.0)
+    calls = 0
+
+    def slow_registration():
+        nonlocal calls
+        calls += 1
+        clock.advance(host_contract.REGISTER_INTERVAL_S * 2)
+        return relay_link.RegistrationOutcome(True, "registered", refresh="refresh")
+
+    link.register_once = slow_registration
+
+    assert link.tick().ok
+    assert link.tick() is None
+    assert calls == 1
+
+
 def test_backoff_has_no_ceiling_past_1024_failures(tmp_path: Path):
     """`float * 2**n` raises OverflowError at n == 1024 (assumption 5): the
     daemon is immortal, so that count is reachable — the delay must clamp."""
@@ -425,6 +443,25 @@ def test_enroll_is_reposted_on_a_schedule_shorter_than_the_store_ttl(tmp_path: P
         >= 7 * 3600 // host_contract.ENROLL_REPOST_INTERVAL_S - 1
     )
     assert link.state == "awaiting-enrollment"
+
+
+def test_slow_unapproved_attempt_reposts_when_due_at_completion(tmp_path: Path):
+    relay = _Relay(register=(401, host_contract.UNAPPROVED_KEY_DETAIL))
+    clock = _Clock()
+    link = _link(tmp_path, relay, clock)
+    link.tick()
+    assert len(relay.posts_to("/enroll")) == 1
+
+    def slow_unapproved():
+        clock.advance(2)
+        return relay_link.RegistrationOutcome(False, "unapproved")
+
+    link.register_once = slow_unapproved
+    clock.advance(host_contract.ENROLL_REPOST_INTERVAL_S - 1)
+    link.register_soon()
+    link.tick()
+
+    assert len(relay.posts_to("/enroll")) == 2
 
 
 def test_enroll_repost_follows_the_servers_advertised_ttl(tmp_path: Path):

--- a/tests/core/daemon/test_relay_link.py
+++ b/tests/core/daemon/test_relay_link.py
@@ -503,6 +503,26 @@ def test_failed_enroll_response_retries_on_the_next_registration_attempt(
     assert len(relay.posts_to("/enroll")) == 2
 
 
+def test_malformed_successful_enroll_response_retries_on_the_next_attempt(
+    tmp_path: Path,
+):
+    relay = _Relay(
+        register=(401, host_contract.UNAPPROVED_KEY_DETAIL),
+        enroll=(204, None),
+    )
+    clock = _Clock()
+    link = _link(tmp_path, relay, clock)
+
+    link.tick()
+    assert len(relay.posts_to("/enroll")) == 1
+    assert "invalid response" in (link.last_error or "")
+
+    _advance_past(clock, link)
+    link.tick()
+
+    assert len(relay.posts_to("/enroll")) == 2
+
+
 def test_challenge_stage_unapproved_self_heals_with_no_prompt(tmp_path: Path):
     relay = _Relay(challenge=(401, host_contract.UNAPPROVED_KEY_DETAIL))
     clock = _Clock()

--- a/tests/core/daemon/test_relay_link.py
+++ b/tests/core/daemon/test_relay_link.py
@@ -17,6 +17,7 @@ import pytest
 
 from mship.core.daemon.capabilities import host_capability_payload, runner_block
 from mship.core.daemon.identity import HostIdentity, force_reidentify
+from mship.core.daemon import relay_link
 from mship.core.daemon.relay_link import RelayLink
 from mship.core.relay import host_contract
 from mship.core.relay.config import RelayConfig
@@ -232,6 +233,19 @@ def test_a_stale_challenge_401_is_transient_not_unapproved(tmp_path: Path):
         assert relay.posts_to(host_contract.ENROLL_PATH) == []
 
 
+def test_an_unrecognised_401_still_enrolls(tmp_path: Path):
+    """The deliberate fallback: only the challenge refusals are transient, so a
+    401 nobody recognises — a proxy's own body, an older relay's wording —
+    enrolls. Enrolling once too often is recoverable; a host that never enrolls
+    can never be approved."""
+    relay = _Relay(register=(401, "Unauthorized"))
+    link = _link(tmp_path, relay, _Clock())
+    outcome = link.tick()
+    assert outcome.kind == "unapproved"
+    assert link.state == "awaiting-enrollment"
+    assert len(relay.posts_to(host_contract.ENROLL_PATH)) == 1
+
+
 # --- tick(): jittered, capped, ceiling-free backoff (AC2/AC3) --------------
 
 def _fail(relay: _Relay, why: str = "boom") -> None:
@@ -285,7 +299,9 @@ def test_jitter_never_schedules_past_the_cap(tmp_path: Path):
             link.tick()
             _advance_past(clock, link)
         assert 0 < link.next_attempt_delay() <= host_contract.MAX_BACKOFF_S
-        assert link.next_attempt_delay() >= host_contract.MAX_BACKOFF_S * (1 - 0.2)
+        assert link.next_attempt_delay() >= host_contract.MAX_BACKOFF_S * (
+            1 - relay_link.JITTER
+        )
 
 
 def test_two_links_do_not_retry_on_the_same_tick(tmp_path: Path):

--- a/tests/core/daemon/test_relay_link.py
+++ b/tests/core/daemon/test_relay_link.py
@@ -76,10 +76,12 @@ class _Relay:
         register=(200, None),
         challenge=(200, None),
         enroll_ttl=host_contract.ENROLL_TTL_S,
+        enroll=(200, None),
     ):
         self.register_status, self.register_detail = register
         self.challenge_status, self.challenge_detail = challenge
         self.enroll_ttl = enroll_ttl
+        self.enroll_status, self.enroll_detail = enroll
         self.calls: list[tuple[str, str, dict | None]] = []
         self.nonce = "nonce-1"
         self.date_header: str | None = None
@@ -101,10 +103,12 @@ class _Relay:
             )
             return _Resp(self.challenge_status, body, headers)
         if url.endswith("/enroll"):
-            return _Resp(
-                200,
-                {"id": "req-1", "status": "pending", "expires_in": self.enroll_ttl},
+            body = (
+                {"id": "req-1", "status": "pending", "expires_in": self.enroll_ttl}
+                if self.enroll_status == 200
+                else {"detail": self.enroll_detail}
             )
+            return _Resp(self.enroll_status, body)
         body = (
             {"status": "registered", "host_id": json["payload"]["host_id"]}
             if self.register_status == 200
@@ -439,6 +443,27 @@ def test_enroll_repost_follows_the_servers_advertised_ttl(tmp_path: Path):
 
     assert len(relay.posts_to("/enroll")) == 2
     assert clock() - started_at < 60
+
+
+@pytest.mark.parametrize("status", [429, 500])
+def test_failed_enroll_response_retries_on_the_next_registration_attempt(
+    tmp_path: Path, status: int
+):
+    relay = _Relay(
+        register=(401, host_contract.UNAPPROVED_KEY_DETAIL),
+        enroll=(status, "enrollment unavailable"),
+    )
+    clock = _Clock()
+    link = _link(tmp_path, relay, clock)
+
+    link.tick()
+    assert len(relay.posts_to("/enroll")) == 1
+    assert "enrollment unavailable" in (link.last_error or "")
+
+    _advance_past(clock, link)
+    link.tick()
+
+    assert len(relay.posts_to("/enroll")) == 2
 
 
 def test_challenge_stage_unapproved_self_heals_with_no_prompt(tmp_path: Path):

--- a/tests/core/daemon/test_relay_link.py
+++ b/tests/core/daemon/test_relay_link.py
@@ -22,7 +22,7 @@ from mship.core.daemon import relay_link
 from mship.core.daemon.relay_link import RelayLink
 from mship.core.relay import host_contract
 from mship.core.relay.config import RelayConfig
-from mship.core.relay.enroll import fingerprint
+from mship.core.relay.enroll import RequestStore, fingerprint
 from mship.core.relay.keys import relay_key_path
 
 RELAY = RelayConfig(host="relay.example")
@@ -77,11 +77,13 @@ class _Relay:
         challenge=(200, None),
         enroll_ttl=host_contract.ENROLL_TTL_S,
         enroll=(200, None),
+        revoke=(200, None),
     ):
         self.register_status, self.register_detail = register
         self.challenge_status, self.challenge_detail = challenge
         self.enroll_ttl = enroll_ttl
         self.enroll_status, self.enroll_detail = enroll
+        self.revoke_status, self.revoke_detail = revoke
         self.calls: list[tuple[str, str, dict | None]] = []
         self.nonce = "nonce-1"
         self.date_header: str | None = None
@@ -102,6 +104,13 @@ class _Relay:
                 else {"detail": self.challenge_detail}
             )
             return _Resp(self.challenge_status, body, headers)
+        if url.endswith(host_contract.REVOKE_PATH):
+            body = (
+                {"status": "revoked"}
+                if self.revoke_status == 200
+                else {"detail": self.revoke_detail}
+            )
+            return _Resp(self.revoke_status, body)
         if url.endswith("/enroll"):
             body = (
                 {"id": "req-1", "status": "pending", "expires_in": self.enroll_ttl}
@@ -184,6 +193,60 @@ def test_register_once_signs_the_posted_payload_and_returns_the_refresh(tmp_path
     # Signed over EXACTLY the bytes posted, with the challenge nonce inside.
     assert body["nonce"] == relay.nonce
     assert body["signature"] == _sign(host_contract.signing_blob(relay.nonce, payload))
+
+
+def test_revoke_relay_key_signs_a_single_use_challenge_with_the_old_key(
+    tmp_path: Path,
+):
+    relay = _Relay()
+    _seed_key(tmp_path)
+
+    relay_link.revoke_relay_key(
+        tmp_path,
+        RELAY,
+        post=relay.post,
+        signer=_sign,
+    )
+
+    body = relay.posts_to(host_contract.REVOKE_PATH)[0]
+    payload = host_contract.key_revocation_payload(fingerprint(PUBKEY))
+    assert body["key_fingerprint"] == fingerprint(PUBKEY)
+    assert body["nonce"] == relay.nonce
+    assert body["signature"] == _sign(
+        host_contract.signing_blob(relay.nonce, payload)
+    )
+
+
+def test_revoke_treats_relay_unapproved_as_already_revoked(tmp_path: Path):
+    relay = _Relay(
+        challenge=(401, host_contract.UNAPPROVED_KEY_DETAIL)
+    )
+    _seed_key(tmp_path)
+
+    relay_link.revoke_relay_key(
+        tmp_path,
+        RELAY,
+        post=relay.post,
+        signer=_sign,
+    )
+
+    assert relay.posts_to(host_contract.REVOKE_PATH) == []
+
+
+def test_revoke_refuses_when_only_the_old_public_key_remains(tmp_path: Path):
+    relay = _Relay()
+    _seed_key(tmp_path)
+    relay_key_path(tmp_path).unlink()
+
+    with pytest.raises(RuntimeError, match="private key is missing"):
+        relay_link.revoke_relay_key(
+            tmp_path,
+            RELAY,
+            post=relay.post,
+            signer=_sign,
+        )
+
+    assert relay.calls == []
 
 
 def test_payload_survives_a_canonical_round_trip(tmp_path: Path):
@@ -412,6 +475,58 @@ def test_unapproved_key_posts_enroll_without_polling(tmp_path: Path):
     assert not any("/status/" in url for _verb, url, _body in relay.calls)
 
 
+def test_stale_approved_enroll_response_does_not_delay_a_new_pending_request(
+    tmp_path: Path,
+):
+    approved = {fingerprint(PUBKEY)}
+    store = RequestStore(
+        tmp_path / "enroll-store",
+        is_approved=lambda identity: identity in approved,
+    )
+    historical = store.create(PUBKEY, "vm")
+    store.approve(historical, tmp_path / "pubkeys")
+
+    class CreateWinsThenRevokeRelay(_Relay):
+        def __init__(self):
+            super().__init__(
+                register=(401, host_contract.UNAPPROVED_KEY_DETAIL)
+            )
+            self.enrollment_ids = []
+
+        def post(self, url, json=None, **kw):
+            if not url.endswith(host_contract.ENROLL_PATH):
+                return super().post(url, json=json, **kw)
+            self.calls.append(("POST", url, json))
+            rid = store.create(json["pubkey"], json["hostname"])
+            self.enrollment_ids.append(rid)
+            if len(self.enrollment_ids) == 1:
+                approved.clear()
+            return _Resp(
+                200,
+                {
+                    "id": rid,
+                    "status": store.get(rid),
+                    "expires_in": store.ttl_seconds,
+                },
+            )
+
+    relay = CreateWinsThenRevokeRelay()
+    clock = _Clock()
+    link = _link(tmp_path, relay, clock)
+
+    link.tick()
+    assert relay.enrollment_ids == [historical]
+
+    _advance_past(clock, link)
+    link.tick()
+
+    assert len(relay.enrollment_ids) == 2
+    assert relay.enrollment_ids[1] != historical
+    assert [rec["id"] for rec in store.list_pending()] == [
+        relay.enrollment_ids[1]
+    ]
+
+
 def test_enroll_is_reposted_on_a_schedule_shorter_than_the_store_ttl(tmp_path: Path):
     """A VM provisioned at 02:00 must still be approvable at 09:00 (AC1)."""
     assert host_contract.ENROLL_REPOST_INTERVAL_S < host_contract.ENROLL_TTL_S
@@ -581,6 +696,33 @@ def test_consecutive_409s_auto_reidentify_loudly_and_return_to_enrollment(
     assert relay.posts_to("/enroll")
 
 
+def test_failed_auto_reidentify_keeps_identity_and_uses_registration_backoff(
+    tmp_path: Path,
+):
+    relay = _Relay(register=(409, "duplicate identity"))
+    clock = _Clock()
+    attempts = []
+
+    def fail_reidentify():
+        attempts.append(clock())
+        raise RuntimeError("relay revocation failed")
+
+    link = _link(tmp_path, relay, clock, reidentify=fail_reidentify)
+    original = link.host_id
+    for attempt in range(RelayLink.DUPLICATE_REIDENTIFY_AFTER):
+        link.tick()
+        if attempt + 1 < RelayLink.DUPLICATE_REIDENTIFY_AFTER:
+            _advance_past(clock, link)
+
+    assert attempts == [clock()]
+    assert link.host_id == original
+    assert link.state == "duplicate-identity"
+    assert "relay revocation failed" in (link.last_error or "")
+    assert link.next_attempt_delay() > 1
+    assert link.tick() is None
+    assert attempts == [clock()]
+
+
 def test_a_success_clears_the_duplicate_counter(tmp_path: Path):
     relay = _Relay(register=(409, "duplicate identity"))
     clock = _Clock()
@@ -677,13 +819,42 @@ def test_capability_payload_has_one_assembler():
 def test_force_reidentify_mints_a_new_id_and_rotates_the_key(tmp_path: Path):
     from mship.core.daemon.identity import ensure_host_identity
 
-    rotated: list[Path] = []
-    first = ensure_host_identity(tmp_path, fingerprint="fp", rotate_key=lambda h: None)
-    fresh = force_reidentify(tmp_path, rotate_key=rotated.append)
+    events = []
+    first = ensure_host_identity(
+        tmp_path, fingerprint="fp", rotate_key=lambda h: None
+    )
+    fresh = force_reidentify(
+        tmp_path,
+        revoke_key=lambda home: events.append(("revoke", home)),
+        rotate_key=lambda home: events.append(("rotate", home)),
+    )
 
     assert fresh.host_id != first.host_id
     assert fresh.cloned_from == first.host_id
     assert fresh.reidentified is True
-    assert rotated == [tmp_path]
+    assert events == [("revoke", tmp_path), ("rotate", tmp_path)]
     # Persisted, so a restart does not fall back to the shadowed identity.
     assert ensure_host_identity(tmp_path, fingerprint="fp").host_id == fresh.host_id
+
+
+def test_force_reidentify_does_not_rotate_when_relay_revocation_fails(
+    tmp_path: Path,
+):
+    from mship.core.daemon.identity import ensure_host_identity
+
+    first = ensure_host_identity(
+        tmp_path, fingerprint="fp", rotate_key=lambda _home: None
+    )
+    rotated = []
+
+    with pytest.raises(RuntimeError, match="relay unavailable"):
+        force_reidentify(
+            tmp_path,
+            revoke_key=lambda _home: (_ for _ in ()).throw(
+                RuntimeError("relay unavailable")
+            ),
+            rotate_key=rotated.append,
+        )
+
+    assert rotated == []
+    assert ensure_host_identity(tmp_path, fingerprint="fp").host_id == first.host_id

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -51,15 +51,18 @@ def _fake_uvicorn(monkeypatch, *, on_serve=None, hold=False):
     Config it builds rather than on a `run()` call. Reaching `uvicorn.run` at
     all is now itself a failure, which is what pins the asyncio branch.
 
-    Returns `(control_kwargs, servers)`. `hold=True` makes `serve()` run until
-    something sets `should_exit`, so a test can drive shutdown; otherwise each
-    server serves once and reports the clean exit a signalled uvicorn does.
+    Returns `(configs, servers)`, in construction order and unfiltered — the
+    shape of a startup is how many servers it builds and what each was given,
+    so a test asserts both rather than reading a dict that only ever holds the
+    kwargs it expected. `hold=True` makes `serve()` run until something sets
+    `should_exit`, so a test can drive shutdown; otherwise each server serves
+    once and reports the clean exit a signalled uvicorn does.
     """
     import asyncio
 
     import uvicorn
 
-    control_kwargs: dict = {}
+    configs: list = []
     servers: list = []
 
     class _Config:
@@ -67,8 +70,7 @@ def _fake_uvicorn(monkeypatch, *, on_serve=None, hold=False):
             self.app = app
             self.kwargs = kwargs
             self.host = kwargs.get("host")
-            if self.host is None:  # the control server, on the unix socket
-                control_kwargs.update(kwargs)
+            configs.append(self)
 
     class _Server:
         def __init__(self, config):
@@ -93,12 +95,12 @@ def _fake_uvicorn(monkeypatch, *, on_serve=None, hold=False):
     monkeypatch.setattr(uvicorn, "Config", _Config)
     monkeypatch.setattr(uvicorn, "Server", _Server)
     monkeypatch.setattr(uvicorn, "run", _forbidden)
-    return control_kwargs, servers
+    return configs, servers
 
 
 def _capture_uvicorn(monkeypatch, on_serve=None):
-    seen, _servers = _fake_uvicorn(monkeypatch, on_serve=on_serve)
-    return seen
+    configs, _servers = _fake_uvicorn(monkeypatch, on_serve=on_serve)
+    return configs
 
 
 def test_main_acquires_lease_then_serves_socket(env_home, monkeypatch):
@@ -110,12 +112,15 @@ def test_main_acquires_lease_then_serves_socket(env_home, monkeypatch):
         lease_seen_held_by_uvicorn["lease"] = json.loads(lease_path(home).read_text())
         lease_seen_held_by_uvicorn["history"] = [e.kind for e in read_history(run_mod.paths.start_history_path(home))]
 
-    seen = _capture_uvicorn(monkeypatch, on_serve=record)
+    configs = _capture_uvicorn(monkeypatch, on_serve=record)
     rc = run_mod.main(home=home, env=env)
     assert rc == 0
-    assert seen["uds"] == str(daemon_socket_path(env, home))
-    assert "host" not in seen and "port" not in seen
-    assert seen["log_config"] is None
+    # No serve bind configured: ONE server, on the unix socket and nothing else.
+    assert len(configs) == 1
+    bound = configs[0].kwargs
+    assert bound["uds"] == str(daemon_socket_path(env, home))
+    assert "host" not in bound and "port" not in bound
+    assert bound["log_config"] is None
     assert lease_seen_held_by_uvicorn["lease"]["pid"] > 0
     assert "start" in lease_seen_held_by_uvicorn["history"]
 
@@ -149,7 +154,7 @@ def test_lost_race_with_live_holder_exits_zero(env_home, foreign_holder, monkeyp
     with caplog.at_level(logging.INFO):
         rc = run_mod.main(home=home, env=env)
     assert rc == 0
-    assert called == {}  # uvicorn never entered
+    assert called == []  # no server was ever configured
     assert any("already running" in r.message for r in caplog.records)
 
 
@@ -159,7 +164,7 @@ def test_lost_race_with_dead_holder_exits_nonzero(env_home, foreign_holder, monk
     monkeypatch.setattr(run_mod, "_probe", lambda sock: None)  # holder never answers
     rc = run_mod.main(home=home, env=env)
     assert rc != 0
-    assert called == {}
+    assert called == []
 
 
 def test_stale_socket_file_is_removed_before_bind(env_home, monkeypatch):
@@ -459,7 +464,7 @@ def test_unbuildable_relay_logs_and_leaves_the_daemon_healthy(env_home, monkeypa
     host without a tunnel, never a host that refuses to start."""
     home, env = env_home
     _seed_config(home, serve=SERVE_BLOCK, relay=RELAY_BLOCK)
-    seen = _capture_uvicorn(monkeypatch)
+    configs = _capture_uvicorn(monkeypatch)
 
     def boom(*a, **k):
         raise RuntimeError("no key material")
@@ -469,7 +474,10 @@ def test_unbuildable_relay_logs_and_leaves_the_daemon_healthy(env_home, monkeypa
     rc = run_mod.main(home=home, env=env)
 
     assert rc == 0
-    assert seen["uds"] == str(daemon_socket_path(env, home))
+    # The serve bind still came up beside the control socket; only the tunnel
+    # is missing.
+    assert [c.kwargs.get("host") for c in configs] == [None, SERVE_BLOCK["host"]]
+    assert configs[0].kwargs["uds"] == str(daemon_socket_path(env, home))
     assert [e.kind for e in read_history(run_mod.paths.start_history_path(home))] == [
         "start", "clean_stop",
     ]
@@ -543,3 +551,34 @@ def test_no_relay_block_means_no_tunnel(tmp_path):
     home.mkdir()
     assert run_mod._relay_config(home) is None
     assert run_mod._build_tunnel(home, None, SERVE_BLOCK) is None
+
+
+@pytest.mark.parametrize("server_count", [1, 2])
+def test_sigterm_sets_the_shared_event_and_stops_every_server(server_count):
+    """Decision (c)'s centerpiece, asserted in-process because a signal handler
+    has no other honest test: uvicorn's own handlers set `should_exit` on the
+    ONE server that installed them, so a tunnel loop beside them would never
+    learn a stop was requested — the daemon would then outlive
+    `TimeoutStopSec`, be SIGKILLed, and orphan its ssh child. Both shapes:
+    control-only (1) and control+host (2)."""
+    import asyncio
+    import os
+    import signal
+
+    class _Server:
+        def __init__(self):
+            self.should_exit = False
+
+    async def scenario():
+        stop = asyncio.Event()
+        servers = [_Server() for _ in range(server_count)]
+        run_mod._install_stop_handlers(stop, servers)
+        if signal.getsignal(signal.SIGTERM) in (signal.SIG_DFL, signal.SIG_IGN):
+            pytest.skip("no asyncio signal handlers on this platform")
+        os.kill(os.getpid(), signal.SIGTERM)
+        await asyncio.wait_for(stop.wait(), timeout=5)
+        return servers
+
+    servers = asyncio.run(scenario())
+
+    assert all(server.should_exit for server in servers)

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -582,3 +582,24 @@ def test_sigterm_sets_the_shared_event_and_stops_every_server(server_count):
     servers = asyncio.run(scenario())
 
     assert all(server.should_exit for server in servers)
+
+
+def test_the_control_app_publishes_the_tunnel_it_was_built_with(env_home, monkeypatch):
+    """#471 Task 9: `/health` is the ONLY reader-visible source of tunnel state
+    (it lives inside this process), so a daemon that builds a tunnel and does
+    not hand it to the control app renders `mship daemon status` blind."""
+    from fastapi.testclient import TestClient
+
+    home, env = env_home
+    _seed_config(home, serve=SERVE_BLOCK, relay=RELAY_BLOCK)
+    configs = _capture_uvicorn(monkeypatch)
+    snapshot = {"state": "online", "subdomain": "hst-fake"}
+    tunnel = _FakeTunnel()
+    tunnel.snapshot = lambda: snapshot
+    monkeypatch.setattr(run_mod, "_build_tunnel", lambda *a: tunnel)
+
+    assert run_mod.main(home=home, env=env) == 0
+
+    body = TestClient(configs[0].app).get("/health").json()
+    assert body["capabilities"]["tunnel"] is True
+    assert body["tunnel"] == snapshot

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -358,6 +358,11 @@ class _FakeTunnel:
     """What the daemon knows about a tunnel: a public URL, a tick and a stop."""
 
     public_url = "https://hst-fake.relay.example"
+    host_id = "hst-production"
+    instance_id = "0123456789abcdef"
+
+    def snapshot(self):
+        return {"state": "online", "subdomain": "hst-fake"}
 
     def __init__(self, *, events=None, stop_after=None, servers=(), raising=False):
         self.ticks = 0
@@ -538,6 +543,8 @@ def test_build_tunnel_dials_the_subdomain_the_link_currently_owns(
     )
 
     tunnel = run_mod._build_tunnel(home, RelayConfig(host="relay.example"), SERVE_BLOCK)
+    assert tunnel.host_id == tunnel._link.host_id
+    assert tunnel.instance_id == tunnel._link.instance_id
     # Stands in for the auto-reidentify `test_relay_link.py` drives end to end.
     tunnel._link.subdomain = "hst-reidentified"
     tunnel._supervisor.start()
@@ -603,3 +610,39 @@ def test_the_control_app_publishes_the_tunnel_it_was_built_with(env_home, monkey
     body = TestClient(configs[0].app).get("/health").json()
     assert body["capabilities"]["tunnel"] is True
     assert body["tunnel"] == snapshot
+
+
+def test_production_host_app_wires_identity_tunnel_and_token_services(
+    env_home, monkeypatch
+):
+    """The composition root must enable the host-facing seams, not merely leave
+    their independently-tested defaults disabled."""
+    from fastapi.testclient import TestClient
+
+    from mship.core.daemon.host_auth import RefreshStore
+
+    home, env = env_home
+    _seed_config(home, serve=SERVE_BLOCK, relay=RELAY_BLOCK)
+    configs = _capture_uvicorn(monkeypatch)
+    tunnel = _FakeTunnel()
+    refresh = RefreshStore(home).issue_refresh(
+        host_id=tunnel.host_id, client="phone"
+    )
+    monkeypatch.setattr(run_mod, "_build_tunnel", lambda *a: tunnel)
+
+    assert run_mod.main(home=home, env=env) == 0
+
+    with TestClient(configs[1].app) as client:
+        health = client.get("/health").json()
+        minted = client.post("/host/token", json={"refresh": refresh})
+        assert minted.status_code == 200
+        authorized = client.get(
+            "/workspaces",
+            headers={"Authorization": f"Bearer {minted.json()['token']}"},
+        )
+
+    assert health["host_id"] == tunnel.host_id
+    assert health["instance_id"] == tunnel.instance_id
+    assert health["tunnel"] == tunnel.snapshot()
+    assert health["runner"] == {"enabled": False, "state": "disabled"}
+    assert authorized.status_code == 200

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import pytest
 
+import mship.core.daemon.host_tunnel as host_tunnel_mod
+import mship.core.daemon.relay_link as relay_link_mod
 import mship.core.daemon.run as run_mod
 from mship.core.daemon.history import read_history
 from mship.core.daemon.lease import DaemonLease
@@ -40,30 +42,75 @@ def env_home(tmp_path, monkeypatch):
             h.close()
 
 
-def _capture_uvicorn(monkeypatch):
-    seen = {}
+def _fake_uvicorn(monkeypatch, *, on_serve=None, hold=False):
+    """Stub uvicorn's Config/Server, and forbid `uvicorn.run` outright.
+
+    The capture seam moved with the code: `_serve_forever` runs on asyncio in
+    every shape now (#471 — a tunnel loop has to live beside the servers, and
+    `uvicorn.run` owns the loop), so what a startup binds is visible on the
+    Config it builds rather than on a `run()` call. Reaching `uvicorn.run` at
+    all is now itself a failure, which is what pins the asyncio branch.
+
+    Returns `(control_kwargs, servers)`. `hold=True` makes `serve()` run until
+    something sets `should_exit`, so a test can drive shutdown; otherwise each
+    server serves once and reports the clean exit a signalled uvicorn does.
+    """
+    import asyncio
+
     import uvicorn
 
-    monkeypatch.setattr(uvicorn, "run", lambda app, **k: seen.update(k))
+    control_kwargs: dict = {}
+    servers: list = []
+
+    class _Config:
+        def __init__(self, app, **kwargs):
+            self.app = app
+            self.kwargs = kwargs
+            self.host = kwargs.get("host")
+            if self.host is None:  # the control server, on the unix socket
+                control_kwargs.update(kwargs)
+
+    class _Server:
+        def __init__(self, config):
+            self.config = config
+            self.started = False
+            self.should_exit = False
+            servers.append(self)
+
+        async def serve(self):
+            self.started = True
+            if on_serve is not None:
+                on_serve()
+            while hold and not self.should_exit:
+                await asyncio.sleep(0)
+            # A real server returns from serve() with should_exit set once it
+            # has been asked to stop; leaving it False reads as a crash.
+            self.should_exit = True
+
+    def _forbidden(app, **kwargs):
+        raise AssertionError("uvicorn.run bypasses the asyncio branch (#471 AC7)")
+
+    monkeypatch.setattr(uvicorn, "Config", _Config)
+    monkeypatch.setattr(uvicorn, "Server", _Server)
+    monkeypatch.setattr(uvicorn, "run", _forbidden)
+    return control_kwargs, servers
+
+
+def _capture_uvicorn(monkeypatch, on_serve=None):
+    seen, _servers = _fake_uvicorn(monkeypatch, on_serve=on_serve)
     return seen
 
 
 def test_main_acquires_lease_then_serves_socket(env_home, monkeypatch):
     home, env = env_home
-    seen = _capture_uvicorn(monkeypatch)
     lease_seen_held_by_uvicorn = {}
 
-    import uvicorn
-
-    real_update = seen.update
-
-    def fake_run(app, **k):
+    def record():
         # By the time uvicorn is entered, lease + history must already exist.
         lease_seen_held_by_uvicorn["lease"] = json.loads(lease_path(home).read_text())
         lease_seen_held_by_uvicorn["history"] = [e.kind for e in read_history(run_mod.paths.start_history_path(home))]
-        real_update(k)
 
-    monkeypatch.setattr(uvicorn, "run", fake_run)
+    seen = _capture_uvicorn(monkeypatch, on_serve=record)
     rc = run_mod.main(home=home, env=env)
     assert rc == 0
     assert seen["uds"] == str(daemon_socket_path(env, home))
@@ -140,9 +187,11 @@ def test_rotating_log_handler_configured(env_home, monkeypatch):
 
 def test_uncaught_exception_lands_in_daemon_log(env_home, monkeypatch):
     home, env = env_home
-    import uvicorn
 
-    monkeypatch.setattr(uvicorn, "run", lambda app, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    def boom():
+        raise RuntimeError("boom")
+
+    _capture_uvicorn(monkeypatch, on_serve=boom)
     rc = run_mod.main(home=home, env=env)
     assert rc != 0
     assert "boom" in (daemon_log_dir(home) / "daemon.log").read_text()
@@ -261,3 +310,236 @@ def test_capture_rotated_before_logging_setup(env_home, monkeypatch):
     monkeypatch.setattr(run_mod, "_run", lambda h, e: order.append("run") or 0)
     assert run_mod.main(home=home, env=env) == 0
     assert order[0] == "rotate", order
+
+
+# ---------------------------------------------------------------------------
+# #471 Task 8: the tunnel beside the servers, and the shutdown that owns it.
+# ---------------------------------------------------------------------------
+
+RELAY_BLOCK = {"host": "relay.example"}
+SERVE_BLOCK = {"host": "127.0.0.1", "port": 47190}
+
+
+def _control_app():
+    from datetime import datetime, timezone
+
+    from mship.core.daemon.control import create_control_app
+
+    return create_control_app(
+        started_at=datetime.now(timezone.utc),
+        version="1",
+        socket_path="/control.sock",
+    )
+
+
+def _seed_config(home, **kwargs):
+    from mship.core.daemon.registry import DaemonConfig, save_daemon_config
+
+    save_daemon_config(home, DaemonConfig(**kwargs))
+
+
+def _seed_relay_key(home):
+    """A keypair on disk so nothing here spawns ssh-keygen (test_relay_link's
+    `_seed_key` discipline)."""
+    from mship.core.relay.keys import relay_key_path
+
+    key = relay_key_path(home)
+    key.parent.mkdir(parents=True, exist_ok=True)
+    key.write_text("PRIVATE")
+    key.with_name(key.name + ".pub").write_text("ssh-ed25519 " + "A" * 68 + " mship\n")
+
+
+class _FakeTunnel:
+    """What the daemon knows about a tunnel: a public URL, a tick and a stop."""
+
+    public_url = "https://hst-fake.relay.example"
+
+    def __init__(self, *, events=None, stop_after=None, servers=(), raising=False):
+        self.ticks = 0
+        self.stopped = False
+        self._events = events if events is not None else []
+        self._stop_after = stop_after
+        self._servers = servers
+        self._raising = raising
+
+    def tick(self):
+        # A tick after stop() means the loop was torn down without being joined
+        # — the window in which a respawn forks an ssh child nothing owns.
+        assert not self.stopped, "ticked after stop()"
+        self.ticks += 1
+        self._events.append("tick")
+        if self._stop_after is not None and self.ticks >= self._stop_after:
+            for server in self._servers:  # a SIGTERM lands on the servers
+                server.should_exit = True
+        if self._raising:
+            raise RuntimeError("tick boom")
+
+    def stop(self):
+        self.stopped = True
+        self._events.append("sup.stop")
+
+
+@pytest.mark.parametrize(
+    ("host_app", "serve_cfg", "with_tunnel", "servers"),
+    [
+        (None, None, False, 1),                 # control-only
+        (object(), SERVE_BLOCK, False, 2),      # control + host
+        (object(), SERVE_BLOCK, True, 2),       # control + host + tunnel
+    ],
+)
+def test_serve_forever_always_runs_on_asyncio(
+    monkeypatch, host_app, serve_cfg, with_tunnel, servers
+):
+    """All three shapes take the asyncio branch: `uvicorn.run` owns the loop
+    and the signal handlers, so a shape that used it would have nowhere to run
+    a tunnel and no way to stop one (the stub raises if it is reached)."""
+    tunnel = _FakeTunnel() if with_tunnel else None
+    _seen, built = _fake_uvicorn(monkeypatch)
+
+    run_mod._serve_forever(
+        _control_app(), Path("/control.sock"), host_app, serve_cfg, tunnel
+    )
+
+    assert len(built) == servers
+    assert tunnel is None or tunnel.stopped
+
+
+def test_shutdown_joins_the_tunnel_then_stops_it_then_records_clean_stop(
+    env_home, monkeypatch
+):
+    """AC7, in order. The join COMPLETING is the first assertion: a hung gather
+    would never reach the side effects, so asserting only those would pass on
+    exactly the bug this shape exists to prevent — and a daemon that outlives
+    `TimeoutStopSec` is SIGKILLed, leaving its ssh child holding the
+    subdomain."""
+    home, env = env_home
+    _seed_config(home, serve=SERVE_BLOCK)
+    events: list[str] = []
+    _seen, servers = _fake_uvicorn(monkeypatch, hold=True)
+    monkeypatch.setattr(host_tunnel_mod, "TICK_INTERVAL_S", 0)
+    tunnel = _FakeTunnel(events=events, stop_after=3, servers=servers)
+    monkeypatch.setattr(run_mod, "_build_tunnel", lambda *a: tunnel)
+    real_clean_stop = run_mod.history.append_clean_stop
+    monkeypatch.setattr(
+        run_mod.history, "append_clean_stop",
+        lambda *a, **k: (events.append("clean_stop"), real_clean_stop(*a, **k))[1],
+    )
+
+    rc = run_mod.main(home=home, env=env)
+
+    assert rc == 0
+    assert tunnel.ticks >= 3
+    assert events[-2:] == ["sup.stop", "clean_stop"]
+
+
+def test_clean_stop_is_recorded_even_when_every_tunnel_tick_raises(
+    env_home, monkeypatch
+):
+    """The tunnel is the half of the daemon that recovers by retrying; a relay
+    outage must not cost the workspaces it serves on the LAN, nor turn a clean
+    shutdown into an unclean-start entry the next boot reports."""
+    home, env = env_home
+    _seed_config(home, serve=SERVE_BLOCK)
+    _seen, servers = _fake_uvicorn(monkeypatch, hold=True)
+    monkeypatch.setattr(host_tunnel_mod, "TICK_INTERVAL_S", 0)
+    tunnel = _FakeTunnel(stop_after=3, servers=servers, raising=True)
+    monkeypatch.setattr(run_mod, "_build_tunnel", lambda *a: tunnel)
+
+    rc = run_mod.main(home=home, env=env)
+
+    assert rc == 0
+    assert [e.kind for e in read_history(run_mod.paths.start_history_path(home))] == [
+        "start", "clean_stop",
+    ]
+    assert "tick boom" in (daemon_log_dir(home) / "daemon.log").read_text()
+
+
+def test_unbuildable_relay_logs_and_leaves_the_daemon_healthy(env_home, monkeypatch):
+    """`_build_registry`'s never-raise discipline: a relay we cannot build is a
+    host without a tunnel, never a host that refuses to start."""
+    home, env = env_home
+    _seed_config(home, serve=SERVE_BLOCK, relay=RELAY_BLOCK)
+    seen = _capture_uvicorn(monkeypatch)
+
+    def boom(*a, **k):
+        raise RuntimeError("no key material")
+
+    monkeypatch.setattr(relay_link_mod, "RelayLink", boom)
+
+    rc = run_mod.main(home=home, env=env)
+
+    assert rc == 0
+    assert seen["uds"] == str(daemon_socket_path(env, home))
+    assert [e.kind for e in read_history(run_mod.paths.start_history_path(home))] == [
+        "start", "clean_stop",
+    ]
+    log_text = (daemon_log_dir(home) / "daemon.log").read_text()
+    assert "relay tunnel unavailable" in log_text and "no key material" in log_text
+
+
+def test_loser_never_builds_a_tunnel_or_spawns_ssh(
+    env_home, foreign_holder, monkeypatch
+):
+    """A process that stands down for the incumbent must not first fork an ssh
+    child onto the subdomain the incumbent is serving."""
+    from mship.core.relay import tunnel as tunnel_mod
+
+    home, env = env_home
+    _seed_config(home, serve=SERVE_BLOCK, relay=RELAY_BLOCK)
+    _capture_uvicorn(monkeypatch)
+    spawned, built = [], []
+    monkeypatch.setattr(
+        tunnel_mod, "_default_proc_factory",
+        lambda argv, log_path=None: spawned.append(argv),
+    )
+    real_build = run_mod._build_tunnel
+    monkeypatch.setattr(
+        run_mod, "_build_tunnel",
+        lambda *a: (built.append(a), real_build(*a))[1],
+    )
+    monkeypatch.setattr(
+        run_mod, "_probe",
+        lambda sock: {"status": "ok"} if str(sock) == foreign_holder else None,
+    )
+
+    assert run_mod.main(home=home, env=env) == 0
+    assert built == [] and spawned == []
+
+
+def test_build_tunnel_dials_the_subdomain_the_link_currently_owns(
+    tmp_path, monkeypatch
+):
+    """AC4's other half: an auto-reidentify moves this host to a NEW subdomain
+    mid-run, and argv frozen at startup would keep re-dialing the one it no
+    longer owns — reconnecting a re-identified host to somebody else's route."""
+    from mship.core.relay import tunnel as tunnel_mod
+    from mship.core.relay.config import RelayConfig
+
+    class _Proc:
+        def poll(self): return None
+        def terminate(self): pass
+        def wait(self, timeout=None): return 0
+
+    home = tmp_path / "home"
+    home.mkdir()
+    _seed_relay_key(home)
+    spawned = []
+    monkeypatch.setattr(
+        tunnel_mod, "_default_proc_factory",
+        lambda argv, log_path=None: (spawned.append(argv), _Proc())[1],
+    )
+
+    tunnel = run_mod._build_tunnel(home, RelayConfig(host="relay.example"), SERVE_BLOCK)
+    # Stands in for the auto-reidentify `test_relay_link.py` drives end to end.
+    tunnel._link.subdomain = "hst-reidentified"
+    tunnel._supervisor.start()
+
+    assert spawned[-1][spawned[-1].index("-R") + 1].startswith("hst-reidentified:")
+    assert str(SERVE_BLOCK["port"]) in spawned[-1][spawned[-1].index("-R") + 1]
+
+
+def test_no_relay_block_means_no_tunnel(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    assert run_mod._relay_config(home) is None
+    assert run_mod._build_tunnel(home, None, SERVE_BLOCK) is None

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -447,6 +447,15 @@ def test_serve_forever_always_runs_on_asyncio(
     assert tunnel is None or tunnel.stopped
 
 
+def test_tunnel_join_timeout_uses_the_reapers_fixed_snapshot_bound(monkeypatch):
+    monkeypatch.setattr(relay_link_mod, "HTTP_TIMEOUT_S", 13)
+    monkeypatch.setattr(host_tunnel_mod, "PROCESS_LIST_TIMEOUT_S", 7)
+    monkeypatch.setattr(host_tunnel_mod, "MAX_PROCESS_LIST_CALLS_PER_REAP", 5)
+    monkeypatch.setattr(host_tunnel_mod, "ORPHAN_EXIT_TIMEOUT_S", 11)
+
+    assert run_mod._tunnel_join_timeout() == 3 * 13 + 5 * 7 + 2 * 11
+
+
 def test_shutdown_joins_the_tunnel_then_stops_it_then_records_clean_stop(
     env_home, monkeypatch
 ):

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -600,6 +600,16 @@ def test_no_relay_block_means_no_tunnel(tmp_path):
     assert run_mod._build_tunnel(home, None, SERVE_BLOCK) is None
 
 
+def test_relay_without_a_local_serve_bind_is_an_error(tmp_path):
+    from mship.core.relay.config import RelayConfig
+
+    home = tmp_path / "home"
+    home.mkdir()
+
+    with pytest.raises(ValueError, match="relay needs a local serve bind"):
+        run_mod._build_tunnel(home, RelayConfig(host="relay.example"), None)
+
+
 def test_configured_tunnel_construction_failure_is_published_without_stopping_local_service(
     env_home, monkeypatch
 ):

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -19,7 +19,12 @@ import mship.core.daemon.relay_link as relay_link_mod
 import mship.core.daemon.run as run_mod
 from mship.core.daemon.history import read_history
 from mship.core.daemon.lease import DaemonLease
-from mship.core.daemon.paths import daemon_log_dir, daemon_socket_path, lease_path
+from mship.core.daemon.paths import (
+    daemon_config_path,
+    daemon_log_dir,
+    daemon_socket_path,
+    lease_path,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -598,6 +603,20 @@ def test_no_relay_block_means_no_tunnel(tmp_path):
     home.mkdir()
     assert run_mod._relay_config(home) is None
     assert run_mod._build_tunnel(home, None, SERVE_BLOCK) is None
+
+
+def test_invalid_relay_config_is_not_reported_as_disabled(tmp_path):
+    home = tmp_path / "home"
+    config_path = daemon_config_path(home)
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        "relay:\n"
+        "  host: relay.example.com\n"
+        "  ssh_port: not-an-integer\n"
+    )
+
+    with pytest.raises(ValueError, match="relay.ssh_port"):
+        run_mod._relay_config(home)
 
 
 def test_relay_without_a_local_serve_bind_is_an_error(tmp_path):

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -5,6 +5,7 @@ exit 0 (launchd's KeepAlive.SuccessfulExit=false relaunches on ANY nonzero exit
 every ThrottleInterval — a permanent hot loop; systemd Restart=on-failure
 already skips 0). Contended-but-dead → nonzero so the supervisor retries.
 """
+
 import json
 import logging
 import multiprocessing
@@ -110,7 +111,9 @@ def test_main_acquires_lease_then_serves_socket(env_home, monkeypatch):
     def record():
         # By the time uvicorn is entered, lease + history must already exist.
         lease_seen_held_by_uvicorn["lease"] = json.loads(lease_path(home).read_text())
-        lease_seen_held_by_uvicorn["history"] = [e.kind for e in read_history(run_mod.paths.start_history_path(home))]
+        lease_seen_held_by_uvicorn["history"] = [
+            e.kind for e in read_history(run_mod.paths.start_history_path(home))
+        ]
 
     configs = _capture_uvicorn(monkeypatch, on_serve=record)
     rc = run_mod.main(home=home, env=env)
@@ -125,7 +128,12 @@ def test_main_acquires_lease_then_serves_socket(env_home, monkeypatch):
     assert "start" in lease_seen_held_by_uvicorn["history"]
 
 
-def _hold_lease(path_str: str, sock_str: str, ready: multiprocessing.Event, done: multiprocessing.Event):
+def _hold_lease(
+    path_str: str,
+    sock_str: str,
+    ready: multiprocessing.Event,
+    done: multiprocessing.Event,
+):
     lease = DaemonLease(Path(path_str))
     assert lease.try_acquire(version="held", socket_path=sock_str) is None
     ready.set()
@@ -147,10 +155,16 @@ def foreign_holder(env_home):
     p.join(timeout=30)
 
 
-def test_lost_race_with_live_holder_exits_zero(env_home, foreign_holder, monkeypatch, caplog):
+def test_lost_race_with_live_holder_exits_zero(
+    env_home, foreign_holder, monkeypatch, caplog
+):
     home, env = env_home
     called = _capture_uvicorn(monkeypatch)
-    monkeypatch.setattr(run_mod, "_probe", lambda sock: {"status": "ok"} if str(sock) == foreign_holder else None)
+    monkeypatch.setattr(
+        run_mod,
+        "_probe",
+        lambda sock: {"status": "ok"} if str(sock) == foreign_holder else None,
+    )
     with caplog.at_level(logging.INFO):
         rc = run_mod.main(home=home, env=env)
     assert rc == 0
@@ -158,7 +172,9 @@ def test_lost_race_with_live_holder_exits_zero(env_home, foreign_holder, monkeyp
     assert any("already running" in r.message for r in caplog.records)
 
 
-def test_lost_race_with_dead_holder_exits_nonzero(env_home, foreign_holder, monkeypatch):
+def test_lost_race_with_dead_holder_exits_nonzero(
+    env_home, foreign_holder, monkeypatch
+):
     home, env = env_home
     called = _capture_uvicorn(monkeypatch)
     monkeypatch.setattr(run_mod, "_probe", lambda sock: None)  # holder never answers
@@ -187,7 +203,9 @@ def test_rotating_log_handler_configured(env_home, monkeypatch):
     assert rotating, "root logger must carry the rotating handler"
     for name in ("uvicorn", "uvicorn.error"):
         lg = logging.getLogger(name)
-        assert any(h in rotating for h in lg.handlers), f"{name} not routed to daemon.log"
+        assert any(h in rotating for h in lg.handlers), (
+            f"{name} not routed to daemon.log"
+        )
 
 
 def test_uncaught_exception_lands_in_daemon_log(env_home, monkeypatch):
@@ -213,8 +231,12 @@ def test_broken_import_still_appends_history(env_home, monkeypatch):
     monkeypatch.setattr(run_mod, "_import_server_stack", broken_import)
     rc = run_mod.main(home=home, env=env)
     assert rc != 0
-    assert [e.kind for e in read_history(run_mod.paths.start_history_path(home))] == ["start"]
-    assert "missing dep after upgrade" in (daemon_log_dir(home) / "daemon.log").read_text()
+    assert [e.kind for e in read_history(run_mod.paths.start_history_path(home))] == [
+        "start"
+    ]
+    assert (
+        "missing dep after upgrade" in (daemon_log_dir(home) / "daemon.log").read_text()
+    )
 
 
 def test_clean_stop_recorded(env_home, monkeypatch):
@@ -278,7 +300,11 @@ def test_tcp_bind_failure_stops_control_and_clears_capability(monkeypatch):
             {"host": "127.0.0.1", "port": 47190},
         )
 
-    assert TestClient(control_app).get("/health").json()["capabilities"]["serve"] is False
+    assert (
+        TestClient(control_app).get("/health").json()["capabilities"]["serve"] is False
+    )
+
+
 def test_oversized_launchd_capture_preserves_latest_evidence_on_start(
     env_home, monkeypatch
 ):
@@ -298,9 +324,9 @@ def test_oversized_launchd_capture_preserves_latest_evidence_on_start(
     assert not capture.exists()
     assert (log_dir / "launchd.err.log.1").read_bytes().endswith(latest)
     assert small.read_text() == "keep me\n"
-    assert "rolled over oversized launchd capture" in (
-        log_dir / "daemon.log"
-    ).read_text()
+    assert (
+        "rolled over oversized launchd capture" in (log_dir / "daemon.log").read_text()
+    )
 
 
 def test_capture_rotated_before_logging_setup(env_home, monkeypatch):
@@ -308,10 +334,12 @@ def test_capture_rotated_before_logging_setup(env_home, monkeypatch):
     configured; rollover must happen first, not inside _configure_logging."""
     home, env = env_home
     order: list[str] = []
-    monkeypatch.setattr(run_mod, "rotate_launchd_captures",
-                        lambda d: order.append("rotate") or [])
-    monkeypatch.setattr(run_mod, "_configure_logging",
-                        lambda h: order.append("logging"))
+    monkeypatch.setattr(
+        run_mod, "rotate_launchd_captures", lambda d: order.append("rotate") or []
+    )
+    monkeypatch.setattr(
+        run_mod, "_configure_logging", lambda h: order.append("logging")
+    )
     monkeypatch.setattr(run_mod, "_run", lambda h, e: order.append("run") or 0)
     assert run_mod.main(home=home, env=env) == 0
     assert order[0] == "rotate", order
@@ -392,9 +420,9 @@ class _FakeTunnel:
 @pytest.mark.parametrize(
     ("host_app", "serve_cfg", "with_tunnel", "servers"),
     [
-        (None, None, False, 1),                 # control-only
-        (object(), SERVE_BLOCK, False, 2),      # control + host
-        (object(), SERVE_BLOCK, True, 2),       # control + host + tunnel
+        (None, None, False, 1),  # control-only
+        (object(), SERVE_BLOCK, False, 2),  # control + host
+        (object(), SERVE_BLOCK, True, 2),  # control + host + tunnel
     ],
 )
 def test_serve_forever_always_runs_on_asyncio(
@@ -431,7 +459,8 @@ def test_shutdown_joins_the_tunnel_then_stops_it_then_records_clean_stop(
     monkeypatch.setattr(run_mod, "_build_tunnel", lambda *a: tunnel)
     real_clean_stop = run_mod.history.append_clean_stop
     monkeypatch.setattr(
-        run_mod.history, "append_clean_stop",
+        run_mod.history,
+        "append_clean_stop",
         lambda *a, **k: (events.append("clean_stop"), real_clean_stop(*a, **k))[1],
     )
 
@@ -459,7 +488,8 @@ def test_clean_stop_is_recorded_even_when_every_tunnel_tick_raises(
 
     assert rc == 0
     assert [e.kind for e in read_history(run_mod.paths.start_history_path(home))] == [
-        "start", "clean_stop",
+        "start",
+        "clean_stop",
     ]
     assert "tick boom" in (daemon_log_dir(home) / "daemon.log").read_text()
 
@@ -484,7 +514,8 @@ def test_unbuildable_relay_logs_and_leaves_the_daemon_healthy(env_home, monkeypa
     assert [c.kwargs.get("host") for c in configs] == [None, SERVE_BLOCK["host"]]
     assert configs[0].kwargs["uds"] == str(daemon_socket_path(env, home))
     assert [e.kind for e in read_history(run_mod.paths.start_history_path(home))] == [
-        "start", "clean_stop",
+        "start",
+        "clean_stop",
     ]
     log_text = (daemon_log_dir(home) / "daemon.log").read_text()
     assert "relay tunnel unavailable" in log_text and "no key material" in log_text
@@ -502,16 +533,19 @@ def test_loser_never_builds_a_tunnel_or_spawns_ssh(
     _capture_uvicorn(monkeypatch)
     spawned, built = [], []
     monkeypatch.setattr(
-        tunnel_mod, "_default_proc_factory",
+        tunnel_mod,
+        "_default_proc_factory",
         lambda argv, log_path=None: spawned.append(argv),
     )
     real_build = run_mod._build_tunnel
     monkeypatch.setattr(
-        run_mod, "_build_tunnel",
+        run_mod,
+        "_build_tunnel",
         lambda *a: (built.append(a), real_build(*a))[1],
     )
     monkeypatch.setattr(
-        run_mod, "_probe",
+        run_mod,
+        "_probe",
         lambda sock: {"status": "ok"} if str(sock) == foreign_holder else None,
     )
 
@@ -529,16 +563,22 @@ def test_build_tunnel_dials_the_subdomain_the_link_currently_owns(
     from mship.core.relay.config import RelayConfig
 
     class _Proc:
-        def poll(self): return None
-        def terminate(self): pass
-        def wait(self, timeout=None): return 0
+        def poll(self):
+            return None
+
+        def terminate(self):
+            pass
+
+        def wait(self, timeout=None):
+            return 0
 
     home = tmp_path / "home"
     home.mkdir()
     _seed_relay_key(home)
     spawned = []
     monkeypatch.setattr(
-        tunnel_mod, "_default_proc_factory",
+        tunnel_mod,
+        "_default_proc_factory",
         lambda argv, log_path=None: (spawned.append(argv), _Proc())[1],
     )
 
@@ -558,6 +598,33 @@ def test_no_relay_block_means_no_tunnel(tmp_path):
     home.mkdir()
     assert run_mod._relay_config(home) is None
     assert run_mod._build_tunnel(home, None, SERVE_BLOCK) is None
+
+
+def test_configured_tunnel_construction_failure_is_published_without_stopping_local_service(
+    env_home, monkeypatch
+):
+    from fastapi.testclient import TestClient
+
+    home, env = env_home
+    _seed_config(home, serve=SERVE_BLOCK, relay=RELAY_BLOCK)
+    configs = _capture_uvicorn(monkeypatch)
+    monkeypatch.setattr(
+        run_mod,
+        "_build_tunnel",
+        lambda *args: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    assert run_mod.main(home=home, env=env) == 0
+    assert len(configs) == 2
+
+    control_health = TestClient(configs[0].app).get("/health").json()
+    host_health = TestClient(configs[1].app).get("/health").json()
+    for health in (control_health, host_health):
+        assert health["tunnel"]["state"] == "error"
+        assert health["tunnel"]["last_error"] == (
+            "relay tunnel initialization failed: boom"
+        )
+    assert control_health["capabilities"]["tunnel"] is False
 
 
 @pytest.mark.parametrize("server_count", [1, 2])
@@ -612,9 +679,7 @@ def test_the_control_app_publishes_the_tunnel_it_was_built_with(env_home, monkey
     assert body["tunnel"] == snapshot
 
 
-def test_production_host_app_tracks_reidentified_tunnel_identity(
-    env_home, monkeypatch
-):
+def test_production_host_app_tracks_reidentified_tunnel_identity(env_home, monkeypatch):
     """The composition root must read the tunnel's current identity: an
     automatic re-identification happens after the host app is already built."""
     from fastapi.testclient import TestClient

--- a/tests/core/daemon/test_run.py
+++ b/tests/core/daemon/test_run.py
@@ -612,11 +612,11 @@ def test_the_control_app_publishes_the_tunnel_it_was_built_with(env_home, monkey
     assert body["tunnel"] == snapshot
 
 
-def test_production_host_app_wires_identity_tunnel_and_token_services(
+def test_production_host_app_tracks_reidentified_tunnel_identity(
     env_home, monkeypatch
 ):
-    """The composition root must enable the host-facing seams, not merely leave
-    their independently-tested defaults disabled."""
+    """The composition root must read the tunnel's current identity: an
+    automatic re-identification happens after the host app is already built."""
     from fastapi.testclient import TestClient
 
     from mship.core.daemon.host_auth import RefreshStore
@@ -625,22 +625,31 @@ def test_production_host_app_wires_identity_tunnel_and_token_services(
     _seed_config(home, serve=SERVE_BLOCK, relay=RELAY_BLOCK)
     configs = _capture_uvicorn(monkeypatch)
     tunnel = _FakeTunnel()
-    refresh = RefreshStore(home).issue_refresh(
-        host_id=tunnel.host_id, client="phone"
+    refresh_store = RefreshStore(home)
+    stale_refresh = refresh_store.issue_refresh(
+        host_id=tunnel.host_id, client="old-phone"
     )
     monkeypatch.setattr(run_mod, "_build_tunnel", lambda *a: tunnel)
 
     assert run_mod.main(home=home, env=env) == 0
 
-    with TestClient(configs[1].app) as client:
+    tunnel.host_id = "hst-reidentified"
+    tunnel.instance_id = "fedcba9876543210"
+    current_refresh = refresh_store.issue_refresh(
+        host_id=tunnel.host_id, client="phone"
+    )
+    host_app = configs[-1].app
+    with TestClient(host_app) as client:
         health = client.get("/health").json()
-        minted = client.post("/host/token", json={"refresh": refresh})
+        stale = client.post("/host/token", json={"refresh": stale_refresh})
+        minted = client.post("/host/token", json={"refresh": current_refresh})
         assert minted.status_code == 200
         authorized = client.get(
             "/workspaces",
             headers={"Authorization": f"Bearer {minted.json()['token']}"},
         )
 
+    assert stale.status_code == 401
     assert health["host_id"] == tunnel.host_id
     assert health["instance_id"] == tunnel.instance_id
     assert health["tunnel"] == tunnel.snapshot()

--- a/tests/core/daemon/test_status.py
+++ b/tests/core/daemon/test_status.py
@@ -48,7 +48,6 @@ def test_healthy_rendering():
     assert s.compatible is True
     assert s.supervised is True
     rendered = s.render()
-    assert "tunnel: not configured (#471)" in rendered
     assert "workspaces: 2 discovered (1 degraded)" in rendered
     assert "runner: not configured (#473)" in rendered
 
@@ -153,3 +152,87 @@ def test_single_unclean_start_is_not_labeled_crash_loop():
     rendered = s.render()
     assert "crash loop" not in rendered
     assert "unclean starts: 1 in last 10m" in rendered
+
+
+# --- the tunnel, as `mship daemon status` reports it (#471 Task 9) ----------
+
+def _tunnel(**kw) -> dict:
+    """A `/health` tunnel block, as the daemon publishes it per tick."""
+    block = {
+        "state": "online",
+        "subdomain": "hst-abc",
+        "public_url": "https://hst-abc.relay.example",
+        "restarts": 0,
+        "last_error": None,
+        "clock_skew_seconds": None,
+    }
+    block.update(kw)
+    return block
+
+
+@pytest.mark.parametrize(
+    ("block", "line"),
+    [
+        (None, "tunnel: disabled (no relay configured)"),
+        (_tunnel(state="disabled"), "tunnel: disabled (no relay configured)"),
+        (
+            _tunnel(state="awaiting-enrollment"),
+            "tunnel: awaiting relay approval (run 'mship relay approve <id>' on the relay host)",
+        ),
+        (_tunnel(), "tunnel: online https://hst-abc.relay.example (0 restarts)"),
+        (_tunnel(state="contended"), "tunnel: contended — another host holds hst-abc"),
+        (
+            _tunnel(state="duplicate-identity"),
+            "tunnel: rejected (duplicate-identity) — re-identifying automatically; "
+            "'mship daemon reidentify' to force",
+        ),
+        (_tunnel(state="connecting"), "tunnel: connecting https://hst-abc.relay.example"),
+        (
+            _tunnel(state="error", last_error="relay refused: 502"),
+            "tunnel: error — relay refused: 502",
+        ),
+    ],
+)
+def test_tunnel_state_renders_per_state(block, line):
+    s = _status(health={**HEALTH, "tunnel": block})
+    assert line in s.render()
+
+
+def test_tunnel_is_unknown_when_the_daemon_is_not_answering():
+    """The tunnel lives INSIDE the daemon process: with no `/health` there is
+    no tunnel state to report, and reporting `disabled` would be a guess."""
+    assert "tunnel: unknown (daemon not running)" in _status(health=None).render()
+
+
+def test_tunnel_and_skew_are_structured_fields_not_only_text():
+    """AC12: `mship --json daemon status` must carry the tunnel as data."""
+    block = _tunnel(clock_skew_seconds=3600.0)
+    s = _status(health={**HEALTH, "tunnel": block})
+    assert s.tunnel == block
+    assert s.clock_skew_seconds == 3600.0
+    # Reported, never gating: a skewed host still renders as online.
+    assert "tunnel: online" in s.render()
+    assert "clock skew: 3600.0s" in s.render()
+
+
+def test_no_tunnel_means_no_skew_field():
+    s = _status(health={**HEALTH, "tunnel": None})
+    assert s.tunnel is None
+    assert s.clock_skew_seconds is None
+    assert "clock skew" not in s.render()
+
+
+@pytest.mark.parametrize("block", [None, _tunnel(), _tunnel(state="contended")])
+def test_restart_blockers_stay_empty_with_the_tunnel_down_and_live(block):
+    """AC7, pinned so #473 does not accidentally make a tunnel a restart
+    blocker: an ssh child is disposable, an unattended worker is not."""
+    _status(health={**HEALTH, "tunnel": block})
+    assert restart_blockers() == []
+
+
+def test_every_tunnel_state_has_a_line():
+    """The states have one owner (`HostTunnel.state()`); a new one added there
+    must not render as a bare state name here."""
+    from mship.core.daemon.host_tunnel import STATES
+
+    assert set(status_mod._TUNNEL_LINES) == set(STATES)

--- a/tests/core/relay/test_caddyfile.py
+++ b/tests/core/relay/test_caddyfile.py
@@ -89,9 +89,13 @@ def test_host_facing_sites_reverse_proxy_so_the_edge_stamps_x_forwarded(site):
 @pytest.mark.parametrize("site", [_ENROLL_SITE, _WILDCARD_SITE])
 def test_no_directive_strips_the_x_forwarded_headers(site):
     # AC9 reads these headers to refuse the standing token on relay-borne
-    # traffic. Deleting or blanking one at the edge fails open, silently.
+    # traffic. Deleting or blanking one at the edge fails open, silently — so
+    # catch every spelling Caddy accepts for touching a header: `header`,
+    # `header_up`, `header_down` and `request_header`, with or without the `-`
+    # delete prefix, and the set-to-empty form.
     body = _site(site).lower()
+    directive = r"(?:request_header|header_up|header_down|header)"
     for header in _EDGE_HEADERS:
-        assert f"header_up -{header}" not in body
-        assert f'header_up {header} ""' not in body
-        assert f"header_down -{header}" not in body
+        name = re.escape(header)
+        assert not re.search(rf"{directive}\s+-\s*{name}\b", body), (site, header)
+        assert not re.search(rf'{directive}\s+{name}\s+""', body), (site, header)

--- a/tests/core/relay/test_caddyfile.py
+++ b/tests/core/relay/test_caddyfile.py
@@ -1,0 +1,97 @@
+"""The relay edge config is part of the contract (AC13).
+
+Every `/hosts` route passes `TestClient` regardless of what Caddy does, so the
+one thing unit tests CAN pin about production is the Caddyfile text itself: the
+enroll site is hardened to `POST /enroll` + `GET /status/*` with a
+`respond "not found" 404` catch-all (`docs/relay-hosting.md`), so without a
+matcher placed *before* that catch-all every new route 404s in production while
+the whole suite is green.
+
+The second pin is AC9's discriminator: the host classifies a request as
+relay-borne from the `X-Forwarded-*` headers the edge stamps. `reverse_proxy`
+stamps them by default, so the failure mode is not a missing directive but an
+added one that strips them — a config edit that would silently let a
+relay-borne request present as loopback and be accepted on the standing token.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from mship.core.daemon.host_app import _EDGE_HEADERS
+from mship.core.relay import host_contract
+
+CADDYFILE = Path(__file__).resolve().parents[3] / "docker" / "relay" / "Caddyfile"
+
+# The two sites that front a mship *host*: the enroll site (which now also
+# carries the host directory) and the wildcard site that fronts every tunnel.
+_ENROLL_SITE = "enroll.{$RELAY_DOMAIN}"
+_WILDCARD_SITE = "*.{$RELAY_DOMAIN}"
+
+
+def _text() -> str:
+    return CADDYFILE.read_text()
+
+
+def _site(name: str) -> str:
+    """The body of one top-level site block, by brace matching."""
+    text = _text()
+    start = text.index(name + " {") + len(name) + 2
+    depth = 1
+    for i in range(start, len(text)):
+        depth += {"{": 1, "}": -1}.get(text[i], 0)
+        if depth == 0:
+            return text[start:i]
+    raise AssertionError(f"unbalanced braces around {name!r}")
+
+
+def test_the_enroll_site_matches_the_hosts_prefix():
+    body = _site(_ENROLL_SITE)
+    assert re.search(
+        r"@hosts\s*\{[^}]*path\s+/hosts\s+/hosts/\*", body
+    ), "the @hosts matcher must cover both the bare prefix and everything under it"
+
+
+def test_every_contract_route_is_covered_by_the_matcher():
+    # The matcher is only sufficient while every route stays under one prefix.
+    for path in host_contract.ROUTE_PATHS:
+        assert path == "/hosts" or path.startswith("/hosts/"), path
+
+
+def test_the_hosts_handler_precedes_the_404_catch_all():
+    body = _site(_ENROLL_SITE)
+    handler = body.index("handle @hosts")
+    catch_all = body.index('respond "not found" 404')
+    assert handler < catch_all, "a handler after the catch-all never runs"
+
+
+def test_the_hosts_handler_caps_the_request_body():
+    body = _site(_ENROLL_SITE)
+    handler = body[body.index("handle @hosts"):]
+    assert re.search(r"request_body\s*\{[^}]*max_size\s+8KB", handler)
+
+
+def test_the_hosts_handler_proxies_to_the_enroll_server():
+    body = _site(_ENROLL_SITE)
+    handler = body[body.index("handle @hosts"):]
+    assert "reverse_proxy 127.0.0.1:47180" in handler
+
+
+@pytest.mark.parametrize("site", [_ENROLL_SITE, _WILDCARD_SITE])
+def test_host_facing_sites_reverse_proxy_so_the_edge_stamps_x_forwarded(site):
+    # `reverse_proxy` is what sets X-Forwarded-For/-Host/-Proto; a site that
+    # `respond`s or rewrites instead would never stamp them.
+    assert "reverse_proxy" in _site(site)
+
+
+@pytest.mark.parametrize("site", [_ENROLL_SITE, _WILDCARD_SITE])
+def test_no_directive_strips_the_x_forwarded_headers(site):
+    # AC9 reads these headers to refuse the standing token on relay-borne
+    # traffic. Deleting or blanking one at the edge fails open, silently.
+    body = _site(site).lower()
+    for header in _EDGE_HEADERS:
+        assert f"header_up -{header}" not in body
+        assert f'header_up {header} ""' not in body
+        assert f"header_down -{header}" not in body

--- a/tests/core/relay/test_config.py
+++ b/tests/core/relay/test_config.py
@@ -8,15 +8,18 @@ from mship.core.config import ConfigLoader
 
 
 def test_from_mapping_full():
-    rc = RelayConfig.from_mapping({"host": "relay.example.com", "ssh_port": 2222, "user": "tunnel"})
+    rc = RelayConfig.from_mapping(
+        {"host": "relay.example.com", "ssh_port": 2222, "user": "tunnel"}
+    )
     assert rc.host == "relay.example.com"
     assert rc.ssh_port == 2222
     assert rc.user == "tunnel"
 
+
 def test_from_mapping_defaults_and_none():
-    assert RelayConfig.from_mapping(None) is None           # no relay configured
+    assert RelayConfig.from_mapping(None) is None  # no relay configured
     rc = RelayConfig.from_mapping({"host": "r.example.com"})
-    assert rc.ssh_port == 2222 and rc.user is None          # defaults
+    assert rc.ssh_port == 2222 and rc.user is None  # defaults
 
 
 def test_relay_host_is_canonicalized_for_dns_and_signed_urls():
@@ -27,12 +30,26 @@ def test_relay_host_is_canonicalized_for_dns_and_signed_urls():
     assert direct.host == "relay.example.com"
 
 
+@pytest.mark.parametrize("port", [0, 65536, True, "2222"])
+def test_relay_ssh_port_must_be_a_real_tcp_port(port):
+    for build in (
+        lambda: RelayConfig(host="relay.example.com", ssh_port=port),
+        lambda: RelayConfig.from_mapping(
+            {"host": "relay.example.com", "ssh_port": port}
+        ),
+    ):
+        with pytest.raises(ValueError, match="relay.ssh_port"):
+            build()
+
+
 def test_config_loader_parses_relay_block(tmp_path: Path):
     """ConfigLoader.load exposes config.relay.host when a relay: block is present."""
     # Create a minimal repo so ConfigLoader doesn't fail path validation
     repo_dir = tmp_path / "myrepo"
     repo_dir.mkdir()
-    (repo_dir / "Taskfile.yml").write_text("version: '3'\ntasks:\n  test:\n    cmds:\n      - echo ok\n")
+    (repo_dir / "Taskfile.yml").write_text(
+        "version: '3'\ntasks:\n  test:\n    cmds:\n      - echo ok\n"
+    )
 
     cfg = tmp_path / "mothership.yaml"
     cfg.write_text(
@@ -60,7 +77,9 @@ def test_config_loader_relay_none_when_absent(tmp_path: Path):
     """WorkspaceConfig.relay is None when no relay: block is in mothership.yaml."""
     repo_dir = tmp_path / "myrepo"
     repo_dir.mkdir()
-    (repo_dir / "Taskfile.yml").write_text("version: '3'\ntasks:\n  test:\n    cmds:\n      - echo ok\n")
+    (repo_dir / "Taskfile.yml").write_text(
+        "version: '3'\ntasks:\n  test:\n    cmds:\n      - echo ok\n"
+    )
 
     cfg = tmp_path / "mothership.yaml"
     cfg.write_text(

--- a/tests/core/relay/test_config.py
+++ b/tests/core/relay/test_config.py
@@ -19,6 +19,14 @@ def test_from_mapping_defaults_and_none():
     assert rc.ssh_port == 2222 and rc.user is None          # defaults
 
 
+def test_relay_host_is_canonicalized_for_dns_and_signed_urls():
+    mapped = RelayConfig.from_mapping({"host": " RELAY.EXAMPLE.COM. "})
+    direct = RelayConfig(host="RELAY.EXAMPLE.COM.")
+
+    assert mapped is not None and mapped.host == "relay.example.com"
+    assert direct.host == "relay.example.com"
+
+
 def test_config_loader_parses_relay_block(tmp_path: Path):
     """ConfigLoader.load exposes config.relay.host when a relay: block is present."""
     # Create a minimal repo so ConfigLoader doesn't fail path validation

--- a/tests/core/relay/test_enroll.py
+++ b/tests/core/relay/test_enroll.py
@@ -118,11 +118,22 @@ def test_same_hostname_does_not_clobber(tmp_path):
     pubkeys = tmp_path / "pubkeys"
     pubkeys.mkdir()
     s = _store(tmp_path)
-    r1 = s.create(_PUB, "laptop")
+    r1 = s.create(_key("first"), "laptop")
     s.approve(r1, pubkeys)
-    r2 = s.create(_PUB, "laptop")
+    r2 = s.create(_key("second"), "laptop")
     s.approve(r2, pubkeys)
     assert len(list(pubkeys.glob("*.pub"))) == 2  # unique filenames
+
+
+def test_reposting_an_approved_key_returns_its_resolved_request(tmp_path):
+    pubkeys = tmp_path / "pubkeys"
+    pubkeys.mkdir()
+    store = _store(tmp_path)
+    rid = store.create(_PUB, "laptop")
+    store.approve(rid, pubkeys)
+
+    assert store.create(_PUB, "laptop") == rid
+    assert store.list_pending() == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/relay/test_enroll.py
+++ b/tests/core/relay/test_enroll.py
@@ -1,4 +1,5 @@
 import json
+import math
 import threading
 
 from pathlib import Path
@@ -250,6 +251,20 @@ def test_malformed_legacy_expiry_does_not_brick_store(tmp_path):
     record = json.loads(path.read_text())
     record["created_at"] = "not-a-time"
     record["expires_at"] = "not-a-time"
+    path.write_text(json.dumps(record))
+
+    assert store.list_pending() == []
+    assert store.get(rid) == "expired"
+
+
+@pytest.mark.parametrize("created_at", [math.nan, math.inf, -math.inf])
+def test_non_finite_pending_creation_time_is_expired(tmp_path, created_at):
+    store = _store(tmp_path)
+    rid = store.create(_PUB, "malformed")
+    path = tmp_path / "store" / "pending" / f"{rid}.json"
+    record = json.loads(path.read_text())
+    record["created_at"] = created_at
+    record["expires_at"] = 10_000.0
     path.write_text(json.dumps(record))
 
     assert store.list_pending() == []

--- a/tests/core/relay/test_enroll.py
+++ b/tests/core/relay/test_enroll.py
@@ -6,6 +6,13 @@ from mship.core.relay.enroll import RequestStore, PendingCapReached, NotPending
 _PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host"
 
 
+def _key(tag: str) -> str:
+    """A distinct (shape-valid) public key per tag — enrollment is deduped by
+    key fingerprint, so a test about *counts* needs distinct keys."""
+    body = "AAAAC3NzaC1lZDI1NTE5AAAAI" + tag.ljust(4, "Z") * 6
+    return f"ssh-ed25519 {body}A host"
+
+
 def test_validate_accepts_ssh_key():
     assert validate_pubkey(_PUB)
     assert validate_pubkey("ssh-rsa AAAAB3NzaC1yc2EAAAAD host")
@@ -96,11 +103,13 @@ def test_expiry_after_ttl(tmp_path):
 
 
 def test_pending_cap_enforced(tmp_path):
+    # Distinct keys: same-key posts are deduped, so the cap can only be reached
+    # by distinct devices.
     s = _store(tmp_path, cap=2)
-    s.create(_PUB, "a")
-    s.create(_PUB, "b")
+    s.create(_key("a"), "a")
+    s.create(_key("b"), "b")
     with pytest.raises(PendingCapReached):
-        s.create(_PUB, "c")
+        s.create(_key("c"), "c")
 
 
 def test_same_hostname_does_not_clobber(tmp_path):
@@ -175,3 +184,49 @@ def test_approve_and_deny_on_corrupt_own_record_raise_cleanly(tmp_path):
     (pending_dir / f"{rid2}.json").write_text("not json at all")
     with pytest.raises(NotPending):
         s.deny(rid2)
+
+
+# --- idempotent enrollment (the daemon re-posts on a schedule) --------------
+
+
+def test_create_is_idempotent_per_key_fingerprint(tmp_path):
+    # The daemon re-posts its enroll request every ENROLL_REPOST_INTERVAL_S while
+    # awaiting approval. Without dedupe, one unapproved host fills the 50-slot cap
+    # in under 9 hours and 429s enrollment for the whole fleet.
+    store = RequestStore(tmp_path)
+    rid = store.create(_PUB, "vm-alpha")
+    for _ in range(10):
+        assert store.create(_PUB, "vm-alpha") == rid
+    assert len(store.list_pending()) == 1
+    assert len(list((tmp_path / "pending").glob("*.json"))) == 1
+
+
+def test_dedupe_is_by_key_not_hostname(tmp_path):
+    store = RequestStore(tmp_path)
+    rid = store.create(_PUB, "vm-alpha")
+    # A renamed host re-posting the same key is still one request…
+    assert store.create(_PUB, "vm-alpha-renamed") == rid
+    # …and a different key is a different request.
+    other = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAISecondKeyBodyBBBBBBBBBBBBBBBBBBBBBBBB two"
+    assert store.create(other, "vm-beta") != rid
+    assert len(store.list_pending()) == 2
+
+
+def test_a_re_post_does_not_extend_the_pending_ttl(tmp_path):
+    # Dedupe must be a pure read: refreshing created_at would make an unapproved
+    # request immortal, and the TTL is what bounds the store.
+    now = [1000.0]
+    store = RequestStore(tmp_path, ttl_seconds=100, clock=lambda: now[0])
+    rid = store.create(_PUB, "vm-alpha")
+    now[0] += 60
+    assert store.create(_PUB, "vm-alpha") == rid
+    now[0] += 60
+    assert store.get(rid) == "expired"
+
+
+def test_a_resolved_request_does_not_block_a_new_one(tmp_path):
+    # Dedupe is scoped to PENDING records: once denied, the same key may re-enroll.
+    store = RequestStore(tmp_path)
+    rid = store.create(_PUB, "vm-alpha")
+    store.deny(rid)
+    assert store.create(_PUB, "vm-alpha") != rid

--- a/tests/core/relay/test_enroll.py
+++ b/tests/core/relay/test_enroll.py
@@ -1,4 +1,5 @@
 import json
+import threading
 
 from pathlib import Path
 
@@ -141,6 +142,62 @@ def test_reposting_an_approved_key_returns_its_resolved_request(tmp_path):
     assert store.create(_PUB, "laptop") == rid
     assert store.list_pending() == []
 
+
+def test_removed_approved_key_can_enroll_again(tmp_path):
+    approved = {fingerprint(_PUB)}
+    store = RequestStore(
+        tmp_path / "store",
+        is_approved=lambda key_fingerprint: key_fingerprint in approved,
+    )
+    rid = store.create(_PUB, "laptop")
+    store.approve(rid, tmp_path / "pubkeys")
+    assert store.create(_PUB, "laptop") == rid
+
+    approved.clear()
+    replacement = store.create(_PUB, "laptop")
+
+    assert replacement != rid
+    assert [rec["id"] for rec in store.list_pending()] == [replacement]
+
+
+
+def test_allowlist_dedupe_and_revocation_share_one_store_lock(tmp_path):
+    entered = threading.Event()
+    release = threading.Event()
+    revoke_started = threading.Event()
+    order = []
+
+    def is_approved(_fingerprint):
+        order.append("dedupe-read")
+        entered.set()
+        release.wait(timeout=1)
+        order.append("dedupe-return")
+        return True
+
+    store = RequestStore(tmp_path / "store", is_approved=is_approved)
+    rid = store.create(_PUB, "laptop")
+    store.approve(rid, tmp_path / "pubkeys")
+    repost = threading.Thread(target=lambda: store.create(_PUB, "laptop"))
+
+    def revoke():
+        revoke_started.set()
+        store.revoke_approved(
+            fingerprint(_PUB),
+            lambda _identity: order.append("revoke"),
+        )
+
+    revocation = threading.Thread(target=revoke)
+    repost.start()
+    assert entered.wait(timeout=1)
+    revocation.start()
+    assert revoke_started.wait(timeout=1)
+    release.set()
+    repost.join(timeout=1)
+    revocation.join(timeout=1)
+    assert not repost.is_alive()
+    assert not revocation.is_alive()
+
+    assert order == ["dedupe-read", "dedupe-return", "revoke"]
 
 # ---------------------------------------------------------------------------
 # Task 2 hardening (security review of commit 5886872)

--- a/tests/core/relay/test_enroll.py
+++ b/tests/core/relay/test_enroll.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from mship.core.relay.enroll import validate_pubkey, fingerprint, sanitize_label
@@ -230,3 +232,40 @@ def test_a_resolved_request_does_not_block_a_new_one(tmp_path):
     rid = store.create(_PUB, "vm-alpha")
     store.deny(rid)
     assert store.create(_PUB, "vm-alpha") != rid
+
+
+def _post_same_key(base_dir: str, barrier):
+    """Subprocess body: one daemon re-posting its enroll request. The barrier
+    puts every writer inside the scan-then-write window at once — without it
+    process startup staggers them and the race never reproduces."""
+    store = RequestStore(Path(base_dir))
+    barrier.wait(timeout=30)
+    store.create(_PUB, "vm-alpha")
+
+
+def test_concurrent_re_posts_of_one_key_leave_exactly_one_record(tmp_path):
+    # The dedupe scan and the write must be one atomic step: the enroll app
+    # serves sync endpoints on a threadpool, so two re-posts of one key really
+    # do interleave. Driven with processes (the `test_state_lock.py` pattern),
+    # which flock serializes exactly as it does threads.
+    import multiprocessing
+
+    store = RequestStore(tmp_path)
+    # Unrelated pending records widen the scan the writers must complete before
+    # they write, so the interleave is reliable rather than a coin flip.
+    for i in range(20):
+        store.create(_key(f"o{i}"), f"other-{i}")
+    writers = 12
+    barrier = multiprocessing.Barrier(writers)
+    procs = [
+        multiprocessing.Process(target=_post_same_key, args=(str(tmp_path), barrier))
+        for _ in range(writers)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)
+        assert p.exitcode == 0
+
+    assert len(store.list_pending()) == 21
+    assert len(list((tmp_path / "pending").glob("*.json"))) == 21

--- a/tests/core/relay/test_enroll.py
+++ b/tests/core/relay/test_enroll.py
@@ -1,3 +1,5 @@
+import json
+
 from pathlib import Path
 
 import pytest
@@ -5,7 +7,9 @@ import pytest
 from mship.core.relay.enroll import validate_pubkey, fingerprint, sanitize_label
 from mship.core.relay.enroll import RequestStore, PendingCapReached, NotPending
 
-_PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host"
+_PUB = (
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host"
+)
 
 
 def _key(tag: str) -> str:
@@ -66,7 +70,9 @@ class _Clock:
 
 
 def _store(tmp_path, ttl=1800, clock=None, cap=50):
-    return RequestStore(tmp_path / "store", ttl_seconds=ttl, max_pending=cap, clock=clock or _Clock())
+    return RequestStore(
+        tmp_path / "store", ttl_seconds=ttl, max_pending=cap, clock=clock or _Clock()
+    )
 
 
 def test_create_then_pending_then_approve_writes_allowlist(tmp_path):
@@ -180,6 +186,19 @@ def test_corrupt_pending_file_does_not_brick_store(tmp_path):
     assert list(pending_dir.glob("*.json.corrupt"))  # bad file moved aside
 
 
+def test_malformed_legacy_expiry_does_not_brick_store(tmp_path):
+    store = _store(tmp_path)
+    rid = store.create(_PUB, "malformed")
+    path = tmp_path / "store" / "pending" / f"{rid}.json"
+    record = json.loads(path.read_text())
+    record["created_at"] = "not-a-time"
+    record["expires_at"] = "not-a-time"
+    path.write_text(json.dumps(record))
+
+    assert store.list_pending() == []
+    assert store.get(rid) == "expired"
+
+
 def test_approve_and_deny_on_corrupt_own_record_raise_cleanly(tmp_path):
     """A truncated/corrupt pending file at approve/deny time → NotPending, not a traceback."""
     pubkeys = tmp_path / "pubkeys"
@@ -220,7 +239,9 @@ def test_dedupe_is_by_key_not_hostname(tmp_path):
     # A renamed host re-posting the same key is still one request…
     assert store.create(_PUB, "vm-alpha-renamed") == rid
     # …and a different key is a different request.
-    other = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAISecondKeyBodyBBBBBBBBBBBBBBBBBBBBBBBB two"
+    other = (
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAISecondKeyBodyBBBBBBBBBBBBBBBBBBBBBBBB two"
+    )
     assert store.create(other, "vm-beta") != rid
     assert len(store.list_pending()) == 2
 
@@ -242,7 +263,9 @@ def test_a_re_post_renews_the_pending_ttl_without_changing_request_id(tmp_path):
     assert store.get(rid) == "expired"
 
 
-def test_pending_request_keeps_the_servers_ttl_when_an_operator_reopens_the_store(tmp_path):
+def test_pending_request_keeps_the_servers_ttl_when_an_operator_reopens_the_store(
+    tmp_path,
+):
     now = [1000.0]
     server = RequestStore(tmp_path, ttl_seconds=7200, clock=lambda: now[0])
     rid = server.create(_PUB, "vm-alpha")

--- a/tests/core/relay/test_enroll.py
+++ b/tests/core/relay/test_enroll.py
@@ -242,6 +242,18 @@ def test_a_re_post_renews_the_pending_ttl_without_changing_request_id(tmp_path):
     assert store.get(rid) == "expired"
 
 
+def test_pending_request_keeps_the_servers_ttl_when_an_operator_reopens_the_store(tmp_path):
+    now = [1000.0]
+    server = RequestStore(tmp_path, ttl_seconds=7200, clock=lambda: now[0])
+    rid = server.create(_PUB, "vm-alpha")
+    operator = RequestStore(tmp_path, clock=lambda: now[0])
+
+    now[0] += 1800
+    assert operator.get(rid) == "pending"
+    now[0] += 5400
+    assert operator.get(rid) == "expired"
+
+
 def test_a_resolved_request_does_not_block_a_new_one(tmp_path):
     # Dedupe is scoped to PENDING records: once denied, the same key may re-enroll.
     store = RequestStore(tmp_path)

--- a/tests/core/relay/test_enroll.py
+++ b/tests/core/relay/test_enroll.py
@@ -214,15 +214,20 @@ def test_dedupe_is_by_key_not_hostname(tmp_path):
     assert len(store.list_pending()) == 2
 
 
-def test_a_re_post_does_not_extend_the_pending_ttl(tmp_path):
-    # Dedupe must be a pure read: refreshing created_at would make an unapproved
-    # request immortal, and the TTL is what bounds the store.
+def test_a_re_post_renews_the_pending_ttl_without_changing_request_id(tmp_path):
+    # The daemon re-post interval is shorter than this TTL specifically so an
+    # unattended request stays approvable while the daemon is still alive.
     now = [1000.0]
     store = RequestStore(tmp_path, ttl_seconds=100, clock=lambda: now[0])
     rid = store.create(_PUB, "vm-alpha")
-    now[0] += 60
+
+    now[0] = 1060.0
     assert store.create(_PUB, "vm-alpha") == rid
-    now[0] += 60
+    assert store.list_pending()[0]["created_at"] == 1060.0
+
+    now[0] = 1159.0
+    assert store.get(rid) == "pending"
+    now[0] = 1160.0
     assert store.get(rid) == "expired"
 
 

--- a/tests/core/relay/test_enroll_app.py
+++ b/tests/core/relay/test_enroll_app.py
@@ -25,13 +25,14 @@ class Harness:
     """One enroll app plus the stores behind it, so a test can assert on both
     the HTTP surface and what actually landed on disk."""
 
-    def __init__(self, client, store, directory, fleet, clock, prober):
+    def __init__(self, client, store, directory, fleet, clock, prober, revoked):
         self.client = client
         self.store = store
         self.directory = directory
         self.fleet = fleet
         self.clock = clock
         self.prober = prober
+        self.revoked = revoked
 
 
 class Clock:
@@ -89,11 +90,13 @@ def _harness(tmp_path, cap=50, answers=None, ttl=host_contract.ENROLL_TTL_S):
     store = RequestStore(base, ttl_seconds=ttl, max_pending=cap)
     clock = Clock()
     prober = Prober(answers)
+    revoked = []
     directory = HostDirectory(
         base,
         relay_domain=RELAY,
         allowed_signers=lambda: FP_A,
         probe=prober,
+        revoke_signer=lambda identity: revoked.append(identity),
         verify=_verify,
         clock=clock,
     )
@@ -101,7 +104,9 @@ def _harness(tmp_path, cap=50, answers=None, ttl=host_contract.ENROLL_TTL_S):
     app = build_enroll_app(
         store, relay_domain=RELAY, host_directory=directory, fleet_tokens=fleet
     )
-    return Harness(TestClient(app), store, directory, fleet, clock, prober)
+    return Harness(
+        TestClient(app), store, directory, fleet, clock, prober, revoked
+    )
 
 
 def _challenge(h, identity=FP_A):
@@ -238,6 +243,41 @@ def test_unapproved_identity_cannot_allocate_challenge_storage(tmp_path):
     assert r.json()["detail"] == host_contract.UNAPPROVED_KEY_DETAIL
     assert list((tmp_path / "s" / "challenges").glob("*.json")) == []
 
+
+def test_signed_key_revocation_removes_the_current_relay_signer(tmp_path):
+    h = _harness(tmp_path)
+    nonce = _challenge(h).json()["nonce"]
+    payload = host_contract.key_revocation_payload(FP_A)
+
+    response = h.client.post(
+        host_contract.REVOKE_PATH,
+        json={
+            "key_fingerprint": FP_A,
+            "nonce": nonce,
+            "signature": _sign(nonce, payload),
+        },
+    )
+
+    assert response.status_code == 200
+    assert h.revoked == [FP_A]
+
+
+
+def test_key_revocation_rejects_a_signature_not_made_by_that_key(tmp_path):
+    h = _harness(tmp_path)
+    nonce = _challenge(h).json()["nonce"]
+
+    response = h.client.post(
+        host_contract.REVOKE_PATH,
+        json={
+            "key_fingerprint": FP_A,
+            "nonce": nonce,
+            "signature": "not-a-valid-signature",
+        },
+    )
+
+    assert response.status_code == 401
+    assert h.revoked == []
 
 # ---------------------------------------------------------------------------
 # /hosts/register

--- a/tests/core/relay/test_enroll_app.py
+++ b/tests/core/relay/test_enroll_app.py
@@ -69,8 +69,8 @@ def _payload(**over):
         "label": "vm-alpha",
         "key_fingerprint": FP_A,
         "machine_fingerprint": MACHINE,
-        "subdomain": "abc123",
-        "public_url": "https://abc123.relay.example",
+        "subdomain": "abc123-a1b2c3",
+        "public_url": f"https://abc123-a1b2c3.{RELAY}",
         "mship_version": "1.2.3",
         "capabilities": {"tunnel": True},
         "runner": {"enabled": False, "state": "disabled"},
@@ -87,6 +87,7 @@ def _harness(tmp_path, cap=50, answers=None, max_challenges=1000):
     prober = Prober(answers)
     directory = HostDirectory(
         base,
+        relay_domain=RELAY,
         allowed_signers=lambda: FP_A,
         probe=prober,
         verify=_verify,
@@ -220,6 +221,16 @@ def test_register_with_a_valid_signature_lands_the_entry(tmp_path):
     assert entry["last_seen"] == h.clock.t                # relay clock, not the payload's
 
 
+def test_signed_non_relay_url_is_a_clean_400(tmp_path):
+    h = _harness(tmp_path)
+    payload = _payload(public_url="http://169.254.169.254/latest/meta-data")
+
+    response = _register(h, payload)
+
+    assert response.status_code == 400
+    assert h.directory.get_host(payload["host_id"]) is None
+
+
 def test_register_never_echoes_the_refresh_credential(tmp_path):
     # `GET /hosts` publishes it to the fleet-token holder BY DESIGN; no other
     # route may widen it — least of all this unauthenticated one.
@@ -256,7 +267,7 @@ def test_register_with_a_traversal_shaped_host_id_is_400(tmp_path):
 def test_duplicate_identity_is_409_naming_the_recovery_command(tmp_path):
     # The clone case: a live incumbent that answers as itself refuses the claim,
     # and the operator's only recovery must be named in the refusal.
-    h = _harness(tmp_path, answers={"https://abc123.relay.example": "inst-1"})
+    h = _harness(tmp_path, answers={f"https://abc123-a1b2c3.{RELAY}": "inst-1"})
     assert _register(h).status_code == 200
     r = _register(h, _payload(instance_id="inst-2"))
     assert r.status_code == 409

--- a/tests/core/relay/test_enroll_app.py
+++ b/tests/core/relay/test_enroll_app.py
@@ -7,7 +7,7 @@ from mship.core.relay import host_contract
 from mship.core.relay.enroll import RequestStore
 from mship.core.relay.enroll_app import build_enroll_app
 from mship.core.relay.fleet_token import FleetTokenStore
-from mship.core.relay.host_directory import HostDirectory
+from mship.core.relay.host_directory import HostDirectory, VerificationBusy
 
 _PUB = (
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host"
@@ -291,6 +291,21 @@ def test_register_with_a_forged_signature_is_401(tmp_path):
     r = _register(h, signature="sig:SHA256:keyA:not-the-blob")
     assert r.status_code == 401
     assert h.directory.get_host(_payload()["host_id"]) is None
+
+
+def test_register_verification_capacity_is_429(tmp_path):
+    h = _harness(tmp_path)
+
+    def busy(*args, **kwargs):
+        raise VerificationBusy
+
+    h.directory.register = busy
+
+    response = _register(h)
+
+    assert response.status_code == 429
+    assert response.json()["detail"] == "signature verification busy; try later"
+    assert response.headers["retry-after"] == "1"
 
 
 def test_register_with_an_unknown_nonce_is_401(tmp_path):

--- a/tests/core/relay/test_enroll_app.py
+++ b/tests/core/relay/test_enroll_app.py
@@ -1,18 +1,125 @@
+import json
+import logging
+
 from fastapi.testclient import TestClient
+from mship.core.relay import host_contract
 from mship.core.relay.enroll import RequestStore
 from mship.core.relay.enroll_app import build_enroll_app
+from mship.core.relay.fleet_token import FleetTokenStore
+from mship.core.relay.host_directory import HostDirectory
 
 _PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host"
+_PUB_B = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAISecondKeyBodyBBBBBBBBBBBBBBBBBBBBBBBB two"
 RELAY = "mship-relay.atomikpanda.com"
+
+FP_A = "SHA256:keyA"
+MACHINE = "machine-fingerprint-copied-by-cp-a"
+
+
+class Harness:
+    """One enroll app plus the stores behind it, so a test can assert on both
+    the HTTP surface and what actually landed on disk."""
+
+    def __init__(self, client, store, directory, fleet, clock, prober):
+        self.client = client
+        self.store = store
+        self.directory = directory
+        self.fleet = fleet
+        self.clock = clock
+        self.prober = prober
+
+
+class Clock:
+    def __init__(self, t=1_000.0):
+        self.t = t
+
+    def __call__(self):
+        return self.t
+
+
+class Prober:
+    """Fake arbitration probe (the `test_host_directory.py` shape)."""
+
+    def __init__(self, answers=None):
+        self.urls: list[str] = []
+        self._answers = answers or {}
+
+    def __call__(self, public_url):
+        self.urls.append(public_url)
+        return self._answers.get(public_url)
+
+
+def _verify(blob, *, signature, identity, allowed_signers, namespace):
+    """Stand-in for `ssh_sig.verify_blob`: `sig:<fp>:<blob>` from an allowlisted key."""
+    if identity not in allowed_signers:
+        return False
+    return signature == f"sig:{identity}:{blob.decode('utf-8', 'replace')}"
+
+
+def _sign(nonce, payload, fingerprint=FP_A):
+    blob = host_contract.signing_blob(nonce, payload)
+    return f"sig:{fingerprint}:{blob.decode('utf-8')}"
+
+
+def _payload(**over):
+    payload = {
+        "host_id": "hst-20260818120000-aaaaaaaa",
+        "instance_id": "inst-1",
+        "label": "vm-alpha",
+        "key_fingerprint": FP_A,
+        "machine_fingerprint": MACHINE,
+        "subdomain": "abc123",
+        "public_url": "https://abc123.relay.example",
+        "mship_version": "1.2.3",
+        "capabilities": {"tunnel": True},
+        "runner": {"enabled": False, "state": "disabled"},
+        "refresh": "refresh-credential-1",
+    }
+    payload.update(over)
+    return payload
+
+
+def _harness(tmp_path, cap=50, answers=None, max_challenges=1000):
+    base = tmp_path / "s"
+    store = RequestStore(base, max_pending=cap)
+    clock = Clock()
+    prober = Prober(answers)
+    directory = HostDirectory(
+        base,
+        allowed_signers=lambda: FP_A,
+        probe=prober,
+        verify=_verify,
+        clock=clock,
+        max_challenges=max_challenges,
+    )
+    fleet = FleetTokenStore(base)
+    app = build_enroll_app(
+        store, relay_domain=RELAY, host_directory=directory, fleet_tokens=fleet
+    )
+    return Harness(TestClient(app), store, directory, fleet, clock, prober)
+
+
+def _register(h, payload=None, nonce=None, signature=None):
+    payload = _payload() if payload is None else payload
+    if nonce is None:
+        nonce = h.client.get(host_contract.CHALLENGE_PATH).json()["nonce"]
+    return h.client.post(
+        host_contract.REGISTER_PATH,
+        json={
+            "nonce": nonce,
+            "signature": _sign(nonce, payload) if signature is None else signature,
+            "payload": payload,
+        },
+    )
 
 
 def _client(tmp_path, cap=50):
-    store = RequestStore(tmp_path / "s", max_pending=cap)
-    return TestClient(build_enroll_app(store, relay_domain=RELAY)), store
+    h = _harness(tmp_path, cap=cap)
+    return h.client, h.store
 
 
 def _ask_client(tmp_path):
-    return TestClient(build_enroll_app(RequestStore(tmp_path / "store"), relay_domain=RELAY))
+    return _harness(tmp_path).client
 
 
 def test_enroll_creates_pending_and_status(tmp_path):
@@ -29,9 +136,11 @@ def test_enroll_rejects_bad_key(tmp_path):
 
 
 def test_enroll_over_cap_429(tmp_path):
+    # Distinct keys: same-key re-posts are deduped, so only distinct devices
+    # can reach the cap.
     c, _ = _client(tmp_path, cap=1)
     c.post("/enroll", json={"pubkey": _PUB, "hostname": "a"})
-    assert c.post("/enroll", json={"pubkey": _PUB, "hostname": "b"}).status_code == 429
+    assert c.post("/enroll", json={"pubkey": _PUB_B, "hostname": "b"}).status_code == 429
 
 
 def test_status_unknown(tmp_path):
@@ -62,3 +171,196 @@ def test_tls_check_rejects_foreign_host(tmp_path):
 def test_tls_check_requires_domain(tmp_path):
     c = _ask_client(tmp_path)
     assert c.get("/tls-check").status_code in (400, 422)
+
+
+# ---------------------------------------------------------------------------
+# /hosts/challenge
+# ---------------------------------------------------------------------------
+
+
+def test_challenge_issues_a_nonce(tmp_path):
+    h = _harness(tmp_path)
+    r = h.client.get(host_contract.CHALLENGE_PATH)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["nonce"] and isinstance(body["nonce"], str)
+    assert body["expires_at"] == h.clock.t + host_contract.CHALLENGE_TTL_S
+
+
+def test_challenge_nonces_are_single_use(tmp_path):
+    h = _harness(tmp_path)
+    assert (
+        h.client.get(host_contract.CHALLENGE_PATH).json()["nonce"]
+        != h.client.get(host_contract.CHALLENGE_PATH).json()["nonce"]
+    )
+
+
+def test_challenge_flood_is_429_not_500(tmp_path):
+    # The route is public and unauthenticated; a flood must be refused cleanly,
+    # never surface the store's typed cap as an unhandled 500.
+    h = _harness(tmp_path, max_challenges=1)
+    h.client.get(host_contract.CHALLENGE_PATH)
+    assert h.client.get(host_contract.CHALLENGE_PATH).status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# /hosts/register
+# ---------------------------------------------------------------------------
+
+
+def test_register_with_a_valid_signature_lands_the_entry(tmp_path):
+    h = _harness(tmp_path)
+    r = _register(h)
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "registered"
+    entry = h.directory.get_host(_payload()["host_id"])
+    assert entry is not None
+    assert entry["instance_id"] == "inst-1"
+    assert entry["last_seen"] == h.clock.t                # relay clock, not the payload's
+
+
+def test_register_never_echoes_the_refresh_credential(tmp_path):
+    # `GET /hosts` publishes it to the fleet-token holder BY DESIGN; no other
+    # route may widen it — least of all this unauthenticated one.
+    h = _harness(tmp_path)
+    assert "refresh-credential-1" not in _register(h).text
+
+
+def test_register_with_an_unapproved_key_is_401(tmp_path):
+    h = _harness(tmp_path)
+    payload = _payload(key_fingerprint="SHA256:notApproved")
+    r = _register(h, payload, signature=_sign("x", payload, "SHA256:notApproved"))
+    assert r.status_code == 401
+    assert h.directory.get_host(payload["host_id"]) is None
+
+
+def test_register_with_a_forged_signature_is_401(tmp_path):
+    h = _harness(tmp_path)
+    r = _register(h, signature="sig:SHA256:keyA:not-the-blob")
+    assert r.status_code == 401
+    assert h.directory.get_host(_payload()["host_id"]) is None
+
+
+def test_register_with_an_unknown_nonce_is_401(tmp_path):
+    h = _harness(tmp_path)
+    payload = _payload()
+    assert _register(h, payload, nonce="deadbeef").status_code == 401
+
+
+def test_register_with_a_traversal_shaped_host_id_is_400(tmp_path):
+    h = _harness(tmp_path)
+    assert _register(h, _payload(host_id="../../etc/passwd")).status_code == 400
+
+
+def test_duplicate_identity_is_409_naming_the_recovery_command(tmp_path):
+    # The clone case: a live incumbent that answers as itself refuses the claim,
+    # and the operator's only recovery must be named in the refusal.
+    h = _harness(tmp_path, answers={"https://abc123.relay.example": "inst-1"})
+    assert _register(h).status_code == 200
+    r = _register(h, _payload(instance_id="inst-2"))
+    assert r.status_code == 409
+    assert "mship daemon reidentify" in r.json()["detail"]
+
+
+def test_register_bounds_every_body_field(tmp_path):
+    h = _harness(tmp_path)
+    oversized = "A" * 100_000
+    for body in (
+        {"nonce": oversized, "signature": "s", "payload": _payload()},
+        {"nonce": "n", "signature": oversized, "payload": _payload()},
+        {"nonce": "n", "signature": "s", "payload": _payload(label=oversized)},
+        {"nonce": "n", "signature": "s", "payload": {f"k{i}": "v" for i in range(500)}},
+        {"nonce": "n", "signature": "s", "payload": _payload(capabilities={
+            f"k{i}": True for i in range(500)})},
+    ):
+        r = h.client.post(host_contract.REGISTER_PATH, json=body)
+        assert 400 <= r.status_code < 500, (body.keys(), r.status_code)
+
+
+# ---------------------------------------------------------------------------
+# GET /hosts
+# ---------------------------------------------------------------------------
+
+
+def test_directory_requires_a_fleet_token(tmp_path):
+    h = _harness(tmp_path)
+    assert h.client.get(host_contract.LIST_PATH).status_code == 401
+
+
+def test_directory_refuses_a_revoked_fleet_token(tmp_path):
+    h = _harness(tmp_path)
+    token = h.fleet.issue("phone")
+    h.fleet.revoke("phone")
+    r = h.client.get(
+        host_contract.LIST_PATH, headers={host_contract.FLEET_TOKEN_HEADER: token}
+    )
+    assert r.status_code == 401
+
+
+def test_directory_lists_registered_hosts_and_pending_enrollments(tmp_path):
+    h = _harness(tmp_path)
+    _register(h)
+    h.client.post("/enroll", json={"pubkey": _PUB_B, "hostname": "fresh-vm"})
+    r = h.client.get(
+        host_contract.LIST_PATH,
+        headers={host_contract.FLEET_TOKEN_HEADER: h.fleet.issue("phone")},
+    )
+    assert r.status_code == 200
+    hosts = r.json()["hosts"]
+    states = {e["state"] for e in hosts}
+    assert states == {"online", "pending-approval"}
+    registered = next(e for e in hosts if e["state"] == "online")
+    # The phone fetches the refresh credential from here — that IS the design.
+    assert registered["refresh"] == "refresh-credential-1"
+    assert registered["host_id"] == _payload()["host_id"]
+    assert next(e for e in hosts if e["state"] == "pending-approval")["label"] == "fresh-vm"
+
+
+def test_directory_publishes_a_deliberate_projection_not_the_raw_record(tmp_path):
+    # A field added to a stored entry must not auto-publish to every paired
+    # phone; the response shape is an allowlist, asserted here.
+    h = _harness(tmp_path)
+    _register(h)
+    path = tmp_path / "s" / "hosts" / f"{_payload()['host_id']}.json"
+    rec = json.loads(path.read_text())
+    rec["operator_note"] = "not for the wire"
+    path.write_text(json.dumps(rec))
+    r = h.client.get(
+        host_contract.LIST_PATH,
+        headers={host_contract.FLEET_TOKEN_HEADER: h.fleet.issue("phone")},
+    )
+    assert "operator_note" not in r.json()["hosts"][0]
+
+
+def test_the_fleet_token_is_never_logged(tmp_path, caplog):
+    h = _harness(tmp_path)
+    _register(h)
+    token = h.fleet.issue("phone")
+    with caplog.at_level(logging.DEBUG):
+        h.client.get(
+            host_contract.LIST_PATH, headers={host_contract.FLEET_TOKEN_HEADER: token}
+        )
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert token not in logged
+    assert "refresh-credential-1" not in logged
+
+
+def test_the_parsed_payload_is_byte_identical_to_what_was_signed(tmp_path):
+    # The catastrophic silent failure: if the body model coerced a value or
+    # filled in a default the client never sent, `canonical_payload` would
+    # differ and EVERY registration would 401 in production while unit tests
+    # over the directory alone stayed green.
+    from mship.core.relay.enroll_app import _RegisterBody
+
+    sent = _payload(mship_version="1.2.3", capabilities={"tunnel": True, "runner": False},
+                    label="wörk-hôst")
+    parsed = _RegisterBody(nonce="n", signature="s", payload=sent).payload
+    assert host_contract.canonical_payload(parsed) == host_contract.canonical_payload(sent)
+
+
+def test_a_future_daemon_field_survives_the_body_model(tmp_path):
+    # The payload is signed as sent, so the app must not drop unknown keys —
+    # dropping one would break the signature rather than merely ignore it.
+    h = _harness(tmp_path)
+    payload = _payload(some_future_field="v")
+    assert _register(h, payload).status_code == 200

--- a/tests/core/relay/test_enroll_app.py
+++ b/tests/core/relay/test_enroll_app.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+import pytest
 from fastapi.testclient import TestClient
 from mship.core.relay import host_contract
 from mship.core.relay.enroll import RequestStore
@@ -262,19 +263,55 @@ def test_duplicate_identity_is_409_naming_the_recovery_command(tmp_path):
     assert "mship daemon reidentify" in r.json()["detail"]
 
 
-def test_register_bounds_every_body_field(tmp_path):
+def _signed_body(h, **payload_over):
+    """A body that would REGISTER (fresh nonce, matching signature) — so a case
+    below can 422 for exactly one reason: the bound it oversizes."""
+    payload = _payload(**payload_over)
+    nonce = h.client.get(host_contract.CHALLENGE_PATH).json()["nonce"]
+    return {"nonce": nonce, "signature": _sign(nonce, payload), "payload": payload}
+
+
+def _oversized_nonce(h):
+    body = _signed_body(h)
+    body["nonce"] = "n" * 200
+    return body
+
+
+def _oversized_signature(h):
+    body = _signed_body(h)
+    body["signature"] = "A" * 9_000
+    return body
+
+
+_BOUNDED_BODIES = {
+    "nonce": _oversized_nonce,
+    "signature": _oversized_signature,
+    "payload-value": lambda h: _signed_body(h, label="w" * 1_000),
+    "payload-key": lambda h: _signed_body(h, **{"k" * 300: "v"}),
+    "payload-field-count": lambda h: _signed_body(h, **{f"x{i}": "v" for i in range(80)}),
+    "nested-key": lambda h: _signed_body(h, capabilities={"k" * 300: True}),
+    "nested-value": lambda h: _signed_body(h, capabilities={"tunnel": "w" * 1_000}),
+    "nested-field-count": lambda h: _signed_body(
+        h, capabilities={f"c{i}": True for i in range(40)}
+    ),
+}
+
+
+def test_the_bounds_control_body_is_otherwise_accepted(tmp_path):
+    # Without this, every case below could be 422ing for an unrelated reason and
+    # the bounds could be deleted with the suite still green.
     h = _harness(tmp_path)
-    oversized = "A" * 100_000
-    for body in (
-        {"nonce": oversized, "signature": "s", "payload": _payload()},
-        {"nonce": "n", "signature": oversized, "payload": _payload()},
-        {"nonce": "n", "signature": "s", "payload": _payload(label=oversized)},
-        {"nonce": "n", "signature": "s", "payload": {f"k{i}": "v" for i in range(500)}},
-        {"nonce": "n", "signature": "s", "payload": _payload(capabilities={
-            f"k{i}": True for i in range(500)})},
-    ):
-        r = h.client.post(host_contract.REGISTER_PATH, json=body)
-        assert 400 <= r.status_code < 500, (body.keys(), r.status_code)
+    assert h.client.post(host_contract.REGISTER_PATH, json=_signed_body(h)).status_code == 200
+
+
+@pytest.mark.parametrize("case", sorted(_BOUNDED_BODIES))
+def test_register_bounds_every_body_field(tmp_path, case):
+    # 422 exactly: pydantic validation is the ONLY thing that may reject these.
+    # Drop the bound and the request is accepted (200) or refused by route logic
+    # (401) — either way this fails, which is what makes the assertion real.
+    h = _harness(tmp_path)
+    r = h.client.post(host_contract.REGISTER_PATH, json=_BOUNDED_BODIES[case](h))
+    assert r.status_code == 422, (case, r.status_code, r.text[:200])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/relay/test_enroll_app.py
+++ b/tests/core/relay/test_enroll_app.py
@@ -80,9 +80,12 @@ def _payload(**over):
     return payload
 
 
-def _harness(tmp_path, cap=50, answers=None, max_challenges=1000):
+def _harness(
+    tmp_path, cap=50, answers=None, max_challenges=1000,
+    ttl=host_contract.ENROLL_TTL_S,
+):
     base = tmp_path / "s"
-    store = RequestStore(base, max_pending=cap)
+    store = RequestStore(base, ttl_seconds=ttl, max_pending=cap)
     clock = Clock()
     prober = Prober(answers)
     directory = HostDirectory(
@@ -115,8 +118,8 @@ def _register(h, payload=None, nonce=None, signature=None):
     )
 
 
-def _client(tmp_path, cap=50):
-    h = _harness(tmp_path, cap=cap)
+def _client(tmp_path, cap=50, ttl=host_contract.ENROLL_TTL_S):
+    h = _harness(tmp_path, cap=cap, ttl=ttl)
     return h.client, h.store
 
 
@@ -124,10 +127,11 @@ def _ask_client(tmp_path):
     return _harness(tmp_path).client
 
 
-def test_enroll_creates_pending_and_status(tmp_path):
-    c, _ = _client(tmp_path)
+def test_enroll_creates_pending_with_the_store_ttl(tmp_path):
+    c, _ = _client(tmp_path, ttl=60)
     r = c.post("/enroll", json={"pubkey": _PUB, "hostname": "laptop"})
     assert r.status_code == 200
+    assert r.json()["expires_in"] == 60
     rid = r.json()["id"]
     assert c.get(f"/status/{rid}").json()["status"] == "pending"
 

--- a/tests/core/relay/test_enroll_app.py
+++ b/tests/core/relay/test_enroll_app.py
@@ -136,6 +136,24 @@ def test_enroll_creates_pending_with_the_store_ttl(tmp_path):
     assert c.get(f"/status/{rid}").json()["status"] == "pending"
 
 
+def test_enroll_repost_observes_an_already_approved_request(tmp_path):
+    client, store = _client(tmp_path)
+    first = client.post("/enroll", json={"pubkey": _PUB, "hostname": "laptop"})
+    rid = first.json()["id"]
+    pubkeys = tmp_path / "pubkeys"
+    pubkeys.mkdir()
+    store.approve(rid, pubkeys)
+
+    repost = client.post("/enroll", json={"pubkey": _PUB, "hostname": "laptop"})
+
+    assert repost.json() == {
+        "id": rid,
+        "status": "approved",
+        "expires_in": host_contract.ENROLL_TTL_S,
+    }
+    assert store.list_pending() == []
+
+
 def test_enroll_rejects_bad_key(tmp_path):
     c, _ = _client(tmp_path)
     assert c.post("/enroll", json={"pubkey": "garbage", "hostname": "x"}).status_code == 400

--- a/tests/core/relay/test_enroll_app.py
+++ b/tests/core/relay/test_enroll_app.py
@@ -329,6 +329,25 @@ def test_duplicate_identity_is_409_naming_the_recovery_command(tmp_path):
     assert "mship daemon reidentify" in r.json()["detail"]
 
 
+def test_one_approved_key_cannot_register_a_second_host_id(tmp_path):
+    h = _harness(tmp_path)
+    assert _register(h).status_code == 200
+    second = _payload(
+        host_id="hst-20260818120000-bbbbbbbb",
+        instance_id="inst-2",
+        subdomain="def456-d4e5f6",
+        public_url=f"https://def456-d4e5f6.{RELAY}",
+    )
+
+    response = _register(h, second)
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == (
+        "approved key is already bound to another host_id; "
+        "run `mship daemon reidentify` to rotate the key"
+    )
+
+
 def _signed_body(h, **payload_over):
     """A body that would REGISTER (fresh nonce, matching signature) — so a case
     below can 422 for exactly one reason: the bound it oversizes."""

--- a/tests/core/relay/test_enroll_app.py
+++ b/tests/core/relay/test_enroll_app.py
@@ -511,6 +511,35 @@ def test_directory_lists_registered_hosts_and_pending_enrollments(tmp_path):
     )
 
 
+@pytest.mark.parametrize(
+    ("field", "bad_value"),
+    [
+        ("last_seen", 10**400),
+        ("first_seen", float("nan")),
+    ],
+)
+def test_directory_degrades_unusable_persisted_timestamps(
+    tmp_path, field, bad_value
+):
+    h = _harness(tmp_path)
+    _register(h)
+    path = tmp_path / "s" / "hosts" / f"{_payload()['host_id']}.json"
+    rec = json.loads(path.read_text())
+    rec[field] = bad_value
+    path.write_text(json.dumps(rec, allow_nan=True))
+
+    response = h.client.get(
+        host_contract.LIST_PATH,
+        headers={host_contract.FLEET_TOKEN_HEADER: h.fleet.issue("phone")},
+    )
+
+    assert response.status_code == 200
+    host = response.json()["hosts"][0]
+    assert host[field] == 0.0
+    if field == "last_seen":
+        assert host["state"] == "offline"
+
+
 def test_directory_publishes_a_deliberate_projection_not_the_raw_record(tmp_path):
     # A field added to a stored entry must not auto-publish to every paired
     # phone; the response shape is an allowlist, asserted here.

--- a/tests/core/relay/test_enroll_app.py
+++ b/tests/core/relay/test_enroll_app.py
@@ -9,8 +9,12 @@ from mship.core.relay.enroll_app import build_enroll_app
 from mship.core.relay.fleet_token import FleetTokenStore
 from mship.core.relay.host_directory import HostDirectory
 
-_PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host"
-_PUB_B = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAISecondKeyBodyBBBBBBBBBBBBBBBBBBBBBBBB two"
+_PUB = (
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA host"
+)
+_PUB_B = (
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAISecondKeyBodyBBBBBBBBBBBBBBBBBBBBBBBB two"
+)
 RELAY = "mship-relay.atomikpanda.com"
 
 FP_A = "SHA256:keyA"
@@ -80,10 +84,7 @@ def _payload(**over):
     return payload
 
 
-def _harness(
-    tmp_path, cap=50, answers=None, max_challenges=1000,
-    ttl=host_contract.ENROLL_TTL_S,
-):
+def _harness(tmp_path, cap=50, answers=None, ttl=host_contract.ENROLL_TTL_S):
     base = tmp_path / "s"
     store = RequestStore(base, ttl_seconds=ttl, max_pending=cap)
     clock = Clock()
@@ -95,7 +96,6 @@ def _harness(
         probe=prober,
         verify=_verify,
         clock=clock,
-        max_challenges=max_challenges,
     )
     fleet = FleetTokenStore(base)
     app = build_enroll_app(
@@ -104,10 +104,16 @@ def _harness(
     return Harness(TestClient(app), store, directory, fleet, clock, prober)
 
 
+def _challenge(h, identity=FP_A):
+    return h.client.post(
+        host_contract.CHALLENGE_PATH, json={"key_fingerprint": identity}
+    )
+
+
 def _register(h, payload=None, nonce=None, signature=None):
     payload = _payload() if payload is None else payload
     if nonce is None:
-        nonce = h.client.get(host_contract.CHALLENGE_PATH).json()["nonce"]
+        nonce = _challenge(h, str(payload["key_fingerprint"])).json()["nonce"]
     return h.client.post(
         host_contract.REGISTER_PATH,
         json={
@@ -156,7 +162,10 @@ def test_enroll_repost_observes_an_already_approved_request(tmp_path):
 
 def test_enroll_rejects_bad_key(tmp_path):
     c, _ = _client(tmp_path)
-    assert c.post("/enroll", json={"pubkey": "garbage", "hostname": "x"}).status_code == 400
+    assert (
+        c.post("/enroll", json={"pubkey": "garbage", "hostname": "x"}).status_code
+        == 400
+    )
 
 
 def test_enroll_over_cap_429(tmp_path):
@@ -164,7 +173,9 @@ def test_enroll_over_cap_429(tmp_path):
     # can reach the cap.
     c, _ = _client(tmp_path, cap=1)
     c.post("/enroll", json={"pubkey": _PUB, "hostname": "a"})
-    assert c.post("/enroll", json={"pubkey": _PUB_B, "hostname": "b"}).status_code == 429
+    assert (
+        c.post("/enroll", json={"pubkey": _PUB_B, "hostname": "b"}).status_code == 429
+    )
 
 
 def test_status_unknown(tmp_path):
@@ -184,7 +195,9 @@ def test_enroll_rejects_oversized_pubkey(tmp_path):
 def test_tls_check_allows_relay_owned_host(tmp_path):
     c = _ask_client(tmp_path)
     assert c.get("/tls-check", params={"domain": f"enroll.{RELAY}"}).status_code == 200
-    assert c.get("/tls-check", params={"domain": f"w-92bbb7.{RELAY}"}).status_code == 200
+    assert (
+        c.get("/tls-check", params={"domain": f"w-92bbb7.{RELAY}"}).status_code == 200
+    )
 
 
 def test_tls_check_rejects_foreign_host(tmp_path):
@@ -204,27 +217,26 @@ def test_tls_check_requires_domain(tmp_path):
 
 def test_challenge_issues_a_nonce(tmp_path):
     h = _harness(tmp_path)
-    r = h.client.get(host_contract.CHALLENGE_PATH)
+    r = _challenge(h)
     assert r.status_code == 200
     body = r.json()
     assert body["nonce"] and isinstance(body["nonce"], str)
     assert body["expires_at"] == h.clock.t + host_contract.CHALLENGE_TTL_S
 
 
-def test_challenge_nonces_are_single_use(tmp_path):
+def test_challenge_is_reused_for_the_same_approved_identity(tmp_path):
     h = _harness(tmp_path)
-    assert (
-        h.client.get(host_contract.CHALLENGE_PATH).json()["nonce"]
-        != h.client.get(host_contract.CHALLENGE_PATH).json()["nonce"]
-    )
+    assert _challenge(h).json()["nonce"] == _challenge(h).json()["nonce"]
 
 
-def test_challenge_flood_is_429_not_500(tmp_path):
-    # The route is public and unauthenticated; a flood must be refused cleanly,
-    # never surface the store's typed cap as an unhandled 500.
-    h = _harness(tmp_path, max_challenges=1)
-    h.client.get(host_contract.CHALLENGE_PATH)
-    assert h.client.get(host_contract.CHALLENGE_PATH).status_code == 429
+def test_unapproved_identity_cannot_allocate_challenge_storage(tmp_path):
+    h = _harness(tmp_path)
+
+    r = _challenge(h, "SHA256:not-approved")
+
+    assert r.status_code == 401
+    assert r.json()["detail"] == host_contract.UNAPPROVED_KEY_DETAIL
+    assert list((tmp_path / "s" / "challenges").glob("*.json")) == []
 
 
 # ---------------------------------------------------------------------------
@@ -240,7 +252,7 @@ def test_register_with_a_valid_signature_lands_the_entry(tmp_path):
     entry = h.directory.get_host(_payload()["host_id"])
     assert entry is not None
     assert entry["instance_id"] == "inst-1"
-    assert entry["last_seen"] == h.clock.t                # relay clock, not the payload's
+    assert entry["last_seen"] == h.clock.t  # relay clock, not the payload's
 
 
 def test_signed_non_relay_url_is_a_clean_400(tmp_path):
@@ -260,10 +272,16 @@ def test_register_never_echoes_the_refresh_credential(tmp_path):
     assert "refresh-credential-1" not in _register(h).text
 
 
-def test_register_with_an_unapproved_key_is_401(tmp_path):
+def test_challenge_cannot_authorize_a_different_identity(tmp_path):
     h = _harness(tmp_path)
+    nonce = _challenge(h).json()["nonce"]
     payload = _payload(key_fingerprint="SHA256:notApproved")
-    r = _register(h, payload, signature=_sign("x", payload, "SHA256:notApproved"))
+    r = _register(
+        h,
+        payload,
+        nonce=nonce,
+        signature=_sign(nonce, payload, "SHA256:notApproved"),
+    )
     assert r.status_code == 401
     assert h.directory.get_host(payload["host_id"]) is None
 
@@ -300,7 +318,7 @@ def _signed_body(h, **payload_over):
     """A body that would REGISTER (fresh nonce, matching signature) — so a case
     below can 422 for exactly one reason: the bound it oversizes."""
     payload = _payload(**payload_over)
-    nonce = h.client.get(host_contract.CHALLENGE_PATH).json()["nonce"]
+    nonce = _challenge(h, str(payload["key_fingerprint"])).json()["nonce"]
     return {"nonce": nonce, "signature": _sign(nonce, payload), "payload": payload}
 
 
@@ -321,7 +339,9 @@ _BOUNDED_BODIES = {
     "signature": _oversized_signature,
     "payload-value": lambda h: _signed_body(h, label="w" * 1_000),
     "payload-key": lambda h: _signed_body(h, **{"k" * 300: "v"}),
-    "payload-field-count": lambda h: _signed_body(h, **{f"x{i}": "v" for i in range(80)}),
+    "payload-field-count": lambda h: _signed_body(
+        h, **{f"x{i}": "v" for i in range(80)}
+    ),
     "nested-key": lambda h: _signed_body(h, capabilities={"k" * 300: True}),
     "nested-value": lambda h: _signed_body(h, capabilities={"tunnel": "w" * 1_000}),
     "nested-field-count": lambda h: _signed_body(
@@ -334,7 +354,10 @@ def test_the_bounds_control_body_is_otherwise_accepted(tmp_path):
     # Without this, every case below could be 422ing for an unrelated reason and
     # the bounds could be deleted with the suite still green.
     h = _harness(tmp_path)
-    assert h.client.post(host_contract.REGISTER_PATH, json=_signed_body(h)).status_code == 200
+    assert (
+        h.client.post(host_contract.REGISTER_PATH, json=_signed_body(h)).status_code
+        == 200
+    )
 
 
 @pytest.mark.parametrize("case", sorted(_BOUNDED_BODIES))
@@ -383,7 +406,10 @@ def test_directory_lists_registered_hosts_and_pending_enrollments(tmp_path):
     # The phone fetches the refresh credential from here — that IS the design.
     assert registered["refresh"] == "refresh-credential-1"
     assert registered["host_id"] == _payload()["host_id"]
-    assert next(e for e in hosts if e["state"] == "pending-approval")["label"] == "fresh-vm"
+    assert (
+        next(e for e in hosts if e["state"] == "pending-approval")["label"]
+        == "fresh-vm"
+    )
 
 
 def test_directory_publishes_a_deliberate_projection_not_the_raw_record(tmp_path):
@@ -422,10 +448,15 @@ def test_the_parsed_payload_is_byte_identical_to_what_was_signed(tmp_path):
     # over the directory alone stayed green.
     from mship.core.relay.enroll_app import _RegisterBody
 
-    sent = _payload(mship_version="1.2.3", capabilities={"tunnel": True, "runner": False},
-                    label="wörk-hôst")
+    sent = _payload(
+        mship_version="1.2.3",
+        capabilities={"tunnel": True, "runner": False},
+        label="wörk-hôst",
+    )
     parsed = _RegisterBody(nonce="n", signature="s", payload=sent).payload
-    assert host_contract.canonical_payload(parsed) == host_contract.canonical_payload(sent)
+    assert host_contract.canonical_payload(parsed) == host_contract.canonical_payload(
+        sent
+    )
 
 
 def test_a_future_daemon_field_survives_the_body_model(tmp_path):

--- a/tests/core/relay/test_enroll_app.py
+++ b/tests/core/relay/test_enroll_app.py
@@ -370,6 +370,31 @@ def test_register_bounds_every_body_field(tmp_path, case):
     assert r.status_code == 422, (case, r.status_code, r.text[:200])
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        _payload(clock_skew_seconds=float("nan")),
+        _payload(runner={"load": float("inf")}),
+    ],
+)
+def test_register_rejects_non_finite_scalars_at_the_request_boundary(tmp_path, payload):
+    h = _harness(tmp_path)
+    client = TestClient(h.client.app, raise_server_exceptions=False)
+    nonce = _challenge(h).json()["nonce"]
+    body = json.dumps(
+        {"nonce": nonce, "signature": "s", "payload": payload},
+        allow_nan=True,
+    )
+
+    response = client.post(
+        host_contract.REGISTER_PATH,
+        content=body,
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 400
+
+
 # ---------------------------------------------------------------------------
 # GET /hosts
 # ---------------------------------------------------------------------------

--- a/tests/core/relay/test_fleet_token.py
+++ b/tests/core/relay/test_fleet_token.py
@@ -6,6 +6,7 @@ plaintext — the `core.daemon.host_auth.RefreshStore` shape, for the same reaso
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 
@@ -101,6 +102,19 @@ def test_token_material_is_owner_only_on_disk(tmp_path):
     for path in (tmp_path / "store").rglob("*"):
         if path.is_file() and not path.name.endswith(".lock"):
             assert path.stat().st_mode & 0o077 == 0, path
+
+
+def test_verify_writes_nothing(tmp_path):
+    store = _store(tmp_path)
+    token = store.issue("phone")
+    lock_path = store.path.with_name(store.path.name + ".lock")
+    before = store.path.read_bytes()
+    os.utime(lock_path, ns=(1_000_000_000, 1_000_000_000))
+    lock_mtime = lock_path.stat().st_mtime_ns
+
+    assert store.verify(token) == "phone"
+    assert store.path.read_bytes() == before
+    assert lock_path.stat().st_mtime_ns == lock_mtime
 
 
 def test_a_corrupt_document_does_not_brick_the_store(tmp_path):

--- a/tests/core/relay/test_fleet_token.py
+++ b/tests/core/relay/test_fleet_token.py
@@ -2,6 +2,7 @@
 `GET /hosts`. Stable per label (re-running the mint command must reprint the same
 QR, not orphan the phone's copy), revocable per label, and never at rest in
 plaintext — the `core.daemon.host_auth.RefreshStore` shape, for the same reasons."""
+
 from __future__ import annotations
 
 import json
@@ -26,6 +27,18 @@ def test_issue_is_stable_for_the_same_label(tmp_path):
 def test_a_second_store_object_over_the_same_dir_derives_the_same_token(tmp_path):
     # The CLI builds a new store per invocation; stability must be on disk.
     assert _store(tmp_path).issue("phone") == _store(tmp_path).issue("phone")
+
+
+def test_reissue_after_root_secret_recovery_returns_a_verifiable_token(tmp_path):
+    store = _store(tmp_path)
+    stale = store.issue("phone")
+    (tmp_path / "store" / "fleet-secret").unlink()
+
+    recovered = store.issue("phone")
+
+    assert recovered != stale
+    assert store.verify(stale) is None
+    assert store.verify(recovered) == "phone"
 
 
 def test_distinct_labels_get_distinct_tokens(tmp_path):
@@ -94,8 +107,8 @@ def test_a_corrupt_document_does_not_brick_the_store(tmp_path):
     store = _store(tmp_path)
     token = store.issue("phone")
     store.path.write_text("{not json")
-    assert store.verify(token) is None            # unverifiable, but no raise
-    assert store.issue("phone")                   # and it self-heals
+    assert store.verify(token) is None  # unverifiable, but no raise
+    assert store.issue("phone")  # and it self-heals
 
 
 def test_labels_are_bounded_so_the_document_cannot_grow_without_limit(tmp_path):

--- a/tests/core/relay/test_fleet_token.py
+++ b/tests/core/relay/test_fleet_token.py
@@ -1,0 +1,108 @@
+"""The relay's per-device fleet tokens: the credential the phone carries to read
+`GET /hosts`. Stable per label (re-running the mint command must reprint the same
+QR, not orphan the phone's copy), revocable per label, and never at rest in
+plaintext — the `core.daemon.host_auth.RefreshStore` shape, for the same reasons."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mship.core.relay.fleet_token import FleetTokenStore
+
+
+def _store(tmp_path, **kw):
+    return FleetTokenStore(tmp_path / "store", **kw)
+
+
+def test_issue_is_stable_for_the_same_label(tmp_path):
+    # Re-running `mship relay fleet-token --label phone` must reprint the SAME
+    # token: a fresh one would silently invalidate the phone already paired.
+    store = _store(tmp_path)
+    first = store.issue("phone")
+    assert store.issue("phone") == first
+
+
+def test_a_second_store_object_over_the_same_dir_derives_the_same_token(tmp_path):
+    # The CLI builds a new store per invocation; stability must be on disk.
+    assert _store(tmp_path).issue("phone") == _store(tmp_path).issue("phone")
+
+
+def test_distinct_labels_get_distinct_tokens(tmp_path):
+    store = _store(tmp_path)
+    assert store.issue("phone") != store.issue("tablet")
+
+
+def test_verify_returns_the_label_behind_a_live_token(tmp_path):
+    store = _store(tmp_path)
+    assert store.verify(store.issue("phone")) == "phone"
+
+
+@pytest.mark.parametrize(
+    "presented",
+    ["", "garbage", "nodot", "../../etc/passwd.x", "0123456789abcdef.wrong-secret"],
+)
+def test_verify_refuses_anything_that_is_not_a_live_token(tmp_path, presented):
+    store = _store(tmp_path)
+    store.issue("phone")
+    assert store.verify(presented) is None
+
+
+def test_revoke_invalidates_only_that_label(tmp_path):
+    store = _store(tmp_path)
+    phone, tablet = store.issue("phone"), store.issue("tablet")
+    assert store.revoke("phone") is True
+    assert store.verify(phone) is None
+    assert store.verify(tablet) == "tablet"
+
+
+def test_revoke_reports_whether_there_was_anything_to_revoke(tmp_path):
+    store = _store(tmp_path)
+    assert store.revoke("never-minted") is False
+
+
+def test_reissue_after_revoke_is_a_different_token(tmp_path):
+    # Revocation must be real: a re-mint under the same label cannot resurrect
+    # the credential the operator just killed.
+    store = _store(tmp_path)
+    revoked = store.issue("phone")
+    store.revoke("phone")
+    fresh = store.issue("phone")
+    assert fresh != revoked
+    assert store.verify(revoked) is None
+    assert store.verify(fresh) == "phone"
+
+
+def test_the_plaintext_token_is_never_written_to_disk(tmp_path):
+    store = _store(tmp_path)
+    token = store.issue("phone")
+    secret = token.split(".", 1)[1]
+    for path in (tmp_path / "store").rglob("*"):
+        if path.is_file():
+            assert secret not in path.read_bytes().decode("utf-8", "replace")
+
+
+def test_token_material_is_owner_only_on_disk(tmp_path):
+    store = _store(tmp_path)
+    store.issue("phone")
+    for path in (tmp_path / "store").rglob("*"):
+        if path.is_file() and not path.name.endswith(".lock"):
+            assert path.stat().st_mode & 0o077 == 0, path
+
+
+def test_a_corrupt_document_does_not_brick_the_store(tmp_path):
+    store = _store(tmp_path)
+    token = store.issue("phone")
+    store.path.write_text("{not json")
+    assert store.verify(token) is None            # unverifiable, but no raise
+    assert store.issue("phone")                   # and it self-heals
+
+
+def test_labels_are_bounded_so_the_document_cannot_grow_without_limit(tmp_path):
+    store = _store(tmp_path, max_labels=2)
+    store.issue("a")
+    store.issue("b")
+    fresh = store.issue("c")
+    # The credential just handed back is never the one the cap drops.
+    assert store.verify(fresh) == "c"
+    assert len(json.loads(store.path.read_text())["labels"]) == 2

--- a/tests/core/relay/test_health.py
+++ b/tests/core/relay/test_health.py
@@ -23,6 +23,18 @@ def test_ok_when_authed_request_succeeds():
     assert calls["url"] == "https://w-ab12.relay/health"
     assert calls["auth"] == "Bearer tok"
 
+def test_health_probe_does_not_follow_relay_redirects():
+    seen = []
+
+    def get(*_args, **kwargs):
+        seen.append(kwargs["follow_redirects"])
+        return _Resp(302)
+
+    probe_health("https://w-ab12.relay", "", get=get)
+
+    assert seen == [False]
+
+
 def test_not_ok_on_401_explains_token():
     ok, detail = verify_relay_reachable("https://w.relay", "tok", get=lambda *a, **k: _Resp(401))
     assert ok is False and "token" in detail.lower()

--- a/tests/core/relay/test_health.py
+++ b/tests/core/relay/test_health.py
@@ -103,3 +103,55 @@ def test_probe_health_carries_transport_error_and_never_raises():
     p = probe_health("https://w-ab12.relay", "tok", get=boom)
     assert p.ok is False and p.status_code is None
     assert "name resolution failed" in p.error
+
+
+# --- the body + Date, for the tunnel's read-back (#471 AC4b) ---------------
+#
+# `probe_health` is the ONE prober, so the daemon's "who is actually answering
+# on my subdomain?" check reads the parsed `/health` body from here rather than
+# growing a second prober beside it.
+
+class _JsonResp:
+    def __init__(self, status, body=None, headers=None, raises=None):
+        self.status_code = status
+        self.headers = headers or {}
+        self._body = body
+        self._raises = raises
+
+    def json(self):
+        if self._raises is not None:
+            raise self._raises
+        return self._body
+
+
+def test_probe_health_carries_the_parsed_body_and_date():
+    p = probe_health("https://w.relay", "tok", get=lambda *a, **k: _JsonResp(
+        200, {"status": "ok", "instance_id": "inst-1"}, {"Date": "Mon, 18 Aug 2026 12:00:00 GMT"}))
+    assert p.body == {"status": "ok", "instance_id": "inst-1"}
+    assert p.date_header == "Mon, 18 Aug 2026 12:00:00 GMT"
+
+
+def test_probe_health_body_is_none_on_malformed_json_and_never_raises():
+    # a captive portal / proxy error page answers 200 with HTML
+    p = probe_health("https://w.relay", "tok", get=lambda *a, **k: _JsonResp(
+        200, raises=ValueError("Expecting value: line 1 column 1 (char 0)")))
+    assert p.ok is True and p.body is None and p.date_header is None
+
+
+def test_probe_health_body_is_none_for_a_non_object_json_body():
+    p = probe_health("https://w.relay", "tok",
+                     get=lambda *a, **k: _JsonResp(200, ["not", "an", "object"]))
+    assert p.body is None
+
+
+def test_probe_health_body_and_date_default_to_none_on_transport_failure():
+    def boom(*a, **k): raise RuntimeError("connection refused")
+    p = probe_health("https://w.relay", "tok", get=boom)
+    assert p.body is None and p.date_header is None
+
+
+def test_probe_health_tolerates_a_response_without_json_or_headers():
+    """`verify_relay_reachable` and `mship.core.topology` read only ok/status/
+    error, and their callers hand in bare response stand-ins."""
+    p = probe_health("https://w.relay", "tok", get=lambda *a, **k: _Resp(200))
+    assert p.ok is True and p.body is None and p.date_header is None

--- a/tests/core/relay/test_host_contract.py
+++ b/tests/core/relay/test_host_contract.py
@@ -132,3 +132,52 @@ def test_signing_blob_binds_the_nonce_and_the_payload_together():
         host_contract.signing_blob("n1", p2),
     }
     assert len(blobs) == 3
+
+
+# --- identity across the ends -----------------------------------------------
+
+
+def test_the_enroll_app_reads_the_contract_module_rather_than_copies():
+    # The relay end must not restate the namespace, header, or route paths: an
+    # equal-but-separate literal drifts silently and 401s / 404s in production
+    # while both ends' unit tests stay green.
+    from mship.core.relay import enroll_app
+
+    assert enroll_app.host_contract is host_contract
+
+
+def test_the_enroll_app_declares_no_wire_literals_of_its_own():
+    import inspect
+
+    from mship.core.relay import enroll_app
+
+    source = inspect.getsource(enroll_app)
+    for literal in (
+        host_contract.HOSTS_PREFIX,
+        host_contract.FLEET_TOKEN_HEADER,
+        host_contract.NAMESPACE,
+    ):
+        assert f'"{literal}' not in source and f"'{literal}" not in source, literal
+
+
+def test_the_enroll_app_serves_exactly_the_contract_routes():
+    from fastapi.routing import APIRoute
+
+    from mship.core.relay import enroll_app, host_directory
+    from mship.core.relay.fleet_token import FleetTokenStore
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as base:
+        app = enroll_app.build_enroll_app(
+            enroll.RequestStore(base),
+            relay_domain="relay.example",
+            host_directory=host_directory.HostDirectory(
+                base, allowed_signers=lambda: "", probe=lambda url: None
+            ),
+            fleet_tokens=FleetTokenStore(base),
+        )
+    served = {r.path for r in app.routes if isinstance(r, APIRoute)}
+    assert set(host_contract.ROUTE_PATHS) <= served
+    # …and the pre-existing surface is untouched (it gates cert issuance).
+    assert {"/enroll", "/status/{rid}", "/tls-check"} <= served

--- a/tests/core/relay/test_host_contract.py
+++ b/tests/core/relay/test_host_contract.py
@@ -66,6 +66,7 @@ def test_the_wire_literals_are_pinned_by_value():
     assert host_contract.HOSTS_PREFIX == "/hosts"
     assert host_contract.CHALLENGE_PATH == "/hosts/challenge"
     assert host_contract.REGISTER_PATH == "/hosts/register"
+    assert host_contract.REVOKE_PATH == "/hosts/revoke"
     assert host_contract.LIST_PATH == "/hosts"
 
 
@@ -77,6 +78,7 @@ def test_every_route_path_lives_under_the_single_hosts_prefix():
         ), path
     assert host_contract.CHALLENGE_PATH in host_contract.ROUTE_PATHS
     assert host_contract.REGISTER_PATH in host_contract.ROUTE_PATHS
+    assert host_contract.REVOKE_PATH in host_contract.ROUTE_PATHS
     assert host_contract.LIST_PATH in host_contract.ROUTE_PATHS
 
 

--- a/tests/core/relay/test_host_contract.py
+++ b/tests/core/relay/test_host_contract.py
@@ -59,6 +59,16 @@ def test_max_backoff_matches_the_tunnel_supervisor_cap():
 # --- AC13: one Caddy matcher is enough --------------------------------------
 
 
+def test_the_wire_literals_are_pinned_by_value():
+    # Symbolic comparisons alone would let a rename sail through green tests
+    # and break every deployed daemon: these strings ARE the wire.
+    assert host_contract.NAMESPACE == "host-registration@mship"
+    assert host_contract.HOSTS_PREFIX == "/hosts"
+    assert host_contract.CHALLENGE_PATH == "/hosts/challenge"
+    assert host_contract.REGISTER_PATH == "/hosts/register"
+    assert host_contract.LIST_PATH == "/hosts"
+
+
 def test_every_route_path_lives_under_the_single_hosts_prefix():
     assert host_contract.ROUTE_PATHS, "routes must be enumerated here, not inline"
     for path in host_contract.ROUTE_PATHS:

--- a/tests/core/relay/test_host_contract.py
+++ b/tests/core/relay/test_host_contract.py
@@ -1,0 +1,124 @@
+"""The host-registration wire contract is a single source (test_contract.py
+style): both ends read the same objects, so they cannot drift — and the bytes
+that get signed are pinned by a golden case, because key order, separators and
+escaping are otherwise free parameters that would ship as "every registration
+401s in production" while unit tests pass in one interpreter."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mship.core.daemon import host_token
+from mship.core.relay import enroll, host_contract, tunnel
+
+
+# --- identity: one owner per constant ---------------------------------------
+
+
+def test_host_token_ttl_has_exactly_one_owner():
+    # Same object, not a copy: the host mints on this TTL and the contract
+    # publishes it, so a change is impossible to make in only one place.
+    assert host_token.HOST_TOKEN_TTL_S is host_contract.HOST_TOKEN_TTL_S
+
+
+def test_enroll_store_ttl_is_the_contract_ttl():
+    # The daemon's re-post schedule is derived from the store's TTL; if the
+    # store had its own copy the schedule could silently outlive it.
+    import inspect
+
+    ttl = inspect.signature(enroll.RequestStore).parameters["ttl_seconds"]
+    assert ttl.default is host_contract.ENROLL_TTL_S
+
+
+def test_enroll_repost_interval_keeps_a_pending_request_alive():
+    # Re-posting must happen strictly more often than the store expires, or an
+    # overnight provision is unapprovable in the morning (AC1/AC8).
+    assert host_contract.ENROLL_REPOST_INTERVAL_S < host_contract.ENROLL_TTL_S
+
+
+def test_directory_staleness_is_derived_so_healthy_hosts_cannot_flap():
+    assert host_contract.DIRECTORY_STALE_S == (
+        3 * host_contract.REGISTER_INTERVAL_S + host_contract.MAX_BACKOFF_S
+    )
+    # A host that misses a beat and reconnects on the worst-case backoff is
+    # still inside the window (AC10: no flap to `offline`).
+    assert (
+        host_contract.REGISTER_INTERVAL_S + host_contract.MAX_BACKOFF_S
+        < host_contract.DIRECTORY_STALE_S
+    )
+
+
+def test_max_backoff_matches_the_tunnel_supervisor_cap():
+    import inspect
+
+    cap = inspect.signature(tunnel.TunnelSupervisor).parameters["max_backoff_delay"]
+    assert cap.default == host_contract.MAX_BACKOFF_S
+
+
+# --- AC13: one Caddy matcher is enough --------------------------------------
+
+
+def test_every_route_path_lives_under_the_single_hosts_prefix():
+    assert host_contract.ROUTE_PATHS, "routes must be enumerated here, not inline"
+    for path in host_contract.ROUTE_PATHS:
+        assert path == host_contract.HOSTS_PREFIX or path.startswith(
+            host_contract.HOSTS_PREFIX + "/"
+        ), path
+    assert host_contract.CHALLENGE_PATH in host_contract.ROUTE_PATHS
+    assert host_contract.REGISTER_PATH in host_contract.ROUTE_PATHS
+    assert host_contract.LIST_PATH in host_contract.ROUTE_PATHS
+
+
+def test_fleet_token_header_is_named_once():
+    assert host_contract.FLEET_TOKEN_HEADER == "Mship-Fleet-Token"
+
+
+# --- golden bytes -----------------------------------------------------------
+
+
+def test_canonical_payload_golden_bytes_over_a_non_ascii_hostname():
+    payload = {"label": "wörk-hôst", "host_id": "hst-1", "count": 2}
+    assert host_contract.canonical_payload(payload) == (
+        b'{"count":2,"host_id":"hst-1","label":"w\xc3\xb6rk-h\xc3\xb4st"}'
+    )
+
+
+def test_canonical_payload_is_insensitive_to_insertion_order():
+    a = {"b": 1, "a": {"z": 1, "y": 2}}
+    b = {"a": {"y": 2, "z": 1}, "b": 1}
+    assert host_contract.canonical_payload(a) == host_contract.canonical_payload(b)
+
+
+def test_canonical_payload_refuses_values_json_cannot_round_trip():
+    # NaN/Infinity are not JSON; emitting them would produce bytes the other
+    # end cannot parse, i.e. a signature over garbage.
+    with pytest.raises(ValueError):
+        host_contract.canonical_payload({"skew": float("nan")})
+
+
+def test_canonical_payload_is_parseable_json():
+    payload = {"label": "wörk-hôst", "host_id": "hst-1"}
+    assert json.loads(host_contract.canonical_payload(payload)) == payload
+
+
+def test_signing_blob_golden_bytes():
+    payload = {"label": "wörk-hôst", "host_id": "hst-1", "count": 2}
+    assert host_contract.signing_blob("n0nce", payload) == (
+        host_contract.NAMESPACE.encode("utf-8")
+        + b"\x00n0nce\x00"
+        + b'{"count":2,"host_id":"hst-1","label":"w\xc3\xb6rk-h\xc3\xb4st"}'
+    )
+
+
+def test_signing_blob_binds_the_nonce_and_the_payload_together():
+    # Neither half may be swapped without changing the bytes (no replay of a
+    # signature onto a different payload, or of a payload onto a new nonce).
+    p1 = {"host_id": "a"}
+    p2 = {"host_id": "b"}
+    blobs = {
+        host_contract.signing_blob("n1", p1),
+        host_contract.signing_blob("n2", p1),
+        host_contract.signing_blob("n1", p2),
+    }
+    assert len(blobs) == 3

--- a/tests/core/relay/test_host_contract.py
+++ b/tests/core/relay/test_host_contract.py
@@ -173,7 +173,8 @@ def test_the_enroll_app_serves_exactly_the_contract_routes():
             enroll.RequestStore(base),
             relay_domain="relay.example",
             host_directory=host_directory.HostDirectory(
-                base, allowed_signers=lambda: "", probe=lambda url: None
+                base, relay_domain="relay.example",
+                allowed_signers=lambda: "", probe=lambda url: None,
             ),
             fleet_tokens=FleetTokenStore(base),
         )

--- a/tests/core/relay/test_host_directory.py
+++ b/tests/core/relay/test_host_directory.py
@@ -19,6 +19,7 @@ from mship.core.relay.host_directory import (
     HostDirectory,
     InvalidHostId,
     SignatureRefused,
+    VerificationBusy,
     probe_instance_id,
 )
 
@@ -181,6 +182,49 @@ def test_invalid_signature_does_not_burn_the_shared_identity_challenge(tmp_path)
     with pytest.raises(SignatureRefused):
         d.register(payload, nonce=nonce, signature="not-a-signature")
 
+    assert (
+        d.register(payload, nonce=nonce, signature=_sign(nonce, payload))["host_id"]
+        == payload["host_id"]
+    )
+
+
+def test_signature_verification_capacity_refuses_without_spending_nonce(tmp_path):
+    entered = threading.Event()
+    release = threading.Event()
+    verify_calls = 0
+
+    def blocking_verify(*args, **kwargs):
+        nonlocal verify_calls
+        verify_calls += 1
+        entered.set()
+        release.wait(timeout=1)
+        return False
+
+    d = HostDirectory(
+        tmp_path,
+        relay_domain="relay.example",
+        allowed_signers=lambda: FP_A,
+        probe=Prober(),
+        verify=blocking_verify,
+        max_concurrent_verifications=1,
+    )
+    payload = _payload()
+    nonce = d.issue_challenge(FP_A)["nonce"]
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        first = executor.submit(
+            d.register, payload, nonce=nonce, signature="forged-first"
+        )
+        assert entered.wait(timeout=1)
+        with pytest.raises(VerificationBusy):
+            d.register(payload, nonce=nonce, signature="forged-second")
+        assert verify_calls == 1
+        assert list((tmp_path / "challenges").glob("*.json"))
+        release.set()
+        with pytest.raises(SignatureRefused):
+            first.result()
+
+    d._verify = _verify
     assert (
         d.register(payload, nonce=nonce, signature=_sign(nonce, payload))["host_id"]
         == payload["host_id"]
@@ -428,6 +472,7 @@ def test_a_stale_entry_is_taken_over_without_probing(tmp_path):
     assert entry["previous_instance_id"] == "inst-1"
     assert probe.urls == [], "a stale incumbent needs no probe"
 
+
 def test_a_stale_host_id_cannot_be_claimed_by_another_approved_key(tmp_path):
     clock = Clock()
     probe = Prober()
@@ -443,7 +488,6 @@ def test_a_stale_host_id_cannot_be_claimed_by_another_approved_key(tmp_path):
 
     assert path.read_bytes() == before
     assert probe.urls == []
-
 
 
 # --- listing ----------------------------------------------------------------

--- a/tests/core/relay/test_host_directory.py
+++ b/tests/core/relay/test_host_directory.py
@@ -172,6 +172,21 @@ def test_the_challenge_store_is_capped(tmp_path):
     assert d.issue_challenge()["nonce"]
 
 
+def test_a_claim_stranded_by_a_crash_is_swept_like_any_challenge(tmp_path):
+    # A crash between the claiming rename and the spending unlink must not
+    # leave a file nothing ever reaps on a public write path.
+    clock = Clock()
+    d = _dir(tmp_path, clock=clock)
+    ch = d.issue_challenge()
+    stranded = (tmp_path / "challenges" / f"{ch['nonce']}.deadbeef.claim")
+    (tmp_path / "challenges" / f"{ch['nonce']}.json").rename(stranded)
+    d.issue_challenge()                       # sweeps, but the claim is live
+    assert stranded.is_file()
+    clock.t += host_contract.CHALLENGE_TTL_S + 1
+    d.issue_challenge()
+    assert not stranded.exists()
+
+
 def test_an_unknown_nonce_is_refused(tmp_path):
     d = _dir(tmp_path)
     payload = _payload()
@@ -424,15 +439,17 @@ def test_a_corrupt_entry_file_is_quarantined_not_fatal(tmp_path):
     assert not (tmp_path / "hosts" / "broken.json").exists()
 
 
-def test_a_non_numeric_last_seen_reads_as_offline_not_as_a_crash(tmp_path):
-    # A hand-edited entry must degrade, not brick every listing (and must not
-    # accidentally read as fresh, which would make it un-takeoverable).
+@pytest.mark.parametrize("bad", ["yesterday", None, "NaN", "Infinity", "-Infinity"])
+def test_an_unusable_last_seen_reads_as_offline_not_as_a_crash(tmp_path, bad):
+    # A hand-edited entry must degrade, not brick every listing — and must not
+    # read as FRESH, which would make it permanently online and un-takeoverable
+    # (`now - nan >= stale` is False, so NaN needs the same treatment as junk).
     clock = Clock()
     d = _dir(tmp_path, clock=clock)
     _register(d)
     path = tmp_path / "hosts" / f"{_payload()['host_id']}.json"
     rec = json.loads(path.read_text())
-    rec["last_seen"] = "yesterday"
+    rec["last_seen"] = bad
     path.write_text(json.dumps(rec))
     assert d.list_hosts()[0]["state"] == "offline"
     assert _register(d, _payload(instance_id="inst-2"))["previous_instance_id"] == "inst-1"

--- a/tests/core/relay/test_host_directory.py
+++ b/tests/core/relay/test_host_directory.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 import json
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -103,6 +104,57 @@ def _register(d, payload=None, *, fingerprint=FP_A, signature=None):
     nonce = d.issue_challenge(str(payload["key_fingerprint"]))["nonce"]
     sig = signature if signature is not None else _sign(nonce, payload, fingerprint)
     return d.register(payload, nonce=nonce, signature=sig)
+
+
+def test_one_approved_key_owns_at_most_one_host_record(tmp_path):
+    d = _dir(tmp_path)
+    first = _payload()
+    second = _payload(
+        host_id="hst-20260818120000-bbbbbbbb",
+        instance_id="inst-2",
+        subdomain="def456-d4e5f6",
+        public_url="https://def456-d4e5f6.relay.example",
+    )
+
+    _register(d, first)
+    with pytest.raises(DuplicateIdentity) as error:
+        _register(d, second)
+    assert "approved key is already bound to another host_id" in str(error.value)
+
+    assert d.get_host(second["host_id"]) is None
+    assert [host["host_id"] for host in d.list_hosts()] == [first["host_id"]]
+
+
+def test_same_key_different_host_ids_are_serialized_after_nonce_consumption(tmp_path):
+    d = _dir(tmp_path)
+    first = _payload()
+    second = _payload(
+        host_id="hst-20260818120000-bbbbbbbb",
+        instance_id="inst-2",
+        subdomain="def456-d4e5f6",
+        public_url="https://def456-d4e5f6.relay.example",
+    )
+    first_spent = threading.Event()
+    release_first = threading.Event()
+    consume = d._consume_nonce
+
+    def consume_then_pause(nonce, identity):
+        consume(nonce, identity)
+        if not first_spent.is_set():
+            first_spent.set()
+            release_first.wait(timeout=1)
+
+    d._consume_nonce = consume_then_pause
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        earlier = executor.submit(_register, d, first)
+        assert first_spent.wait(timeout=1)
+        assert _register(d, second)["host_id"] == second["host_id"]
+        release_first.set()
+        with pytest.raises(DuplicateIdentity):
+            earlier.result()
+
+    assert d.get_host(first["host_id"]) is None
+    assert [host["host_id"] for host in d.list_hosts()] == [second["host_id"]]
 
 
 # --- challenges -------------------------------------------------------------
@@ -562,6 +614,42 @@ def test_a_corrupt_entry_file_is_quarantined_not_fatal(tmp_path):
     assert [h["host_id"] for h in d.list_hosts()] == [_payload()["host_id"]]
     assert (tmp_path / "hosts" / "broken.json.corrupt").is_file()
     assert not (tmp_path / "hosts" / "broken.json").exists()
+
+
+def test_quarantine_cannot_move_a_concurrently_repaired_host_record(
+    tmp_path, monkeypatch
+):
+    d = _dir(tmp_path)
+    host_id = _payload()["host_id"]
+    path = tmp_path / "hosts" / f"{host_id}.json"
+    path.write_text("{not json")
+    corrupt_read = threading.Event()
+    writer_finished = threading.Event()
+    read_text = Path.read_text
+
+    def pause_after_corrupt_read(self, *args, **kwargs):
+        raw = read_text(self, *args, **kwargs)
+        if self == path and raw == "{not json" and not corrupt_read.is_set():
+            corrupt_read.set()
+            writer_finished.wait(timeout=0.1)
+        return raw
+
+    monkeypatch.setattr(Path, "read_text", pause_after_corrupt_read)
+
+    def register():
+        try:
+            return _register(d)
+        finally:
+            writer_finished.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        reader = executor.submit(d.get_host, host_id)
+        assert corrupt_read.wait(timeout=1)
+        writer = executor.submit(register)
+        reader.result()
+        assert writer.result()["host_id"] == host_id
+
+    assert d.get_host(host_id)["instance_id"] == "inst-1"
 
 
 @pytest.mark.parametrize("bad", ["yesterday", None, "NaN", "Infinity", "-Infinity"])

--- a/tests/core/relay/test_host_directory.py
+++ b/tests/core/relay/test_host_directory.py
@@ -486,6 +486,22 @@ def test_a_signed_registration_cannot_publish_a_non_relay_url(tmp_path, public_u
     assert d.get_host(_payload()["host_id"]) is None
 
 
+@pytest.mark.parametrize("subdomain", ("enroll", "egress"))
+def test_a_host_cannot_claim_a_reserved_relay_route(tmp_path, subdomain):
+    d = _dir(tmp_path)
+
+    with pytest.raises(ValueError):
+        _register(
+            d,
+            _payload(
+                subdomain=subdomain,
+                public_url=f"https://{subdomain}.relay.example",
+            ),
+        )
+
+    assert d.get_host(_payload()["host_id"]) is None
+
+
 def test_instance_probe_never_follows_a_relay_redirect():
     calls = []
 

--- a/tests/core/relay/test_host_directory.py
+++ b/tests/core/relay/test_host_directory.py
@@ -11,6 +11,7 @@ import pytest
 
 from mship.core.relay import host_contract
 from mship.core.relay.host_directory import (
+    ChallengeCapReached,
     ChallengeRefused,
     DuplicateIdentity,
     HostDirectory,
@@ -122,6 +123,53 @@ def test_an_expired_nonce_is_refused_on_the_relay_clock(tmp_path):
     with pytest.raises(ChallengeRefused):
         d.register(payload, nonce=ch["nonce"], signature=_sign(ch["nonce"], payload))
     assert d.get_host(payload["host_id"]) is None
+
+
+def test_a_nonce_is_claimed_before_it_is_read_so_a_racing_twin_loses(tmp_path):
+    """Two registrations quoting one nonce must not BOTH pass the check.
+
+    Reachable in one process: the enroll app serves sync endpoints on a
+    threadpool. The interleave is simulated by re-entering `_consume_nonce`
+    from inside the read — i.e. a second consumer arriving after the first has
+    read the record but before it finished — which an exists()-read-unlink
+    sequence would let through.
+    """
+    d = _dir(tmp_path)
+    nonce = d.issue_challenge()["nonce"]
+    losers = []
+    real_read = d._read_challenge
+
+    def racing_read(path):
+        rec = real_read(path)
+        if not losers:
+            try:
+                d._consume_nonce(nonce)
+                losers.append("ADMITTED")
+            except ChallengeRefused:
+                losers.append("refused")
+        return rec
+
+    d._read_challenge = racing_read
+    d._consume_nonce(nonce)                       # the winner
+    assert losers == ["refused"]
+    assert list((tmp_path / "challenges").iterdir()) == []
+
+
+def test_the_challenge_store_is_capped(tmp_path):
+    # Public, unauthenticated, and every call writes a file: the store is the
+    # security boundary (`RequestStore.create`'s max_pending precedent).
+    clock = Clock()
+    d = HostDirectory(
+        tmp_path, allowed_signers=lambda: FP_A, verify=_verify,
+        probe=Prober(), clock=clock, max_challenges=3,
+    )
+    for _ in range(3):
+        d.issue_challenge()
+    with pytest.raises(ChallengeCapReached):
+        d.issue_challenge()
+    # The cap is on LIVE challenges: it clears itself one TTL later.
+    clock.t += host_contract.CHALLENGE_TTL_S + 1
+    assert d.issue_challenge()["nonce"]
 
 
 def test_an_unknown_nonce_is_refused(tmp_path):
@@ -267,6 +315,18 @@ def test_an_unreachable_incumbent_yields_a_takeover_recording_the_predecessor(tm
     assert len(list((tmp_path / "hosts").glob("*.json"))) == 1
 
 
+def test_a_heartbeat_after_a_takeover_keeps_the_predecessor_on_record(tmp_path):
+    clock = Clock()
+    probe = Prober(raises=TimeoutError("no route"))
+    d = _incumbent(tmp_path, probe, clock)
+    clock.t += 10
+    _register(d, _payload(instance_id="inst-2"))
+    clock.t += 10
+    # The takeover is a fact about the entry; the next idempotent re-post must
+    # not silently erase who used to hold it.
+    assert _register(d, _payload(instance_id="inst-2"))["previous_instance_id"] == "inst-1"
+
+
 def test_a_probe_returning_no_id_yields_a_takeover(tmp_path):
     clock = Clock()
     probe = Prober({})            # answered, but not by an mship host
@@ -362,6 +422,20 @@ def test_a_corrupt_entry_file_is_quarantined_not_fatal(tmp_path):
     assert [h["host_id"] for h in d.list_hosts()] == [_payload()["host_id"]]
     assert (tmp_path / "hosts" / "broken.json.corrupt").is_file()
     assert not (tmp_path / "hosts" / "broken.json").exists()
+
+
+def test_a_non_numeric_last_seen_reads_as_offline_not_as_a_crash(tmp_path):
+    # A hand-edited entry must degrade, not brick every listing (and must not
+    # accidentally read as fresh, which would make it un-takeoverable).
+    clock = Clock()
+    d = _dir(tmp_path, clock=clock)
+    _register(d)
+    path = tmp_path / "hosts" / f"{_payload()['host_id']}.json"
+    rec = json.loads(path.read_text())
+    rec["last_seen"] = "yesterday"
+    path.write_text(json.dumps(rec))
+    assert d.list_hosts()[0]["state"] == "offline"
+    assert _register(d, _payload(instance_id="inst-2"))["previous_instance_id"] == "inst-1"
 
 
 def test_the_directory_survives_a_process_restart(tmp_path):

--- a/tests/core/relay/test_host_directory.py
+++ b/tests/core/relay/test_host_directory.py
@@ -1,0 +1,371 @@
+"""The relay host directory: the relay never asserts identity — every entry it
+writes is backed by a signature it verified against the same `pubkeys/`
+allowlist sish authenticates against, every freshness decision is stamped by
+the relay's own clock, and a second live claimant is arbitrated by probing the
+incumbent rather than by trusting a copyable fingerprint."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mship.core.relay import host_contract
+from mship.core.relay.host_directory import (
+    ChallengeRefused,
+    DuplicateIdentity,
+    HostDirectory,
+    InvalidHostId,
+    SignatureRefused,
+)
+
+FP_A = "SHA256:keyA"
+FP_B = "SHA256:keyB"
+MACHINE = "machine-fingerprint-copied-by-cp-a"
+
+
+class Clock:
+    """Injected relay clock: time only moves when a test moves it."""
+
+    def __init__(self, t=1_000.0):
+        self.t = t
+
+    def __call__(self):
+        return self.t
+
+
+class Prober:
+    """Fake arbitration probe: records the URLs probed, returns scripted ids."""
+
+    def __init__(self, answers=None, raises=None):
+        self.urls: list[str] = []
+        self._answers = answers or {}
+        self._raises = raises
+
+    def __call__(self, public_url):
+        self.urls.append(public_url)
+        if self._raises is not None:
+            raise self._raises
+        return self._answers.get(public_url)
+
+
+def _verify(blob, *, signature, identity, allowed_signers, namespace):
+    """Stand-in for `ssh_sig.verify_blob`: a signature is `sig:<fingerprint>`
+    over the exact expected blob, and only allowlisted keys can verify."""
+    assert namespace is host_contract.NAMESPACE
+    if identity not in allowed_signers:
+        return False
+    return signature == f"sig:{identity}:{blob.decode('utf-8', 'replace')}"
+
+
+def _sign(nonce, payload, fingerprint=FP_A):
+    blob = host_contract.signing_blob(nonce, payload)
+    return f"sig:{fingerprint}:{blob.decode('utf-8')}"
+
+
+def _payload(**over):
+    payload = {
+        "host_id": "hst-20260818120000-aaaaaaaa",
+        "instance_id": "inst-1",
+        "label": "vm-alpha",
+        "key_fingerprint": FP_A,
+        "machine_fingerprint": MACHINE,
+        "subdomain": "abc123",
+        "public_url": "https://abc123.relay.example",
+        "mship_version": "1.2.3",
+        "capabilities": {"tunnel": True},
+        "runner": {"enabled": False, "state": "disabled"},
+        "refresh": "refresh-token-1",
+    }
+    payload.update(over)
+    return payload
+
+
+def _dir(tmp_path, clock=None, probe=None, signers=(FP_A,)):
+    return HostDirectory(
+        tmp_path,
+        allowed_signers=lambda: "\n".join(signers),
+        verify=_verify,
+        probe=probe if probe is not None else Prober(),
+        clock=clock or Clock(),
+    )
+
+
+def _register(d, payload=None, *, fingerprint=FP_A, signature=None):
+    payload = payload if payload is not None else _payload()
+    nonce = d.issue_challenge()["nonce"]
+    sig = signature if signature is not None else _sign(nonce, payload, fingerprint)
+    return d.register(payload, nonce=nonce, signature=sig)
+
+
+# --- challenges -------------------------------------------------------------
+
+
+def test_a_nonce_is_single_use_and_relay_stamped(tmp_path):
+    clock = Clock(5_000.0)
+    d = _dir(tmp_path, clock=clock)
+    ch = d.issue_challenge()
+    assert ch["issued_at"] == 5_000.0
+    assert ch["expires_at"] == 5_000.0 + host_contract.CHALLENGE_TTL_S
+    payload = _payload()
+    d.register(payload, nonce=ch["nonce"], signature=_sign(ch["nonce"], payload))
+    # Replay of the same nonce is refused even with a perfect signature.
+    with pytest.raises(ChallengeRefused):
+        d.register(payload, nonce=ch["nonce"], signature=_sign(ch["nonce"], payload))
+
+
+def test_an_expired_nonce_is_refused_on_the_relay_clock(tmp_path):
+    clock = Clock()
+    d = _dir(tmp_path, clock=clock)
+    ch = d.issue_challenge()
+    clock.t += host_contract.CHALLENGE_TTL_S + 1
+    payload = _payload()
+    with pytest.raises(ChallengeRefused):
+        d.register(payload, nonce=ch["nonce"], signature=_sign(ch["nonce"], payload))
+    assert d.get_host(payload["host_id"]) is None
+
+
+def test_an_unknown_nonce_is_refused(tmp_path):
+    d = _dir(tmp_path)
+    payload = _payload()
+    with pytest.raises(ChallengeRefused):
+        d.register(payload, nonce="never-issued", signature=_sign("never-issued", payload))
+
+
+# --- the relay must not assert identity -------------------------------------
+
+
+def test_a_verified_registration_writes_one_entry(tmp_path):
+    clock = Clock(9_000.0)
+    d = _dir(tmp_path, clock=clock)
+    entry = _register(d)
+    on_disk = json.loads(
+        (tmp_path / "hosts" / f"{_payload()['host_id']}.json").read_text()
+    )
+    assert on_disk == entry
+    assert entry["instance_id"] == "inst-1"
+    assert entry["public_url"] == "https://abc123.relay.example"
+    assert entry["last_seen"] == 9_000.0 and entry["first_seen"] == 9_000.0
+    assert list((tmp_path / "hosts").glob("*.json")) != []
+
+
+def test_the_store_is_owner_only_because_an_entry_carries_a_refresh_credential(tmp_path):
+    d = _dir(tmp_path)
+    _register(d)
+    assert oct((tmp_path / "hosts").stat().st_mode & 0o777) == "0o700"
+    assert oct((tmp_path / "challenges").stat().st_mode & 0o777) == "0o700"
+    entry = tmp_path / "hosts" / f"{_payload()['host_id']}.json"
+    assert oct(entry.stat().st_mode & 0o777) == "0o600"
+
+
+@pytest.mark.parametrize(
+    "kind", ["unsigned", "wrong-key", "tampered-payload", "not-allowlisted"]
+)
+def test_no_entry_is_ever_written_without_a_verified_signature(tmp_path, kind):
+    d = _dir(tmp_path)
+    payload = _payload()
+    nonce = d.issue_challenge()["nonce"]
+    if kind == "unsigned":
+        sig = ""
+    elif kind == "wrong-key":
+        # Signed by an allowlisted key that is NOT the one the payload claims.
+        sig = _sign(nonce, payload, fingerprint=FP_B)
+    elif kind == "tampered-payload":
+        sig = _sign(nonce, _payload(public_url="https://evil.example"))
+    else:
+        payload = _payload(key_fingerprint=FP_B)
+        sig = _sign(nonce, payload, fingerprint=FP_B)
+    with pytest.raises(SignatureRefused):
+        d.register(payload, nonce=nonce, signature=sig)
+    assert d.get_host(payload["host_id"]) is None
+    assert list((tmp_path / "hosts").glob("*.json")) == []
+
+
+def test_a_traversal_shaped_host_id_never_touches_the_filesystem(tmp_path):
+    d = _dir(tmp_path)
+    payload = _payload(host_id="../../evil")
+    nonce = d.issue_challenge()["nonce"]
+    with pytest.raises(InvalidHostId):
+        d.register(payload, nonce=nonce, signature=_sign(nonce, payload))
+    assert list(tmp_path.rglob("*evil*")) == []
+    assert d.get_host("../../evil") is None
+
+
+# --- AC10: the relay's clock is the only clock that counts ------------------
+
+
+def test_a_skewed_payload_timestamp_changes_neither_staleness_nor_takeover(tmp_path):
+    clock = Clock(10_000.0)
+    d = _dir(tmp_path, clock=clock)
+    entry = _register(d, _payload(last_seen=0.0, registered_at=10_000.0 + 3_600))
+    assert entry["last_seen"] == 10_000.0
+    clock.t += host_contract.DIRECTORY_STALE_S - 1
+    assert d.list_hosts()[0]["state"] == "online"
+    clock.t += 2
+    assert d.list_hosts()[0]["state"] == "offline"
+
+
+# --- AC11: idempotence ------------------------------------------------------
+
+
+def test_re_registration_by_the_same_identity_is_idempotent(tmp_path):
+    clock = Clock(1_000.0)
+    d = _dir(tmp_path, clock=clock)
+    first = _register(d)
+    clock.t += 30
+    second = _register(d, _payload(capabilities={"tunnel": True, "runner": False}))
+    assert len(list((tmp_path / "hosts").glob("*.json"))) == 1
+    assert second["last_seen"] == 1_030.0
+    assert second["first_seen"] == first["first_seen"]
+    assert second["capabilities"] == {"tunnel": True, "runner": False}
+    # The refresh credential is re-published, never re-minted or appended.
+    assert second["refresh"] == first["refresh"]
+    assert "previous_instance_id" not in second or second["previous_instance_id"] is None
+
+
+def test_ten_reconnects_leave_exactly_one_entry(tmp_path):
+    clock = Clock()
+    d = _dir(tmp_path, clock=clock)
+    for _ in range(10):
+        clock.t += 5
+        _register(d)
+    assert len(list((tmp_path / "hosts").glob("*.json"))) == 1
+
+
+# --- AC4b: restart vs clone, arbitrated by probing --------------------------
+
+
+def _incumbent(tmp_path, probe, clock):
+    d = _dir(tmp_path, clock=clock, probe=probe)
+    _register(d)
+    return d
+
+
+def test_a_live_incumbent_answering_with_its_own_id_refuses_the_clone(tmp_path):
+    clock = Clock()
+    probe = Prober({"https://abc123.relay.example": "inst-1"})
+    d = _incumbent(tmp_path, probe, clock)
+    before = (tmp_path / "hosts" / f"{_payload()['host_id']}.json").read_bytes()
+    clock.t += 10
+    clone = _payload(instance_id="inst-2", refresh="refresh-token-2",
+                     public_url="https://clone.relay.example")
+    with pytest.raises(DuplicateIdentity) as e:
+        _register(d, clone)
+    assert probe.urls == ["https://abc123.relay.example"]
+    # The incumbent's entry is byte-identical: the clone changed nothing.
+    assert (tmp_path / "hosts" / f"{_payload()['host_id']}.json").read_bytes() == before
+    assert "reidentify" in str(e.value)
+
+
+def test_an_unreachable_incumbent_yields_a_takeover_recording_the_predecessor(tmp_path):
+    clock = Clock()
+    probe = Prober(raises=TimeoutError("no route"))
+    d = _incumbent(tmp_path, probe, clock)
+    clock.t += 10
+    entry = _register(d, _payload(instance_id="inst-2"))
+    assert entry["instance_id"] == "inst-2"
+    assert entry["previous_instance_id"] == "inst-1"
+    assert len(list((tmp_path / "hosts").glob("*.json"))) == 1
+
+
+def test_a_probe_returning_no_id_yields_a_takeover(tmp_path):
+    clock = Clock()
+    probe = Prober({})            # answered, but not by an mship host
+    d = _incumbent(tmp_path, probe, clock)
+    clock.t += 10
+    assert _register(d, _payload(instance_id="inst-2"))["previous_instance_id"] == "inst-1"
+
+
+def test_a_probe_answering_with_the_claimants_id_is_a_restart_takeover(tmp_path):
+    # The old tunnel is gone and sish now routes the subdomain to the new
+    # process: this is a restart, not a clone.
+    clock = Clock()
+    probe = Prober({"https://abc123.relay.example": "inst-2"})
+    d = _incumbent(tmp_path, probe, clock)
+    clock.t += 10
+    entry = _register(d, _payload(instance_id="inst-2"))
+    assert entry["instance_id"] == "inst-2"
+    assert entry["previous_instance_id"] == "inst-1"
+
+
+def test_a_different_machine_fingerprint_against_a_live_incumbent_is_refused(tmp_path):
+    clock = Clock()
+    probe = Prober({"https://abc123.relay.example": "inst-1"})
+    d = _incumbent(tmp_path, probe, clock)
+    clock.t += 10
+    with pytest.raises(DuplicateIdentity):
+        _register(d, _payload(instance_id="inst-3", machine_fingerprint="other-machine"))
+
+
+def test_a_stale_entry_is_taken_over_without_probing(tmp_path):
+    clock = Clock()
+    probe = Prober({"https://abc123.relay.example": "inst-1"})
+    d = _incumbent(tmp_path, probe, clock)
+    probe.urls.clear()
+    clock.t += host_contract.DIRECTORY_STALE_S + 1
+    entry = _register(d, _payload(instance_id="inst-2"))
+    assert entry["previous_instance_id"] == "inst-1"
+    assert probe.urls == [], "a stale incumbent needs no probe"
+
+
+# --- listing ----------------------------------------------------------------
+
+
+def test_list_hosts_marks_stale_entries_offline_and_merges_pending(tmp_path):
+    clock = Clock()
+    d = _dir(tmp_path, clock=clock)
+    _register(d)
+    pending = [{
+        "id": "abc", "hostname": "vm-beta", "fingerprint": FP_B,
+        "created_at": clock.t, "status": "pending",
+    }]
+    listed = d.list_hosts(pending=pending)
+    assert [h["state"] for h in listed] == ["online", "pending-approval"]
+    assert listed[1]["label"] == "vm-beta"
+    assert listed[1]["key_fingerprint"] == FP_B
+    clock.t += host_contract.DIRECTORY_STALE_S + 1
+    assert d.list_hosts()[0]["state"] == "offline"
+
+
+def test_a_pending_request_for_an_already_registered_key_is_not_listed_twice(tmp_path):
+    d = _dir(tmp_path)
+    _register(d)
+    pending = [{"id": "abc", "hostname": "vm-alpha", "fingerprint": FP_A,
+                "created_at": 0.0, "status": "pending"}]
+    assert [h["state"] for h in d.list_hosts(pending=pending)] == ["online"]
+
+
+def test_two_hosts_stay_independent(tmp_path):
+    clock = Clock()
+    d = _dir(tmp_path, clock=clock, signers=(FP_A, FP_B))
+    _register(d)
+    beta = _payload(host_id="hst-20260818120000-bbbbbbbb", instance_id="inst-b",
+                    key_fingerprint=FP_B, machine_fingerprint="machine-b",
+                    subdomain="def456", public_url="https://def456.relay.example",
+                    refresh="refresh-b")
+    _register(d, beta, fingerprint=FP_B)
+    clock.t += host_contract.DIRECTORY_STALE_S + 1
+    # Alpha goes stale; beta re-registers and is unaffected by its neighbour.
+    _register(d, beta, fingerprint=FP_B)
+    states = {h["host_id"]: h["state"] for h in d.list_hosts()}
+    assert states == {
+        _payload()["host_id"]: "offline",
+        beta["host_id"]: "online",
+    }
+    subdomains = {h["subdomain"] for h in d.list_hosts()}
+    assert subdomains == {"abc123", "def456"}
+
+
+def test_a_corrupt_entry_file_is_quarantined_not_fatal(tmp_path):
+    d = _dir(tmp_path)
+    _register(d)
+    (tmp_path / "hosts" / "broken.json").write_text("{not json")
+    assert [h["host_id"] for h in d.list_hosts()] == [_payload()["host_id"]]
+    assert (tmp_path / "hosts" / "broken.json.corrupt").is_file()
+    assert not (tmp_path / "hosts" / "broken.json").exists()
+
+
+def test_the_directory_survives_a_process_restart(tmp_path):
+    # On-disk store (AC3): a fresh HostDirectory over the same dir sees it.
+    clock = Clock()
+    _register(_dir(tmp_path, clock=clock))
+    assert _dir(tmp_path, clock=clock).get_host(_payload()["host_id"])["label"] == "vm-alpha"

--- a/tests/core/relay/test_host_directory.py
+++ b/tests/core/relay/test_host_directory.py
@@ -664,7 +664,9 @@ def test_an_unusable_last_seen_reads_as_offline_not_as_a_crash(tmp_path, bad):
     rec = json.loads(path.read_text())
     rec["last_seen"] = bad
     path.write_text(json.dumps(rec))
-    assert d.list_hosts()[0]["state"] == "offline"
+    listed = d.list_hosts()[0]
+    assert listed["state"] == "offline"
+    assert listed["last_seen"] == 0.0
     assert (
         _register(d, _payload(instance_id="inst-2"))["previous_instance_id"] == "inst-1"
     )

--- a/tests/core/relay/test_host_directory.py
+++ b/tests/core/relay/test_host_directory.py
@@ -428,6 +428,23 @@ def test_a_stale_entry_is_taken_over_without_probing(tmp_path):
     assert entry["previous_instance_id"] == "inst-1"
     assert probe.urls == [], "a stale incumbent needs no probe"
 
+def test_a_stale_host_id_cannot_be_claimed_by_another_approved_key(tmp_path):
+    clock = Clock()
+    probe = Prober()
+    d = _dir(tmp_path, clock=clock, probe=probe, signers=(FP_A, FP_B))
+    _register(d)
+    path = tmp_path / "hosts" / f"{_payload()['host_id']}.json"
+    before = path.read_bytes()
+    clock.t += host_contract.DIRECTORY_STALE_S + 1
+
+    claimant = _payload(instance_id="inst-2", key_fingerprint=FP_B)
+    with pytest.raises(DuplicateIdentity):
+        _register(d, claimant, fingerprint=FP_B)
+
+    assert path.read_bytes() == before
+    assert probe.urls == []
+
+
 
 # --- listing ----------------------------------------------------------------
 

--- a/tests/core/relay/test_host_directory.py
+++ b/tests/core/relay/test_host_directory.py
@@ -26,6 +26,7 @@ from mship.core.relay.host_directory import (
 
 FP_A = "SHA256:keyA"
 FP_B = "SHA256:keyB"
+FP_C = "SHA256:keyC"
 MACHINE = "machine-fingerprint-copied-by-cp-a"
 SUBDOMAIN = "abc123-a1b2c3"
 PUBLIC_URL = f"https://{SUBDOMAIN}.relay.example"
@@ -155,6 +156,73 @@ def test_same_key_different_host_ids_are_serialized_after_nonce_consumption(tmp_
 
     assert d.get_host(first["host_id"]) is None
     assert [host["host_id"] for host in d.list_hosts()] == [second["host_id"]]
+
+
+def test_concurrent_hosts_cannot_claim_the_same_relay_subdomain(tmp_path):
+    d = _dir(tmp_path, signers=(FP_A, FP_B, FP_C))
+    seed = _payload(
+        subdomain="seed123-a1b2c3",
+        public_url="https://seed123-a1b2c3.relay.example",
+    )
+    _register(d, seed)
+    seed_path = tmp_path / "hosts" / f"{seed['host_id']}.json"
+    barrier = threading.Barrier(2)
+    read_rec = d._read_rec
+
+    def read_seed_then_pause(path, **kwargs):
+        rec = read_rec(path, **kwargs)
+        if path == seed_path:
+            try:
+                barrier.wait(timeout=0.1)
+            except threading.BrokenBarrierError:
+                pass
+        return rec
+
+    d._read_rec = read_seed_then_pause
+    payloads = [
+        _payload(
+            host_id="hst-20260818120000-bbbbbbbb",
+            instance_id="inst-2",
+            key_fingerprint=FP_B,
+        ),
+        _payload(
+            host_id="hst-20260818120000-cccccccc",
+            instance_id="inst-3",
+            key_fingerprint=FP_C,
+        ),
+    ]
+
+    def register(payload):
+        try:
+            _register(d, payload, fingerprint=str(payload["key_fingerprint"]))
+            return "registered"
+        except DuplicateIdentity:
+            return "duplicate"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(register, payloads))
+
+    assert sorted(outcomes) == ["duplicate", "registered"]
+    claimed = [
+        host for host in d.list_hosts() if host["subdomain"] == SUBDOMAIN
+    ]
+    assert len(claimed) == 1
+
+
+def test_registered_host_cannot_move_to_another_relay_subdomain(tmp_path):
+    d = _dir(tmp_path)
+    _register(d)
+
+    with pytest.raises(DuplicateIdentity):
+        _register(
+            d,
+            _payload(
+                subdomain="def456-d4e5f6",
+                public_url="https://def456-d4e5f6.relay.example",
+            ),
+        )
+
+    assert d.get_host(_payload()["host_id"])["subdomain"] == SUBDOMAIN
 
 
 # --- challenges -------------------------------------------------------------

--- a/tests/core/relay/test_host_directory.py
+++ b/tests/core/relay/test_host_directory.py
@@ -3,6 +3,7 @@ writes is backed by a signature it verified against the same `pubkeys/`
 allowlist sish authenticates against, every freshness decision is stamped by
 the relay's own clock, and a second live claimant is arbitrated by probing the
 incumbent rather than by trusting a copyable fingerprint."""
+
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
@@ -13,7 +14,6 @@ import pytest
 
 from mship.core.relay import host_contract
 from mship.core.relay.host_directory import (
-    ChallengeCapReached,
     ChallengeRefused,
     DuplicateIdentity,
     HostDirectory,
@@ -99,7 +99,7 @@ def _dir(tmp_path, clock=None, probe=None, signers=(FP_A,)):
 
 def _register(d, payload=None, *, fingerprint=FP_A, signature=None):
     payload = payload if payload is not None else _payload()
-    nonce = d.issue_challenge()["nonce"]
+    nonce = d.issue_challenge(str(payload["key_fingerprint"]))["nonce"]
     sig = signature if signature is not None else _sign(nonce, payload, fingerprint)
     return d.register(payload, nonce=nonce, signature=sig)
 
@@ -110,7 +110,7 @@ def _register(d, payload=None, *, fingerprint=FP_A, signature=None):
 def test_a_nonce_is_single_use_and_relay_stamped(tmp_path):
     clock = Clock(5_000.0)
     d = _dir(tmp_path, clock=clock)
-    ch = d.issue_challenge()
+    ch = d.issue_challenge(FP_A)
     assert ch["issued_at"] == 5_000.0
     assert ch["expires_at"] == 5_000.0 + host_contract.CHALLENGE_TTL_S
     payload = _payload()
@@ -123,7 +123,7 @@ def test_a_nonce_is_single_use_and_relay_stamped(tmp_path):
 def test_an_expired_nonce_is_refused_on_the_relay_clock(tmp_path):
     clock = Clock()
     d = _dir(tmp_path, clock=clock)
-    ch = d.issue_challenge()
+    ch = d.issue_challenge(FP_A)
     clock.t += host_contract.CHALLENGE_TTL_S + 1
     payload = _payload()
     with pytest.raises(ChallengeRefused):
@@ -141,7 +141,7 @@ def test_a_nonce_is_claimed_before_it_is_read_so_a_racing_twin_loses(tmp_path):
     sequence would let through.
     """
     d = _dir(tmp_path)
-    nonce = d.issue_challenge()["nonce"]
+    nonce = d.issue_challenge(FP_A)["nonce"]
     losers = []
     real_read = d._read_challenge
 
@@ -149,34 +149,68 @@ def test_a_nonce_is_claimed_before_it_is_read_so_a_racing_twin_loses(tmp_path):
         rec = real_read(path)
         if not losers:
             try:
-                d._consume_nonce(nonce)
+                d._consume_nonce(nonce, FP_A)
                 losers.append("ADMITTED")
             except ChallengeRefused:
                 losers.append("refused")
         return rec
 
     d._read_challenge = racing_read
-    d._consume_nonce(nonce)                       # the winner
+    d._consume_nonce(nonce, FP_A)  # the winner
     assert losers == ["refused"]
     assert list((tmp_path / "challenges").glob("*.json")) == []
 
 
-def test_the_challenge_store_is_capped(tmp_path):
-    # Public, unauthenticated, and every call writes a file: the store is the
-    # security boundary (`RequestStore.create`'s max_pending precedent).
+def test_challenges_are_bounded_to_one_live_record_per_approved_identity(tmp_path):
     clock = Clock()
-    d = HostDirectory(
-        tmp_path, relay_domain="relay.example",
-        allowed_signers=lambda: FP_A, verify=_verify,
-        probe=Prober(), clock=clock, max_challenges=3,
+    d = _dir(tmp_path, clock=clock, signers=(FP_A, FP_B))
+
+    first = d.issue_challenge(FP_A)
+    assert d.issue_challenge(FP_A) == first
+    assert d.issue_challenge(FP_B)["nonce"] != first["nonce"]
+    assert len(list((tmp_path / "challenges").glob("*.json"))) == 2
+    with pytest.raises(SignatureRefused):
+        d.issue_challenge("SHA256:not-approved")
+
+
+def test_invalid_signature_does_not_burn_the_shared_identity_challenge(tmp_path):
+    d = _dir(tmp_path)
+    payload = _payload()
+    nonce = d.issue_challenge(FP_A)["nonce"]
+
+    with pytest.raises(SignatureRefused):
+        d.register(payload, nonce=nonce, signature="not-a-signature")
+
+    assert (
+        d.register(payload, nonce=nonce, signature=_sign(nonce, payload))["host_id"]
+        == payload["host_id"]
     )
-    for _ in range(3):
-        d.issue_challenge()
-    with pytest.raises(ChallengeCapReached):
-        d.issue_challenge()
-    # The cap is on LIVE challenges: it clears itself one TTL later.
-    clock.t += host_contract.CHALLENGE_TTL_S + 1
-    assert d.issue_challenge()["nonce"]
+
+
+def test_two_valid_registrations_sharing_a_nonce_admit_exactly_one(tmp_path):
+    d = _dir(tmp_path)
+    payload = _payload()
+    nonce = d.issue_challenge(FP_A)["nonce"]
+    barrier = threading.Barrier(2)
+
+    def verify_together(*args, **kwargs):
+        valid = _verify(*args, **kwargs)
+        barrier.wait(timeout=1)
+        return valid
+
+    d._verify = verify_together
+
+    def register():
+        try:
+            d.register(payload, nonce=nonce, signature=_sign(nonce, payload))
+            return "registered"
+        except ChallengeRefused:
+            return "refused"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(lambda _: register(), range(2)))
+
+    assert sorted(outcomes) == ["refused", "registered"]
 
 
 def test_a_claim_stranded_by_a_crash_is_swept_like_any_challenge(tmp_path):
@@ -184,13 +218,13 @@ def test_a_claim_stranded_by_a_crash_is_swept_like_any_challenge(tmp_path):
     # leave a file nothing ever reaps on a public write path.
     clock = Clock()
     d = _dir(tmp_path, clock=clock)
-    ch = d.issue_challenge()
-    stranded = (tmp_path / "challenges" / f"{ch['nonce']}.deadbeef.claim")
+    ch = d.issue_challenge(FP_A)
+    stranded = tmp_path / "challenges" / f"{ch['nonce']}.deadbeef.claim"
     (tmp_path / "challenges" / f"{ch['nonce']}.json").rename(stranded)
-    d.issue_challenge()                       # sweeps, but the claim is live
+    d.issue_challenge(FP_A)  # sweeps, but the claim is live
     assert stranded.is_file()
     clock.t += host_contract.CHALLENGE_TTL_S + 1
-    d.issue_challenge()
+    d.issue_challenge(FP_A)
     assert not stranded.exists()
 
 
@@ -198,7 +232,9 @@ def test_an_unknown_nonce_is_refused(tmp_path):
     d = _dir(tmp_path)
     payload = _payload()
     with pytest.raises(ChallengeRefused):
-        d.register(payload, nonce="never-issued", signature=_sign("never-issued", payload))
+        d.register(
+            payload, nonce="never-issued", signature=_sign("never-issued", payload)
+        )
 
 
 # --- the relay must not assert identity -------------------------------------
@@ -218,7 +254,9 @@ def test_a_verified_registration_writes_one_entry(tmp_path):
     assert list((tmp_path / "hosts").glob("*.json")) != []
 
 
-def test_the_store_is_owner_only_because_an_entry_carries_a_refresh_credential(tmp_path):
+def test_the_store_is_owner_only_because_an_entry_carries_a_refresh_credential(
+    tmp_path,
+):
     d = _dir(tmp_path)
     _register(d)
     assert oct((tmp_path / "hosts").stat().st_mode & 0o777) == "0o700"
@@ -227,13 +265,11 @@ def test_the_store_is_owner_only_because_an_entry_carries_a_refresh_credential(t
     assert oct(entry.stat().st_mode & 0o777) == "0o600"
 
 
-@pytest.mark.parametrize(
-    "kind", ["unsigned", "wrong-key", "tampered-payload", "not-allowlisted"]
-)
+@pytest.mark.parametrize("kind", ["unsigned", "wrong-key", "tampered-payload"])
 def test_no_entry_is_ever_written_without_a_verified_signature(tmp_path, kind):
     d = _dir(tmp_path)
     payload = _payload()
-    nonce = d.issue_challenge()["nonce"]
+    nonce = d.issue_challenge(FP_A)["nonce"]
     if kind == "unsigned":
         sig = ""
     elif kind == "wrong-key":
@@ -241,9 +277,6 @@ def test_no_entry_is_ever_written_without_a_verified_signature(tmp_path, kind):
         sig = _sign(nonce, payload, fingerprint=FP_B)
     elif kind == "tampered-payload":
         sig = _sign(nonce, _payload(public_url="https://evil.example"))
-    else:
-        payload = _payload(key_fingerprint=FP_B)
-        sig = _sign(nonce, payload, fingerprint=FP_B)
     with pytest.raises(SignatureRefused):
         d.register(payload, nonce=nonce, signature=sig)
     assert d.get_host(payload["host_id"]) is None
@@ -253,7 +286,7 @@ def test_no_entry_is_ever_written_without_a_verified_signature(tmp_path, kind):
 def test_a_traversal_shaped_host_id_never_touches_the_filesystem(tmp_path):
     d = _dir(tmp_path)
     payload = _payload(host_id="../../evil")
-    nonce = d.issue_challenge()["nonce"]
+    nonce = d.issue_challenge(FP_A)["nonce"]
     with pytest.raises(InvalidHostId):
         d.register(payload, nonce=nonce, signature=_sign(nonce, payload))
     assert list(tmp_path.rglob("*evil*")) == []
@@ -289,7 +322,9 @@ def test_re_registration_by_the_same_identity_is_idempotent(tmp_path):
     assert second["capabilities"] == {"tunnel": True, "runner": False}
     # The refresh credential is re-published, never re-minted or appended.
     assert second["refresh"] == first["refresh"]
-    assert "previous_instance_id" not in second or second["previous_instance_id"] is None
+    assert (
+        "previous_instance_id" not in second or second["previous_instance_id"] is None
+    )
 
 
 def test_ten_reconnects_leave_exactly_one_entry(tmp_path):
@@ -345,15 +380,19 @@ def test_a_heartbeat_after_a_takeover_keeps_the_predecessor_on_record(tmp_path):
     clock.t += 10
     # The takeover is a fact about the entry; the next idempotent re-post must
     # not silently erase who used to hold it.
-    assert _register(d, _payload(instance_id="inst-2"))["previous_instance_id"] == "inst-1"
+    assert (
+        _register(d, _payload(instance_id="inst-2"))["previous_instance_id"] == "inst-1"
+    )
 
 
 def test_a_probe_returning_no_id_yields_a_takeover(tmp_path):
     clock = Clock()
-    probe = Prober({})            # answered, but not by an mship host
+    probe = Prober({})  # answered, but not by an mship host
     d = _incumbent(tmp_path, probe, clock)
     clock.t += 10
-    assert _register(d, _payload(instance_id="inst-2"))["previous_instance_id"] == "inst-1"
+    assert (
+        _register(d, _payload(instance_id="inst-2"))["previous_instance_id"] == "inst-1"
+    )
 
 
 def test_a_probe_answering_with_the_claimants_id_is_a_restart_takeover(tmp_path):
@@ -374,7 +413,9 @@ def test_a_different_machine_fingerprint_against_a_live_incumbent_is_refused(tmp
     d = _incumbent(tmp_path, probe, clock)
     clock.t += 10
     with pytest.raises(DuplicateIdentity):
-        _register(d, _payload(instance_id="inst-3", machine_fingerprint="other-machine"))
+        _register(
+            d, _payload(instance_id="inst-3", machine_fingerprint="other-machine")
+        )
 
 
 def test_a_stale_entry_is_taken_over_without_probing(tmp_path):
@@ -395,10 +436,15 @@ def test_list_hosts_marks_stale_entries_offline_and_merges_pending(tmp_path):
     clock = Clock()
     d = _dir(tmp_path, clock=clock)
     _register(d)
-    pending = [{
-        "id": "abc", "hostname": "vm-beta", "fingerprint": FP_B,
-        "created_at": clock.t, "status": "pending",
-    }]
+    pending = [
+        {
+            "id": "abc",
+            "hostname": "vm-beta",
+            "fingerprint": FP_B,
+            "created_at": clock.t,
+            "status": "pending",
+        }
+    ]
     listed = d.list_hosts(pending=pending)
     assert [h["state"] for h in listed] == ["online", "pending-approval"]
     assert listed[1]["label"] == "vm-beta"
@@ -410,8 +456,15 @@ def test_list_hosts_marks_stale_entries_offline_and_merges_pending(tmp_path):
 def test_a_pending_request_for_an_already_registered_key_is_not_listed_twice(tmp_path):
     d = _dir(tmp_path)
     _register(d)
-    pending = [{"id": "abc", "hostname": "vm-alpha", "fingerprint": FP_A,
-                "created_at": 0.0, "status": "pending"}]
+    pending = [
+        {
+            "id": "abc",
+            "hostname": "vm-alpha",
+            "fingerprint": FP_A,
+            "created_at": 0.0,
+            "status": "pending",
+        }
+    ]
     assert [h["state"] for h in d.list_hosts(pending=pending)] == ["online"]
 
 
@@ -419,11 +472,15 @@ def test_two_hosts_stay_independent(tmp_path):
     clock = Clock()
     d = _dir(tmp_path, clock=clock, signers=(FP_A, FP_B))
     _register(d)
-    beta = _payload(host_id="hst-20260818120000-bbbbbbbb", instance_id="inst-b",
-                    key_fingerprint=FP_B, machine_fingerprint="machine-b",
-                    subdomain="def456-d4e5f6",
-                    public_url="https://def456-d4e5f6.relay.example",
-                    refresh="refresh-b")
+    beta = _payload(
+        host_id="hst-20260818120000-bbbbbbbb",
+        instance_id="inst-b",
+        key_fingerprint=FP_B,
+        machine_fingerprint="machine-b",
+        subdomain="def456-d4e5f6",
+        public_url="https://def456-d4e5f6.relay.example",
+        refresh="refresh-b",
+    )
     _register(d, beta, fingerprint=FP_B)
     clock.t += host_contract.DIRECTORY_STALE_S + 1
     # Alpha goes stale; beta re-registers and is unaffected by its neighbour.
@@ -459,14 +516,19 @@ def test_an_unusable_last_seen_reads_as_offline_not_as_a_crash(tmp_path, bad):
     rec["last_seen"] = bad
     path.write_text(json.dumps(rec))
     assert d.list_hosts()[0]["state"] == "offline"
-    assert _register(d, _payload(instance_id="inst-2"))["previous_instance_id"] == "inst-1"
+    assert (
+        _register(d, _payload(instance_id="inst-2"))["previous_instance_id"] == "inst-1"
+    )
 
 
 def test_the_directory_survives_a_process_restart(tmp_path):
     # On-disk store (AC3): a fresh HostDirectory over the same dir sees it.
     clock = Clock()
     _register(_dir(tmp_path, clock=clock))
-    assert _dir(tmp_path, clock=clock).get_host(_payload()["host_id"])["label"] == "vm-alpha"
+    assert (
+        _dir(tmp_path, clock=clock).get_host(_payload()["host_id"])["label"]
+        == "vm-alpha"
+    )
 
 
 @pytest.mark.parametrize(
@@ -521,15 +583,8 @@ def test_instance_probe_never_follows_a_relay_redirect():
     ]
 
 
-def test_concurrent_challenges_cannot_exceed_the_live_cap(tmp_path):
-    d = HostDirectory(
-        tmp_path,
-        allowed_signers=lambda: FP_A,
-        relay_domain="relay.example",
-        verify=_verify,
-        probe=Prober(),
-        max_challenges=1,
-    )
+def test_concurrent_requests_for_one_identity_share_one_live_challenge(tmp_path):
+    d = _dir(tmp_path)
     barrier = threading.Barrier(2)
     sweep = d._sweep_challenges
 
@@ -542,23 +597,15 @@ def test_concurrent_challenges_cannot_exceed_the_live_cap(tmp_path):
         return live
 
     d._sweep_challenges = racing_sweep
-
-    def issue():
-        try:
-            d.issue_challenge()
-            return "issued"
-        except ChallengeCapReached:
-            return "capped"
-
     with ThreadPoolExecutor(max_workers=2) as executor:
-        outcomes = list(executor.map(lambda _: issue(), range(2)))
+        challenges = list(executor.map(lambda _: d.issue_challenge(FP_A), range(2)))
 
-    assert sorted(outcomes) == ["capped", "issued"]
+    assert challenges[0] == challenges[1]
     assert len(list((tmp_path / "challenges").glob("*.json"))) == 1
 
 
 def test_same_host_registration_arbitration_is_serialized(tmp_path):
-    d = _dir(tmp_path)
+    d = _dir(tmp_path, signers=(FP_A, FP_B))
     _register(d)
     entry_path = tmp_path / "hosts" / f"{_payload()['host_id']}.json"
     barrier = threading.Barrier(2)
@@ -572,8 +619,14 @@ def test_same_host_registration_arbitration_is_serialized(tmp_path):
         return None if incumbent_id == "inst-1" else incumbent_id
 
     d._probe = probe
-    payloads = [_payload(instance_id="inst-2"), _payload(instance_id="inst-3")]
-    nonces = [d.issue_challenge()["nonce"] for _ in payloads]
+    payloads = [
+        _payload(instance_id="inst-2", key_fingerprint=FP_A),
+        _payload(instance_id="inst-3", key_fingerprint=FP_B),
+    ]
+    nonces = [
+        d.issue_challenge(str(payload["key_fingerprint"]))["nonce"]
+        for payload in payloads
+    ]
 
     def register(index):
         payload = payloads[index]
@@ -581,7 +634,9 @@ def test_same_host_registration_arbitration_is_serialized(tmp_path):
             d.register(
                 payload,
                 nonce=nonces[index],
-                signature=_sign(nonces[index], payload),
+                signature=_sign(
+                    nonces[index], payload, str(payload["key_fingerprint"])
+                ),
             )
             return "registered"
         except DuplicateIdentity:

--- a/tests/core/relay/test_host_directory.py
+++ b/tests/core/relay/test_host_directory.py
@@ -5,7 +5,9 @@ the relay's own clock, and a second live claimant is arbitrated by probing the
 incumbent rather than by trusting a copyable fingerprint."""
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 import json
+import threading
 
 import pytest
 
@@ -17,11 +19,14 @@ from mship.core.relay.host_directory import (
     HostDirectory,
     InvalidHostId,
     SignatureRefused,
+    probe_instance_id,
 )
 
 FP_A = "SHA256:keyA"
 FP_B = "SHA256:keyB"
 MACHINE = "machine-fingerprint-copied-by-cp-a"
+SUBDOMAIN = "abc123-a1b2c3"
+PUBLIC_URL = f"https://{SUBDOMAIN}.relay.example"
 
 
 class Clock:
@@ -70,8 +75,8 @@ def _payload(**over):
         "label": "vm-alpha",
         "key_fingerprint": FP_A,
         "machine_fingerprint": MACHINE,
-        "subdomain": "abc123",
-        "public_url": "https://abc123.relay.example",
+        "subdomain": SUBDOMAIN,
+        "public_url": PUBLIC_URL,
         "mship_version": "1.2.3",
         "capabilities": {"tunnel": True},
         "runner": {"enabled": False, "state": "disabled"},
@@ -84,6 +89,7 @@ def _payload(**over):
 def _dir(tmp_path, clock=None, probe=None, signers=(FP_A,)):
     return HostDirectory(
         tmp_path,
+        relay_domain="relay.example",
         allowed_signers=lambda: "\n".join(signers),
         verify=_verify,
         probe=probe if probe is not None else Prober(),
@@ -152,7 +158,7 @@ def test_a_nonce_is_claimed_before_it_is_read_so_a_racing_twin_loses(tmp_path):
     d._read_challenge = racing_read
     d._consume_nonce(nonce)                       # the winner
     assert losers == ["refused"]
-    assert list((tmp_path / "challenges").iterdir()) == []
+    assert list((tmp_path / "challenges").glob("*.json")) == []
 
 
 def test_the_challenge_store_is_capped(tmp_path):
@@ -160,7 +166,8 @@ def test_the_challenge_store_is_capped(tmp_path):
     # security boundary (`RequestStore.create`'s max_pending precedent).
     clock = Clock()
     d = HostDirectory(
-        tmp_path, allowed_signers=lambda: FP_A, verify=_verify,
+        tmp_path, relay_domain="relay.example",
+        allowed_signers=lambda: FP_A, verify=_verify,
         probe=Prober(), clock=clock, max_challenges=3,
     )
     for _ in range(3):
@@ -206,7 +213,7 @@ def test_a_verified_registration_writes_one_entry(tmp_path):
     )
     assert on_disk == entry
     assert entry["instance_id"] == "inst-1"
-    assert entry["public_url"] == "https://abc123.relay.example"
+    assert entry["public_url"] == PUBLIC_URL
     assert entry["last_seen"] == 9_000.0 and entry["first_seen"] == 9_000.0
     assert list((tmp_path / "hosts").glob("*.json")) != []
 
@@ -305,15 +312,14 @@ def _incumbent(tmp_path, probe, clock):
 
 def test_a_live_incumbent_answering_with_its_own_id_refuses_the_clone(tmp_path):
     clock = Clock()
-    probe = Prober({"https://abc123.relay.example": "inst-1"})
+    probe = Prober({PUBLIC_URL: "inst-1"})
     d = _incumbent(tmp_path, probe, clock)
     before = (tmp_path / "hosts" / f"{_payload()['host_id']}.json").read_bytes()
     clock.t += 10
-    clone = _payload(instance_id="inst-2", refresh="refresh-token-2",
-                     public_url="https://clone.relay.example")
+    clone = _payload(instance_id="inst-2", refresh="refresh-token-2")
     with pytest.raises(DuplicateIdentity) as e:
         _register(d, clone)
-    assert probe.urls == ["https://abc123.relay.example"]
+    assert probe.urls == [PUBLIC_URL]
     # The incumbent's entry is byte-identical: the clone changed nothing.
     assert (tmp_path / "hosts" / f"{_payload()['host_id']}.json").read_bytes() == before
     assert "reidentify" in str(e.value)
@@ -354,7 +360,7 @@ def test_a_probe_answering_with_the_claimants_id_is_a_restart_takeover(tmp_path)
     # The old tunnel is gone and sish now routes the subdomain to the new
     # process: this is a restart, not a clone.
     clock = Clock()
-    probe = Prober({"https://abc123.relay.example": "inst-2"})
+    probe = Prober({PUBLIC_URL: "inst-2"})
     d = _incumbent(tmp_path, probe, clock)
     clock.t += 10
     entry = _register(d, _payload(instance_id="inst-2"))
@@ -364,7 +370,7 @@ def test_a_probe_answering_with_the_claimants_id_is_a_restart_takeover(tmp_path)
 
 def test_a_different_machine_fingerprint_against_a_live_incumbent_is_refused(tmp_path):
     clock = Clock()
-    probe = Prober({"https://abc123.relay.example": "inst-1"})
+    probe = Prober({PUBLIC_URL: "inst-1"})
     d = _incumbent(tmp_path, probe, clock)
     clock.t += 10
     with pytest.raises(DuplicateIdentity):
@@ -373,7 +379,7 @@ def test_a_different_machine_fingerprint_against_a_live_incumbent_is_refused(tmp
 
 def test_a_stale_entry_is_taken_over_without_probing(tmp_path):
     clock = Clock()
-    probe = Prober({"https://abc123.relay.example": "inst-1"})
+    probe = Prober({PUBLIC_URL: "inst-1"})
     d = _incumbent(tmp_path, probe, clock)
     probe.urls.clear()
     clock.t += host_contract.DIRECTORY_STALE_S + 1
@@ -415,7 +421,8 @@ def test_two_hosts_stay_independent(tmp_path):
     _register(d)
     beta = _payload(host_id="hst-20260818120000-bbbbbbbb", instance_id="inst-b",
                     key_fingerprint=FP_B, machine_fingerprint="machine-b",
-                    subdomain="def456", public_url="https://def456.relay.example",
+                    subdomain="def456-d4e5f6",
+                    public_url="https://def456-d4e5f6.relay.example",
                     refresh="refresh-b")
     _register(d, beta, fingerprint=FP_B)
     clock.t += host_contract.DIRECTORY_STALE_S + 1
@@ -427,7 +434,7 @@ def test_two_hosts_stay_independent(tmp_path):
         beta["host_id"]: "online",
     }
     subdomains = {h["subdomain"] for h in d.list_hosts()}
-    assert subdomains == {"abc123", "def456"}
+    assert subdomains == {SUBDOMAIN, "def456-d4e5f6"}
 
 
 def test_a_corrupt_entry_file_is_quarantined_not_fatal(tmp_path):
@@ -460,3 +467,112 @@ def test_the_directory_survives_a_process_restart(tmp_path):
     clock = Clock()
     _register(_dir(tmp_path, clock=clock))
     assert _dir(tmp_path, clock=clock).get_host(_payload()["host_id"])["label"] == "vm-alpha"
+
+
+@pytest.mark.parametrize(
+    "public_url",
+    (
+        "http://169.254.169.254/latest/meta-data",
+        "http://127.0.0.1:8080",
+        "https://foreign.example",
+    ),
+)
+def test_a_signed_registration_cannot_publish_a_non_relay_url(tmp_path, public_url):
+    d = _dir(tmp_path)
+
+    with pytest.raises(ValueError):
+        _register(d, _payload(public_url=public_url))
+
+    assert d.get_host(_payload()["host_id"]) is None
+
+
+def test_instance_probe_never_follows_a_relay_redirect():
+    calls = []
+
+    class Redirect:
+        status_code = 302
+
+    def get(url, **kwargs):
+        calls.append((url, kwargs))
+        return Redirect()
+
+    assert probe_instance_id(PUBLIC_URL, get=get) is None
+    assert calls == [
+        (
+            f"{PUBLIC_URL}/health",
+            {"timeout": 5.0, "follow_redirects": False},
+        )
+    ]
+
+
+def test_concurrent_challenges_cannot_exceed_the_live_cap(tmp_path):
+    d = HostDirectory(
+        tmp_path,
+        allowed_signers=lambda: FP_A,
+        relay_domain="relay.example",
+        verify=_verify,
+        probe=Prober(),
+        max_challenges=1,
+    )
+    barrier = threading.Barrier(2)
+    sweep = d._sweep_challenges
+
+    def racing_sweep():
+        live = sweep()
+        try:
+            barrier.wait(timeout=0.1)
+        except threading.BrokenBarrierError:
+            pass
+        return live
+
+    d._sweep_challenges = racing_sweep
+
+    def issue():
+        try:
+            d.issue_challenge()
+            return "issued"
+        except ChallengeCapReached:
+            return "capped"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(lambda _: issue(), range(2)))
+
+    assert sorted(outcomes) == ["capped", "issued"]
+    assert len(list((tmp_path / "challenges").glob("*.json"))) == 1
+
+
+def test_same_host_registration_arbitration_is_serialized(tmp_path):
+    d = _dir(tmp_path)
+    _register(d)
+    entry_path = tmp_path / "hosts" / f"{_payload()['host_id']}.json"
+    barrier = threading.Barrier(2)
+
+    def probe(_public_url):
+        incumbent_id = json.loads(entry_path.read_text())["instance_id"]
+        try:
+            barrier.wait(timeout=0.1)
+        except threading.BrokenBarrierError:
+            pass
+        return None if incumbent_id == "inst-1" else incumbent_id
+
+    d._probe = probe
+    payloads = [_payload(instance_id="inst-2"), _payload(instance_id="inst-3")]
+    nonces = [d.issue_challenge()["nonce"] for _ in payloads]
+
+    def register(index):
+        payload = payloads[index]
+        try:
+            d.register(
+                payload,
+                nonce=nonces[index],
+                signature=_sign(nonces[index], payload),
+            )
+            return "registered"
+        except DuplicateIdentity:
+            return "duplicate"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(register, range(2)))
+
+    assert sorted(outcomes) == ["duplicate", "registered"]
+    assert d.get_host(_payload()["host_id"])["instance_id"] in {"inst-2", "inst-3"}

--- a/tests/core/relay/test_keys.py
+++ b/tests/core/relay/test_keys.py
@@ -1,3 +1,6 @@
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from mship.core.relay.keys import (
     ensure_relay_key,
@@ -13,7 +16,18 @@ def test_ensure_subdomain_secret_creates_stable_0600_secret(tmp_path):
     assert isinstance(s1, bytes) and len(s1) >= 32
     path = tmp_path / ".mothership" / "relay-subdomain-secret"
     assert oct(path.stat().st_mode & 0o777) == "0o600"
-    assert ensure_subdomain_secret(home=tmp_path) == s1   # stable across calls
+    assert ensure_subdomain_secret(home=tmp_path) == s1  # stable across calls
+
+
+def test_ensure_subdomain_secret_tightens_existing_secret_permissions(tmp_path):
+    path = tmp_path / ".mothership" / "relay-subdomain-secret"
+    path.parent.mkdir(mode=0o755)
+    path.write_bytes(b"x" * 32)
+    path.chmod(0o644)
+
+    assert ensure_subdomain_secret(home=tmp_path) == b"x" * 32
+    assert oct(path.parent.stat().st_mode & 0o777) == "0o700"
+    assert oct(path.stat().st_mode & 0o777) == "0o600"
 
 
 def test_ensure_subdomain_secret_regenerates_truncated_file(tmp_path):
@@ -25,19 +39,54 @@ def test_ensure_subdomain_secret_regenerates_truncated_file(tmp_path):
     s = ensure_subdomain_secret(home=tmp_path)
     assert len(s) >= 32
     assert path.read_bytes() == s
-    assert ensure_subdomain_secret(home=tmp_path) == s   # now stable
+    assert ensure_subdomain_secret(home=tmp_path) == s  # now stable
+
+
+def test_concurrent_secret_creation_returns_one_persisted_value(tmp_path, monkeypatch):
+    from mship.core.relay import keys
+
+    real_open = keys.os.open
+    first_open = threading.Event()
+
+    def pause_first_creator(*args, **kwargs):
+        fd = real_open(*args, **kwargs)
+        if not first_open.is_set():
+            first_open.set()
+            time.sleep(0.05)
+        return fd
+
+    monkeypatch.setattr(keys.os, "open", pause_first_creator)
+    barrier = threading.Barrier(8)
+
+    def create():
+        barrier.wait()
+        return ensure_subdomain_secret(home=tmp_path)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        secrets = list(executor.map(lambda _: create(), range(8)))
+
+    assert len(set(secrets)) == 1
+    assert subdomain_secret_path(tmp_path).read_bytes() == secrets[0]
+
 
 def test_generates_key_when_absent(tmp_path):
     calls = []
-    def fake_run(argv):                      # stand in for subprocess
+
+    def fake_run(argv):  # stand in for subprocess
         calls.append(argv)
         key = tmp_path / ".mothership" / "relay_ed25519"
-        key.write_text("PRIV"); (Path(str(key) + ".pub")).write_text("ssh-ed25519 AAAA mship-relay\n")
+        key.write_text("PRIV")
+        (Path(str(key) + ".pub")).write_text("ssh-ed25519 AAAA mship-relay\n")
         return 0
+
     path = ensure_relay_key(home=tmp_path, runner=fake_run)
-    assert path == tmp_path / ".mothership" / "relay_ed25519" or path.name == "relay_ed25519"
+    assert (
+        path == tmp_path / ".mothership" / "relay_ed25519"
+        or path.name == "relay_ed25519"
+    )
     assert any("ssh-keygen" in a for a in calls[0])
     assert relay_public_key(path).startswith("ssh-ed25519 ")
+
 
 def test_idempotent_when_present(tmp_path):
     # pre-create the key; runner must NOT be called
@@ -49,6 +98,7 @@ def test_idempotent_when_present(tmp_path):
     pub_path.write_text("ssh-ed25519 BBBB mship-relay\n")
 
     calls = []
+
     def fake_run(argv):
         calls.append(argv)
         return 0
@@ -60,8 +110,12 @@ def test_idempotent_when_present(tmp_path):
 
 # --- read-only path accessors (a reporter must not generate keys) ---
 
+
 def test_paths_are_readable_without_creating_anything(tmp_path):
-    assert subdomain_secret_path(tmp_path) == tmp_path / ".mothership" / "relay-subdomain-secret"
+    assert (
+        subdomain_secret_path(tmp_path)
+        == tmp_path / ".mothership" / "relay-subdomain-secret"
+    )
     assert relay_key_path(tmp_path) == tmp_path / ".mothership" / "relay_ed25519"
     # Read-only: asking for the paths must not create the dir or the files.
     assert not (tmp_path / ".mothership").exists()

--- a/tests/core/relay/test_pairing.py
+++ b/tests/core/relay/test_pairing.py
@@ -10,3 +10,14 @@ def test_parse_rejects_wrong_scheme():
     import pytest
     with pytest.raises(ValueError):
         parse_pair_link("https://add?url=x")
+
+
+def test_relay_account_link_carries_the_relay_and_the_fleet_token():
+    from mship.core.relay.pairing import build_relay_account_link
+
+    link = build_relay_account_link(relay="relay.example.com", token="abc.def+/=")
+    assert link.startswith("groundcontrol://add-relay?")
+    # quote (not quote_plus), so the token round-trips byte-for-byte.
+    assert "relay=relay.example.com" in link
+    assert "token=abc.def%2B%2F%3D" in link
+    assert " " not in link

--- a/tests/core/relay/test_run_token.py
+++ b/tests/core/relay/test_run_token.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from mship.core.relay.grants import Scope
 from mship.core.relay.run_token import issue_run_token, verify_run_token
+from mship.core.relay.token_clock import SKEW_SECONDS
 
 
 def test_issue_returns_plaintext_and_verify_accepts(tmp_path: Path):
@@ -45,3 +46,25 @@ def test_verify_rejects_expired(tmp_path: Path):
 def test_verify_rejects_unknown_token(tmp_path: Path):
     (tmp_path / "run-tokens").mkdir(parents=True, exist_ok=True)
     assert verify_run_token(tmp_path, "deadbeef.secret") is None
+
+
+# --- expiry is owned by token_clock, not by a bare `clock() >= expires_at` ---
+# The run token is presented across machines (worker → relay), so the relay's
+# wall clock can legitimately sit a little ahead of the issuer's; the shared
+# helper's skew grace is what keeps that from 401ing a live run.
+
+
+def test_verify_accepts_within_the_skew_grace(tmp_path: Path):
+    token = issue_run_token(tmp_path, enrollment_id="enr1",
+                            scope=Scope(repos=("acme/api",), push_branch="feat/x"),
+                            ttl_seconds=100, clock=lambda: 1000.0)
+    just_inside = 1100.0 + SKEW_SECONDS - 1
+    assert verify_run_token(tmp_path, token, clock=lambda: just_inside) is not None
+
+
+def test_verify_rejects_beyond_the_skew_grace(tmp_path: Path):
+    token = issue_run_token(tmp_path, enrollment_id="enr1",
+                            scope=Scope(repos=("acme/api",), push_branch="feat/x"),
+                            ttl_seconds=100, clock=lambda: 1000.0)
+    just_outside = 1100.0 + SKEW_SECONDS
+    assert verify_run_token(tmp_path, token, clock=lambda: just_outside) is None

--- a/tests/core/relay/test_run_token.py
+++ b/tests/core/relay/test_run_token.py
@@ -1,3 +1,5 @@
+import json
+
 from pathlib import Path
 from mship.core.relay.grants import Scope
 from mship.core.relay.run_token import issue_run_token, verify_run_token
@@ -46,6 +48,23 @@ def test_verify_rejects_expired(tmp_path: Path):
 def test_verify_rejects_unknown_token(tmp_path: Path):
     (tmp_path / "run-tokens").mkdir(parents=True, exist_ok=True)
     assert verify_run_token(tmp_path, "deadbeef.secret") is None
+
+
+def test_verify_rejects_a_malformed_persisted_expiry(tmp_path: Path):
+    token = issue_run_token(
+        tmp_path,
+        enrollment_id="enr1",
+        scope=Scope(repos=("acme/api",), push_branch="feat/x"),
+        ttl_seconds=3600,
+        clock=lambda: 1000.0,
+    )
+    token_id, _secret = token.split(".", 1)
+    path = tmp_path / "run-tokens" / f"{token_id}.json"
+    record = json.loads(path.read_text())
+    record["expires_at"] = "not-a-number"
+    path.write_text(json.dumps(record))
+
+    assert verify_run_token(tmp_path, token, clock=lambda: 1000.0) is None
 
 
 # --- expiry is owned by token_clock, not by a bare `clock() >= expires_at` ---

--- a/tests/core/relay/test_run_token.py
+++ b/tests/core/relay/test_run_token.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from mship.core.relay.grants import Scope
 from mship.core.relay.run_token import issue_run_token, verify_run_token
-from mship.core.relay.token_clock import SKEW_SECONDS
+from mship.core.relay.token_clock import SKEW_SECONDS, is_expired
 
 
 def test_issue_returns_plaintext_and_verify_accepts(tmp_path: Path):
@@ -68,3 +68,8 @@ def test_verify_rejects_beyond_the_skew_grace(tmp_path: Path):
                             ttl_seconds=100, clock=lambda: 1000.0)
     just_outside = 1100.0 + SKEW_SECONDS
     assert verify_run_token(tmp_path, token, clock=lambda: just_outside) is None
+
+
+def test_non_finite_expiry_fails_closed():
+    for expires_at in (float("nan"), float("inf"), float("-inf")):
+        assert is_expired(expires_at, now=1000.0) is True

--- a/tests/core/relay/test_ssh_sig.py
+++ b/tests/core/relay/test_ssh_sig.py
@@ -144,9 +144,10 @@ def test_verify_never_shells_out_for_an_empty_allowlist():
 # --- allowed_signers -------------------------------------------------------
 
 
-def test_build_allowed_signers_emits_one_line_per_approved_key(tmp_path):
+def test_build_allowed_signers_emits_approved_keys_regardless_of_filename(tmp_path):
     (tmp_path / "a.pub").write_text(PUB + "\n")
-    (tmp_path / "b.pub").write_text(PUB2 + "\n")
+    (tmp_path / "team").mkdir()
+    (tmp_path / "team" / "key-without-suffix").write_text(PUB2 + "\n")
     from mship.core.relay.enroll import fingerprint
 
     lines = build_allowed_signers(tmp_path).strip().splitlines()

--- a/tests/core/relay/test_ssh_sig.py
+++ b/tests/core/relay/test_ssh_sig.py
@@ -12,13 +12,14 @@ import pytest
 from mship.core.relay.ssh_sig import (
     SignatureError,
     build_allowed_signers,
+    revoke_allowed_key,
     sign_blob,
     verify_blob,
 )
 
 NS = "mship-host-registration"
 PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLE01 host-a"
-PUB2 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLE02 host-b"
+PUB2 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEXAMPLEEXAMPLEEXAMPLEEXAMPLEFXAMPLE02 host-b"
 
 
 class Recorder:
@@ -170,6 +171,17 @@ def test_build_allowed_signers_skips_what_validate_pubkey_rejects(tmp_path):
 
 def test_build_allowed_signers_on_a_missing_dir_is_empty(tmp_path):
     assert build_allowed_signers(tmp_path / "nope") == ""
+
+
+def test_revoke_allowed_key_removes_every_copy_of_only_that_fingerprint(tmp_path):
+    from mship.core.relay.enroll import fingerprint
+
+    (tmp_path / "a.pub").write_text(PUB + "\n")
+    (tmp_path / "duplicate.pub").write_text(PUB + "\n")
+    (tmp_path / "other.pub").write_text(PUB2 + "\n")
+
+    assert revoke_allowed_key(tmp_path, fingerprint(PUB)) == 2
+    assert sorted(path.name for path in tmp_path.iterdir()) == ["other.pub"]
 
 
 # --- real round trip -------------------------------------------------------

--- a/tests/core/relay/test_ssh_sig.py
+++ b/tests/core/relay/test_ssh_sig.py
@@ -1,0 +1,189 @@
+"""The ssh-keygen signature boundary: exact argv, typed failures, and a real
+round-trip when ssh-keygen is present (the fake can only prove the argv shape,
+not that ssh-keygen accepts it)."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mship.core.relay.ssh_sig import (
+    SignatureError,
+    build_allowed_signers,
+    sign_blob,
+    verify_blob,
+)
+
+NS = "mship-host-registration"
+PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLE01 host-a"
+PUB2 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLE02 host-b"
+
+
+class Recorder:
+    """Fake ssh-keygen: records (argv, stdin), returns scripted results."""
+
+    def __init__(self, result=None, raises=None):
+        self.calls: list[tuple[list[str], bytes]] = []
+        self._result = result
+        self._raises = raises
+
+    def __call__(self, argv, input_bytes):
+        self.calls.append((list(argv), input_bytes))
+        if self._raises is not None:
+            raise self._raises
+        if self._result is not None:
+            return self._result
+        return subprocess.CompletedProcess(argv, 0, stdout=b"SIG\n", stderr=b"")
+
+
+def _argv(rec):
+    return rec.calls[0][0]
+
+
+# --- sign ------------------------------------------------------------------
+
+
+def test_sign_builds_the_ssh_keygen_sign_argv_and_feeds_the_blob_on_stdin(tmp_path):
+    rec = Recorder()
+    sig = sign_blob(b"payload-bytes", key_path=tmp_path / "k", namespace=NS, runner=rec)
+    argv, stdin = rec.calls[0]
+    assert argv[:3] == ["ssh-keygen", "-Y", "sign"]
+    # Ordering: every flag carries its own value, and stdin ("-") is last so
+    # the blob is never mistaken for a flag argument.
+    assert argv[argv.index("-f") + 1] == str(tmp_path / "k")
+    assert argv[argv.index("-n") + 1] == NS
+    assert argv[-1] == "-"
+    assert stdin == b"payload-bytes"
+    assert sig == "SIG"
+
+
+def test_sign_raises_typed_error_on_nonzero_exit(tmp_path):
+    rec = Recorder(subprocess.CompletedProcess([], 1, stdout=b"", stderr=b"no such key"))
+    with pytest.raises(SignatureError) as e:
+        sign_blob(b"x", key_path=tmp_path / "k", namespace=NS, runner=rec)
+    assert "no such key" in str(e.value)
+
+
+def test_sign_wraps_a_raising_runner_never_leaking_calledprocesserror(tmp_path):
+    rec = Recorder(raises=subprocess.CalledProcessError(1, ["ssh-keygen"]))
+    with pytest.raises(SignatureError):
+        sign_blob(b"x", key_path=tmp_path / "k", namespace=NS, runner=rec)
+
+
+def test_sign_wraps_a_missing_ssh_keygen(tmp_path):
+    rec = Recorder(raises=FileNotFoundError("ssh-keygen"))
+    with pytest.raises(SignatureError):
+        sign_blob(b"x", key_path=tmp_path / "k", namespace=NS, runner=rec)
+
+
+# --- verify ----------------------------------------------------------------
+
+
+def test_verify_builds_the_ssh_keygen_verify_argv_over_temp_files():
+    rec = Recorder()
+    assert verify_blob(
+        b"payload-bytes",
+        signature="SIG",
+        identity="SHA256:abc",
+        allowed_signers=f"SHA256:abc {PUB}\n",
+        namespace=NS,
+        runner=rec,
+    ) is True
+    argv, stdin = rec.calls[0]
+    assert argv[:3] == ["ssh-keygen", "-Y", "verify"]
+    assert argv[argv.index("-n") + 1] == NS
+    assert argv[argv.index("-I") + 1] == "SHA256:abc"
+    signers = Path(argv[argv.index("-f") + 1])
+    sig = Path(argv[argv.index("-s") + 1])
+    # The two files exist only for the duration of the call; assert on the
+    # recorded content-bearing paths' names, not their (temp) location.
+    assert signers.name and sig.name
+    assert stdin == b"payload-bytes"
+
+
+def test_verify_returns_false_on_a_bad_signature_without_raising():
+    rec = Recorder(subprocess.CompletedProcess([], 255, stdout=b"", stderr=b"incorrect signature"))
+    assert verify_blob(
+        b"x", signature="SIG", identity="SHA256:abc",
+        allowed_signers=f"SHA256:abc {PUB}\n", namespace=NS, runner=rec,
+    ) is False
+
+
+def test_verify_wraps_a_raising_runner_in_signature_error():
+    rec = Recorder(raises=subprocess.CalledProcessError(1, ["ssh-keygen"]))
+    with pytest.raises(SignatureError):
+        verify_blob(
+            b"x", signature="SIG", identity="SHA256:abc",
+            allowed_signers=f"SHA256:abc {PUB}\n", namespace=NS, runner=rec,
+        )
+
+
+def test_verify_never_shells_out_for_an_empty_allowlist():
+    """No approved key can possibly have signed it — refuse before spawning."""
+    rec = Recorder()
+    assert verify_blob(
+        b"x", signature="SIG", identity="SHA256:abc",
+        allowed_signers="", namespace=NS, runner=rec,
+    ) is False
+    assert rec.calls == []
+
+
+# --- allowed_signers -------------------------------------------------------
+
+
+def test_build_allowed_signers_emits_one_line_per_approved_key(tmp_path):
+    (tmp_path / "a.pub").write_text(PUB + "\n")
+    (tmp_path / "b.pub").write_text(PUB2 + "\n")
+    from mship.core.relay.enroll import fingerprint
+
+    lines = build_allowed_signers(tmp_path).strip().splitlines()
+    assert len(lines) == 2
+    for line, pub in zip(lines, (PUB, PUB2)):
+        principal, ktype, body = line.split()[:3]
+        assert principal == fingerprint(pub)
+        assert (ktype, body) == tuple(pub.split()[:2])
+
+
+def test_build_allowed_signers_skips_what_validate_pubkey_rejects(tmp_path):
+    (tmp_path / "good.pub").write_text(PUB + "\n")
+    (tmp_path / "junk.pub").write_text("not-a-key\n")
+    (tmp_path / "injected.pub").write_text(PUB + "\nssh-ed25519 AAAAsmuggled evil\n")
+    out = build_allowed_signers(tmp_path)
+    assert out.strip().count("\n") == 0
+    assert "evil" not in out and "not-a-key" not in out
+
+
+def test_build_allowed_signers_on_a_missing_dir_is_empty(tmp_path):
+    assert build_allowed_signers(tmp_path / "nope") == ""
+
+
+# --- real round trip -------------------------------------------------------
+
+
+@pytest.mark.skipif(shutil.which("ssh-keygen") is None, reason="ssh-keygen not installed")
+def test_real_round_trip_signs_and_verifies_against_the_pubkeys_allowlist(tmp_path):
+    key = tmp_path / "id_ed25519"
+    subprocess.run(
+        ["ssh-keygen", "-t", "ed25519", "-f", str(key), "-N", "", "-q"], check=True
+    )
+    pubkeys = tmp_path / "pubkeys"
+    pubkeys.mkdir()
+    (pubkeys / "host.pub").write_text((tmp_path / "id_ed25519.pub").read_text())
+    from mship.core.relay.enroll import fingerprint
+
+    fp = fingerprint((tmp_path / "id_ed25519.pub").read_text())
+    signers = build_allowed_signers(pubkeys)
+    blob = "hôst-registratiön".encode("utf-8")
+
+    sig = sign_blob(blob, key_path=key, namespace=NS)
+    assert verify_blob(blob, signature=sig, identity=fp,
+                       allowed_signers=signers, namespace=NS) is True
+    # Tampered payload, wrong namespace and unknown identity all fail closed.
+    assert verify_blob(blob + b"!", signature=sig, identity=fp,
+                       allowed_signers=signers, namespace=NS) is False
+    assert verify_blob(blob, signature=sig, identity=fp,
+                       allowed_signers=signers, namespace="other-ns") is False
+    assert verify_blob(blob, signature=sig, identity="SHA256:nobody",
+                       allowed_signers=signers, namespace=NS) is False

--- a/tests/core/relay/test_ssh_sig.py
+++ b/tests/core/relay/test_ssh_sig.py
@@ -162,6 +162,7 @@ def test_build_allowed_signers_skips_what_validate_pubkey_rejects(tmp_path):
     (tmp_path / "good.pub").write_text(PUB + "\n")
     (tmp_path / "junk.pub").write_text("not-a-key\n")
     (tmp_path / "injected.pub").write_text(PUB + "\nssh-ed25519 AAAAsmuggled evil\n")
+    (tmp_path / "binary").write_bytes(b"\xff")
     out = build_allowed_signers(tmp_path)
     assert out.strip().count("\n") == 0
     assert "evil" not in out and "not-a-key" not in out

--- a/tests/core/relay/test_ssh_sig.py
+++ b/tests/core/relay/test_ssh_sig.py
@@ -22,15 +22,25 @@ PUB2 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLE
 
 
 class Recorder:
-    """Fake ssh-keygen: records (argv, stdin), returns scripted results."""
+    """Fake ssh-keygen: records (argv, stdin), returns scripted results.
+
+    Also snapshots the CONTENT of any `-f`/`-s` file while the call is in
+    flight — they are temp files the caller deletes on return, so asserting
+    after the fact could only see their names."""
 
     def __init__(self, result=None, raises=None):
         self.calls: list[tuple[list[str], bytes]] = []
+        self.files: dict[str, str] = {}
         self._result = result
         self._raises = raises
 
     def __call__(self, argv, input_bytes):
         self.calls.append((list(argv), input_bytes))
+        for flag in ("-f", "-s"):
+            if flag in argv:
+                path = Path(argv[argv.index(flag) + 1])
+                if path.is_file():
+                    self.files[flag] = path.read_text()
         if self._raises is not None:
             raise self._raises
         if self._result is not None:
@@ -95,12 +105,13 @@ def test_verify_builds_the_ssh_keygen_verify_argv_over_temp_files():
     assert argv[:3] == ["ssh-keygen", "-Y", "verify"]
     assert argv[argv.index("-n") + 1] == NS
     assert argv[argv.index("-I") + 1] == "SHA256:abc"
-    signers = Path(argv[argv.index("-f") + 1])
-    sig = Path(argv[argv.index("-s") + 1])
-    # The two files exist only for the duration of the call; assert on the
-    # recorded content-bearing paths' names, not their (temp) location.
-    assert signers.name and sig.name
+    # The two files exist only for the duration of the call — assert what
+    # ssh-keygen actually reads out of them.
+    assert rec.files["-f"] == f"SHA256:abc {PUB}\n"
+    assert rec.files["-s"] == "SIG\n"
     assert stdin == b"payload-bytes"
+    # …and nothing is left behind afterwards.
+    assert not Path(argv[argv.index("-f") + 1]).exists()
 
 
 def test_verify_returns_false_on_a_bad_signature_without_raising():

--- a/tests/core/relay/test_ssh_sig.py
+++ b/tests/core/relay/test_ssh_sig.py
@@ -61,11 +61,10 @@ def test_sign_builds_the_ssh_keygen_sign_argv_and_feeds_the_blob_on_stdin(tmp_pa
     sig = sign_blob(b"payload-bytes", key_path=tmp_path / "k", namespace=NS, runner=rec)
     argv, stdin = rec.calls[0]
     assert argv[:3] == ["ssh-keygen", "-Y", "sign"]
-    # Ordering: every flag carries its own value, and stdin ("-") is last so
-    # the blob is never mistaken for a flag argument.
-    assert argv[argv.index("-f") + 1] == str(tmp_path / "k")
-    assert argv[argv.index("-n") + 1] == NS
-    assert argv[-1] == "-"
+    # With no positional input file, ssh-keygen reads the blob from stdin and
+    # writes the armored signature to stdout. A literal "-" names a file.
+    assert argv[-1] == "-q"
+    assert "-" not in argv
     assert stdin == b"payload-bytes"
     assert sig == "SIG"
 

--- a/tests/core/relay/test_tunnel_supervisor.py
+++ b/tests/core/relay/test_tunnel_supervisor.py
@@ -6,15 +6,30 @@ from mship.core.relay.tunnel import BACKOFF_JITTER, TunnelSupervisor
 
 
 class FakeProc:
-    def __init__(self): self._alive = True; self.terminated = False
-    def poll(self): return None if self._alive else 0
-    def terminate(self): self.terminated = True; self._alive = False
-    def wait(self, timeout=None): self._alive = False; return 0
+    def __init__(self):
+        self._alive = True
+        self.terminated = False
+
+    def poll(self):
+        return None if self._alive else 0
+
+    def terminate(self):
+        self.terminated = True
+        self._alive = False
+
+    def wait(self, timeout=None):
+        self._alive = False
+        return 0
 
 
 def test_start_then_stop_terminates_process():
     procs = []
-    def factory(argv): p = FakeProc(); procs.append(p); return p
+
+    def factory(argv):
+        p = FakeProc()
+        procs.append(p)
+        return p
+
     sup = TunnelSupervisor(argv=["ssh", "..."], proc_factory=factory)
     sup.start()
     assert sup.is_running() and len(procs) == 1
@@ -54,7 +69,11 @@ def test_stop_kills_a_process_that_ignores_terminate():
 def test_restart_on_unexpected_exit():
     """tick() respawns the process when it exits unexpectedly (not via stop())."""
     procs = []
-    def factory(argv): p = FakeProc(); procs.append(p); return p
+
+    def factory(argv):
+        p = FakeProc()
+        procs.append(p)
+        return p
 
     sup = TunnelSupervisor(argv=["ssh", "..."], proc_factory=factory, backoff_delay=0)
     sup.start()
@@ -73,10 +92,16 @@ def test_restart_on_unexpected_exit():
 def test_backoff_gates_respawn():
     """tick() must NOT respawn until the backoff delay has elapsed."""
     procs = []
-    def factory(argv): p = FakeProc(); procs.append(p); return p
+
+    def factory(argv):
+        p = FakeProc()
+        procs.append(p)
+        return p
 
     t = [0.0]
-    def fake_clock(): return t[0]
+
+    def fake_clock():
+        return t[0]
 
     sup = TunnelSupervisor(
         argv=["ssh", "..."],
@@ -105,13 +130,19 @@ def test_backoff_gates_respawn():
 # --- #471: an immortal daemon owns this supervisor, so the backoff must be
 # --- clamped, jittered from an injected RNG, and reset by a healthy run.
 
+
 def _sup(procs, clock, **kw):
-    def factory(argv): p = FakeProc(); procs.append(p); return p
+    def factory(argv):
+        p = FakeProc()
+        procs.append(p)
+        return p
+
     kw.setdefault("backoff_delay", 5.0)
     kw.setdefault("max_backoff_delay", 60.0)
-    kw.setdefault("rng", lambda: 0.0)          # no jitter unless a test asks
-    return TunnelSupervisor(argv=["ssh", "..."], proc_factory=factory,
-                            clock=lambda: clock[0], **kw)
+    kw.setdefault("rng", lambda: 0.0)  # no jitter unless a test asks
+    return TunnelSupervisor(
+        argv=["ssh", "..."], proc_factory=factory, clock=lambda: clock[0], **kw
+    )
 
 
 def test_backoff_is_clamped_past_1024_restarts():
@@ -120,13 +151,13 @@ def test_backoff_is_clamped_past_1024_restarts():
     procs, t = [], [0.0]
     sup = _sup(procs, t)
     sup.start()
-    sup._restart_count = 2000                  # what 17h of flapping leaves behind
+    sup._restart_count = 2000  # what 17h of flapping leaves behind
 
     procs[0]._alive = False
-    sup.tick()                                 # must not raise OverflowError
+    sup.tick()  # must not raise OverflowError
     assert len(procs) == 1, "capped delay still gates the respawn"
 
-    t[0] = 60.0                                # the cap, not 5 * 2**2000
+    t[0] = 60.0  # the cap, not 5 * 2**2000
     sup.tick()
     assert len(procs) == 2
     assert sup.restart_count == 2001
@@ -140,12 +171,12 @@ def test_a_healthy_run_resets_the_restart_count():
     sup.start()
     sup._restart_count = 9
 
-    t[0] = 500.0                               # the child held for 500s
+    t[0] = 500.0  # the child held for 500s
     procs[0]._alive = False
     sup.tick()
     assert sup.restart_count == 0, "the streak ended when the run went healthy"
 
-    t[0] = 505.0                               # one base delay later, not the cap
+    t[0] = 505.0  # one base delay later, not the cap
     sup.tick()
     assert len(procs) == 2 and sup.restart_count == 1
 
@@ -156,7 +187,7 @@ def test_a_short_run_does_not_reset_the_restart_count():
     sup.start()
     sup._restart_count = 3
 
-    t[0] = 2.0                                 # died well inside the backoff cap
+    t[0] = 2.0  # died well inside the backoff cap
     procs[0]._alive = False
     sup.tick()
     assert sup.restart_count == 3
@@ -172,7 +203,7 @@ def test_jitter_comes_from_the_injected_rng_and_only_shortens():
         sup._restart_count = 2000
         procs[0]._alive = False
 
-        sup.tick()                             # freezes the jittered delay
+        sup.tick()  # freezes the jittered delay
         delay = sup.next_delay()
         assert 60.0 * (1 - BACKOFF_JITTER) <= delay <= 60.0
 
@@ -188,8 +219,8 @@ def test_two_supervisors_do_not_respawn_on_the_same_tick():
     """A fleet that all lost the relay in one second must not stampede it."""
     t = [0.0]
     slow_procs, fast_procs = [], []
-    slow = _sup(slow_procs, t, rng=lambda: 0.0)     # full delay
-    fast = _sup(fast_procs, t, rng=lambda: 1.0)     # 20% off it
+    slow = _sup(slow_procs, t, rng=lambda: 0.0)  # full delay
+    fast = _sup(fast_procs, t, rng=lambda: 1.0)  # 20% off it
     for sup, procs in ((slow, slow_procs), (fast, fast_procs)):
         sup.start()
         sup._restart_count = 2000
@@ -197,7 +228,8 @@ def test_two_supervisors_do_not_respawn_on_the_same_tick():
         sup.tick()
 
     t[0] = 60.0 * (1 - BACKOFF_JITTER)
-    slow.tick(); fast.tick()
+    slow.tick()
+    fast.tick()
     assert len(fast_procs) == 2 and len(slow_procs) == 1
 
 
@@ -206,21 +238,22 @@ def test_a_spawn_that_raises_never_reads_as_a_healthy_run():
     exit-detection wipe the streak once the delay reaches the cap, so the
     escalation the clamp exists for sawtooths at restart_count 1 forever."""
     procs, t = [], [0.0]
-    sup = _sup(procs, t)                       # backoff 5s, cap 60s
+    sup = _sup(procs, t)  # backoff 5s, cap 60s
     sup.start()
     procs[0]._alive = False
     sup._proc_factory = lambda argv: (_ for _ in ()).throw(OSError("ssh: not found"))
 
     counts = []
+    sup.tick()  # freeze the delay for the process that exited
     for _ in range(10):
-        t[0] += 1000.0                         # far past the healthy-run threshold
-        sup.tick()                             # freeze the delay for this exit
-        t[0] += 1000.0
+        t[0] += 1000.0  # far past each scheduled retry
         with pytest.raises(OSError):
-            sup.tick()                         # the respawn attempt itself fails
+            sup.tick()
         counts.append(sup.restart_count)
 
-    assert counts == list(range(1, 11)), "the failure streak did not escalate monotonically"
+    assert counts == list(range(1, 11)), (
+        "the failure streak did not escalate monotonically"
+    )
     assert len(procs) == 1 and sup.spawn_count == 1
 
 

--- a/tests/core/relay/test_tunnel_supervisor.py
+++ b/tests/core/relay/test_tunnel_supervisor.py
@@ -264,3 +264,35 @@ def test_plain_stop_is_reversible_but_a_final_stop_is_not():
 
     assert len(procs) == 2
     assert not sup.is_running()
+
+
+def test_final_stop_terminates_a_child_created_during_spawn():
+    """Shutdown can close the latch while a blocking process factory is still
+    creating the session-started ssh child on the tunnel executor thread."""
+    from threading import Event, Thread
+
+    factory_entered = Event()
+    release_factory = Event()
+    procs = []
+
+    def factory(argv):
+        factory_entered.set()
+        assert release_factory.wait(timeout=5)
+        proc = FakeProc()
+        procs.append(proc)
+        return proc
+
+    sup = TunnelSupervisor(argv=["ssh", "..."], proc_factory=factory)
+    spawning = Thread(target=sup.start)
+    spawning.start()
+    assert factory_entered.wait(timeout=5)
+
+    sup.stop(final=True)
+    release_factory.set()
+    spawning.join(timeout=5)
+
+    assert not spawning.is_alive()
+    assert len(procs) == 1
+    assert procs[0].terminated
+    assert sup.spawn_count == 0
+    assert not sup.is_running()

--- a/tests/core/relay/test_tunnel_supervisor.py
+++ b/tests/core/relay/test_tunnel_supervisor.py
@@ -1,3 +1,5 @@
+import subprocess
+
 import pytest
 
 from mship.core.relay.tunnel import BACKOFF_JITTER, TunnelSupervisor
@@ -18,6 +20,35 @@ def test_start_then_stop_terminates_process():
     assert sup.is_running() and len(procs) == 1
     sup.stop()
     assert procs[0].terminated and not sup.is_running()
+
+
+def test_stop_kills_a_process_that_ignores_terminate():
+    class WedgedProc(FakeProc):
+        def __init__(self):
+            super().__init__()
+            self.killed = False
+
+        def terminate(self):
+            self.terminated = True
+
+        def wait(self, timeout=None):
+            if self._alive:
+                raise subprocess.TimeoutExpired("ssh", timeout)
+            return 0
+
+        def kill(self):
+            self.killed = True
+            self._alive = False
+
+    proc = WedgedProc()
+    sup = TunnelSupervisor(argv=["ssh", "..."], proc_factory=lambda _argv: proc)
+    sup.start()
+
+    sup.stop(final=True)
+
+    assert proc.terminated
+    assert proc.killed
+    assert not sup.is_running()
 
 
 def test_restart_on_unexpected_exit():

--- a/tests/core/relay/test_tunnel_supervisor.py
+++ b/tests/core/relay/test_tunnel_supervisor.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mship.core.relay.tunnel import BACKOFF_JITTER, TunnelSupervisor
 
 
@@ -166,3 +168,45 @@ def test_two_supervisors_do_not_respawn_on_the_same_tick():
     t[0] = 60.0 * (1 - BACKOFF_JITTER)
     slow.tick(); fast.tick()
     assert len(fast_procs) == 2 and len(slow_procs) == 1
+
+
+def test_a_spawn_that_raises_never_reads_as_a_healthy_run():
+    """A failed spawn started no run at all. Stamping one lets the next
+    exit-detection wipe the streak once the delay reaches the cap, so the
+    escalation the clamp exists for sawtooths at restart_count 1 forever."""
+    procs, t = [], [0.0]
+    sup = _sup(procs, t)                       # backoff 5s, cap 60s
+    sup.start()
+    procs[0]._alive = False
+    sup._proc_factory = lambda argv: (_ for _ in ()).throw(OSError("ssh: not found"))
+
+    counts = []
+    for _ in range(10):
+        t[0] += 1000.0                         # far past the healthy-run threshold
+        sup.tick()                             # freeze the delay for this exit
+        t[0] += 1000.0
+        with pytest.raises(OSError):
+            sup.tick()                         # the respawn attempt itself fails
+        counts.append(sup.restart_count)
+
+    assert counts == list(range(1, 11)), "the failure streak did not escalate monotonically"
+    assert len(procs) == 1 and sup.spawn_count == 1
+
+
+def test_spawn_count_only_ever_increases():
+    """The signal a caller needs for 'a new child exists': `restart_count` is
+    reset by a healthy run and zeroed by start(), and this is not."""
+    procs, t = [], [0.0]
+    sup = _sup(procs, t, backoff_delay=0.0)
+    sup.start()
+    assert sup.spawn_count == 1
+
+    for _ in range(3):
+        procs[-1]._alive = False
+        sup.tick()
+    assert sup.spawn_count == 4 and sup.restart_count == 3
+
+    sup.stop()
+    sup.start()
+    assert sup.restart_count == 0, "start() resets the restart counter"
+    assert sup.spawn_count == 5, "...but never the spawn counter"

--- a/tests/core/relay/test_tunnel_supervisor.py
+++ b/tests/core/relay/test_tunnel_supervisor.py
@@ -210,3 +210,32 @@ def test_spawn_count_only_ever_increases():
     sup.start()
     assert sup.restart_count == 0, "start() resets the restart counter"
     assert sup.spawn_count == 5, "...but never the spawn counter"
+
+
+def test_callable_argv_is_re_resolved_at_every_spawn():
+    """#471 AC4: an auto-reidentify mints a new host id and therefore a new
+    subdomain, so an argv frozen at construction would reconnect the
+    re-identified host to a subdomain it no longer owns."""
+    procs, spawned = [], []
+    subdomain = ["old-sub"]
+
+    def factory(argv):
+        spawned.append(argv)
+        proc = FakeProc()
+        procs.append(proc)
+        return proc
+
+    sup = TunnelSupervisor(
+        argv=lambda: ["ssh", "-R", f"{subdomain[0]}:80:localhost:47190"],
+        proc_factory=factory,
+        backoff_delay=0,
+    )
+    sup.start()
+    assert spawned[0][-1].startswith("old-sub:")
+
+    subdomain[0] = "new-sub"
+    procs[0]._alive = False
+    sup.tick()
+
+    assert len(spawned) == 2
+    assert spawned[1][-1].startswith("new-sub:")

--- a/tests/core/relay/test_tunnel_supervisor.py
+++ b/tests/core/relay/test_tunnel_supervisor.py
@@ -1,4 +1,4 @@
-from mship.core.relay.tunnel import TunnelSupervisor
+from mship.core.relay.tunnel import BACKOFF_JITTER, TunnelSupervisor
 
 
 class FakeProc:
@@ -67,3 +67,102 @@ def test_backoff_gates_respawn():
     sup.tick()
     assert len(procs) == 2, "should have respawned after backoff delay elapsed"
     assert sup.is_running()
+
+
+# --- #471: an immortal daemon owns this supervisor, so the backoff must be
+# --- clamped, jittered from an injected RNG, and reset by a healthy run.
+
+def _sup(procs, clock, **kw):
+    def factory(argv): p = FakeProc(); procs.append(p); return p
+    kw.setdefault("backoff_delay", 5.0)
+    kw.setdefault("max_backoff_delay", 60.0)
+    kw.setdefault("rng", lambda: 0.0)          # no jitter unless a test asks
+    return TunnelSupervisor(argv=["ssh", "..."], proc_factory=factory,
+                            clock=lambda: clock[0], **kw)
+
+
+def test_backoff_is_clamped_past_1024_restarts():
+    """`backoff_delay * 2 ** restart_count` overflows a float at 1024 — ~17h of
+    failures, unreachable for a CLI and routine for a daemon that never exits."""
+    procs, t = [], [0.0]
+    sup = _sup(procs, t)
+    sup.start()
+    sup._restart_count = 2000                  # what 17h of flapping leaves behind
+
+    procs[0]._alive = False
+    sup.tick()                                 # must not raise OverflowError
+    assert len(procs) == 1, "capped delay still gates the respawn"
+
+    t[0] = 60.0                                # the cap, not 5 * 2**2000
+    sup.tick()
+    assert len(procs) == 2
+    assert sup.restart_count == 2001
+
+
+def test_a_healthy_run_resets_the_restart_count():
+    """A tunnel that held for longer than the worst-case backoff ended a failure
+    streak; the next drop must retry fast rather than at the cap."""
+    procs, t = [], [0.0]
+    sup = _sup(procs, t)
+    sup.start()
+    sup._restart_count = 9
+
+    t[0] = 500.0                               # the child held for 500s
+    procs[0]._alive = False
+    sup.tick()
+    assert sup.restart_count == 0, "the streak ended when the run went healthy"
+
+    t[0] = 505.0                               # one base delay later, not the cap
+    sup.tick()
+    assert len(procs) == 2 and sup.restart_count == 1
+
+
+def test_a_short_run_does_not_reset_the_restart_count():
+    procs, t = [], [0.0]
+    sup = _sup(procs, t)
+    sup.start()
+    sup._restart_count = 3
+
+    t[0] = 2.0                                 # died well inside the backoff cap
+    procs[0]._alive = False
+    sup.tick()
+    assert sup.restart_count == 3
+
+
+def test_jitter_comes_from_the_injected_rng_and_only_shortens():
+    """Downward only: `MAX_BACKOFF_S` stays the true maximum, which is what
+    `host_contract.DIRECTORY_STALE_S` is derived from."""
+    for value in (0.0, 0.5, 1.0):
+        procs, t = [], [0.0]
+        sup = _sup(procs, t, rng=lambda v=value: v)
+        sup.start()
+        sup._restart_count = 2000
+        procs[0]._alive = False
+
+        sup.tick()                             # freezes the jittered delay
+        delay = sup.next_delay()
+        assert 60.0 * (1 - BACKOFF_JITTER) <= delay <= 60.0
+
+        t[0] = delay - 0.001
+        sup.tick()
+        assert len(procs) == 1, "respawned before its own jittered delay"
+        t[0] = delay
+        sup.tick()
+        assert len(procs) == 2
+
+
+def test_two_supervisors_do_not_respawn_on_the_same_tick():
+    """A fleet that all lost the relay in one second must not stampede it."""
+    t = [0.0]
+    slow_procs, fast_procs = [], []
+    slow = _sup(slow_procs, t, rng=lambda: 0.0)     # full delay
+    fast = _sup(fast_procs, t, rng=lambda: 1.0)     # 20% off it
+    for sup, procs in ((slow, slow_procs), (fast, fast_procs)):
+        sup.start()
+        sup._restart_count = 2000
+        procs[0]._alive = False
+        sup.tick()
+
+    t[0] = 60.0 * (1 - BACKOFF_JITTER)
+    slow.tick(); fast.tick()
+    assert len(fast_procs) == 2 and len(slow_procs) == 1

--- a/tests/core/relay/test_tunnel_supervisor.py
+++ b/tests/core/relay/test_tunnel_supervisor.py
@@ -239,3 +239,28 @@ def test_callable_argv_is_re_resolved_at_every_spawn():
 
     assert len(spawned) == 2
     assert spawned[1][-1].startswith("new-sub:")
+
+
+def test_plain_stop_is_reversible_but_a_final_stop_is_not():
+    """`HostTunnel` stops the child to sit out a duplicate identity and dials
+    again when it clears, so stop() must stay reversible — while the shutdown
+    path must be able to latch it shut against a tick still in flight (#471
+    AC7)."""
+    procs = []
+
+    def factory(argv):
+        procs.append(FakeProc())
+        return procs[-1]
+
+    sup = TunnelSupervisor(argv=["ssh", "..."], proc_factory=factory)
+    sup.start()
+    sup.stop()
+    sup.start()
+    assert len(procs) == 2, "a transient stop must not end the tunnel for good"
+
+    sup.stop(final=True)
+    sup.start()
+    sup.tick()
+
+    assert len(procs) == 2
+    assert not sup.is_running()

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -43,6 +43,26 @@ def test_health(tmp_path):
     assert r.json() == {"status": "ok", "workspace": "test-ws"}
 
 
+def test_health_carries_daemon_workspace_identity_when_provided(tmp_path):
+    state = StateManager(tmp_path / ".mothership")
+    app = create_app(
+        specs_dir=tmp_path / "specs",
+        state_manager=state,
+        log_manager=None,
+        workspace_root=tmp_path,
+        workspace_name="test-ws",
+        host_id="host-a",
+        workspace_id="ws-a",
+    )
+
+    assert TestClient(app).get("/health").json() == {
+        "status": "ok",
+        "workspace": "test-ws",
+        "host_id": "host-a",
+        "workspace_id": "ws-a",
+    }
+
+
 def test_list_specs(tmp_path):
     _seed_spec(tmp_path)
     r = TestClient(_app(tmp_path)).get("/specs")

--- a/tests/test_runtime_imports.py
+++ b/tests/test_runtime_imports.py
@@ -1,0 +1,19 @@
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module",
+    (
+        "mship.cli.relay",
+        "mship.core.daemon.host_tunnel",
+        "mship.core.daemon.relay_link",
+        "mship.core.daemon.run",
+        "mship.core.relay.enroll",
+        "mship.core.relay.fleet_token",
+        "mship.core.relay.host_directory",
+    ),
+)
+def test_runtime_modules_import(module):
+    importlib.import_module(module)

--- a/tests/util/test_shell.py
+++ b/tests/util/test_shell.py
@@ -28,7 +28,11 @@ def test_run_streaming_uses_new_process_group_on_windows():
     CREATE_NEW_PROCESS_GROUP = 0x00000200  # Windows constant, may not exist on Linux
     runner = ShellRunner()
     with patch("mship.util.shell.os.name", "nt"):
-        with patch("mship.util.shell.subprocess.CREATE_NEW_PROCESS_GROUP", CREATE_NEW_PROCESS_GROUP, create=True):
+        with patch(
+            "mship.util.shell.subprocess.CREATE_NEW_PROCESS_GROUP",
+            CREATE_NEW_PROCESS_GROUP,
+            create=True,
+        ):
             with patch("subprocess.Popen") as mock_popen:
                 runner.run_streaming("sleep 1", cwd=Path("."))
                 kwargs = mock_popen.call_args.kwargs
@@ -207,9 +211,7 @@ def test_cancellable_run_argv_accepts_supported_posix_hosts(
     if platform == "linux":
         process_dir = proc_root / "123"
         process_dir.mkdir(parents=True)
-        (process_dir / "stat").write_bytes(
-            b"123 (python) S 1 123 0 0 0 0 0\n"
-        )
+        (process_dir / "stat").write_bytes(b"123 (python) S 1 123 0 0 0 0 0\n")
     popen = _successful_popen()
     monkeypatch.setattr(shell_module.os, "name", "posix")
     monkeypatch.setattr(shell_module.sys, "platform", platform)
@@ -279,11 +281,17 @@ while True:
     runner_thread = threading.Thread(target=run_command, daemon=True)
     runner_thread.start()
     deadline = time.monotonic() + 5
-    while not ready_path.exists() and time.monotonic() < deadline:
-        threading.Event().wait(0.01)
-    assert ready_path.exists(), "descendant did not report readiness"
+    descendant_pid_text = ""
+    while not descendant_pid_text and time.monotonic() < deadline:
+        try:
+            descendant_pid_text = ready_path.read_text()
+        except FileNotFoundError:
+            pass
+        if not descendant_pid_text:
+            threading.Event().wait(0.01)
+    assert descendant_pid_text, "descendant did not report readiness"
 
-    descendant_pid = int(ready_path.read_text())
+    descendant_pid = int(descendant_pid_text)
     process_group = os.getpgid(descendant_pid)
     proc_stat = Path(f"/proc/{descendant_pid}/stat")
     try:
@@ -376,9 +384,7 @@ def test_forced_group_cleanup_reaps_leader_before_absence_wait(
 def test_linux_group_scan_accepts_non_utf8_process_name(tmp_path, monkeypatch):
     process_dir = tmp_path / "123"
     process_dir.mkdir()
-    (process_dir / "stat").write_bytes(
-        b"123 (\xff process) S 1 424242 0 0 0 0 0\n"
-    )
+    (process_dir / "stat").write_bytes(b"123 (\xff process) S 1 424242 0 0 0 0 0\n")
     real_scandir = os.scandir
 
     def scan_test_proc(path):
@@ -396,9 +402,7 @@ def test_linux_group_scan_accepts_zombie_with_unreadable_unrelated_stat(
 ):
     zombie_dir = tmp_path / "123"
     zombie_dir.mkdir()
-    (zombie_dir / "stat").write_bytes(
-        b"123 (zombie) Z 1 424242 0 0 0 0 0\n"
-    )
+    (zombie_dir / "stat").write_bytes(b"123 (zombie) Z 1 424242 0 0 0 0 0\n")
     unreadable_dir = tmp_path / "456"
     unreadable_dir.mkdir()
     (unreadable_dir / "stat").write_bytes(b"malformed")

--- a/uv.lock
+++ b/uv.lock
@@ -559,7 +559,7 @@ wheels = [
 
 [[package]]
 name = "mothership"
-version = "0.5.56"
+version = "0.5.54"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -559,7 +559,7 @@ wheels = [
 
 [[package]]
 name = "mothership"
-version = "0.5.54"
+version = "0.5.56"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

- Add machine-bound host identity, process-instance arbitration, short-lived host bearers, refresh credentials, signed relay registration, and the relay host directory.
- Run and supervise the host tunnel inside the always-on daemon; expose accurate health/status and re-identification behavior; harden shutdown, request-size, and enrollment-renewal boundaries.
- Add Ground Control relay accounts, persisted hosts, token refresh, identity-verified workspace adoption, direct/relay failover, legacy deep-link compatibility, re-pair actions, and time-driven host-state rendering.
- Document tunnel registration, relay hosting changes, security behavior, and the manual VM/relay verification boundary.

## Test plan

- [x] `mship test` iteration 36: Mothership passed (`4,897 passed`)
- [x] `mship test` iteration 36: Ground Control `BUILD SUCCESSFUL`
- [x] PR review regressions cover shutdown escalation, relay registration locking and URL ownership, live identity propagation, enrollment TTL negotiation, host endpoint fallback, fleet refresh propagation, direct-only ladder state, atomic fleet replacement, monotonic contact freshness, and queue deduplication

Closes atomikpanda/mothership#471


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tunnel registration so a relay host can reach the phone without a static address
> - Introduces a full host-tunnel registration stack: stable `host_id`/`instance_id` identity ([identity.py](https://github.com/atomikpanda/mothership/pull/478/files#diff-de4eef758f8c9770c2b1fd1a6e979ea094869abb4f1a42a905f6da29255eea4e)), relay subdomain derivation, SSH-signed registration payloads ([ssh_sig.py](https://github.com/atomikpanda/mothership/pull/478/files#diff-adc00f4f406800420cc24fb31cdb6df6b455f4ccf651fe7b180af6d37bb6d3c0)), and a host directory on the relay ([host_directory.py](https://github.com/atomikpanda/mothership/pull/478/files#diff-dfb539fbe3723131e8b55029b2ccab06a9dabcd4213ae84a930e7ba8375e9778)).
> - Adds `RelayLink` ([relay_link.py](https://github.com/atomikpanda/mothership/pull/478/files#diff-c950efa45c2f6c24e0c52fc6e97c37666319fef690664f22fcb491c8ff2137a6)) and `TunnelSupervisor` ([tunnel.py](https://github.com/atomikpanda/mothership/pull/478/files#diff-805bb3c57d4db5c28988b9032d830f8a71900604b668a7c98cc887cf4f92d2ca)) to manage the sish tunnel process with jittered exponential backoff, thread-safe stop/kill escalation, and a callable `argv` for runtime subdomain changes.
> - Extends the daemon run loop ([run.py](https://github.com/atomikpanda/mothership/pull/478/files#diff-a63f43d9b1b57a9eaeb1b2f00798e55ac1503006bd8b295a7a886ef18f49a551)) to drive `tunnel.tick()` concurrently with the control and host servers under a shared asyncio stop event, with bounded shutdown and coordinated signal handling.
> - Adds a short-lived bearer token model: `RefreshStore` ([host_auth.py](https://github.com/atomikpanda/mothership/pull/478/files#diff-872d31f861156d25abc5bcb2283ff6a7227cb0fc091b9dd5319e5a7a603cc3d2)) issues long-lived refresh credentials; `issue_host_token` ([host_token.py](https://github.com/atomikpanda/mothership/pull/478/files#diff-b981d2d1aaca16415d77c08dbbb7d40981137f4ff8a05b53910e0e5f8f89a283)) mints short-lived bearers; relay-borne requests require a valid bearer and cannot use the standing token.
> - Relay operator tooling: `mship relay fleet-token` mints/revokes per-device tokens with QR output; `mship relay hosts` lists the directory; `mship daemon reidentify` rotates identity and relay key; Caddy routes `/hosts/*` to the enroll server with an 8 KB body cap.
> - Risk: `except ValueError, KeyError:` in [enroll.py](https://github.com/atomikpanda/mothership/pull/478/files#diff-623ba9e86fc2e6503bf43ed63c7bff71ca54fb09c91501ebb823fd6b489ea685) is invalid Python 3 syntax and will cause a `SyntaxError` on import of the relay CLI module.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e970b77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->