### PR TITLE
Ground Control active and archived inboxes

### DIFF
--- a/.github/workflows/agentic-review.yml
+++ b/.github/workflows/agentic-review.yml
@@ -2,7 +2,7 @@ name: agentic-review
 
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review, synchronize]
+    types: [opened, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -75,16 +75,21 @@ def register(parent: typer.Typer, get_container):
             output.error("Could not derive a spec id from the title; pass --id explicitly.")
             raise typer.Exit(1)
         from mship.core.spec_storage import SpecLocked
+        from mship.core.spec_store import SpecArtifactConflict
 
-        path = store.path_for(spec)
         try:
             if force:
-                store.save(spec)
-            elif not store.create_if_absent(spec):
-                output.error(f"Spec already exists: {path}\n  Pass --force to overwrite.")
-                raise typer.Exit(1)
+                path = store.save(spec)
+            else:
+                path = store.create_if_absent(spec)
+                if path is None:
+                    output.error(f"Spec already exists: {store.path_for(spec)}\n  Pass --force to overwrite.")
+                    raise typer.Exit(1)
         except SpecLocked:
             output.error(f"Spec {spec.id!r} already exists but is locked.")
+            raise typer.Exit(1)
+        except SpecArtifactConflict as exc:
+            output.error(f"Cannot create spec {spec.id!r}: {exc}")
             raise typer.Exit(1)
 
         if output.human_mode:
@@ -861,7 +866,7 @@ def register(parent: typer.Typer, get_container):
         local/encrypted, git rm the ciphertext when moving back). Run after editing
         `spec_storage` in mothership.yaml — it reads the target mode from config."""
         from pathlib import Path
-        from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+        from mship.core.spec_store import SPECS_DIRNAME, SpecArtifactConflict, SpecStore
         from mship.core.spec_storage import SpecStorage
         from mship.util.git import GitRunner
 
@@ -879,41 +884,55 @@ def register(parent: typer.Typer, get_container):
         target_store = SpecStore(specs_dir, storage=target_storage)
 
         migrated = 0
-        for spec, locked_id, old_path in reader.read_all():
-            if spec is None:
+        for scanned_spec, locked_id, _ in reader.read_all():
+            if scanned_spec is None:
                 output.error(
                     f"Cannot migrate {locked_id!r}: it is encrypted and no key is present. "
                     f"Restore `.mothership/spec-key` first."
                 )
                 raise typer.Exit(1)
-            new_path = target_store.save(spec)  # writes the target representation
-            # Every git step below FAILS LOUD: a swallowed failure could report a
-            # successful migration while leaving plaintext indexed/tracked (a leak) or
-            # the new representation untracked (a clean/clone loses the migrated spec).
-            # `is_tracked` guards keep it idempotent (re-migrating to the same mode is
-            # a no-op, not a spurious error).
             try:
-                if new_path.resolve() != old_path.resolve():
-                    # Suffix changed (.md <-> .md.enc): the old file must leave BOTH the
-                    # working tree AND the index, or a mode meant to hide it keeps a
-                    # readable/restorable copy.
-                    if git.is_tracked(workspace_root, old_path):
-                        git.rm(workspace_root, old_path, force=True)   # index + working tree
-                    elif old_path.exists():
-                        old_path.unlink()                          # untracked: just the file
-                if target == "committed":
-                    git.remove_from_gitignore(workspace_root, f"{SPECS_DIRNAME}/*.md")
-                    git.add(workspace_root, new_path)              # public + tracked again
-                elif target == "encrypted":
-                    git.add(workspace_root, new_path)              # track the ciphertext
-                elif target == "local":
-                    # committed -> local: same .md path; stop TRACKING it (save() already
-                    # gitignored specs/*.md). Untrack only if currently tracked.
-                    if git.is_tracked(workspace_root, new_path):
-                        git.rm(workspace_root, new_path, cached=True, force=True)
+                # Re-resolve after acquiring the same per-spec lock writers use. The
+                # source read, target write, and old-artifact removal are one critical
+                # section, so an inbox/lifecycle save cannot land in an artifact the
+                # migration then discards.
+                with target_store.locked(scanned_spec.id) as source:
+                    if source is None:
+                        raise SpecArtifactConflict(
+                            f"spec {scanned_spec.id!r} vanished while migration was waiting"
+                        )
+                    spec = source.spec
+                    old_path = source.physical_path
+                    new_path = target_store.save_migrated_unlocked(spec)
+                    # Every git step below FAILS LOUD: a swallowed failure could report a
+                    # successful migration while leaving plaintext indexed/tracked (a leak) or
+                    # the new representation untracked (a clean/clone loses the migrated spec).
+                    # `is_tracked` guards keep it idempotent (re-migrating to the same mode is
+                    # a no-op, not a spurious error).
+                    if new_path.resolve() != old_path.resolve():
+                        # Suffix changed (.md <-> .md.enc): the old file must leave BOTH the
+                        # working tree AND the index, or a mode meant to hide it keeps a
+                        # readable/restorable copy.
+                        if git.is_tracked(workspace_root, old_path):
+                            git.rm(workspace_root, old_path, force=True)   # index + working tree
+                        elif old_path.exists():
+                            old_path.unlink()                          # untracked: just the file
+                    if target == "committed":
+                        git.remove_from_gitignore(workspace_root, f"{SPECS_DIRNAME}/*.md")
+                        git.add(workspace_root, new_path)              # public + tracked again
+                    elif target == "encrypted":
+                        git.add(workspace_root, new_path)              # track the ciphertext
+                    elif target == "local":
+                        # committed -> local: same .md path; stop TRACKING it (save() already
+                        # gitignored specs/*.md). Untrack only if currently tracked.
+                        if git.is_tracked(workspace_root, new_path):
+                            git.rm(workspace_root, new_path, cached=True, force=True)
+            except SpecArtifactConflict as exc:
+                output.error(f"Cannot migrate {scanned_spec.id!r}: {exc}")
+                raise typer.Exit(1)
             except Exception as e:
                 output.error(
-                    f"Migration of {spec.id!r} to {target!r} FAILED at a git step: {e}. "
+                    f"Migration of {scanned_spec.id!r} to {target!r} FAILED at a git step: {e}. "
                     f"The store may be half-migrated — resolve the git state "
                     f"(check `git status` for staged/uncommitted spec changes) and re-run. "
                     f"No migration was reported as complete."

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -869,7 +869,9 @@ def register(parent: typer.Typer, get_container):
         from mship.core.spec_store import (
             SPECS_DIRNAME, SpecArtifactConflict, SpecStore, parse_spec,
         )
-        from mship.core.spec_storage import SpecLocked, SpecStorage
+        from mship.core.spec_storage import (
+            SpecLocked, SpecStorage, canonical_spec_id_from_filename,
+        )
         from mship.util.git import GitRunner
 
         output = Output()
@@ -886,9 +888,10 @@ def register(parent: typer.Typer, get_container):
         target_storage = SpecStorage(specs_dir, mode=target, workspace_root=workspace_root)
         target_store = SpecStore(specs_dir, storage=target_storage)
         scanned_specs = []
+        preflight_ids: set[str] = set()
         for path in reader.iter_physical():
             try:
-                scanned_specs.append(parse_spec(reader.decode_file(path)))
+                scanned_spec = parse_spec(reader.decode_file(path))
             except SpecLocked as locked:
                 output.error(
                     f"Cannot migrate {locked.spec_id!r}: it is encrypted and no key is present. "
@@ -897,6 +900,27 @@ def register(parent: typer.Typer, get_container):
                 raise typer.Exit(1)
             except Exception as exc:
                 output.error(f"Cannot migrate {path}: malformed or unreadable artifact: {exc}")
+                raise typer.Exit(1)
+            scanned_specs.append(scanned_spec)
+            preflight_ids.add(scanned_spec.id)
+            canonical_id = canonical_spec_id_from_filename(path)
+            if canonical_id is not None:
+                preflight_ids.add(canonical_id)
+
+        # Resolve every parsed and canonical id before the first write. A later
+        # collision must abort the whole migration, never after earlier artifacts
+        # were already re-materialised in the target representation.
+        for spec_id in preflight_ids:
+            try:
+                target_store.read_strict(spec_id)
+            except SpecLocked as locked:
+                output.error(
+                    f"Cannot migrate {locked.spec_id!r}: it is encrypted and no key is present. "
+                    f"Restore `.mothership/spec-key` first."
+                )
+                raise typer.Exit(1)
+            except SpecArtifactConflict as exc:
+                output.error(f"Cannot migrate {spec_id!r}: {exc}")
                 raise typer.Exit(1)
 
         migrated = 0

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -787,7 +787,17 @@ def register(parent: typer.Typer, get_container):
         """Show structured detail for a spec (non-TTY: pure JSON)."""
         output = Output()
         store = _spec_store()
-        spec = store.find_by_id(spec_id)
+        from mship.core.spec_storage import SpecLocked
+        from mship.core.spec_store import SpecParseError
+        try:
+            spec = store.read_strict(spec_id)
+        except SpecLocked:
+            spec = None
+        except SpecParseError as exc:
+            output.error(f"Cannot show spec {spec_id!r}: {exc}")
+            raise typer.Exit(1)
+        except ValueError:
+            spec = None
         if spec is None:
             output.error(f"No spec with id {spec_id!r}.")
             raise typer.Exit(1)

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -75,7 +75,7 @@ def register(parent: typer.Typer, get_container):
             output.error("Could not derive a spec id from the title; pass --id explicitly.")
             raise typer.Exit(1)
         from mship.core.spec_storage import SpecLocked
-        from mship.core.spec_store import SpecArtifactConflict
+        from mship.core.spec_store import SpecParseError
 
         try:
             if force:
@@ -88,7 +88,7 @@ def register(parent: typer.Typer, get_container):
         except SpecLocked:
             output.error(f"Spec {spec.id!r} already exists but is locked.")
             raise typer.Exit(1)
-        except SpecArtifactConflict as exc:
+        except SpecParseError as exc:
             output.error(f"Cannot create spec {spec.id!r}: {exc}")
             raise typer.Exit(1)
 

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -74,8 +74,15 @@ def register(parent: typer.Typer, get_container):
         except ValueError:
             output.error("Could not derive a spec id from the title; pass --id explicitly.")
             raise typer.Exit(1)
+        from mship.core.spec_storage import SpecLocked
+
         path = store.path_for(spec)
-        if path.exists() and not force:
+        try:
+            existing = store.read_strict(spec.id)
+        except SpecLocked:
+            output.error(f"Spec {spec.id!r} already exists but is locked.")
+            raise typer.Exit(1)
+        if existing is not None and not force:
             output.error(f"Spec already exists: {path}\n  Pass --force to overwrite.")
             raise typer.Exit(1)
         store.save(spec)

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -901,41 +901,42 @@ def register(parent: typer.Typer, get_container):
 
         migrated = 0
         for scanned_spec in scanned_specs:
-            # Re-resolve after acquiring the same per-spec lock writers use. The
-            # source read, target write, and old-artifact removal are one critical
-            # section, so an inbox/lifecycle save cannot land in an artifact the
-            # migration then discards.
-            with target_store.locked(scanned_spec.id) as source:
-                if source is None:
-                    raise SpecArtifactConflict(
-                        f"spec {scanned_spec.id!r} vanished while migration was waiting"
-                    )
-                spec = source.spec
-                old_path = source.physical_path
-                new_path = target_store.save_migrated_unlocked(spec)
-                # Every git step below FAILS LOUD: a swallowed failure could report a
-                # successful migration while leaving plaintext indexed/tracked (a leak) or
-                # the new representation untracked (a clean/clone loses the migrated spec).
-                # `is_tracked` guards keep it idempotent (re-migrating to the same mode is
-                # a no-op, not a spurious error).
-                if new_path.resolve() != old_path.resolve():
-                    # Suffix changed (.md <-> .md.enc): the old file must leave BOTH the
-                    # working tree AND the index, or a mode meant to hide it keeps a
-                    # readable/restorable copy.
-                    if git.is_tracked(workspace_root, old_path):
-                        git.rm(workspace_root, old_path, force=True)   # index + working tree
-                    elif old_path.exists():
-                        old_path.unlink()                          # untracked: just the file
-                if target == "committed":
-                    git.remove_from_gitignore(workspace_root, f"{SPECS_DIRNAME}/*.md")
-                    git.add(workspace_root, new_path)              # public + tracked again
-                elif target == "encrypted":
-                    git.add(workspace_root, new_path)              # track the ciphertext
-                elif target == "local":
-                    # committed -> local: same .md path; stop TRACKING it (save() already
-                    # gitignored specs/*.md). Untrack only if currently tracked.
-                    if git.is_tracked(workspace_root, new_path):
-                        git.rm(workspace_root, new_path, cached=True, force=True)
+            try:
+                # Re-resolve after acquiring the same per-spec lock writers use. The
+                # source read, target write, and old-artifact removal are one critical
+                # section, so an inbox/lifecycle save cannot land in an artifact the
+                # migration then discards.
+                with target_store.locked(scanned_spec.id) as source:
+                    if source is None:
+                        raise SpecArtifactConflict(
+                            f"spec {scanned_spec.id!r} vanished while migration was waiting"
+                        )
+                    spec = source.spec
+                    old_path = source.physical_path
+                    new_path = target_store.save_migrated_unlocked(spec)
+                    # Every git step below FAILS LOUD: a swallowed failure could report a
+                    # successful migration while leaving plaintext indexed/tracked (a leak) or
+                    # the new representation untracked (a clean/clone loses the migrated spec).
+                    # `is_tracked` guards keep it idempotent (re-migrating to the same mode is
+                    # a no-op, not a spurious error).
+                    if new_path.resolve() != old_path.resolve():
+                        # Suffix changed (.md <-> .md.enc): the old file must leave BOTH the
+                        # working tree AND the index, or a mode meant to hide it keeps a
+                        # readable/restorable copy.
+                        if git.is_tracked(workspace_root, old_path):
+                            git.rm(workspace_root, old_path, force=True)   # index + working tree
+                        elif old_path.exists():
+                            old_path.unlink()                          # untracked: just the file
+                    if target == "committed":
+                        git.remove_from_gitignore(workspace_root, f"{SPECS_DIRNAME}/*.md")
+                        git.add(workspace_root, new_path)              # public + tracked again
+                    elif target == "encrypted":
+                        git.add(workspace_root, new_path)              # track the ciphertext
+                    elif target == "local":
+                        # committed -> local: same .md path; stop TRACKING it (save() already
+                        # gitignored specs/*.md). Untrack only if currently tracked.
+                        if git.is_tracked(workspace_root, new_path):
+                            git.rm(workspace_root, new_path, cached=True, force=True)
             except SpecArtifactConflict as exc:
                 output.error(f"Cannot migrate {scanned_spec.id!r}: {exc}")
                 raise typer.Exit(1)

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -78,14 +78,14 @@ def register(parent: typer.Typer, get_container):
 
         path = store.path_for(spec)
         try:
-            existing = store.read_strict(spec.id)
+            if force:
+                store.save(spec)
+            elif not store.create_if_absent(spec):
+                output.error(f"Spec already exists: {path}\n  Pass --force to overwrite.")
+                raise typer.Exit(1)
         except SpecLocked:
             output.error(f"Spec {spec.id!r} already exists but is locked.")
             raise typer.Exit(1)
-        if existing is not None and not force:
-            output.error(f"Spec already exists: {path}\n  Pass --force to overwrite.")
-            raise typer.Exit(1)
-        store.save(spec)
 
         if output.human_mode:
             output.success(f"Created spec: {path}")

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -742,7 +742,7 @@ def register(parent: typer.Typer, get_container):
         """List all specs (TTY: table; non-TTY: JSON envelope)."""
         output = Output()
         store = _spec_store()
-        specs = store.list()
+        specs = store.list_tolerant()
         items = [
             {
                 "id": s.id,

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -83,7 +83,13 @@ def register(parent: typer.Typer, get_container):
             else:
                 path = store.create_if_absent(spec)
                 if path is None:
-                    output.error(f"Spec already exists: {store.path_for(spec)}\n  Pass --force to overwrite.")
+                    existing = store.resolve_artifact(spec.id)
+                    existing_path = (
+                        existing.physical_path if existing is not None else store.path_for(spec)
+                    )
+                    output.error(
+                        f"Spec already exists: {existing_path}\n  Pass --force to overwrite."
+                    )
                     raise typer.Exit(1)
         except SpecLocked:
             output.error(f"Spec {spec.id!r} already exists but is locked.")
@@ -386,6 +392,9 @@ def register(parent: typer.Typer, get_container):
             raise typer.Exit(1)
         except SpecParseError as e:
             output.error(f"{spec_id}: invalid spec — {e}")
+            raise typer.Exit(1)
+        except ValueError as e:
+            output.error(str(e))
             raise typer.Exit(1)
         if spec is None:
             output.error(f"No spec file for id {spec_id!r} in {workspace_root / SPECS_DIRNAME}.")

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -866,8 +866,10 @@ def register(parent: typer.Typer, get_container):
         local/encrypted, git rm the ciphertext when moving back). Run after editing
         `spec_storage` in mothership.yaml — it reads the target mode from config."""
         from pathlib import Path
-        from mship.core.spec_store import SPECS_DIRNAME, SpecArtifactConflict, SpecStore
-        from mship.core.spec_storage import SpecStorage
+        from mship.core.spec_store import (
+            SPECS_DIRNAME, SpecArtifactConflict, SpecStore, parse_spec,
+        )
+        from mship.core.spec_storage import SpecLocked, SpecStorage
         from mship.util.git import GitRunner
 
         output = Output()
@@ -877,56 +879,63 @@ def register(parent: typer.Typer, get_container):
         target = container.config().spec_storage
         git = GitRunner()
 
-        # Read every current file suffix-agnostically (needs the key for any .md.enc);
-        # write each into the target representation.
+        # Preflight every physical artifact before mutating anything. `read_all`
+        # deliberately skips bad entries for resilient display; migration cannot:
+        # reporting success after omitting ciphertext or corruption loses data.
         reader = SpecStorage(specs_dir, workspace_root=workspace_root)
         target_storage = SpecStorage(specs_dir, mode=target, workspace_root=workspace_root)
         target_store = SpecStore(specs_dir, storage=target_storage)
-
-        migrated = 0
-        for scanned_spec, locked_id, _ in reader.read_all():
-            if scanned_spec is None:
+        scanned_specs = []
+        for path in reader.iter_physical():
+            try:
+                scanned_specs.append(parse_spec(reader.decode_file(path)))
+            except SpecLocked as locked:
                 output.error(
-                    f"Cannot migrate {locked_id!r}: it is encrypted and no key is present. "
+                    f"Cannot migrate {locked.spec_id!r}: it is encrypted and no key is present. "
                     f"Restore `.mothership/spec-key` first."
                 )
                 raise typer.Exit(1)
-            try:
-                # Re-resolve after acquiring the same per-spec lock writers use. The
-                # source read, target write, and old-artifact removal are one critical
-                # section, so an inbox/lifecycle save cannot land in an artifact the
-                # migration then discards.
-                with target_store.locked(scanned_spec.id) as source:
-                    if source is None:
-                        raise SpecArtifactConflict(
-                            f"spec {scanned_spec.id!r} vanished while migration was waiting"
-                        )
-                    spec = source.spec
-                    old_path = source.physical_path
-                    new_path = target_store.save_migrated_unlocked(spec)
-                    # Every git step below FAILS LOUD: a swallowed failure could report a
-                    # successful migration while leaving plaintext indexed/tracked (a leak) or
-                    # the new representation untracked (a clean/clone loses the migrated spec).
-                    # `is_tracked` guards keep it idempotent (re-migrating to the same mode is
-                    # a no-op, not a spurious error).
-                    if new_path.resolve() != old_path.resolve():
-                        # Suffix changed (.md <-> .md.enc): the old file must leave BOTH the
-                        # working tree AND the index, or a mode meant to hide it keeps a
-                        # readable/restorable copy.
-                        if git.is_tracked(workspace_root, old_path):
-                            git.rm(workspace_root, old_path, force=True)   # index + working tree
-                        elif old_path.exists():
-                            old_path.unlink()                          # untracked: just the file
-                    if target == "committed":
-                        git.remove_from_gitignore(workspace_root, f"{SPECS_DIRNAME}/*.md")
-                        git.add(workspace_root, new_path)              # public + tracked again
-                    elif target == "encrypted":
-                        git.add(workspace_root, new_path)              # track the ciphertext
-                    elif target == "local":
-                        # committed -> local: same .md path; stop TRACKING it (save() already
-                        # gitignored specs/*.md). Untrack only if currently tracked.
-                        if git.is_tracked(workspace_root, new_path):
-                            git.rm(workspace_root, new_path, cached=True, force=True)
+            except Exception as exc:
+                output.error(f"Cannot migrate {path}: malformed or unreadable artifact: {exc}")
+                raise typer.Exit(1)
+
+        migrated = 0
+        for scanned_spec in scanned_specs:
+            # Re-resolve after acquiring the same per-spec lock writers use. The
+            # source read, target write, and old-artifact removal are one critical
+            # section, so an inbox/lifecycle save cannot land in an artifact the
+            # migration then discards.
+            with target_store.locked(scanned_spec.id) as source:
+                if source is None:
+                    raise SpecArtifactConflict(
+                        f"spec {scanned_spec.id!r} vanished while migration was waiting"
+                    )
+                spec = source.spec
+                old_path = source.physical_path
+                new_path = target_store.save_migrated_unlocked(spec)
+                # Every git step below FAILS LOUD: a swallowed failure could report a
+                # successful migration while leaving plaintext indexed/tracked (a leak) or
+                # the new representation untracked (a clean/clone loses the migrated spec).
+                # `is_tracked` guards keep it idempotent (re-migrating to the same mode is
+                # a no-op, not a spurious error).
+                if new_path.resolve() != old_path.resolve():
+                    # Suffix changed (.md <-> .md.enc): the old file must leave BOTH the
+                    # working tree AND the index, or a mode meant to hide it keeps a
+                    # readable/restorable copy.
+                    if git.is_tracked(workspace_root, old_path):
+                        git.rm(workspace_root, old_path, force=True)   # index + working tree
+                    elif old_path.exists():
+                        old_path.unlink()                          # untracked: just the file
+                if target == "committed":
+                    git.remove_from_gitignore(workspace_root, f"{SPECS_DIRNAME}/*.md")
+                    git.add(workspace_root, new_path)              # public + tracked again
+                elif target == "encrypted":
+                    git.add(workspace_root, new_path)              # track the ciphertext
+                elif target == "local":
+                    # committed -> local: same .md path; stop TRACKING it (save() already
+                    # gitignored specs/*.md). Untrack only if currently tracked.
+                    if git.is_tracked(workspace_root, new_path):
+                        git.rm(workspace_root, new_path, cached=True, force=True)
             except SpecArtifactConflict as exc:
                 output.error(f"Cannot migrate {scanned_spec.id!r}: {exc}")
                 raise typer.Exit(1)

--- a/src/mship/cli/view/_workitems.py
+++ b/src/mship/cli/view/_workitems.py
@@ -20,7 +20,10 @@ def load_workitem_index(container) -> list[WorkItemSummary]:
         state_dir = Path(container.state_dir())
         workspace_root = Path(container.config_path()).parent
         items = WorkItemStore(state_dir / "workitems").list()
-        specs = {s.id: s for s in SpecStore(workspace_root / SPECS_DIRNAME).list()}
+        specs = {
+            spec.id: spec
+            for spec in SpecStore(workspace_root / SPECS_DIRNAME).list_tolerant()
+        }
         tasks = dict(container.state_manager().load().tasks)
     except Exception:
         return []

--- a/src/mship/cli/view/spec.py
+++ b/src/mship/cli/view/spec.py
@@ -18,6 +18,8 @@ from textual.widgets import Markdown, Static
 from mship.cli.view._base import ViewApp
 from mship.cli.view._modals import RequestChangesModal
 from mship.cli.view._placeholders import placeholder_for
+from mship.core.spec_store import SpecParseError
+from mship.core.spec_storage import SpecLocked
 from mship.core.view.actions import approve_spec_by_id, request_changes_by_id
 from mship.core.task_resolver import (
     AmbiguousTaskError,
@@ -25,7 +27,11 @@ from mship.core.task_resolver import (
     UnknownTaskError,
     resolve_task,
 )
-from mship.core.view.spec_discovery import SpecNotFoundError, find_spec
+from mship.core.view.spec_discovery import (
+    SpecNotFoundError,
+    find_spec,
+    read_spec_source,
+)
 from mship.core.view.web_port import NoFreePortError, pick_port
 
 
@@ -134,12 +140,19 @@ class SpecView(ViewApp):
                 self.call_after_refresh(self._restore_scroll, prev_y, was_at_end)
                 return
             try:
-                source = path.read_text()
-            except OSError:
+                source = read_spec_source(path, self._workspace_root)
+            except SpecLocked as exc:
+                error_msg = f"Spec locked: {exc}"
+                self._last_source = ""
+                self._last_error = error_msg
+                self._markdown.update("")
+                self._error_static.update(error_msg)
+                self.call_after_refresh(self._restore_scroll, prev_y, was_at_end)
+                return
+            except (OSError, SpecParseError):
                 # The spec file can be deleted/renamed/replaced between the provider
                 # resolving it and this read (spec transitions rewrite the file). Show
-                # the hint and keep following — the next tick re-resolves; never raise
-                # out of the timer callback (that would stop the pane refreshing).
+                # the hint and keep following — the next tick re-resolves.
                 self._last_source = follow_hint()
                 self._last_error = ""
                 self._markdown.update(follow_hint())
@@ -186,7 +199,7 @@ class SpecView(ViewApp):
                 task=slug_for_tick,
                 state=state,
             )
-            source = path.read_text()
+            source = read_spec_source(path, self._workspace_root)
             header = self._header_provider() if self._header_provider else None
             if header:
                 source = f"**{header}**\n\n{source}"
@@ -194,6 +207,18 @@ class SpecView(ViewApp):
             self._last_error = ""
             self._markdown.update(source)
             self._error_static.update("")
+        except SpecLocked as e:
+            error_msg = f"Spec locked: {e}"
+            self._last_source = ""
+            self._last_error = error_msg
+            self._markdown.update("")
+            self._error_static.update(error_msg)
+        except SpecParseError as e:
+            error_msg = f"Spec unavailable: {e}"
+            self._last_source = ""
+            self._last_error = error_msg
+            self._markdown.update("")
+            self._error_static.update(error_msg)
         except SpecNotFoundError as e:
             if self._name_or_path is None:
                 body = self._render_task_fallback(slug_for_tick, state, default_error=str(e))
@@ -289,12 +314,16 @@ class SpecView(ViewApp):
             self._refresh_content()
 
 
-def _render_html(spec_path: Path) -> bytes:
+def _render_html(spec_path: Path, workspace_root: Path | None = None) -> bytes:
+    try:
+        source = read_spec_source(spec_path, workspace_root)
+    except (SpecLocked, SpecParseError) as exc:
+        source = f"# Spec unavailable\n\n{exc}\n"
     try:
         from markdown_it import MarkdownIt  # type: ignore
-        body_html = MarkdownIt().render(spec_path.read_text())
+        body_html = MarkdownIt().render(source)
     except ImportError:
-        body_html = f"<pre>{html.escape(spec_path.read_text())}</pre>"
+        body_html = f"<pre>{html.escape(source)}</pre>"
     doc = f"""<!doctype html>
 <html><head><meta charset="utf-8"><title>{html.escape(spec_path.name)}</title>
 <style>body{{font-family:system-ui;max-width:780px;margin:2rem auto;padding:0 1rem;line-height:1.55}}
@@ -304,10 +333,19 @@ pre{{padding:.6em;overflow:auto}}</style>
     return doc.encode("utf-8")
 
 
+def _echo_spec_source(path: Path, workspace_root: Path) -> None:
+    try:
+        typer.echo(read_spec_source(path, workspace_root), nl=False)
+    except (SpecLocked, SpecParseError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+
 def serve_spec_web(
     spec_path: Path,
     start_port: int = None,
     explicit_port: int | None = None,
+    workspace_root: Path | None = None,
 ) -> tuple[HTTPServer, int, threading.Thread]:
     port = pick_port(
         start=start_port if start_port is not None else 47213,
@@ -316,7 +354,7 @@ def serve_spec_web(
 
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self):  # noqa: N802
-            body = _render_html(spec_path)
+            body = _render_html(spec_path, workspace_root)
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
@@ -332,9 +370,13 @@ def serve_spec_web(
     return server, port, thread
 
 
-def _serve_web(path: Path, port: int | None) -> None:
+def _serve_web(path: Path, port: int | None, workspace_root: Path) -> None:
     try:
-        server, chosen, _t = serve_spec_web(path, explicit_port=port)
+        server, chosen, _t = serve_spec_web(
+            path,
+            explicit_port=port,
+            workspace_root=workspace_root,
+        )
     except NoFreePortError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(code=1)
@@ -437,7 +479,7 @@ def register(app: typer.Typer, get_container):
                     from mship.cli.view._follow import follow_hint
                     typer.echo(follow_hint())
                     return
-                typer.echo(path.read_text(), nl=False)
+                _echo_spec_source(path, workspace_root)
                 return
 
             def _header():
@@ -521,7 +563,7 @@ def register(app: typer.Typer, get_container):
             except SpecNotFoundError as e:
                 typer.echo(f"Error: {e}", err=True)
                 raise typer.Exit(code=1)
-            _serve_web(path, port)
+            _serve_web(path, port, workspace_root)
             return
 
         # Non-TTY short-circuit (#124): the SpecView TUI hangs forever when
@@ -536,7 +578,7 @@ def register(app: typer.Typer, get_container):
             except SpecNotFoundError as e:
                 typer.echo(f"Error: {e}", err=True)
                 raise typer.Exit(code=1)
-            typer.echo(path.read_text(), nl=False)
+            _echo_spec_source(path, workspace_root)
             return
 
         header_provider = None

--- a/src/mship/cli/workitem.py
+++ b/src/mship/cli/workitem.py
@@ -405,7 +405,7 @@ def register(parent: typer.Typer, get_container) -> None:
         state_manager = container.state_manager()
         log_mgr = container.log_manager()
 
-        specs_by_id = {s.id: s for s in specs.list()}
+        specs_by_id = {s.id: s for s in specs.list_tolerant()}
         spec_approved = {sid: (s.status == "approved") for sid, s in specs_by_id.items()}
         run_state = RunStateRepo(_workspace_origin(workspace_root), state_dir / "run-state")
 

--- a/src/mship/cli/workitem.py
+++ b/src/mship/cli/workitem.py
@@ -196,7 +196,7 @@ def register(parent: typer.Typer, get_container) -> None:
         items, specs, state_manager, msgs, _ = _ctx()
         summaries = build_workitem_index(
             items.list(include_archived=all_items),
-            {s.id: s for s in specs.list()},
+            {s.id: s for s in specs.list_tolerant()},
             dict(state_manager.load().tasks),
             {t.id: t for t in msgs.list()},
             # build_workitem_index now also defaults to excluding archived items

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1004,8 +1004,8 @@ def register(app: typer.Typer, get_container):
                 closed_count=closed_count,
                 completed_without_prs=completed_without_prs,
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            output.warning(f"spec lifecycle not advanced: {exc}")
 
         # Advance a WorkItem's completion state when its last live task merges+closes.
         # Spec-bound items (incl. features spawned via `spawn --work-item`, whose spec
@@ -1026,8 +1026,8 @@ def register(app: typer.Typer, get_container):
                 closed_count=closed_count,
                 completed_without_prs=completed_without_prs,
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            output.warning(f"WorkItem lifecycle not advanced: {exc}")
 
         # Close linked GitHub tracker issues (#386). Fail-open like the
         # advances above: failures warn, the close never blocks on them.

--- a/src/mship/core/inbox.py
+++ b/src/mship/core/inbox.py
@@ -106,7 +106,6 @@ def apply_inbox_action(
         return False
     if (
         (action == "archive" and metadata.manual_archived)
-        or (action == "restore" and not metadata.manual_archived)
         or (action == "pin" and metadata.pinned)
         or (action == "unpin" and not metadata.pinned)
     ):

--- a/src/mship/core/inbox.py
+++ b/src/mship/core/inbox.py
@@ -25,6 +25,7 @@ class InboxMetadata(BaseModel):
     pinned: bool = False
     manual_archived: bool = False
     restored_at: datetime | None = None
+    last_mutated_at: datetime | None = None
     mutation_ids: dict[str, InboxAction] = Field(default_factory=dict)
 
 
@@ -101,4 +102,9 @@ def apply_inbox_action(
         metadata.pinned = True
     else:
         metadata.pinned = False
+    metadata.last_mutated_at = max(
+        now,
+        metadata.last_mutated_at + timedelta(microseconds=1)
+        if metadata.last_mutated_at is not None else now,
+    )
     return True

--- a/src/mship/core/inbox.py
+++ b/src/mship/core/inbox.py
@@ -67,7 +67,7 @@ def classify_thread(
 ) -> InboxClassification:
     """Classify a thread without changing its inbox or domain state."""
     metadata = thread.inbox
-    if metadata.pinned or thread.needs_you or thread.needs_decision:
+    if metadata.pinned or thread.awaiting_reply or thread.needs_you or thread.needs_decision:
         return InboxClassification(state="active")
     if metadata.manual_archived:
         return InboxClassification(state="archived", archive_reason="manual")

--- a/src/mship/core/inbox.py
+++ b/src/mship/core/inbox.py
@@ -19,6 +19,7 @@ InboxArchiveReason = Literal[
 
 _SEVEN_DAYS = timedelta(days=7)
 _ACTIONS = frozenset(("archive", "restore", "pin", "unpin"))
+_MAX_MUTATION_IDS = 256
 
 
 class InboxMetadata(BaseModel):
@@ -103,7 +104,16 @@ def apply_inbox_action(
                 f"mutation id {mutation_id!r} already used for {previous!r}, not {action!r}"
             )
         return False
+    if (
+        (action == "archive" and metadata.manual_archived)
+        or (action == "restore" and not metadata.manual_archived)
+        or (action == "pin" and metadata.pinned)
+        or (action == "unpin" and not metadata.pinned)
+    ):
+        return False
     metadata.mutation_ids[mutation_id] = action
+    while len(metadata.mutation_ids) > _MAX_MUTATION_IDS:
+        metadata.mutation_ids.pop(next(iter(metadata.mutation_ids)))
     if action == "archive":
         metadata.manual_archived = True
     elif action == "restore":

--- a/src/mship/core/inbox.py
+++ b/src/mship/core/inbox.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
@@ -34,8 +34,16 @@ class InboxClassification(BaseModel):
     archive_reason: InboxArchiveReason | None = None
 
 
+def _utc(dt: datetime) -> datetime:
+    """Interpret legacy naive persisted timestamps as UTC."""
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
 def _restore_is_effective(metadata: InboxMetadata, now: datetime) -> bool:
-    return metadata.restored_at is not None and now - metadata.restored_at < _SEVEN_DAYS
+    return (
+        metadata.restored_at is not None
+        and _utc(now) - _utc(metadata.restored_at) < _SEVEN_DAYS
+    )
 
 
 def classify_thread(
@@ -55,7 +63,7 @@ def classify_thread(
         return InboxClassification(state="active")
     if linked and linked_terminal:
         return InboxClassification(state="archived", archive_reason="linked_terminal")
-    if not linked and now - thread.updated_at >= _SEVEN_DAYS:
+    if not linked and _utc(now) - _utc(thread.updated_at) >= _SEVEN_DAYS:
         return InboxClassification(state="archived", archive_reason="inactive_unlinked")
     return InboxClassification(state="active")
 
@@ -71,7 +79,10 @@ def classify_spec(spec: Spec, *, now: datetime) -> InboxClassification:
         return InboxClassification(state="active")
     if spec.status == "archived":
         return InboxClassification(state="archived", archive_reason="lifecycle_archived")
-    if spec.status == "implemented" and now - spec.updated_at >= _SEVEN_DAYS:
+    if (
+        spec.status == "implemented"
+        and _utc(now) - _utc(spec.updated_at) >= _SEVEN_DAYS
+    ):
         return InboxClassification(state="archived", archive_reason="implemented")
     return InboxClassification(state="active")
 

--- a/src/mship/core/inbox.py
+++ b/src/mship/core/inbox.py
@@ -108,14 +108,15 @@ def apply_inbox_action(
         metadata.manual_archived = True
     elif action == "restore":
         metadata.manual_archived = False
-        metadata.restored_at = now
+        metadata.restored_at = _utc(now)
     elif action == "pin":
         metadata.pinned = True
     else:
         metadata.pinned = False
+    mutation_now = _utc(now)
     metadata.last_mutated_at = max(
-        now,
-        metadata.last_mutated_at + timedelta(microseconds=1)
-        if metadata.last_mutated_at is not None else now,
+        mutation_now,
+        _utc(metadata.last_mutated_at) + timedelta(microseconds=1)
+        if metadata.last_mutated_at is not None else mutation_now,
     )
     return True

--- a/src/mship/core/inbox.py
+++ b/src/mship/core/inbox.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, NamedTuple
 
 from pydantic import BaseModel, Field
 
@@ -16,6 +16,17 @@ InboxArchiveReason = Literal[
     "manual", "linked_terminal", "inactive_unlinked",
     "implemented", "lifecycle_archived",
 ]
+
+class InboxMutationResult(NamedTuple):
+    """Durability and domain-effect outcomes of an inbox mutation request."""
+
+    persisted: bool
+    applied: bool
+
+
+_DUPLICATE_MUTATION = InboxMutationResult(persisted=False, applied=False)
+_RETAINED_NOOP_MUTATION = InboxMutationResult(persisted=True, applied=False)
+_APPLIED_MUTATION = InboxMutationResult(persisted=True, applied=True)
 
 _SEVEN_DAYS = timedelta(days=7)
 _ACTIONS = frozenset(("archive", "restore", "pin", "unpin"))
@@ -93,8 +104,8 @@ def apply_inbox_action(
     action: InboxAction,
     mutation_id: str,
     now: datetime,
-) -> bool:
-    """Mutate in place; return False for an identical retry."""
+) -> InboxMutationResult:
+    """Mutate inbox metadata and report whether it must persist and was applied."""
     if action not in _ACTIONS:
         raise ValueError(f"unknown inbox action: {action!r}")
     previous = metadata.mutation_ids.get(mutation_id)
@@ -103,16 +114,19 @@ def apply_inbox_action(
             raise ValueError(
                 f"mutation id {mutation_id!r} already used for {previous!r}, not {action!r}"
             )
-        return False
-    if (
+        return _DUPLICATE_MUTATION
+
+    is_state_equivalent = (
         (action == "archive" and metadata.manual_archived)
         or (action == "pin" and metadata.pinned)
         or (action == "unpin" and not metadata.pinned)
-    ):
-        return False
+    )
     metadata.mutation_ids[mutation_id] = action
     while len(metadata.mutation_ids) > _MAX_MUTATION_IDS:
         metadata.mutation_ids.pop(next(iter(metadata.mutation_ids)))
+    if is_state_equivalent:
+        return _RETAINED_NOOP_MUTATION
+
     if action == "archive":
         metadata.manual_archived = True
     elif action == "restore":
@@ -128,4 +142,4 @@ def apply_inbox_action(
         _utc(metadata.last_mutated_at) + timedelta(microseconds=1)
         if metadata.last_mutated_at is not None else mutation_now,
     )
-    return True
+    return _APPLIED_MUTATION

--- a/src/mship/core/inbox.py
+++ b/src/mship/core/inbox.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from mship.core.message import Thread
+    from mship.core.spec import Spec
+
+
+InboxState = Literal["active", "archived"]
+InboxAction = Literal["archive", "restore", "pin", "unpin"]
+InboxArchiveReason = Literal[
+    "manual", "linked_terminal", "inactive_unlinked",
+    "implemented", "lifecycle_archived",
+]
+
+_SEVEN_DAYS = timedelta(days=7)
+_ACTIONS = frozenset(("archive", "restore", "pin", "unpin"))
+
+
+class InboxMetadata(BaseModel):
+    pinned: bool = False
+    manual_archived: bool = False
+    restored_at: datetime | None = None
+    mutation_ids: dict[str, InboxAction] = Field(default_factory=dict)
+
+
+class InboxClassification(BaseModel):
+    state: InboxState
+    archive_reason: InboxArchiveReason | None = None
+
+
+def _restore_is_effective(metadata: InboxMetadata, now: datetime) -> bool:
+    return metadata.restored_at is not None and now - metadata.restored_at < _SEVEN_DAYS
+
+
+def classify_thread(
+    thread: Thread,
+    *,
+    linked: bool,
+    linked_terminal: bool,
+    now: datetime,
+) -> InboxClassification:
+    """Classify a thread without changing its inbox or domain state."""
+    metadata = thread.inbox
+    if metadata.pinned or thread.needs_you or thread.needs_decision:
+        return InboxClassification(state="active")
+    if metadata.manual_archived:
+        return InboxClassification(state="archived", archive_reason="manual")
+    if _restore_is_effective(metadata, now):
+        return InboxClassification(state="active")
+    if linked and linked_terminal:
+        return InboxClassification(state="archived", archive_reason="linked_terminal")
+    if not linked and now - thread.updated_at >= _SEVEN_DAYS:
+        return InboxClassification(state="archived", archive_reason="inactive_unlinked")
+    return InboxClassification(state="active")
+
+
+def classify_spec(spec: Spec, *, now: datetime) -> InboxClassification:
+    """Classify a spec without changing its inbox or lifecycle state."""
+    metadata = spec.inbox
+    if metadata.pinned:
+        return InboxClassification(state="active")
+    if metadata.manual_archived:
+        return InboxClassification(state="archived", archive_reason="manual")
+    if _restore_is_effective(metadata, now):
+        return InboxClassification(state="active")
+    if spec.status == "archived":
+        return InboxClassification(state="archived", archive_reason="lifecycle_archived")
+    if spec.status == "implemented" and now - spec.updated_at >= _SEVEN_DAYS:
+        return InboxClassification(state="archived", archive_reason="implemented")
+    return InboxClassification(state="active")
+
+
+def apply_inbox_action(
+    metadata: InboxMetadata,
+    action: InboxAction,
+    mutation_id: str,
+    now: datetime,
+) -> bool:
+    """Mutate in place; return False for an identical retry."""
+    if action not in _ACTIONS:
+        raise ValueError(f"unknown inbox action: {action!r}")
+    previous = metadata.mutation_ids.get(mutation_id)
+    if previous is not None:
+        if previous != action:
+            raise ValueError(
+                f"mutation id {mutation_id!r} already used for {previous!r}, not {action!r}"
+            )
+        return False
+    metadata.mutation_ids[mutation_id] = action
+    if action == "archive":
+        metadata.manual_archived = True
+    elif action == "restore":
+        metadata.manual_archived = False
+        metadata.restored_at = now
+    elif action == "pin":
+        metadata.pinned = True
+    else:
+        metadata.pinned = False
+    return True

--- a/src/mship/core/message.py
+++ b/src/mship/core/message.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, computed_field, model_validator
+from pydantic import BaseModel, Field, computed_field, model_validator
+
+
+from mship.core.inbox import InboxMetadata
 
 
 class DecisionPayload(BaseModel):
@@ -52,6 +55,7 @@ class Thread(BaseModel):
     # Symmetric to `seen_at`; drives Ground Control's "Read" indicator (#345). A human message
     # reads as Read iff `agent_seen_at is not None and agent_seen_at >= message.created_at`.
     agent_seen_at: datetime | None = None
+    inbox: InboxMetadata = Field(default_factory=InboxMetadata)
     messages: list[Message] = []
 
     @computed_field  # serialized into model_dump()/JSON (a plain @property is not)

--- a/src/mship/core/message_store.py
+++ b/src/mship/core/message_store.py
@@ -4,7 +4,7 @@ import fcntl
 import tempfile
 import uuid
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
@@ -86,7 +86,14 @@ class MessageStore:
         if not self._dir.is_dir():
             return []
         threads = [Thread.model_validate_json(p.read_text()) for p in self._dir.glob("*.json")]
-        return sorted(threads, key=lambda t: t.updated_at, reverse=True)
+        return sorted(
+            threads,
+            key=lambda thread: (
+                thread.updated_at.replace(tzinfo=timezone.utc)
+                if thread.updated_at.tzinfo is None else thread.updated_at
+            ),
+            reverse=True,
+        )
 
     def create_thread(self, subject: str, text: str, now: datetime, task_slug: str | None = None) -> Thread:
         tid = _new_id(now)

--- a/src/mship/core/message_store.py
+++ b/src/mship/core/message_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import fcntl
+import re
 import tempfile
 import uuid
 from contextlib import contextmanager
@@ -44,16 +45,23 @@ class MessageStore:
         self._dir = Path(messages_dir)
 
     def _path(self, thread_id: str) -> Path:
-        if (not thread_id or "/" in thread_id or "\\" in thread_id
-                or thread_id in (".", "..") or thread_id.startswith(".")):
+        # Thread IDs cross the HTTP boundary, so prove both a strict component
+        # grammar and resolved containment before using one as a filesystem path.
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*", thread_id):
             raise ValueError(f"unsafe thread id: {thread_id!r}")
-        return self._dir / f"{thread_id}.json"
+        base = self._dir.resolve()
+        path = (base / f"{thread_id}.json").resolve()
+        if path.parent != base:
+            raise ValueError(f"unsafe thread id: {thread_id!r}")
+        return path
 
     def _lock_path(self, thread_id: str) -> Path:
-        """Per-thread lock file (`<id>.json.lock`). Reuses `_path`'s id validation.
-        Not matched by `list()`'s `*.json` glob, so it stays invisible to reads."""
-        p = self._path(thread_id)
-        return p.with_name(p.name + ".lock")
+        """Per-thread lock file guarded by the same containment proof as data."""
+        path = self._path(thread_id)
+        lock_path = path.with_name(path.name + ".lock").resolve()
+        if lock_path.parent != path.parent:
+            raise ValueError(f"unsafe thread id: {thread_id!r}")
+        return lock_path
 
     def save(self, thread: Thread) -> Path:
         self._dir.mkdir(parents=True, exist_ok=True)
@@ -119,15 +127,16 @@ class MessageStore:
         action: InboxAction,
         mutation_id: str,
         now: datetime,
-    ) -> Thread:
-        """Apply one idempotent inbox mutation without changing thread content."""
+    ) -> tuple[Thread, bool]:
+        """Apply an inbox action and report whether this request changed it."""
         with _locked(self._lock_path(thread_id), fcntl.LOCK_EX):
             thread = self.get(thread_id)
             if thread is None:
                 raise KeyError(thread_id)
-            if apply_inbox_action(thread.inbox, action, mutation_id, now):
+            applied = apply_inbox_action(thread.inbox, action, mutation_id, now)
+            if applied:
                 self.save(thread)
-            return thread
+            return thread, applied
 
     def mark_seen(self, thread_id: str, seen_at: datetime) -> Thread:
         """Advance the operator's read cursor (monotonic — never regresses).

--- a/src/mship/core/message_store.py
+++ b/src/mship/core/message_store.py
@@ -8,6 +8,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
+from mship.core.inbox import InboxAction, apply_inbox_action
+
+
 from mship.core.message import DecisionPayload, Message, Thread
 
 
@@ -109,6 +112,22 @@ class MessageStore:
             thread.updated_at = now
             self.save(thread)
             return msg
+
+    def mutate_inbox(
+        self,
+        thread_id: str,
+        action: InboxAction,
+        mutation_id: str,
+        now: datetime,
+    ) -> Thread:
+        """Apply one idempotent inbox mutation without changing thread content."""
+        with _locked(self._lock_path(thread_id), fcntl.LOCK_EX):
+            thread = self.get(thread_id)
+            if thread is None:
+                raise KeyError(thread_id)
+            if apply_inbox_action(thread.inbox, action, mutation_id, now):
+                self.save(thread)
+            return thread
 
     def mark_seen(self, thread_id: str, seen_at: datetime) -> Thread:
         """Advance the operator's read cursor (monotonic — never regresses).

--- a/src/mship/core/message_store.py
+++ b/src/mship/core/message_store.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import fcntl
-import re
 import tempfile
 import uuid
 from contextlib import contextmanager
@@ -45,9 +44,10 @@ class MessageStore:
         self._dir = Path(messages_dir)
 
     def _path(self, thread_id: str) -> Path:
-        # Thread IDs cross the HTTP boundary, so prove both a strict component
-        # grammar and resolved containment before using one as a filesystem path.
-        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*", thread_id):
+        # Preserve historical IDs (anything except separators/hidden components)
+        # while proving resolved direct-child containment at the filesystem edge.
+        if (not thread_id or "/" in thread_id or "\\" in thread_id
+                or thread_id in (".", "..") or thread_id.startswith(".")):
             raise ValueError(f"unsafe thread id: {thread_id!r}")
         base = self._dir.resolve()
         path = (base / f"{thread_id}.json").resolve()

--- a/src/mship/core/message_store.py
+++ b/src/mship/core/message_store.py
@@ -128,15 +128,15 @@ class MessageStore:
         mutation_id: str,
         now: datetime,
     ) -> tuple[Thread, bool]:
-        """Apply an inbox action and report whether this request changed it."""
+        """Apply an inbox action and report whether it changed inbox state."""
         with _locked(self._lock_path(thread_id), fcntl.LOCK_EX):
             thread = self.get(thread_id)
             if thread is None:
                 raise KeyError(thread_id)
-            applied = apply_inbox_action(thread.inbox, action, mutation_id, now)
-            if applied:
+            result = apply_inbox_action(thread.inbox, action, mutation_id, now)
+            if result.persisted:
                 self.save(thread)
-            return thread, applied
+            return thread, result.applied
 
     def mark_seen(self, thread_id: str, seen_at: datetime) -> Thread:
         """Advance the operator's read cursor (monotonic — never regresses).

--- a/src/mship/core/message_wait.py
+++ b/src/mship/core/message_wait.py
@@ -14,12 +14,21 @@ from datetime import datetime
 from typing import Callable
 
 
+def _change_at(thread) -> datetime:
+    """Mailbox content or inbox mutation time, whichever is newer."""
+    inbox_mutation = getattr(getattr(thread, "inbox", None), "last_mutated_at", None)
+    return max(thread.updated_at, inbox_mutation or thread.updated_at)
+
+
 def changed_since(threads, since: datetime):
-    """Return (changed, cursor): threads whose updated_at is strictly after
-    `since`, and the high-water cursor = max(updated_at across all threads, since)
-    (so the cursor never moves backwards)."""
-    changed = [t for t in threads if t.updated_at > since]
-    cursor = max([since, *(t.updated_at for t in threads)])
+    """Return changed threads and the monotonic high-water change cursor.
+
+    Inbox mutations are durable mailbox changes but deliberately do not alter
+    ``Thread.updated_at`` (which remains the content ordering timestamp).
+    """
+    change_times = [(thread, _change_at(thread)) for thread in threads]
+    changed = [thread for thread, change_at in change_times if change_at > since]
+    cursor = max([since, *(change_at for _, change_at in change_times)])
     return changed, cursor
 
 
@@ -65,7 +74,8 @@ def wait_for_change(
 ) -> WaitResult:
     """Block until `load_fn()` yields a thread changed since `since` that also
     satisfies `predicate` (default: any change), or `timeout` seconds elapse.
-    The cursor always advances to the latest seen updated_at, even on timeout."""
+    The cursor always advances to the latest content or inbox-mutation change,
+    even on timeout."""
     deadline = now_fn() + timeout
     while True:
         changed, cursor = changed_since(load_fn(), since)

--- a/src/mship/core/message_wait.py
+++ b/src/mship/core/message_wait.py
@@ -33,6 +33,7 @@ def changed_since(threads, since: datetime, *, include_inbox: bool = False):
     Agent mailbox waits retain content-only semantics by default. The serve
     inbox surface opts into durable inbox mutations explicitly.
     """
+    since = _utc(since)
     change_times = [(thread, _change_at(thread, include_inbox)) for thread in threads]
     changed = [thread for thread, change_at in change_times if change_at > since]
     cursor = max([since, *(change_at for _, change_at in change_times)])

--- a/src/mship/core/message_wait.py
+++ b/src/mship/core/message_wait.py
@@ -14,19 +14,21 @@ from datetime import datetime
 from typing import Callable
 
 
-def _change_at(thread) -> datetime:
-    """Mailbox content or inbox mutation time, whichever is newer."""
+def _change_at(thread, include_inbox: bool) -> datetime:
+    """Content time, or inbox time when a caller explicitly opts in."""
+    if not include_inbox:
+        return thread.updated_at
     inbox_mutation = getattr(getattr(thread, "inbox", None), "last_mutated_at", None)
     return max(thread.updated_at, inbox_mutation or thread.updated_at)
 
 
-def changed_since(threads, since: datetime):
+def changed_since(threads, since: datetime, *, include_inbox: bool = False):
     """Return changed threads and the monotonic high-water change cursor.
 
-    Inbox mutations are durable mailbox changes but deliberately do not alter
-    ``Thread.updated_at`` (which remains the content ordering timestamp).
+    Agent mailbox waits retain content-only semantics by default. The serve
+    inbox surface opts into durable inbox mutations explicitly.
     """
-    change_times = [(thread, _change_at(thread)) for thread in threads]
+    change_times = [(thread, _change_at(thread, include_inbox)) for thread in threads]
     changed = [thread for thread, change_at in change_times if change_at > since]
     cursor = max([since, *(change_at for _, change_at in change_times)])
     return changed, cursor
@@ -74,8 +76,7 @@ def wait_for_change(
 ) -> WaitResult:
     """Block until `load_fn()` yields a thread changed since `since` that also
     satisfies `predicate` (default: any change), or `timeout` seconds elapse.
-    The cursor always advances to the latest content or inbox-mutation change,
-    even on timeout."""
+    The cursor always advances to the latest selected change, even on timeout."""
     deadline = now_fn() + timeout
     while True:
         changed, cursor = changed_since(load_fn(), since)

--- a/src/mship/core/message_wait.py
+++ b/src/mship/core/message_wait.py
@@ -10,16 +10,21 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable
+
+
+def _utc(dt: datetime) -> datetime:
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
 
 
 def _change_at(thread, include_inbox: bool) -> datetime:
     """Content time, or inbox time when a caller explicitly opts in."""
+    content_at = _utc(thread.updated_at)
     if not include_inbox:
-        return thread.updated_at
+        return content_at
     inbox_mutation = getattr(getattr(thread, "inbox", None), "last_mutated_at", None)
-    return max(thread.updated_at, inbox_mutation or thread.updated_at)
+    return max(content_at, _utc(inbox_mutation) if inbox_mutation else content_at)
 
 
 def changed_since(threads, since: datetime, *, include_inbox: bool = False):

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -981,16 +981,23 @@ def create_app(
         set_prose_verdict,
     )
     from mship.core.spec_questions import add_question, answer_question
+    from mship.core.spec_store import SpecArtifactConflict
 
     def _load_or_404(spec_id: str):
-        spec = store.find_by_id(spec_id)
+        try:
+            spec = store.find_by_id(spec_id)
+        except SpecArtifactConflict as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
         if spec is None:
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
         return spec
 
     def _save_and_review(spec):
         spec.updated_at = datetime.now(timezone.utc)
-        store.save(spec)
+        try:
+            store.save(spec)
+        except SpecArtifactConflict as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
         return build_review(spec)
 
     def _auto_approve_if_ready(spec):
@@ -1128,6 +1135,7 @@ def create_app(
     @app.post("/specs")
     def post_create_spec(body: NewSpecBody):
         from mship.core.spec_storage import SpecLocked
+        from mship.core.spec_store import SpecArtifactConflict
 
         now = datetime.now(timezone.utc)
         try:
@@ -1141,9 +1149,11 @@ def create_app(
             created = store.create_if_absent(spec)
         except SpecLocked:
             raise HTTPException(status_code=409, detail=f"spec {spec.id!r} already exists but is locked")
-        if not created:
+        except SpecArtifactConflict as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+        if created is None:
             raise HTTPException(status_code=409, detail=f"spec {spec.id!r} already exists")
-        return spec.model_dump(mode="json")
+        return {**spec.model_dump(mode="json"), "path": str(created)}
 
     @app.post("/specs/{spec_id}/draft")
     def post_draft(spec_id: str, body: DraftIntentBody):

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -330,7 +330,7 @@ def create_app(
     `get_gh_token`."""
     from fastapi import Depends, FastAPI, HTTPException
 
-    from mship.core.spec_store import SpecStore
+    from mship.core.spec_store import SpecArtifactConflict, SpecStore
     from mship.core.spec_storage import SpecStorage, resolve_mode
     from mship.core.message_store import MessageStore
     from mship.core.workitem_store import WorkItemStore
@@ -629,6 +629,8 @@ def create_app(
             spec, applied = store.mutate_inbox(spec_id, action, body.mutation_id, now)
         except SpecLocked:
             raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
+        except SpecArtifactConflict as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
         except KeyError:
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
         except ValueError as exc:
@@ -639,7 +641,10 @@ def create_app(
 
     @app.get("/specs/{spec_id}/review")
     def get_review(spec_id: str):
-        spec = store.find_by_id(spec_id)
+        try:
+            spec = store.find_by_id(spec_id)
+        except SpecArtifactConflict as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
         if spec is None:
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
         return build_review(spec)
@@ -981,7 +986,6 @@ def create_app(
         set_prose_verdict,
     )
     from mship.core.spec_questions import add_question, answer_question
-    from mship.core.spec_store import SpecArtifactConflict
 
     def _load_or_404(spec_id: str):
         try:
@@ -1135,7 +1139,6 @@ def create_app(
     @app.post("/specs")
     def post_create_spec(body: NewSpecBody):
         from mship.core.spec_storage import SpecLocked
-        from mship.core.spec_store import SpecArtifactConflict
 
         now = datetime.now(timezone.utc)
         try:

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -9,9 +9,9 @@ import time as _time
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 # The only fastapi names imported at MODULE scope, and they have to be: this
 # module is `from __future__ import annotations`, so a handler's annotations are
@@ -32,7 +32,8 @@ from mship.core.spec_transition import (
     approve_spec,
     request_changes_spec,
 )
-from mship.core.view.thread_links import index_thread_work_items
+from mship.core.inbox import InboxAction, classify_spec, classify_thread
+from mship.core.view.thread_links import index_thread_inbox_links
 from mship.core.workitem import Phase
 from mship.util.shell import ShellRunner
 
@@ -113,6 +114,17 @@ class CaptureBody(BaseModel):
 
 class SeenBody(BaseModel):
     seen_at: str | None = None
+
+
+class InboxMutationBody(BaseModel):
+    mutation_id: str
+
+    @field_validator("mutation_id")
+    @classmethod
+    def validate_mutation_id(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("mutation_id must not be blank")
+        return value
 
 
 class UnattendedBody(BaseModel):
@@ -525,42 +537,23 @@ def create_app(
 
     from mship.core.spec_review import build_review
 
-    @app.get("/specs")
-    def list_specs():
-        out = []
-        for spec, locked_id, _path in _spec_storage.read_all():
-            if spec is None:
-                # Encrypted spec, no key on this host: surface a LOCKED marker so
-                # Ground Control can show it without ever leaking ciphertext.
-                out.append({
-                    "id": locked_id, "locked": True, "status": "locked",
-                    "title": None, "task_slug": None, "affected_repos": [],
-                })
-            else:
-                out.append({
-                    "id": spec.id, "title": spec.title, "status": spec.status,
-                    "task_slug": spec.task_slug, "affected_repos": spec.affected_repos,
-                    "locked": False,
-                })
-        return out
+    def _matches_inbox_filter(payload: dict, inbox: Literal["active", "archived", "all"]) -> bool:
+        return inbox == "all" or payload["inbox_state"] == inbox
 
-    @app.get("/specs/{spec_id}")
-    def get_spec(spec_id: str):
-        # Resolve via the LOCKED-aware seam (not store.find_by_id, which loads
-        # EVERY file and would raise on a sibling locked spec — making a coexisting
-        # plaintext spec unreachable). A locked match returns a marker (200), not
-        # ciphertext and not a 500.
-        spec = None
-        for candidate, locked_id, _path in _spec_storage.read_all():
-            if candidate is None:
-                if locked_id == spec_id:
-                    return {"id": spec_id, "locked": True, "status": "locked"}
-                continue
-            if candidate.id == spec_id:
-                spec = candidate
-                break
-        if spec is None:
-            raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
+    def _matches_search(query: str | None, *values: str | None) -> bool:
+        if not query:
+            return True
+        needle = query.casefold()
+        return any(needle in (value or "").casefold() for value in values)
+
+    def _stamp_spec_inbox(payload: dict, spec, now: datetime) -> dict:
+        classification = classify_spec(spec, now=now)
+        payload["inbox_state"] = classification.state
+        payload["archive_reason"] = classification.archive_reason
+        payload["pinned"] = spec.inbox.pinned
+        return payload
+
+    def _spec_payload(spec, now: datetime | None = None) -> dict:
         data = spec.model_dump(mode="json")
         data["locked"] = False
         # Resolve the linked WorkItem's kind (feature/bug/chore) so the Queue review cards can show
@@ -573,8 +566,70 @@ def create_app(
                 wi = workitems.get(spec.work_item_id)
                 data["work_item_kind"] = wi.kind if wi is not None else None
             except Exception:
-                data["work_item_kind"] = None
-        return data
+                pass
+        return _stamp_spec_inbox(data, spec, now or datetime.now(timezone.utc))
+
+    @app.get("/specs")
+    def list_specs(
+        inbox: Literal["active", "archived", "all"] = "all",
+        q: str | None = None,
+    ):
+        now = datetime.now(timezone.utc)
+        out = []
+        for spec, locked_id, _path in _spec_storage.read_all():
+            if spec is None:
+                # Encrypted spec, no key on this host: surface a LOCKED marker so
+                # Ground Control can show it without ever leaking ciphertext.
+                payload = {
+                    "id": locked_id, "locked": True, "status": "locked",
+                    "title": None, "task_slug": None, "affected_repos": [],
+                    "inbox_state": "active", "archive_reason": None, "pinned": False,
+                }
+            else:
+                payload = _stamp_spec_inbox({
+                    "id": spec.id, "title": spec.title, "status": spec.status,
+                    "task_slug": spec.task_slug, "affected_repos": spec.affected_repos,
+                    "locked": False,
+                }, spec, now)
+            if (_matches_inbox_filter(payload, inbox)
+                    and _matches_search(q, payload["id"], payload["title"])):
+                out.append(payload)
+        return out
+
+    @app.get("/specs/{spec_id}")
+    def get_spec(spec_id: str):
+        # Resolve via the LOCKED-aware seam (not store.find_by_id, which loads
+        # EVERY file and would raise on a sibling locked spec — making a coexisting
+        # plaintext spec unreachable). A locked match returns a marker (200), not
+        # ciphertext and not a 500.
+        spec = None
+        for candidate, locked_id, _path in _spec_storage.read_all():
+            if candidate is None:
+                if locked_id == spec_id:
+                    return {
+                        "id": spec_id, "locked": True, "status": "locked",
+                        "inbox_state": "active", "archive_reason": None, "pinned": False,
+                    }
+                continue
+            if candidate.id == spec_id:
+                spec = candidate
+                break
+        if spec is None:
+            raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
+        return _spec_payload(spec)
+
+    @app.post("/specs/{spec_id}/inbox/{action}")
+    def post_spec_inbox_action(spec_id: str, action: InboxAction, body: InboxMutationBody):
+        now = datetime.now(timezone.utc)
+        try:
+            spec = store.mutate_inbox(spec_id, action, body.mutation_id, now)
+        except KeyError:
+            raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
+        if spec.task_slug:
+            state_manager.record_activity(spec.task_slug, now)
+        return _spec_payload(spec, now)
 
     @app.get("/specs/{spec_id}/review")
     def get_review(spec_id: str):
@@ -1246,42 +1301,69 @@ def create_app(
             raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
         return _thread_payload(t)
 
-    def _summaries(threads):
-        threads = list(threads)
-        # Stamp each summary with the single WorkItem that owns the thread (direct thread_ids
-        # membership, else indirect via spec_id/task_slug) so Ground Control can group the
-        # messages surface by work item. Invariant: a thread resolves to AT MOST ONE item.
-        # include_archived=True: link ownership survives archival (mirrors _thread_payload's
-        # resolution). Best-effort — a corrupt WorkItem must never 500 the list, so the store
-        # scan is guarded and index_thread_work_items degrades to None, matching get_spec's
-        # work_item_kind stamping.
+    def _thread_inbox_links(threads, all_items=None):
+        if all_items is None:
+            try:
+                all_items = list(workitems.list(include_archived=True))
+            except Exception:
+                all_items = []
         try:
-            all_items = list(workitems.list(include_archived=True))
+            specs_by_id = {spec.id: spec for spec in store.list()}
         except Exception:
-            all_items = []
-        wi_by_thread = index_thread_work_items(threads, all_items)
+            specs_by_id = {}
+        try:
+            tasks_by_slug = dict(state_manager.load().tasks)
+        except Exception:
+            tasks_by_slug = {}
+        return index_thread_inbox_links(threads, all_items, specs_by_id, tasks_by_slug)
+
+    def _summaries(threads, now: datetime | None = None):
+        threads = list(threads)
+        now = now or datetime.now(timezone.utc)
+        links_by_thread = _thread_inbox_links(threads)
+        summaries = []
+        for thread in threads:
+            link = links_by_thread[thread.id]
+            classification = classify_thread(
+                thread, linked=link.work_item_id is not None,
+                linked_terminal=link.terminal, now=now,
+            )
+            summaries.append({
+                "id": thread.id, "subject": thread.subject,
+                "updated_at": thread.updated_at.isoformat(),
+                "awaiting_reply": thread.awaiting_reply,
+                # Unhandled agent event (e.g. a PR merge) feeds GC's group attention rollup.
+                "awaiting_agent_event": thread.awaiting_agent_event,
+                "needs_you": thread.needs_you,
+                "needs_decision": thread.needs_decision,
+                "unseen": thread.unseen,
+                "agent_seen_at": thread.agent_seen_at.isoformat() if thread.agent_seen_at else None,
+                "last_message": thread.messages[-1].text[:120] if thread.messages else "",
+                "message_count": len(thread.messages),
+                "work_item_id": link.work_item_id,
+                "inbox_state": classification.state,
+                "archive_reason": classification.archive_reason,
+                "pinned": thread.inbox.pinned,
+            })
+        return summaries
+
+    def _filtered_summaries(threads, inbox: Literal["active", "archived", "all"], q: str | None):
         return [
-            {
-                "id": t.id, "subject": t.subject,
-                "updated_at": t.updated_at.isoformat(),
-                "awaiting_reply": t.awaiting_reply,
-                # unhandled agent `event` (e.g. a PR merge) — feeds GC's group attention rollup.
-                "awaiting_agent_event": t.awaiting_agent_event,
-                "needs_you": t.needs_you,
-                "needs_decision": t.needs_decision,
-                "unseen": t.unseen,
-                "agent_seen_at": t.agent_seen_at.isoformat() if t.agent_seen_at else None,
-                "last_message": (t.messages[-1].text[:120] if t.messages else ""),
-                "message_count": len(t.messages),
-                "work_item_id": wi_by_thread.get(t.id),
-            }
-            for t in threads
+            summary for summary in _summaries(threads)
+            if (_matches_inbox_filter(summary, inbox)
+                and _matches_search(q, summary["subject"], summary["last_message"]))
         ]
 
     @app.get("/threads")
-    async def list_threads(wait: int = 0, since: Optional[str] = None, timeout: float = 25.0):
+    async def list_threads(
+        wait: int = 0,
+        since: Optional[str] = None,
+        timeout: float = 25.0,
+        inbox: Literal["active", "archived", "all"] = "all",
+        q: str | None = None,
+    ):
         if not wait:
-            return _summaries(msgs.list())
+            return _filtered_summaries(msgs.list(), inbox, q)
         from mship.core.message_wait import changed_since
         timeout = max(0.0, min(timeout, 30.0))  # cap for the relay idle-read timeout
         try:
@@ -1294,12 +1376,26 @@ def create_app(
         deadline = _time.monotonic() + timeout
         while True:
             changed, cursor = changed_since(msgs.list(), since_dt)
-            if changed:
-                return {"threads": _summaries(changed), "cursor": cursor.isoformat(), "timed_out": False}
+            threads = _filtered_summaries(changed, inbox, q)
+            if threads:
+                return {"threads": threads, "cursor": cursor.isoformat(), "timed_out": False}
             remaining = deadline - _time.monotonic()
             if remaining <= 0:
                 return {"threads": [], "cursor": cursor.isoformat(), "timed_out": True}
             await asyncio.sleep(min(interval, remaining))
+
+    @app.post("/threads/{thread_id}/inbox/{action}")
+    def post_thread_inbox_action(thread_id: str, action: InboxAction, body: InboxMutationBody):
+        now = datetime.now(timezone.utc)
+        try:
+            thread = msgs.mutate_inbox(thread_id, action, body.mutation_id, now)
+        except KeyError:
+            raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
+        if thread.task_slug:
+            state_manager.record_activity(thread.task_slug, now)
+        return _thread_payload(thread, now)
 
     @app.get("/threads/{thread_id}")
     def get_thread(thread_id: str):
@@ -1309,10 +1405,7 @@ def create_app(
         return _thread_payload(t)
 
     # --- work items (phase-aware cockpit spine) ---
-    # `workitems` and `_item_msg_lock` are defined earlier (see comment above
-    # `_lifespan`).
     from mship.core.view.workitem_index import build_workitem_index
-    from mship.core.view.thread_links import resolve_thread_work_item
     from mship.core.view.entity_links import linkify_entities
 
     # Serializes POST /specs/{id}/dispatch. Same threadpool hazard as above: two
@@ -1363,30 +1456,24 @@ def create_app(
             include_archived=True,
         )[0]
 
-    def _thread_payload(t):
-        """Enrich a thread's dumped dict with the WorkItem it's related to (read-time
-        inversion of the WorkItem link graph — see thread_links.resolve_thread_work_item)
-        and auto-linkify native entity refs (wi-/spec/task ids) in agent message text
-        (see entity_links.linkify_entities). Human messages are left untouched — the
-        linkifier only rewrites text the agent produced. Shared by every handler that
-        returns a full thread: GET /threads/{id}, POST /threads, POST /threads/{id}/messages,
-        POST /threads/{id}/seen. The GET /threads list/summary endpoint is unaffected."""
+    def _thread_payload(t, now: datetime | None = None):
+        """Enrich a thread with its WorkItem and computed inbox state."""
         data = t.model_dump(mode="json")
-        # include_archived=True: this is link/ownership resolution (which WorkItem does
-        # this thread belong to?), not a user-facing listing. A thread stays linked to its
-        # WorkItem after that item is archived (MOS-228 T3), so resolving with the default
-        # archived-excluding list() would wrongly report work_item_id=null here. The
-        # user-facing filter still applies at GET /items (_workitem_index above) and
-        # `item list` — only this internal resolution needs the full set.
-        # Best-effort scans (one corrupt/forward-incompatible workitem/spec file must not 500 the
-        # thread read paths — mirrors _summaries' guard; the thread itself still resolves).
-        all_items = _safe(lambda: list(workitems.list(include_archived=True)), [])  # reused below
-        wi_id = resolve_thread_work_item(t.id, t.spec_id, t.task_slug, all_items)
-        data["work_item_id"] = wi_id
-        if wi_id is None:
+        # include_archived=True: this is link ownership resolution, not a user-facing listing.
+        all_items = _safe(lambda: list(workitems.list(include_archived=True)), [])
+        link = _thread_inbox_links([t], all_items)[t.id]
+        data["work_item_id"] = link.work_item_id
+        classification = classify_thread(
+            t, linked=link.work_item_id is not None, linked_terminal=link.terminal,
+            now=now or datetime.now(timezone.utc),
+        )
+        data["inbox_state"] = classification.state
+        data["archive_reason"] = classification.archive_reason
+        data["pinned"] = t.inbox.pinned
+        if link.work_item_id is None:
             data["work_item"] = None
         else:
-            summ = _summarize_item(wi_id)
+            summ = _summarize_item(link.work_item_id)
             data["work_item"] = None if summ is None else {
                 "id": summ.id, "title": summ.title, "kind": summ.kind, "phase": summ.phase,
             }

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1190,6 +1190,8 @@ def create_app(
 
     @app.post("/specs/{spec_id}/apply")
     def post_apply(spec_id: str, body: ApplyDraftBody):
+        from mship.core.spec_storage import SpecLocked
+
         spec = _load_or_404(spec_id)
         if not body.bypass_status_gate:
             try:
@@ -1205,6 +1207,8 @@ def create_app(
         spec.updated_at = datetime.now(timezone.utc)
         try:
             store.save(spec)
+        except SpecLocked:
+            raise HTTPException(status_code=409, detail=f"spec {spec.id!r} is locked")
         except SpecParseError as exc:
             _raise_spec_conflict(exc)
         return spec.model_dump(mode="json")
@@ -1277,6 +1281,8 @@ def create_app(
         # lands. Re-loading the spec inside the lock (rather than reusing the copy
         # loaded before it) means the second caller sees the first's work_item_id
         # already set and reuses it instead of creating a duplicate WorkItem.
+        from mship.core.spec_storage import SpecLocked
+
         try:
             with _dispatch_lock:
                 spec = _load_or_404(spec_id)
@@ -1303,6 +1309,8 @@ def create_app(
                         "dispatch handoff notify failed (spec=%s task=%s) — "
                         "dispatch itself succeeded", result.spec.id, result.task.slug,
                     )
+        except SpecLocked:
+            raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
         except (DispatchError, SpecParseError) as exc:
             _raise_spec_conflict(exc)
         return {

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1545,7 +1545,7 @@ def create_app(
     def _workitem_index(include_archived: bool = False):
         return build_workitem_index(
             _safe(lambda: workitems.list(include_archived=include_archived), []),
-            _safe(lambda: {s.id: s for s in store.list()}, {}),
+            _safe(lambda: {s.id: s for s in store.list_tolerant()}, {}),
             _safe(lambda: dict(state_manager.load().tasks), {}),
             _safe(lambda: {t.id: t for t in msgs.list()}, {}),
             include_archived=include_archived,
@@ -1561,7 +1561,13 @@ def create_app(
         wi = workitems.get(item_id)
         if wi is None:
             return None
-        spec = _safe(lambda: store.read_strict(wi.spec_id), None) if wi.spec_id else None
+        spec = _safe(
+            lambda: next(
+                (s for s in store.list_tolerant() if s.id == wi.spec_id),
+                None,
+            ),
+            None,
+        ) if wi.spec_id else None
         tasks = state_manager.load().tasks
         return build_workitem_index(
             [wi],
@@ -1593,7 +1599,7 @@ def create_app(
                 "id": summ.id, "title": summ.title, "kind": summ.kind, "phase": summ.phase,
             }
         item_ids = {w.id for w in all_items}
-        spec_ids = _safe(lambda: {s.id for s in store.list()}, set())
+        spec_ids = _safe(lambda: {s.id for s in store.list_tolerant()}, set())
         task_slugs = _safe(lambda: set(state_manager.load().tasks.keys()), set())
         for msg in data.get("messages", []):
             if msg.get("role") == "agent" and msg.get("text"):

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -642,8 +642,12 @@ def create_app(
 
     @app.get("/specs/{spec_id}/review")
     def get_review(spec_id: str):
+        from mship.core.spec_storage import SpecLocked
+
         try:
-            spec = store.find_by_id(spec_id)
+            spec = store.read_strict(spec_id)
+        except SpecLocked:
+            raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
         except SpecParseError as exc:
             raise HTTPException(status_code=409, detail=str(exc))
         if spec is None:
@@ -992,8 +996,12 @@ def create_app(
         raise HTTPException(status_code=409, detail=str(exc))
 
     def _load_or_404(spec_id: str):
+        from mship.core.spec_storage import SpecLocked
+
         try:
-            spec = store.find_by_id(spec_id)
+            spec = store.read_strict(spec_id)
+        except SpecLocked:
+            raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
         except SpecParseError as exc:
             _raise_spec_conflict(exc)
         if spec is None:
@@ -1001,9 +1009,13 @@ def create_app(
         return spec
 
     def _save_and_review(spec):
+        from mship.core.spec_storage import SpecLocked
+
         spec.updated_at = datetime.now(timezone.utc)
         try:
             store.save(spec)
+        except SpecLocked:
+            raise HTTPException(status_code=409, detail=f"spec {spec.id!r} is locked")
         except SpecParseError as exc:
             _raise_spec_conflict(exc)
         return build_review(spec)

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1508,6 +1508,7 @@ def create_app(
         # include_archived=True: this is link ownership resolution, not a user-facing listing.
         all_items, uncertain = workitems.list_tolerant_with_uncertainty(include_archived=True)
         link = _thread_inbox_links([t])[t.id]
+        data["work_item_id"] = link.work_item_id
         classification = classify_thread(
             t, linked=link.work_item_id is not None or link.uncertain,
             linked_terminal=link.terminal, now=now or datetime.now(timezone.utc),

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1314,7 +1314,9 @@ def create_app(
 
     def _thread_inbox_links(threads, all_items=None):
         if all_items is None:
-            all_items = workitems.list_tolerant(include_archived=True)
+            all_items, uncertain = workitems.list_tolerant_with_uncertainty(include_archived=True)
+        else:
+            uncertain = False
         from mship.core.spec_store import parse_spec
 
         specs_by_id = {}
@@ -1328,7 +1330,9 @@ def create_app(
             tasks_by_slug = dict(state_manager.load().tasks)
         except Exception:
             tasks_by_slug = {}
-        return index_thread_inbox_links(threads, all_items, specs_by_id, tasks_by_slug)
+        return index_thread_inbox_links(
+            threads, all_items, specs_by_id, tasks_by_slug, uncertain=uncertain,
+        )
 
     def _summaries(threads, now: datetime | None = None):
         threads = list(threads)
@@ -1338,7 +1342,7 @@ def create_app(
         for thread in threads:
             link = links_by_thread[thread.id]
             classification = classify_thread(
-                thread, linked=link.work_item_id is not None,
+                thread, linked=link.work_item_id is not None or link.uncertain,
                 linked_terminal=link.terminal, now=now,
             )
             summaries.append({
@@ -1502,12 +1506,11 @@ def create_app(
         """Enrich a thread with its WorkItem and computed inbox state."""
         data = t.model_dump(mode="json")
         # include_archived=True: this is link ownership resolution, not a user-facing listing.
-        all_items = workitems.list_tolerant(include_archived=True)
-        link = _thread_inbox_links([t], all_items)[t.id]
-        data["work_item_id"] = link.work_item_id
+        all_items, uncertain = workitems.list_tolerant_with_uncertainty(include_archived=True)
+        link = _thread_inbox_links([t])[t.id]
         classification = classify_thread(
-            t, linked=link.work_item_id is not None, linked_terminal=link.terminal,
-            now=now or datetime.now(timezone.utc),
+            t, linked=link.work_item_id is not None or link.uncertain,
+            linked_terminal=link.terminal, now=now or datetime.now(timezone.utc),
         )
         data["inbox_state"] = classification.state
         data["archive_reason"] = classification.archive_reason

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -576,7 +576,7 @@ def create_app(
     ):
         now = datetime.now(timezone.utc)
         out = []
-        for spec, locked_id, _path in _spec_storage.read_all():
+        for spec, locked_id, _path in store.list_tolerant_entries():
             if spec is None:
                 # Encrypted spec, no key on this host: surface a LOCKED marker only
                 # in the unfiltered view. It has no plaintext metadata to classify.
@@ -650,6 +650,8 @@ def create_app(
             raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
         except SpecParseError as exc:
             raise HTTPException(status_code=409, detail=str(exc))
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
         if spec is None:
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
         return build_review(spec)
@@ -1004,6 +1006,8 @@ def create_app(
             raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
         except SpecParseError as exc:
             _raise_spec_conflict(exc)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
         if spec is None:
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
         return spec

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1138,12 +1138,11 @@ def create_app(
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc))
         try:
-            existing = store.read_strict(spec.id)
+            created = store.create_if_absent(spec)
         except SpecLocked:
             raise HTTPException(status_code=409, detail=f"spec {spec.id!r} already exists but is locked")
-        if existing is not None:
+        if not created:
             raise HTTPException(status_code=409, detail=f"spec {spec.id!r} already exists")
-        store.save(spec)
         return spec.model_dump(mode="json")
 
     @app.post("/specs/{spec_id}/draft")
@@ -1315,14 +1314,16 @@ def create_app(
 
     def _thread_inbox_links(threads, all_items=None):
         if all_items is None:
+            all_items = workitems.list_tolerant(include_archived=True)
+        from mship.core.spec_store import parse_spec
+
+        specs_by_id = {}
+        for path in _spec_storage.iter_physical():
             try:
-                all_items = list(workitems.list(include_archived=True))
+                spec = parse_spec(_spec_storage.decode_file(path))
             except Exception:
-                all_items = []
-        try:
-            specs_by_id = {spec.id: spec for spec in store.list()}
-        except Exception:
-            specs_by_id = {}
+                continue
+            specs_by_id[spec.id] = spec
         try:
             tasks_by_slug = dict(state_manager.load().tasks)
         except Exception:
@@ -1501,7 +1502,7 @@ def create_app(
         """Enrich a thread with its WorkItem and computed inbox state."""
         data = t.model_dump(mode="json")
         # include_archived=True: this is link ownership resolution, not a user-facing listing.
-        all_items = _safe(lambda: list(workitems.list(include_archived=True)), [])
+        all_items = workitems.list_tolerant(include_archived=True)
         link = _thread_inbox_links([t], all_items)[t.id]
         data["work_item_id"] = link.work_item_id
         classification = classify_thread(

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1379,6 +1379,7 @@ def create_app(
 
         specs_by_id = {}
         ambiguous_spec_ids = set()
+        unknown_renamed_artifact = False
         for path in _spec_storage.iter_physical():
             canonical_id = canonical_spec_id_from_filename(path)
             try:
@@ -1387,6 +1388,8 @@ def create_app(
                 if canonical_id is not None:
                     specs_by_id.pop(canonical_id, None)
                     ambiguous_spec_ids.add(canonical_id)
+                else:
+                    unknown_renamed_artifact = True
                 continue
             if canonical_id is not None and canonical_id != spec.id:
                 for ambiguous_id in (canonical_id, spec.id):
@@ -1398,6 +1401,8 @@ def create_app(
                 ambiguous_spec_ids.add(spec.id)
             elif spec.id not in ambiguous_spec_ids:
                 specs_by_id[spec.id] = spec
+        if unknown_renamed_artifact:
+            ambiguous_spec_ids.update(specs_by_id)
         try:
             tasks_by_slug = dict(state_manager.load().tasks)
         except Exception:

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -620,14 +620,18 @@ def create_app(
 
     @app.post("/specs/{spec_id}/inbox/{action}")
     def post_spec_inbox_action(spec_id: str, action: InboxAction, body: InboxMutationBody):
+        from mship.core.spec_storage import SpecLocked
+
         now = datetime.now(timezone.utc)
         try:
-            spec = store.mutate_inbox(spec_id, action, body.mutation_id, now)
+            spec, applied = store.mutate_inbox(spec_id, action, body.mutation_id, now)
+        except SpecLocked:
+            raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
         except KeyError:
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc))
-        if spec.task_slug:
+        if applied and spec.task_slug:
             state_manager.record_activity(spec.task_slug, now)
         return _spec_payload(spec, now)
 
@@ -1347,11 +1351,20 @@ def create_app(
             })
         return summaries
 
+    def _matches_thread_filter(
+        summary: dict,
+        inbox: Literal["active", "archived", "all"],
+        q: str | None,
+    ) -> bool:
+        return (
+            _matches_inbox_filter(summary, inbox)
+            and _matches_search(q, summary["subject"], summary["last_message"])
+        )
+
     def _filtered_summaries(threads, inbox: Literal["active", "archived", "all"], q: str | None):
         return [
             summary for summary in _summaries(threads)
-            if (_matches_inbox_filter(summary, inbox)
-                and _matches_search(q, summary["subject"], summary["last_message"]))
+            if _matches_thread_filter(summary, inbox, q)
         ]
 
     @app.get("/threads")
@@ -1376,24 +1389,41 @@ def create_app(
         deadline = _time.monotonic() + timeout
         while True:
             changed, cursor = changed_since(msgs.list(), since_dt)
-            threads = _filtered_summaries(changed, inbox, q)
-            if threads:
-                return {"threads": threads, "cursor": cursor.isoformat(), "timed_out": False}
+            summaries = _summaries(changed)
+            threads = [
+                summary for summary in summaries
+                if _matches_thread_filter(summary, inbox, q)
+            ]
+            # A filtered client must remove items that changed out of its view.
+            # The response keeps `threads` filter-pure; legacy clients ignore the
+            # additive tombstones field, while newer clients remove these ids.
+            removed_ids = [
+                summary["id"] for summary in summaries
+                if not _matches_thread_filter(summary, inbox, q)
+            ]
+            if threads or removed_ids:
+                return {
+                    "threads": threads, "removed_ids": removed_ids,
+                    "cursor": cursor.isoformat(), "timed_out": False,
+                }
             remaining = deadline - _time.monotonic()
             if remaining <= 0:
-                return {"threads": [], "cursor": cursor.isoformat(), "timed_out": True}
+                return {
+                    "threads": [], "removed_ids": [],
+                    "cursor": cursor.isoformat(), "timed_out": True,
+                }
             await asyncio.sleep(min(interval, remaining))
 
     @app.post("/threads/{thread_id}/inbox/{action}")
     def post_thread_inbox_action(thread_id: str, action: InboxAction, body: InboxMutationBody):
         now = datetime.now(timezone.utc)
         try:
-            thread = msgs.mutate_inbox(thread_id, action, body.mutation_id, now)
+            thread, applied = msgs.mutate_inbox(thread_id, action, body.mutation_id, now)
         except KeyError:
             raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc))
-        if thread.task_slug:
+        if applied and thread.task_slug:
             state_manager.record_activity(thread.task_slug, now)
         return _thread_payload(thread, now)
 
@@ -1519,7 +1549,7 @@ def create_app(
                 task_slug = wi.task_slugs[0] if wi.task_slugs else None
                 thread = msgs.create_thread(subject=subject, text=body.text, now=now, task_slug=task_slug)
                 workitems.add_thread(item_id, thread.id, now=now)
-                return thread.model_dump(mode="json")
+                return _thread_payload(thread, now)
             try:
                 msgs.append(tid, "human", body.text, now)
             except KeyError:
@@ -1527,7 +1557,7 @@ def create_app(
             t = msgs.get(tid)
             if t is None:
                 raise HTTPException(status_code=404, detail=f"no thread {tid!r}")
-            return t.model_dump(mode="json")
+            return _thread_payload(t, now)
 
     @app.post("/items/{item_id}/unattended")
     def post_item_unattended(item_id: str, body: UnattendedBody):

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -330,7 +330,7 @@ def create_app(
     `get_gh_token`."""
     from fastapi import Depends, FastAPI, HTTPException
 
-    from mship.core.spec_store import SpecParseError, SpecStore
+    from mship.core.spec_store import SpecParseError, SpecRepresentationMismatch, SpecStore
     from mship.core.spec_storage import SpecStorage, resolve_mode
     from mship.core.message_store import MessageStore
     from mship.core.workitem_store import WorkItemStore
@@ -988,11 +988,14 @@ def create_app(
     )
     from mship.core.spec_questions import add_question, answer_question
 
+    def _raise_spec_conflict(exc: SpecParseError | SpecRepresentationMismatch) -> None:
+        raise HTTPException(status_code=409, detail=str(exc))
+
     def _load_or_404(spec_id: str):
         try:
             spec = store.find_by_id(spec_id)
         except SpecParseError as exc:
-            raise HTTPException(status_code=409, detail=str(exc))
+            _raise_spec_conflict(exc)
         if spec is None:
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
         return spec
@@ -1002,7 +1005,7 @@ def create_app(
         try:
             store.save(spec)
         except SpecParseError as exc:
-            raise HTTPException(status_code=409, detail=str(exc))
+            _raise_spec_conflict(exc)
         return build_review(spec)
 
     def _auto_approve_if_ready(spec):
@@ -1090,6 +1093,8 @@ def create_app(
             raise HTTPException(status_code=409, detail="cannot approve: " + "; ".join(e.blockers))
         except InvalidTransition as e:
             raise HTTPException(status_code=409, detail=str(e))
+        except SpecParseError as exc:
+            _raise_spec_conflict(exc)
         return build_review(spec)
 
     @app.post("/specs/{spec_id}/request-changes")
@@ -1113,7 +1118,12 @@ def create_app(
         # its own `record_rejection` call. This also supersedes the old
         # decorative "spec request-changes (api): …" log line — the
         # structured record is the parsed source now.
-        request_changes_spec(spec, store, body.reason, log_manager=log_manager, actor="operator")
+        try:
+            request_changes_spec(
+                spec, store, body.reason, log_manager=log_manager, actor="operator",
+            )
+        except SpecParseError as exc:
+            _raise_spec_conflict(exc)
         return build_review(spec)
 
     @app.post("/specs/{spec_id}/archive")
@@ -1151,10 +1161,12 @@ def create_app(
             raise HTTPException(status_code=400, detail=str(exc))
         try:
             created = store.create_if_absent(spec)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
         except SpecLocked:
             raise HTTPException(status_code=409, detail=f"spec {spec.id!r} already exists but is locked")
         except SpecParseError as exc:
-            raise HTTPException(status_code=409, detail=str(exc))
+            _raise_spec_conflict(exc)
         if created is None:
             raise HTTPException(status_code=409, detail=f"spec {spec.id!r} already exists")
         return {**spec.model_dump(mode="json"), "path": str(created)}
@@ -1179,7 +1191,10 @@ def create_app(
         spec.status = "needs_review"
         spec.clarification_reason = None
         spec.updated_at = datetime.now(timezone.utc)
-        store.save(spec)
+        try:
+            store.save(spec)
+        except SpecParseError as exc:
+            _raise_spec_conflict(exc)
         return spec.model_dump(mode="json")
 
     @app.post("/capture")
@@ -1276,8 +1291,8 @@ def create_app(
                         "dispatch handoff notify failed (spec=%s task=%s) — "
                         "dispatch itself succeeded", result.spec.id, result.task.slug,
                     )
-        except DispatchError as e:
-            raise HTTPException(status_code=409, detail=str(e))
+        except (DispatchError, SpecParseError) as exc:
+            _raise_spec_conflict(exc)
         return {
             "spec": result.spec.model_dump(mode="json"),
             "task_slug": result.task.slug,
@@ -1331,14 +1346,24 @@ def create_app(
             all_items, uncertain = workitems.list_tolerant_with_uncertainty(include_archived=True)
         else:
             uncertain = False
+        from mship.core.spec_storage import canonical_spec_id_from_filename
         from mship.core.spec_store import parse_spec
 
         specs_by_id = {}
         ambiguous_spec_ids = set()
         for path in _spec_storage.iter_physical():
+            canonical_id = canonical_spec_id_from_filename(path)
             try:
                 spec = parse_spec(_spec_storage.decode_file(path))
             except Exception:
+                if canonical_id is not None:
+                    specs_by_id.pop(canonical_id, None)
+                    ambiguous_spec_ids.add(canonical_id)
+                continue
+            if canonical_id is not None and canonical_id != spec.id:
+                for ambiguous_id in (canonical_id, spec.id):
+                    specs_by_id.pop(ambiguous_id, None)
+                    ambiguous_spec_ids.add(ambiguous_id)
                 continue
             if spec.id in specs_by_id:
                 specs_by_id.pop(spec.id)

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -578,12 +578,14 @@ def create_app(
         out = []
         for spec, locked_id, _path in _spec_storage.read_all():
             if spec is None:
-                # Encrypted spec, no key on this host: surface a LOCKED marker so
-                # Ground Control can show it without ever leaking ciphertext.
+                # Encrypted spec, no key on this host: surface a LOCKED marker only
+                # in the unfiltered view. It has no plaintext metadata to classify.
+                if inbox != "all":
+                    continue
                 payload = {
                     "id": locked_id, "locked": True, "status": "locked",
                     "title": None, "task_slug": None, "affected_repos": [],
-                    "inbox_state": "active", "archive_reason": None, "pinned": False,
+                    "inbox_state": None, "archive_reason": None, "pinned": False,
                 }
             else:
                 payload = _stamp_spec_inbox({
@@ -608,7 +610,7 @@ def create_app(
                 if locked_id == spec_id:
                     return {
                         "id": spec_id, "locked": True, "status": "locked",
-                        "inbox_state": "active", "archive_reason": None, "pinned": False,
+                        "inbox_state": None, "archive_reason": None, "pinned": False,
                     }
                 continue
             if candidate.id == spec_id:
@@ -1125,15 +1127,21 @@ def create_app(
 
     @app.post("/specs")
     def post_create_spec(body: NewSpecBody):
+        from mship.core.spec_storage import SpecLocked
+
         now = datetime.now(timezone.utc)
         try:
             spec = new_spec(
                 body.title, now=now, spec_id=body.id,
                 affected_repos=body.affected_repos, task_slug=body.task_slug,
             )
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e))
-        if store.find_by_id(spec.id) is not None:
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        try:
+            existing = store.read_strict(spec.id)
+        except SpecLocked:
+            raise HTTPException(status_code=409, detail=f"spec {spec.id!r} already exists but is locked")
+        if existing is not None:
             raise HTTPException(status_code=409, detail=f"spec {spec.id!r} already exists")
         store.save(spec)
         return spec.model_dump(mode="json")
@@ -1279,12 +1287,12 @@ def create_app(
         now = datetime.now(timezone.utc)
         try:
             msgs.append(thread_id, "human", body.text, now)
-        except KeyError:
+            thread = msgs.get(thread_id)
+        except (KeyError, ValueError):
             raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
-        t = msgs.get(thread_id)
-        if t is None:
+        if thread is None:
             raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
-        return _thread_payload(t)
+        return _thread_payload(thread)
 
     @app.post("/threads/{thread_id}/seen")
     def post_seen(thread_id: str, body: SeenBody):
@@ -1300,10 +1308,10 @@ def create_app(
         else:
             seen_dt = datetime.now(timezone.utc)
         try:
-            t = msgs.mark_seen(thread_id, seen_dt)
-        except KeyError:
+            thread = msgs.mark_seen(thread_id, seen_dt)
+        except (KeyError, ValueError):
             raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
-        return _thread_payload(t)
+        return _thread_payload(thread)
 
     def _thread_inbox_links(threads, all_items=None):
         if all_items is None:
@@ -1388,7 +1396,7 @@ def create_app(
         interval = 1.0
         deadline = _time.monotonic() + timeout
         while True:
-            changed, cursor = changed_since(msgs.list(), since_dt)
+            changed, cursor = changed_since(msgs.list(), since_dt, include_inbox=True)
             summaries = _summaries(changed)
             threads = [
                 summary for summary in summaries
@@ -1429,10 +1437,13 @@ def create_app(
 
     @app.get("/threads/{thread_id}")
     def get_thread(thread_id: str):
-        t = msgs.get(thread_id)
-        if t is None:
+        try:
+            thread = msgs.get(thread_id)
+        except ValueError:
             raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
-        return _thread_payload(t)
+        if thread is None:
+            raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
+        return _thread_payload(thread)
 
     # --- work items (phase-aware cockpit spine) ---
     from mship.core.view.workitem_index import build_workitem_index

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -331,7 +331,7 @@ def create_app(
     from fastapi import Depends, FastAPI, HTTPException
 
     from mship.core.spec_store import SpecStore
-    from mship.core.spec_storage import SpecStorage
+    from mship.core.spec_storage import SpecStorage, resolve_mode
     from mship.core.message_store import MessageStore
     from mship.core.workitem_store import WorkItemStore
 
@@ -339,7 +339,7 @@ def create_app(
     # `store` decrypts `.md.enc` with the local key for display; `_spec_storage`
     # exposes read_all() so the list/detail endpoints can render a LOCKED marker
     # (never ciphertext, never a 500) when the key is absent on this host.
-    _spec_mode = getattr(config, "spec_storage", "committed") if config is not None else "committed"
+    _spec_mode = getattr(config, "spec_storage", None) or resolve_mode(workspace_root)
     _spec_storage = SpecStorage(specs_dir, mode=_spec_mode, workspace_root=workspace_root)
     store = SpecStore(specs_dir, storage=_spec_storage)
     pr_manager = PRManager(ShellRunner(), cwd=workspace_root)

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -331,7 +331,7 @@ def create_app(
     from fastapi import Depends, FastAPI, HTTPException
 
     from mship.core.spec_store import SpecParseError, SpecRepresentationMismatch, SpecStore
-    from mship.core.spec_storage import SpecStorage, resolve_mode
+    from mship.core.spec_storage import SpecLocked, SpecStorage, resolve_mode
     from mship.core.message_store import MessageStore
     from mship.core.workitem_store import WorkItemStore
 
@@ -1105,6 +1105,8 @@ def create_app(
             raise HTTPException(status_code=409, detail="cannot approve: " + "; ".join(e.blockers))
         except InvalidTransition as e:
             raise HTTPException(status_code=409, detail=str(e))
+        except SpecLocked:
+            raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
         except SpecParseError as exc:
             _raise_spec_conflict(exc)
         return build_review(spec)
@@ -1134,6 +1136,8 @@ def create_app(
             request_changes_spec(
                 spec, store, body.reason, log_manager=log_manager, actor="operator",
             )
+        except SpecLocked:
+            raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
         except SpecParseError as exc:
             _raise_spec_conflict(exc)
         return build_review(spec)

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -600,25 +600,26 @@ def create_app(
 
     @app.get("/specs/{spec_id}")
     def get_spec(spec_id: str):
-        # Resolve via the LOCKED-aware seam (not store.find_by_id, which loads
-        # EVERY file and would raise on a sibling locked spec — making a coexisting
-        # plaintext spec unreachable). A locked match returns a marker (200), not
-        # ciphertext and not a 500.
-        spec = None
-        for candidate, locked_id, _path in _spec_storage.read_all():
-            if candidate is None:
-                if locked_id == spec_id:
-                    return {
-                        "id": spec_id, "locked": True, "status": "locked",
-                        "inbox_state": None, "archive_reason": None, "pinned": False,
-                    }
-                continue
-            if candidate.id == spec_id:
-                spec = candidate
-                break
-        if spec is None:
+        # Use the single-artifact resolver rather than the resilient list seam:
+        # detail views must report collisions instead of selecting an arbitrary file.
+        from mship.core.spec_storage import SpecLocked
+
+        try:
+            artifact = store.resolve_artifact(spec_id)
+        except SpecLocked as locked:
+            if locked.spec_id == spec_id:
+                return {
+                    "id": spec_id, "locked": True, "status": "locked",
+                    "inbox_state": None, "archive_reason": None, "pinned": False,
+                }
+            raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is blocked by locked storage")
+        except SpecArtifactConflict as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
+        if artifact is None:
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
-        return _spec_payload(spec)
+        return _spec_payload(artifact.spec)
 
     @app.post("/specs/{spec_id}/inbox/{action}")
     def post_spec_inbox_action(spec_id: str, action: InboxAction, body: InboxMutationBody):
@@ -1333,18 +1334,24 @@ def create_app(
         from mship.core.spec_store import parse_spec
 
         specs_by_id = {}
+        ambiguous_spec_ids = set()
         for path in _spec_storage.iter_physical():
             try:
                 spec = parse_spec(_spec_storage.decode_file(path))
             except Exception:
                 continue
-            specs_by_id[spec.id] = spec
+            if spec.id in specs_by_id:
+                specs_by_id.pop(spec.id)
+                ambiguous_spec_ids.add(spec.id)
+            elif spec.id not in ambiguous_spec_ids:
+                specs_by_id[spec.id] = spec
         try:
             tasks_by_slug = dict(state_manager.load().tasks)
         except Exception:
             tasks_by_slug = {}
         return index_thread_inbox_links(
             threads, all_items, specs_by_id, tasks_by_slug, uncertain=uncertain,
+            ambiguous_spec_ids=frozenset(ambiguous_spec_ids),
         )
 
     def _summaries(threads, now: datetime | None = None):

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -330,7 +330,7 @@ def create_app(
     `get_gh_token`."""
     from fastapi import Depends, FastAPI, HTTPException
 
-    from mship.core.spec_store import SpecArtifactConflict, SpecStore
+    from mship.core.spec_store import SpecParseError, SpecStore
     from mship.core.spec_storage import SpecStorage, resolve_mode
     from mship.core.message_store import MessageStore
     from mship.core.workitem_store import WorkItemStore
@@ -613,7 +613,7 @@ def create_app(
                     "inbox_state": None, "archive_reason": None, "pinned": False,
                 }
             raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is blocked by locked storage")
-        except SpecArtifactConflict as exc:
+        except SpecParseError as exc:
             raise HTTPException(status_code=409, detail=str(exc))
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc))
@@ -630,7 +630,7 @@ def create_app(
             spec, applied = store.mutate_inbox(spec_id, action, body.mutation_id, now)
         except SpecLocked:
             raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
-        except SpecArtifactConflict as exc:
+        except SpecParseError as exc:
             raise HTTPException(status_code=409, detail=str(exc))
         except KeyError:
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
@@ -644,7 +644,7 @@ def create_app(
     def get_review(spec_id: str):
         try:
             spec = store.find_by_id(spec_id)
-        except SpecArtifactConflict as exc:
+        except SpecParseError as exc:
             raise HTTPException(status_code=409, detail=str(exc))
         if spec is None:
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
@@ -991,7 +991,7 @@ def create_app(
     def _load_or_404(spec_id: str):
         try:
             spec = store.find_by_id(spec_id)
-        except SpecArtifactConflict as exc:
+        except SpecParseError as exc:
             raise HTTPException(status_code=409, detail=str(exc))
         if spec is None:
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
@@ -1001,7 +1001,7 @@ def create_app(
         spec.updated_at = datetime.now(timezone.utc)
         try:
             store.save(spec)
-        except SpecArtifactConflict as exc:
+        except SpecParseError as exc:
             raise HTTPException(status_code=409, detail=str(exc))
         return build_review(spec)
 
@@ -1153,7 +1153,7 @@ def create_app(
             created = store.create_if_absent(spec)
         except SpecLocked:
             raise HTTPException(status_code=409, detail=f"spec {spec.id!r} already exists but is locked")
-        except SpecArtifactConflict as exc:
+        except SpecParseError as exc:
             raise HTTPException(status_code=409, detail=str(exc))
         if created is None:
             raise HTTPException(status_code=409, detail=f"spec {spec.id!r} already exists")

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1492,7 +1492,7 @@ def create_app(
         wi = workitems.get(item_id)
         if wi is None:
             return None
-        spec = store.find_by_id(wi.spec_id) if wi.spec_id else None
+        spec = _safe(lambda: store.read_strict(wi.spec_id), None) if wi.spec_id else None
         tasks = state_manager.load().tasks
         return build_workitem_index(
             [wi],

--- a/src/mship/core/spec.py
+++ b/src/mship/core/spec.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
+
+
+from mship.core.inbox import InboxMetadata
 
 
 # MOS-240: collapsed status vocabulary (was 8: captured/drafting/needs_review/
@@ -70,6 +73,7 @@ class Spec(BaseModel):
     work_item_id: str | None = None
     clarification_reason: str | None = None
     prose_verdicts: dict[str, ProseVerdict] = {}
+    inbox: InboxMetadata = Field(default_factory=InboxMetadata)
 
     @model_validator(mode="before")
     @classmethod

--- a/src/mship/core/spec_lifecycle.py
+++ b/src/mship/core/spec_lifecycle.py
@@ -36,7 +36,7 @@ def advance_spec_on_close(
     from mship.core.spec_store import SpecStore
 
     store = SpecStore(specs_dir)
-    spec = store.find_by_id(task.spec_id)
+    spec = store.read_strict(task.spec_id)
     if spec is None or spec.status != "dispatched":
         return
 

--- a/src/mship/core/spec_storage.py
+++ b/src/mship/core/spec_storage.py
@@ -91,7 +91,15 @@ class SpecStorage:
         self.specs_dir.mkdir(parents=True, exist_ok=True)
         physical = self.physical_path(stem)
         if self.mode == "encrypted":
-            key = spec_key.load_or_generate_key(self.workspace_root, git=self._git)
+            key = spec_key.load_key(self.workspace_root)
+            if key is None:
+                locked = next(
+                    (path for path in self.iter_physical() if path.name.endswith(".md.enc")),
+                    None,
+                )
+                if locked is not None:
+                    raise SpecLocked(spec_id_from_filename(locked))
+                key = spec_key.load_or_generate_key(self.workspace_root, git=self._git)
             self._atomic_write_bytes(physical, spec_key.encrypt(key, text))
         else:
             self._atomic_write_text(physical, text)

--- a/src/mship/core/spec_storage.py
+++ b/src/mship/core/spec_storage.py
@@ -130,13 +130,13 @@ class SpecStorage:
                 raise SpecLocked(spec_id_from_filename(path))
             try:
                 return spec_key.decrypt(key, path.read_bytes())
-            except (InvalidToken, UnicodeError, ValueError) as exc:
+            except (InvalidToken, OSError, UnicodeError, ValueError) as exc:
                 from mship.core.spec_store import SpecParseError
 
                 raise SpecParseError("encrypted spec could not be decoded") from exc
         try:
             return path.read_text()
-        except UnicodeError as exc:
+        except (OSError, UnicodeError) as exc:
             from mship.core.spec_store import SpecParseError
 
             raise SpecParseError("plaintext spec could not be decoded") from exc

--- a/src/mship/core/spec_storage.py
+++ b/src/mship/core/spec_storage.py
@@ -18,6 +18,7 @@ writer under an encrypted workspace can never accidentally emit plaintext.
 from __future__ import annotations
 
 import re
+from cryptography.fernet import InvalidToken
 import tempfile
 from pathlib import Path
 from typing import Iterator, Literal
@@ -30,7 +31,7 @@ SpecMode = Literal["committed", "local", "encrypted"]
 # Physical encrypted file is `<date>-<id>.md.enc` (the logical stem keeps `.md`).
 ENC_SUFFIX = ".enc"
 
-_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-(?P<id>.+)$")
+_CANONICAL_FILENAME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-(?P<id>.+)\.md(?:\.enc)?$")
 
 
 class SpecLocked(Exception):
@@ -41,16 +42,21 @@ class SpecLocked(Exception):
         self.spec_id = spec_id
 
 
+def canonical_spec_id_from_filename(path: Path) -> str | None:
+    """Return a dated artifact's authoritative filename id, if its name is canonical."""
+    match = _CANONICAL_FILENAME_RE.match(Path(path).name)
+    return match.group("id") if match else None
+
+
 def spec_id_from_filename(path: Path) -> str:
-    """`2026-07-22-foo-bar.md[.enc]` -> `foo-bar`. Best-effort: strips the suffix
-    and the leading `YYYY-MM-DD-`, so a locked spec's id is still knowable."""
-    name = path.name
+    """`2026-07-22-foo-bar.md[.enc]` -> `foo-bar`; otherwise return its bare stem."""
+    name = Path(path).name
+    canonical_id = canonical_spec_id_from_filename(path)
+    if canonical_id is not None:
+        return canonical_id
     if name.endswith(ENC_SUFFIX):
         name = name[: -len(ENC_SUFFIX)]
-    if name.endswith(".md"):
-        name = name[: -len(".md")]
-    m = _ID_RE.match(name)
-    return m.group("id") if m else name
+    return name[:-len(".md")] if name.endswith(".md") else name
 
 
 class SpecStorage:
@@ -116,7 +122,12 @@ class SpecStorage:
             key = spec_key.load_key(self.workspace_root)
             if key is None:
                 raise SpecLocked(spec_id_from_filename(path))
-            return spec_key.decrypt(key, path.read_bytes())
+            try:
+                return spec_key.decrypt(key, path.read_bytes())
+            except (InvalidToken, UnicodeError) as exc:
+                from mship.core.spec_store import SpecParseError
+
+                raise SpecParseError("encrypted spec could not be decoded") from exc
         return path.read_text()
 
     def read_all(self) -> Iterator[tuple[object | None, str | None, Path]]:
@@ -133,7 +144,7 @@ class SpecStorage:
             except SpecLocked as locked:
                 yield (None, locked.spec_id, path)
                 continue
-            except (OSError, UnicodeError):
+            except (OSError, UnicodeError, SpecParseError):
                 continue
             try:
                 yield (parse_spec(text), None, path)

--- a/src/mship/core/spec_storage.py
+++ b/src/mship/core/spec_storage.py
@@ -106,7 +106,13 @@ class SpecStorage:
                 if locked is not None:
                     raise SpecLocked(spec_id_from_filename(locked))
                 key = spec_key.load_or_generate_key(self.workspace_root, git=self._git)
-            self._atomic_write_bytes(physical, spec_key.encrypt(key, text))
+            try:
+                encrypted = spec_key.encrypt(key, text)
+            except (UnicodeError, ValueError) as exc:
+                from mship.core.spec_store import SpecParseError
+
+                raise SpecParseError("encrypted spec could not be encoded") from exc
+            self._atomic_write_bytes(physical, encrypted)
         else:
             self._atomic_write_text(physical, text)
             if self.mode == "local":
@@ -124,11 +130,16 @@ class SpecStorage:
                 raise SpecLocked(spec_id_from_filename(path))
             try:
                 return spec_key.decrypt(key, path.read_bytes())
-            except (InvalidToken, UnicodeError) as exc:
+            except (InvalidToken, UnicodeError, ValueError) as exc:
                 from mship.core.spec_store import SpecParseError
 
                 raise SpecParseError("encrypted spec could not be decoded") from exc
-        return path.read_text()
+        try:
+            return path.read_text()
+        except UnicodeError as exc:
+            from mship.core.spec_store import SpecParseError
+
+            raise SpecParseError("plaintext spec could not be decoded") from exc
 
     def read_all(self) -> Iterator[tuple[object | None, str | None, Path]]:
         """Yield (spec_or_None, locked_id_or_None, path) for every spec file.
@@ -147,9 +158,13 @@ class SpecStorage:
             except (OSError, UnicodeError, SpecParseError):
                 continue
             try:
-                yield (parse_spec(text), None, path)
+                spec = parse_spec(text)
             except SpecParseError:
                 continue
+            canonical_id = canonical_spec_id_from_filename(path)
+            if canonical_id is not None and spec.id != canonical_id:
+                continue
+            yield (spec, None, path)
 
     # --- atomic write helpers (mirror SpecStore.save) --------------------
     def _atomic_write_text(self, path: Path, text: str) -> None:

--- a/src/mship/core/spec_storage.py
+++ b/src/mship/core/spec_storage.py
@@ -97,7 +97,10 @@ class SpecStorage:
         self.specs_dir.mkdir(parents=True, exist_ok=True)
         physical = self.physical_path(stem)
         if self.mode == "encrypted":
-            key = spec_key.load_key(self.workspace_root)
+            try:
+                key = spec_key.load_key(self.workspace_root)
+            except OSError as exc:
+                raise SpecLocked(spec_id_from_filename(physical)) from exc
             if key is None:
                 locked = next(
                     (path for path in self.iter_physical() if path.name.endswith(".md.enc")),
@@ -125,7 +128,10 @@ class SpecStorage:
         with no key — never returns ciphertext or plaintext-fallback."""
         path = Path(path)
         if path.name.endswith(".md" + ENC_SUFFIX):
-            key = spec_key.load_key(self.workspace_root)
+            try:
+                key = spec_key.load_key(self.workspace_root)
+            except OSError as exc:
+                raise SpecLocked(spec_id_from_filename(path)) from exc
             if key is None:
                 raise SpecLocked(spec_id_from_filename(path))
             try:

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -124,6 +124,14 @@ class SpecStore:
                 spec.inbox = current.inbox
             return self._save_unlocked(spec)
 
+    def create_if_absent(self, spec: Spec) -> bool:
+        """Atomically persist a new spec; False when its id already exists."""
+        with _locked(self._lock_path(spec.id)):
+            if self.read_strict(spec.id) is not None:
+                return False
+            self._save_unlocked(spec)
+            return True
+
     def load(self, path: Path) -> Spec:
         return parse_spec(self._storage.decode_file(Path(path)))
 

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -161,15 +161,17 @@ class SpecStore:
         return None
 
     def read_strict(self, spec_id: str) -> Spec | None:
-        """Read one logical spec by frontmatter id, preserving LOCKED visibility."""
+        """Read an exact physical ID strictly, then tolerate alias-scan siblings."""
         from mship.core.spec_storage import SpecLocked, spec_id_from_filename
 
-        for path in self._storage.iter_physical():
+        paths = list(self._storage.iter_physical())
+        for path in paths:
+            if spec_id_from_filename(path) == spec_id:
+                return parse_spec(self._storage.decode_file(path))
+        for path in paths:
             try:
                 spec = parse_spec(self._storage.decode_file(path))
-            except SpecLocked:
-                if spec_id_from_filename(path) == spec_id:
-                    raise
+            except (SpecLocked, SpecParseError):
                 continue
             if spec.id == spec_id:
                 return spec

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -147,6 +147,42 @@ class SpecStore:
             return physical_path.with_name(physical_path.name[:-4])
         return physical_path
 
+
+    def _canonical_paths_by_id(self) -> dict[str, list[Path]]:
+        from mship.core.spec_storage import canonical_spec_id_from_filename
+
+        paths_by_id: dict[str, list[Path]] = {}
+        for path in self._storage.iter_physical():
+            canonical_id = canonical_spec_id_from_filename(path)
+            if canonical_id is not None:
+                paths_by_id.setdefault(canonical_id, []).append(path)
+        return paths_by_id
+
+    def _tolerant_conflicted_ids(self) -> set[str]:
+        from mship.core.spec_storage import (
+            SpecLocked,
+            canonical_spec_id_from_filename,
+        )
+
+        conflicts = {
+            spec_id
+            for spec_id, paths in self._canonical_paths_by_id().items()
+            if len(paths) > 1
+        }
+        for path in self._storage.iter_physical():
+            canonical_id = canonical_spec_id_from_filename(path)
+            if canonical_id is None:
+                continue
+            try:
+                spec = parse_spec(self._storage.decode_file(path))
+            except SpecLocked:
+                continue
+            except SpecParseError:
+                conflicts.add(canonical_id)
+                continue
+            if spec.id != canonical_id:
+                conflicts.update((canonical_id, spec.id))
+        return conflicts
     def resolve_artifact(self, spec_id: str) -> ResolvedSpecArtifact | None:
         """Resolve exactly one parsed artifact for ``spec_id`` or fail closed."""
         from mship.core.spec_storage import (
@@ -154,6 +190,12 @@ class SpecStore:
         )
 
         self._validate_id(spec_id)
+        canonical_paths = self._canonical_paths_by_id().get(spec_id, [])
+        if len(canonical_paths) > 1:
+            paths = ", ".join(str(path) for path in canonical_paths)
+            raise SpecArtifactConflict(
+                f"spec id {spec_id!r} has multiple physical artifacts: {paths}"
+            )
         matches: list[tuple[Spec, Path]] = []
         exact_locked: SpecLocked | None = None
         locked_renamed: Path | None = None
@@ -258,6 +300,12 @@ class SpecStore:
         """
         from mship.core.spec_storage import SpecLocked, canonical_spec_id_from_filename
 
+        for spec_id, paths in self._canonical_paths_by_id().items():
+            if len(paths) > 1:
+                rendered = ", ".join(str(path) for path in paths)
+                raise SpecArtifactConflict(
+                    f"spec id {spec_id!r} has multiple physical artifacts: {rendered}"
+                )
         specs: list[Spec] = []
         paths_by_id: dict[str, Path] = {}
         for path in self._storage.iter_physical():
@@ -281,11 +329,28 @@ class SpecStore:
             specs.append(spec)
         return specs
 
+    def list_tolerant_entries(self) -> list[tuple[Spec | None, str | None, Path]]:
+        """List one readable-or-locked entry per non-conflicting logical id."""
+        entries_by_id: dict[
+            str,
+            list[tuple[Spec | None, str | None, Path]],
+        ] = {}
+        unavailable_ids = self._tolerant_conflicted_ids()
+        for spec, locked_id, path in self._storage.read_all():
+            logical_id = spec.id if isinstance(spec, Spec) else locked_id
+            if logical_id is not None:
+                entries_by_id.setdefault(logical_id, []).append((spec, locked_id, path))
+        return [
+            entries[0]
+            for spec_id, entries in entries_by_id.items()
+            if len(entries) == 1 and spec_id not in unavailable_ids
+        ]
+
     def list_tolerant(self) -> list[Spec]:
-        """List readable, identity-valid specs while omitting unavailable artifacts."""
+        """List unique readable specs while omitting unavailable logical ids."""
         return [
             spec
-            for spec, _locked_id, _path in self._storage.read_all()
+            for spec, _locked_id, _path in self.list_tolerant_entries()
             if isinstance(spec, Spec)
         ]
 
@@ -295,7 +360,7 @@ class SpecStore:
 
         try:
             artifact = self.resolve_artifact(spec_id)
-        except SpecLocked:
+        except (SpecLocked, ValueError):
             return None
         return artifact.spec if artifact is not None else None
 

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -149,21 +149,27 @@ class SpecStore:
         from mship.core.spec_storage import SpecLocked, spec_id_from_filename
 
         self._validate_id(spec_id)
+        paths = self._storage.iter_physical()
         matches: list[tuple[Spec, Path]] = []
-        for physical_path in self._storage.iter_physical():
-            filename_id = spec_id_from_filename(physical_path)
-            try:
-                parsed = parse_spec(self._storage.decode_file(physical_path))
-            except SpecLocked:
-                if filename_id == spec_id:
-                    raise
-                continue
-            if filename_id == spec_id and parsed.id != spec_id:
+        exact_paths = [
+            path for path in paths if spec_id_from_filename(path) == spec_id
+        ]
+        for physical_path in exact_paths:
+            parsed = parse_spec(self._storage.decode_file(physical_path))
+            if parsed.id != spec_id:
                 raise SpecArtifactConflict(
                     f"spec id {spec_id!r} collides with {physical_path} "
                     f"whose frontmatter id is {parsed.id!r}"
                 )
-            if filename_id == spec_id or parsed.id == spec_id:
+            matches.append((parsed, physical_path))
+        for physical_path in paths:
+            if physical_path in exact_paths:
+                continue
+            try:
+                parsed = parse_spec(self._storage.decode_file(physical_path))
+            except (SpecLocked, SpecParseError):
+                continue
+            if parsed.id == spec_id:
                 matches.append((parsed, physical_path))
         if len(matches) > 1:
             paths = ", ".join(str(path) for _, path in matches)

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -262,16 +262,17 @@ class SpecStore:
             try:
                 spec = parse_spec(self._storage.decode_file(path))
             except SpecLocked:
-                if canonical_id is not None:
-                    existing_path = paths_by_id.get(canonical_id)
-                    if existing_path is not None:
-                        raise SpecArtifactConflict(
-                            f"spec id {canonical_id!r} has multiple physical artifacts: "
-                            f"{existing_path}, {path}"
-                        )
-                    paths_by_id[canonical_id] = path
-                continue
-            except (OSError, SpecParseError):
+                if canonical_id is None:
+                    raise SpecArtifactConflict(
+                        f"spec store has an unreadable renamed artifact: {path}"
+                    )
+                existing_path = paths_by_id.get(canonical_id)
+                if existing_path is not None:
+                    raise SpecArtifactConflict(
+                        f"spec id {canonical_id!r} has multiple physical artifacts: "
+                        f"{existing_path}, {path}"
+                    )
+                paths_by_id[canonical_id] = path
                 continue
             if canonical_id is not None and spec.id != canonical_id:
                 raise SpecArtifactConflict(

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -170,12 +170,13 @@ class SpecStore:
         action: InboxAction,
         mutation_id: str,
         now: datetime,
-    ) -> Spec:
-        """Apply one idempotent inbox mutation without changing the spec lifecycle."""
+    ) -> tuple[Spec, bool]:
+        """Apply an inbox action and report whether this request changed it."""
         with _locked(self._lock_path(spec_id)):
             spec = self.read_strict(spec_id)
             if spec is None:
                 raise KeyError(spec_id)
-            if apply_inbox_action(spec.inbox, action, mutation_id, now):
+            applied = apply_inbox_action(spec.inbox, action, mutation_id, now)
+            if applied:
                 self._save_unlocked(spec)
-            return spec
+            return spec, applied

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -187,13 +187,13 @@ class SpecStore:
         mutation_id: str,
         now: datetime,
     ) -> tuple[Spec, bool]:
-        """Apply an inbox action and report whether this request changed it."""
+        """Apply an inbox action and report whether it changed inbox state."""
         with _locked(self._lock_path(spec_id)):
             spec = self.read_strict(spec_id)
             if spec is None:
                 raise KeyError(spec_id)
-            applied = apply_inbox_action(spec.inbox, action, mutation_id, now)
-            if applied:
+            result = apply_inbox_action(spec.inbox, action, mutation_id, now)
+            if result.persisted:
                 for path in self._storage.iter_physical():
                     try:
                         if parse_spec(self._storage.decode_file(path)).id == spec_id:
@@ -203,4 +203,4 @@ class SpecStore:
                         continue
                 else:
                     raise KeyError(spec_id)
-            return spec, applied
+            return spec, result.applied

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 import fcntl
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -72,10 +73,12 @@ def parse_spec(text: str) -> Spec:
     body = "".join(lines[end + 1:])
     try:
         data = yaml.safe_load(fm_text) or {}
+        if not isinstance(data, Mapping):
+            raise SpecParseError("spec frontmatter must be a mapping")
         return Spec(**data, body=body)
     except yaml.YAMLError as exc:
         raise SpecParseError(f"invalid YAML frontmatter: {exc}") from exc
-    except ValidationError as exc:
+    except (TypeError, ValidationError) as exc:
         raise SpecParseError(f"spec frontmatter failed validation: {exc}") from exc
 
 
@@ -146,40 +149,49 @@ class SpecStore:
 
     def resolve_artifact(self, spec_id: str) -> ResolvedSpecArtifact | None:
         """Resolve exactly one parsed artifact for ``spec_id`` or fail closed."""
-        from mship.core.spec_storage import SpecLocked, spec_id_from_filename
+        from mship.core.spec_storage import (
+            SpecLocked, canonical_spec_id_from_filename,
+        )
 
         self._validate_id(spec_id)
-        paths = self._storage.iter_physical()
         matches: list[tuple[Spec, Path]] = []
-        exact_paths = [
-            path for path in paths if spec_id_from_filename(path) == spec_id
-        ]
-        for physical_path in exact_paths:
-            parsed = parse_spec(self._storage.decode_file(physical_path))
-            if parsed.id != spec_id:
-                raise SpecArtifactConflict(
-                    f"spec id {spec_id!r} collides with {physical_path} "
-                    f"whose frontmatter id is {parsed.id!r}"
-                )
-            matches.append((parsed, physical_path))
-        locked_alias: SpecLocked | None = None
-        for physical_path in paths:
-            if physical_path in exact_paths:
-                continue
+        exact_locked: SpecLocked | None = None
+        locked_renamed: Path | None = None
+        for physical_path in self._storage.iter_physical():
+            canonical_id = canonical_spec_id_from_filename(physical_path)
             try:
                 parsed = parse_spec(self._storage.decode_file(physical_path))
             except SpecLocked as locked:
-                locked_alias = locked
+                if canonical_id == spec_id:
+                    exact_locked = locked
+                elif canonical_id is None:
+                    locked_renamed = physical_path
                 continue
             except SpecParseError:
+                if canonical_id == spec_id:
+                    raise
+                continue
+
+            if canonical_id is not None and parsed.id != canonical_id:
+                if spec_id in (canonical_id, parsed.id):
+                    raise SpecArtifactConflict(
+                        f"canonical artifact {physical_path} binds {canonical_id!r}, "
+                        f"not frontmatter id {parsed.id!r}"
+                    )
                 continue
             if parsed.id == spec_id:
                 matches.append((parsed, physical_path))
-        # A readable exact name proves that a locked legacy alias belongs elsewhere.
-        # Without that proof, ciphertext under a renamed stem has unknowable content;
-        # treating it as absent could generate a replacement key and artifact.
-        if locked_alias is not None and not exact_paths:
-            raise locked_alias
+
+        if locked_renamed is not None:
+            raise SpecArtifactConflict(
+                f"spec id {spec_id!r} has an unreadable renamed artifact: {locked_renamed}"
+            )
+        if exact_locked is not None:
+            if matches:
+                raise SpecArtifactConflict(
+                    f"spec id {spec_id!r} has both locked and readable artifacts"
+                )
+            raise exact_locked
         if len(matches) > 1:
             paths = ", ".join(str(path) for _, path in matches)
             raise SpecArtifactConflict(

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -192,14 +192,21 @@ class SpecStore:
                 raise KeyError(spec_id)
             result = apply_inbox_action(spec.inbox, action, mutation_id, now)
             if result.persisted:
+                matched = None
                 for path in self._storage.iter_physical():
                     try:
                         if parse_spec(self._storage.decode_file(path)).id == spec_id:
-                            stem = path.with_name(path.name[:-4]) if path.name.endswith(".enc") else path
-                            self._storage.write(stem, serialize_spec(spec))
+                            matched = path
                             break
                     except Exception:
                         continue
-                else:
+                if matched is None:
                     raise KeyError(spec_id)
+                from mship.core.spec_storage import SpecStorage
+
+                mode = "encrypted" if matched.name.endswith(".enc") else "committed"
+                logical = matched.with_name(matched.name[:-4]) if mode == "encrypted" else matched
+                SpecStorage(
+                    self._dir, mode=mode, workspace_root=self._storage.workspace_root,
+                ).write(logical, serialize_spec(spec))
             return spec, result.applied

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -247,22 +247,45 @@ class SpecStore:
         return parse_spec(self._storage.decode_file(Path(path)))
 
     def list(self) -> list[Spec]:
-        # Skip LOCKED specs (encrypted, no key — an expected, graceful state) so one
-        # un-decryptable file doesn't block the readable siblings or every routed CLI
-        # op via find_by_id (Greptile #402 "one locked file blocks all"). But do NOT
-        # swallow a corrupt/unreadable store: a malformed spec PROPAGATES so it can't
-        # silently vanish from the list — which would let resolve_bound_spec return
-        # None and finish --require-evidence skip a required check (Greptile #341).
-        # (serve's LOCKED-aware display uses the fully-tolerant read_all; the gate's
-        # list must fail safe on corruption, so it only tolerates the locked case.)
-        from mship.core.spec_storage import SpecLocked
+        """Tolerantly list readable artifacts while preserving identity invariants.
+
+        Decode/parse failures are unavailable artifacts for CLI/display, but an
+        artifact that claims a canonical filename's id differently — or more than
+        one artifact for an id — is a store conflict that lifecycle gates must see.
+        """
+        from mship.core.spec_storage import SpecLocked, canonical_spec_id_from_filename
+
         specs: list[Spec] = []
+        paths_by_id: dict[str, Path] = {}
         for path in self._storage.iter_physical():
+            canonical_id = canonical_spec_id_from_filename(path)
             try:
-                text = self._storage.decode_file(path)
+                spec = parse_spec(self._storage.decode_file(path))
             except SpecLocked:
+                if canonical_id is not None:
+                    existing_path = paths_by_id.get(canonical_id)
+                    if existing_path is not None:
+                        raise SpecArtifactConflict(
+                            f"spec id {canonical_id!r} has multiple physical artifacts: "
+                            f"{existing_path}, {path}"
+                        )
+                    paths_by_id[canonical_id] = path
                 continue
-            specs.append(parse_spec(text))   # SpecParseError / read errors propagate
+            except (OSError, SpecParseError):
+                continue
+            if canonical_id is not None and spec.id != canonical_id:
+                raise SpecArtifactConflict(
+                    f"canonical artifact {path} binds {canonical_id!r}, "
+                    f"not frontmatter id {spec.id!r}"
+                )
+            existing_path = paths_by_id.get(spec.id)
+            if existing_path is not None:
+                raise SpecArtifactConflict(
+                    f"spec id {spec.id!r} has multiple physical artifacts: "
+                    f"{existing_path}, {path}"
+                )
+            paths_by_id[spec.id] = path
+            specs.append(spec)
         return specs
 
     def find_by_id(self, spec_id: str) -> Spec | None:

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -98,9 +98,9 @@ class SpecStore:
             raise ValueError(f"unsafe spec id for filename: {spec_id!r}")
 
     def _lock_path(self, spec_id: str) -> Path:
-        """Per-spec lock that is independent of the storage mode's physical path."""
+        """Per-spec runtime lock, outside storage-mode-managed spec artifacts."""
         self._validate_id(spec_id)
-        return self._dir / f".{spec_id}.inbox.lock"
+        return self.workspace_root / ".mothership" / "locks" / "specs" / f"{spec_id}.lock"
 
     def path_for(self, spec: Spec) -> Path:
         """Logical `.md` stem for a spec: `<specs_dir>/<created_at date>-<id>.md`.

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -112,8 +112,17 @@ class SpecStore:
         self._validate_id(spec.id)
         return self._dir / f"{spec.created_at:%Y-%m-%d}-{spec.id}.md"
 
-    def save(self, spec: Spec) -> Path:
+    def _save_unlocked(self, spec: Spec) -> Path:
+        """Persist a spec while its per-spec lock is already held."""
         return self._storage.write(self.path_for(spec), serialize_spec(spec))
+
+    def save(self, spec: Spec) -> Path:
+        """Persist lifecycle changes without clobbering durable inbox metadata."""
+        with _locked(self._lock_path(spec.id)):
+            current = self.read_strict(spec.id)
+            if current is not None:
+                spec.inbox = current.inbox
+            return self._save_unlocked(spec)
 
     def load(self, path: Path) -> Spec:
         return parse_spec(self._storage.decode_file(Path(path)))
@@ -168,5 +177,5 @@ class SpecStore:
             if spec is None:
                 raise KeyError(spec_id)
             if apply_inbox_action(spec.inbox, action, mutation_id, now):
-                self.save(spec)
+                self._save_unlocked(spec)
             return spec

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -162,15 +162,24 @@ class SpecStore:
                     f"whose frontmatter id is {parsed.id!r}"
                 )
             matches.append((parsed, physical_path))
+        locked_alias: SpecLocked | None = None
         for physical_path in paths:
             if physical_path in exact_paths:
                 continue
             try:
                 parsed = parse_spec(self._storage.decode_file(physical_path))
-            except (SpecLocked, SpecParseError):
+            except SpecLocked as locked:
+                locked_alias = locked
+                continue
+            except SpecParseError:
                 continue
             if parsed.id == spec_id:
                 matches.append((parsed, physical_path))
+        # A readable exact name proves that a locked legacy alias belongs elsewhere.
+        # Without that proof, ciphertext under a renamed stem has unknowable content;
+        # treating it as absent could generate a replacement key and artifact.
+        if locked_alias is not None and not exact_paths:
+            raise locked_alias
         if len(matches) > 1:
             paths = ", ".join(str(path) for _, path in matches)
             raise SpecArtifactConflict(
@@ -245,7 +254,13 @@ class SpecStore:
         return specs
 
     def find_by_id(self, spec_id: str) -> Spec | None:
-        artifact = self.resolve_artifact(spec_id)
+        """Tolerant compatibility lookup: locked artifacts are unavailable."""
+        from mship.core.spec_storage import SpecLocked
+
+        try:
+            artifact = self.resolve_artifact(spec_id)
+        except SpecLocked:
+            return None
         return artifact.spec if artifact is not None else None
 
     def read_strict(self, spec_id: str) -> Spec | None:

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -161,15 +161,18 @@ class SpecStore:
         return None
 
     def read_strict(self, spec_id: str) -> Spec | None:
-        """Strictly read ONE spec by id: returns the parsed Spec, None if no file
-        exists for the id, and RAISES SpecLocked (encrypted, no key) or
-        SpecParseError (malformed) rather than swallowing them — for callers like
-        `mship spec validate` that must report locked/invalid, not silently skip
-        (the resilient `list`/`find_by_id` skip both)."""
-        from mship.core.spec_storage import spec_id_from_filename
+        """Read one logical spec by frontmatter id, preserving LOCKED visibility."""
+        from mship.core.spec_storage import SpecLocked, spec_id_from_filename
+
         for path in self._storage.iter_physical():
-            if spec_id_from_filename(path) == spec_id:
-                return parse_spec(self._storage.decode_file(path))
+            try:
+                spec = parse_spec(self._storage.decode_file(path))
+            except SpecLocked:
+                if spec_id_from_filename(path) == spec_id:
+                    raise
+                continue
+            if spec.id == spec_id:
+                return spec
         return None
 
     def mutate_inbox(

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -168,9 +168,7 @@ class SpecStore:
         for path in paths:
             if spec_id_from_filename(path) == spec_id:
                 spec = parse_spec(self._storage.decode_file(path))
-                if spec.id == spec_id:
-                    return spec
-                break
+                return spec if spec.id == spec_id else None
         for path in paths:
             try:
                 spec = parse_spec(self._storage.decode_file(path))
@@ -197,7 +195,8 @@ class SpecStore:
                 for path in self._storage.iter_physical():
                     try:
                         if parse_spec(self._storage.decode_file(path)).id == spec_id:
-                            self._storage.write(path, serialize_spec(spec))
+                            stem = path.with_name(path.name[:-4]) if path.name.endswith(".enc") else path
+                            self._storage.write(stem, serialize_spec(spec))
                             break
                     except Exception:
                         continue

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -167,9 +167,13 @@ class SpecStore:
                 elif canonical_id is None:
                     locked_renamed = physical_path
                 continue
-            except SpecParseError:
+            except SpecParseError as exc:
                 if canonical_id == spec_id:
                     raise
+                if canonical_id is None:
+                    raise SpecArtifactConflict(
+                        f"spec store has an unreadable renamed artifact: {physical_path}"
+                    ) from exc
                 continue
 
             if canonical_id is not None and parsed.id != canonical_id:
@@ -247,11 +251,10 @@ class SpecStore:
         return parse_spec(self._storage.decode_file(Path(path)))
 
     def list(self) -> list[Spec]:
-        """Tolerantly list readable artifacts while preserving identity invariants.
+        """Strictly list artifacts for workflow gates.
 
-        Decode/parse failures are unavailable artifacts for CLI/display, but an
-        artifact that claims a canonical filename's id differently — or more than
-        one artifact for an id — is a store conflict that lifecycle gates must see.
+        Locked, corrupt, conflicting, or duplicate artifacts fail closed. Display
+        callers that must preserve readable siblings use ``list_tolerant``.
         """
         from mship.core.spec_storage import SpecLocked, canonical_spec_id_from_filename
 
@@ -262,18 +265,7 @@ class SpecStore:
             try:
                 spec = parse_spec(self._storage.decode_file(path))
             except SpecLocked:
-                if canonical_id is None:
-                    raise SpecArtifactConflict(
-                        f"spec store has an unreadable renamed artifact: {path}"
-                    )
-                existing_path = paths_by_id.get(canonical_id)
-                if existing_path is not None:
-                    raise SpecArtifactConflict(
-                        f"spec id {canonical_id!r} has multiple physical artifacts: "
-                        f"{existing_path}, {path}"
-                    )
-                paths_by_id[canonical_id] = path
-                continue
+                raise
             if canonical_id is not None and spec.id != canonical_id:
                 raise SpecArtifactConflict(
                     f"canonical artifact {path} binds {canonical_id!r}, "
@@ -288,6 +280,14 @@ class SpecStore:
             paths_by_id[spec.id] = path
             specs.append(spec)
         return specs
+
+    def list_tolerant(self) -> list[Spec]:
+        """List readable, identity-valid specs while omitting unavailable artifacts."""
+        return [
+            spec
+            for spec, _locked_id, _path in self._storage.read_all()
+            if isinstance(spec, Spec)
+        ]
 
     def find_by_id(self, spec_id: str) -> Spec | None:
         """Tolerant compatibility lookup: locked artifacts are unavailable."""

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -1,12 +1,31 @@
 from __future__ import annotations
 
-import yaml
+import fcntl
+from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
+
+import yaml
 from pydantic import ValidationError
+
+from mship.core.inbox import InboxAction, apply_inbox_action
+
 
 from mship.core.spec import Spec
 
 SPECS_DIRNAME = "specs"  # canonical name of the workspace-level specs directory
+
+
+@contextmanager
+def _locked(lock_path: Path):
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
 
 
 class SpecParseError(Exception):
@@ -73,6 +92,16 @@ class SpecStore:
         (view/actions.py's LogManager) don't restate the convention."""
         return self._storage.workspace_root
 
+    def _validate_id(self, spec_id: str) -> None:
+        if (not spec_id or "/" in spec_id or "\\" in spec_id
+                or spec_id in (".", "..") or spec_id.startswith(".")):
+            raise ValueError(f"unsafe spec id for filename: {spec_id!r}")
+
+    def _lock_path(self, spec_id: str) -> Path:
+        """Per-spec lock that is independent of the storage mode's physical path."""
+        self._validate_id(spec_id)
+        return self._dir / f".{spec_id}.inbox.lock"
+
     def path_for(self, spec: Spec) -> Path:
         """Logical `.md` stem for a spec: `<specs_dir>/<created_at date>-<id>.md`.
 
@@ -80,8 +109,7 @@ class SpecStore:
         the storage layer at write time. Saving again with the same id + creation
         date overwrites the file (this is the intended update mechanism).
         """
-        if not spec.id or "/" in spec.id or "\\" in spec.id or spec.id in (".", "..") or spec.id.startswith("."):
-            raise ValueError(f"unsafe spec id for filename: {spec.id!r}")
+        self._validate_id(spec.id)
         return self._dir / f"{spec.created_at:%Y-%m-%d}-{spec.id}.md"
 
     def save(self, spec: Spec) -> Path:
@@ -126,3 +154,19 @@ class SpecStore:
             if spec_id_from_filename(path) == spec_id:
                 return parse_spec(self._storage.decode_file(path))
         return None
+
+    def mutate_inbox(
+        self,
+        spec_id: str,
+        action: InboxAction,
+        mutation_id: str,
+        now: datetime,
+    ) -> Spec:
+        """Apply one idempotent inbox mutation without changing the spec lifecycle."""
+        with _locked(self._lock_path(spec_id)):
+            spec = self.read_strict(spec_id)
+            if spec is None:
+                raise KeyError(spec_id)
+            if apply_inbox_action(spec.inbox, action, mutation_id, now):
+                self.save(spec)
+            return spec

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import fcntl
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import Iterator, Literal
 
 import yaml
 from pydantic import ValidationError
@@ -30,6 +32,25 @@ def _locked(lock_path: Path):
 
 class SpecParseError(Exception):
     pass
+
+
+class SpecArtifactConflict(SpecParseError):
+    """A spec id does not map to exactly one trustworthy on-disk artifact."""
+
+
+class SpecRepresentationMismatch(SpecArtifactConflict):
+    """An existing artifact would require changing representation outside migration."""
+
+
+@dataclass(frozen=True)
+class ResolvedSpecArtifact:
+    """The sole authoritative on-disk artifact for one logical spec id."""
+
+    spec: Spec
+    logical_path: Path
+    physical_path: Path
+    representation: Literal["plaintext", "encrypted"]
+    policy: Literal["committed", "local", "encrypted"]
 
 
 # MOS-240: legacy spec statuses (captured/drafting/needs_clarification) are mapped
@@ -112,25 +133,88 @@ class SpecStore:
         self._validate_id(spec.id)
         return self._dir / f"{spec.created_at:%Y-%m-%d}-{spec.id}.md"
 
-    def _save_unlocked(self, spec: Spec) -> Path:
-        """Persist a spec while its per-spec lock is already held."""
+    @contextmanager
+    def locked(self, spec_id: str) -> Iterator[ResolvedSpecArtifact | None]:
+        """Hold the per-spec lock while resolving and mutating its physical artifact."""
+        with _locked(self._lock_path(spec_id)):
+            yield self.resolve_artifact(spec_id)
+
+    def _logical_path(self, physical_path: Path) -> Path:
+        if physical_path.name.endswith(".enc"):
+            return physical_path.with_name(physical_path.name[:-4])
+        return physical_path
+
+    def resolve_artifact(self, spec_id: str) -> ResolvedSpecArtifact | None:
+        """Resolve exactly one parsed artifact for ``spec_id`` or fail closed."""
+        from mship.core.spec_storage import SpecLocked, spec_id_from_filename
+
+        self._validate_id(spec_id)
+        matches: list[tuple[Spec, Path]] = []
+        for physical_path in self._storage.iter_physical():
+            filename_id = spec_id_from_filename(physical_path)
+            try:
+                parsed = parse_spec(self._storage.decode_file(physical_path))
+            except SpecLocked:
+                if filename_id == spec_id:
+                    raise
+                continue
+            if filename_id == spec_id and parsed.id != spec_id:
+                raise SpecArtifactConflict(
+                    f"spec id {spec_id!r} collides with {physical_path} "
+                    f"whose frontmatter id is {parsed.id!r}"
+                )
+            if filename_id == spec_id or parsed.id == spec_id:
+                matches.append((parsed, physical_path))
+        if len(matches) > 1:
+            paths = ", ".join(str(path) for _, path in matches)
+            raise SpecArtifactConflict(
+                f"spec id {spec_id!r} has multiple physical artifacts: {paths}"
+            )
+        if not matches:
+            return None
+        spec, physical_path = matches[0]
+        encrypted = physical_path.name.endswith(".enc")
+        return ResolvedSpecArtifact(
+            spec=spec,
+            logical_path=self._logical_path(physical_path),
+            physical_path=physical_path,
+            representation="encrypted" if encrypted else "plaintext",
+            policy="encrypted" if encrypted else self._storage.mode,
+        )
+
+    def _save_unlocked(
+        self, spec: Spec, artifact: ResolvedSpecArtifact | None = None,
+    ) -> Path:
+        """Persist under the caller-held lock without replacing the selected artifact."""
+        artifact = artifact if artifact is not None else self.resolve_artifact(spec.id)
+        target_representation = "encrypted" if self._storage.mode == "encrypted" else "plaintext"
+        if artifact is not None:
+            if artifact.representation != target_representation:
+                raise SpecRepresentationMismatch(
+                    f"spec {spec.id!r} is {artifact.representation} at "
+                    f"{artifact.physical_path}; migrate storage before writing it as "
+                    f"{target_representation}"
+                )
+            return self._storage.write(artifact.logical_path, serialize_spec(spec))
+        return self._storage.write(self.path_for(spec), serialize_spec(spec))
+
+    def save_migrated_unlocked(self, spec: Spec) -> Path:
+        """Write the configured representation while ``locked(spec.id)`` is held."""
         return self._storage.write(self.path_for(spec), serialize_spec(spec))
 
     def save(self, spec: Spec) -> Path:
         """Persist lifecycle changes without clobbering durable inbox metadata."""
-        with _locked(self._lock_path(spec.id)):
-            current = self.read_strict(spec.id)
-            if current is not None:
-                spec.inbox = current.inbox
-            return self._save_unlocked(spec)
+        with self.locked(spec.id) as artifact:
+            if artifact is not None:
+                spec.inbox = artifact.spec.inbox
+            return self._save_unlocked(spec, artifact)
 
-    def create_if_absent(self, spec: Spec) -> bool:
-        """Atomically persist a new spec; False when its id already exists."""
-        with _locked(self._lock_path(spec.id)):
-            if self.read_strict(spec.id) is not None:
-                return False
-            self._save_unlocked(spec)
-            return True
+    def create_if_absent(self, spec: Spec) -> Path | None:
+        """Atomically create a spec and return its actual physical path."""
+        with self.locked(spec.id) as artifact:
+            if artifact is not None:
+                return None
+            return self._save_unlocked(spec)
 
     def load(self, path: Path) -> Spec:
         return parse_spec(self._storage.decode_file(Path(path)))
@@ -155,28 +239,13 @@ class SpecStore:
         return specs
 
     def find_by_id(self, spec_id: str) -> Spec | None:
-        for spec in self.list():
-            if spec.id == spec_id:
-                return spec
-        return None
+        artifact = self.resolve_artifact(spec_id)
+        return artifact.spec if artifact is not None else None
 
     def read_strict(self, spec_id: str) -> Spec | None:
-        """Read an exact physical ID strictly, then tolerate alias-scan siblings."""
-        from mship.core.spec_storage import SpecLocked, spec_id_from_filename
-
-        paths = list(self._storage.iter_physical())
-        for path in paths:
-            if spec_id_from_filename(path) == spec_id:
-                spec = parse_spec(self._storage.decode_file(path))
-                return spec if spec.id == spec_id else None
-        for path in paths:
-            try:
-                spec = parse_spec(self._storage.decode_file(path))
-            except (SpecLocked, SpecParseError):
-                continue
-            if spec.id == spec_id:
-                return spec
-        return None
+        """Strictly resolve one physical artifact for an id."""
+        artifact = self.resolve_artifact(spec_id)
+        return artifact.spec if artifact is not None else None
 
     def mutate_inbox(
         self,
@@ -186,27 +255,11 @@ class SpecStore:
         now: datetime,
     ) -> tuple[Spec, bool]:
         """Apply an inbox action and report whether it changed inbox state."""
-        with _locked(self._lock_path(spec_id)):
-            spec = self.read_strict(spec_id)
-            if spec is None:
+        with self.locked(spec_id) as artifact:
+            if artifact is None:
                 raise KeyError(spec_id)
+            spec = artifact.spec
             result = apply_inbox_action(spec.inbox, action, mutation_id, now)
             if result.persisted:
-                matched = None
-                for path in self._storage.iter_physical():
-                    try:
-                        if parse_spec(self._storage.decode_file(path)).id == spec_id:
-                            matched = path
-                            break
-                    except Exception:
-                        continue
-                if matched is None:
-                    raise KeyError(spec_id)
-                from mship.core.spec_storage import SpecStorage
-
-                mode = "encrypted" if matched.name.endswith(".enc") else "committed"
-                logical = matched.with_name(matched.name[:-4]) if mode == "encrypted" else matched
-                SpecStorage(
-                    self._dir, mode=mode, workspace_root=self._storage.workspace_root,
-                ).write(logical, serialize_spec(spec))
+                self._save_unlocked(spec, artifact)
             return spec, result.applied

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -345,7 +345,6 @@ class SpecStore:
             for spec_id, entries in entries_by_id.items()
             if len(entries) == 1 and spec_id not in unavailable_ids
         ]
-
     def list_tolerant(self) -> list[Spec]:
         """List unique readable specs while omitting unavailable logical ids."""
         return [
@@ -360,7 +359,7 @@ class SpecStore:
 
         try:
             artifact = self.resolve_artifact(spec_id)
-        except (SpecLocked, ValueError):
+        except (SpecLocked, SpecParseError, ValueError):
             return None
         return artifact.spec if artifact is not None else None
 

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -167,7 +167,10 @@ class SpecStore:
         paths = list(self._storage.iter_physical())
         for path in paths:
             if spec_id_from_filename(path) == spec_id:
-                return parse_spec(self._storage.decode_file(path))
+                spec = parse_spec(self._storage.decode_file(path))
+                if spec.id == spec_id:
+                    return spec
+                break
         for path in paths:
             try:
                 spec = parse_spec(self._storage.decode_file(path))

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -194,5 +194,13 @@ class SpecStore:
                 raise KeyError(spec_id)
             applied = apply_inbox_action(spec.inbox, action, mutation_id, now)
             if applied:
-                self._save_unlocked(spec)
+                for path in self._storage.iter_physical():
+                    try:
+                        if parse_spec(self._storage.decode_file(path)).id == spec_id:
+                            self._storage.write(path, serialize_spec(spec))
+                            break
+                    except Exception:
+                        continue
+                else:
+                    raise KeyError(spec_id)
             return spec, applied

--- a/src/mship/core/view/spec_discovery.py
+++ b/src/mship/core/view/spec_discovery.py
@@ -42,6 +42,14 @@ def _find_in_specs_dir(workspace_root: Path, *, spec_id=None, task_slug=None):
             return path
     return None
 
+def read_spec_source(path: Path, workspace_root: Path | None = None) -> str:
+    """Read plaintext from a discovered spec path without leaking ciphertext."""
+    from mship.core.spec_storage import SpecStorage
+
+    path = Path(path)
+    root = Path(workspace_root) if workspace_root is not None else path.parent.parent
+    return SpecStorage(path.parent, workspace_root=root).decode_file(path)
+
 
 def blessed_spec_path(workspace_root: Path, slug: str) -> Path:
     return workspace_root / BLESSED_TASK_SPEC_DIR / slug / "SPEC.md"
@@ -137,7 +145,13 @@ def _newest_across(roots: list[Path], task: str | None) -> Path:
     candidates: list[Path] = []
     for root in roots:
         if root.is_dir():
-            candidates.extend(p for p in root.iterdir() if p.is_file() and p.suffix == ".md")
+            candidates.extend(
+                path
+                for path in root.iterdir()
+                if path.is_file() and (
+                    path.name.endswith(".md") or path.name.endswith(".md.enc")
+                )
+            )
     if not candidates:
         where = f"task {task!r}" if task else f"{roots[0] if roots else '?'}"
         raise SpecNotFoundError(f"No specs found in {where}")
@@ -148,7 +162,13 @@ def _available_msg(roots: list[Path]) -> str:
     names: set[str] = set()
     for r in roots:
         if r.is_dir():
-            names.update(p.name for p in r.iterdir() if p.is_file() and p.suffix == ".md")
+            names.update(
+                path.name
+                for path in r.iterdir()
+                if path.is_file() and (
+                    path.name.endswith(".md") or path.name.endswith(".md.enc")
+                )
+            )
     if not names:
         return ""
     shown = sorted(names)[:5]

--- a/src/mship/core/view/thread_links.py
+++ b/src/mship/core/view/thread_links.py
@@ -1,8 +1,47 @@
 """Read-time resolution of a thread's related WorkItem (inverts the WorkItem link graph)."""
 from __future__ import annotations
-
+from dataclasses import dataclass
 from typing import Iterable
 
+from mship.core.view.workitem_index import compute_phase
+
+
+@dataclass(frozen=True)
+class ThreadInboxLink:
+    work_item_id: str | None
+    terminal: bool
+
+
+def index_thread_inbox_links(
+    threads: Iterable,
+    items: Iterable,
+    specs_by_id: dict,
+    tasks_by_slug: dict,
+) -> dict[str, ThreadInboxLink]:
+    """Resolve each thread's WorkItem once and derive whether that owner is done."""
+    try:
+        item_list = list(items)
+        index = _build_link_index(item_list)
+        items_by_id = {item.id: item for item in item_list}
+    except Exception:
+        return {thread.id: ThreadInboxLink(None, False) for thread in threads}
+
+    links: dict[str, ThreadInboxLink] = {}
+    for thread in threads:
+        try:
+            work_item_id = _resolve_from_index(
+                thread.id, thread.spec_id, thread.task_slug, index,
+            )
+            item = items_by_id.get(work_item_id)
+            terminal = item is not None and compute_phase(
+                item,
+                specs_by_id.get(item.spec_id) if item.spec_id else None,
+                [tasks_by_slug[slug] for slug in item.task_slugs if slug in tasks_by_slug],
+            ) == "done"
+            links[thread.id] = ThreadInboxLink(work_item_id, terminal)
+        except Exception:
+            links[thread.id] = ThreadInboxLink(None, False)
+    return links
 
 def _build_link_index(items: Iterable):
     """Build the three reverse lookups (thread_id / spec_id / task_slug -> work_item_id)

--- a/src/mship/core/view/thread_links.py
+++ b/src/mship/core/view/thread_links.py
@@ -20,6 +20,7 @@ def index_thread_inbox_links(
     tasks_by_slug: dict,
     *,
     uncertain: bool = False,
+    ambiguous_spec_ids: frozenset[str] = frozenset(),
 ) -> dict[str, ThreadInboxLink]:
     """Resolve each thread's WorkItem once and derive whether that owner is done."""
     try:
@@ -36,7 +37,8 @@ def index_thread_inbox_links(
                 thread.id, thread.spec_id, thread.task_slug, index,
             )
             item = items_by_id.get(work_item_id)
-            terminal = item is not None and compute_phase(
+            ambiguous_spec = item is not None and item.spec_id in ambiguous_spec_ids
+            terminal = not ambiguous_spec and item is not None and compute_phase(
                 item,
                 specs_by_id.get(item.spec_id) if item.spec_id else None,
                 [tasks_by_slug[slug] for slug in item.task_slugs if slug in tasks_by_slug],
@@ -44,7 +46,8 @@ def index_thread_inbox_links(
             links[thread.id] = ThreadInboxLink(
                 work_item_id,
                 terminal,
-                uncertain and work_item_id is None
+                ambiguous_spec
+                or (uncertain and work_item_id is None)
                 or (work_item_id is None and bool(thread.spec_id or thread.task_slug)),
             )
         except Exception:

--- a/src/mship/core/view/thread_links.py
+++ b/src/mship/core/view/thread_links.py
@@ -42,7 +42,10 @@ def index_thread_inbox_links(
                 [tasks_by_slug[slug] for slug in item.task_slugs if slug in tasks_by_slug],
             ) == "done"
             links[thread.id] = ThreadInboxLink(
-                work_item_id, terminal, uncertain and work_item_id is None,
+                work_item_id,
+                terminal,
+                uncertain and work_item_id is None
+                or (work_item_id is None and bool(thread.spec_id or thread.task_slug)),
             )
         except Exception:
             links[thread.id] = ThreadInboxLink(None, False, True)

--- a/src/mship/core/view/thread_links.py
+++ b/src/mship/core/view/thread_links.py
@@ -33,12 +33,12 @@ def index_thread_inbox_links(
     links: dict[str, ThreadInboxLink] = {}
     for thread in threads:
         try:
-            work_item_id = _resolve_from_index(
+            work_item_id, ownership_ambiguous = _resolve_with_ambiguity(
                 thread.id, thread.spec_id, thread.task_slug, index,
             )
             item = items_by_id.get(work_item_id)
             ambiguous_spec = item is not None and item.spec_id in ambiguous_spec_ids
-            terminal = not ambiguous_spec and item is not None and compute_phase(
+            terminal = not ownership_ambiguous and not ambiguous_spec and item is not None and compute_phase(
                 item,
                 specs_by_id.get(item.spec_id) if item.spec_id else None,
                 [tasks_by_slug[slug] for slug in item.task_slugs if slug in tasks_by_slug],
@@ -46,7 +46,8 @@ def index_thread_inbox_links(
             links[thread.id] = ThreadInboxLink(
                 work_item_id,
                 terminal,
-                ambiguous_spec
+                ownership_ambiguous
+                or ambiguous_spec
                 or (uncertain and work_item_id is None)
                 or (work_item_id is None and bool(thread.spec_id or thread.task_slug)),
             )
@@ -55,37 +56,41 @@ def index_thread_inbox_links(
     return links
 
 def _build_link_index(items: Iterable):
-    """Build the three reverse lookups (thread_id / spec_id / task_slug -> work_item_id)
-    once, so a whole thread list can be resolved without re-scanning `items` per thread."""
-    # Per-item guard: a single corrupt/unreadable WorkItem degrades ONLY its own threads (they fall
-    # back to None), not every thread — a coarse whole-index try/except would blank healthy items too.
-    by_thread: dict = {}
-    by_spec: dict = {}
-    by_task: dict = {}
+    """Build reverse owner sets for thread, spec, and task links once per batch."""
+    by_thread: dict[str, set[str]] = {}
+    by_spec: dict[str, set[str]] = {}
+    by_task: dict[str, set[str]] = {}
     for w in items:
         try:
             for tid in w.thread_ids:
-                by_thread[tid] = w.id
+                by_thread.setdefault(tid, set()).add(w.id)
             if w.spec_id:
-                by_spec[w.spec_id] = w.id
+                by_spec.setdefault(w.spec_id, set()).add(w.id)
             for slug in w.task_slugs:
-                by_task[slug] = w.id
+                by_task.setdefault(slug, set()).add(w.id)
         except Exception:
             continue
     return by_thread, by_spec, by_task
 
 
-def _resolve_from_index(thread_id: str, spec_id: str | None, task_slug: str | None, index) -> str | None:
-    """Resolve one thread against a prebuilt index. Precedence: explicit thread_ids link >
-    spec_id > task_slug. Direct membership is exclusive, so this yields AT MOST ONE item."""
+def _resolve_with_ambiguity(
+    thread_id: str, spec_id: str | None, task_slug: str | None, index,
+) -> tuple[str | None, bool]:
+    """Resolve one link at the first applicable precedence, preserving ambiguity."""
     by_thread, by_spec, by_task = index
-    if thread_id in by_thread:
-        return by_thread[thread_id]
-    if spec_id and spec_id in by_spec:
-        return by_spec[spec_id]
-    if task_slug and task_slug in by_task:
-        return by_task[task_slug]
-    return None
+    for key, owners in (
+        (thread_id, by_thread),
+        (spec_id, by_spec),
+        (task_slug, by_task),
+    ):
+        if key and key in owners:
+            matches = owners[key]
+            return (next(iter(matches)), False) if len(matches) == 1 else (None, True)
+    return None, False
+
+
+def _resolve_from_index(thread_id: str, spec_id: str | None, task_slug: str | None, index) -> str | None:
+    return _resolve_with_ambiguity(thread_id, spec_id, task_slug, index)[0]
 
 
 def resolve_thread_work_item(
@@ -98,8 +103,7 @@ def resolve_thread_work_item(
 
     Precedence: explicit thread_ids link > spec_id > task_slug.
     `items` is any iterable of objects with .id/.spec_id/.task_slugs/.thread_ids.
-    A thread resolves to AT MOST ONE WorkItem (direct membership is exclusive; the
-    indirect fallback resolves to exactly one item deterministically).
+    A duplicate owner at the selected precedence is ambiguous and resolves to None.
     """
     return _resolve_from_index(thread_id, spec_id, task_slug, _build_link_index(items))
 

--- a/src/mship/core/view/thread_links.py
+++ b/src/mship/core/view/thread_links.py
@@ -10,6 +10,7 @@ from mship.core.view.workitem_index import compute_phase
 class ThreadInboxLink:
     work_item_id: str | None
     terminal: bool
+    uncertain: bool = False
 
 
 def index_thread_inbox_links(
@@ -17,6 +18,8 @@ def index_thread_inbox_links(
     items: Iterable,
     specs_by_id: dict,
     tasks_by_slug: dict,
+    *,
+    uncertain: bool = False,
 ) -> dict[str, ThreadInboxLink]:
     """Resolve each thread's WorkItem once and derive whether that owner is done."""
     try:
@@ -38,9 +41,11 @@ def index_thread_inbox_links(
                 specs_by_id.get(item.spec_id) if item.spec_id else None,
                 [tasks_by_slug[slug] for slug in item.task_slugs if slug in tasks_by_slug],
             ) == "done"
-            links[thread.id] = ThreadInboxLink(work_item_id, terminal)
+            links[thread.id] = ThreadInboxLink(
+                work_item_id, terminal, uncertain and work_item_id is None,
+            )
         except Exception:
-            links[thread.id] = ThreadInboxLink(None, False)
+            links[thread.id] = ThreadInboxLink(None, False, True)
     return links
 
 def _build_link_index(items: Iterable):

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -108,7 +108,7 @@ def resolve_bound_spec(task, workspace_root: Path):
     if wi_id is not None:
         wi = WorkItemStore(Path(workspace_root) / ".mothership" / "workitems").get(wi_id)
         if wi is not None and wi.spec_id:
-            bound = specs.find_by_id(wi.spec_id)
+            bound = specs.read_strict(wi.spec_id)
             if bound is None:
                 raise BoundSpecUnresolved(
                     f"WorkItem {wi_id} links spec {wi.spec_id!r}, but that spec was not "

--- a/src/mship/core/workitem_lifecycle.py
+++ b/src/mship/core/workitem_lifecycle.py
@@ -81,7 +81,7 @@ def advance_workitem_on_close(
         from mship.core.spec_store import SpecStore
 
         sstore = SpecStore(specs_dir)
-        spec = sstore.find_by_id(item.spec_id)
+        spec = sstore.read_strict(item.spec_id)
         if spec is not None and spec.status in ("approved", "dispatched"):
             now = datetime.now(timezone.utc)
             spec.status = "implemented"

--- a/src/mship/core/workitem_store.py
+++ b/src/mship/core/workitem_store.py
@@ -4,7 +4,7 @@ import fcntl
 import tempfile
 import uuid
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from mship.core.state import StateManager
@@ -109,7 +109,12 @@ class WorkItemStore:
                 uncertain = True
         if not include_archived:
             items = [item for item in items if not item.archived]
-        return sorted(items, key=lambda item: item.updated_at, reverse=True), uncertain
+        return sorted(
+            items,
+            key=lambda item: item.updated_at.replace(tzinfo=timezone.utc)
+            if item.updated_at.tzinfo is None else item.updated_at,
+            reverse=True,
+        ), uncertain
 
     def list_tolerant(self, include_archived: bool = False) -> list[WorkItem]:
         return self.list_tolerant_with_uncertainty(include_archived)[0]

--- a/src/mship/core/workitem_store.py
+++ b/src/mship/core/workitem_store.py
@@ -94,6 +94,20 @@ class WorkItemStore:
             items = [item for item in items if not item.archived]
         return sorted(items, key=lambda w: w.updated_at, reverse=True)
 
+    def list_tolerant(self, include_archived: bool = False) -> list[WorkItem]:
+        """Read healthy work items while allowing unrelated corrupt files to degrade."""
+        if not self._dir.is_dir():
+            return []
+        items: list[WorkItem] = []
+        for path in self._dir.glob("*.json"):
+            try:
+                items.append(WorkItem.model_validate_json(path.read_text()))
+            except Exception:
+                continue
+        if not include_archived:
+            items = [item for item in items if not item.archived]
+        return sorted(items, key=lambda item: item.updated_at, reverse=True)
+
     def create(self, title: str, kind: Kind, workspace: str, now: datetime) -> WorkItem:
         item = WorkItem(id=_new_id(now), title=title, workspace=workspace, kind=kind,
                         created_at=now, updated_at=now)

--- a/src/mship/core/workitem_store.py
+++ b/src/mship/core/workitem_store.py
@@ -94,19 +94,25 @@ class WorkItemStore:
             items = [item for item in items if not item.archived]
         return sorted(items, key=lambda w: w.updated_at, reverse=True)
 
-    def list_tolerant(self, include_archived: bool = False) -> list[WorkItem]:
-        """Read healthy work items while allowing unrelated corrupt files to degrade."""
+    def list_tolerant_with_uncertainty(
+        self, include_archived: bool = False,
+    ) -> tuple[list[WorkItem], bool]:
+        """Read healthy items and report whether any artifact was unreadable."""
         if not self._dir.is_dir():
-            return []
+            return [], False
         items: list[WorkItem] = []
+        uncertain = False
         for path in self._dir.glob("*.json"):
             try:
                 items.append(WorkItem.model_validate_json(path.read_text()))
             except Exception:
-                continue
+                uncertain = True
         if not include_archived:
             items = [item for item in items if not item.archived]
-        return sorted(items, key=lambda item: item.updated_at, reverse=True)
+        return sorted(items, key=lambda item: item.updated_at, reverse=True), uncertain
+
+    def list_tolerant(self, include_archived: bool = False) -> list[WorkItem]:
+        return self.list_tolerant_with_uncertainty(include_archived)[0]
 
     def create(self, title: str, kind: Kind, workspace: str, now: datetime) -> WorkItem:
         item = WorkItem(id=_new_id(now), title=title, workspace=workspace, kind=kind,

--- a/tests/cli/test_inbox_wait.py
+++ b/tests/cli/test_inbox_wait.py
@@ -77,6 +77,21 @@ def test_wait_ignores_agent_reply(tmp_path: Path):
         _reset()
 
 
+def test_wait_ignores_inbox_only_mutation_on_an_old_awaiting_thread(tmp_path: Path):
+    cfg, state_dir, store = _bootstrap(tmp_path)
+    created = datetime.now(timezone.utc) - timedelta(minutes=1)
+    thread = store.create_thread("s", "q", created)
+    store.mutate_inbox(thread.id, "archive", "device-archive", created + timedelta(seconds=1))
+    _override(cfg, state_dir)
+    try:
+        result = runner.invoke(app, ["inbox", "wait", "--since", created.isoformat(), "--timeout", "0.1"])
+        payload = json.loads(result.output)
+        assert payload["timed_out"] is True
+        assert payload["threads"] == []
+    finally:
+        _reset()
+
+
 def test_wait_matches_event_thread_even_after_interleaved_human_message(tmp_path: Path):
     # MOS-194 (Greptile finding on PR #307): a dispatch/PR event is a signal FOR
     # THE AGENT. A human posting on the thread afterwards (e.g. a quick "thanks"

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -6,6 +6,9 @@ import pytest
 from typer.testing import CliRunner
 
 from mship.cli import app, container
+from mship.core import spec_key
+from mship.core.spec import Spec
+from mship.core.spec_storage import SpecStorage
 from mship.core.spec_store import SpecStore
 from mship.core.state import StateManager, Task, WorkspaceState
 
@@ -100,6 +103,25 @@ def test_spec_new_refuses_existing(configured_app_with_task: Path):
     assert result.exit_code != 0
     assert "exists" in result.output.lower() or "already" in result.output.lower()
 
+
+
+def test_spec_new_refuses_duplicate_locked_spec(configured_app_with_task: Path):
+    workspace = configured_app_with_task
+    (workspace / "mothership.yaml").write_text(
+        "workspace: test\nrepos: {}\nspec_storage: encrypted\n",
+    )
+    now = datetime.now(timezone.utc)
+    encrypted = SpecStorage(workspace / "specs", mode="encrypted", workspace_root=workspace)
+    SpecStore(workspace / "specs", storage=encrypted).save(Spec(
+        id="locked-spec", title="Locked", status="draft", created_at=now, updated_at=now,
+    ))
+    spec_key.keyfile_path(workspace).unlink()
+    container.config.reset()
+
+    result = runner.invoke(app, ["spec", "new", "--id", "locked-spec", "--title", "Replacement"])
+
+    assert result.exit_code != 0
+    assert "locked" in result.output.lower()
 
 def test_spec_new_force_overwrites(configured_app_with_task: Path):
     runner.invoke(app, ["spec", "new", "--title", "Add labels"])

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -123,6 +123,34 @@ def test_spec_new_refuses_duplicate_locked_spec(configured_app_with_task: Path):
     assert result.exit_code != 0
     assert "locked" in result.output.lower()
 
+
+def test_spec_new_duplicate_reports_the_existing_encrypted_artifact(
+    configured_app_with_task: Path,
+):
+    workspace = configured_app_with_task
+    (workspace / "mothership.yaml").write_text(
+        "workspace: test\nrepos: {}\nspec_storage: encrypted\n",
+    )
+    created = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    encrypted = SpecStorage(workspace / "specs", mode="encrypted", workspace_root=workspace)
+    existing = SpecStore(workspace / "specs", storage=encrypted).save(Spec(
+        id="existing-spec",
+        title="Existing",
+        status="draft",
+        created_at=created,
+        updated_at=created,
+    ))
+    container.config.reset()
+
+    result = runner.invoke(
+        app,
+        ["spec", "new", "--id", "existing-spec", "--title", "Replacement"],
+    )
+
+    assert result.exit_code != 0
+    assert str(existing) in result.output
+    assert existing.name.endswith(".md.enc")
+
 def test_spec_new_force_overwrites(configured_app_with_task: Path):
     runner.invoke(app, ["spec", "new", "--title", "Add labels"])
     result = runner.invoke(app, ["spec", "new", "--title", "Add labels", "--force"])
@@ -366,6 +394,16 @@ def test_spec_validate_flags_missing_section(configured_app_with_task: Path):
 def test_spec_validate_unknown_id_errors(configured_app_with_task: Path):
     result = runner.invoke(app, ["spec", "validate", "nope"])
     assert result.exit_code != 0
+
+def test_spec_validate_unsafe_id_is_a_controlled_cli_error(
+    configured_app_with_task: Path,
+):
+    result = runner.invoke(app, ["spec", "validate", ".hidden"])
+
+    assert result.exit_code != 0
+    assert "unsafe spec id" in result.output
+    assert result.exception is not None
+    assert result.exception.__class__.__name__ == "SystemExit"
 
 
 def test_spec_apply_rejects_malformed_json(configured_app_with_task: Path, tmp_path):

--- a/tests/cli/test_spec_lifecycle_close.py
+++ b/tests/cli/test_spec_lifecycle_close.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from mship.core import spec_key
+from mship.core.spec_storage import SpecLocked, SpecStorage
 from mship.core.spec_draft import new_spec
 from mship.core.spec_store import SpecStore, SPECS_DIRNAME
 from mship.core.state import Task, WorkspaceState, StateManager
@@ -128,6 +130,27 @@ class TestSpecLifecycleOnClose:
             merged_count=1,
             closed_count=0,
         )
+
+    def test_close_raises_for_locked_bound_spec(self, tmp_path):
+        specs_dir = tmp_path / SPECS_DIRNAME
+        encrypted = SpecStore(
+            specs_dir,
+            storage=SpecStorage(specs_dir, mode="encrypted", workspace_root=tmp_path),
+        )
+        spec = new_spec("Feature", now=_NOW, task_slug="mytask")
+        spec.status = "dispatched"
+        encrypted.save(spec)
+        spec_key.keyfile_path(tmp_path).unlink()
+
+        from mship.core.spec_lifecycle import advance_spec_on_close
+
+        with pytest.raises(SpecLocked):
+            advance_spec_on_close(
+                task=_make_task(tmp_path, spec_id=spec.id),
+                specs_dir=specs_dir,
+                merged_count=1,
+                closed_count=0,
+            )
 
 
 class TestSpecImplementedCommand:

--- a/tests/cli/test_spec_list_show.py
+++ b/tests/cli/test_spec_list_show.py
@@ -138,6 +138,16 @@ class TestSpecShow:
         result = runner.invoke(app, ["spec", "show", "nonexistent"])
         assert result.exit_code != 0
 
+    def test_show_unsafe_id_reports_missing_without_a_traceback(self, tmp_path):
+        (tmp_path / "specs").mkdir()
+
+        result = CliRunner().invoke(_app(tmp_path), ["spec", "show", ".hidden"])
+
+        assert result.exit_code != 0
+        assert "No spec" in result.output
+        assert result.exception is not None
+        assert result.exception.__class__.__name__ == "SystemExit"
+
     def test_show_body_included(self, tmp_path):
         """JSON response includes the spec body."""
         _, ids = _make_store(tmp_path, count=1)

--- a/tests/cli/test_spec_list_show.py
+++ b/tests/cli/test_spec_list_show.py
@@ -148,6 +148,19 @@ class TestSpecShow:
         assert result.exception is not None
         assert result.exception.__class__.__name__ == "SystemExit"
 
+    def test_show_duplicate_id_reports_conflict_without_a_traceback(self, tmp_path):
+        _, ids = _make_store(tmp_path, count=1)
+        original = next((tmp_path / "specs").glob(f"*-{ids[0]}.md"))
+        duplicate = original.with_name(f"2030-01-01-{ids[0]}.md")
+        duplicate.write_text(original.read_text())
+
+        result = CliRunner().invoke(_app(tmp_path), ["spec", "show", ids[0]])
+
+        assert result.exit_code != 0
+        assert "multiple physical artifacts" in result.output
+        assert result.exception is not None
+        assert result.exception.__class__.__name__ == "SystemExit"
+
     def test_show_body_included(self, tmp_path):
         """JSON response includes the spec body."""
         _, ids = _make_store(tmp_path, count=1)

--- a/tests/cli/test_spec_list_show.py
+++ b/tests/cli/test_spec_list_show.py
@@ -89,6 +89,15 @@ class TestSpecList:
         data = json.loads(result.output)
         assert data["specs"] == []
 
+    def test_list_preserves_readable_specs_when_one_artifact_is_malformed(self, tmp_path):
+        _make_store(tmp_path)
+        (tmp_path / "specs" / "2026-01-03-broken.md").write_text("not a spec")
+
+        result = CliRunner().invoke(_app(tmp_path), ["spec", "list"])
+
+        assert result.exit_code == 0, result.output
+        assert len(json.loads(result.output)["specs"]) == 2
+
     def test_list_tty_shows_ids_and_statuses(self, tmp_path):
         """TTY output contains spec ids and statuses."""
         _make_store(tmp_path)

--- a/tests/cli/test_spec_migrate_storage.py
+++ b/tests/cli/test_spec_migrate_storage.py
@@ -128,3 +128,35 @@ def test_migration_preflight_rejects_malformed_artifact_before_writing(workspace
     assert "malformed" in result.output.lower()
     assert list((workspace / "specs").glob("*.md.enc")) == []
     assert original.is_file()
+
+
+def test_migration_preflight_rejects_later_duplicate_before_any_write(workspace: Path):
+    original = next((workspace / "specs").glob("*-design-x.md"))
+    duplicate = workspace / "specs" / "2026-08-26-design-x.md"
+    duplicate.write_text(original.read_text())
+    _set_mode(workspace, "encrypted")
+
+    result = runner.invoke(app, ["spec", "migrate-storage"])
+
+    assert result.exit_code != 0
+    assert "multiple physical artifacts" in result.output
+    assert list((workspace / "specs").glob("*.md.enc")) == []
+    assert original.is_file()
+    assert duplicate.is_file()
+
+
+def test_migration_preflight_rejects_canonical_frontmatter_mismatch_before_any_write(
+    workspace: Path,
+):
+    original = next((workspace / "specs").glob("*-design-x.md"))
+    mismatch = workspace / "specs" / "2026-08-26-physical-id.md"
+    mismatch.write_text(original.read_text())
+    _set_mode(workspace, "encrypted")
+
+    result = runner.invoke(app, ["spec", "migrate-storage"])
+
+    assert result.exit_code != 0
+    assert "canonical artifact" in result.output
+    assert list((workspace / "specs").glob("*.md.enc")) == []
+    assert original.is_file()
+    assert mismatch.is_file()

--- a/tests/cli/test_spec_migrate_storage.py
+++ b/tests/cli/test_spec_migrate_storage.py
@@ -115,3 +115,16 @@ def test_migration_holds_spec_lock_until_mutation_can_write_target(
     writer.join(timeout=1)
     assert mutation_finished.is_set()
     assert store.find_by_id("design-x").inbox.manual_archived is True
+
+
+def test_migration_preflight_rejects_malformed_artifact_before_writing(workspace: Path):
+    original = next((workspace / "specs").glob("*-design-x.md"))
+    (workspace / "specs" / "z-malformed.md").write_text("not a spec")
+    _set_mode(workspace, "encrypted")
+
+    result = runner.invoke(app, ["spec", "migrate-storage"])
+
+    assert result.exit_code != 0
+    assert "malformed" in result.output.lower()
+    assert list((workspace / "specs").glob("*.md.enc")) == []
+    assert original.is_file()

--- a/tests/cli/test_spec_migrate_storage.py
+++ b/tests/cli/test_spec_migrate_storage.py
@@ -1,5 +1,5 @@
 import subprocess
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Event, Thread
 
@@ -132,7 +132,8 @@ def test_migration_preflight_rejects_malformed_artifact_before_writing(workspace
 
 def test_migration_preflight_rejects_later_duplicate_before_any_write(workspace: Path):
     original = next((workspace / "specs").glob("*-design-x.md"))
-    duplicate = workspace / "specs" / "2026-08-27-design-x.md"
+    duplicate_date = datetime.fromisoformat(original.name[:10]) + timedelta(days=1)
+    duplicate = workspace / "specs" / f"{duplicate_date:%Y-%m-%d}-design-x.md"
     duplicate.write_text(original.read_text())
     _set_mode(workspace, "encrypted")
 

--- a/tests/cli/test_spec_migrate_storage.py
+++ b/tests/cli/test_spec_migrate_storage.py
@@ -59,7 +59,7 @@ def test_migrate_committed_to_local(workspace: Path):
     md = list((workspace / "specs").glob("*.md"))
     assert len(md) == 1 and "Design X" in md[0].read_text()  # still readable locally
     # Untracked + gitignored now.
-    assert "design-x" not in _git(workspace, "ls-files", "specs").stdout
+    assert not any("design-x" in path for path in _git(workspace, "ls-files", "specs").stdout.splitlines())
     check = subprocess.run(
         ["git", "check-ignore", "-q", str(md[0].relative_to(workspace))], cwd=workspace
     )

--- a/tests/cli/test_spec_migrate_storage.py
+++ b/tests/cli/test_spec_migrate_storage.py
@@ -132,7 +132,7 @@ def test_migration_preflight_rejects_malformed_artifact_before_writing(workspace
 
 def test_migration_preflight_rejects_later_duplicate_before_any_write(workspace: Path):
     original = next((workspace / "specs").glob("*-design-x.md"))
-    duplicate = workspace / "specs" / "2026-08-26-design-x.md"
+    duplicate = workspace / "specs" / "2026-08-27-design-x.md"
     duplicate.write_text(original.read_text())
     _set_mode(workspace, "encrypted")
 

--- a/tests/cli/test_spec_migrate_storage.py
+++ b/tests/cli/test_spec_migrate_storage.py
@@ -1,10 +1,14 @@
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
+from threading import Event, Thread
 
 import pytest
 from typer.testing import CliRunner
 
 from mship.cli import app, container
+from mship.core.spec_store import SpecStore
+from mship.core.spec_storage import SpecStorage
 
 runner = CliRunner()
 
@@ -75,3 +79,39 @@ def test_migrate_encrypted_back_to_committed(workspace: Path):
     md = list((workspace / "specs").glob("*.md"))
     assert len(md) == 1 and "Design X" in md[0].read_text()
     assert list((workspace / "specs").glob("*.md.enc")) == []  # ciphertext gone
+
+
+def test_migration_holds_spec_lock_until_mutation_can_write_target(
+    workspace: Path, monkeypatch,
+):
+    _set_mode(workspace, "encrypted")
+    store = SpecStore(workspace / "specs")
+    mutation_finished = Event()
+    mutation_started = Event()
+    original_write = SpecStorage.write
+    writer: Thread | None = None
+
+    def mutate() -> None:
+        store.mutate_inbox(
+            "design-x", "archive", "archive-during-migration",
+            datetime(2026, 8, 26, tzinfo=timezone.utc),
+        )
+        mutation_finished.set()
+
+    def interleave_migration(storage, path, text):
+        nonlocal writer
+        if storage.mode == "encrypted" and writer is None:
+            writer = Thread(target=mutate)
+            writer.start()
+            mutation_started.set()
+            assert not mutation_finished.wait(timeout=0.1)
+        return original_write(storage, path, text)
+
+    monkeypatch.setattr(SpecStorage, "write", interleave_migration)
+    res = runner.invoke(app, ["spec", "migrate-storage"])
+    assert res.exit_code == 0, res.output
+    assert mutation_started.is_set()
+    assert writer is not None
+    writer.join(timeout=1)
+    assert mutation_finished.is_set()
+    assert store.find_by_id("design-x").inbox.manual_archived is True

--- a/tests/cli/test_spec_storage_cli.py
+++ b/tests/cli/test_spec_storage_cli.py
@@ -5,6 +5,7 @@ import pytest
 from typer.testing import CliRunner
 
 from mship.cli import app, container
+from mship.core import spec_key
 
 runner = CliRunner()
 
@@ -75,6 +76,17 @@ def test_spec_validate_under_encrypted(encrypted_workspace: Path):
     # validate found + decoded the ENCRYPTED spec rather than reporting "no spec
     # file" (which is what a raw *.md glob would do against a *.md.enc store).
     assert "No spec file for id" not in res.output
+
+
+def test_spec_show_treats_locked_artifact_as_unavailable(encrypted_workspace: Path):
+    runner.invoke(app, ["spec", "new", "--title", "Hidden plan", "--id", "hidden-plan"])
+    spec_key.keyfile_path(encrypted_workspace).unlink()
+
+    result = runner.invoke(app, ["spec", "show", "hidden-plan"])
+
+    assert result.exit_code != 0
+    assert result.exception is None
+    assert "no spec" in result.output.lower()
 
 
 def test_spec_validate_reports_malformed_not_nameerror(tmp_path: Path):

--- a/tests/cli/test_spec_storage_cli.py
+++ b/tests/cli/test_spec_storage_cli.py
@@ -44,7 +44,7 @@ def test_spec_new_reports_the_encrypted_physical_path(encrypted_workspace: Path)
 
     assert res.exit_code == 0, res.output
     assert json.loads(res.stdout)["path"].endswith("hidden-plan.md.enc")
-    assert "Back up" in res.stderr
+    assert "BACK THIS FILE UP" in res.stderr
 
 
 def test_spec_show_decrypts_with_key(encrypted_workspace: Path):

--- a/tests/cli/test_spec_storage_cli.py
+++ b/tests/cli/test_spec_storage_cli.py
@@ -43,7 +43,8 @@ def test_spec_new_reports_the_encrypted_physical_path(encrypted_workspace: Path)
     res = runner.invoke(app, ["--json", "spec", "new", "--title", "Hidden plan", "--id", "hidden-plan"])
 
     assert res.exit_code == 0, res.output
-    assert json.loads(res.output)["path"].endswith("hidden-plan.md.enc")
+    assert json.loads(res.stdout)["path"].endswith("hidden-plan.md.enc")
+    assert "Back up" in res.stderr
 
 
 def test_spec_show_decrypts_with_key(encrypted_workspace: Path):

--- a/tests/cli/test_spec_storage_cli.py
+++ b/tests/cli/test_spec_storage_cli.py
@@ -39,6 +39,13 @@ def test_spec_new_under_encrypted_writes_ciphertext(encrypted_workspace: Path):
     assert list((encrypted_workspace / "specs").glob("*.md")) == []
 
 
+def test_spec_new_reports_the_encrypted_physical_path(encrypted_workspace: Path):
+    res = runner.invoke(app, ["--json", "spec", "new", "--title", "Hidden plan", "--id", "hidden-plan"])
+
+    assert res.exit_code == 0, res.output
+    assert json.loads(res.output)["path"].endswith("hidden-plan.md.enc")
+
+
 def test_spec_show_decrypts_with_key(encrypted_workspace: Path):
     runner.invoke(app, ["spec", "new", "--title", "Hidden plan", "--id", "hidden-plan"])
     res = runner.invoke(app, ["--json", "spec", "show", "hidden-plan"])

--- a/tests/cli/test_spec_storage_cli.py
+++ b/tests/cli/test_spec_storage_cli.py
@@ -85,7 +85,7 @@ def test_spec_show_treats_locked_artifact_as_unavailable(encrypted_workspace: Pa
     result = runner.invoke(app, ["spec", "show", "hidden-plan"])
 
     assert result.exit_code != 0
-    assert result.exception is None
+    assert "SpecLocked" not in result.output
     assert "no spec" in result.output.lower()
 
 

--- a/tests/cli/test_workitem.py
+++ b/tests/cli/test_workitem.py
@@ -6,10 +6,12 @@ from types import SimpleNamespace
 from typer.testing import CliRunner
 
 from mship.cli import app, container
+from mship.core import spec_key
 from mship.cli.workitem import _branch_state_for, _probe_ref_names
 from mship.core.run_state import RunStateRepo
 from mship.core.spec import Spec
 from mship.core.spec_store import SpecStore
+from mship.core.spec_storage import SpecStorage
 from mship.core.state import StateManager, Task, WorkspaceState
 
 runner = CliRunner()
@@ -308,6 +310,30 @@ def test_new_then_list_roundtrip(tmp_path):
         container.config_path.reset_override()
         container.state_dir.reset_override()
         container.config.reset()
+
+
+def test_item_list_preserves_healthy_items_when_an_encrypted_spec_is_locked(tmp_path):
+    _isolate(tmp_path)
+    try:
+        created = runner.invoke(app, ["item", "new", "Healthy item", "--kind", "chore"])
+        assert created.exit_code == 0, created.output
+        now = datetime(2026, 8, 27, tzinfo=timezone.utc)
+        storage = SpecStorage(tmp_path / "specs", mode="encrypted", workspace_root=tmp_path)
+        SpecStore(tmp_path / "specs", storage=storage).save(Spec(
+            id="locked",
+            title="Locked",
+            status="draft",
+            created_at=now,
+            updated_at=now,
+        ))
+        spec_key.keyfile_path(tmp_path).unlink()
+
+        result = runner.invoke(app, ["--json", "item", "list"])
+
+        assert result.exit_code == 0, result.output
+        assert [row["title"] for row in json.loads(result.output)] == ["Healthy item"]
+    finally:
+        _reset()
 
 
 def test_new_with_invalid_kind_errors_cleanly(tmp_path):

--- a/tests/cli/test_workitem.py
+++ b/tests/cli/test_workitem.py
@@ -106,6 +106,28 @@ def test_item_run_next_noop_exit_zero_when_empty(tmp_path):
         _reset()
 
 
+def test_item_run_next_ignores_an_unrelated_locked_spec(tmp_path):
+    _isolate(tmp_path)
+    try:
+        now = datetime(2026, 8, 27, tzinfo=timezone.utc)
+        storage = SpecStorage(tmp_path / "specs", mode="encrypted", workspace_root=tmp_path)
+        SpecStore(tmp_path / "specs", storage=storage).save(Spec(
+            id="locked",
+            title="Locked",
+            status="draft",
+            created_at=now,
+            updated_at=now,
+        ))
+        spec_key.keyfile_path(tmp_path).unlink()
+
+        result = runner.invoke(app, ["--json", "item", "run-next"])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {"runnable": False}
+    finally:
+        _reset()
+
+
 def test_item_bail_logs_reason_and_releases(tmp_path):
     _isolate(tmp_path)
     origin = _make_origin(tmp_path)

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -2548,6 +2548,37 @@ def test_close_push_only_completion_advances_spec_and_workitem(configured_git_ap
     assert "t" not in sm.load().tasks
 
 
+def test_close_warns_when_locked_spec_blocks_lifecycle(configured_git_app):
+    from typer.testing import CliRunner
+    from mship.cli import app as _app
+    from mship.core import spec_key
+    from mship.core.spec_storage import SpecStorage
+    from mship.core.spec_store import SpecStore
+
+    sm, spec_store, _wi_store, _wi_id, spec_id = _seed_pushonly_lifecycle(
+        configured_git_app
+    )
+    spec = spec_store.find_by_id(spec_id)
+    next((configured_git_app / "specs").glob(f"*-{spec_id}.md")).unlink()
+    encrypted_store = SpecStore(
+        configured_git_app / "specs",
+        storage=SpecStorage(
+            configured_git_app / "specs",
+            mode="encrypted",
+            workspace_root=configured_git_app,
+        ),
+    )
+    encrypted_store.save(spec)
+    spec_key.keyfile_path(configured_git_app).unlink()
+
+    result = CliRunner().invoke(_app, ["close", "--yes", "--task", "t"])
+
+    assert result.exit_code == 0, result.output
+    assert "spec lifecycle not advanced" in result.output
+    assert "encrypted and no key is available" in result.output
+    assert "t" not in sm.load().tasks
+
+
 def test_close_abandon_does_not_advance_lifecycle(configured_git_app):
     """--abandon is discarded work: spec and WorkItem stay unadvanced."""
     from typer.testing import CliRunner

--- a/tests/cli/view/test_base.py
+++ b/tests/cli/view/test_base.py
@@ -68,4 +68,5 @@ async def test_auto_follow_when_pinned_to_bottom():
         app.content = "\n".join(f"line {i}" for i in range(400)) + "\n"
         app.action_force_refresh()
         await pilot.pause()
+        await pilot.pause()
         assert app.body_scroll_y() > y_end_before, "should auto-follow when pinned to bottom"

--- a/tests/cli/view/test_base.py
+++ b/tests/cli/view/test_base.py
@@ -42,20 +42,23 @@ async def test_quit_key():
 
 @pytest.mark.asyncio
 async def test_scroll_position_preserved_across_refresh():
-    app = _CountingView(watch=True, interval=0.05)
+    app = _CountingView(watch=False, interval=0.05)
     app.content = "\n".join(f"line {i}" for i in range(200)) + "\n"
     async with app.run_test() as pilot:
         await pilot.pause()
         app.scroll_body_to(50)
+        await pilot.pause()
         y_before = app.body_scroll_y()
+        assert y_before == 50, "should apply the requested non-bottom position"
         app.content = "\n".join(f"line {i}" for i in range(201)) + "\n"  # grew
-        await pilot.pause(0.15)
+        app.action_force_refresh()
+        await pilot.pause()
         assert app.body_scroll_y() == y_before, "should not yank when user scrolled away"
 
 
 @pytest.mark.asyncio
 async def test_auto_follow_when_pinned_to_bottom():
-    app = _CountingView(watch=True, interval=0.05)
+    app = _CountingView(watch=False, interval=0.05)
     app.content = "\n".join(f"line {i}" for i in range(200)) + "\n"
     async with app.run_test() as pilot:
         await pilot.pause()
@@ -63,5 +66,6 @@ async def test_auto_follow_when_pinned_to_bottom():
         await pilot.pause()
         y_end_before = app.body_scroll_y()
         app.content = "\n".join(f"line {i}" for i in range(400)) + "\n"
-        await pilot.pause(0.15)
-        assert app.body_scroll_y() >= y_end_before, "should auto-follow when pinned to bottom"
+        app.action_force_refresh()
+        await pilot.pause()
+        assert app.body_scroll_y() > y_end_before, "should auto-follow when pinned to bottom"

--- a/tests/cli/view/test_spec_view.py
+++ b/tests/cli/view/test_spec_view.py
@@ -4,7 +4,10 @@ from pathlib import Path
 
 import pytest
 
-from mship.cli.view.spec import SpecView, serve_spec_web
+from mship.cli.view.spec import SpecView, _render_html, serve_spec_web
+from mship.core.spec import Spec
+from mship.core.spec_storage import SpecStorage
+from mship.core.spec_store import SpecStore
 
 
 @pytest.mark.asyncio
@@ -19,6 +22,88 @@ async def test_spec_view_renders_markdown(tmp_path: Path):
         assert "Body text" in view.rendered_text()
 
 
+@pytest.mark.asyncio
+async def test_spec_view_decrypts_an_encrypted_path_provider(tmp_path: Path):
+    from datetime import datetime, timezone
+
+    spec = Spec(
+        id="encrypted",
+        title="Encrypted",
+        status="draft",
+        created_at=datetime(2026, 8, 27, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 8, 27, tzinfo=timezone.utc),
+        body="## Problem\n\nDECRYPTED-BODY\n",
+    )
+    specs_dir = tmp_path / "docs" / "superpowers" / "specs"
+    storage = SpecStorage(specs_dir, mode="encrypted", workspace_root=tmp_path)
+    path = SpecStore(specs_dir, storage=storage).save(spec)
+    view = SpecView(
+        workspace_root=tmp_path,
+        name_or_path=None,
+        watch=False,
+        interval=1.0,
+        path_provider=lambda: path,
+    )
+
+    async with view.run_test() as pilot:
+        await pilot.pause()
+
+        assert "DECRYPTED-BODY" in view.rendered_text()
+        assert "gAAAA" not in view.rendered_text()
+
+
+
+@pytest.mark.asyncio
+async def test_spec_view_reports_malformed_encrypted_content_without_crashing(
+    tmp_path: Path,
+):
+    from datetime import datetime, timezone
+
+    spec = Spec(
+        id="broken",
+        title="Broken",
+        status="draft",
+        created_at=datetime(2026, 8, 27, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 8, 27, tzinfo=timezone.utc),
+    )
+    specs_dir = tmp_path / "specs"
+    storage = SpecStorage(specs_dir, mode="encrypted", workspace_root=tmp_path)
+    path = SpecStore(specs_dir, storage=storage).save(spec)
+    path.write_bytes(b"invalid-fernet-token")
+    view = SpecView(
+        workspace_root=tmp_path,
+        name_or_path=str(path),
+        watch=False,
+        interval=1.0,
+    )
+
+    async with view.run_test() as pilot:
+        await pilot.pause()
+
+        assert "encrypted spec could not be decoded" in view.rendered_text()
+
+
+def test_spec_web_reports_malformed_encrypted_content_without_ciphertext(
+    tmp_path: Path,
+):
+    from datetime import datetime, timezone
+
+    spec = Spec(
+        id="broken-web",
+        title="Broken web",
+        status="draft",
+        created_at=datetime(2026, 8, 27, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 8, 27, tzinfo=timezone.utc),
+    )
+    specs_dir = tmp_path / "specs"
+    storage = SpecStorage(specs_dir, mode="encrypted", workspace_root=tmp_path)
+    path = SpecStore(specs_dir, storage=storage).save(spec)
+    path.write_bytes(b"invalid-fernet-token")
+
+    rendered = _render_html(path, workspace_root=tmp_path).decode()
+
+    assert "encrypted spec could not be decoded" in rendered
+    assert "invalid-fernet-token" not in rendered
 @pytest.mark.asyncio
 async def test_spec_view_missing_spec(tmp_path: Path):
     view = SpecView(workspace_root=tmp_path, name_or_path="nope", watch=False, interval=1.0)

--- a/tests/cli/view/test_workitems_helper.py
+++ b/tests/cli/view/test_workitems_helper.py
@@ -1,8 +1,11 @@
 from datetime import datetime, timezone
 
+from pathlib import Path
 from mship.cli import container
+from mship.core import spec_key
 from mship.core.spec import Spec
 from mship.core.spec_store import SPECS_DIRNAME, SpecStore
+from mship.core.spec_storage import SpecStorage
 from mship.core.state import StateManager, Task, WorkspaceState
 from mship.core.workitem import WorkItem
 from mship.core.workitem_store import WorkItemStore
@@ -89,5 +92,34 @@ def test_load_workitem_index_survives_broken_message_store(tmp_path, monkeypatch
         assert [s.id for s in index] == ["wi-1"]   # grouping intact despite bad messages
         assert index[0].task_slugs == ["a"]
         assert index[0].spec_id == "spec-1"
+    finally:
+        _teardown()
+
+
+def test_load_workitem_index_preserves_healthy_items_when_an_encrypted_spec_is_locked(
+    tmp_path: Path,
+):
+    _setup(tmp_path)
+    try:
+        locked = Spec(
+            id="locked",
+            title="Locked",
+            status="needs_review",
+            created_at=_now(),
+            updated_at=_now(),
+            body="secret",
+        )
+        storage = SpecStorage(
+            tmp_path / SPECS_DIRNAME,
+            mode="encrypted",
+            workspace_root=tmp_path,
+        )
+        SpecStore(tmp_path / SPECS_DIRNAME, storage=storage).save(locked)
+        spec_key.keyfile_path(tmp_path).unlink()
+
+        index = load_workitem_index(container)
+
+        assert [summary.id for summary in index] == ["wi-1"]
+        assert index[0].phase == "in_flight"
     finally:
         _teardown()

--- a/tests/core/test_inbox.py
+++ b/tests/core/test_inbox.py
@@ -230,3 +230,19 @@ def test_naive_last_mutation_timestamp_is_normalized_before_ordering():
 
     assert apply_inbox_action(metadata, "archive", "device", NOW) is True
     assert metadata.last_mutated_at.tzinfo == timezone.utc
+
+
+def test_mutation_ledger_retains_newest_256_and_noops_after_eviction():
+    metadata = InboxMetadata()
+    for i in range(257):
+        action = "archive" if i % 2 == 0 else "restore"
+        assert apply_inbox_action(metadata, action, f"mutation-{i}", NOW + timedelta(seconds=i))
+
+    assert len(metadata.mutation_ids) == 256
+    assert "mutation-0" not in metadata.mutation_ids
+    assert "mutation-1" in metadata.mutation_ids
+    timestamp = metadata.last_mutated_at
+    assert apply_inbox_action(metadata, "archive", "mutation-257", NOW + timedelta(days=1)) is False
+    assert metadata.last_mutated_at == timestamp
+    assert apply_inbox_action(metadata, "restore", "mutation-1", NOW + timedelta(days=1)) is False
+    assert metadata.last_mutated_at == timestamp

--- a/tests/core/test_inbox.py
+++ b/tests/core/test_inbox.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from mship.core.inbox import InboxMetadata, classify_spec, classify_thread
+from mship.core.inbox import InboxMetadata, apply_inbox_action, classify_spec, classify_thread
 from mship.core.message import DecisionPayload, Message, Thread
 from mship.core.spec import Spec
 
@@ -194,3 +194,14 @@ def test_unpin_falls_back_to_retained_manual_archive_metadata():
     result = classify_thread(thread, linked=False, linked_terminal=False, now=NOW)
 
     assert (result.state, result.archive_reason) == ("archived", "manual")
+
+
+def test_new_inbox_action_stamps_change_once_and_retry_preserves_it():
+    metadata = InboxMetadata()
+    first = NOW + timedelta(seconds=1)
+
+    assert apply_inbox_action(metadata, "archive", "device-1", first) is True
+    assert metadata.last_mutated_at == first
+
+    assert apply_inbox_action(metadata, "archive", "device-1", first + timedelta(seconds=1)) is False
+    assert metadata.last_mutated_at == first

--- a/tests/core/test_inbox.py
+++ b/tests/core/test_inbox.py
@@ -196,14 +196,29 @@ def test_unpin_falls_back_to_retained_manual_archive_metadata():
     assert (result.state, result.archive_reason) == ("archived", "manual")
 
 
+def test_inbox_action_result_distinguishes_persistence_from_application():
+    metadata = InboxMetadata(manual_archived=True, last_mutated_at=NOW)
+
+    result = apply_inbox_action(metadata, "archive", "device-1", NOW + timedelta(seconds=1))
+
+    assert result.persisted is True
+    assert result.applied is False
+    assert metadata.mutation_ids == {"device-1": "archive"}
+    assert metadata.last_mutated_at == NOW
+
+
 def test_new_inbox_action_stamps_change_once_and_retry_preserves_it():
     metadata = InboxMetadata()
     first = NOW + timedelta(seconds=1)
 
-    assert apply_inbox_action(metadata, "archive", "device-1", first) is True
+    result = apply_inbox_action(metadata, "archive", "device-1", first)
+    assert result.persisted is True
+    assert result.applied is True
     assert metadata.last_mutated_at == first
 
-    assert apply_inbox_action(metadata, "archive", "device-1", first + timedelta(seconds=1)) is False
+    result = apply_inbox_action(metadata, "archive", "device-1", first + timedelta(seconds=1))
+    assert result.persisted is False
+    assert result.applied is False
     assert metadata.last_mutated_at == first
 
 
@@ -228,21 +243,30 @@ def test_naive_spec_updated_at_and_restore_are_normalized_at_exact_boundaries():
 def test_naive_last_mutation_timestamp_is_normalized_before_ordering():
     metadata = InboxMetadata(last_mutated_at=(NOW + timedelta(seconds=1)).replace(tzinfo=None))
 
-    assert apply_inbox_action(metadata, "archive", "device", NOW) is True
+    result = apply_inbox_action(metadata, "archive", "device", NOW)
+    assert result.applied is True
     assert metadata.last_mutated_at.tzinfo == timezone.utc
 
 
-def test_mutation_ledger_retains_newest_256_and_noops_after_eviction():
+def test_mutation_ledger_retains_newest_256_and_persists_state_equivalent_actions():
     metadata = InboxMetadata()
     for i in range(257):
         action = "archive" if i % 2 == 0 else "restore"
-        assert apply_inbox_action(metadata, action, f"mutation-{i}", NOW + timedelta(seconds=i))
+        assert apply_inbox_action(metadata, action, f"mutation-{i}", NOW + timedelta(seconds=i)).applied
 
     assert len(metadata.mutation_ids) == 256
     assert "mutation-0" not in metadata.mutation_ids
     assert "mutation-1" in metadata.mutation_ids
     timestamp = metadata.last_mutated_at
-    assert apply_inbox_action(metadata, "archive", "mutation-257", NOW + timedelta(days=1)) is False
+
+    duplicate = apply_inbox_action(metadata, "restore", "mutation-1", NOW + timedelta(days=1))
+    assert duplicate.persisted is False
+    assert duplicate.applied is False
     assert metadata.last_mutated_at == timestamp
-    assert apply_inbox_action(metadata, "restore", "mutation-1", NOW + timedelta(days=1)) is False
+
+    no_op = apply_inbox_action(metadata, "archive", "mutation-257", NOW + timedelta(days=1))
+    assert no_op.persisted is True
+    assert no_op.applied is False
+    assert len(metadata.mutation_ids) == 256
+    assert "mutation-1" not in metadata.mutation_ids
     assert metadata.last_mutated_at == timestamp

--- a/tests/core/test_inbox.py
+++ b/tests/core/test_inbox.py
@@ -205,3 +205,21 @@ def test_new_inbox_action_stamps_change_once_and_retry_preserves_it():
 
     assert apply_inbox_action(metadata, "archive", "device-1", first + timedelta(seconds=1)) is False
     assert metadata.last_mutated_at == first
+
+
+def test_naive_thread_updated_at_is_normalized_for_exact_inactivity_boundary():
+    thread = _thread(updated_at=(NOW - SEVEN_DAYS).replace(tzinfo=None))
+
+    result = classify_thread(thread, linked=False, linked_terminal=False, now=NOW)
+
+    assert (result.state, result.archive_reason) == ("archived", "inactive_unlinked")
+
+
+def test_naive_spec_updated_at_and_restore_are_normalized_at_exact_boundaries():
+    implemented = _spec(status="implemented", updated_at=(NOW - SEVEN_DAYS).replace(tzinfo=None))
+    restored = _spec(status="archived", inbox=InboxMetadata(
+        restored_at=(NOW - SEVEN_DAYS).replace(tzinfo=None),
+    ))
+
+    assert classify_spec(implemented, now=NOW).archive_reason == "implemented"
+    assert classify_spec(restored, now=NOW).archive_reason == "lifecycle_archived"

--- a/tests/core/test_inbox.py
+++ b/tests/core/test_inbox.py
@@ -1,0 +1,196 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from mship.core.inbox import InboxMetadata, classify_spec, classify_thread
+from mship.core.message import DecisionPayload, Message, Thread
+from mship.core.spec import Spec
+
+
+SEVEN_DAYS = timedelta(days=7)
+NOW = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+
+
+def _thread(**changes) -> Thread:
+    values = {
+        "id": "thread-1",
+        "subject": "Subject",
+        "created_at": NOW - SEVEN_DAYS,
+        "updated_at": NOW,
+    }
+    values.update(changes)
+    return Thread(**values)
+
+
+def _spec(**changes) -> Spec:
+    values = {
+        "id": "spec-1",
+        "title": "Spec",
+        "status": "draft",
+        "created_at": NOW - SEVEN_DAYS,
+        "updated_at": NOW,
+    }
+    values.update(changes)
+    return Spec(**values)
+
+
+@pytest.mark.parametrize(
+    ("thread", "linked", "linked_terminal", "expected"),
+    [
+        pytest.param(
+            _thread(inbox=InboxMetadata(pinned=True, manual_archived=True)),
+            True,
+            True,
+            ("active", None),
+            id="pin-overrides-every-archival-rule",
+        ),
+        pytest.param(
+            _thread(
+                inbox=InboxMetadata(manual_archived=True),
+                messages=[
+                    Message(
+                        id="attention",
+                        thread_id="thread-1",
+                        role="agent",
+                        text="Need you",
+                        kind="needs_you",
+                        created_at=NOW,
+                    )
+                ],
+            ),
+            True,
+            True,
+            ("active", None),
+            id="needs-you-overrides-manual-archive",
+        ),
+        pytest.param(
+            _thread(
+                inbox=InboxMetadata(manual_archived=True),
+                messages=[
+                    Message(
+                        id="decision",
+                        thread_id="thread-1",
+                        role="agent",
+                        text="Choose",
+                        kind="decision",
+                        decision=DecisionPayload(options=["one"]),
+                        created_at=NOW,
+                    )
+                ],
+            ),
+            True,
+            True,
+            ("active", None),
+            id="decision-overrides-manual-archive",
+        ),
+        pytest.param(
+            _thread(inbox=InboxMetadata(manual_archived=True)),
+            False,
+            False,
+            ("archived", "manual"),
+            id="manual-archive-precedes-inactivity",
+        ),
+        pytest.param(
+            _thread(inbox=InboxMetadata(restored_at=NOW - SEVEN_DAYS + timedelta(microseconds=1))),
+            True,
+            True,
+            ("active", None),
+            id="restore-grace-is-strictly-less-than-seven-days",
+        ),
+        pytest.param(
+            _thread(inbox=InboxMetadata(restored_at=NOW - SEVEN_DAYS)),
+            True,
+            True,
+            ("archived", "linked_terminal"),
+            id="restore-grace-expires-at-exact-seven-day-boundary",
+        ),
+        pytest.param(
+            _thread(updated_at=NOW - SEVEN_DAYS + timedelta(microseconds=1)),
+            False,
+            False,
+            ("active", None),
+            id="unlinked-activity-is-active-before-boundary",
+        ),
+        pytest.param(
+            _thread(updated_at=NOW - SEVEN_DAYS),
+            False,
+            False,
+            ("archived", "inactive_unlinked"),
+            id="unlinked-activity-archives-at-boundary",
+        ),
+        pytest.param(
+            _thread(updated_at=NOW),
+            False,
+            False,
+            ("active", None),
+            id="new-unlinked-activity-resets-inactivity",
+        ),
+        pytest.param(
+            _thread(),
+            True,
+            False,
+            ("active", None),
+            id="nonterminal-link-does-not-archive",
+        ),
+    ],
+)
+def test_classify_thread_precedence(thread, linked, linked_terminal, expected):
+    result = classify_thread(thread, linked=linked, linked_terminal=linked_terminal, now=NOW)
+    assert (result.state, result.archive_reason) == expected
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        pytest.param(
+            _spec(status="archived", inbox=InboxMetadata(pinned=True)),
+            ("active", None),
+            id="pin-overrides-lifecycle-archive",
+        ),
+        pytest.param(
+            _spec(status="archived", inbox=InboxMetadata(manual_archived=True)),
+            ("archived", "manual"),
+            id="manual-archive-precedes-lifecycle-archive",
+        ),
+        pytest.param(
+            _spec(status="archived", inbox=InboxMetadata(restored_at=NOW - SEVEN_DAYS + timedelta(microseconds=1))),
+            ("active", None),
+            id="restore-keeps-lifecycle-archived-spec-active-during-grace",
+        ),
+        pytest.param(
+            _spec(status="archived", inbox=InboxMetadata(restored_at=NOW - SEVEN_DAYS)),
+            ("archived", "lifecycle_archived"),
+            id="lifecycle-archived-spec-restores-at-exact-boundary",
+        ),
+        pytest.param(
+            _spec(status="implemented", updated_at=NOW - SEVEN_DAYS + timedelta(microseconds=1)),
+            ("active", None),
+            id="implemented-spec-active-before-boundary",
+        ),
+        pytest.param(
+            _spec(status="implemented", updated_at=NOW - SEVEN_DAYS),
+            ("archived", "implemented"),
+            id="implemented-spec-archives-at-boundary",
+        ),
+        pytest.param(
+            _spec(status="implemented", updated_at=NOW),
+            ("active", None),
+            id="implemented-spec-update-resets-inactivity",
+        ),
+        *[
+            pytest.param(_spec(status=status), ("active", None), id=f"{status}-lifecycle-is-active")
+            for status in ("draft", "needs_review", "approved", "dispatched")
+        ],
+    ],
+)
+def test_classify_spec_precedence(spec, expected):
+    result = classify_spec(spec, now=NOW)
+    assert (result.state, result.archive_reason) == expected
+
+
+def test_unpin_falls_back_to_retained_manual_archive_metadata():
+    thread = _thread(inbox=InboxMetadata(pinned=False, manual_archived=True, restored_at=NOW))
+
+    result = classify_thread(thread, linked=False, linked_terminal=False, now=NOW)
+
+    assert (result.state, result.archive_reason) == ("archived", "manual")

--- a/tests/core/test_inbox.py
+++ b/tests/core/test_inbox.py
@@ -223,3 +223,10 @@ def test_naive_spec_updated_at_and_restore_are_normalized_at_exact_boundaries():
 
     assert classify_spec(implemented, now=NOW).archive_reason == "implemented"
     assert classify_spec(restored, now=NOW).archive_reason == "lifecycle_archived"
+
+
+def test_naive_last_mutation_timestamp_is_normalized_before_ordering():
+    metadata = InboxMetadata(last_mutated_at=(NOW + timedelta(seconds=1)).replace(tzinfo=None))
+
+    assert apply_inbox_action(metadata, "archive", "device", NOW) is True
+    assert metadata.last_mutated_at.tzinfo == timezone.utc

--- a/tests/core/test_message_store.py
+++ b/tests/core/test_message_store.py
@@ -243,7 +243,7 @@ def test_mutate_inbox_pin_unpin_preserves_thread_manual_and_restore_metadata(tmp
     inbox = store.get(thread.id).inbox
     assert inbox.pinned is False
     assert inbox.manual_archived is True
-    assert inbox.restored_at == now
+    assert inbox.restored_at == now + timedelta(minutes=1)
 
 
 def test_mutate_inbox_does_not_change_thread_domain_content(tmp_path):

--- a/tests/core/test_message_store.py
+++ b/tests/core/test_message_store.py
@@ -54,12 +54,18 @@ def test_get_missing_is_none(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "thread_id", ["../escape", "/tmp/escape", "thread/child", r"thread\child", "%2Fescape"],
+    "thread_id", ["../escape", "/tmp/escape", "thread/child", r"thread\child"],
 )
 def test_unsafe_thread_id_rejected(tmp_path, thread_id):
     with pytest.raises(ValueError):
         _store(tmp_path)._path(thread_id)
 
+
+
+
+def test_legacy_safe_thread_id_remains_valid(tmp_path):
+    path = _store(tmp_path)._path("legacy%2Fthread id")
+    assert path.name == "legacy%2Fthread id.json"
 
 def test_thread_path_rejects_symlink_escape(tmp_path):
     store = _store(tmp_path)

--- a/tests/core/test_message_store.py
+++ b/tests/core/test_message_store.py
@@ -203,14 +203,15 @@ def test_mutate_inbox_duplicate_restore_is_a_noop(tmp_path):
     store = _store(tmp_path)
     thread = store.create_thread("x", "body", now)
 
-    _, applied = store.mutate_inbox(thread.id, "restore", "restore-1", now)
-    _, retried = store.mutate_inbox(thread.id, "restore", "restore-1", now + timedelta(minutes=1))
+    store.mutate_inbox(thread.id, "archive", "archive-1", now)
+    _, applied = store.mutate_inbox(thread.id, "restore", "restore-1", now + timedelta(minutes=1))
+    _, retried = store.mutate_inbox(thread.id, "restore", "restore-1", now + timedelta(minutes=2))
     assert applied is True
     assert retried is False
 
     saved = store.get(thread.id)
-    assert saved.inbox.restored_at == now
-    assert saved.inbox.mutation_ids == {"restore-1": "restore"}
+    assert saved.inbox.restored_at == now + timedelta(minutes=1)
+    assert saved.inbox.mutation_ids["restore-1"] == "restore"
 
 
 def test_mutate_inbox_commits_thread_actions_in_order(tmp_path):
@@ -233,10 +234,11 @@ def test_mutate_inbox_pin_unpin_preserves_thread_manual_and_restore_metadata(tmp
     store = _store(tmp_path)
     thread = store.create_thread("x", "body", now)
 
-    store.mutate_inbox(thread.id, "restore", "restore-1", now)
-    store.mutate_inbox(thread.id, "archive", "archive-1", now + timedelta(minutes=1))
-    store.mutate_inbox(thread.id, "pin", "pin-1", now + timedelta(minutes=2))
-    store.mutate_inbox(thread.id, "unpin", "unpin-1", now + timedelta(minutes=3))
+    store.mutate_inbox(thread.id, "archive", "archive-0", now)
+    store.mutate_inbox(thread.id, "restore", "restore-1", now + timedelta(minutes=1))
+    store.mutate_inbox(thread.id, "archive", "archive-1", now + timedelta(minutes=2))
+    store.mutate_inbox(thread.id, "pin", "pin-1", now + timedelta(minutes=3))
+    store.mutate_inbox(thread.id, "unpin", "unpin-1", now + timedelta(minutes=4))
 
     inbox = store.get(thread.id).inbox
     assert inbox.pinned is False

--- a/tests/core/test_message_store.py
+++ b/tests/core/test_message_store.py
@@ -213,6 +213,20 @@ def test_mutate_inbox_duplicate_restore_is_a_noop(tmp_path):
     assert saved.inbox.restored_at == now + timedelta(minutes=1)
     assert saved.inbox.mutation_ids["restore-1"] == "restore"
 
+def test_mutate_inbox_persists_new_state_equivalent_thread_action(tmp_path):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = _store(tmp_path)
+    thread = store.create_thread("x", "body", now)
+
+    _, applied = store.mutate_inbox(thread.id, "unpin", "unpin-1", now + timedelta(minutes=1))
+
+    assert applied is False
+    saved = _store(tmp_path).get(thread.id)
+    assert saved.inbox.mutation_ids == {"unpin-1": "unpin"}
+    assert saved.inbox.last_mutated_at is None
+    with pytest.raises(ValueError):
+        _store(tmp_path).mutate_inbox(thread.id, "archive", "unpin-1", now + timedelta(minutes=2))
+
 
 def test_mutate_inbox_commits_thread_actions_in_order(tmp_path):
     now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)

--- a/tests/core/test_message_store.py
+++ b/tests/core/test_message_store.py
@@ -289,3 +289,14 @@ def test_mutate_inbox_rejects_conflicting_thread_mutation_identity(tmp_path):
 
     with pytest.raises(ValueError):
         store.mutate_inbox(thread.id, "restore", "mutation-1", now + timedelta(minutes=1))
+
+
+def test_list_sorts_mixed_legacy_naive_and_aware_updated_at_as_utc(tmp_path):
+    store = _store(tmp_path)
+    base = datetime(2026, 6, 23, tzinfo=timezone.utc)
+    older = store.create_thread("older", "x", base)
+    newer = store.create_thread("newer", "x", base + timedelta(minutes=1))
+    newer.updated_at = datetime(2026, 6, 23, 0, 1)
+    store.save(newer)
+
+    assert [thread.id for thread in store.list()] == [newer.id, older.id]

--- a/tests/core/test_message_store.py
+++ b/tests/core/test_message_store.py
@@ -178,3 +178,78 @@ def test_append_decision_roundtrips(tmp_path):
     assert got.messages[-1].kind == "decision"
     assert got.messages[-1].decision.options == ["a", "b"]
     assert got.needs_decision is True
+
+
+def test_mutate_inbox_duplicate_restore_is_a_noop(tmp_path):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = _store(tmp_path)
+    thread = store.create_thread("x", "body", now)
+
+    store.mutate_inbox(thread.id, "restore", "restore-1", now)
+    store.mutate_inbox(thread.id, "restore", "restore-1", now + timedelta(minutes=1))
+
+    saved = store.get(thread.id)
+    assert saved.inbox.restored_at == now
+    assert saved.inbox.mutation_ids == {"restore-1": "restore"}
+
+
+def test_mutate_inbox_commits_thread_actions_in_order(tmp_path):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = _store(tmp_path)
+    archive_then_restore = store.create_thread("one", "body", now)
+    restore_then_archive = store.create_thread("two", "body", now)
+
+    store.mutate_inbox(archive_then_restore.id, "archive", "archive-1", now)
+    store.mutate_inbox(archive_then_restore.id, "restore", "restore-1", now + timedelta(minutes=1))
+    store.mutate_inbox(restore_then_archive.id, "restore", "restore-2", now)
+    store.mutate_inbox(restore_then_archive.id, "archive", "archive-2", now + timedelta(minutes=1))
+
+    assert store.get(archive_then_restore.id).inbox.manual_archived is False
+    assert store.get(restore_then_archive.id).inbox.manual_archived is True
+
+
+def test_mutate_inbox_pin_unpin_preserves_thread_manual_and_restore_metadata(tmp_path):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = _store(tmp_path)
+    thread = store.create_thread("x", "body", now)
+
+    store.mutate_inbox(thread.id, "restore", "restore-1", now)
+    store.mutate_inbox(thread.id, "archive", "archive-1", now + timedelta(minutes=1))
+    store.mutate_inbox(thread.id, "pin", "pin-1", now + timedelta(minutes=2))
+    store.mutate_inbox(thread.id, "unpin", "unpin-1", now + timedelta(minutes=3))
+
+    inbox = store.get(thread.id).inbox
+    assert inbox.pinned is False
+    assert inbox.manual_archived is True
+    assert inbox.restored_at == now
+
+
+def test_mutate_inbox_does_not_change_thread_domain_content(tmp_path):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = _store(tmp_path)
+    thread = store.create_thread("subject", "body", now)
+    before = thread.model_dump(exclude={"inbox"})
+
+    store.mutate_inbox(thread.id, "archive", "archive-1", now + timedelta(minutes=1))
+
+    assert store.get(thread.id).model_dump(exclude={"inbox"}) == before
+
+
+@pytest.mark.parametrize("action", ["unknown", ""])
+def test_mutate_inbox_rejects_unknown_thread_action(tmp_path, action):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = _store(tmp_path)
+    thread = store.create_thread("x", "body", now)
+
+    with pytest.raises(ValueError):
+        store.mutate_inbox(thread.id, action, "action-1", now)
+
+
+def test_mutate_inbox_rejects_conflicting_thread_mutation_identity(tmp_path):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = _store(tmp_path)
+    thread = store.create_thread("x", "body", now)
+    store.mutate_inbox(thread.id, "archive", "mutation-1", now)
+
+    with pytest.raises(ValueError):
+        store.mutate_inbox(thread.id, "restore", "mutation-1", now + timedelta(minutes=1))

--- a/tests/core/test_message_store.py
+++ b/tests/core/test_message_store.py
@@ -53,11 +53,23 @@ def test_get_missing_is_none(tmp_path):
     assert _store(tmp_path).get("missing") is None
 
 
-def test_unsafe_thread_id_rejected(tmp_path):
-    s = _store(tmp_path)
+@pytest.mark.parametrize(
+    "thread_id", ["../escape", "/tmp/escape", "thread/child", r"thread\child", "%2Fescape"],
+)
+def test_unsafe_thread_id_rejected(tmp_path, thread_id):
     with pytest.raises(ValueError):
-        s._path("../escape")
+        _store(tmp_path)._path(thread_id)
 
+
+def test_thread_path_rejects_symlink_escape(tmp_path):
+    store = _store(tmp_path)
+    store._dir.mkdir(parents=True)
+    outside = tmp_path / "outside.json"
+    outside.write_text("{}")
+    (store._dir / "victim.json").symlink_to(outside)
+
+    with pytest.raises(ValueError):
+        store._path("victim")
 
 def test_awaiting_reply_is_serialized(tmp_path):
     # @computed_field: awaiting_reply must appear in model_dump()/JSON, not just as a property.
@@ -185,8 +197,10 @@ def test_mutate_inbox_duplicate_restore_is_a_noop(tmp_path):
     store = _store(tmp_path)
     thread = store.create_thread("x", "body", now)
 
-    store.mutate_inbox(thread.id, "restore", "restore-1", now)
-    store.mutate_inbox(thread.id, "restore", "restore-1", now + timedelta(minutes=1))
+    _, applied = store.mutate_inbox(thread.id, "restore", "restore-1", now)
+    _, retried = store.mutate_inbox(thread.id, "restore", "restore-1", now + timedelta(minutes=1))
+    assert applied is True
+    assert retried is False
 
     saved = store.get(thread.id)
     assert saved.inbox.restored_at == now

--- a/tests/core/test_message_wait.py
+++ b/tests/core/test_message_wait.py
@@ -23,15 +23,25 @@ def test_changed_since_filters_newer_and_reports_cursor():
 
 
 
-def test_changed_since_uses_newer_inbox_mutation_without_reordering_content():
+def test_changed_since_can_include_newer_inbox_mutation_without_reordering_content():
+    thread = _thread("a", T0)
+    thread.inbox.last_mutated_at = T0 + timedelta(seconds=5)
+
+    changed, cursor = changed_since([thread], T0, include_inbox=True)
+
+    assert changed == [thread]
+    assert cursor == T0 + timedelta(seconds=5)
+    assert thread.updated_at == T0
+
+
+def test_changed_since_ignores_inbox_only_change_by_default():
     thread = _thread("a", T0)
     thread.inbox.last_mutated_at = T0 + timedelta(seconds=5)
 
     changed, cursor = changed_since([thread], T0)
 
-    assert changed == [thread]
-    assert cursor == T0 + timedelta(seconds=5)
-    assert thread.updated_at == T0
+    assert changed == []
+    assert cursor == T0
 
 def test_changed_since_empty_when_nothing_newer():
     threads = [_thread("a", T0)]

--- a/tests/core/test_message_wait.py
+++ b/tests/core/test_message_wait.py
@@ -22,6 +22,17 @@ def test_changed_since_filters_newer_and_reports_cursor():
     assert cursor == T0 + timedelta(seconds=5)        # high-water mark
 
 
+
+def test_changed_since_uses_newer_inbox_mutation_without_reordering_content():
+    thread = _thread("a", T0)
+    thread.inbox.last_mutated_at = T0 + timedelta(seconds=5)
+
+    changed, cursor = changed_since([thread], T0)
+
+    assert changed == [thread]
+    assert cursor == T0 + timedelta(seconds=5)
+    assert thread.updated_at == T0
+
 def test_changed_since_empty_when_nothing_newer():
     threads = [_thread("a", T0)]
     changed, cursor = changed_since(threads, T0 + timedelta(seconds=10))

--- a/tests/core/test_message_wait.py
+++ b/tests/core/test_message_wait.py
@@ -142,3 +142,13 @@ def test_stamp_agent_seen_swallows_store_errors():
             raise KeyError(tid)   # e.g. thread deleted mid-flight
 
     stamp_agent_seen(BoomStore(), [_thread("h", T0, role="human")], T0)  # must not raise
+
+
+def test_changed_since_treats_naive_legacy_cursor_as_utc():
+    naive_since = datetime(2026, 6, 30, 12, 0, 0)
+    thread = _thread("a", T0 + timedelta(seconds=1))
+
+    changed, cursor = changed_since([thread], naive_since)
+
+    assert changed == [thread]
+    assert cursor == T0 + timedelta(seconds=1)

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -947,6 +947,7 @@ def test_threads_filter_search_and_mutate_inbox_without_deleting_content(tmp_pat
     now = datetime.now(timezone.utc)
     messages = MessageStore(tmp_path / ".mothership" / "messages")
     archived = messages.create_thread("Old discussion", "needle in history", now.replace(year=now.year - 1))
+    messages.append(archived.id, "agent", "resolved", archived.updated_at)
     active = messages.create_thread("Current discussion", "needle today", now)
     client = TestClient(_app(tmp_path))
 
@@ -1005,6 +1006,7 @@ def test_thread_linked_to_done_work_item_is_archived(tmp_path):
     ))
     messages = MessageStore(tmp_path / ".mothership" / "messages")
     thread = messages.create_thread("Linked", "content", now)
+    messages.append(thread.id, "agent", "resolved", now)
     items = WorkItemStore(tmp_path / ".mothership" / "workitems")
     item = items.create("Implemented", "feature", "test-ws", now)
     items.link_spec(item.id, "implemented", now)
@@ -1025,6 +1027,7 @@ def test_threads_keep_healthy_terminal_link_with_corrupt_work_item(tmp_path):
     ))
     messages = MessageStore(tmp_path / ".mothership" / "messages")
     thread = messages.create_thread("Linked", "content", now)
+    messages.append(thread.id, "agent", "resolved", now)
     items = WorkItemStore(tmp_path / ".mothership" / "workitems")
     item = items.create("Implemented", "feature", "test-ws", now)
     items.link_spec(item.id, "implemented", now)

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -949,6 +949,7 @@ def test_threads_filter_search_and_mutate_inbox_without_deleting_content(tmp_pat
     archived = messages.create_thread("Old discussion", "needle in history", now.replace(year=now.year - 1))
     messages.append(archived.id, "agent", "resolved", archived.updated_at)
     active = messages.create_thread("Current discussion", "needle today", now)
+    messages.append(active.id, "agent", "needle resolved", now)
     client = TestClient(_app(tmp_path))
 
     all_threads = client.get("/threads").json()

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -963,6 +963,21 @@ def test_threads_filter_search_and_mutate_inbox_without_deleting_content(tmp_pat
     assert client.post(f"/threads/{active.id}/inbox/nope", json={"mutation_id": "bad-1"}).status_code == 422
 
 
+def test_thread_inbox_retry_does_not_repeat_task_activity(tmp_path):
+    state, log = _seed_task(tmp_path)
+    now = datetime.now(timezone.utc)
+    thread = MessageStore(tmp_path / ".mothership" / "messages").create_thread(
+        "task thread", "body", now, task_slug="dq",
+    )
+    client = TestClient(_app_with(tmp_path, state, log))
+
+    client.post(f"/threads/{thread.id}/inbox/archive", json={"mutation_id": "device-archive"})
+    first_activity = state.load().tasks["dq"].last_activity_at
+    client.post(f"/threads/{thread.id}/inbox/archive", json={"mutation_id": "device-archive"})
+
+    assert state.load().tasks["dq"].last_activity_at == first_activity
+
+
 
 def test_thread_linked_to_done_work_item_is_archived(tmp_path):
     now = datetime.now(timezone.utc)

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -1012,6 +1012,46 @@ def test_thread_linked_to_done_work_item_is_archived(tmp_path):
     assert summary["inbox_state"] == "archived"
     assert summary["archive_reason"] == "linked_terminal"
 
+
+def test_threads_keep_healthy_terminal_link_with_corrupt_work_item(tmp_path):
+    now = datetime.now(timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(
+        id="implemented", title="Implemented", status="implemented",
+        created_at=now, updated_at=now,
+    ))
+    messages = MessageStore(tmp_path / ".mothership" / "messages")
+    thread = messages.create_thread("Linked", "content", now)
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    item = items.create("Implemented", "feature", "test-ws", now)
+    items.link_spec(item.id, "implemented", now)
+    items.add_thread(item.id, thread.id, now)
+    (tmp_path / ".mothership" / "workitems" / "corrupt.json").write_text("{")
+
+    response = TestClient(_app(tmp_path)).get("/threads", params={"inbox": "all"})
+
+    assert response.status_code == 200
+    summary = next(summary for summary in response.json() if summary["id"] == thread.id)
+    assert summary["work_item_id"] == item.id
+    assert summary["inbox_state"] == "archived"
+    assert summary["archive_reason"] == "linked_terminal"
+
+
+def test_threads_keep_old_unknown_linkage_active_with_corrupt_work_item(tmp_path):
+    now = datetime.now(timezone.utc)
+    messages = MessageStore(tmp_path / ".mothership" / "messages")
+    thread = messages.create_thread("Old unknown", "content", now.replace(year=now.year - 1))
+    workitems_dir = tmp_path / ".mothership" / "workitems"
+    workitems_dir.mkdir(parents=True)
+    (workitems_dir / "corrupt.json").write_text("{")
+
+    response = TestClient(_app(tmp_path)).get("/threads", params={"inbox": "all"})
+
+    assert response.status_code == 200
+    summary = next(summary for summary in response.json() if summary["id"] == thread.id)
+    assert summary["work_item_id"] is None
+    assert summary["inbox_state"] == "active"
+    assert summary["archive_reason"] is None
+
 def test_threads_explicit_subject(tmp_path):
     client = TestClient(_app(tmp_path))
     t = client.post("/threads", json={"text": "body", "subject": "My subject"}).json()

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -67,7 +67,11 @@ def test_list_specs(tmp_path):
     _seed_spec(tmp_path)
     r = TestClient(_app(tmp_path)).get("/specs")
     assert r.status_code == 200
-    assert r.json() == [{"id": "dq", "title": "Decision queue", "status": "needs_review", "task_slug": "dq", "affected_repos": [], "locked": False}]
+    assert r.json() == [{
+        "id": "dq", "title": "Decision queue", "status": "needs_review",
+        "task_slug": "dq", "affected_repos": [], "locked": False,
+        "inbox_state": "active", "archive_reason": None, "pinned": False,
+    }]
 
 
 def test_get_spec_and_404(tmp_path):
@@ -924,6 +928,60 @@ def test_threads_404s(tmp_path):
     assert client.get("/threads/nope").status_code == 404
     assert client.post("/threads/nope/messages", json={"text": "x"}).status_code == 404
 
+
+def test_threads_filter_search_and_mutate_inbox_without_deleting_content(tmp_path):
+    now = datetime.now(timezone.utc)
+    messages = MessageStore(tmp_path / ".mothership" / "messages")
+    archived = messages.create_thread("Old discussion", "needle in history", now.replace(year=now.year - 1))
+    active = messages.create_thread("Current discussion", "needle today", now)
+    client = TestClient(_app(tmp_path))
+
+    all_threads = client.get("/threads").json()
+    assert {thread["id"] for thread in all_threads} == {archived.id, active.id}
+    assert {thread["inbox_state"] for thread in all_threads} == {"active", "archived"}
+    assert next(thread for thread in all_threads if thread["id"] == archived.id)["archive_reason"] == "inactive_unlinked"
+    assert client.get("/threads", params={"inbox": "active", "q": "needle"}).json()[0]["id"] == active.id
+    assert client.get("/threads", params={"inbox": "archived"}).json()[0]["id"] == archived.id
+    assert client.get("/threads", params={"inbox": "unknown"}).status_code == 422
+
+    first = client.post(
+        f"/threads/{active.id}/inbox/archive", json={"mutation_id": "phone-archive-1"},
+    )
+    retry = client.post(
+        f"/threads/{active.id}/inbox/archive", json={"mutation_id": "phone-archive-1"},
+    )
+    assert first.status_code == retry.status_code == 200
+    assert first.json() == retry.json()
+    assert first.json()["inbox_state"] == "archived"
+    assert client.get(f"/threads/{active.id}").json()["messages"][0]["text"] == "needle today"
+    assert client.get("/threads", params={"inbox": "all", "q": "current"}).json()[0]["id"] == active.id
+    assert client.post(f"/threads/{active.id}/inbox/pin", json={"mutation_id": "desktop-pin-1"}).json()["inbox_state"] == "active"
+    assert client.post(f"/threads/{active.id}/inbox/unpin", json={"mutation_id": "phone-unpin-1"}).json()["inbox_state"] == "archived"
+    assert client.post(f"/threads/{active.id}/inbox/restore", json={"mutation_id": "desktop-restore-1"}).json()["inbox_state"] == "active"
+    assert client.post(f"/threads/{active.id}/inbox/archive", json={"mutation_id": " "}).status_code == 422
+    assert client.post("/threads/nope/inbox/archive", json={"mutation_id": "missing-1"}).status_code == 404
+    assert client.post(f"/threads/{active.id}/inbox/nope", json={"mutation_id": "bad-1"}).status_code == 422
+
+
+
+def test_thread_linked_to_done_work_item_is_archived(tmp_path):
+    now = datetime.now(timezone.utc)
+    SpecStore(tmp_path / "specs").save(Spec(
+        id="implemented", title="Implemented", status="implemented",
+        created_at=now, updated_at=now,
+    ))
+    messages = MessageStore(tmp_path / ".mothership" / "messages")
+    thread = messages.create_thread("Linked", "content", now)
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    item = items.create("Implemented", "feature", "test-ws", now)
+    items.link_spec(item.id, "implemented", now)
+    items.add_thread(item.id, thread.id, now)
+
+    summary = TestClient(_app(tmp_path)).get("/threads", params={"inbox": "archived"}).json()[0]
+
+    assert summary["id"] == thread.id
+    assert summary["inbox_state"] == "archived"
+    assert summary["archive_reason"] == "linked_terminal"
 
 def test_threads_explicit_subject(tmp_path):
     client = TestClient(_app(tmp_path))

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -9,6 +9,7 @@ from mship.core.serve import create_app
 from mship.core.spec import AcceptanceCriterion, OpenQuestion, Spec
 from mship.core.spec_body import render_body
 from mship.core.spec_store import SpecStore
+from mship.core.spec_storage import SpecStorage
 from mship.core.state import StateManager, Task, WorkspaceState
 from mship.core.log import LogManager
 from mship.core.workitem_store import WorkItemStore
@@ -1041,6 +1042,43 @@ def test_malformed_canonical_spec_keeps_linked_terminal_thread_active(tmp_path):
     item = items.create("Implemented", "feature", "test-ws", now)
     items.link_spec(item.id, spec.id, now)
     path.write_text("not a valid spec")
+
+    summary = TestClient(_app(tmp_path)).get("/threads", params={"inbox": "all"}).json()[0]
+
+    assert summary["work_item_id"] == item.id
+    assert summary["inbox_state"] == "active"
+    assert summary["archive_reason"] is None
+
+
+def test_renamed_locked_spec_alias_keeps_linked_terminal_thread_active(tmp_path):
+    now = datetime.now(timezone.utc)
+    spec = Spec(
+        id="implemented",
+        title="Implemented",
+        status="implemented",
+        created_at=now,
+        updated_at=now,
+    )
+    SpecStore(tmp_path / "specs").save(spec)
+    encrypted_root = tmp_path / "encrypted-source"
+    encrypted_storage = SpecStorage(
+        encrypted_root / "specs",
+        mode="encrypted",
+        workspace_root=encrypted_root,
+    )
+    encrypted_path = SpecStore(
+        encrypted_root / "specs",
+        storage=encrypted_storage,
+    ).save(spec)
+    (tmp_path / "specs" / "legacy.md.enc").write_bytes(encrypted_path.read_bytes())
+
+    messages = MessageStore(tmp_path / ".mothership" / "messages")
+    thread = messages.create_thread("Linked", "content", now)
+    messages.append(thread.id, "agent", "resolved", now)
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    item = items.create("Implemented", "feature", "test-ws", now)
+    items.link_spec(item.id, spec.id, now)
+    items.add_thread(item.id, thread.id, now)
 
     summary = TestClient(_app(tmp_path)).get("/threads", params={"inbox": "all"}).json()[0]
 

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -939,7 +939,8 @@ def test_threads_404s(tmp_path):
     ],
 )
 def test_unsafe_thread_ids_are_controlled_4xx(tmp_path, method, path, body):
-    response = getattr(TestClient(_app(tmp_path)), method)(path, json=body)
+    client = TestClient(_app(tmp_path))
+    response = client.get(path) if method == "get" else client.post(path, json=body)
     assert 400 <= response.status_code < 500
 
 def test_threads_filter_search_and_mutate_inbox_without_deleting_content(tmp_path):

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -929,6 +929,19 @@ def test_threads_404s(tmp_path):
     assert client.post("/threads/nope/messages", json={"text": "x"}).status_code == 404
 
 
+
+@pytest.mark.parametrize(
+    ("method", "path", "body"),
+    [
+        ("get", "/threads/.hidden", None),
+        ("post", "/threads/.hidden/messages", {"text": "x"}),
+        ("post", "/threads/.hidden/seen", {}),
+    ],
+)
+def test_unsafe_thread_ids_are_controlled_4xx(tmp_path, method, path, body):
+    response = getattr(TestClient(_app(tmp_path)), method)(path, json=body)
+    assert 400 <= response.status_code < 500
+
 def test_threads_filter_search_and_mutate_inbox_without_deleting_content(tmp_path):
     now = datetime.now(timezone.utc)
     messages = MessageStore(tmp_path / ".mothership" / "messages")

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -977,19 +977,23 @@ def test_threads_filter_search_and_mutate_inbox_without_deleting_content(tmp_pat
     assert client.post(f"/threads/{active.id}/inbox/nope", json={"mutation_id": "bad-1"}).status_code == 422
 
 
-def test_thread_inbox_retry_does_not_repeat_task_activity(tmp_path):
+def test_thread_state_equivalent_inbox_action_persists_without_task_activity(tmp_path):
     state, log = _seed_task(tmp_path)
     now = datetime.now(timezone.utc)
-    thread = MessageStore(tmp_path / ".mothership" / "messages").create_thread(
-        "task thread", "body", now, task_slug="dq",
-    )
+    messages = MessageStore(tmp_path / ".mothership" / "messages")
+    thread = messages.create_thread("task thread", "body", now, task_slug="dq")
     client = TestClient(_app_with(tmp_path, state, log))
 
     client.post(f"/threads/{thread.id}/inbox/archive", json={"mutation_id": "device-archive"})
     first_activity = state.load().tasks["dq"].last_activity_at
-    client.post(f"/threads/{thread.id}/inbox/archive", json={"mutation_id": "device-archive"})
+    first_mutation = messages.get(thread.id).inbox.last_mutated_at
+    response = client.post(f"/threads/{thread.id}/inbox/unpin", json={"mutation_id": "device-unpin"})
 
+    assert response.status_code == 200
     assert state.load().tasks["dq"].last_activity_at == first_activity
+    saved = messages.get(thread.id)
+    assert saved.inbox.mutation_ids["device-unpin"] == "unpin"
+    assert saved.inbox.last_mutated_at == first_mutation
 
 
 
@@ -1096,10 +1100,30 @@ def test_thread_detail_null_work_item_when_unrelated(tmp_path):
 
     client = TestClient(_app(tmp_path))
     tid = client.post("/threads", json={"text": "hi"}).json()["id"]
-
     body = client.get(f"/threads/{tid}").json()
     assert body["work_item_id"] is None
     assert body["work_item"] is None
+
+
+def test_thread_detail_tolerates_an_unrelated_corrupt_spec(tmp_path):
+    _seed_spec(tmp_path)
+    now = datetime(2026, 7, 8, tzinfo=timezone.utc)
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="Decision queue", kind="feature", workspace="test-ws", now=now)
+    items.link_spec(wi.id, "dq", now=now)
+
+    client = TestClient(_app(tmp_path))
+    tid = client.post("/threads", json={"text": "hi"}).json()["id"]
+    MessageStore(tmp_path / ".mothership" / "messages").link_spec(tid, "dq")
+    (tmp_path / "specs" / "corrupt.md").write_text("{")
+
+    response = client.get(f"/threads/{tid}")
+
+    assert response.status_code == 200
+    assert response.json()["work_item_id"] == wi.id
+    assert response.json()["work_item"] == {
+        "id": wi.id, "title": "Decision queue", "kind": "feature", "phase": "shaping",
+    }
 
 
 def test_thread_detail_resolves_work_item_id_when_archived(tmp_path):

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -629,6 +629,12 @@ def test_post_create_spec_explicit_id(tmp_path):
     assert r.status_code == 200 and r.json()["id"] == "custom"
 
 
+
+def test_post_create_spec_unsafe_id_is_422(tmp_path):
+    response = TestClient(_app(tmp_path)).post("/specs", json={"title": "Anything", "id": "../unsafe"})
+
+    assert response.status_code == 422
+
 def test_post_create_spec_collision_409(tmp_path):
     client = TestClient(_app(tmp_path))
     assert client.post("/specs", json={"title": "Dup"}).status_code == 200
@@ -1018,6 +1024,29 @@ def test_thread_linked_to_done_work_item_is_archived(tmp_path):
     assert summary["id"] == thread.id
     assert summary["inbox_state"] == "archived"
     assert summary["archive_reason"] == "linked_terminal"
+
+
+def test_malformed_canonical_spec_keeps_linked_terminal_thread_active(tmp_path):
+    now = datetime.now(timezone.utc)
+    spec = Spec(
+        id="implemented", title="Implemented", status="implemented",
+        created_at=now, updated_at=now,
+    )
+    path = SpecStore(tmp_path / "specs").save(spec)
+    messages = MessageStore(tmp_path / ".mothership" / "messages")
+    thread = messages.create_thread("Linked", "content", now)
+    messages.append(thread.id, "agent", "resolved", now)
+    messages.link_spec(thread.id, spec.id)
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    item = items.create("Implemented", "feature", "test-ws", now)
+    items.link_spec(item.id, spec.id, now)
+    path.write_text("not a valid spec")
+
+    summary = TestClient(_app(tmp_path)).get("/threads", params={"inbox": "all"}).json()[0]
+
+    assert summary["work_item_id"] == item.id
+    assert summary["inbox_state"] == "active"
+    assert summary["archive_reason"] is None
 
 
 def test_threads_keep_healthy_terminal_link_with_corrupt_work_item(tmp_path):

--- a/tests/core/test_serve_items.py
+++ b/tests/core/test_serve_items.py
@@ -95,6 +95,10 @@ def test_post_item_message_creates_and_links_thread_when_none(tmp_path):
     thread = resp.json()
     assert [m["text"] for m in thread["messages"]] == ["focus on the edge cases"]
     assert thread["subject"] == "Ship the parser"
+    assert thread["work_item_id"] == wi.id
+    assert thread["inbox_state"] == "active"
+    assert thread["archive_reason"] is None
+    assert thread["pinned"] is False
 
     # The work item is now linked to the new thread, so the console can find it.
     relinked = items.get(wi.id)
@@ -113,6 +117,8 @@ def test_post_item_message_appends_to_existing_thread(tmp_path):
     resp = client.post(f"/items/{wi.id}/messages", json={"text": "second"})
     assert resp.status_code == 200
     assert [m["text"] for m in resp.json()["messages"]] == ["first", "second"]
+    assert resp.json()["work_item_id"] == wi.id
+    assert resp.json()["inbox_state"] == "active"
     # No duplicate thread was created.
     assert items.get(wi.id).thread_ids == [thread.id]
 

--- a/tests/core/test_serve_spec_locked.py
+++ b/tests/core/test_serve_spec_locked.py
@@ -112,7 +112,7 @@ def test_serve_create_reports_encrypted_physical_path(tmp_path: Path):
     ("method", "path", "body"),
     [
         ("get", "/specs/locked-one/review", None),
-        ("post", "/specs/locked-one/question", {"text": "Why?"}),
+        ("post", "/specs/locked-one/questions", {"text": "Why?"}),
     ],
 )
 def test_serve_review_and_write_paths_report_locked_spec_as_conflict(

--- a/tests/core/test_serve_spec_locked.py
+++ b/tests/core/test_serve_spec_locked.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from mship.core import spec_key
@@ -57,6 +58,14 @@ def test_serve_shows_locked_state_without_key(tmp_path: Path):
     assert "gAAAA" not in str(body)
 
 
+@pytest.mark.parametrize("inbox", ["active", "archived"])
+def test_serve_excludes_locked_specs_from_explicit_inbox_filters(tmp_path: Path, inbox: str):
+    _write_encrypted_spec(tmp_path)
+    spec_key.keyfile_path(tmp_path).unlink()
+
+    assert _client(tmp_path).get("/specs", params={"inbox": inbox}).json() == []
+
+
 def test_serve_get_locked_spec_returns_marker_not_error(tmp_path: Path):
     _write_encrypted_spec(tmp_path)
     spec_key.keyfile_path(tmp_path).unlink()
@@ -78,3 +87,13 @@ def test_serve_rejects_inbox_mutation_for_locked_spec_without_leaking_content(tm
     assert response.status_code == 409
     assert "locked" in response.json()["detail"]
     assert "SECRET" not in response.text
+
+
+def test_serve_create_refuses_duplicate_locked_spec_as_conflict(tmp_path: Path):
+    _write_encrypted_spec(tmp_path)
+    spec_key.keyfile_path(tmp_path).unlink()
+
+    response = _client(tmp_path).post("/specs", json={"id": "locked-one", "title": "Replacement"})
+
+    assert response.status_code == 409
+    assert "locked" in response.json()["detail"]

--- a/tests/core/test_serve_spec_locked.py
+++ b/tests/core/test_serve_spec_locked.py
@@ -97,3 +97,12 @@ def test_serve_create_refuses_duplicate_locked_spec_as_conflict(tmp_path: Path):
 
     assert response.status_code == 409
     assert "locked" in response.json()["detail"]
+
+
+def test_serve_create_reports_encrypted_physical_path(tmp_path: Path):
+    response = _client(tmp_path).post(
+        "/specs", json={"id": "new-secret", "title": "New secret"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["path"].endswith("new-secret.md.enc")

--- a/tests/core/test_serve_spec_locked.py
+++ b/tests/core/test_serve_spec_locked.py
@@ -8,7 +8,7 @@ from mship.core import spec_key
 from mship.core.config import WorkspaceConfig
 from mship.core.serve import create_app
 from mship.core.spec import Spec
-from mship.core.spec_storage import SpecStorage
+from mship.core.spec_storage import SpecLocked, SpecStorage
 from mship.core.spec_store import SPECS_DIRNAME, SpecStore
 
 
@@ -125,3 +125,31 @@ def test_serve_review_and_write_paths_report_locked_spec_as_conflict(
 
     assert response.status_code == 409
     assert "locked" in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    ("helper", "path", "body"),
+    [
+        ("approve_spec", "/specs/locked-one/approve", {"bypass_gate": True}),
+        (
+            "request_changes_spec",
+            "/specs/locked-one/request-changes",
+            {"reason": "Needs revision"},
+        ),
+    ],
+)
+def test_transition_save_race_maps_locked_storage_to_conflict(
+    tmp_path: Path, monkeypatch, helper: str, path: str, body: dict,
+):
+    import mship.core.serve as serve
+
+    _write_encrypted_spec(tmp_path)
+
+    def raise_locked(*_args, **_kwargs):
+        raise SpecLocked("locked-one")
+
+    monkeypatch.setattr(serve, helper, raise_locked)
+    response = _client(tmp_path).post(path, json=body)
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "spec 'locked-one' is locked"

--- a/tests/core/test_serve_spec_locked.py
+++ b/tests/core/test_serve_spec_locked.py
@@ -57,6 +57,50 @@ def test_serve_shows_locked_state_without_key(tmp_path: Path):
     # No ciphertext leaked into the response.
     assert "gAAAA" not in str(body)
 
+def test_serve_omits_duplicate_readable_spec_ids_but_preserves_healthy_rows(
+    tmp_path: Path,
+):
+    _write_encrypted_spec(tmp_path)
+    specs_dir = tmp_path / SPECS_DIRNAME
+    original = next(specs_dir.glob("*-locked-one.md.enc"))
+    original.with_name("2026-07-23-locked-one.md.enc").write_bytes(original.read_bytes())
+    healthy = Spec(
+        id="healthy",
+        title="Healthy",
+        status="draft",
+        created_at=datetime(2026, 7, 24, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 7, 24, tzinfo=timezone.utc),
+    )
+    storage = SpecStorage(specs_dir, mode="encrypted", workspace_root=tmp_path)
+    SpecStore(specs_dir, storage=storage).save(healthy)
+
+    body = _client(tmp_path).get("/specs").json()
+
+    assert [row["id"] for row in body] == ["healthy"]
+
+
+def test_serve_omits_duplicate_locked_ids_but_preserves_healthy_plaintext(
+    tmp_path: Path,
+):
+    _write_encrypted_spec(tmp_path)
+    specs_dir = tmp_path / SPECS_DIRNAME
+    original = next(specs_dir.glob("*-locked-one.md.enc"))
+    original.with_name("2026-07-23-locked-one.md.enc").write_bytes(original.read_bytes())
+    healthy = Spec(
+        id="healthy",
+        title="Healthy",
+        status="draft",
+        created_at=datetime(2026, 7, 24, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 7, 24, tzinfo=timezone.utc),
+    )
+    plaintext = SpecStorage(specs_dir, mode="committed", workspace_root=tmp_path)
+    SpecStore(specs_dir, storage=plaintext).save(healthy)
+    spec_key.keyfile_path(tmp_path).unlink()
+
+    body = _client(tmp_path).get("/specs").json()
+
+    assert [row["id"] for row in body] == ["healthy"]
+
 
 @pytest.mark.parametrize("inbox", ["active", "archived"])
 def test_serve_excludes_locked_specs_from_explicit_inbox_filters(tmp_path: Path, inbox: str):
@@ -125,6 +169,21 @@ def test_serve_review_and_write_paths_report_locked_spec_as_conflict(
 
     assert response.status_code == 409
     assert "locked" in response.json()["detail"]
+
+@pytest.mark.parametrize(
+    ("method", "path", "body"),
+    [
+        ("get", "/specs/.hidden/review", None),
+        ("post", "/specs/.hidden/questions", {"text": "Why?"}),
+    ],
+)
+def test_serve_strict_routes_reject_unsafe_spec_ids_without_a_server_error(
+    tmp_path: Path, method: str, path: str, body: dict | None,
+):
+    response = _client(tmp_path).request(method, path, json=body)
+
+    assert response.status_code == 422
+    assert "unsafe spec id" in response.json()["detail"]
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_serve_spec_locked.py
+++ b/tests/core/test_serve_spec_locked.py
@@ -106,3 +106,22 @@ def test_serve_create_reports_encrypted_physical_path(tmp_path: Path):
 
     assert response.status_code == 200
     assert response.json()["path"].endswith("new-secret.md.enc")
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "body"),
+    [
+        ("get", "/specs/locked-one/review", None),
+        ("post", "/specs/locked-one/question", {"text": "Why?"}),
+    ],
+)
+def test_serve_review_and_write_paths_report_locked_spec_as_conflict(
+    tmp_path: Path, method: str, path: str, body: dict | None,
+):
+    _write_encrypted_spec(tmp_path)
+    spec_key.keyfile_path(tmp_path).unlink()
+
+    response = _client(tmp_path).request(method, path, json=body)
+
+    assert response.status_code == 409
+    assert "locked" in response.json()["detail"]

--- a/tests/core/test_serve_spec_locked.py
+++ b/tests/core/test_serve_spec_locked.py
@@ -65,3 +65,16 @@ def test_serve_get_locked_spec_returns_marker_not_error(tmp_path: Path):
     data = resp.json()
     assert data["id"] == "locked-one" and data["locked"] is True
     assert "SECRET" not in resp.text
+
+
+def test_serve_rejects_inbox_mutation_for_locked_spec_without_leaking_content(tmp_path: Path):
+    _write_encrypted_spec(tmp_path)
+    spec_key.keyfile_path(tmp_path).unlink()
+
+    response = _client(tmp_path).post(
+        "/specs/locked-one/inbox/archive", json={"mutation_id": "device-archive"},
+    )
+
+    assert response.status_code == 409
+    assert "locked" in response.json()["detail"]
+    assert "SECRET" not in response.text

--- a/tests/core/test_serve_specs.py
+++ b/tests/core/test_serve_specs.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from mship.core.serve import create_app
+from mship.core.spec import Spec
+from mship.core.spec_store import SpecStore
+from mship.core.state import StateManager
+
+
+def _client(tmp_path: Path) -> TestClient:
+    return TestClient(create_app(
+        specs_dir=tmp_path / "specs",
+        state_manager=StateManager(tmp_path / ".mothership"),
+        log_manager=None,
+        workspace_root=tmp_path,
+        workspace_name="test-ws",
+    ))
+
+
+def _seed(tmp_path: Path) -> tuple[Spec, Spec]:
+    now = datetime.now(timezone.utc)
+    active = Spec(
+        id="active", title="Needle design", status="draft",
+        created_at=now, updated_at=now,
+    )
+    archived = Spec(
+        id="archived", title="Completed design", status="implemented",
+        created_at=now - timedelta(days=8), updated_at=now - timedelta(days=8),
+        body="implementation content",
+    )
+    store = SpecStore(tmp_path / "specs")
+    store.save(active)
+    store.save(archived)
+    return active, archived
+
+
+def test_specs_filter_search_and_compatibility_default(tmp_path: Path):
+    active, archived = _seed(tmp_path)
+    client = _client(tmp_path)
+
+    all_specs = client.get("/specs")
+    assert all_specs.status_code == 200
+    assert {spec["id"] for spec in all_specs.json()} == {active.id, archived.id}
+    assert {spec["inbox_state"] for spec in all_specs.json()} == {"active", "archived"}
+    assert next(spec for spec in all_specs.json() if spec["id"] == archived.id)["archive_reason"] == "implemented"
+    assert client.get("/specs", params={"inbox": "active", "q": "needle"}).json()[0]["id"] == active.id
+    assert client.get("/specs", params={"inbox": "archived"}).json()[0]["id"] == archived.id
+    assert client.get("/specs", params={"inbox": "unknown"}).status_code == 422
+
+
+def test_spec_inbox_mutations_are_ordered_idempotent_and_non_destructive(tmp_path: Path):
+    active, _ = _seed(tmp_path)
+    client = _client(tmp_path)
+
+    first = client.post(f"/specs/{active.id}/inbox/archive", json={"mutation_id": "phone-archive-1"})
+    retry = client.post(f"/specs/{active.id}/inbox/archive", json={"mutation_id": "phone-archive-1"})
+    assert first.status_code == retry.status_code == 200
+    assert first.json() == retry.json()
+    assert first.json()["inbox_state"] == "archived"
+    assert client.post(f"/specs/{active.id}/inbox/pin", json={"mutation_id": "desktop-pin-1"}).json()["inbox_state"] == "active"
+    assert client.post(f"/specs/{active.id}/inbox/unpin", json={"mutation_id": "phone-unpin-1"}).json()["inbox_state"] == "archived"
+    assert client.post(f"/specs/{active.id}/inbox/restore", json={"mutation_id": "desktop-restore-1"}).json()["inbox_state"] == "active"
+    assert SpecStore(tmp_path / "specs").find_by_id(active.id) is not None
+    assert client.post(f"/specs/{active.id}/inbox/archive", json={"mutation_id": " "}).status_code == 422
+    assert client.post("/specs/nope/inbox/archive", json={"mutation_id": "missing-1"}).status_code == 404
+    assert client.post(f"/specs/{active.id}/inbox/nope", json={"mutation_id": "bad-1"}).status_code == 422

--- a/tests/core/test_serve_specs.py
+++ b/tests/core/test_serve_specs.py
@@ -68,6 +68,23 @@ def test_spec_inbox_mutations_are_ordered_idempotent_and_non_destructive(tmp_pat
     assert client.post(f"/specs/{active.id}/inbox/nope", json={"mutation_id": "bad-1"}).status_code == 422
 
 
+def test_spec_duplicate_artifacts_are_conflicts_for_review_and_inbox(tmp_path: Path):
+    active, _ = _seed(tmp_path)
+    canonical = next((tmp_path / "specs").glob("*-active.md"))
+    (tmp_path / "specs" / "renamed.md").write_bytes(canonical.read_bytes())
+    client = _client(tmp_path)
+
+    for response in (
+        client.get(f"/specs/{active.id}/review"),
+        client.post(
+            f"/specs/{active.id}/inbox/archive",
+            json={"mutation_id": "duplicate-archive"},
+        ),
+    ):
+        assert response.status_code == 409
+        assert "multiple physical artifacts" in response.json()["detail"]
+
+
 def test_spec_state_equivalent_inbox_action_persists_without_task_activity(tmp_path: Path):
     now = datetime.now(timezone.utc)
     state = StateManager(tmp_path / ".mothership")

--- a/tests/core/test_serve_specs.py
+++ b/tests/core/test_serve_specs.py
@@ -86,6 +86,27 @@ def test_spec_duplicate_artifacts_are_conflicts_for_review_and_inbox(tmp_path: P
         assert "multiple physical artifacts" in response.json()["detail"]
 
 
+def test_malformed_exact_spec_is_a_controlled_storage_conflict(tmp_path: Path):
+    specs_dir = tmp_path / "specs"
+    specs_dir.mkdir()
+    (specs_dir / f"{datetime.now(timezone.utc):%Y-%m-%d}-malformed.md").write_text(
+        "not a spec"
+    )
+    client = _client(tmp_path)
+
+    for response in (
+        client.get("/specs/malformed"),
+        client.get("/specs/malformed/review"),
+        client.post(
+            "/specs/malformed/inbox/archive",
+            json={"mutation_id": "malformed-archive"},
+        ),
+        client.post("/specs", json={"id": "malformed", "title": "Replacement"}),
+    ):
+        assert response.status_code == 409
+        assert "frontmatter" in response.json()["detail"]
+
+
 def test_spec_state_equivalent_inbox_action_persists_without_task_activity(tmp_path: Path):
     now = datetime.now(timezone.utc)
     state = StateManager(tmp_path / ".mothership")

--- a/tests/core/test_serve_specs.py
+++ b/tests/core/test_serve_specs.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from mship.core.serve import create_app
 from mship.core.spec import Spec
 from mship.core.spec_store import SpecStore
-from mship.core.state import StateManager
+from mship.core.state import StateManager, Task, WorkspaceState
 
 
 def _client(tmp_path: Path) -> TestClient:
@@ -66,3 +66,25 @@ def test_spec_inbox_mutations_are_ordered_idempotent_and_non_destructive(tmp_pat
     assert client.post(f"/specs/{active.id}/inbox/archive", json={"mutation_id": " "}).status_code == 422
     assert client.post("/specs/nope/inbox/archive", json={"mutation_id": "missing-1"}).status_code == 404
     assert client.post(f"/specs/{active.id}/inbox/nope", json={"mutation_id": "bad-1"}).status_code == 422
+
+
+def test_spec_inbox_retry_does_not_repeat_task_activity(tmp_path: Path):
+    now = datetime.now(timezone.utc)
+    state = StateManager(tmp_path / ".mothership")
+    state.save(WorkspaceState(tasks={"spec-task": Task(
+        slug="spec-task", description="d", phase="dev", created_at=now,
+        affected_repos=[], branch="feat/spec-task",
+    )}))
+    active, _ = _seed(tmp_path)
+    active.task_slug = "spec-task"
+    SpecStore(tmp_path / "specs").save(active)
+    client = TestClient(create_app(
+        specs_dir=tmp_path / "specs", state_manager=state, log_manager=None,
+        workspace_root=tmp_path, workspace_name="test-ws",
+    ))
+
+    client.post("/specs/active/inbox/archive", json={"mutation_id": "device-archive"})
+    first_activity = state.load().tasks["spec-task"].last_activity_at
+    client.post("/specs/active/inbox/archive", json={"mutation_id": "device-archive"})
+
+    assert state.load().tasks["spec-task"].last_activity_at == first_activity

--- a/tests/core/test_serve_specs.py
+++ b/tests/core/test_serve_specs.py
@@ -68,7 +68,7 @@ def test_spec_inbox_mutations_are_ordered_idempotent_and_non_destructive(tmp_pat
     assert client.post(f"/specs/{active.id}/inbox/nope", json={"mutation_id": "bad-1"}).status_code == 422
 
 
-def test_spec_inbox_retry_does_not_repeat_task_activity(tmp_path: Path):
+def test_spec_state_equivalent_inbox_action_persists_without_task_activity(tmp_path: Path):
     now = datetime.now(timezone.utc)
     state = StateManager(tmp_path / ".mothership")
     state.save(WorkspaceState(tasks={"spec-task": Task(
@@ -77,7 +77,8 @@ def test_spec_inbox_retry_does_not_repeat_task_activity(tmp_path: Path):
     )}))
     active, _ = _seed(tmp_path)
     active.task_slug = "spec-task"
-    SpecStore(tmp_path / "specs").save(active)
+    specs = SpecStore(tmp_path / "specs")
+    specs.save(active)
     client = TestClient(create_app(
         specs_dir=tmp_path / "specs", state_manager=state, log_manager=None,
         workspace_root=tmp_path, workspace_name="test-ws",
@@ -85,6 +86,11 @@ def test_spec_inbox_retry_does_not_repeat_task_activity(tmp_path: Path):
 
     client.post("/specs/active/inbox/archive", json={"mutation_id": "device-archive"})
     first_activity = state.load().tasks["spec-task"].last_activity_at
-    client.post("/specs/active/inbox/archive", json={"mutation_id": "device-archive"})
+    first_mutation = specs.find_by_id(active.id).inbox.last_mutated_at
+    response = client.post("/specs/active/inbox/unpin", json={"mutation_id": "device-unpin"})
 
+    assert response.status_code == 200
     assert state.load().tasks["spec-task"].last_activity_at == first_activity
+    saved = specs.find_by_id(active.id)
+    assert saved.inbox.mutation_ids["device-unpin"] == "unpin"
+    assert saved.inbox.last_mutated_at == first_mutation

--- a/tests/core/test_serve_specs.py
+++ b/tests/core/test_serve_specs.py
@@ -75,6 +75,7 @@ def test_spec_duplicate_artifacts_are_conflicts_for_review_and_inbox(tmp_path: P
     client = _client(tmp_path)
 
     for response in (
+        client.get(f"/specs/{active.id}"),
         client.get(f"/specs/{active.id}/review"),
         client.post(
             f"/specs/{active.id}/inbox/archive",

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -55,6 +55,7 @@ def test_wait_applies_inbox_and_search_filters_without_changing_cursor(tmp_path:
     client, store = _client(tmp_path)
     updated_at = datetime.now(timezone.utc) - timedelta(days=7, seconds=1)
     thread = store.create_thread("Needle old thread", "body", updated_at)
+    store.append(thread.id, "agent", "resolved", updated_at)
     since = (updated_at - timedelta(seconds=1)).isoformat()
 
     response = client.get("/threads", params={
@@ -88,6 +89,9 @@ def test_each_inbox_action_wakes_wait_once_without_changing_content_timestamp(
     client, store = _client(tmp_path)
     created_at = datetime.now(timezone.utc) - initial_age
     thread = store.create_thread("inbox mutation", "body", created_at)
+    if action == "restore":
+        store.append(thread.id, "agent", "resolved", created_at)
+        assert client.get("/threads", params={"inbox": "archived"}).json()[0]["id"] == thread.id
     since = created_at
     if setup_action is not None:
         setup_response = client.post(
@@ -157,6 +161,7 @@ def test_wait_reports_removed_ids_when_an_inbox_mutation_leaves_the_filter(
     client, store = _client(tmp_path)
     updated_at = datetime.now(timezone.utc) - initial_age
     thread = store.create_thread("filter transition", "body", updated_at)
+    store.append(thread.id, "agent", "resolved", updated_at)
     client.post(f"/threads/{thread.id}/inbox/{action}", json={"mutation_id": f"device-{action}"})
 
     response = client.get("/threads", params={

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
+
 from fastapi.testclient import TestClient
 
 from mship.core.serve import create_app
@@ -65,6 +67,46 @@ def test_wait_applies_inbox_and_search_filters_without_changing_cursor(tmp_path:
     assert [summary["id"] for summary in body["threads"]] == [thread.id]
     assert body["cursor"] == updated_at.isoformat()
 
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_state"),
+    [
+        ("archive", "archived"),
+        ("restore", "active"),
+        ("pin", "active"),
+        ("unpin", "active"),
+    ],
+)
+def test_each_inbox_action_wakes_wait_once_without_changing_content_timestamp(
+    tmp_path: Path, action: str, expected_state: str,
+):
+    client, store = _client(tmp_path)
+    created_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    thread = store.create_thread("inbox mutation", "body", created_at)
+
+    action_response = client.post(
+        f"/threads/{thread.id}/inbox/{action}", json={"mutation_id": f"device-{action}"},
+    )
+    assert action_response.status_code == 200
+    assert action_response.json()["inbox_state"] == expected_state
+    assert store.get(thread.id).updated_at == created_at
+
+    woke = client.get("/threads", params={"wait": 1, "since": created_at.isoformat(), "timeout": 0})
+    assert woke.status_code == 200
+    assert woke.json()["timed_out"] is False
+    assert [summary["id"] for summary in woke.json()["threads"]] == [thread.id]
+    cursor = woke.json()["cursor"]
+
+    retry = client.post(
+        f"/threads/{thread.id}/inbox/{action}", json={"mutation_id": f"device-{action}"},
+    )
+    assert retry.status_code == 200
+    no_second_change = client.get("/threads", params={"wait": 1, "since": cursor, "timeout": 0})
+    assert no_second_change.status_code == 200
+    assert no_second_change.json()["timed_out"] is True
+    assert no_second_change.json()["threads"] == []
+    assert no_second_change.json()["cursor"] == cursor
 
 def test_wait_times_out_with_empty_list(tmp_path: Path):
     client, _ = _client(tmp_path)

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -89,8 +89,9 @@ def test_each_inbox_action_wakes_wait_once_without_changing_content_timestamp(
     client, store = _client(tmp_path)
     created_at = datetime.now(timezone.utc) - initial_age
     thread = store.create_thread("inbox mutation", "body", created_at)
-    if action == "restore":
+    if action in {"archive", "restore"}:
         store.append(thread.id, "agent", "resolved", created_at)
+    if action == "restore":
         assert client.get("/threads", params={"inbox": "archived"}).json()[0]["id"] == thread.id
     since = created_at
     if setup_action is not None:

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -70,20 +70,33 @@ def test_wait_applies_inbox_and_search_filters_without_changing_cursor(tmp_path:
 
 
 @pytest.mark.parametrize(
-    ("action", "expected_state"),
+    ("action", "expected_state", "initial_age", "setup_action"),
     [
-        ("archive", "archived"),
-        ("restore", "active"),
-        ("pin", "active"),
-        ("unpin", "active"),
+        ("archive", "archived", timedelta(minutes=1), None),
+        ("restore", "active", timedelta(days=8), None),
+        ("pin", "active", timedelta(minutes=1), None),
+        ("unpin", "active", timedelta(minutes=1), "pin"),
     ],
 )
 def test_each_inbox_action_wakes_wait_once_without_changing_content_timestamp(
-    tmp_path: Path, action: str, expected_state: str,
+    tmp_path: Path,
+    action: str,
+    expected_state: str,
+    initial_age: timedelta,
+    setup_action: str | None,
 ):
     client, store = _client(tmp_path)
-    created_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    created_at = datetime.now(timezone.utc) - initial_age
     thread = store.create_thread("inbox mutation", "body", created_at)
+    since = created_at
+    if setup_action is not None:
+        setup_response = client.post(
+            f"/threads/{thread.id}/inbox/{setup_action}",
+            json={"mutation_id": f"setup-{setup_action}"},
+        )
+        assert setup_response.status_code == 200
+        since = store.get(thread.id).inbox.last_mutated_at
+        assert since is not None
 
     action_response = client.post(
         f"/threads/{thread.id}/inbox/{action}", json={"mutation_id": f"device-{action}"},
@@ -92,7 +105,7 @@ def test_each_inbox_action_wakes_wait_once_without_changing_content_timestamp(
     assert action_response.json()["inbox_state"] == expected_state
     assert store.get(thread.id).updated_at == created_at
 
-    woke = client.get("/threads", params={"wait": 1, "since": created_at.isoformat(), "timeout": 0})
+    woke = client.get("/threads", params={"wait": 1, "since": since.isoformat(), "timeout": 0})
     assert woke.status_code == 200
     assert woke.json()["timed_out"] is False
     assert [summary["id"] for summary in woke.json()["threads"]] == [thread.id]
@@ -107,6 +120,25 @@ def test_each_inbox_action_wakes_wait_once_without_changing_content_timestamp(
     assert no_second_change.json()["timed_out"] is True
     assert no_second_change.json()["threads"] == []
     assert no_second_change.json()["cursor"] == cursor
+
+
+def test_unpin_noop_does_not_wake_wait(tmp_path: Path):
+    client, store = _client(tmp_path)
+    created_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    thread = store.create_thread("inbox mutation", "body", created_at)
+
+    response = client.post(
+        f"/threads/{thread.id}/inbox/unpin", json={"mutation_id": "device-unpin"},
+    )
+    assert response.status_code == 200
+
+    wait = client.get(
+        "/threads",
+        params={"wait": 1, "since": created_at.isoformat(), "timeout": 0},
+    )
+    assert wait.status_code == 200
+    assert wait.json()["timed_out"] is True
+    assert wait.json()["threads"] == []
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -11,6 +11,8 @@ from mship.core.serve import create_app
 from mship.core.message_store import MessageStore
 from mship.core.state import StateManager
 from mship.core.workitem_store import WorkItemStore
+from mship.core.spec import Spec
+from mship.core.spec_store import SpecStore, serialize_spec
 
 
 def _client(tmp_path: Path, auth_token=None) -> tuple[TestClient, MessageStore]:
@@ -274,3 +276,38 @@ def test_agent_seen_at_exposed_on_list_and_detail(tmp_path: Path):
     store.mark_agent_seen(t.id, now)
     assert client.get("/threads").json()[0]["agent_seen_at"] is not None
     assert client.get(f"/threads/{t.id}").json()["agent_seen_at"] is not None
+
+
+def test_duplicate_spec_ids_keep_only_their_linked_threads_active(tmp_path: Path):
+    """A duplicate spec id must not arbitrarily make its linked thread terminal."""
+    client, messages = _client(tmp_path)
+    now = datetime.now(timezone.utc)
+    items = _workitems(tmp_path)
+    ambiguous_thread = messages.create_thread("ambiguous", "body", now)
+    messages.link_spec(ambiguous_thread.id, "duplicate-spec", now)
+    ambiguous_item = items.create("Ambiguous", "feature", "test-ws", now)
+    items.link_spec(ambiguous_item.id, "duplicate-spec", now)
+
+    healthy_thread = messages.create_thread("healthy", "body", now)
+    messages.link_spec(healthy_thread.id, "healthy-spec", now)
+    healthy_item = items.create("Healthy", "feature", "test-ws", now)
+    items.link_spec(healthy_item.id, "healthy-spec", now)
+
+    specs = SpecStore(tmp_path / "specs")
+    specs.save(Spec(
+        id="duplicate-spec", title="draft", status="draft",
+        created_at=now, updated_at=now,
+    ))
+    duplicate = Spec(
+        id="duplicate-spec", title="implemented copy", status="implemented",
+        created_at=now, updated_at=now,
+    )
+    (tmp_path / "specs" / "z-duplicate.md").write_text(serialize_spec(duplicate))
+    specs.save(Spec(
+        id="healthy-spec", title="implemented", status="implemented",
+        created_at=now, updated_at=now,
+    ))
+
+    summaries = {summary["id"]: summary for summary in client.get("/threads").json()}
+    assert summaries[ambiguous_thread.id]["inbox_state"] == "active"
+    assert summaries[healthy_thread.id]["inbox_state"] == "archived"

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -49,6 +49,23 @@ def test_wait_returns_changed_when_newer_than_since(tmp_path: Path):
     assert "cursor" in body
 
 
+def test_wait_applies_inbox_and_search_filters_without_changing_cursor(tmp_path: Path):
+    client, store = _client(tmp_path)
+    updated_at = datetime.now(timezone.utc) - timedelta(days=7, seconds=1)
+    thread = store.create_thread("Needle old thread", "body", updated_at)
+    since = (updated_at - timedelta(seconds=1)).isoformat()
+
+    response = client.get("/threads", params={
+        "wait": 1, "since": since, "timeout": 0.1, "inbox": "archived", "q": "needle",
+    })
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["timed_out"] is False
+    assert [summary["id"] for summary in body["threads"]] == [thread.id]
+    assert body["cursor"] == updated_at.isoformat()
+
+
 def test_wait_times_out_with_empty_list(tmp_path: Path):
     client, _ = _client(tmp_path)
     r = client.get("/threads", params={"wait": 1, "timeout": 0.1})  # since defaults to now

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -307,6 +307,8 @@ def test_duplicate_spec_ids_keep_only_their_linked_threads_active(tmp_path: Path
         id="healthy-spec", title="implemented", status="implemented",
         created_at=now, updated_at=now,
     ))
+    messages.append(ambiguous_thread.id, "agent", "resolved", now)
+    messages.append(healthy_thread.id, "agent", "resolved", now)
 
     summaries = {summary["id"]: summary for summary in client.get("/threads").json()}
     assert summaries[ambiguous_thread.id]["inbox_state"] == "active"

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -108,6 +108,31 @@ def test_each_inbox_action_wakes_wait_once_without_changing_content_timestamp(
     assert no_second_change.json()["threads"] == []
     assert no_second_change.json()["cursor"] == cursor
 
+
+@pytest.mark.parametrize(
+    ("initial_age", "action", "inbox"),
+    [
+        (timedelta(minutes=1), "archive", "active"),
+        (timedelta(days=8), "restore", "archived"),
+    ],
+)
+def test_wait_reports_removed_ids_when_an_inbox_mutation_leaves_the_filter(
+    tmp_path: Path, initial_age: timedelta, action: str, inbox: str,
+):
+    client, store = _client(tmp_path)
+    updated_at = datetime.now(timezone.utc) - initial_age
+    thread = store.create_thread("filter transition", "body", updated_at)
+    client.post(f"/threads/{thread.id}/inbox/{action}", json={"mutation_id": f"device-{action}"})
+
+    response = client.get("/threads", params={
+        "wait": 1, "since": updated_at.isoformat(), "timeout": 0, "inbox": inbox,
+    })
+
+    assert response.status_code == 200
+    assert response.json()["timed_out"] is False
+    assert response.json()["threads"] == []
+    assert response.json()["removed_ids"] == [thread.id]
+
 def test_wait_times_out_with_empty_list(tmp_path: Path):
     client, _ = _client(tmp_path)
     r = client.get("/threads", params={"wait": 1, "timeout": 0.1})  # since defaults to now

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -131,6 +131,9 @@ def test_unpin_noop_does_not_wake_wait(tmp_path: Path):
         f"/threads/{thread.id}/inbox/unpin", json={"mutation_id": "device-unpin"},
     )
     assert response.status_code == 200
+    saved = store.get(thread.id)
+    assert saved.inbox.mutation_ids == {"device-unpin": "unpin"}
+    assert saved.inbox.last_mutated_at is None
 
     wait = client.get(
         "/threads",

--- a/tests/core/test_spec_storage.py
+++ b/tests/core/test_spec_storage.py
@@ -259,6 +259,41 @@ def test_find_by_id_tolerates_locked_exact_artifact_but_read_strict_does_not(tmp
     with pytest.raises(SpecLocked):
         store.read_strict("secret-thing")
 
+def test_duplicate_locked_canonical_artifacts_are_a_conflict_without_the_key(
+    tmp_path: Path,
+):
+    store = _store(tmp_path, "encrypted")
+    original = store.save(_spec())
+    duplicate = original.with_name("2026-07-23-secret-thing.md.enc")
+    duplicate.write_bytes(original.read_bytes())
+    spec_key.keyfile_path(tmp_path).unlink()
+
+    with pytest.raises(SpecArtifactConflict, match="multiple physical artifacts") as exc:
+        store.read_strict("secret-thing")
+
+    assert str(original) in str(exc.value)
+    assert str(duplicate) in str(exc.value)
+
+
+def test_unreadable_encryption_key_is_reported_as_locked(
+    tmp_path: Path,
+    monkeypatch,
+):
+    store = _store(tmp_path, "encrypted")
+    store.save(_spec())
+    key_path = spec_key.keyfile_path(tmp_path)
+    read_bytes = Path.read_bytes
+
+    def deny_key_read(path: Path):
+        if path == key_path:
+            raise PermissionError("denied")
+        return read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", deny_key_read)
+
+    with pytest.raises(SpecLocked, match="no key is available"):
+        store.read_strict("secret-thing")
+
 
 def test_create_refuses_any_locked_ciphertext_without_creating_a_replacement_key(tmp_path: Path):
     store = _store(tmp_path, "encrypted")
@@ -434,6 +469,38 @@ def test_malformed_encryption_key_is_parse_error_for_reads_and_writes(tmp_path: 
     another.id = "another"
     with pytest.raises(SpecParseError):
         encrypted.save(another)
+
+def test_list_tolerant_omits_duplicate_ids_and_preserves_healthy_specs(
+    tmp_path: Path,
+):
+    store = _store(tmp_path, "committed")
+    duplicate = _spec()
+    duplicate.id = "duplicate"
+    first = store.save(duplicate)
+    first.with_name("2026-07-23-duplicate.md").write_text(first.read_text())
+    healthy = _spec()
+    healthy.id = "healthy"
+    store.save(healthy)
+
+    assert [spec.id for spec in store.list_tolerant()] == ["healthy"]
+
+
+def test_list_tolerant_omits_both_ids_bound_by_a_canonical_mismatch(
+    tmp_path: Path,
+):
+    specs_dir = tmp_path / SPECS_DIRNAME
+    specs_dir.mkdir()
+    mismatched = _spec()
+    mismatched.id = "shared"
+    (specs_dir / "2026-07-22-physical-id.md").write_text(serialize_spec(mismatched))
+    (specs_dir / "2026-07-23-shared.md").write_text(serialize_spec(mismatched))
+    unrelated = _spec()
+    unrelated.id = "unrelated"
+    (specs_dir / "2026-07-24-unrelated.md").write_text(serialize_spec(unrelated))
+
+    assert [spec.id for spec in _store(tmp_path, "committed").list_tolerant()] == [
+        "unrelated",
+    ]
 
 
 def test_tolerant_scan_skips_canonical_filename_frontmatter_mismatch(tmp_path: Path):

--- a/tests/core/test_spec_storage.py
+++ b/tests/core/test_spec_storage.py
@@ -201,12 +201,9 @@ def test_list_skips_locked_file_and_returns_readable_siblings(tmp_path: Path):
     assert plain.find_by_id("readable-one") is not None
 
 
-def test_read_strict_raises_and_list_skips_locked_but_propagates_malformed(tmp_path: Path):
-    # read_strict must RAISE on a locked OR malformed spec (so `mship spec validate`
-    # can report it). list() only tolerates the LOCKED case (encrypted, no key — an
-    # expected, graceful state); a MALFORMED spec PROPAGATES out of list() so a
-    # corrupt store can't silently vanish a spec from the gate (Greptile #341 —
-    # resolve_bound_spec must fail safe, not return None).
+def test_read_strict_raises_while_tolerant_list_skips_locked_and_malformed(tmp_path: Path):
+    # Strict readers surface unavailable artifacts to lifecycle/API gates. Tolerant
+    # lists preserve readable siblings for CLI/display.
     enc = _store(tmp_path, "encrypted")
     enc.save(_spec())
     (tmp_path / ".mothership" / "spec-key").unlink()     # secret-thing.enc now LOCKED
@@ -214,15 +211,12 @@ def test_read_strict_raises_and_list_skips_locked_but_propagates_malformed(tmp_p
     (tmp_path / SPECS_DIRNAME).mkdir(parents=True, exist_ok=True)
     (tmp_path / SPECS_DIRNAME / "2026-07-22-broken.md").write_text("not a valid spec at all")
     store = _store(tmp_path, "committed")
-    from mship.core.spec_store import SpecParseError
     with pytest.raises(SpecLocked):
         store.read_strict("secret-thing")
     with pytest.raises(SpecParseError):
         store.read_strict("broken")
     assert store.read_strict("nope") is None            # unrelated locked canonical is ignorable
-    # list() skips the locked file but must NOT swallow the malformed one:
-    with pytest.raises(SpecParseError):
-        store.list()
+    assert store.list() == []
 
 def test_local_lifecycle_save_reapplies_gitignore_for_renamed_artifact(tmp_path: Path):
     _git_init(tmp_path)
@@ -330,6 +324,7 @@ def test_invalid_encrypted_token_is_a_controlled_parse_error_and_tolerant_scan_s
 
     assert "not a valid fernet token" not in str(exc.value)
     assert [spec.id for spec, _, _ in encrypted._storage.read_all()] == ["readable"]
+    assert [spec.id for spec in encrypted.list()] == ["readable"]
 
 
 def test_readable_exact_conflicts_with_locked_renamed_artifact(tmp_path: Path):
@@ -382,3 +377,62 @@ def test_canonical_filename_frontmatter_mismatch_conflicts_for_both_ids(tmp_path
         store.read_strict("physical-id")
     with pytest.raises(SpecArtifactConflict):
         store.read_strict("frontmatter-id")
+
+def test_plaintext_invalid_utf8_is_parse_error_and_tolerant_reads_skip_it(tmp_path: Path):
+    specs_dir = tmp_path / SPECS_DIRNAME
+    specs_dir.mkdir()
+    (specs_dir / "2026-07-22-broken.md").write_bytes(b"\xff")
+    readable = _spec()
+    readable.id = "readable"
+    store = _store(tmp_path, "committed")
+    store.save(readable)
+
+    with pytest.raises(SpecParseError):
+        store.read_strict("broken")
+
+    assert [spec.id for spec in store.list()] == ["readable"]
+    assert [spec.id for spec, _, _ in store._storage.read_all()] == ["readable"]
+
+
+def test_malformed_encryption_key_is_parse_error_for_reads_and_writes(tmp_path: Path):
+    encrypted = _store(tmp_path, "encrypted")
+    encrypted.save(_spec())
+    spec_key.keyfile_path(tmp_path).write_bytes(b"malformed-fernet-key")
+
+    with pytest.raises(SpecParseError):
+        encrypted.read_strict("secret-thing")
+    assert encrypted.list() == []
+    assert list(encrypted._storage.read_all()) == []
+
+    another = _spec()
+    another.id = "another"
+    with pytest.raises(SpecParseError):
+        encrypted.save(another)
+
+
+def test_tolerant_scan_skips_canonical_filename_frontmatter_mismatch(tmp_path: Path):
+    mismatched = _spec()
+    mismatched.id = "frontmatter-id"
+    path = tmp_path / SPECS_DIRNAME / "2026-07-22-physical-id.md"
+    path.parent.mkdir()
+    path.write_text(serialize_spec(mismatched))
+
+    assert list(_store(tmp_path, "committed")._storage.read_all()) == []
+
+
+def test_list_fails_closed_on_canonical_mismatch_and_duplicate_ids(tmp_path: Path):
+    mismatched = _spec()
+    mismatched.id = "frontmatter-id"
+    specs_dir = tmp_path / SPECS_DIRNAME
+    specs_dir.mkdir()
+    (specs_dir / "2026-07-22-physical-id.md").write_text(serialize_spec(mismatched))
+    with pytest.raises(SpecArtifactConflict):
+        _store(tmp_path, "committed").list()
+
+    (specs_dir / "2026-07-22-physical-id.md").unlink()
+    duplicate = _spec()
+    duplicate.id = "same-id"
+    (specs_dir / "2026-07-22-same-id.md").write_text(serialize_spec(duplicate))
+    (specs_dir / "2026-07-23-same-id.md").write_text(serialize_spec(duplicate))
+    with pytest.raises(SpecArtifactConflict):
+        _store(tmp_path, "committed").list()

--- a/tests/core/test_spec_storage.py
+++ b/tests/core/test_spec_storage.py
@@ -8,7 +8,7 @@ from mship.core import spec_key
 from mship.core.spec import Spec
 from mship.core.spec_storage import SpecLocked, SpecStorage, spec_id_from_filename
 from mship.core.spec_store import (
-    SPECS_DIRNAME, SpecArtifactConflict, SpecStore, serialize_spec,
+    SPECS_DIRNAME, SpecArtifactConflict, SpecParseError, SpecStore, serialize_spec,
 )
 
 
@@ -219,8 +219,7 @@ def test_read_strict_raises_and_list_skips_locked_but_propagates_malformed(tmp_p
         store.read_strict("secret-thing")
     with pytest.raises(SpecParseError):
         store.read_strict("broken")
-    with pytest.raises(SpecLocked):
-        store.read_strict("nope")                       # unknown locked alias is fail-closed
+    assert store.read_strict("nope") is None            # unrelated locked canonical is ignorable
     # list() skips the locked file but must NOT swallow the malformed one:
     with pytest.raises(SpecParseError):
         store.list()
@@ -299,7 +298,7 @@ def test_create_refuses_unknown_locked_alias_without_creating_a_replacement_key(
     new_spec = _spec()
     new_spec.id = "real-id"
 
-    with pytest.raises(SpecLocked):
+    with pytest.raises(SpecArtifactConflict):
         store.create_if_absent(new_spec)
 
     assert spec_key.load_key(tmp_path) is None
@@ -316,3 +315,70 @@ def test_exact_readable_artifact_remains_resolvable_beside_unrelated_locked_sibl
     spec_key.keyfile_path(tmp_path).unlink()
 
     assert committed.read_strict("readable").id == "readable"
+
+
+def test_invalid_encrypted_token_is_a_controlled_parse_error_and_tolerant_scan_skips_it(tmp_path: Path):
+    encrypted = _store(tmp_path, "encrypted")
+    broken = encrypted.save(_spec())
+    broken.write_bytes(b"not a valid fernet token")
+    readable = _spec()
+    readable.id = "readable"
+    _store(tmp_path, "committed").save(readable)
+
+    with pytest.raises(SpecParseError) as exc:
+        encrypted.read_strict("secret-thing")
+
+    assert "not a valid fernet token" not in str(exc.value)
+    assert [spec.id for spec, _, _ in encrypted._storage.read_all()] == ["readable"]
+
+
+def test_readable_exact_conflicts_with_locked_renamed_artifact(tmp_path: Path):
+    committed = _store(tmp_path, "committed")
+    readable = _spec()
+    readable.id = "readable"
+    committed.save(readable)
+    encrypted = _store(tmp_path, "encrypted")
+    locked = encrypted.save(_spec())
+    spec_key.keyfile_path(tmp_path).unlink()
+    locked.rename(locked.with_name("legacy.md.enc"))
+
+    with pytest.raises(SpecArtifactConflict):
+        committed.read_strict("readable")
+
+
+def test_locked_exact_conflicts_with_readable_alias_for_same_id(tmp_path: Path):
+    encrypted = _store(tmp_path, "encrypted")
+    spec = _spec()
+    locked = encrypted.save(spec)
+    locked.with_name("legacy.md").write_text(serialize_spec(spec))
+    spec_key.keyfile_path(tmp_path).unlink()
+
+    with pytest.raises(SpecArtifactConflict):
+        encrypted.read_strict(spec.id)
+
+
+def test_readable_renamed_artifact_ignores_locked_canonical_sibling_for_different_id(tmp_path: Path):
+    readable = _spec()
+    readable.id = "readable"
+    committed = _store(tmp_path, "committed")
+    canonical = committed.save(readable)
+    canonical.rename(canonical.with_name("legacy-readable.md"))
+    encrypted = _store(tmp_path, "encrypted")
+    encrypted.save(_spec())
+    spec_key.keyfile_path(tmp_path).unlink()
+
+    assert committed.read_strict("readable").id == "readable"
+
+
+def test_canonical_filename_frontmatter_mismatch_conflicts_for_both_ids(tmp_path: Path):
+    store = _store(tmp_path, "committed")
+    frontmatter = _spec()
+    frontmatter.id = "frontmatter-id"
+    path = tmp_path / SPECS_DIRNAME / "2026-07-22-physical-id.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(serialize_spec(frontmatter))
+
+    with pytest.raises(SpecArtifactConflict):
+        store.read_strict("physical-id")
+    with pytest.raises(SpecArtifactConflict):
+        store.read_strict("frontmatter-id")

--- a/tests/core/test_spec_storage.py
+++ b/tests/core/test_spec_storage.py
@@ -195,9 +195,10 @@ def test_list_skips_locked_file_and_returns_readable_siblings(tmp_path: Path):
     enc.save(_spec())                                   # writes a .md.enc + a key
     (tmp_path / ".mothership" / "spec-key").unlink()    # now that .enc is LOCKED
 
-    ids = {s.id for s in plain.list()}
-    assert "readable-one" in ids                        # readable sibling survives
-    assert "secret-thing" not in ids                    # the locked one is skipped, not crashing
+    with pytest.raises(SpecLocked):
+        plain.list()
+    ids = {s.id for s in plain.list_tolerant()}
+    assert ids == {"readable-one"}
     assert plain.find_by_id("readable-one") is not None
 
 
@@ -327,6 +328,27 @@ def test_invalid_encrypted_token_is_a_controlled_parse_error_and_tolerant_scan_s
     assert [spec.id for spec, _, _ in encrypted._storage.read_all()] == ["readable"]
     with pytest.raises(SpecParseError):
         encrypted.list()
+
+
+def test_malformed_renamed_artifact_blocks_strict_resolution(tmp_path: Path):
+    store = _store(tmp_path, "committed")
+    readable = _spec()
+    readable.id = "readable"
+    store.save(readable)
+    (tmp_path / SPECS_DIRNAME / "legacy.md").write_text("not a spec")
+
+    with pytest.raises(SpecArtifactConflict, match="unreadable renamed artifact"):
+        store.read_strict("readable")
+
+
+def test_unreadable_exact_artifact_is_a_controlled_parse_error(tmp_path: Path):
+    path = tmp_path / SPECS_DIRNAME / "2026-07-22-broken.md"
+    path.mkdir(parents=True)
+    store = _store(tmp_path, "committed")
+
+    with pytest.raises(SpecParseError, match="plaintext spec could not be decoded"):
+        store.read_strict("broken")
+    assert store.list_tolerant() == []
 
 
 def test_readable_exact_conflicts_with_locked_renamed_artifact(tmp_path: Path):

--- a/tests/core/test_spec_storage.py
+++ b/tests/core/test_spec_storage.py
@@ -183,16 +183,18 @@ def test_no_module_serializes_specs_outside_storage_layer():
 
 def test_list_skips_locked_file_and_returns_readable_siblings(tmp_path: Path):
     # Greptile "One Locked File Blocks All Specs": a locked .md.enc must not abort
-    # list()/find_by_id — the readable plaintext siblings still come back.
+    # list()/find_by_id — an exact readable sibling remains addressable.
     from datetime import datetime, timezone
     from mship.core.spec import Spec
-    enc = _store(tmp_path, "encrypted")
-    enc.save(_spec())                                   # writes a .md.enc + a key
-    (tmp_path / ".mothership" / "spec-key").unlink()    # now that .enc is LOCKED
+
     plain = _store(tmp_path, "committed")
     now = datetime(2026, 7, 22, 10, 0, 0, tzinfo=timezone.utc)
     plain.save(Spec(id="readable-one", title="Readable", status="draft",
                     created_at=now, updated_at=now, body="## Problem\n\nok\n"))
+    enc = _store(tmp_path, "encrypted")
+    enc.save(_spec())                                   # writes a .md.enc + a key
+    (tmp_path / ".mothership" / "spec-key").unlink()    # now that .enc is LOCKED
+
     ids = {s.id for s in plain.list()}
     assert "readable-one" in ids                        # readable sibling survives
     assert "secret-thing" not in ids                    # the locked one is skipped, not crashing
@@ -217,7 +219,8 @@ def test_read_strict_raises_and_list_skips_locked_but_propagates_malformed(tmp_p
         store.read_strict("secret-thing")
     with pytest.raises(SpecParseError):
         store.read_strict("broken")
-    assert store.read_strict("nope") is None            # genuinely-missing id
+    with pytest.raises(SpecLocked):
+        store.read_strict("nope")                       # unknown locked alias is fail-closed
     # list() skips the locked file but must NOT swallow the malformed one:
     with pytest.raises(SpecParseError):
         store.list()
@@ -304,12 +307,12 @@ def test_create_refuses_unknown_locked_alias_without_creating_a_replacement_key(
 
 
 def test_exact_readable_artifact_remains_resolvable_beside_unrelated_locked_sibling(tmp_path: Path):
-    encrypted = _store(tmp_path, "encrypted")
-    encrypted.save(_spec())
-    spec_key.keyfile_path(tmp_path).unlink()
     readable = _spec()
     readable.id = "readable"
     committed = _store(tmp_path, "committed")
     committed.save(readable)
+    encrypted = _store(tmp_path, "encrypted")
+    encrypted.save(_spec())
+    spec_key.keyfile_path(tmp_path).unlink()
 
     assert committed.read_strict("readable").id == "readable"

--- a/tests/core/test_spec_storage.py
+++ b/tests/core/test_spec_storage.py
@@ -7,7 +7,9 @@ import pytest
 from mship.core import spec_key
 from mship.core.spec import Spec
 from mship.core.spec_storage import SpecLocked, SpecStorage, spec_id_from_filename
-from mship.core.spec_store import SPECS_DIRNAME, SpecStore, serialize_spec
+from mship.core.spec_store import (
+    SPECS_DIRNAME, SpecArtifactConflict, SpecStore, serialize_spec,
+)
 
 
 def _spec():
@@ -62,6 +64,13 @@ def test_encrypted_round_trips_with_key(tmp_path: Path):
     store.save(_spec())
     loaded = store.find_by_id("secret-thing")
     assert "THE-SECRET-MARKER" in loaded.body
+
+
+def test_create_if_absent_returns_encrypted_physical_path(tmp_path: Path):
+    path = _store(tmp_path, "encrypted").create_if_absent(_spec())
+
+    assert path is not None
+    assert path.name == "2026-07-22-secret-thing.md.enc"
 
 
 def test_no_key_holder_cannot_read_encrypted_spec(tmp_path: Path):
@@ -212,3 +221,32 @@ def test_read_strict_raises_and_list_skips_locked_but_propagates_malformed(tmp_p
     # list() skips the locked file but must NOT swallow the malformed one:
     with pytest.raises(SpecParseError):
         store.list()
+
+def test_local_lifecycle_save_reapplies_gitignore_for_renamed_artifact(tmp_path: Path):
+    _git_init(tmp_path)
+    store = _store(tmp_path, "local")
+    spec = _spec()
+    path = store.save(spec)
+    renamed = path.with_name("legacy.md")
+    path.rename(renamed)
+    (tmp_path / ".gitignore").write_text("kept-rule\n")
+    spec.status = "needs_review"
+
+    assert store.save(spec) == renamed
+    assert (tmp_path / ".gitignore").read_text() == "kept-rule\nspecs/*.md\n"
+    assert subprocess.run(
+        ["git", "check-ignore", "-q", str(renamed.relative_to(tmp_path))], cwd=tmp_path,
+    ).returncode == 0
+
+
+def test_encrypted_artifact_does_not_fallback_to_plaintext_under_committed_policy(tmp_path: Path):
+    encrypted = _store(tmp_path, "encrypted")
+    spec = _spec()
+    encrypted_path = encrypted.save(spec)
+    committed = SpecStore(tmp_path / SPECS_DIRNAME)
+
+    with pytest.raises(SpecArtifactConflict):
+        committed.save(spec)
+
+    assert encrypted_path.is_file()
+    assert not encrypted_path.with_suffix("").exists()

--- a/tests/core/test_spec_storage.py
+++ b/tests/core/test_spec_storage.py
@@ -201,9 +201,9 @@ def test_list_skips_locked_file_and_returns_readable_siblings(tmp_path: Path):
     assert plain.find_by_id("readable-one") is not None
 
 
-def test_read_strict_raises_while_tolerant_list_skips_locked_and_malformed(tmp_path: Path):
-    # Strict readers surface unavailable artifacts to lifecycle/API gates. Tolerant
-    # lists preserve readable siblings for CLI/display.
+def test_read_strict_and_gate_list_surface_malformed_specs_but_skip_locked(tmp_path: Path):
+    # Tolerant storage scans preserve readable siblings for display. SpecStore.list
+    # is also a workflow-gate input, so it skips locked specs but fails on corruption.
     enc = _store(tmp_path, "encrypted")
     enc.save(_spec())
     (tmp_path / ".mothership" / "spec-key").unlink()     # secret-thing.enc now LOCKED
@@ -216,7 +216,8 @@ def test_read_strict_raises_while_tolerant_list_skips_locked_and_malformed(tmp_p
     with pytest.raises(SpecParseError):
         store.read_strict("broken")
     assert store.read_strict("nope") is None            # unrelated locked canonical is ignorable
-    assert store.list() == []
+    with pytest.raises(SpecParseError):
+        store.list()
 
 def test_local_lifecycle_save_reapplies_gitignore_for_renamed_artifact(tmp_path: Path):
     _git_init(tmp_path)
@@ -324,7 +325,8 @@ def test_invalid_encrypted_token_is_a_controlled_parse_error_and_tolerant_scan_s
 
     assert "not a valid fernet token" not in str(exc.value)
     assert [spec.id for spec, _, _ in encrypted._storage.read_all()] == ["readable"]
-    assert [spec.id for spec in encrypted.list()] == ["readable"]
+    with pytest.raises(SpecParseError):
+        encrypted.list()
 
 
 def test_readable_exact_conflicts_with_locked_renamed_artifact(tmp_path: Path):
@@ -378,7 +380,7 @@ def test_canonical_filename_frontmatter_mismatch_conflicts_for_both_ids(tmp_path
     with pytest.raises(SpecArtifactConflict):
         store.read_strict("frontmatter-id")
 
-def test_plaintext_invalid_utf8_is_parse_error_and_tolerant_reads_skip_it(tmp_path: Path):
+def test_plaintext_invalid_utf8_is_parse_error_but_tolerant_storage_scan_skips_it(tmp_path: Path):
     specs_dir = tmp_path / SPECS_DIRNAME
     specs_dir.mkdir()
     (specs_dir / "2026-07-22-broken.md").write_bytes(b"\xff")
@@ -390,7 +392,8 @@ def test_plaintext_invalid_utf8_is_parse_error_and_tolerant_reads_skip_it(tmp_pa
     with pytest.raises(SpecParseError):
         store.read_strict("broken")
 
-    assert [spec.id for spec in store.list()] == ["readable"]
+    with pytest.raises(SpecParseError):
+        store.list()
     assert [spec.id for spec, _, _ in store._storage.read_all()] == ["readable"]
 
 
@@ -401,7 +404,8 @@ def test_malformed_encryption_key_is_parse_error_for_reads_and_writes(tmp_path: 
 
     with pytest.raises(SpecParseError):
         encrypted.read_strict("secret-thing")
-    assert encrypted.list() == []
+    with pytest.raises(SpecParseError):
+        encrypted.list()
     assert list(encrypted._storage.read_all()) == []
 
     another = _spec()

--- a/tests/core/test_spec_storage.py
+++ b/tests/core/test_spec_storage.py
@@ -250,3 +250,66 @@ def test_encrypted_artifact_does_not_fallback_to_plaintext_under_committed_polic
 
     assert encrypted_path.is_file()
     assert not encrypted_path.with_suffix("").exists()
+
+
+def test_find_by_id_tolerates_locked_exact_artifact_but_read_strict_does_not(tmp_path: Path):
+    store = _store(tmp_path, "encrypted")
+    store.save(_spec())
+    spec_key.keyfile_path(tmp_path).unlink()
+
+    assert store.find_by_id("secret-thing") is None
+    with pytest.raises(SpecLocked):
+        store.read_strict("secret-thing")
+
+
+def test_create_refuses_any_locked_ciphertext_without_creating_a_replacement_key(tmp_path: Path):
+    store = _store(tmp_path, "encrypted")
+    store.save(_spec())
+    spec_key.keyfile_path(tmp_path).unlink()
+    new_spec = _spec()
+    new_spec.id = "different-id"
+
+    with pytest.raises(SpecLocked):
+        store.create_if_absent(new_spec)
+
+    assert spec_key.load_key(tmp_path) is None
+    assert not (tmp_path / SPECS_DIRNAME / "2026-07-22-different-id.md.enc").exists()
+
+
+def test_storage_write_refuses_to_generate_key_when_ciphertext_exists(tmp_path: Path):
+    store = _store(tmp_path, "encrypted")
+    store.save(_spec())
+    spec_key.keyfile_path(tmp_path).unlink()
+    storage = SpecStorage(tmp_path / SPECS_DIRNAME, mode="encrypted", workspace_root=tmp_path)
+
+    with pytest.raises(SpecLocked):
+        storage.write(tmp_path / SPECS_DIRNAME / "2026-07-22-direct.md", "body")
+
+    assert spec_key.load_key(tmp_path) is None
+
+
+def test_create_refuses_unknown_locked_alias_without_creating_a_replacement_key(tmp_path: Path):
+    store = _store(tmp_path, "encrypted")
+    locked_path = store.save(_spec())
+    spec_key.keyfile_path(tmp_path).unlink()
+    locked_path.rename(locked_path.with_name("renamed.md.enc"))
+    new_spec = _spec()
+    new_spec.id = "real-id"
+
+    with pytest.raises(SpecLocked):
+        store.create_if_absent(new_spec)
+
+    assert spec_key.load_key(tmp_path) is None
+    assert not (tmp_path / SPECS_DIRNAME / "2026-07-22-real-id.md.enc").exists()
+
+
+def test_exact_readable_artifact_remains_resolvable_beside_unrelated_locked_sibling(tmp_path: Path):
+    encrypted = _store(tmp_path, "encrypted")
+    encrypted.save(_spec())
+    spec_key.keyfile_path(tmp_path).unlink()
+    readable = _spec()
+    readable.id = "readable"
+    committed = _store(tmp_path, "committed")
+    committed.save(readable)
+
+    assert committed.read_strict("readable").id == "readable"

--- a/tests/core/test_spec_store.py
+++ b/tests/core/test_spec_store.py
@@ -94,6 +94,11 @@ def test_invalid_schema_frontmatter_raises_spec_parse_error():
 def test_malformed_yaml_raises_spec_parse_error():
     with pytest.raises(SpecParseError):
         parse_spec("---\nid: [unclosed\n---\nbody\n")
+@pytest.mark.parametrize("frontmatter", ["[]", "a scalar"])
+def test_non_mapping_frontmatter_raises_spec_parse_error(frontmatter: str):
+    with pytest.raises(SpecParseError):
+        parse_spec(f"---\n{frontmatter}\n---\nbody\n")
+
 
 
 def _new_spec(spec_id: str):

--- a/tests/core/test_spec_store.py
+++ b/tests/core/test_spec_store.py
@@ -200,8 +200,22 @@ def test_mutate_inbox_does_not_change_spec_domain_content_or_lifecycle(tmp_path:
     before = spec.model_dump(exclude={"inbox"})
 
     store.mutate_inbox(spec.id, "archive", "archive-1", datetime(2026, 8, 25, tzinfo=timezone.utc))
-
     assert store.find_by_id(spec.id).model_dump(exclude={"inbox"}) == before
+
+
+
+def test_inbox_mutation_keeps_runtime_lock_out_of_specs_directory(tmp_path: Path):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    specs_dir = tmp_path / "specs"
+    store = SpecStore(specs_dir)
+    spec = _new_spec("alpha")
+    store.save(spec)
+
+    store.mutate_inbox(spec.id, "archive", "archive-1", now)
+
+    assert [path.name for path in specs_dir.iterdir()] == ["2026-06-13-alpha.md"]
+    assert store._lock_path(spec.id) == tmp_path / ".mothership" / "locks" / "specs" / "alpha.lock"
+
 
 
 @pytest.mark.parametrize("action", ["unknown", ""])

--- a/tests/core/test_spec_store.py
+++ b/tests/core/test_spec_store.py
@@ -6,7 +6,9 @@ from threading import Event, Thread
 import pytest
 
 from mship.core.spec import AcceptanceCriterion, AcceptanceEvidence, OpenQuestion, Spec
-from mship.core.spec_store import SpecParseError, SpecStore, parse_spec, serialize_spec
+from mship.core.spec_store import (
+    SpecArtifactConflict, SpecParseError, SpecStore, parse_spec, serialize_spec,
+)
 from mship.core.spec_storage import SpecStorage
 
 def _spec():
@@ -325,3 +327,52 @@ def test_mutate_inbox_resolves_renamed_physical_spec_by_frontmatter_id(tmp_path)
     assert applied is True
     assert mutated.inbox.manual_archived is True
     assert mutated.status == "needs_review"
+
+def test_lifecycle_save_overwrites_renamed_artifact(tmp_path: Path):
+    store = SpecStore(tmp_path / "specs")
+    spec = _new_spec("alpha")
+    original = store.save(spec)
+    renamed = original.with_name("legacy-alpha.md")
+    original.rename(renamed)
+    spec.status = "needs_review"
+
+    assert store.save(spec) == renamed
+    assert renamed.is_file()
+    assert not original.exists()
+
+
+def test_mutation_fails_closed_when_canonical_and_alias_both_match(tmp_path: Path):
+    store = SpecStore(tmp_path / "specs")
+    spec = _new_spec("alpha")
+    canonical = store.save(spec)
+    canonical.with_name("legacy-alpha.md").write_text(canonical.read_text())
+
+    with pytest.raises(SpecArtifactConflict):
+        store.mutate_inbox(
+            spec.id, "archive", "archive-1", datetime(2026, 8, 25, tzinfo=timezone.utc),
+        )
+
+
+def test_create_rejects_target_filename_collision_with_other_frontmatter(tmp_path: Path):
+    store = SpecStore(tmp_path / "specs")
+    candidate = _new_spec("alpha")
+    collision = _new_spec("other")
+    target = store.path_for(candidate)
+    target.parent.mkdir(parents=True)
+    target.write_text(serialize_spec(collision))
+
+    with pytest.raises(SpecArtifactConflict):
+        store.create_if_absent(candidate)
+
+
+def test_save_propagates_storage_write_failure(tmp_path: Path, monkeypatch):
+    store = SpecStore(tmp_path / "specs")
+    spec = _new_spec("alpha")
+    store.save(spec)
+
+    def fail_write(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(SpecStorage, "write", fail_write)
+    with pytest.raises(OSError, match="disk full"):
+        store.save(spec)

--- a/tests/core/test_spec_store.py
+++ b/tests/core/test_spec_store.py
@@ -181,15 +181,16 @@ def test_mutate_inbox_pin_unpin_preserves_spec_manual_and_restore_metadata(tmp_p
     spec = _new_spec("alpha")
     store.save(spec)
 
-    store.mutate_inbox(spec.id, "restore", "restore-1", now)
-    store.mutate_inbox(spec.id, "archive", "archive-1", now.replace(minute=1))
-    store.mutate_inbox(spec.id, "pin", "pin-1", now.replace(minute=2))
-    store.mutate_inbox(spec.id, "unpin", "unpin-1", now.replace(minute=3))
+    store.mutate_inbox(spec.id, "archive", "archive-0", now)
+    store.mutate_inbox(spec.id, "restore", "restore-1", now.replace(minute=1))
+    store.mutate_inbox(spec.id, "archive", "archive-1", now.replace(minute=2))
+    store.mutate_inbox(spec.id, "pin", "pin-1", now.replace(minute=3))
+    store.mutate_inbox(spec.id, "unpin", "unpin-1", now.replace(minute=4))
 
     inbox = store.find_by_id(spec.id).inbox
     assert inbox.pinned is False
     assert inbox.manual_archived is True
-    assert inbox.restored_at == now
+    assert inbox.restored_at == now.replace(minute=1)
 
 
 def test_mutate_inbox_does_not_change_spec_domain_content_or_lifecycle(tmp_path: Path):

--- a/tests/core/test_spec_store.py
+++ b/tests/core/test_spec_store.py
@@ -140,3 +140,85 @@ def test_path_for_rejects_unsafe_id(tmp_path: Path):
     bad.id = "../escape"
     with pytest.raises(ValueError):
         store.save(bad)
+
+
+def test_mutate_inbox_duplicate_restore_is_a_noop(tmp_path: Path):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = SpecStore(tmp_path / "specs")
+    spec = _new_spec("alpha")
+    store.save(spec)
+
+    store.mutate_inbox(spec.id, "restore", "restore-1", now)
+    store.mutate_inbox(spec.id, "restore", "restore-1", now.replace(minute=1))
+
+    saved = store.find_by_id(spec.id)
+    assert saved.inbox.restored_at == now
+    assert saved.inbox.mutation_ids == {"restore-1": "restore"}
+
+
+def test_mutate_inbox_commits_spec_actions_in_order(tmp_path: Path):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = SpecStore(tmp_path / "specs")
+    archive_then_restore = _new_spec("one")
+    restore_then_archive = _new_spec("two")
+    store.save(archive_then_restore)
+    store.save(restore_then_archive)
+
+    store.mutate_inbox(archive_then_restore.id, "archive", "archive-1", now)
+    store.mutate_inbox(archive_then_restore.id, "restore", "restore-1", now.replace(minute=1))
+    store.mutate_inbox(restore_then_archive.id, "restore", "restore-2", now)
+    store.mutate_inbox(restore_then_archive.id, "archive", "archive-2", now.replace(minute=1))
+
+    assert store.find_by_id(archive_then_restore.id).inbox.manual_archived is False
+    assert store.find_by_id(restore_then_archive.id).inbox.manual_archived is True
+
+
+def test_mutate_inbox_pin_unpin_preserves_spec_manual_and_restore_metadata(tmp_path: Path):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = SpecStore(tmp_path / "specs")
+    spec = _new_spec("alpha")
+    store.save(spec)
+
+    store.mutate_inbox(spec.id, "restore", "restore-1", now)
+    store.mutate_inbox(spec.id, "archive", "archive-1", now.replace(minute=1))
+    store.mutate_inbox(spec.id, "pin", "pin-1", now.replace(minute=2))
+    store.mutate_inbox(spec.id, "unpin", "unpin-1", now.replace(minute=3))
+
+    inbox = store.find_by_id(spec.id).inbox
+    assert inbox.pinned is False
+    assert inbox.manual_archived is True
+    assert inbox.restored_at == now
+
+
+def test_mutate_inbox_does_not_change_spec_domain_content_or_lifecycle(tmp_path: Path):
+    store = SpecStore(tmp_path / "specs")
+    spec = _new_spec("alpha")
+    spec.status = "implemented"
+    store.save(spec)
+    before = spec.model_dump(exclude={"inbox"})
+
+    store.mutate_inbox(spec.id, "archive", "archive-1", datetime(2026, 8, 25, tzinfo=timezone.utc))
+
+    assert store.find_by_id(spec.id).model_dump(exclude={"inbox"}) == before
+
+
+@pytest.mark.parametrize("action", ["unknown", ""])
+def test_mutate_inbox_rejects_unknown_spec_action(tmp_path: Path, action: str):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = SpecStore(tmp_path / "specs")
+    spec = _new_spec("alpha")
+    store.save(spec)
+
+    with pytest.raises(ValueError):
+        store.mutate_inbox(spec.id, action, "action-1", now)
+
+
+def test_mutate_inbox_rejects_conflicting_spec_mutation_identity(tmp_path: Path):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = SpecStore(tmp_path / "specs")
+    spec = _new_spec("alpha")
+    store.save(spec)
+    store.mutate_inbox(spec.id, "archive", "mutation-1", now)
+
+    with pytest.raises(ValueError):
+        store.mutate_inbox(spec.id, "restore", "mutation-1", now.replace(minute=1))

--- a/tests/core/test_spec_store.py
+++ b/tests/core/test_spec_store.py
@@ -157,6 +157,21 @@ def test_mutate_inbox_duplicate_restore_is_a_noop(tmp_path: Path):
     assert saved.inbox.restored_at == now
     assert saved.inbox.mutation_ids == {"restore-1": "restore"}
 
+def test_mutate_inbox_persists_new_state_equivalent_spec_action(tmp_path: Path):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = SpecStore(tmp_path / "specs")
+    spec = _new_spec("alpha")
+    store.save(spec)
+
+    _, applied = store.mutate_inbox(spec.id, "unpin", "unpin-1", now)
+
+    assert applied is False
+    saved = SpecStore(tmp_path / "specs").find_by_id(spec.id)
+    assert saved.inbox.mutation_ids == {"unpin-1": "unpin"}
+    assert saved.inbox.last_mutated_at is None
+
+    with pytest.raises(ValueError):
+        SpecStore(tmp_path / "specs").mutate_inbox(spec.id, "archive", "unpin-1", now)
 
 def test_mutate_inbox_commits_spec_actions_in_order(tmp_path: Path):
     now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)

--- a/tests/core/test_spec_store.py
+++ b/tests/core/test_spec_store.py
@@ -7,7 +7,7 @@ import pytest
 
 from mship.core.spec import AcceptanceCriterion, AcceptanceEvidence, OpenQuestion, Spec
 from mship.core.spec_store import SpecParseError, SpecStore, parse_spec, serialize_spec
-
+from mship.core.spec_storage import SpecStorage
 
 def _spec():
     now = datetime(2026, 6, 13, 10, 0, 0, tzinfo=timezone.utc)
@@ -282,12 +282,12 @@ def test_concurrent_inbox_mutation_cannot_overwrite_lifecycle_save(tmp_path: Pat
     lifecycle_update = store.find_by_id(spec.id)
     lifecycle_update.status = "needs_review"
 
-    original_write = store._storage.write
+    original_write = SpecStorage.write
     lifecycle_write_started = Event()
     lifecycle_writer = Thread(target=lambda: store.save(lifecycle_update))
     writer_started = False
 
-    def interleave_lifecycle_save(path, text):
+    def interleave_lifecycle_save(storage, path, text):
         nonlocal writer_started
         saved = parse_spec(text)
         if saved.inbox.manual_archived and not writer_started:
@@ -299,11 +299,12 @@ def test_concurrent_inbox_mutation_cannot_overwrite_lifecycle_save(tmp_path: Pat
             lifecycle_write_started.wait(timeout=0.2)
         if saved.status == "needs_review":
             lifecycle_write_started.set()
-        return original_write(path, text)
+        return original_write(storage, path, text)
 
-    monkeypatch.setattr(store._storage, "write", interleave_lifecycle_save)
+    monkeypatch.setattr(SpecStorage, "write", interleave_lifecycle_save)
     store.mutate_inbox(spec.id, "archive", "archive-1", now)
     lifecycle_writer.join()
+    assert lifecycle_write_started.wait(timeout=0.2)
 
     saved = store.find_by_id(spec.id)
     assert saved.status == "needs_review"

--- a/tests/core/test_spec_store.py
+++ b/tests/core/test_spec_store.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
 from pathlib import Path
 
+from threading import Event, Thread
+
 import pytest
 
 from mship.core.spec import AcceptanceCriterion, AcceptanceEvidence, OpenQuestion, Spec
@@ -222,3 +224,58 @@ def test_mutate_inbox_rejects_conflicting_spec_mutation_identity(tmp_path: Path)
 
     with pytest.raises(ValueError):
         store.mutate_inbox(spec.id, "restore", "mutation-1", now.replace(minute=1))
+
+
+def test_stale_lifecycle_save_preserves_current_inbox_metadata(tmp_path: Path):
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = SpecStore(tmp_path / "specs")
+    spec = _new_spec("alpha")
+    store.save(spec)
+    stale_lifecycle_copy = store.find_by_id(spec.id)
+
+    store.mutate_inbox(spec.id, "archive", "archive-1", now)
+    stale_lifecycle_copy.status = "needs_review"
+    store.save(stale_lifecycle_copy)
+
+    saved = store.find_by_id(spec.id)
+    assert saved.status == "needs_review"
+    assert saved.inbox.manual_archived is True
+    assert saved.inbox.mutation_ids == {"archive-1": "archive"}
+
+
+def test_concurrent_inbox_mutation_cannot_overwrite_lifecycle_save(tmp_path: Path, monkeypatch):
+    """The lifecycle save landing while mutation persistence is pending wins both fields."""
+    now = datetime(2026, 8, 25, 12, tzinfo=timezone.utc)
+    store = SpecStore(tmp_path / "specs")
+    spec = _new_spec("alpha")
+    store.save(spec)
+    lifecycle_update = store.find_by_id(spec.id)
+    lifecycle_update.status = "needs_review"
+
+    original_write = store._storage.write
+    lifecycle_write_started = Event()
+    lifecycle_writer = Thread(target=lambda: store.save(lifecycle_update))
+    writer_started = False
+
+    def interleave_lifecycle_save(path, text):
+        nonlocal writer_started
+        saved = parse_spec(text)
+        if saved.inbox.manual_archived and not writer_started:
+            writer_started = True
+            lifecycle_writer.start()
+            # Before the lock-safe owner, the lifecycle writer reaches storage here
+            # and the pending inbox write then clobbers its status. With the owner,
+            # it blocks until this write releases the per-spec lock.
+            lifecycle_write_started.wait(timeout=0.2)
+        if saved.status == "needs_review":
+            lifecycle_write_started.set()
+        return original_write(path, text)
+
+    monkeypatch.setattr(store._storage, "write", interleave_lifecycle_save)
+    store.mutate_inbox(spec.id, "archive", "archive-1", now)
+    lifecycle_writer.join()
+
+    saved = store.find_by_id(spec.id)
+    assert saved.status == "needs_review"
+    assert saved.inbox.manual_archived is True
+    assert saved.inbox.mutation_ids == {"archive-1": "archive"}

--- a/tests/core/test_spec_store.py
+++ b/tests/core/test_spec_store.py
@@ -293,3 +293,18 @@ def test_concurrent_inbox_mutation_cannot_overwrite_lifecycle_save(tmp_path: Pat
     assert saved.status == "needs_review"
     assert saved.inbox.manual_archived is True
     assert saved.inbox.mutation_ids == {"archive-1": "archive"}
+
+
+def test_mutate_inbox_resolves_renamed_physical_spec_by_frontmatter_id(tmp_path):
+    store = SpecStore(tmp_path / "specs")
+    spec = _spec()
+    original = store.save(spec)
+    original.rename(original.with_name("renamed.md"))
+
+    mutated, applied = store.mutate_inbox(
+        spec.id, "archive", "device-archive", datetime(2026, 8, 25, tzinfo=timezone.utc),
+    )
+
+    assert applied is True
+    assert mutated.inbox.manual_archived is True
+    assert mutated.status == "needs_review"

--- a/tests/core/test_workitem_lifecycle.py
+++ b/tests/core/test_workitem_lifecycle.py
@@ -11,8 +11,12 @@ after a clean full merge:
 """
 from datetime import datetime, timezone
 
+import pytest
+
+from mship.core import spec_key
 from mship.core.spec_draft import new_spec
 from mship.core.spec_store import SpecStore
+from mship.core.spec_storage import SpecLocked, SpecStorage
 from mship.core.state import Task, WorkspaceState
 from mship.core.workitem_lifecycle import advance_workitem_on_close
 from mship.core.workitem_store import WorkItemStore
@@ -211,6 +215,23 @@ def test_spec_bound_missing_spec_no_raise(tmp_path):
     _call(tmp_path, t, state)  # no exception
 
     assert store.get(wi.id).phase_override is None
+
+def test_spec_bound_close_raises_for_locked_spec(tmp_path):
+    specs_dir = tmp_path / "specs"
+    encrypted = SpecStore(
+        specs_dir,
+        storage=SpecStorage(specs_dir, mode="encrypted", workspace_root=tmp_path),
+    )
+    spec = new_spec("Feature", now=_now(), task_slug="task-a")
+    spec.status = "approved"
+    encrypted.save(spec)
+    spec_key.keyfile_path(tmp_path).unlink()
+    store, wi = _store_with_item(tmp_path, kind="feature", spec_id=spec.id)
+    store.add_task(wi.id, "task-a", now=_now())
+    task = _task("task-a", wi.id)
+
+    with pytest.raises(SpecLocked):
+        _call(tmp_path, task, WorkspaceState(tasks={"task-a": task}))
 
 
 # --- push-only completion (completed_without_prs) ------------------------------

--- a/tests/core/view/test_spec_readers_encrypted.py
+++ b/tests/core/view/test_spec_readers_encrypted.py
@@ -5,11 +5,17 @@ parse error (spec-storage-visibility-policy ac2)."""
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 from mship.core import spec_key
 from mship.core.spec import Spec
-from mship.core.spec_storage import SpecStorage
+from mship.core.spec_storage import SpecLocked, SpecStorage
 from mship.core.spec_store import SPECS_DIRNAME, SpecStore
-from mship.core.view.spec_discovery import _find_in_specs_dir
+from mship.core.view.spec_discovery import (
+    _find_in_specs_dir,
+    find_spec,
+    read_spec_source,
+)
 from mship.core.view.spec_selection import scan_canonical_specs
 
 
@@ -47,3 +53,18 @@ def test_find_in_specs_dir_finds_encrypted_by_task_slug(tmp_path: Path):
     _write_encrypted(tmp_path, "enc-three", task_slug="my-task")
     found = _find_in_specs_dir(tmp_path, task_slug="my-task")
     assert found is not None and found.name.endswith(".md.enc")
+
+
+def test_default_discovery_reads_encrypted_specs_and_reports_locked_without_key(
+    tmp_path: Path,
+):
+    _write_encrypted(tmp_path, "enc-default")
+
+    found = find_spec(tmp_path, None)
+
+    assert found.name.endswith(".md.enc")
+    assert "ENCRYPTED-BODY" in read_spec_source(found)
+
+    spec_key.keyfile_path(tmp_path).unlink()
+    with pytest.raises(SpecLocked):
+        read_spec_source(found)

--- a/tests/core/view/test_thread_links.py
+++ b/tests/core/view/test_thread_links.py
@@ -1,4 +1,6 @@
-from mship.core.view.thread_links import index_thread_work_items, resolve_thread_work_item
+from mship.core.view.thread_links import (
+    index_thread_inbox_links, index_thread_work_items, resolve_thread_work_item,
+)
 
 
 class _Item:
@@ -85,3 +87,38 @@ def test_corrupt_item_degrades_only_its_own_threads():
     good = _Item("wi-good", thread_ids=["t-good"])
     out = index_thread_work_items([_Thread("t-good"), _Thread("t-orphan")], [good, _Bad()])
     assert out == {"t-good": "wi-good", "t-orphan": None}
+
+
+def test_ambiguous_selected_link_precedence_resolves_to_none():
+    direct = [_Item("wi-a", thread_ids=["t1"]), _Item("wi-b", thread_ids=["t1"])]
+    assert resolve_thread_work_item("t1", "unique-spec", "unique-task", direct) is None
+    assert index_thread_work_items([_Thread("t1", "unique-spec", "unique-task")], direct) == {
+        "t1": None,
+    }
+
+
+def test_ambiguous_spec_or_task_owner_resolves_to_none():
+    assert resolve_thread_work_item(
+        "t1", "shared", None, [_Item("wi-a", spec_id="shared"), _Item("wi-b", spec_id="shared")],
+    ) is None
+    assert resolve_thread_work_item(
+        "t1", None, "shared", [_Item("wi-a", task_slugs=["shared"]), _Item("wi-b", task_slugs=["shared"])],
+    ) is None
+
+
+def test_unique_direct_owner_wins_over_ambiguous_spec_owner():
+    items = [
+        _Item("wi-direct", thread_ids=["t1"]),
+        _Item("wi-a", spec_id="shared"),
+        _Item("wi-b", spec_id="shared"),
+    ]
+    assert resolve_thread_work_item("t1", "shared", None, items) == "wi-direct"
+
+
+def test_ambiguous_selected_owner_is_uncertain_and_nonterminal():
+    items = [_Item("wi-a", thread_ids=["t1"]), _Item("wi-b", thread_ids=["t1"])]
+    link = index_thread_inbox_links([_Thread("t1")], items, {}, {})["t1"]
+
+    assert link.work_item_id is None
+    assert link.terminal is False
+    assert link.uncertain is True

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -469,6 +469,35 @@ def test_resolve_bound_spec_explicit_spec_id_bypasses_status_filter(tmp_path):
     assert resolve_bound_spec(task, tmp_path).id == "nr"
 
 
+def test_resolve_bound_spec_propagates_locked_explicit_link(tmp_path):
+    import pytest
+    from mship.core import spec_key
+    from mship.core.spec_storage import SpecLocked, SpecStorage
+
+    now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    items = WorkItemStore(tmp_path / ".mothership" / "workitems")
+    wi = items.create(title="F", kind="feature", workspace="ws", now=now)
+    encrypted = SpecStore(
+        tmp_path / "specs",
+        storage=SpecStorage(
+            tmp_path / "specs", mode="encrypted", workspace_root=tmp_path,
+        ),
+    )
+    encrypted.save(Spec(
+        id="locked", title="S", status="approved",
+        created_at=now, updated_at=now,
+    ))
+    items.link_spec(wi.id, "locked", now=now)
+    spec_key.keyfile_path(tmp_path).unlink()
+    task = Task(
+        slug="t", description="d", phase="dev", created_at=now,
+        affected_repos=["shared"], branch="feat/t", work_item_id=wi.id,
+    )
+
+    with pytest.raises(SpecLocked):
+        resolve_bound_spec(task, tmp_path)
+
+
 def test_resolve_bound_spec_propagates_corrupt_store_error(tmp_path):
     # Greptile #341: a corrupt/unreadable spec store must NOT be silently turned into
     # None (which would make finish --require-evidence skip the required check).


### PR DESCRIPTION
## Summary
- add durable, idempotent pin/archive/restore metadata for threads and specs
- centralize active/archive precedence, exact seven-day boundaries, and archive reasons
- expose compatible active/archived/all list and search filters plus non-destructive mutation routes
- preserve inbox metadata across concurrent spec lifecycle writes and wake thread long-pollers on inbox mutations

## Integration order
Merge this Mothership API/storage PR before the Ground Control consumer PR.

## Test plan
- [x] focused classifier/store/API/wait suites
- [x] `mship test --repos mothership` — iteration 5 passed
- [x] `task lint` — Ruff and Pyrefly passed
- [x] final multi-repo review and scoped fix re-review passed

---

## Acceptance criteria

- [x] `ac1` Given any thread or spec with pin metadata set, when it is classified, then its inbox state is active regardless of manual archive metadata, restore age, linked terminal state, inactivity, implementation age, or lifecycle-archived state. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac2` Given an unpinned thread marked needs-you or containing an unanswered decision, when it is classified, then its inbox state is active even if it otherwise qualifies for manual, linked-terminal, or inactivity archival. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac3` Given an unpinned item without a higher-precedence thread attention condition, when its latest manual archive action is later than its latest restore action, then it is archived immediately with archive reason manual. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac4` Given an item whose latest restore is later than its latest manual archive, when less than exactly seven days have elapsed since that restore, then it is active; when exactly seven days or more have elapsed, then restore no longer affects classification and the applicable lifecycle, linkage, or inactivity rule determines its state. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac5` Given a restored linked thread whose WorkItem/task is terminal, when less than seven days have elapsed since restore, then it is active and the WorkItem/task remains terminal; at exactly seven days after restore, it is archived with reason linked_terminal unless pin or a thread attention condition applies. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac6` Given an unpinned linked thread with no needs-you work, no unanswered decision, and no effective restore grace, when its linked WorkItem/task is terminal, then it is archived with reason linked_terminal; when the linked WorkItem/task is nonterminal, then terminal linkage does not archive it. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac7` Given an unpinned unlinked thread with no needs-you work, no unanswered decision, no later manual archive, and no effective restore grace, when its latest activity is less than seven days old, then it is active; at exactly seven days after its latest activity and thereafter, it is archived with reason inactive_unlinked. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac8` Given an unlinked thread receives new qualifying activity after having become archived for inactivity, when it is classified, then the seven-day inactivity period is measured from that new activity and the thread is active until the new exact boundary. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac9` Given an unpinned spec with no effective later manual archive or restore grace, when its lifecycle state is draft, needs_review, approved, or dispatched, then it is active. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac10` Given an unpinned implemented spec with no effective later manual archive or restore grace, when less than seven days have elapsed since its latest implementation or update timestamp, then it is active; at exactly seven days and thereafter, it is archived with reason implemented. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac11` Given an implemented spec receives a qualifying update, when it is classified, then its seven-day active period is measured from that update rather than the earlier implementation timestamp. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac12` Given an unpinned lifecycle-archived spec with no effective later restore grace, when it is classified, then it is archived immediately with reason lifecycle_archived. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac13` Given a lifecycle-archived spec is restored, when less than seven days have elapsed since restore, then it is active while its lifecycle remains archived; at exactly seven days after restore, it is archived again with reason lifecycle_archived unless pinned. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac14` Given an item is manually archived during an active restore grace period, when the archive action is committed after the restore, then it is archived immediately with reason manual unless pin or a thread attention condition has higher precedence, and its domain lifecycle is unchanged. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac15` Given an archived item is pinned, when the pin action is committed, then it becomes active; given that same item is later unpinned, then classification immediately falls back to the applicable manual, restore, lifecycle, linkage, or inactivity rule without altering domain lifecycle. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac16` Given archive, restore, pin, or unpin requests are retried with the same mutation identity, when Mothership processes the retries, then the durable inbox outcome is the same as processing the logical mutation once. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac17` Given conflicting inbox mutations are submitted from two devices, when both are committed, then every subsequent read on both devices reflects the same result based on Mothership's authoritative mutation order; tests cover archive versus restore, pin versus unpin, and archive versus pin races. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac18` Given a Mothership thread or spec list request explicitly uses active, archived, or all, when results are returned, then every result matches the requested classifier state, all includes both states, and each result exposes its computed inbox state and archive reason, with archive reason absent or null for active items. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac19` Given an existing Mothership API consumer omits the inbox filter, when it lists or searches threads or specs, then the effective filter is all and records are not excluded due to inbox classification. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac20` Given a search term and an active, archived, or all filter, when thread or spec search is executed, then matching is restricted to the selected filter and returns the same classification and archive reason as the corresponding list/read API. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac21` Given Ground Control opens the thread inbox or spec inbox on Android, then Active is the default selected tab, an Archived tab is available, and each tab displays only items classified for that tab by Mothership. — test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac22` Given a user searches from either the Active or Archived Ground Control tab for threads or specs, then results remain scoped to that tab and include matching items from the durable Mothership state. — test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac23` Given a Ground Control user views an item, then pin is available for an unpinned item, unpin is available for a pinned item, archive is available when a manual archive can change its inbox outcome, and restore is available for an archived item; after a successful action, another device displays the same durable state after refresh or synchronization. — test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac24` Given any archive, restore, pin, or unpin action, when storage and API records are inspected, then no thread, spec, message, WorkItem/task, lifecycle record, or associated content has been deleted, and the item remains retrievable through the all filter and applicable search. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
- [x] `ac25` Automated tests in mothership cover classifier precedence, exact seven-day boundaries, linked and unlinked thread rules, all listed spec lifecycle states, archive reasons, mutation retries and races, search/filter behavior, compatibility defaults, and non-deletion; automated Android tests in ground-control cover default tabs, tab-scoped search, all four actions, and cross-device/server-backed state refresh. — test:test-runs/5.mothership, test:test-runs/6.ground-control, test:test-runs/6.mothership
---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `ground-control-active-and-archived`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/81 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/485 | this PR |

⚠ Merge in order: ground-control → mothership