### PR TITLE
Fix host tunnel read-back empty Bearer header

### DIFF
--- a/src/mship/core/relay/health.py
+++ b/src/mship/core/relay/health.py
@@ -22,7 +22,7 @@ class HealthProbe:
 
 def probe_health(public_url: str, token: str, *, get: Callable | None = None,
                  timeout: float = 8.0) -> HealthProbe:
-    """Probe `<public_url>/health` with the bearer token. Never raises.
+    """Probe `<public_url>/health`, authenticating only when a token is provided.
 
     The single reachability prober for the codebase: `verify_relay_reachable`
     renders its prose from this, and `mship.core.topology` maps the status code
@@ -35,8 +35,9 @@ def probe_health(public_url: str, token: str, *, get: Callable | None = None,
         import httpx
         get = lambda url, **kw: httpx.get(url, **kw)
     url = public_url.rstrip("/") + "/health"
+    headers = {"Authorization": f"Bearer {token}"} if token else None
     try:
-        r = get(url, headers={"Authorization": f"Bearer {token}"},
+        r = get(url, headers=headers,
                 timeout=timeout, follow_redirects=False)
     except Exception as e:  # transport/DNS/TLS error
         return HealthProbe(ok=False, error=str(e))

--- a/tests/core/relay/test_health.py
+++ b/tests/core/relay/test_health.py
@@ -34,6 +34,18 @@ def test_health_probe_does_not_follow_relay_redirects():
 
     assert seen == [False]
 
+def test_health_probe_omits_authorization_when_token_is_empty():
+    seen = {}
+
+    def get(*_args, **kwargs):
+        seen["headers"] = kwargs["headers"]
+        return _Resp(200)
+
+    probe = probe_health("https://w-ab12.relay", "", get=get)
+
+    assert probe.ok is True
+    assert not seen["headers"]
+
 
 def test_not_ok_on_401_explains_token():
     ok, detail = verify_relay_reachable("https://w.relay", "tok", get=lambda *a, **k: _Resp(401))

--- a/tests/test_finish_gate.py
+++ b/tests/test_finish_gate.py
@@ -29,6 +29,8 @@ def finish_gate_workspace(workspace_with_git: Path):
     state_dir.mkdir(exist_ok=True)
     container.config_path.override(workspace_with_git / "mothership.yaml")
     container.state_dir.override(state_dir)
+    container.config.reset()
+    container.state_manager.reset()
 
     def _default_run(cmd, cwd, env=None):
         if "gh auth status" in cmd:


### PR DESCRIPTION
## Summary
- omit the Authorization header when a relay health probe has no token
- cover unauthenticated host-tunnel read-back without changing authenticated probes
- reset cached config/state providers in the finish-gate fixture so xdist file scheduling is order-independent

## Test plan
- [x] regression test fails before the health-probe fix
- [x] `uv run pytest -q tests/core/relay/test_health.py` — 17 passed
- [x] `task lint`
- [x] `mship test` iteration 3 — pass in 97.6s
- [x] independent reviewer — ready, no findings
