### PR TITLE
Require explicit relay owner store

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -67,14 +67,19 @@ safe-skips foreign links, files, and directories unless `--force` is explicit.
 extension compatibility and recommends `mship skill install --only omp` (plus
 `--force` for foreign content) when repair is needed.
 
-`mship relay` manages the reverse-tunnel relay client keys (for `mship serve --relay`, see [`relay-hosting.md`](relay-hosting.md)):
+`mship relay` manages reverse-tunnel client keys and relay-owner state (for
+`mship serve --relay`, see [`relay-hosting.md`](relay-hosting.md)). Every
+relay-owner command uses the same explicit `<store>` as `enroll-server`:
 
 ```bash
-mship relay setup                                   # generate the relay SSH key (if absent) + print an enroll command
-mship relay enroll                                  # from a NEW device: request relay access (owner approves/denies)
-mship relay enroll-server                           # run the public enroll endpoint on the relay host
-mship relay requests                                # list pending enroll requests (id · hostname · fingerprint)
-mship relay approve <id> | deny <id>                # approve (add key to allowlist) / deny a pending request
+mship relay setup                                             # generate the client relay SSH key
+mship relay enroll                                            # request relay access from a new device
+mship relay enroll-server --store-dir <store> ...             # run the public endpoint on the relay host
+mship relay requests --store-dir <store>                      # list pending enrollment requests
+mship relay approve <id> --store-dir <store> --pubkeys-dir <pubkeys>
+mship relay deny <id> --store-dir <store>
+mship relay fleet-token --label phone --relay-domain <relay> --store-dir <store>
+mship relay hosts --store-dir <store>                         # list the daemon host directory
 ```
 
 ## Work items & specs

--- a/docs/cloud-worker-auth-spine.md
+++ b/docs/cloud-worker-auth-spine.md
@@ -101,11 +101,16 @@ to such secrets makes the attach-at-egress boundary more load-bearing, not less.
 ## 5. Operator setup
 
 ```bash
+RELAY_STORE=/path/to/docker/relay/pending-store
+RELAY_PUBKEYS=/path/to/docker/relay/pubkeys
+
 # 1. Approve the worker's enrollment (existing enroll flow).
-mship relay approve <enrollment-id>
+mship relay approve <enrollment-id> \
+  --store-dir "$RELAY_STORE" --pubkeys-dir "$RELAY_PUBKEYS"
 
 # 2. Set the CEILING — the repos this enrollment may EVER touch.
-mship relay grant <enrollment-id> --provider github-app --repos owner/a,owner/b
+mship relay grant <enrollment-id> --store-dir "$RELAY_STORE" \
+  --provider github-app --repos owner/a,owner/b
 
 # 3. Issue a PER-RUN token (repos ⊆ ceiling, one push branch). Printed ONCE.
 mship relay issue-run-token <enrollment-id> --repos owner/a --push-branch feat/<slug>

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -95,7 +95,9 @@ With a relay configured, the daemon does two things beside the servers on the
 same asyncio loop: it keeps an `ssh -R` tunnel to the relay up, and it keeps
 this host's entry in the relay's host directory current. Together they are what
 makes a freshly provisioned VM reachable from the phone with **no address typed
-anywhere** — the phone scans one relay QR and reads the directory.
+anywhere** — the phone scans one relay QR and reads the directory. See
+[Which pairing QR do I need?](relay-hosting.md#which-pairing-qr-do-i-need) for
+the distinction between one-workspace and daemon-fleet pairing.
 
 ### Identity
 
@@ -126,8 +128,9 @@ aside to `<name>.pre-reidentify-<UTC timestamp>` and a new one generated. The
 rotation is the point — the clone still holds a copy of the old private key and
 that key is still in the relay's `pubkeys/`, so keeping it would let the twin go
 on authenticating as this host. The new key is unapproved by construction, so
-the host lands back in the enrollment queue and needs one more
-`mship relay approve <id>` on the relay box.
+the host lands back in the enrollment queue and needs one more approval on the
+relay box: inspect the live enroll-server command, then run `mship relay approve
+<id> --store-dir <relay-store> --pubkeys-dir <relay-pubkeys>`.
 
 ### Tokens
 
@@ -193,7 +196,8 @@ tunnel authenticates with (`ssh-keygen -Y sign`, namespace
 after a failure it backs off from 2s to a 60s cap, jittered **downward** so a
 fleet returning after a relay redeploy does not retry in lockstep.
 
-`mship relay hosts` on the relay box lists the directory; a host that has not
+`mship relay hosts --store-dir <relay-store>` on the relay box lists the
+directory; a host that has not
 re-registered within 240s (three intervals plus a worst-case backoff) reads as
 `offline` there rather than disappearing.
 
@@ -206,7 +210,7 @@ answering, `status` says so rather than guessing:
 | state | what `mship daemon status` prints |
 |---|---|
 | `disabled` | `tunnel: disabled (no relay configured)` |
-| `awaiting-enrollment` | `tunnel: awaiting relay approval (run 'mship relay approve <id>' on the relay host)` |
+| `awaiting-enrollment` | `tunnel: awaiting relay approval (on relay host, inspect \`pgrep -af 'mship.*relay.*enroll-server'\`, then run \`mship relay approve <id> --store-dir <relay-store> --pubkeys-dir <relay-pubkeys>\`)` |
 | `connecting` | `tunnel: connecting <public_url>` |
 | `online` | `tunnel: online <public_url> (<n> restarts)` |
 | `contended` | `tunnel: contended — another host holds <subdomain>` |

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -18,6 +18,47 @@ internet
 
 ---
 
+## Which pairing QR do I need?
+
+Ground Control accepts two different QR credentials:
+
+| Goal | Command | Run it on |
+|---|---|---|
+| Add one running workspace | `mship pair --relay-host <relay-domain>` | That workspace's host, from its workspace directory |
+| Add every workspace discovered by `mship daemon` | `mship relay fleet-token` | The central relay box |
+
+The daemon/fleet QR must use the same state directory as the running
+`enroll-server`. On the central relay box, inspect the live process rather than
+assuming a working directory or reading a unit file that may not have been
+restarted:
+
+```bash
+pgrep -af 'mship.*relay.*enroll-server'
+```
+
+Copy the absolute `--store-dir` from that command. Supply the relay domain from
+its `--relay-domain` argument when present, or from the `RELAY_DOMAIN` value used
+by the service. Then run the matching CLI as the same operating-system user:
+
+```bash
+mship relay fleet-token \
+  --label <phone-name> \
+  --relay-domain <relay-domain> \
+  --store-dir <absolute-store-dir>
+```
+
+The command prints a `groundcontrol://add-relay?...` link and a terminal QR.
+In Ground Control, open **Settings → Relay account → Add relay account** and
+scan it. Re-running the command with the same label reprints the same
+credential; it does not unpair an existing phone.
+
+The QR is a fleet-wide read credential. Do not share it or send its deep link
+to an external QR generator. A different store can mint a valid-looking QR,
+but the running relay will reject it because it verifies against its own
+`fleet-tokens.json`.
+
+---
+
 ## Prerequisites
 
 | Requirement | Notes |
@@ -155,10 +196,10 @@ mship relay enroll-server \
 
 `--relay-domain` can also be set via the `RELAY_DOMAIN` environment variable. The enroll-server is reached from the internet only through Caddy at `https://enroll.<relay>` — the raw `:47180` port is not accessible externally.
 
-Every owner-side command must receive its applicable `--store-dir` and
-`--pubkeys-dir` explicitly. The examples below use
-`/path/to/docker/relay/pending-store` and `/path/to/docker/relay/pubkeys`;
-substitute the exact values from the running unit's `ExecStart`.
+Every owner-side command requires the exact `--store-dir` used by the running
+enroll-server; commands that write sish keys also need its `--pubkeys-dir`.
+Use absolute paths. See [Which pairing QR do I need?](#which-pairing-qr-do-i-need)
+for the live-process discovery command.
 
 > **Important — keep the enroll-server supervised.** The enroll-server backs Caddy's on-demand TLS `ask` endpoint, which gates cert issuance **and renewal** for every relay subdomain — not just new enrollment requests. If the enroll-server is down, Caddy cannot renew existing certs and will refuse to issue new ones for serve subdomains. Unlike sish and Caddy (which Docker Compose restarts automatically), the enroll-server runs outside the compose stack and **must run under a supervisor so it survives reboots**.
 >

--- a/docs/unattended-cloud-runner.md
+++ b/docs/unattended-cloud-runner.md
@@ -112,14 +112,19 @@ With **no** App creds the egress-server **fails closed** — every request retur
 ### C. Enroll a worker identity + set its ceiling
 
 ```bash
+RELAY_STORE=/path/to/docker/relay/pending-store
+RELAY_PUBKEYS=/path/to/docker/relay/pubkeys
+
 # The worker device requests access; you approve it (existing enroll flow):
 mship relay enroll          # from the worker device — requests relay access
-mship relay requests        # on the relay host — list pending (id · host · fp)
-mship relay approve <request-id>
+mship relay requests --store-dir "$RELAY_STORE"  # on relay host: pending id/host/fp
+mship relay approve <request-id> \
+  --store-dir "$RELAY_STORE" --pubkeys-dir "$RELAY_PUBKEYS"
 
 # Set the CEILING — the repos this enrollment may EVER touch (superset of any
 # single run's repos):
-mship relay grant <enrollment-id> --provider github-app \
+mship relay grant <enrollment-id> --store-dir "$RELAY_STORE" \
+  --provider github-app \
   --repos owner/workspace-repo,owner/member-a,owner/member-b
 ```
 

--- a/src/mship/cli/daemon.py
+++ b/src/mship/cli/daemon.py
@@ -410,8 +410,11 @@ def register(parent: typer.Typer, get_container):
         out.print(
             f"re-identified as {ident.host_id} (was {ident.cloned_from})\n"
             f"new relay subdomain: {host_subdomain_for(home, ident.host_id)}\n"
-            "the rotated key needs approving again (`mship relay approve <id>` on "
-            "the relay host); run `mship daemon restart` to dial with it"
+            "the rotated key needs approving again on the relay host; inspect "
+            "the live server with:\n"
+            "  pgrep -af 'mship.*relay.*enroll-server'\n"
+            "then run `mship relay approve <id> --store-dir <relay-store> "
+            "--pubkeys-dir <relay-pubkeys>` and `mship daemon restart`"
         )
 
     @daemon_app.command("logs")

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -22,12 +22,30 @@ from mship.core.relay.config import canonical_relay_host
 
 
 def _require_store_dir(value: str | None) -> str:
-    if value is None:
+    if value is None or not value.strip():
         raise typer.BadParameter(
             "--store-dir must match the running enroll-server. Inspect its live "
             "command with `pgrep -af 'mship.*relay.*enroll-server'`."
         )
     return value
+
+
+def _require_pubkeys_dir(value: str | None) -> str:
+    if value is None or not value.strip():
+        raise typer.BadParameter(
+            "--pubkeys-dir must name the sish allowlist directory."
+        )
+    return value
+
+
+def _required_pubkeys_dir():
+    return typer.Option(
+        None,
+        "--pubkeys-dir",
+        metavar="PATH",
+        callback=_require_pubkeys_dir,
+        help="sish pubkeys allowlist directory. Required explicitly.",
+    )
 
 
 def _required_store_dir():
@@ -185,13 +203,7 @@ def register(parent: typer.Typer, get_container):
 
     @relay_app.command("enroll-server")
     def enroll_server(
-        pubkeys_dir: str = typer.Option(
-            "./pubkeys",
-            "--pubkeys-dir",
-            help="Allowlist dir used by 'mship relay approve' "
-            "(this server only creates pending requests; "
-            "it never writes keys).",
-        ),
+        pubkeys_dir: str = _required_pubkeys_dir(),
         store_dir: str = _required_store_dir(),
         port: int = typer.Option(47180, "--port", help="Port to listen on."),
         host: str = typer.Option(
@@ -241,11 +253,7 @@ def register(parent: typer.Typer, get_container):
     def approve_cmd(
         rid: str = typer.Argument(..., help="Request ID to approve."),
         store_dir: str = _required_store_dir(),
-        pubkeys_dir: str = typer.Option(
-            "./pubkeys",
-            "--pubkeys-dir",
-            help="Directory where approved keys are written (sish pubkeys/).",
-        ),
+        pubkeys_dir: str = _required_pubkeys_dir(),
     ):
         """Approve a pending request: add its key to the allowlist (sish picks it up, no restart)."""
         from pathlib import Path

--- a/src/mship/cli/relay.py
+++ b/src/mship/cli/relay.py
@@ -21,6 +21,28 @@ from mship.cli.output import Output
 from mship.core.relay.config import canonical_relay_host
 
 
+def _require_store_dir(value: str | None) -> str:
+    if value is None:
+        raise typer.BadParameter(
+            "--store-dir must match the running enroll-server. Inspect its live "
+            "command with `pgrep -af 'mship.*relay.*enroll-server'`."
+        )
+    return value
+
+
+def _required_store_dir():
+    return typer.Option(
+        None,
+        "--store-dir",
+        metavar="PATH",
+        callback=_require_store_dir,
+        help=(
+            "Relay state directory shared with enroll-server. Required so an "
+            "owner command cannot silently use a different store."
+        ),
+    )
+
+
 def enroll_base_url(*, enroll_url, relay_host, config_host):
     """Resolve the enroll endpoint base URL. Precedence:
     explicit --enroll-url  >  --relay-host  >  configured relay.host.
@@ -170,11 +192,7 @@ def register(parent: typer.Typer, get_container):
             "(this server only creates pending requests; "
             "it never writes keys).",
         ),
-        store_dir: str = typer.Option(
-            "./pending-store",
-            "--store-dir",
-            help="Directory for pending enroll request state.",
-        ),
+        store_dir: str = _required_store_dir(),
         port: int = typer.Option(47180, "--port", help="Port to listen on."),
         host: str = typer.Option(
             "127.0.0.1", "--host", help="Interface to bind (loopback; Caddy fronts it)."
@@ -204,11 +222,7 @@ def register(parent: typer.Typer, get_container):
 
     @relay_app.command("requests")
     def requests_cmd(
-        store_dir: str = typer.Option(
-            "./pending-store",
-            "--store-dir",
-            help="Directory for pending enroll request state.",
-        ),
+        store_dir: str = _required_store_dir(),
     ):
         """List pending enroll requests (id · hostname · fingerprint)."""
         from pathlib import Path
@@ -226,11 +240,7 @@ def register(parent: typer.Typer, get_container):
     @relay_app.command("approve")
     def approve_cmd(
         rid: str = typer.Argument(..., help="Request ID to approve."),
-        store_dir: str = typer.Option(
-            "./pending-store",
-            "--store-dir",
-            help="Directory for pending enroll request state.",
-        ),
+        store_dir: str = _required_store_dir(),
         pubkeys_dir: str = typer.Option(
             "./pubkeys",
             "--pubkeys-dir",
@@ -255,11 +265,7 @@ def register(parent: typer.Typer, get_container):
     @relay_app.command("deny")
     def deny_cmd(
         rid: str = typer.Argument(..., help="Request ID to deny."),
-        store_dir: str = typer.Option(
-            "./pending-store",
-            "--store-dir",
-            help="Directory for pending enroll request state.",
-        ),
+        store_dir: str = _required_store_dir(),
     ):
         """Deny a pending request (does not touch the allowlist)."""
         from pathlib import Path
@@ -287,11 +293,7 @@ def register(parent: typer.Typer, get_container):
             "--label",
             help="Nickname for the device this token is for (e.g. phone).",
         ),
-        store_dir: str = typer.Option(
-            "./pending-store",
-            "--store-dir",
-            help="Directory for pending enroll request state.",
-        ),
+        store_dir: str = _required_store_dir(),
         relay_domain: str = typer.Option(
             lambda: os.environ.get("RELAY_DOMAIN", ""),
             "--relay-domain",
@@ -341,11 +343,7 @@ def register(parent: typer.Typer, get_container):
 
     @relay_app.command("hosts")
     def hosts_cmd(
-        store_dir: str = typer.Option(
-            "./pending-store",
-            "--store-dir",
-            help="Directory for pending enroll request state.",
-        ),
+        store_dir: str = _required_store_dir(),
     ):
         """List the relay's host directory (host_id · label · state · last_seen)."""
         import time
@@ -407,11 +405,7 @@ def register(parent: typer.Typer, get_container):
         repos: str = typer.Option(
             ..., "--repos", help="Ceiling repos owner/a,owner/b."
         ),
-        store_dir: str = typer.Option(
-            "./pending-store",
-            "--store-dir",
-            help="Enroll request store (to confirm approval).",
-        ),
+        store_dir: str = _required_store_dir(),
         grant_store_dir: str = typer.Option(
             "./grants-store",
             "--grant-store-dir",
@@ -503,7 +497,10 @@ def register(parent: typer.Typer, get_container):
         )
         if ceiling is None:
             out.error(
-                f"enrollment {rid!r} has no github-app grant; run `mship relay grant` first"
+                f"enrollment {rid!r} has no github-app grant; on the relay host, "
+                "inspect `pgrep -af 'mship.*relay.*enroll-server'`, then run "
+                f"`mship relay grant {rid} --store-dir <relay-store> "
+                "--provider github-app --repos <ceiling-repos>`"
             )
             raise typer.Exit(1)
         try:
@@ -648,7 +645,11 @@ def register(parent: typer.Typer, get_container):
             out.error("enroll server returned an unexpected response (no request id)")
             raise typer.Exit(1)
         out.print(
-            f"requested (id {rid}) — ask the relay owner to run: mship relay approve {rid}"
+            f"requested (id {rid}) — on the relay host, inspect the live "
+            "enroll-server command:\n"
+            "  pgrep -af 'mship.*relay.*enroll-server'\n"
+            f"then run: mship relay approve {rid} --store-dir <relay-store> "
+            "--pubkeys-dir <relay-pubkeys>"
         )
         if not wait:
             return

--- a/src/mship/core/daemon/status.py
+++ b/src/mship/core/daemon/status.py
@@ -46,8 +46,10 @@ _LOOP_WINDOW_S = 600
 _TUNNEL_LINES = {
     "disabled": "tunnel: disabled (no relay configured)",
     "awaiting-enrollment": (
-        "tunnel: awaiting relay approval "
-        "(run 'mship relay approve <id>' on the relay host)"
+        "tunnel: awaiting relay approval (on relay host, inspect "
+        "`pgrep -af 'mship.*relay.*enroll-server'`, then run "
+        "`mship relay approve <id> --store-dir <relay-store> "
+        "--pubkeys-dir <relay-pubkeys>`)"
     ),
     "connecting": "tunnel: connecting {public_url}",
     "online": "tunnel: online {public_url} ({restarts} restarts)",

--- a/src/mship/core/relay/fleet_token.py
+++ b/src/mship/core/relay/fleet_token.py
@@ -3,8 +3,9 @@ relay's host directory (`GET /hosts`).
 
 The `core.daemon.host_auth.RefreshStore` shape, for the same two reasons:
 
-- **Stable per label.** `mship relay fleet-token --label phone` is the command
-  that prints the QR, and an operator will run it again just to re-display it.
+- **Stable per label.** `mship relay fleet-token --label phone --store-dir
+  <relay-store>` prints the QR, and an operator will run it again just to
+  re-display it.
   A fresh secret on every run would silently unpair the phone that already
   scanned the last one — so the secret is *derived* from a relay root secret
   plus a per-label nonce, and a re-mint recomputes it and writes nothing.

--- a/tests/cli/test_daemon.py
+++ b/tests/cli/test_daemon.py
@@ -1023,6 +1023,9 @@ def test_reidentify_prints_the_new_subdomain(cli, tmp_path, no_keygen):
 
     assert res.exit_code == 0, res.output
     assert host_subdomain_for(tmp_path, _identity(tmp_path)["host_id"]) in res.output
+    assert "--store-dir <relay-store>" in res.output
+    assert "--pubkeys-dir <relay-pubkeys>" in res.output
+    assert "pgrep -af" in res.output
 
 
 def test_reidentify_keep_identity_adopts_the_fingerprint_without_reminting(

--- a/tests/cli/test_relay_cli.py
+++ b/tests/cli/test_relay_cli.py
@@ -662,3 +662,6 @@ def test_enroll_no_wait_returns_after_post(tmp_path, monkeypatch):
     )
     assert r.exit_code == 0, r.output
     assert "rid123" in r.output
+    assert "--store-dir <relay-store>" in r.output
+    assert "--pubkeys-dir <relay-pubkeys>" in r.output
+    assert "pgrep -af" in r.output

--- a/tests/cli/test_relay_grant.py
+++ b/tests/cli/test_relay_grant.py
@@ -69,6 +69,30 @@ def test_issue_run_token_within_ceiling_prints_token(tmp_path: Path):
     assert rt is not None and rt.enrollment_id == rid
 
 
+def test_issue_run_token_without_a_grant_points_to_the_relay_store(tmp_path: Path):
+    rid = _approved_enrollment(tmp_path)
+    result = CliRunner().invoke(
+        _app(),
+        [
+            "relay",
+            "issue-run-token",
+            rid,
+            "--repos",
+            "acme/api",
+            "--push-branch",
+            "feat/x",
+            "--grant-store-dir",
+            str(tmp_path / "grants-store"),
+            "--run-token-dir",
+            str(tmp_path / "run-tokens-store"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "mship relay grant" in result.output
+    assert "--store-dir <relay-store>" in result.output
+    assert "pgrep -af" in result.output
+
+
 def test_issue_run_token_repo_outside_ceiling_fails(tmp_path: Path):
     rid = _approved_enrollment(tmp_path)
     GrantStore(tmp_path / "grants-store").set_grant(

--- a/tests/cli/test_relay_hosts.py
+++ b/tests/cli/test_relay_hosts.py
@@ -69,7 +69,7 @@ def test_fleet_token_requires_an_explicit_store_dir(monkeypatch, tmp_path):
     )
     assert res.exit_code != 0
     assert "--store-dir" in unstyle(res.output)
-    assert "pgrep -af" in res.output
+    assert "pgrep -af" in unstyle(res.output)
     assert not (tmp_path / "pending-store").exists()
 
 

--- a/tests/cli/test_relay_hosts.py
+++ b/tests/cli/test_relay_hosts.py
@@ -13,6 +13,8 @@ import json
 import re
 import time
 
+from click import unstyle
+
 import pytest
 import typer
 from typer.testing import CliRunner
@@ -66,7 +68,7 @@ def test_fleet_token_requires_an_explicit_store_dir(monkeypatch, tmp_path):
         "relay.example.com",
     )
     assert res.exit_code != 0
-    assert "--store-dir" in res.output
+    assert "--store-dir" in unstyle(res.output)
     assert "pgrep -af" in res.output
     assert not (tmp_path / "pending-store").exists()
 
@@ -101,7 +103,7 @@ def test_owner_commands_reject_blank_store_dirs_without_touching_current_dir(
     res = _run(command, *arguments, "--store-dir", store_dir)
 
     assert res.exit_code != 0
-    assert "--store-dir" in res.output
+    assert "--store-dir" in unstyle(res.output)
     assert request_id not in res.output
     after = {
         path.relative_to(tmp_path): path.read_bytes()
@@ -133,7 +135,7 @@ def test_approve_requires_an_explicit_nonblank_pubkeys_dir(
     res = _run("approve", request_id, "--store-dir", str(store_dir), *pubkeys_option)
 
     assert res.exit_code != 0
-    assert "--pubkeys-dir" in res.output
+    assert "--pubkeys-dir" in unstyle(res.output)
     assert RequestStore(store_dir).get(request_id) == "pending"
     assert list(current_dir.iterdir()) == []
 
@@ -161,7 +163,7 @@ def test_enroll_server_requires_an_explicit_nonblank_pubkeys_dir(
     )
 
     assert res.exit_code != 0
-    assert "--pubkeys-dir" in res.output
+    assert "--pubkeys-dir" in unstyle(res.output)
     assert not started
 
 

--- a/tests/cli/test_relay_hosts.py
+++ b/tests/cli/test_relay_hosts.py
@@ -2,10 +2,9 @@
 
 `mship relay fleet-token` mints the phone's credential and prints the QR that
 carries it; `mship relay hosts` is the owner's view of the same directory the
-phone reads. Both default `--store-dir`/`--pubkeys-dir` exactly as the shipped
-`requests`/`approve` commands do, and `enroll-server` wires the directory from
-those same two directories — the `pubkeys/` allowlist being the one sish
-authenticates against is what makes signature-auth and tunnel-auth one identity.
+phone reads. Every relay-owner command requires the exact `--store-dir` used by
+`enroll-server`; the `pubkeys/` allowlist remains the one sish authenticates
+against, making signature-auth and tunnel-auth one identity.
 """
 
 from __future__ import annotations
@@ -55,6 +54,20 @@ def _token_line(result):
 
 
 # --- fleet-token ------------------------------------------------------------
+
+def test_fleet_token_requires_an_explicit_store_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    res = _run(
+        "fleet-token",
+        "--label",
+        "phone",
+        "--relay-domain",
+        "relay.example.com",
+    )
+    assert res.exit_code != 0
+    assert "--store-dir" in res.output
+    assert "pgrep -af" in res.output
+    assert not (tmp_path / "pending-store").exists()
 
 
 def test_fleet_token_mints_and_prints_the_pairing_link(tmp_path):

--- a/tests/cli/test_relay_hosts.py
+++ b/tests/cli/test_relay_hosts.py
@@ -13,6 +13,7 @@ import json
 import re
 import time
 
+import pytest
 import typer
 from typer.testing import CliRunner
 
@@ -68,6 +69,100 @@ def test_fleet_token_requires_an_explicit_store_dir(monkeypatch, tmp_path):
     assert "--store-dir" in res.output
     assert "pgrep -af" in res.output
     assert not (tmp_path / "pending-store").exists()
+
+
+@pytest.mark.parametrize("store_dir", ["", " \t "], ids=["empty", "whitespace"])
+@pytest.mark.parametrize(
+    ("command", "arguments"),
+    [
+        ("requests", ()),
+        (
+            "fleet-token",
+            ("--label", "phone", "--relay-domain", "relay.example.com"),
+        ),
+    ],
+)
+def test_owner_commands_reject_blank_store_dirs_without_touching_current_dir(
+    monkeypatch, tmp_path, command, arguments, store_dir
+):
+    from mship.core.relay.enroll import RequestStore
+
+    monkeypatch.chdir(tmp_path)
+    request_id = RequestStore(tmp_path).create(
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAA host",
+        "laptop",
+    )
+    before = {
+        path.relative_to(tmp_path): path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+
+    res = _run(command, *arguments, "--store-dir", store_dir)
+
+    assert res.exit_code != 0
+    assert "--store-dir" in res.output
+    assert request_id not in res.output
+    after = {
+        path.relative_to(tmp_path): path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+
+
+@pytest.mark.parametrize(
+    "pubkeys_option",
+    [(), ("--pubkeys-dir", ""), ("--pubkeys-dir", " \t ")],
+    ids=["missing", "empty", "whitespace"],
+)
+def test_approve_requires_an_explicit_nonblank_pubkeys_dir(
+    monkeypatch, tmp_path, pubkeys_option
+):
+    from mship.core.relay.enroll import RequestStore
+
+    current_dir = tmp_path / "current"
+    current_dir.mkdir()
+    store_dir = tmp_path / "store"
+    request_id = RequestStore(store_dir).create(
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBodyAAAAAAAAAAAAAAAAAAAA host",
+        "laptop",
+    )
+    monkeypatch.chdir(current_dir)
+
+    res = _run("approve", request_id, "--store-dir", str(store_dir), *pubkeys_option)
+
+    assert res.exit_code != 0
+    assert "--pubkeys-dir" in res.output
+    assert RequestStore(store_dir).get(request_id) == "pending"
+    assert list(current_dir.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    "pubkeys_option",
+    [(), ("--pubkeys-dir", ""), ("--pubkeys-dir", " \t ")],
+    ids=["missing", "empty", "whitespace"],
+)
+def test_enroll_server_requires_an_explicit_nonblank_pubkeys_dir(
+    monkeypatch, tmp_path, pubkeys_option
+):
+    started = []
+    monkeypatch.setattr(
+        relay_mod, "_enroll_server_impl", lambda **kwargs: started.append(kwargs)
+    )
+
+    res = _run(
+        "enroll-server",
+        "--store-dir",
+        str(tmp_path / "store"),
+        "--relay-domain",
+        "relay.example.com",
+        *pubkeys_option,
+    )
+
+    assert res.exit_code != 0
+    assert "--pubkeys-dir" in res.output
+    assert not started
 
 
 def test_fleet_token_mints_and_prints_the_pairing_link(tmp_path):

--- a/tests/core/daemon/test_status.py
+++ b/tests/core/daemon/test_status.py
@@ -177,7 +177,10 @@ def _tunnel(**kw) -> dict:
         (_tunnel(state="disabled"), "tunnel: disabled (no relay configured)"),
         (
             _tunnel(state="awaiting-enrollment"),
-            "tunnel: awaiting relay approval (run 'mship relay approve <id>' on the relay host)",
+            "tunnel: awaiting relay approval (on relay host, inspect "
+            "`pgrep -af 'mship.*relay.*enroll-server'`, then run "
+            "`mship relay approve <id> --store-dir <relay-store> "
+            "--pubkeys-dir <relay-pubkeys>`)",
         ),
         (_tunnel(), "tunnel: online https://hst-abc.relay.example (0 restarts)"),
         (_tunnel(state="contended"), "tunnel: contended — another host holds hst-abc"),


### PR DESCRIPTION
## Summary
- require the enroll-server's explicit `--store-dir` for every relay-owner command, preventing valid-looking credentials and state from being written to the wrong directory
- make missing-store, enrollment approval, daemon status/re-identification, and missing-grant guidance point operators to the live enroll-server command and complete owner commands
- document the distinction between one-workspace pairing and daemon-fleet pairing, including the central-relay user/store/domain invariants

## Test plan
- [x] `mship test --repos mothership`
- [x] `task lint`
- [x] `uv run --group docs mkdocs build --strict`
- [x] smoke `mship relay fleet-token` without `--store-dir` and verify it exits 2 with live-process discovery guidance
