### PR TITLE
ci: adopt trusted agentic reviewer v1.2

### DIFF
--- a/.github/workflows/agentic-review.yml
+++ b/.github/workflows/agentic-review.yml
@@ -1,7 +1,7 @@
 name: agentic-review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize]
 
 permissions:


### PR DESCRIPTION
## Summary
- switch the reviewer caller to base-controlled `pull_request_target`
- continue tracking `@v1` and `central_ref: v1`, now resolving to reviewer `v1.2.0`

## Why
Reviewer v1.2.0 deliberately skips legacy `pull_request` callers because their entry-point workflow is not base-controlled. Without this migration, review jobs resolve the new version but skip before running any steps.

## Test plan
- [x] workflow parses as YAML
- [x] caller contains `pull_request_target` and no legacy `pull_request` trigger
- [x] reusable workflow and support both remain pinned to `v1`
