### PR TITLE
Protect reviewed specs during apply

### DIFF
--- a/src/mship/cli/capture.py
+++ b/src/mship/cli/capture.py
@@ -60,28 +60,33 @@ def _attach_evidence(
         workspace_root = Path(container.config_path()).parent
         mode = resolve_evidence_mode(container.config())
         store = SpecStore(workspace_root / "specs")
-        spec = store.find_by_id(target.spec_id)
-        if spec is None:
-            output.warning(f"could not attach evidence: no spec {target.spec_id!r}")
-            return
-        crit = next((c for c in spec.acceptance_criteria if c.id == target.criterion_id), None)
-        if crit is None:
-            output.warning(
-                f"could not attach evidence: {target.spec_id!r} has no criterion "
-                f"{target.criterion_id!r}"
-            )
-            return
-        note_where = provenance_note(worktree, container.shell())
-        for a in artifacts:
-            ref = store_artifact(workspace_root, target.spec_id, a.path, mode=mode)
-            crit.evidence.append(
-                AcceptanceEvidence(
-                    kind="artifact",
-                    ref=ref,
-                    note=f"{a.kind} · {platform or 'default'} · {note_where}",
+        # Load, mutate, and save under the same per-spec lock. Capturing an
+        # artifact can take long enough for an apply to replace the draft; saving
+        # a pre-lock snapshot after that replacement would otherwise restore the
+        # old body and review state.
+        with store.locked(target.spec_id) as artifact:
+            if artifact is None:
+                output.warning(f"could not attach evidence: no spec {target.spec_id!r}")
+                return
+            spec = artifact.spec
+            crit = next((c for c in spec.acceptance_criteria if c.id == target.criterion_id), None)
+            if crit is None:
+                output.warning(
+                    f"could not attach evidence: {target.spec_id!r} has no criterion "
+                    f"{target.criterion_id!r}"
                 )
-            )
-        store.save(spec)
+                return
+            note_where = provenance_note(worktree, container.shell())
+            for a in artifacts:
+                ref = store_artifact(workspace_root, target.spec_id, a.path, mode=mode)
+                crit.evidence.append(
+                    AcceptanceEvidence(
+                        kind="artifact",
+                        ref=ref,
+                        note=f"{a.kind} · {platform or 'default'} · {note_where}",
+                    )
+                )
+            store.save_while_locked(spec, artifact)
         # human_mode only: `success` writes to STDOUT, which in JSON mode already
         # carries the capture payload — a confirmation line there would corrupt
         # it for `| jq`. Warnings above are safe (they go to stderr in JSON mode).

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -97,6 +97,9 @@ def register(parent: typer.Typer, get_container):
         except SpecParseError as exc:
             output.error(f"Cannot create spec {spec.id!r}: {exc}")
             raise typer.Exit(1)
+        except ValueError as exc:
+            output.error(f"Cannot create spec {spec.id!r}: {exc}")
+            raise typer.Exit(1)
 
         if output.human_mode:
             output.success(f"Created spec: {path}")

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -556,11 +556,14 @@ def register(parent: typer.Typer, get_container):
             output.error(f"No spec with id {spec_id!r}.")
             raise typer.Exit(1)
         try:
-            approve_spec(spec, store, bypass_gate=bypass_gate)
+            spec = approve_spec(spec, store, bypass_gate=bypass_gate)
         except ApprovalBlocked as e:
             output.error("Cannot approve — " + "; ".join(e.blockers) + ". Use --bypass-gate to override.")
             raise typer.Exit(1)
         except InvalidTransition as e:
+            output.error(str(e))
+            raise typer.Exit(1)
+        except ValueError as e:
             output.error(str(e))
             raise typer.Exit(1)
         path = store.path_for(spec)
@@ -684,6 +687,7 @@ def register(parent: typer.Typer, get_container):
         except DispatchError as e:
             output.error(str(e))
             raise typer.Exit(1)
+        spec = result.spec
 
         if closes_canonical and spec.work_item_id:
             # Fail-open: dispatch already completed, so a linking failure must
@@ -740,7 +744,7 @@ def register(parent: typer.Typer, get_container):
         # "spec request-changes: …" log line — the structured record is the
         # parsed source now.
         try:
-            request_changes_spec(
+            spec = request_changes_spec(
                 spec, store, reason,
                 log_manager=container.log_manager(),
                 actor=os.environ.get("USER") or "unknown",
@@ -919,24 +923,36 @@ def register(parent: typer.Typer, get_container):
             output.json(data)
 
     def _simple_transition(target_status: str, spec_id: str) -> None:
-        """Shared logic for implemented/archive: validate transition and save."""
+        """Transition the current spec under its per-spec lock."""
         from datetime import datetime, timezone
         from mship.core.spec import InvalidTransition, validate_transition
+        from mship.core.spec_storage import SpecLocked
+        from mship.core.spec_store import SpecParseError
 
         output = Output()
         store = _spec_store()
-        spec = store.find_by_id(spec_id)
-        if spec is None:
-            output.error(f"No spec with id {spec_id!r}.")
-            raise typer.Exit(1)
         try:
-            validate_transition(spec.status, target_status)
+            with store.locked(spec_id) as artifact:
+                if artifact is None:
+                    output.error(f"No spec with id {spec_id!r}.")
+                    raise typer.Exit(1)
+                spec = artifact.spec
+                validate_transition(spec.status, target_status)
+                spec.status = target_status
+                spec.updated_at = datetime.now(timezone.utc)
+                store.save_while_locked(spec, artifact)
         except InvalidTransition as e:
             output.error(str(e))
             raise typer.Exit(1)
-        spec.status = target_status
-        spec.updated_at = datetime.now(timezone.utc)
-        store.save(spec)
+        except SpecLocked as exc:
+            output.error(f"Cannot update spec {spec_id!r}: {exc}")
+            raise typer.Exit(1)
+        except SpecParseError as exc:
+            output.error(f"Cannot update spec {spec_id!r}: {exc}")
+            raise typer.Exit(1)
+        except ValueError as exc:
+            output.error(str(exc))
+            raise typer.Exit(1)
         if output.human_mode:
             output.success(f"Spec {spec.id} → {target_status}")
         else:

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -169,11 +169,15 @@ def register(parent: typer.Typer, get_container):
         """
         import json
         import sys
-        from datetime import datetime, timezone
         from pathlib import Path
         from pydantic import ValidationError
-        from mship.core.spec import SpecDraft, InvalidTransition, validate_transition
-        from mship.core.spec_draft import apply_draft, parse_spec_markdown
+        from mship.core.spec import InvalidTransition, SpecDraft
+        from mship.core.spec_draft import (
+            MissingSpec, ReviewDiscardRequired, apply_draft_transaction,
+            parse_spec_markdown,
+        )
+        from mship.core.spec_storage import SpecLocked
+        from mship.core.spec_store import SpecParseError
 
         output = Output()
 
@@ -210,79 +214,56 @@ def register(parent: typer.Typer, get_container):
 
         container = get_container()
         store = _spec_store()
-        spec = store.find_by_id(spec_id)
-        if spec is None:
-            output.error(f"No spec with id {spec_id!r}.")
-            raise typer.Exit(1)
-
-        reviewed_unit_count = sum(
-            criterion.verdict != "unreviewed"
-            for criterion in spec.acceptance_criteria
-        ) + sum(
-            verdict.verdict != "unreviewed"
-            for verdict in spec.prose_verdicts.values()
-        )
-        if reviewed_unit_count:
-            planned_spec = spec.model_copy(deep=True)
-            apply_draft(planned_spec, draft)
-            discarded_review_count = reviewed_unit_count - (
-                sum(
-                    criterion.verdict != "unreviewed"
-                    for criterion in planned_spec.acceptance_criteria
-                ) + sum(
-                    verdict.verdict != "unreviewed"
-                    for verdict in planned_spec.prose_verdicts.values()
-                )
+        try:
+            result = apply_draft_transaction(
+                store,
+                spec_id,
+                draft,
+                bypass_status_gate=bypass_status_gate,
+                discard_review=discard_review,
             )
-        else:
-            discarded_review_count = 0
-        if discarded_review_count and not discard_review:
-            unit_noun = "unit" if discarded_review_count == 1 else "units"
-            output.error(
-                f"Cannot apply draft: review state for {discarded_review_count} review "
-                f"{unit_noun} would be discarded. "
-                "Re-run with --discard-review to continue."
-            )
+        except ReviewDiscardRequired as exc:
+            output.error(str(exc))
             raise typer.Exit(1)
-
-        if not bypass_status_gate:
-            try:
-                validate_transition(spec.status, "needs_review")
-            except InvalidTransition as e:
-                output.error(f"{e}. Use --bypass-status-gate to override.")
-                raise typer.Exit(1)
-
-        # `apply_draft` drops verdicts whose source units changed while preserving
-        # evidence and review state on unchanged acceptance criteria.
-
-        # MOS-215/MOS-240: applying a (re)drafted spec supersedes any pending
-        # request-changes, so clear the reason — a freshly applied draft carries
-        # no outstanding clarification ask. (A brand-new draft has none anyway.)
-        apply_draft(spec, draft)
-        spec.status = "needs_review"
-        spec.clarification_reason = None
-        spec.updated_at = datetime.now(timezone.utc)
-        path = store.save(spec)
+        except InvalidTransition as exc:
+            output.error(f"{exc}. Use --bypass-status-gate to override.")
+            raise typer.Exit(1)
+        except ValueError as exc:
+            output.error(str(exc))
+            raise typer.Exit(1)
+        except SpecLocked as exc:
+            output.error(f"Cannot apply draft for spec {spec_id!r}: {exc}")
+            raise typer.Exit(1)
+        except SpecParseError as exc:
+            output.error(f"Cannot apply draft for spec {spec_id!r}: {exc}")
+            raise typer.Exit(1)
+        if isinstance(result, MissingSpec):
+            output.error(f"No spec with id {result.spec_id!r}.")
+            raise typer.Exit(1)
 
         # Agent-agnostic activity heartbeat: applying a drafted spec is task work.
         # No-ops when the spec's bound task_slug isn't (yet) a live task.
-        if spec.task_slug:
-            container.state_manager().record_activity(spec.task_slug)
+        if result.spec.task_slug:
+            container.state_manager().record_activity(result.spec.task_slug)
 
         if output.human_mode:
-            if discarded_review_count:
-                unit_noun = "unit" if discarded_review_count == 1 else "units"
+            if result.discarded_review_count:
+                unit_noun = "unit" if result.discarded_review_count == 1 else "units"
                 output.success(
-                    f"Applied draft → {spec.status}; review state was discarded for "
-                    f"{discarded_review_count} review {unit_noun}: {path}"
+                    f"Applied draft → {result.spec.status}; review state was discarded for "
+                    f"{result.discarded_review_count} review {unit_noun}: {result.path}"
                 )
             else:
-                output.success(f"Applied draft → {spec.status}: {path}")
+                output.success(f"Applied draft → {result.spec.status}: {result.path}")
         else:
-            payload = {"id": spec.id, "status": spec.status, "path": str(path)}
-            if discarded_review_count:
+            payload = {
+                "id": result.spec.id,
+                "status": result.spec.status,
+                "path": str(result.path),
+            }
+            if result.discarded_review_count:
                 payload["review_state_discarded"] = True
-                payload["discarded_review_count"] = discarded_review_count
+                payload["discarded_review_count"] = result.discarded_review_count
             output.json(payload)
 
     @spec_app.command("review")
@@ -341,37 +322,46 @@ def register(parent: typer.Typer, get_container):
         from mship.core.spec_review import (
             PROSE_UNIT_IDS, set_criterion_verdict, set_prose_verdict,
         )
+        from mship.core.spec_storage import SpecLocked
+        from mship.core.spec_store import SpecParseError
 
         output = Output()
         store = _spec_store()
-        spec = store.find_by_id(spec_id)
-        if spec is None:
-            output.error(f"No spec with id {spec_id!r}.")
-            raise typer.Exit(1)
-
-        # Route on the unit id: prose sections (PROSE_UNIT_IDS) get a prose
-        # verdict; anything else goes down the unchanged AC path. An id that is
-        # neither errors listing BOTH vocabularies — the core setters each only
-        # know their own.
-        ac_ids = [c.id for c in spec.acceptance_criteria]
         try:
-            if criterion_id in PROSE_UNIT_IDS:
-                set_prose_verdict(spec, criterion_id, verdict_value)
-            elif criterion_id in ac_ids:
-                set_criterion_verdict(spec, criterion_id, verdict_value)
-            else:
-                output.error(
-                    f"no acceptance criterion or prose section {criterion_id!r}; "
-                    f"acceptance criteria: {', '.join(ac_ids) or '(none)'}; "
-                    f"prose sections: {', '.join(sorted(PROSE_UNIT_IDS))}"
-                )
-                raise typer.Exit(1)
-        except ValueError as e:
-            output.error(str(e))
-            raise typer.Exit(1)
+            with store.locked(spec_id) as artifact:
+                if artifact is None:
+                    output.error(f"No spec with id {spec_id!r}.")
+                    raise typer.Exit(1)
+                spec = artifact.spec.model_copy(deep=True)
 
-        spec.updated_at = datetime.now(timezone.utc)
-        path = store.save(spec)
+                # Route on the unit id: prose sections (PROSE_UNIT_IDS) get a prose
+                # verdict; anything else goes down the unchanged AC path. An id that is
+                # neither errors listing BOTH vocabularies — the core setters each only
+                # know their own.
+                ac_ids = [c.id for c in spec.acceptance_criteria]
+                if criterion_id in PROSE_UNIT_IDS:
+                    set_prose_verdict(spec, criterion_id, verdict_value)
+                elif criterion_id in ac_ids:
+                    set_criterion_verdict(spec, criterion_id, verdict_value)
+                else:
+                    output.error(
+                        f"no acceptance criterion or prose section {criterion_id!r}; "
+                        f"acceptance criteria: {', '.join(ac_ids) or '(none)'}; "
+                        f"prose sections: {', '.join(sorted(PROSE_UNIT_IDS))}"
+                    )
+                    raise typer.Exit(1)
+
+                spec.updated_at = datetime.now(timezone.utc)
+                path = store.save_while_locked(spec, artifact)
+        except ValueError as exc:
+            output.error(str(exc))
+            raise typer.Exit(1)
+        except SpecLocked as exc:
+            output.error(f"Cannot update spec {spec_id!r}: {exc}")
+            raise typer.Exit(1)
+        except SpecParseError as exc:
+            output.error(f"Cannot update spec {spec_id!r}: {exc}")
+            raise typer.Exit(1)
         if output.human_mode:
             output.success(f"{criterion_id} → {verdict_value}: {path}")
         else:
@@ -392,23 +382,30 @@ def register(parent: typer.Typer, get_container):
         """Attach an evidence entry to one acceptance criterion (no status change)."""
         from datetime import datetime, timezone
         from mship.core.spec_review import infer_evidence_kind, set_criterion_evidence
+        from mship.core.spec_storage import SpecLocked
+        from mship.core.spec_store import SpecParseError
 
         output = Output()
         store = _spec_store()
-        spec = store.find_by_id(spec_id)
-        if spec is None:
-            output.error(f"No spec with id {spec_id!r}.")
-            raise typer.Exit(1)
-
         resolved_kind = kind or infer_evidence_kind(ref)
         try:
-            set_criterion_evidence(spec, criterion_id, resolved_kind, ref, note)
-        except ValueError as e:
-            output.error(str(e))
+            with store.locked(spec_id) as artifact:
+                if artifact is None:
+                    output.error(f"No spec with id {spec_id!r}.")
+                    raise typer.Exit(1)
+                spec = artifact.spec.model_copy(deep=True)
+                set_criterion_evidence(spec, criterion_id, resolved_kind, ref, note)
+                spec.updated_at = datetime.now(timezone.utc)
+                path = store.save_while_locked(spec, artifact)
+        except ValueError as exc:
+            output.error(str(exc))
             raise typer.Exit(1)
-
-        spec.updated_at = datetime.now(timezone.utc)
-        path = store.save(spec)
+        except SpecLocked as exc:
+            output.error(f"Cannot update spec {spec_id!r}: {exc}")
+            raise typer.Exit(1)
+        except SpecParseError as exc:
+            output.error(f"Cannot update spec {spec_id!r}: {exc}")
+            raise typer.Exit(1)
         if output.human_mode:
             output.success(f"{criterion_id} += {resolved_kind}:{ref}: {path}")
         else:
@@ -480,13 +477,29 @@ def register(parent: typer.Typer, get_container):
         """Add an open question to a spec."""
         from datetime import datetime, timezone
         from mship.core.spec_questions import add_question
+        from mship.core.spec_storage import SpecLocked
+        from mship.core.spec_store import SpecParseError
+
         output = Output()
         store = _spec_store()
-        spec = store.find_by_id(spec_id)
-        if spec is None:
-            output.error(f"No spec with id {spec_id!r}."); raise typer.Exit(1)
-        q = add_question(spec, text)
-        spec.updated_at = datetime.now(timezone.utc); store.save(spec)
+        try:
+            with store.locked(spec_id) as artifact:
+                if artifact is None:
+                    output.error(f"No spec with id {spec_id!r}.")
+                    raise typer.Exit(1)
+                spec = artifact.spec.model_copy(deep=True)
+                q = add_question(spec, text)
+                spec.updated_at = datetime.now(timezone.utc)
+                store.save_while_locked(spec, artifact)
+        except ValueError as exc:
+            output.error(str(exc))
+            raise typer.Exit(1)
+        except SpecLocked as exc:
+            output.error(f"Cannot update spec {spec_id!r}: {exc}")
+            raise typer.Exit(1)
+        except SpecParseError as exc:
+            output.error(f"Cannot update spec {spec_id!r}: {exc}")
+            raise typer.Exit(1)
         if output.human_mode:
             output.success(f"Added {q.id}: {text}")
         else:
@@ -497,16 +510,29 @@ def register(parent: typer.Typer, get_container):
         """Answer an open question (does not change status)."""
         from datetime import datetime, timezone
         from mship.core.spec_questions import answer_question
+        from mship.core.spec_storage import SpecLocked
+        from mship.core.spec_store import SpecParseError
+
         output = Output()
         store = _spec_store()
-        spec = store.find_by_id(spec_id)
-        if spec is None:
-            output.error(f"No spec with id {spec_id!r}."); raise typer.Exit(1)
         try:
-            answer_question(spec, q_id, answer_text)
-        except ValueError as e:
-            output.error(str(e)); raise typer.Exit(1)
-        spec.updated_at = datetime.now(timezone.utc); store.save(spec)
+            with store.locked(spec_id) as artifact:
+                if artifact is None:
+                    output.error(f"No spec with id {spec_id!r}.")
+                    raise typer.Exit(1)
+                spec = artifact.spec.model_copy(deep=True)
+                answer_question(spec, q_id, answer_text)
+                spec.updated_at = datetime.now(timezone.utc)
+                store.save_while_locked(spec, artifact)
+        except ValueError as exc:
+            output.error(str(exc))
+            raise typer.Exit(1)
+        except SpecLocked as exc:
+            output.error(f"Cannot update spec {spec_id!r}: {exc}")
+            raise typer.Exit(1)
+        except SpecParseError as exc:
+            output.error(f"Cannot update spec {spec_id!r}: {exc}")
+            raise typer.Exit(1)
         if output.human_mode:
             output.success(f"{q_id} answered.")
         else:

--- a/src/mship/cli/spec.py
+++ b/src/mship/cli/spec.py
@@ -152,6 +152,11 @@ def register(parent: typer.Typer, get_container):
         from_json: Optional[str] = typer.Option(None, "--from-json", help="Path to the draft JSON, or - for stdin."),
         from_file: Optional[str] = typer.Option(None, "--from-file", help="Path to a rendered spec markdown file, or - for stdin."),
         bypass_status_gate: bool = typer.Option(False, "--bypass-status-gate", help="Apply regardless of current status."),
+        discard_review: bool = typer.Option(
+            False,
+            "--discard-review",
+            help="Discard reviewed verdict state that applying would replace.",
+        ),
     ):
         """Ingest a drafted spec, render the body, set fields, advance to needs_review.
 
@@ -210,12 +215,45 @@ def register(parent: typer.Typer, get_container):
             output.error(f"No spec with id {spec_id!r}.")
             raise typer.Exit(1)
 
+        reviewed_unit_count = sum(
+            criterion.verdict != "unreviewed"
+            for criterion in spec.acceptance_criteria
+        ) + sum(
+            verdict.verdict != "unreviewed"
+            for verdict in spec.prose_verdicts.values()
+        )
+        if reviewed_unit_count:
+            planned_spec = spec.model_copy(deep=True)
+            apply_draft(planned_spec, draft)
+            discarded_review_count = reviewed_unit_count - (
+                sum(
+                    criterion.verdict != "unreviewed"
+                    for criterion in planned_spec.acceptance_criteria
+                ) + sum(
+                    verdict.verdict != "unreviewed"
+                    for verdict in planned_spec.prose_verdicts.values()
+                )
+            )
+        else:
+            discarded_review_count = 0
+        if discarded_review_count and not discard_review:
+            unit_noun = "unit" if discarded_review_count == 1 else "units"
+            output.error(
+                f"Cannot apply draft: review state for {discarded_review_count} review "
+                f"{unit_noun} would be discarded. "
+                "Re-run with --discard-review to continue."
+            )
+            raise typer.Exit(1)
+
         if not bypass_status_gate:
             try:
                 validate_transition(spec.status, "needs_review")
             except InvalidTransition as e:
                 output.error(f"{e}. Use --bypass-status-gate to override.")
                 raise typer.Exit(1)
+
+        # `apply_draft` drops verdicts whose source units changed while preserving
+        # evidence and review state on unchanged acceptance criteria.
 
         # MOS-215/MOS-240: applying a (re)drafted spec supersedes any pending
         # request-changes, so clear the reason — a freshly applied draft carries
@@ -232,9 +270,20 @@ def register(parent: typer.Typer, get_container):
             container.state_manager().record_activity(spec.task_slug)
 
         if output.human_mode:
-            output.success(f"Applied draft → {spec.status}: {path}")
+            if discarded_review_count:
+                unit_noun = "unit" if discarded_review_count == 1 else "units"
+                output.success(
+                    f"Applied draft → {spec.status}; review state was discarded for "
+                    f"{discarded_review_count} review {unit_noun}: {path}"
+                )
+            else:
+                output.success(f"Applied draft → {spec.status}: {path}")
         else:
-            output.json({"id": spec.id, "status": spec.status, "path": str(path)})
+            payload = {"id": spec.id, "status": spec.status, "path": str(path)}
+            if discarded_review_count:
+                payload["review_state_discarded"] = True
+                payload["discarded_review_count"] = discarded_review_count
+            output.json(payload)
 
     @spec_app.command("review")
     def review(

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1731,16 +1731,20 @@ def register(app: typer.Typer, get_container):
                 _al_commits.extend(
                     commits_since_base(shell, _al_path, _al_base, task.branch)
                 )
-            _al_links = compute_evidence_links(
-                bound_spec, _al_commits, passing_test_run_refs(task),
-            )
-            if _al_links:
-                for _al_link in _al_links:
-                    set_criterion_evidence(
-                        bound_spec, _al_link.criterion_id, _al_link.kind, _al_link.ref,
+            _al_store = SpecStore(workspace_root / SPECS_DIRNAME)
+            with _al_store.locked(bound_spec.id) as _al_artifact:
+                if _al_artifact is not None:
+                    bound_spec = _al_artifact.spec
+                    _al_links = compute_evidence_links(
+                        bound_spec, _al_commits, passing_test_run_refs(task),
                     )
-                bound_spec.updated_at = _dt_al.now(_tz_al.utc)
-                SpecStore(workspace_root / SPECS_DIRNAME).save(bound_spec)
+                    if _al_links:
+                        for _al_link in _al_links:
+                            set_criterion_evidence(
+                                bound_spec, _al_link.criterion_id, _al_link.kind, _al_link.ref,
+                            )
+                        bound_spec.updated_at = _dt_al.now(_tz_al.utc)
+                        _al_store.save_while_locked(bound_spec, _al_artifact)
 
         # The acceptance-criteria PR-body section is rendered PER REPO, because
         # under `published` evidence storage rendering it also publishes the

--- a/src/mship/core/evidence_store.py
+++ b/src/mship/core/evidence_store.py
@@ -252,6 +252,9 @@ def resolve_ref(workspace_root: Path, spec_id: str, ref: str) -> Path:
     if Path(_logical_ref(ref)).suffix.lower() not in CONTENT_TYPES:
         raise BadEvidenceRef(f"unsupported evidence extension in {ref!r}")
 
+    if "\0" in spec_id:
+        raise BadEvidenceRef(f"malformed spec id {spec_id!r}")
+
     store_root = Path(os.path.realpath(evidence_root(workspace_root)))
     root = Path(os.path.realpath(evidence_dir(workspace_root, spec_id)))
     # realpath normalises `..` away, so a spec id like `../other-spec` lands

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -79,6 +79,7 @@ class DraftIntentBody(BaseModel):
 class ApplyDraftBody(BaseModel):
     draft: SpecDraft
     bypass_status_gate: bool = False
+    discard_review: bool = False
 
 
 class QuestionBody(BaseModel):
@@ -1012,6 +1013,7 @@ def create_app(
             raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
         return spec
 
+
     def _save_and_review(spec):
         from mship.core.spec_storage import SpecLocked
 
@@ -1020,6 +1022,28 @@ def create_app(
             store.save(spec)
         except SpecLocked:
             raise HTTPException(status_code=409, detail=f"spec {spec.id!r} is locked")
+        except SpecParseError as exc:
+            _raise_spec_conflict(exc)
+        return build_review(spec)
+
+    def _mutate_review(spec_id: str, mutate, *, auto_approve: bool = False):
+        """Load, mutate, and persist one review write under the spec's lock."""
+        try:
+            store._validate_id(spec_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
+        try:
+            with store.locked(spec_id) as artifact:
+                if artifact is None:
+                    raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
+                spec = artifact.spec
+                mutate(spec)
+                if auto_approve:
+                    _auto_approve_if_ready(spec)
+                spec.updated_at = datetime.now(timezone.utc)
+                store.save_while_locked(spec, artifact)
+        except SpecLocked:
+            raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
         except SpecParseError as exc:
             _raise_spec_conflict(exc)
         return build_review(spec)
@@ -1044,49 +1068,57 @@ def create_app(
 
     @app.post("/specs/{spec_id}/verdict")
     def post_verdict(spec_id: str, body: VerdictBody):
-        spec = _load_or_404(spec_id)
         try:
-            set_criterion_verdict(spec, body.criterion_id, body.verdict, body.comment)
+            return _mutate_review(
+                spec_id,
+                lambda spec: set_criterion_verdict(
+                    spec, body.criterion_id, body.verdict, body.comment,
+                ),
+                auto_approve=True,
+            )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
-        _auto_approve_if_ready(spec)
-        return _save_and_review(spec)
 
     @app.post("/specs/{spec_id}/prose-verdict")
     def post_prose_verdict(spec_id: str, body: ProseVerdictBody):
-        spec = _load_or_404(spec_id)
         try:
-            set_prose_verdict(spec, body.section_id, body.verdict, body.comment)
+            return _mutate_review(
+                spec_id,
+                lambda spec: set_prose_verdict(
+                    spec, body.section_id, body.verdict, body.comment,
+                ),
+                auto_approve=True,
+            )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
-        _auto_approve_if_ready(spec)
-        return _save_and_review(spec)
 
     @app.post("/specs/{spec_id}/evidence")
     def post_evidence(spec_id: str, body: EvidenceBody):
-        spec = _load_or_404(spec_id)
         kind = body.kind or infer_evidence_kind(body.ref)
         try:
-            set_criterion_evidence(spec, body.criterion_id, kind, body.ref, body.note)
+            return _mutate_review(
+                spec_id,
+                lambda spec: set_criterion_evidence(
+                    spec, body.criterion_id, kind, body.ref, body.note,
+                ),
+            )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
-        return _save_and_review(spec)
 
     @app.post("/specs/{spec_id}/questions")
     def post_question(spec_id: str, body: QuestionBody):
-        spec = _load_or_404(spec_id)
-        add_question(spec, body.text)
-        return _save_and_review(spec)
+        return _mutate_review(spec_id, lambda spec: add_question(spec, body.text))
 
     @app.post("/specs/{spec_id}/questions/{qid}/answer")
     def post_answer(spec_id: str, qid: str, body: AnswerBody):
-        spec = _load_or_404(spec_id)
         try:
-            answer_question(spec, qid, body.answer)
+            return _mutate_review(
+                spec_id,
+                lambda spec: answer_question(spec, qid, body.answer),
+                auto_approve=True,
+            )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
-        _auto_approve_if_ready(spec)
-        return _save_and_review(spec)
 
     # InvalidTransition/validate_transition stay imported here for the archive +
     # apply endpoints below; the explicit approve/request-changes transitions now
@@ -1165,7 +1197,10 @@ def create_app(
 
     # --- capture-write endpoints (B3): the phone Capture path over HTTP ---
 
-    from mship.core.spec_draft import apply_draft, build_draft_prompt, new_spec
+    from mship.core.spec_draft import (
+        MissingSpec, ReviewDiscardRequired, apply_draft_transaction,
+        build_draft_prompt, new_spec,
+    )
 
     @app.post("/specs")
     def post_create_spec(body: NewSpecBody):
@@ -1198,28 +1233,34 @@ def create_app(
 
     @app.post("/specs/{spec_id}/apply")
     def post_apply(spec_id: str, body: ApplyDraftBody):
-        from mship.core.spec_storage import SpecLocked
-
-        spec = _load_or_404(spec_id)
-        if not body.bypass_status_gate:
-            try:
-                validate_transition(spec.status, "needs_review")
-            except InvalidTransition as e:
-                raise HTTPException(status_code=409, detail=str(e))
-        # MOS-215/MOS-240: applying a (re)drafted spec supersedes any pending
-        # request-changes, so clear the reason — a freshly applied draft carries
-        # no outstanding clarification ask. (A brand-new draft has none anyway.)
-        apply_draft(spec, body.draft)
-        spec.status = "needs_review"
-        spec.clarification_reason = None
-        spec.updated_at = datetime.now(timezone.utc)
         try:
-            store.save(spec)
+            store._validate_id(spec_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
+
+        try:
+            result = apply_draft_transaction(
+                store,
+                spec_id,
+                body.draft,
+                bypass_status_gate=body.bypass_status_gate,
+                discard_review=body.discard_review,
+            )
+        except ReviewDiscardRequired as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+        except InvalidTransition as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
         except SpecLocked:
-            raise HTTPException(status_code=409, detail=f"spec {spec.id!r} is locked")
+            raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
         except SpecParseError as exc:
             _raise_spec_conflict(exc)
-        return spec.model_dump(mode="json")
+        if isinstance(result, MissingSpec):
+            raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
+        return {
+            **result.spec.model_dump(mode="json"),
+            "review_state_discarded": bool(result.discarded_review_count),
+            "discarded_review_count": result.discarded_review_count,
+        }
 
     @app.post("/capture")
     def post_capture(body: CaptureBody):

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1014,16 +1014,25 @@ def create_app(
         return spec
 
 
-    def _save_and_review(spec):
+    def _archive_and_review(spec_id: str):
+        """Transition to archived from the current artifact under its spec lock."""
         from mship.core.spec_storage import SpecLocked
 
-        spec.updated_at = datetime.now(timezone.utc)
         try:
-            store.save(spec)
+            with store.locked(spec_id) as artifact:
+                if artifact is None:
+                    raise HTTPException(status_code=404, detail=f"no spec {spec_id!r}")
+                spec = artifact.spec
+                validate_transition(spec.status, "archived")
+                spec.status = "archived"
+                spec.updated_at = datetime.now(timezone.utc)
+                store.save_while_locked(spec, artifact)
         except SpecLocked:
-            raise HTTPException(status_code=409, detail=f"spec {spec.id!r} is locked")
+            raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
         except SpecParseError as exc:
             _raise_spec_conflict(exc)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
         return build_review(spec)
 
     def _mutate_review(spec_id: str, mutate, *, auto_approve: bool = False):
@@ -1136,7 +1145,7 @@ def create_app(
             # success, not a spurious approved->approved 409.
             return build_review(spec)
         try:
-            approve_spec(spec, store, bypass_gate=body.bypass_gate)
+            spec = approve_spec(spec, store, bypass_gate=body.bypass_gate)
         except ApprovalBlocked as e:
             raise HTTPException(status_code=409, detail="cannot approve: " + "; ".join(e.blockers))
         except InvalidTransition as e:
@@ -1145,37 +1154,29 @@ def create_app(
             raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
         except SpecParseError as exc:
             _raise_spec_conflict(exc)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
         return build_review(spec)
 
     @app.post("/specs/{spec_id}/request-changes")
     def post_request_changes(spec_id: str, body: ReasonBody):
         spec = _load_or_404(spec_id)
-        # #447 review: every durable rejection record must carry real reason
-        # text — reject empty/whitespace before anything is written.
+        # Every durable rejection record must carry real reason text; reject it
+        # before the shared locked transition performs any write.
         if not body.reason or not body.reason.strip():
             raise HTTPException(status_code=400, detail="reason must not be empty")
-        # MOS-240: request-changes sends the spec back to the editable `draft`
-        # status carrying a non-null clarification_reason (the dropped
-        # needs_clarification status is now expressed by that field alone).
         try:
-            validate_transition(spec.status, "draft")
-        except InvalidTransition as e:
-            raise HTTPException(status_code=409, detail=str(e))
-        # #458 P1 class fix: the durable rejection record is now written
-        # inside `request_changes_spec` itself (record-then-transition,
-        # fail-loud on a write failure), so every caller — CLI, serve, and
-        # the TUI views — gets it automatically instead of each remembering
-        # its own `record_rejection` call. This also supersedes the old
-        # decorative "spec request-changes (api): …" log line — the
-        # structured record is the parsed source now.
-        try:
-            request_changes_spec(
+            spec = request_changes_spec(
                 spec, store, body.reason, log_manager=log_manager, actor="operator",
             )
+        except InvalidTransition as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except SpecLocked:
             raise HTTPException(status_code=409, detail=f"spec {spec_id!r} is locked")
         except SpecParseError as exc:
             _raise_spec_conflict(exc)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
         return build_review(spec)
 
     @app.post("/specs/{spec_id}/archive")
@@ -1185,15 +1186,12 @@ def create_app(
         already-archived spec is rejected (409).
 
         Finding 4: returns the same fuller review payload as approve/request-changes
-        (via `_save_and_review`) rather than a bare `{id,status}`, so a client cache
-        isn't degraded on the round-trip."""
-        spec = _load_or_404(spec_id)
+        rather than a bare `{id,status}`, so a client cache isn't degraded on the
+        round-trip."""
         try:
-            validate_transition(spec.status, "archived")
+            return _archive_and_review(spec_id)
         except InvalidTransition as e:
             raise HTTPException(status_code=409, detail=str(e))
-        spec.status = "archived"
-        return _save_and_review(spec)
 
     # --- capture-write endpoints (B3): the phone Capture path over HTTP ---
 

--- a/src/mship/core/spec_dispatch.py
+++ b/src/mship/core/spec_dispatch.py
@@ -135,6 +135,39 @@ def dispatch_spec(
     workspace_root: Path | None = None,
     docs_dir: str = "docs",
 ) -> DispatchResult:
+    """Dispatch the current spec without saving a pre-lock snapshot."""
+    with store.locked(spec.id) as artifact:
+        if artifact is None:
+            raise DispatchError(f"spec {spec.id!r} no longer exists")
+        return _dispatch_current(
+            artifact.spec,
+            state_manager=state_manager,
+            store=store,
+            artifact=artifact,
+            spawn_fn=spawn_fn,
+            now=now,
+            workitems=workitems,
+            workspace=workspace,
+            task_slug=task_slug,
+            workspace_root=workspace_root,
+            docs_dir=docs_dir,
+        )
+
+
+def _dispatch_current(
+    spec: Spec,
+    *,
+    state_manager,
+    store,
+    artifact,
+    spawn_fn: Callable[[Spec], Task],
+    now: datetime,
+    workitems,
+    workspace: str,
+    task_slug: str | None = None,
+    workspace_root: Path | None = None,
+    docs_dir: str = "docs",
+) -> DispatchResult:
     """Bind an approved (or already-dispatched) spec to a task.
 
     Task selection, in order:
@@ -229,7 +262,7 @@ def dispatch_spec(
     spec.status = "dispatched"
     spec.task_slug = chosen_slug
     spec.updated_at = now
-    store.save(spec)
+    store.save_while_locked(spec, artifact)
 
     # Point the handoff at the task's implementation plan when one resolves (the
     # WorkItem's linked `plan_path` wins, else the docs/plans convention) so the

--- a/src/mship/core/spec_draft.py
+++ b/src/mship/core/spec_draft.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
 
-from mship.core.spec import AcceptanceCriterion, BodySection, OpenQuestion, Spec, SpecDraft
+from mship.core.spec import (
+    AcceptanceCriterion, BodySection, OpenQuestion, Spec, SpecDraft, validate_transition,
+)
 from mship.core.spec_body import parse_body_sections, render_body
+from mship.core.spec_store import SpecStore
 from mship.util.slug import slugify
 
 
@@ -89,6 +94,84 @@ or pipe it directly:
 
     cat draft.json | mship spec apply {spec_id} --from-json -
 """
+
+
+@dataclass(frozen=True)
+class MissingSpec:
+    """The requested spec id had no current artifact to apply."""
+
+    spec_id: str
+
+
+class ReviewDiscardRequired(Exception):
+    """Applying would remove protected review metadata without authorization."""
+
+    def __init__(self, discarded_review_count: int) -> None:
+        self.discarded_review_count = discarded_review_count
+        unit_noun = "unit" if discarded_review_count == 1 else "units"
+        super().__init__(
+            f"Cannot apply draft: review state for {discarded_review_count} review "
+            f"{unit_noun} would be discarded. Re-run with --discard-review to continue."
+        )
+
+
+@dataclass(frozen=True)
+class ApplyDraftResult:
+    spec: Spec
+    path: Path
+    discarded_review_count: int
+
+
+def _protected_review_unit_count(spec: Spec) -> int:
+    return (
+        sum(
+            criterion.verdict != "unreviewed"
+            or bool(criterion.comment)
+            or bool(criterion.evidence)
+            for criterion in spec.acceptance_criteria
+        )
+        + sum(
+            verdict.verdict != "unreviewed" or bool(verdict.comment)
+            for verdict in spec.prose_verdicts.values()
+        )
+        + sum(question.answer is not None for question in spec.open_questions)
+    )
+
+
+def apply_draft_transaction(
+    store: SpecStore,
+    spec_id: str,
+    draft: SpecDraft,
+    *,
+    bypass_status_gate: bool = False,
+    discard_review: bool = False,
+    now: datetime | None = None,
+) -> ApplyDraftResult | MissingSpec:
+    """Atomically apply a draft and persist its lifecycle transition."""
+    with store.locked(spec_id) as artifact:
+        if artifact is None:
+            return MissingSpec(spec_id=spec_id)
+
+        applied = artifact.spec.model_copy(deep=True)
+        apply_draft(applied, draft)
+        discarded_review_count = (
+            _protected_review_unit_count(artifact.spec)
+            - _protected_review_unit_count(applied)
+        )
+        if discarded_review_count and not discard_review:
+            raise ReviewDiscardRequired(discarded_review_count)
+        if not bypass_status_gate:
+            validate_transition(applied.status, "needs_review")
+
+        applied.status = "needs_review"
+        applied.clarification_reason = None
+        applied.updated_at = now or datetime.now(timezone.utc)
+        path = store.save_while_locked(applied, artifact)
+        return ApplyDraftResult(
+            spec=applied,
+            path=path,
+            discarded_review_count=discarded_review_count,
+        )
 
 
 def apply_draft(spec: Spec, draft: SpecDraft) -> Spec:
@@ -176,14 +259,35 @@ def apply_draft(spec: Spec, draft: SpecDraft) -> Spec:
         if prior is not None:
             new_acs.append(AcceptanceCriterion(
                 id=ac_id, text=t, verdict=prior.verdict,
-                evidence=list(prior.evidence),
+                evidence=list(prior.evidence), comment=prior.comment,
             ))
         else:
             new_acs.append(AcceptanceCriterion(id=ac_id, text=t))
     spec.acceptance_criteria = new_acs
+
+    prior_questions = list(spec.open_questions)
+    consumed_questions = [False] * len(prior_questions)
+    matched_questions: list[OpenQuestion | None] = [None] * len(draft.open_questions)
+    for i, text in enumerate(draft.open_questions):
+        question_id = f"q{i + 1}"
+        for j, prior in enumerate(prior_questions):
+            if not consumed_questions[j] and prior.id == question_id and prior.text == text:
+                matched_questions[i], consumed_questions[j] = prior, True
+                break
+    for i, text in enumerate(draft.open_questions):
+        if matched_questions[i] is not None:
+            continue
+        for j, prior in enumerate(prior_questions):
+            if not consumed_questions[j] and prior.text == text:
+                matched_questions[i], consumed_questions[j] = prior, True
+                break
     spec.open_questions = [
-        OpenQuestion(id=f"q{i + 1}", text=t)
-        for i, t in enumerate(draft.open_questions)
+        OpenQuestion(
+            id=f"q{i + 1}",
+            text=text,
+            answer=prior.answer if prior is not None else None,
+        )
+        for i, (text, prior) in enumerate(zip(draft.open_questions, matched_questions))
     ]
     return spec
 

--- a/src/mship/core/spec_lifecycle.py
+++ b/src/mship/core/spec_lifecycle.py
@@ -36,10 +36,10 @@ def advance_spec_on_close(
     from mship.core.spec_store import SpecStore
 
     store = SpecStore(specs_dir)
-    spec = store.read_strict(task.spec_id)
-    if spec is None or spec.status != "dispatched":
-        return
-
-    spec.status = "implemented"
-    spec.updated_at = datetime.now(timezone.utc)
-    store.save(spec)
+    with store.locked(task.spec_id) as artifact:
+        if artifact is None or artifact.spec.status != "dispatched":
+            return
+        spec = artifact.spec
+        spec.status = "implemented"
+        spec.updated_at = datetime.now(timezone.utc)
+        store.save_while_locked(spec, artifact)

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -275,12 +275,18 @@ class SpecStore:
         """Write the configured representation while ``locked(spec.id)`` is held."""
         return self._storage.write(self.path_for(spec), serialize_spec(spec))
 
+    def save_while_locked(
+        self, spec: Spec, artifact: ResolvedSpecArtifact | None,
+    ) -> Path:
+        """Persist while ``locked(spec.id)`` is held, preserving durable inbox data."""
+        if artifact is not None:
+            spec.inbox = artifact.spec.inbox
+        return self._save_unlocked(spec, artifact)
+
     def save(self, spec: Spec) -> Path:
         """Persist lifecycle changes without clobbering durable inbox metadata."""
         with self.locked(spec.id) as artifact:
-            if artifact is not None:
-                spec.inbox = artifact.spec.inbox
-            return self._save_unlocked(spec, artifact)
+            return self.save_while_locked(spec, artifact)
 
     def create_if_absent(self, spec: Spec) -> Path | None:
         """Atomically create a spec and return its actual physical path."""

--- a/src/mship/core/spec_store.py
+++ b/src/mship/core/spec_store.py
@@ -117,7 +117,7 @@ class SpecStore:
         return self._storage.workspace_root
 
     def _validate_id(self, spec_id: str) -> None:
-        if (not spec_id or "/" in spec_id or "\\" in spec_id
+        if (not spec_id or "\x00" in spec_id or "/" in spec_id or "\\" in spec_id
                 or spec_id in (".", "..") or spec_id.startswith(".")):
             raise ValueError(f"unsafe spec id for filename: {spec_id!r}")
 

--- a/src/mship/core/spec_transition.py
+++ b/src/mship/core/spec_transition.py
@@ -2,9 +2,9 @@
 (core/serve.py), the CLI (cli/spec.py), and the views (core/view/actions.py).
 
 Extracted so the terminal and the phone cannot diverge: every writer performs the
-identical guard (approval_blockers + validate_transition) and the identical atomic
-store write (SpecStore.save = tempfile + os.replace). Callers own only their own
-concerns (HTTP status mapping, CLI output, journal appends, view messaging)."""
+identical guard and reloads, mutates, and persists under the same per-spec lock
+as draft apply. Callers own only their own concerns (HTTP status mapping, CLI
+output, and view messaging)."""
 from __future__ import annotations
 
 import json
@@ -32,17 +32,22 @@ class ApprovalBlocked(Exception):
         self.blockers = list(blockers)
 
 
-def approve_spec(spec: Spec, store: SpecStore, *, bypass_gate: bool = False) -> None:
-    """needs_review -> approved. Raises ApprovalBlocked (gate) or InvalidTransition."""
-    if not bypass_gate:
-        blockers = approval_blockers(spec)
-        if blockers:
-            raise ApprovalBlocked(blockers)
-    validate_transition(spec.status, "approved")
-    spec.status = "approved"
-    spec.clarification_reason = None
-    spec.updated_at = datetime.now(timezone.utc)
-    store.save(spec)
+def approve_spec(spec: Spec, store: SpecStore, *, bypass_gate: bool = False) -> Spec:
+    """Approve the current revision under the same lock as draft apply."""
+    with store.locked(spec.id) as artifact:
+        if artifact is None:
+            raise ValueError(f"No spec with id {spec.id!r}.")
+        current = artifact.spec
+        if not bypass_gate:
+            blockers = approval_blockers(current)
+            if blockers:
+                raise ApprovalBlocked(blockers)
+        validate_transition(current.status, "approved")
+        current.status = "approved"
+        current.clarification_reason = None
+        current.updated_at = datetime.now(timezone.utc)
+        store.save_while_locked(current, artifact)
+        return current
 
 
 def record_rejection(
@@ -83,26 +88,25 @@ def request_changes_spec(
     log_manager: LogManager | None,
     actor: str,
     now: datetime | None = None,
-) -> None:
-    """needs_review/approved -> draft carrying `reason`. Raises InvalidTransition.
+) -> Spec:
+    """Return the current spec to draft under the same lock as draft apply.
 
-    Writes the durable rejection record itself (record_rejection), in this
-    order: reject empty/whitespace reason -> validate_transition -> durable
-    record -> status flip -> save. Folding the record into the shared
-    transition (rather than leaving it to each caller) is the class fix for
-    #458 P1: the CLI, serve, and the TUI views (core/view/actions.py) all
-    call this one function, so none of them can transition a spec without
-    also logging why — the earlier per-caller convention let the view path
-    (`mship view queue/spec/workitem`) silently skip it.
+    The durable rejection record is appended before the in-lock status write, so
+    an append failure leaves the persisted spec unchanged.
     """
     if not reason or not reason.strip():
         raise ValueError("reason must not be empty")
-    validate_transition(spec.status, "draft")
     if now is None:
         now = datetime.now(timezone.utc)
-    if log_manager is not None:
-        record_rejection(log_manager, spec.id, actor, reason, now)
-    spec.status = "draft"
-    spec.clarification_reason = reason
-    spec.updated_at = now
-    store.save(spec)
+    with store.locked(spec.id) as artifact:
+        if artifact is None:
+            raise ValueError(f"No spec with id {spec.id!r}.")
+        current = artifact.spec
+        validate_transition(current.status, "draft")
+        if log_manager is not None:
+            record_rejection(log_manager, current.id, actor, reason, now)
+        current.status = "draft"
+        current.clarification_reason = reason
+        current.updated_at = now
+        store.save_while_locked(current, artifact)
+        return current

--- a/src/mship/core/view/actions.py
+++ b/src/mship/core/view/actions.py
@@ -40,6 +40,8 @@ def approve_spec_by_id(store: SpecStore, spec_id: str | None) -> ActionOutcome:
         return ActionOutcome(False, f"Cannot approve {spec_id}: {'; '.join(e.blockers)}")
     except InvalidTransition as e:
         return ActionOutcome(False, str(e))
+    except ValueError as e:
+        return ActionOutcome(False, str(e))
     return ActionOutcome(True, f"Approved {spec_id}.", new_status="approved")
 
 

--- a/src/mship/core/workitem_lifecycle.py
+++ b/src/mship/core/workitem_lifecycle.py
@@ -81,16 +81,18 @@ def advance_workitem_on_close(
         from mship.core.spec_store import SpecStore
 
         sstore = SpecStore(specs_dir)
-        spec = sstore.read_strict(item.spec_id)
-        if spec is not None and spec.status in ("approved", "dispatched"):
+        with sstore.locked(item.spec_id) as artifact:
+            if artifact is None or artifact.spec.status not in ("approved", "dispatched"):
+                return
+            spec = artifact.spec
             now = datetime.now(timezone.utc)
             spec.status = "implemented"
             spec.updated_at = now
-            sstore.save(spec)
-            # Bubble the freshly-done WorkItem to the top of list()'s updated_at-desc
-            # view too (mirrors the spec-less phase_override bump below). The override
-            # stays None — the spec drives `done`; this only refreshes updated_at.
-            store.set_phase_override(wid, None, now=now)
+            sstore.save_while_locked(spec, artifact)
+        # Bubble the freshly-done WorkItem to the top of list()'s updated_at-desc
+        # view too (mirrors the spec-less phase_override bump below). The override
+        # stays None — the spec drives `done`; this only refreshes updated_at.
+        store.set_phase_override(wid, None, now=now)
         return
 
     # Spec-less: stamp done directly. The updated_at bump (mirrors

--- a/src/mship/core/workitem_migrate.py
+++ b/src/mship/core/workitem_migrate.py
@@ -19,21 +19,23 @@ def wrap_existing(items: WorkItemStore, specs: SpecStore, state: StateManager,
     task_by_slug = dict(state_now.tasks)
 
     # 1) Specs -> feature items (carrying their linked task).
-    for spec in specs.list():
-        if spec.work_item_id:
-            continue
-        wi = items.create(title=spec.title, kind="feature", workspace=workspace, now=now)
-        created.append(wi.id)
-        items.link_spec(wi.id, spec.id, now=now)
-        spec.work_item_id = wi.id
-        specs.save(spec)
-        if spec.task_slug and spec.task_slug in task_by_slug:
-            items.add_task(wi.id, spec.task_slug, now=now)
+    for candidate in specs.list():
+        with specs.locked(candidate.id) as artifact:
+            if artifact is None or artifact.spec.work_item_id:
+                continue
+            spec = artifact.spec
+            wi = items.create(title=spec.title, kind="feature", workspace=workspace, now=now)
+            created.append(wi.id)
+            items.link_spec(wi.id, spec.id, now=now)
+            spec.work_item_id = wi.id
+            specs.save_while_locked(spec, artifact)
+            if spec.task_slug and spec.task_slug in task_by_slug:
+                items.add_task(wi.id, spec.task_slug, now=now)
 
-            def _set(s, _slug=spec.task_slug, _wid=wi.id):
-                if _slug in s.tasks:
-                    s.tasks[_slug].work_item_id = _wid
-            state.mutate(_set)
+                def _set(s, _slug=spec.task_slug, _wid=wi.id):
+                    if _slug in s.tasks:
+                        s.tasks[_slug].work_item_id = _wid
+                state.mutate(_set)
 
     # 2) Orphan tasks (no work_item_id yet) -> attach to an existing item, or
     # else get a feature/chore item of their own. A task's spec_id (or a

--- a/tests/cli/test_capture_evidence.py
+++ b/tests/cli/test_capture_evidence.py
@@ -10,8 +10,10 @@ capture into a bad exit code.
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import Event, Thread, current_thread
 
 import pytest
 from typer.testing import CliRunner
@@ -185,3 +187,70 @@ def test_malformed_evidence_target_is_actionable(workspace_with_spec: Path):
     assert "could not attach evidence" in result.output
     assert "<spec-id>:<criterion-id>" in result.output
     assert _criterion(workspace_with_spec).evidence == []
+
+def test_capture_evidence_does_not_restore_stale_spec_after_apply(
+    workspace_with_spec: Path, monkeypatch,
+):
+    """A capture that starts before apply must not save its pre-apply snapshot."""
+    from mship.core.spec_draft import SpecDraft, apply_draft_transaction
+
+    apply_started = Event()
+    capture_locked = Event()
+    apply_result: dict[str, object] = {}
+    original_locked = SpecStore.locked
+
+    @contextmanager
+    def record_capture_lock(self, spec_id):
+        if current_thread().name == "MainThread":
+            capture_locked.set()
+        with original_locked(self, spec_id) as artifact:
+            yield artifact
+
+    def apply_replacement() -> None:
+        apply_started.set()
+        try:
+            apply_draft_transaction(
+                SpecStore(workspace_with_spec / "specs"),
+                "dq",
+                SpecDraft(
+                    problem="New problem",
+                    user_story="New story",
+                    approach="New approach",
+                    acceptance_criteria=["replacement criterion"],
+                ),
+                bypass_status_gate=True,
+                discard_review=True,
+            )
+        except BaseException as exc:
+            apply_result["error"] = exc
+
+    def start_apply(*_args, **_kwargs) -> str:
+        thread = Thread(target=apply_replacement)
+        apply_result["thread"] = thread
+        thread.start()
+        assert apply_started.wait(timeout=5)
+        # Before the lock fix this blocks until apply has persisted the
+        # replacement, forcing the stale capture save to run afterward. With
+        # the fix capture already holds the lock, so let it release it instead.
+        if not capture_locked.is_set():
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+        return "capture.png"
+
+    monkeypatch.setattr(SpecStore, "locked", record_capture_lock)
+    monkeypatch.setattr("mship.core.evidence_store.store_artifact", start_apply)
+    result = runner.invoke(
+        app, ["capture", "--task", "t", "--repo", "app", "--evidence", "dq:ac1"]
+    )
+    assert result.exit_code == 0, result.output
+    assert capture_locked.is_set()
+    thread = apply_result["thread"]
+    assert isinstance(thread, Thread)
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert "error" not in apply_result
+
+    persisted = SpecStore(workspace_with_spec / "specs").find_by_id("dq")
+    assert persisted is not None
+    assert persisted.acceptance_criteria[0].text == "replacement criterion"
+    assert "New approach" in persisted.body

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -331,13 +331,32 @@ def test_spec_draft_unknown_id_errors(configured_app_with_task: Path):
 import json as _json
 
 
-def _draft_json() -> str:
+def _draft_json(acceptance_criteria: list[str] | None = None) -> str:
     return _json.dumps({
         "problem": "P", "user_story": "U", "approach": "A",
-        "acceptance_criteria": ["view questions"], "open_questions": ["Android?"],
-        "non_goals": ["chat"], "risks": [], "affected_repos": ["mothership"],
+        "acceptance_criteria": acceptance_criteria or ["view questions"],
+        "open_questions": ["Android?"], "non_goals": ["chat"], "risks": [],
+        "affected_repos": ["mothership"],
     })
 
+
+def _apply_reviewed_spec(workspace: Path, tmp_path: Path) -> Path:
+    runner.invoke(app, ["spec", "new", "--task", "add-labels"])
+    draft = tmp_path / "draft.json"
+    draft.write_text(_draft_json(["view questions", "sync status"]))
+    assert runner.invoke(
+        app, ["spec", "apply", "add-labels", "--from-json", str(draft)],
+    ).exit_code == 0
+    assert runner.invoke(
+        app, ["spec", "verdict", "add-labels", "ac1", "approved"],
+    ).exit_code == 0
+    assert runner.invoke(
+        app, ["spec", "verdict", "add-labels", "ac2", "flagged"],
+    ).exit_code == 0
+    store = _store(workspace)
+    spec = store.find_by_id("add-labels")
+    assert spec is not None
+    return store.path_for(spec)
 
 def test_spec_apply_merges_and_advances_status(configured_app_with_task: Path, tmp_path):
     runner.invoke(app, ["spec", "new", "--title", "Decision queue", "--id", "dq"])
@@ -368,6 +387,174 @@ def test_spec_apply_refuses_wrong_status(configured_app_with_task: Path, tmp_pat
     forced = runner.invoke(app, ["spec", "apply", "dq", "--from-json", str(jf), "--bypass-status-gate"])
     assert forced.exit_code == 0, forced.output
 
+
+def test_spec_apply_refuses_reviewed_spec_without_discarding_review(
+    configured_app_with_task: Path, tmp_path: Path,
+):
+    artifact = _apply_reviewed_spec(configured_app_with_task, tmp_path)
+    before = artifact.read_bytes()
+    activity_before = StateManager(
+        configured_app_with_task / ".mothership",
+    ).load().tasks["add-labels"].last_activity_at
+    replacement = tmp_path / "replacement.json"
+    replacement.write_text(_draft_json(["new criterion"]))
+
+    ordinary = runner.invoke(
+        app, ["spec", "apply", "add-labels", "--from-json", str(replacement)],
+    )
+    assert ordinary.exit_code != 0
+    assert "2 review units" in ordinary.output
+    assert "discard-review" in ordinary.output
+    assert artifact.read_bytes() == before
+    assert StateManager(
+        configured_app_with_task / ".mothership",
+    ).load().tasks["add-labels"].last_activity_at == activity_before
+
+    bypassed = runner.invoke(
+        app,
+        [
+            "spec", "apply", "add-labels", "--from-json", str(replacement),
+            "--bypass-status-gate",
+        ],
+    )
+    assert bypassed.exit_code != 0
+    assert "2 review units" in bypassed.output
+    assert "discard-review" in bypassed.output
+    assert artifact.read_bytes() == before
+    assert StateManager(
+        configured_app_with_task / ".mothership",
+    ).load().tasks["add-labels"].last_activity_at == activity_before
+
+
+def test_spec_apply_refuses_reviewed_prose_without_discarding_review(
+    configured_app_with_task: Path, tmp_path: Path,
+):
+    runner.invoke(app, ["spec", "new", "--task", "add-labels"])
+    initial = tmp_path / "initial.json"
+    initial.write_text(_draft_json())
+    assert runner.invoke(
+        app, ["spec", "apply", "add-labels", "--from-json", str(initial)],
+    ).exit_code == 0
+    assert runner.invoke(
+        app, ["spec", "verdict", "add-labels", "problem", "approved"],
+    ).exit_code == 0
+    store = _store(configured_app_with_task)
+    spec = store.find_by_id("add-labels")
+    assert spec is not None
+    assert [criterion.verdict for criterion in spec.acceptance_criteria] == ["unreviewed"]
+    artifact = store.path_for(spec)
+    before = artifact.read_bytes()
+    activity_before = StateManager(
+        configured_app_with_task / ".mothership",
+    ).load().tasks["add-labels"].last_activity_at
+    replacement = tmp_path / "replacement.json"
+    replacement.write_text(_json.dumps({
+        **_json.loads(_draft_json()),
+        "problem": "Replacement problem",
+    }))
+
+    ordinary = runner.invoke(
+        app, ["spec", "apply", "add-labels", "--from-json", str(replacement)],
+    )
+    assert ordinary.exit_code != 0
+    assert "1 review unit" in ordinary.output
+    assert "discard-review" in ordinary.output
+    assert artifact.read_bytes() == before
+    assert StateManager(
+        configured_app_with_task / ".mothership",
+    ).load().tasks["add-labels"].last_activity_at == activity_before
+
+    bypassed = runner.invoke(
+        app,
+        [
+            "spec", "apply", "add-labels", "--from-json", str(replacement),
+            "--bypass-status-gate",
+        ],
+    )
+    assert bypassed.exit_code != 0
+    assert "1 review unit" in bypassed.output
+    assert "discard-review" in bypassed.output
+    assert artifact.read_bytes() == before
+    assert StateManager(
+        configured_app_with_task / ".mothership",
+    ).load().tasks["add-labels"].last_activity_at == activity_before
+
+    discarded = runner.invoke(
+        app,
+        [
+            "spec", "apply", "add-labels", "--from-json", str(replacement),
+            "--bypass-status-gate", "--discard-review",
+        ],
+    )
+    assert discarded.exit_code == 0, discarded.output
+    payload = _json.loads(discarded.output)
+    assert payload["discarded_review_count"] == 1
+    assert "Replacement problem" not in discarded.output
+    spec = store.find_by_id("add-labels")
+    assert spec is not None
+    assert spec.prose_verdicts == {}
+
+
+def test_spec_apply_discard_review_resets_replaced_json_criteria(
+    configured_app_with_task: Path, tmp_path: Path,
+):
+    _apply_reviewed_spec(configured_app_with_task, tmp_path)
+    replacement = tmp_path / "replacement.json"
+    replacement.write_text(_draft_json(["new criterion"]))
+
+    result = runner.invoke(
+        app,
+        [
+            "spec", "apply", "add-labels", "--from-json", str(replacement),
+            "--bypass-status-gate", "--discard-review",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = _json.loads(result.output)
+    assert payload["review_state_discarded"] is True
+    assert payload["discarded_review_count"] == 2
+    assert "new criterion" not in result.output
+    spec = _store(configured_app_with_task).find_by_id("add-labels")
+    assert [c.verdict for c in spec.acceptance_criteria] == ["unreviewed"]
+
+
+def test_spec_apply_discard_review_preserves_unreviewed_criterion_evidence(
+    configured_app_with_task: Path, tmp_path: Path,
+):
+    runner.invoke(app, ["spec", "new", "--task", "add-labels"])
+    initial = tmp_path / "initial.json"
+    initial.write_text(_draft_json(["replace criterion", "keep criterion"]))
+    assert runner.invoke(
+        app, ["spec", "apply", "add-labels", "--from-json", str(initial)],
+    ).exit_code == 0
+    assert runner.invoke(
+        app, ["spec", "verdict", "add-labels", "ac1", "approved"],
+    ).exit_code == 0
+    assert runner.invoke(
+        app, ["spec", "evidence", "add-labels", "ac2", "test-runs/1"],
+    ).exit_code == 0
+    replacement = tmp_path / "replacement.json"
+    replacement.write_text(_draft_json(["replacement criterion", "keep criterion"]))
+
+    result = runner.invoke(
+        app,
+        [
+            "spec", "apply", "add-labels", "--from-json", str(replacement),
+            "--bypass-status-gate", "--discard-review",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = _json.loads(result.output)
+    assert payload["discarded_review_count"] == 1
+    spec = _store(configured_app_with_task).find_by_id("add-labels")
+    assert [criterion.verdict for criterion in spec.acceptance_criteria] == [
+        "unreviewed", "unreviewed",
+    ]
+    assert [evidence.ref for evidence in spec.acceptance_criteria[1].evidence] == [
+        "test-runs/1",
+    ]
 
 # --- spec validate (#146) ---
 
@@ -1050,6 +1237,32 @@ def test_spec_apply_stamps_bound_task_activity(configured_app_with_task: Path, t
 
 
 # --- spec apply --from-file (#298 item 1) ---
+
+
+def test_spec_apply_discard_review_reports_human_markdown_result(
+    configured_app_with_task: Path, tmp_path: Path, monkeypatch,
+):
+    from mship.cli.output import Output
+
+    monkeypatch.setattr(Output, "is_tty", property(lambda self: True))
+    _apply_reviewed_spec(configured_app_with_task, tmp_path)
+    replacement = tmp_path / "replacement.md"
+    replacement.write_text(_draft_md())
+
+    result = runner.invoke(
+        app,
+        [
+            "spec", "apply", "add-labels", "--from-file", str(replacement),
+            "--bypass-status-gate", "--discard-review",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "review state was discarded for 1 review unit" in result.output.lower()
+    assert "view questions" not in result.output
+    assert "sync status" not in result.output
+    spec = _store(configured_app_with_task).find_by_id("add-labels")
+    assert [c.verdict for c in spec.acceptance_criteria] == ["approved"]
 
 
 def _draft_md() -> str:

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -379,14 +379,15 @@ def test_spec_apply_rejects_invalid_json(configured_app_with_task: Path, tmp_pat
     assert result.exit_code != 0
 
 
+@pytest.mark.parametrize("spec_id", ["../unsafe", "nul\x00unsafe"])
 def test_spec_apply_rejects_unsafe_spec_id_without_traceback(
-    configured_app_with_task: Path, tmp_path: Path,
+    configured_app_with_task: Path, tmp_path: Path, spec_id: str,
 ):
     draft = tmp_path / "draft.json"
     draft.write_text(_draft_json())
 
     result = runner.invoke(
-        app, ["spec", "apply", "../unsafe", "--from-json", str(draft)],
+        app, ["spec", "apply", spec_id, "--from-json", str(draft)],
     )
 
     assert result.exit_code != 0

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -158,6 +158,20 @@ def test_spec_new_force_overwrites(configured_app_with_task: Path):
     assert result.exit_code == 0, result.output
 
 
+@pytest.mark.parametrize("args", [[], ["--force"]], ids=["ordinary", "force"])
+def test_spec_new_rejects_nul_id_without_traceback(
+    configured_app_with_task: Path,
+    args: list[str],
+):
+    result = runner.invoke(
+        app,
+        ["spec", "new", "--title", "Unsafe", "--id", "unsafe\x00id", *args],
+    )
+
+    assert result.exit_code != 0
+    assert "unsafe spec id" in result.output.lower()
+    assert "traceback" not in result.output.lower()
+
 def test_spec_new_unknown_task_errors(configured_app_with_task: Path):
     result = runner.invoke(app, ["spec", "new", "--task", "nope"])
     assert result.exit_code != 0

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -1,6 +1,7 @@
 """Tests for `mship spec new` (#126, #145)."""
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import Event, Thread
 
 import pytest
 from typer.testing import CliRunner
@@ -378,6 +379,20 @@ def test_spec_apply_rejects_invalid_json(configured_app_with_task: Path, tmp_pat
     assert result.exit_code != 0
 
 
+def test_spec_apply_rejects_unsafe_spec_id_without_traceback(
+    configured_app_with_task: Path, tmp_path: Path,
+):
+    draft = tmp_path / "draft.json"
+    draft.write_text(_draft_json())
+
+    result = runner.invoke(
+        app, ["spec", "apply", "../unsafe", "--from-json", str(draft)],
+    )
+
+    assert result.exit_code != 0
+    assert "unsafe spec id" in result.output
+    assert "Traceback" not in result.output
+
 def test_spec_apply_refuses_wrong_status(configured_app_with_task: Path, tmp_path):
     runner.invoke(app, ["spec", "new", "--title", "Decision queue", "--id", "dq"])
     jf = tmp_path / "draft.json"; jf.write_text(_draft_json())
@@ -556,6 +571,385 @@ def test_spec_apply_discard_review_preserves_unreviewed_criterion_evidence(
         "test-runs/1",
     ]
 
+
+def test_spec_apply_preserves_unchanged_review_state_and_answers(
+    configured_app_with_task: Path, tmp_path: Path,
+):
+    runner.invoke(app, ["spec", "new", "--task", "add-labels"])
+    draft = tmp_path / "draft.json"
+    draft.write_text(_draft_json())
+    assert runner.invoke(
+        app, ["spec", "apply", "add-labels", "--from-json", str(draft)],
+    ).exit_code == 0
+    assert runner.invoke(
+        app, ["spec", "verdict", "add-labels", "ac1", "approved"],
+    ).exit_code == 0
+    assert runner.invoke(
+        app, ["spec", "evidence", "add-labels", "ac1", "test-runs/1"],
+    ).exit_code == 0
+    assert runner.invoke(
+        app, ["spec", "verdict", "add-labels", "problem", "flagged"],
+    ).exit_code == 0
+    assert runner.invoke(
+        app, ["spec", "answer", "add-labels", "q1", "Keep Android support"],
+    ).exit_code == 0
+    store = _store(configured_app_with_task)
+    spec = store.find_by_id("add-labels")
+    assert spec is not None
+    spec.acceptance_criteria[0].comment = "criterion review"
+    spec.prose_verdicts["problem"].comment = "prose review"
+    store.save(spec)
+
+    result = runner.invoke(
+        app,
+        [
+            "spec", "apply", "add-labels", "--from-json", str(draft),
+            "--bypass-status-gate",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "review_state_discarded" not in _json.loads(result.output)
+    persisted = store.find_by_id("add-labels")
+    assert persisted is not None
+    assert persisted.acceptance_criteria[0].verdict == "approved"
+    assert persisted.acceptance_criteria[0].comment == "criterion review"
+    assert [evidence.ref for evidence in persisted.acceptance_criteria[0].evidence] == [
+        "test-runs/1",
+    ]
+    assert persisted.prose_verdicts["problem"].verdict == "flagged"
+    assert persisted.prose_verdicts["problem"].comment == "prose review"
+    assert persisted.open_questions[0].answer == "Keep Android support"
+
+
+def test_spec_apply_refuses_to_discard_an_answered_question(
+    configured_app_with_task: Path, tmp_path: Path,
+):
+    runner.invoke(app, ["spec", "new", "--task", "add-labels"])
+    initial = tmp_path / "initial.json"
+    initial.write_text(_draft_json())
+    assert runner.invoke(
+        app, ["spec", "apply", "add-labels", "--from-json", str(initial)],
+    ).exit_code == 0
+    assert runner.invoke(
+        app, ["spec", "answer", "add-labels", "q1", "Keep Android support"],
+    ).exit_code == 0
+    replacement = tmp_path / "replacement.json"
+    replacement.write_text(_json.dumps({
+        **_json.loads(_draft_json()),
+        "open_questions": ["Should we support iOS?"],
+    }))
+
+    refused = runner.invoke(
+        app,
+        [
+            "spec", "apply", "add-labels", "--from-json", str(replacement),
+            "--bypass-status-gate",
+        ],
+    )
+
+    assert refused.exit_code != 0
+    assert "1 review unit" in refused.output
+    assert "discard-review" in refused.output
+    preserved = _store(configured_app_with_task).find_by_id("add-labels")
+    assert preserved is not None
+    assert preserved.open_questions[0].answer == "Keep Android support"
+
+    discarded = runner.invoke(
+        app,
+        [
+            "spec", "apply", "add-labels", "--from-json", str(replacement),
+            "--bypass-status-gate", "--discard-review",
+        ],
+    )
+
+    assert discarded.exit_code == 0, discarded.output
+    payload = _json.loads(discarded.output)
+    assert payload["discarded_review_count"] == 1
+    assert "Should we support iOS?" not in discarded.output
+    replaced = _store(configured_app_with_task).find_by_id("add-labels")
+    assert replaced is not None
+    assert replaced.open_questions[0].answer is None
+
+
+def test_spec_verdict_does_not_overwrite_an_apply_from_a_stale_snapshot(
+    configured_app_with_task: Path, tmp_path: Path, monkeypatch,
+):
+    runner.invoke(app, ["spec", "new", "--task", "add-labels"])
+    initial = tmp_path / "initial.json"
+    initial.write_text(_draft_json(["old criterion"]))
+    assert runner.invoke(
+        app, ["spec", "apply", "add-labels", "--from-json", str(initial)],
+    ).exit_code == 0
+    assert runner.invoke(
+        app, ["spec", "verdict", "add-labels", "ac1", "approved"],
+    ).exit_code == 0
+    store = _store(configured_app_with_task)
+    stale_spec = store.find_by_id("add-labels")
+    assert stale_spec is not None
+    replacement = tmp_path / "replacement.json"
+    replacement.write_text(_draft_json(["new criterion"]))
+
+    original_save_while_locked = SpecStore.save_while_locked
+    apply_ready_to_persist = Event()
+    allow_apply_to_persist = Event()
+
+    def pause_apply_persistence(self, spec, artifact):
+        if (
+            spec.id == "add-labels"
+            and spec.acceptance_criteria[0].text == "new criterion"
+        ):
+            apply_ready_to_persist.set()
+            assert allow_apply_to_persist.wait(timeout=5)
+        return original_save_while_locked(self, spec, artifact)
+
+    monkeypatch.setattr(SpecStore, "save_while_locked", pause_apply_persistence)
+
+    from typer.main import get_command
+
+    callbacks = get_command(app).commands["spec"].commands
+    apply_callback = callbacks["apply"].callback
+    verdict_callback = callbacks["verdict"].callback
+    assert apply_callback is not None
+    assert verdict_callback is not None
+
+    apply_result = {}
+
+    def apply_draft():
+        try:
+            apply_callback(
+                spec_id="add-labels",
+                from_json=str(replacement),
+                from_file=None,
+                bypass_status_gate=True,
+                discard_review=True,
+            )
+        except BaseException as exc:
+            apply_result["error"] = exc
+
+    apply_thread = Thread(target=apply_draft)
+    apply_thread.start()
+    assert apply_ready_to_persist.wait(timeout=5)
+
+    original_find_by_id = SpecStore.find_by_id
+
+    def stale_find_by_id(self, spec_id):
+        if spec_id == "add-labels":
+            return stale_spec.model_copy(deep=True)
+        return original_find_by_id(self, spec_id)
+
+    monkeypatch.setattr(SpecStore, "find_by_id", stale_find_by_id)
+    verdict_result = {}
+
+    def record_verdict():
+        try:
+            verdict_callback(
+                spec_id="add-labels",
+                criterion_id="ac1",
+                verdict_value="approved",
+            )
+        except BaseException as exc:
+            verdict_result["error"] = exc
+
+    verdict_thread = Thread(target=record_verdict)
+    verdict_thread.start()
+    allow_apply_to_persist.set()
+    apply_thread.join(timeout=5)
+    verdict_thread.join(timeout=5)
+
+    assert not apply_thread.is_alive()
+    assert not verdict_thread.is_alive()
+    assert "error" not in apply_result
+    assert "error" not in verdict_result
+    persisted = original_find_by_id(store, "add-labels")
+    assert persisted is not None
+    assert persisted.acceptance_criteria[0].text == "new criterion"
+    assert persisted.acceptance_criteria[0].verdict == "approved"
+
+
+def test_spec_ask_does_not_overwrite_an_apply_from_a_stale_snapshot(
+    configured_app_with_task: Path, tmp_path: Path, monkeypatch,
+):
+    from threading import current_thread
+    from typer.main import get_command
+
+    runner.invoke(app, ["spec", "new", "--task", "add-labels"])
+    initial = tmp_path / "initial.json"
+    initial.write_text(_draft_json(["old criterion"]))
+    assert runner.invoke(
+        app, ["spec", "apply", "add-labels", "--from-json", str(initial)],
+    ).exit_code == 0
+    replacement = tmp_path / "replacement.json"
+    replacement.write_text(_draft_json(["new criterion"]))
+
+    original_save_while_locked = SpecStore.save_while_locked
+    apply_ready_to_persist = Event()
+    allow_apply_to_persist = Event()
+
+    def pause_apply_persistence(self, spec, artifact):
+        if (
+            spec.id == "add-labels"
+            and spec.acceptance_criteria[0].text == "new criterion"
+        ):
+            apply_ready_to_persist.set()
+            assert allow_apply_to_persist.wait(timeout=5)
+        return original_save_while_locked(self, spec, artifact)
+
+    monkeypatch.setattr(SpecStore, "save_while_locked", pause_apply_persistence)
+
+    callbacks = get_command(app).commands["spec"].commands
+    apply_callback = callbacks["apply"].callback
+    ask_callback = callbacks["ask"].callback
+    assert apply_callback is not None
+    assert ask_callback is not None
+
+    apply_result = {}
+
+    def apply_draft():
+        try:
+            apply_callback(
+                spec_id="add-labels",
+                from_json=str(replacement),
+                from_file=None,
+                bypass_status_gate=True,
+                discard_review=True,
+            )
+        except BaseException as exc:
+            apply_result["error"] = exc
+
+    apply_thread = Thread(target=apply_draft)
+    apply_thread.start()
+    assert apply_ready_to_persist.wait(timeout=5)
+
+    original_locked = SpecStore.locked
+    ask_waiting_for_lock = Event()
+
+    def detect_ask_lock(self, spec_id):
+        if current_thread().name == "ask-writer":
+            ask_waiting_for_lock.set()
+        return original_locked(self, spec_id)
+
+    monkeypatch.setattr(SpecStore, "locked", detect_ask_lock)
+    ask_result = {}
+
+    def ask_question():
+        try:
+            ask_callback(
+                spec_id="add-labels",
+                text="Should we support tablets?",
+            )
+        except BaseException as exc:
+            ask_result["error"] = exc
+
+    ask_thread = Thread(target=ask_question, name="ask-writer")
+    ask_thread.start()
+    assert ask_waiting_for_lock.wait(timeout=5)
+    allow_apply_to_persist.set()
+    apply_thread.join(timeout=5)
+    ask_thread.join(timeout=5)
+
+    assert not apply_thread.is_alive()
+    assert not ask_thread.is_alive()
+    assert "error" not in apply_result
+    assert "error" not in ask_result
+    persisted = _store(configured_app_with_task).find_by_id("add-labels")
+    assert persisted is not None
+    assert persisted.acceptance_criteria[0].text == "new criterion"
+    assert [question.text for question in persisted.open_questions] == [
+        "Android?", "Should we support tablets?",
+    ]
+
+
+def test_spec_answer_does_not_overwrite_an_apply_from_a_stale_snapshot(
+    configured_app_with_task: Path, tmp_path: Path, monkeypatch,
+):
+    from threading import current_thread
+    from typer.main import get_command
+
+    runner.invoke(app, ["spec", "new", "--task", "add-labels"])
+    initial = tmp_path / "initial.json"
+    initial.write_text(_draft_json(["old criterion"]))
+    assert runner.invoke(
+        app, ["spec", "apply", "add-labels", "--from-json", str(initial)],
+    ).exit_code == 0
+    replacement = tmp_path / "replacement.json"
+    replacement.write_text(_draft_json(["new criterion"]))
+
+    original_save_while_locked = SpecStore.save_while_locked
+    apply_ready_to_persist = Event()
+    allow_apply_to_persist = Event()
+
+    def pause_apply_persistence(self, spec, artifact):
+        if (
+            spec.id == "add-labels"
+            and spec.acceptance_criteria[0].text == "new criterion"
+        ):
+            apply_ready_to_persist.set()
+            assert allow_apply_to_persist.wait(timeout=5)
+        return original_save_while_locked(self, spec, artifact)
+
+    monkeypatch.setattr(SpecStore, "save_while_locked", pause_apply_persistence)
+
+    callbacks = get_command(app).commands["spec"].commands
+    apply_callback = callbacks["apply"].callback
+    answer_callback = callbacks["answer"].callback
+    assert apply_callback is not None
+    assert answer_callback is not None
+
+    apply_result = {}
+
+    def apply_draft():
+        try:
+            apply_callback(
+                spec_id="add-labels",
+                from_json=str(replacement),
+                from_file=None,
+                bypass_status_gate=True,
+                discard_review=True,
+            )
+        except BaseException as exc:
+            apply_result["error"] = exc
+
+    apply_thread = Thread(target=apply_draft)
+    apply_thread.start()
+    assert apply_ready_to_persist.wait(timeout=5)
+
+    original_locked = SpecStore.locked
+    answer_waiting_for_lock = Event()
+
+    def detect_answer_lock(self, spec_id):
+        if current_thread().name == "answer-writer":
+            answer_waiting_for_lock.set()
+        return original_locked(self, spec_id)
+
+    monkeypatch.setattr(SpecStore, "locked", detect_answer_lock)
+    answer_result = {}
+
+    def answer_question():
+        try:
+            answer_callback(
+                spec_id="add-labels",
+                q_id="q1",
+                answer_text="yes",
+            )
+        except BaseException as exc:
+            answer_result["error"] = exc
+
+    answer_thread = Thread(target=answer_question, name="answer-writer")
+    answer_thread.start()
+    assert answer_waiting_for_lock.wait(timeout=5)
+    allow_apply_to_persist.set()
+    apply_thread.join(timeout=5)
+    answer_thread.join(timeout=5)
+
+    assert not apply_thread.is_alive()
+    assert not answer_thread.is_alive()
+    assert "error" not in apply_result
+    assert "error" not in answer_result
+    persisted = _store(configured_app_with_task).find_by_id("add-labels")
+    assert persisted is not None
+    assert persisted.acceptance_criteria[0].text == "new criterion"
+    assert persisted.open_questions[0].answer == "yes"
 # --- spec validate (#146) ---
 
 

--- a/tests/core/test_evidence_resolve.py
+++ b/tests/core/test_evidence_resolve.py
@@ -50,6 +50,24 @@ def test_refuses_a_ref_with_a_trailing_newline(tmp_path):
         resolve_ref(tmp_path, "s", ref + "\n")
 
 
+@pytest.mark.parametrize(
+    ("spec_id", "ref_suffix"),
+    [("s\0", ""), ("s", "\0")],
+)
+def test_refuses_embedded_nul_in_paths_before_realpath(
+    tmp_path, monkeypatch, spec_id, ref_suffix
+):
+    """NUL belongs to the request boundary, not the OS path API."""
+    ref = _stored(tmp_path)
+
+    def realpath_called(path):
+        pytest.fail(f"unexpected realpath for {path!r}")
+
+    monkeypatch.setattr(os.path, "realpath", realpath_called)
+    with pytest.raises(BadEvidenceRef):
+        resolve_ref(tmp_path, spec_id, ref + ref_suffix)
+
+
 def test_refuses_a_symlink_pointing_out_of_the_store(tmp_path):
     _stored(tmp_path)
     secret = tmp_path / "secret.png"; secret.write_bytes(b"nope")

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -1555,23 +1555,3 @@ def test_get_task_serializes_activity_fields(tmp_path):
     assert body["phase_entered_at"].startswith("2026-07-13T12:00:00")
 
 
-def test_approve_endpoint_uses_shared_transition(tmp_path, monkeypatch):
-    called = {}
-    import mship.core.serve as serve_mod
-
-    def spy(spec, store, *, bypass_gate=False):
-        called["hit"] = (spec.id, bypass_gate)
-        spec.status = "approved"
-        spec.clarification_reason = None
-        store.save(spec)
-    monkeypatch.setattr(serve_mod, "approve_spec", spy, raising=False)
-
-    now = datetime(2026, 6, 14, tzinfo=timezone.utc)
-    SpecStore(tmp_path / "specs").save(Spec(
-        id="ready", title="ready", status="needs_review", created_at=now, updated_at=now,
-        body=render_body("p", "u", "a"),
-        acceptance_criteria=[AcceptanceCriterion(id="ac1", text="x", verdict="approved")],
-        open_questions=[]))
-    r = TestClient(_app(tmp_path)).post("/specs/ready/approve", json={})
-    assert r.status_code == 200 and r.json()["status"] == "approved"
-    assert called["hit"] == ("ready", False)

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -1,3 +1,6 @@
+from contextlib import contextmanager
+from threading import Event, Thread
+
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -685,14 +688,152 @@ def test_post_apply_unknown_spec_404(tmp_path):
     assert r.status_code == 404
 
 
-def test_post_apply_illegal_transition_409_and_bypass(tmp_path):
-    _seed_spec(tmp_path)   # status needs_review already
+def test_post_apply_refuses_invalid_transition_without_mutating_spec(tmp_path):
+    _seed_spec(tmp_path)
     client = TestClient(_app(tmp_path))
-    draft = {"draft": {"problem": "P", "user_story": "U", "approach": "A"}}
-    assert client.post("/specs/dq/apply", json=draft).status_code == 409      # needs_review → needs_review illegal
-    ok = client.post("/specs/dq/apply", json={**draft, "bypass_status_gate": True})
-    assert ok.status_code == 200 and ok.json()["status"] == "needs_review"
+    before = SpecStore(tmp_path / "specs").find_by_id("dq")
+    assert before is not None
 
+    response = client.post("/specs/dq/apply", json={"draft": {
+        "problem": "replacement", "user_story": "U", "approach": "A",
+        "acceptance_criteria": ["replacement"],
+    }})
+
+    assert response.status_code == 409
+    assert "traceback" not in response.text.lower()
+    after = SpecStore(tmp_path / "specs").find_by_id("dq")
+    assert after is not None
+    assert after.model_dump(mode="json") == before.model_dump(mode="json")
+
+
+def test_post_apply_bypass_still_refuses_review_discard_without_mutation(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+    before = SpecStore(tmp_path / "specs").find_by_id("dq")
+    assert before is not None
+
+    response = client.post("/specs/dq/apply", json={
+        "draft": {
+            "problem": "replacement", "user_story": "U", "approach": "A",
+            "acceptance_criteria": ["replacement"],
+        },
+        "bypass_status_gate": True,
+    })
+
+    assert response.status_code == 409
+    assert "discard" in response.json()["detail"]
+    assert "traceback" not in response.text.lower()
+    after = SpecStore(tmp_path / "specs").find_by_id("dq")
+    assert after is not None
+    assert after.model_dump(mode="json") == before.model_dump(mode="json")
+
+
+def test_post_apply_discard_review_reports_redacted_discard_state(tmp_path):
+    _seed_spec(tmp_path)
+    client = TestClient(_app(tmp_path))
+
+    response = client.post("/specs/dq/apply", json={
+        "draft": {
+            "problem": "replacement", "user_story": "U", "approach": "A",
+            "acceptance_criteria": ["replacement"],
+        },
+        "bypass_status_gate": True,
+        "discard_review": True,
+    })
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "needs_review"
+    assert response.json()["review_state_discarded"] is True
+    assert response.json()["discarded_review_count"] == 1
+
+
+def test_post_apply_preserves_unchanged_review_comment_and_answer(tmp_path):
+    _seed_spec(tmp_path)
+    store = SpecStore(tmp_path / "specs")
+    spec = store.find_by_id("dq")
+    assert spec is not None
+    spec.acceptance_criteria[0].comment = "clear enough"
+    spec.open_questions[0].answer = "yes"
+    store.save(spec)
+    client = TestClient(_app(tmp_path))
+
+    response = client.post("/specs/dq/apply", json={
+        "draft": {
+            "problem": "the problem", "user_story": "as a user", "approach": "the approach",
+            "acceptance_criteria": ["view questions"],
+            "open_questions": ["Mobile too?"],
+        },
+        "bypass_status_gate": True,
+    })
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["review_state_discarded"] is False
+    assert body["discarded_review_count"] == 0
+    assert body["acceptance_criteria"][0]["comment"] == "clear enough"
+    assert body["open_questions"][0]["answer"] == "yes"
+
+
+def test_review_write_waits_for_atomic_apply_and_uses_fresh_spec(tmp_path, monkeypatch):
+    _seed_spec(tmp_path)
+    app = _app(tmp_path)
+    review_started = Event()
+    review_request_active = Event()
+    review_lock_acquired = Event()
+    review_responses = []
+    reviewer: Thread | None = None
+    original_locked = SpecStore.locked
+    original_save_while_locked = SpecStore.save_while_locked
+
+    @contextmanager
+    def track_reviewer_lock(self, spec_id):
+        is_reviewer = review_request_active.is_set()
+        if is_reviewer:
+            review_started.set()
+        with original_locked(self, spec_id) as artifact:
+            if is_reviewer:
+                review_lock_acquired.set()
+            yield artifact
+
+    def post_review():
+        review_request_active.set()
+        response = TestClient(app).post(
+            "/specs/dq/verdict",
+            json={"criterion_id": "ac1", "verdict": "approved", "comment": "late review"},
+        )
+        review_responses.append(response)
+
+    def pause_apply_save(self, spec, artifact):
+        nonlocal reviewer
+        if reviewer is None:
+            reviewer = Thread(target=post_review, name="api-reviewer")
+            reviewer.start()
+            assert review_started.wait(timeout=1)
+            assert not review_lock_acquired.wait(timeout=0.1)
+        return original_save_while_locked(self, spec, artifact)
+
+    monkeypatch.setattr(SpecStore, "locked", track_reviewer_lock)
+    monkeypatch.setattr(SpecStore, "save_while_locked", pause_apply_save)
+
+    response = TestClient(app).post("/specs/dq/apply", json={
+        "draft": {
+            "problem": "replacement", "user_story": "as a user", "approach": "the approach",
+            "acceptance_criteria": ["view questions"],
+            "open_questions": ["Mobile too?"],
+        },
+        "bypass_status_gate": True,
+    })
+
+    assert response.status_code == 200
+    assert reviewer is not None
+    reviewer.join(timeout=1)
+    assert not reviewer.is_alive()
+    assert review_lock_acquired.is_set()
+    assert review_responses[0].status_code == 200
+    persisted = SpecStore(tmp_path / "specs").find_by_id("dq")
+    assert persisted is not None
+    assert persisted.acceptance_criteria[0].comment == "late review"
+    assert persisted.body == render_body("replacement", "as a user", "the approach")
 
 def test_post_apply_revising_clears_clarification_reason(tmp_path):
     """MOS-215/MOS-240: applying a revised draft to a spec that was sent back

--- a/tests/core/test_serve_evidence_blob.py
+++ b/tests/core/test_serve_evidence_blob.py
@@ -106,6 +106,17 @@ def test_unresolvable_ref_is_404_not_403(tmp_path: Path, bad: str):
     assert r.status_code == 404, r.text
 
 
+@pytest.mark.parametrize("path_template", [
+    "/specs/dq%00/evidence/{ref}/blob",
+    "/specs/dq/evidence/{ref}%00/blob",
+])
+def test_url_encoded_nul_in_evidence_path_is_404(tmp_path: Path, path_template: str):
+    _seed_spec(tmp_path)
+    ref = _seed_evidence(tmp_path)
+    r = _client(tmp_path).get(path_template.format(ref=ref), headers=AUTH)
+    assert r.status_code == 404, r.text
+
+
 def test_traversing_spec_id_is_404(tmp_path: Path):
     """Two distinct shapes, both 404 — the second is the one that reaches us.
 

--- a/tests/core/test_serve_spec_locked.py
+++ b/tests/core/test_serve_spec_locked.py
@@ -170,28 +170,29 @@ def test_serve_review_and_write_paths_report_locked_spec_as_conflict(
     assert response.status_code == 409
     assert "locked" in response.json()["detail"]
 
+@pytest.mark.parametrize("spec_id", [".hidden", "%00"])
 @pytest.mark.parametrize(
     ("method", "path", "body"),
     [
-        ("get", "/specs/.hidden/review", None),
+        ("get", "/specs/{spec_id}/review", None),
         (
             "post",
-            "/specs/.hidden/verdict",
+            "/specs/{spec_id}/verdict",
             {"criterion_id": "ac-1", "verdict": "approved"},
         ),
         (
             "post",
-            "/specs/.hidden/prose-verdict",
+            "/specs/{spec_id}/prose-verdict",
             {"section_id": "problem", "verdict": "approved"},
         ),
         (
             "post",
-            "/specs/.hidden/evidence",
+            "/specs/{spec_id}/evidence",
             {"criterion_id": "ac-1", "ref": "test:tests/core/test_serve_spec_locked.py"},
         ),
         (
             "post",
-            "/specs/.hidden/apply",
+            "/specs/{spec_id}/apply",
             {
                 "draft": {
                     "problem": "Problem",
@@ -200,14 +201,16 @@ def test_serve_review_and_write_paths_report_locked_spec_as_conflict(
                 },
             },
         ),
-        ("post", "/specs/.hidden/questions", {"text": "Why?"}),
-        ("post", "/specs/.hidden/questions/q-1/answer", {"answer": "Because."}),
+        ("post", "/specs/{spec_id}/questions", {"text": "Why?"}),
+        ("post", "/specs/{spec_id}/questions/q-1/answer", {"answer": "Because."}),
     ],
 )
 def test_serve_strict_routes_reject_unsafe_spec_ids_without_a_server_error(
-    tmp_path: Path, method: str, path: str, body: dict | None,
+    tmp_path: Path, spec_id: str, method: str, path: str, body: dict | None,
 ):
-    response = _client(tmp_path).request(method, path, json=body)
+    response = _client(tmp_path).request(
+        method, path.format(spec_id=spec_id), json=body,
+    )
 
     assert response.status_code == 422
     assert "unsafe spec id" in response.json()["detail"]

--- a/tests/core/test_serve_spec_locked.py
+++ b/tests/core/test_serve_spec_locked.py
@@ -174,7 +174,34 @@ def test_serve_review_and_write_paths_report_locked_spec_as_conflict(
     ("method", "path", "body"),
     [
         ("get", "/specs/.hidden/review", None),
+        (
+            "post",
+            "/specs/.hidden/verdict",
+            {"criterion_id": "ac-1", "verdict": "approved"},
+        ),
+        (
+            "post",
+            "/specs/.hidden/prose-verdict",
+            {"section_id": "problem", "verdict": "approved"},
+        ),
+        (
+            "post",
+            "/specs/.hidden/evidence",
+            {"criterion_id": "ac-1", "ref": "test:tests/core/test_serve_spec_locked.py"},
+        ),
+        (
+            "post",
+            "/specs/.hidden/apply",
+            {
+                "draft": {
+                    "problem": "Problem",
+                    "user_story": "User story",
+                    "approach": "Approach",
+                },
+            },
+        ),
         ("post", "/specs/.hidden/questions", {"text": "Why?"}),
+        ("post", "/specs/.hidden/questions/q-1/answer", {"answer": "Because."}),
     ],
 )
 def test_serve_strict_routes_reject_unsafe_spec_ids_without_a_server_error(

--- a/tests/core/test_serve_specs.py
+++ b/tests/core/test_serve_specs.py
@@ -1,7 +1,8 @@
+from fastapi.testclient import TestClient
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-
-from fastapi.testclient import TestClient
+from threading import Event, Thread, current_thread
 
 from mship.core.serve import create_app
 from mship.core.spec import Spec
@@ -133,3 +134,61 @@ def test_spec_state_equivalent_inbox_action_persists_without_task_activity(tmp_p
     saved = specs.find_by_id(active.id)
     assert saved.inbox.mutation_ids["device-unpin"] == "unpin"
     assert saved.inbox.last_mutated_at == first_mutation
+
+def test_archive_uses_the_post_apply_spec_instead_of_a_stale_snapshot(
+    tmp_path: Path, monkeypatch,
+):
+    from mship.core.spec_draft import SpecDraft, apply_draft_transaction
+
+    now = datetime.now(timezone.utc)
+    store = SpecStore(tmp_path / "specs")
+    store.save(Spec(
+        id="transition", title="Transition", status="approved",
+        created_at=now, updated_at=now,
+        acceptance_criteria=[],
+        body="## Problem\n\nOld\n",
+    ))
+    archive_waiting = Event()
+    allow_archive = Event()
+    original_locked = SpecStore.locked
+
+    @contextmanager
+    def pause_archive_lock(self, spec_id):
+        if current_thread().name != "MainThread":
+            archive_waiting.set()
+            assert allow_archive.wait(timeout=5)
+        with original_locked(self, spec_id) as artifact:
+            yield artifact
+
+    monkeypatch.setattr(SpecStore, "locked", pause_archive_lock)
+    client = _client(tmp_path)
+    archive_result: dict[str, object] = {}
+
+    def archive() -> None:
+        archive_result["response"] = client.post("/specs/transition/archive")
+
+    archive_thread = Thread(target=archive, name="archive-writer")
+    archive_thread.start()
+    assert archive_waiting.wait(timeout=5)
+
+    applied = apply_draft_transaction(
+        store,
+        "transition",
+        SpecDraft(
+            problem="New problem",
+            user_story="New story",
+            approach="New approach",
+        ),
+        bypass_status_gate=True,
+    )
+    assert applied.spec.id == "transition"
+    allow_archive.set()
+    archive_thread.join(timeout=5)
+    assert not archive_thread.is_alive()
+
+    response = archive_result["response"]
+    assert response.status_code == 200
+    persisted = store.find_by_id("transition")
+    assert persisted is not None
+    assert persisted.status == "archived"
+    assert "New approach" in persisted.body

--- a/tests/core/test_spec_dispatch.py
+++ b/tests/core/test_spec_dispatch.py
@@ -6,6 +6,7 @@ import pytest
 from mship.core.spec import AcceptanceCriterion, Spec
 from mship.core.spec_body import render_body
 from mship.core.spec_store import SpecStore
+from mship.core.spec_draft import SpecDraft, apply_draft_transaction
 from mship.core.state import StateManager, Task, WorkspaceState
 from mship.core.spec_dispatch import DispatchError, build_dispatch_handoff, dispatch_spec
 from mship.core.workitem_store import WorkItemStore
@@ -160,6 +161,36 @@ def test_dispatch_spec_requires_approved(tmp_path):
             workitems=items, workspace=WORKSPACE,
         )
 
+
+
+def test_dispatch_does_not_restore_a_snapshot_stale_after_apply(tmp_path):
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
+    sm.save(WorkspaceState(tasks={"dq": _task()}))
+    stale = _approved_spec()
+    store.save(stale)
+
+    apply_draft_transaction(
+        store,
+        stale.id,
+        SpecDraft(
+            problem="New problem",
+            user_story="New story",
+            approach="New approach",
+        ),
+        bypass_status_gate=True,
+        discard_review=True,
+    )
+
+    with pytest.raises(DispatchError):
+        dispatch_spec(
+            stale, state_manager=sm, store=store, spawn_fn=lambda s: None, now=NOW,
+            workitems=items, workspace=WORKSPACE,
+        )
+
+    persisted = store.find_by_id(stale.id)
+    assert persisted is not None
+    assert persisted.status == "needs_review"
+    assert "New approach" in persisted.body
 
 def test_dispatch_spec_auto_spawn_requires_affected_repos(tmp_path):
     sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)

--- a/tests/core/test_spec_draft.py
+++ b/tests/core/test_spec_draft.py
@@ -1,4 +1,28 @@
-from mship.core.spec_draft import build_draft_prompt
+from datetime import datetime, timezone
+from threading import Event, Thread
+
+import pytest
+
+from mship.core.spec import (
+    AcceptanceCriterion,
+    AcceptanceEvidence,
+    OpenQuestion,
+    Spec,
+    SpecDraft,
+)
+from mship.core.spec_body import validate_body_structure
+from mship.core.spec_draft import (
+    MissingSpec,
+    ReviewDiscardRequired,
+    SPEC_BODY_TEMPLATE,
+    apply_draft,
+    apply_draft_transaction,
+    build_draft_prompt,
+    new_spec,
+)
+from mship.core.spec_store import SpecStore
+
+
 
 
 def test_build_draft_prompt_contains_intent_schema_and_apply():
@@ -9,18 +33,6 @@ def test_build_draft_prompt_contains_intent_schema_and_apply():
     assert "open_questions" in prompt
     assert "mship spec apply decision-queue --from-json" in prompt  # how to apply
     assert "only" in prompt.lower()                         # "output only JSON"
-
-
-from datetime import datetime, timezone
-
-from mship.core.spec import (
-    AcceptanceCriterion,
-    AcceptanceEvidence,
-    Spec,
-    SpecDraft,
-)
-from mship.core.spec_draft import apply_draft
-from mship.core.spec_body import validate_body_structure
 
 
 def _spec():
@@ -61,6 +73,45 @@ def test_apply_draft_preserves_evidence_and_verdict_for_unchanged_ac():
     out = apply_draft(spec, draft)
     assert out.acceptance_criteria[0].verdict == "approved"     # preserved
     assert out.acceptance_criteria[0].evidence == [AcceptanceEvidence(kind="test", ref="test-runs/5")]
+
+
+def test_apply_draft_preserves_comment_for_unchanged_criterion():
+    spec = _spec()
+    spec.acceptance_criteria = [
+        AcceptanceCriterion(
+            id="ac1", text="view questions", verdict="approved", comment="reviewed",
+        ),
+    ]
+
+    out = apply_draft(
+        spec,
+        SpecDraft(
+            problem="P", user_story="U", approach="A",
+            acceptance_criteria=["view questions"],
+        ),
+    )
+
+    assert out.acceptance_criteria[0].comment == "reviewed"
+
+
+def test_apply_draft_preserves_answered_questions_once_per_duplicate_text():
+    spec = _spec()
+    spec.open_questions = [
+        OpenQuestion(id="q1", text="Who owns this?", answer="Platform"),
+        OpenQuestion(id="q2", text="Who owns this?", answer="Infrastructure"),
+    ]
+
+    out = apply_draft(
+        spec,
+        SpecDraft(
+            problem="P", user_story="U", approach="A",
+            open_questions=["Who owns this?", "Who owns this?", "Who owns this?"],
+        ),
+    )
+
+    assert [question.answer for question in out.open_questions] == [
+        "Platform", "Infrastructure", None,
+    ]
 
 
 def test_apply_draft_preserves_prose_verdicts_for_unchanged_sections():
@@ -244,9 +295,6 @@ def test_apply_draft_insert_plus_collision_tiebreak_is_positional_and_lossless()
     assert all_refs == ["E2"]
 
 
-import pytest
-
-from mship.core.spec_draft import new_spec, SPEC_BODY_TEMPLATE
 
 
 def test_new_spec_defaults_id_from_title():
@@ -295,3 +343,245 @@ def test_apply_draft_renders_additional_sections():
 
 def test_build_draft_prompt_mentions_additional_sections():
     assert "additional_sections" in build_draft_prompt("x", "intent")
+
+
+def test_apply_draft_transaction_returns_missing_spec(tmp_path):
+    result = apply_draft_transaction(
+        SpecStore(tmp_path / "specs"),
+        "missing",
+        SpecDraft(problem="P", user_story="U", approach="A"),
+    )
+
+    assert result == MissingSpec(spec_id="missing")
+
+
+@pytest.mark.parametrize("bypass_status_gate", [False, True])
+def test_apply_draft_transaction_refuses_review_loss_without_discard(
+    tmp_path, bypass_status_gate,
+):
+    store = SpecStore(tmp_path / "specs")
+    spec = _spec()
+    spec.status = "needs_review"
+    spec.acceptance_criteria = [
+        AcceptanceCriterion(id="ac1", text="old", verdict="approved"),
+    ]
+    spec.open_questions = [OpenQuestion(id="q1", text="Why?", answer="Because.")]
+    store.save(spec)
+
+    with pytest.raises(ReviewDiscardRequired) as raised:
+        apply_draft_transaction(
+            store,
+            spec.id,
+            SpecDraft(
+                problem="P", user_story="U", approach="A",
+                acceptance_criteria=["new"],
+                open_questions=["Different question?"],
+            ),
+            bypass_status_gate=bypass_status_gate,
+        )
+
+    assert raised.value.discarded_review_count == 2
+    persisted = store.find_by_id(spec.id)
+    assert persisted is not None
+    assert persisted.acceptance_criteria[0].text == "old"
+    assert persisted.open_questions[0].answer == "Because."
+
+
+def test_apply_draft_transaction_refuses_lost_unreviewed_criterion_evidence(tmp_path):
+    store = SpecStore(tmp_path / "specs")
+    spec = _spec()
+    spec.acceptance_criteria = [
+        AcceptanceCriterion(
+            id="ac1", text="old",
+            evidence=[AcceptanceEvidence(kind="test", ref="test-runs/1")],
+        ),
+    ]
+    store.save(spec)
+
+    with pytest.raises(ReviewDiscardRequired) as raised:
+        apply_draft_transaction(
+            store,
+            spec.id,
+            SpecDraft(
+                problem="P", user_story="U", approach="A",
+                acceptance_criteria=["new"],
+            ),
+        )
+
+    assert raised.value.discarded_review_count == 1
+
+
+def test_apply_draft_transaction_refuses_lost_unreviewed_criterion_comment(tmp_path):
+    store = SpecStore(tmp_path / "specs")
+    spec = _spec()
+    spec.acceptance_criteria = [
+        AcceptanceCriterion(id="ac1", text="old", comment="Needs discussion."),
+    ]
+    store.save(spec)
+
+    with pytest.raises(ReviewDiscardRequired) as raised:
+        apply_draft_transaction(
+            store,
+            spec.id,
+            SpecDraft(
+                problem="P", user_story="U", approach="A",
+                acceptance_criteria=["new"],
+            ),
+        )
+
+    assert raised.value.discarded_review_count == 1
+
+
+def test_apply_draft_transaction_refuses_lost_unreviewed_prose_comment(tmp_path):
+    from mship.core.spec import ProseVerdict
+    from mship.core.spec_body import render_body
+
+    store = SpecStore(tmp_path / "specs")
+    spec = _spec()
+    spec.body = render_body("P", "U", "old approach")
+    spec.prose_verdicts = {
+        "approach": ProseVerdict(comment="Needs discussion."),
+    }
+    store.save(spec)
+
+    with pytest.raises(ReviewDiscardRequired) as raised:
+        apply_draft_transaction(
+            store,
+            spec.id,
+            SpecDraft(problem="P", user_story="U", approach="new approach"),
+        )
+
+    assert raised.value.discarded_review_count == 1
+
+
+
+def test_apply_draft_transaction_persists_unchanged_review_state(tmp_path):
+    store = SpecStore(tmp_path / "specs")
+    spec = _spec()
+    spec.acceptance_criteria = [
+        AcceptanceCriterion(
+            id="ac1", text="keep", verdict="approved", comment="reviewed",
+            evidence=[AcceptanceEvidence(kind="test", ref="test-runs/1")],
+        ),
+    ]
+    spec.open_questions = [OpenQuestion(id="q1", text="Why?", answer="Because.")]
+    store.save(spec)
+    now = datetime(2026, 8, 27, tzinfo=timezone.utc)
+
+    result = apply_draft_transaction(
+        store,
+        spec.id,
+        SpecDraft(
+            problem="P", user_story="U", approach="A",
+            acceptance_criteria=["keep"],
+            open_questions=["Why?"],
+        ),
+        now=now,
+    )
+
+    assert result.discarded_review_count == 0
+    assert result.spec.updated_at == now
+    assert result.spec.status == "needs_review"
+    assert result.spec.acceptance_criteria[0].comment == "reviewed"
+    assert result.spec.open_questions[0].answer == "Because."
+    assert result.path == store.path_for(result.spec)
+
+
+def test_apply_draft_transaction_discards_only_replaced_review_units(tmp_path):
+    from mship.core.spec import ProseVerdict
+    from mship.core.spec_body import render_body
+
+    store = SpecStore(tmp_path / "specs")
+    spec = _spec()
+    spec.body = render_body("P", "U", "old approach")
+    spec.acceptance_criteria = [
+        AcceptanceCriterion(
+            id="ac1", text="keep", verdict="approved", comment="kept",
+            evidence=[AcceptanceEvidence(kind="test", ref="test-runs/1")],
+        ),
+        AcceptanceCriterion(id="ac2", text="replace", verdict="flagged"),
+    ]
+    spec.prose_verdicts = {
+        "problem": ProseVerdict(verdict="approved", comment="still applies"),
+        "approach": ProseVerdict(verdict="flagged"),
+    }
+    spec.open_questions = [
+        OpenQuestion(id="q1", text="Keep?", answer="Yes."),
+        OpenQuestion(id="q2", text="Replace?", answer="No."),
+    ]
+    store.save(spec)
+
+    result = apply_draft_transaction(
+        store,
+        spec.id,
+        SpecDraft(
+            problem="P", user_story="U", approach="new approach",
+            acceptance_criteria=["keep", "replacement"],
+            open_questions=["Keep?", "Replacement?"],
+        ),
+        discard_review=True,
+    )
+
+    assert result.discarded_review_count == 3
+    kept_criterion = result.spec.acceptance_criteria[0]
+    assert kept_criterion.verdict == "approved"
+    assert kept_criterion.comment == "kept"
+    assert kept_criterion.evidence == [
+        AcceptanceEvidence(kind="test", ref="test-runs/1"),
+    ]
+    assert result.spec.prose_verdicts == {
+        "problem": ProseVerdict(verdict="approved", comment="still applies"),
+    }
+    assert [question.answer for question in result.spec.open_questions] == ["Yes.", None]
+
+
+def test_apply_draft_transaction_keeps_lock_through_loss_check_and_save(
+    tmp_path, monkeypatch,
+):
+    store = SpecStore(tmp_path / "specs")
+    spec = _spec()
+    spec.acceptance_criteria = [
+        AcceptanceCriterion(id="ac1", text="keep", verdict="approved"),
+    ]
+    store.save(spec)
+    review_attempted = Event()
+    review_acquired = Event()
+    original_save = store.save_while_locked
+    reviewer: Thread | None = None
+
+    def record_review():
+        review_attempted.set()
+        with store.locked(spec.id) as artifact:
+            assert artifact is not None
+            review_acquired.set()
+            artifact.spec.acceptance_criteria[0].comment = "late review"
+            original_save(artifact.spec, artifact)
+
+    def save_after_review_attempt(applied, artifact):
+        nonlocal reviewer
+        reviewer = Thread(target=record_review)
+        reviewer.start()
+        assert review_attempted.wait(timeout=1)
+        assert not review_acquired.wait(timeout=0.1)
+        return original_save(applied, artifact)
+
+    monkeypatch.setattr(store, "save_while_locked", save_after_review_attempt)
+
+    result = apply_draft_transaction(
+        store,
+        spec.id,
+        SpecDraft(
+            problem="P", user_story="U", approach="A",
+            acceptance_criteria=["keep"],
+        ),
+    )
+    assert reviewer is not None
+    reviewer.join(timeout=1)
+
+    assert not reviewer.is_alive()
+    assert review_attempted.is_set()
+    assert review_acquired.is_set()
+    assert result.spec.acceptance_criteria[0].comment is None
+    persisted = store.find_by_id(spec.id)
+    assert persisted is not None
+    assert persisted.acceptance_criteria[0].comment == "late review"

--- a/tests/core/test_spec_transition.py
+++ b/tests/core/test_spec_transition.py
@@ -8,6 +8,7 @@ from mship.core.log import LogManager
 from mship.core.spec import AcceptanceCriterion, InvalidTransition, OpenQuestion, Spec
 from mship.core.spec_store import SpecStore
 from mship.core.spec_transition import ApprovalBlocked, approve_spec, request_changes_spec
+from mship.core.spec_draft import SpecDraft, apply_draft_transaction
 
 
 def _dt():
@@ -34,6 +35,33 @@ def test_approve_transitions_and_persists_via_store(tmp_path):
     assert reloaded.clarification_reason is None
 
 
+
+def test_approve_does_not_restore_a_snapshot_stale_after_apply(tmp_path):
+    store = SpecStore(tmp_path / "specs")
+    store.save(_reviewable())
+    stale = store.find_by_id("s1")
+    assert stale is not None
+
+    apply_draft_transaction(
+        store,
+        "s1",
+        SpecDraft(
+            problem="New problem",
+            user_story="New story",
+            approach="New approach",
+            acceptance_criteria=["replacement"],
+        ),
+        bypass_status_gate=True,
+        discard_review=True,
+    )
+    approve_spec(stale, store, bypass_gate=True)
+
+    persisted = store.find_by_id("s1")
+    assert persisted is not None
+    assert persisted.status == "approved"
+    assert persisted.acceptance_criteria[0].text == "replacement"
+    assert "New approach" in persisted.body
+
 def test_approve_blocked_by_open_questions_does_not_write(tmp_path):
     store = SpecStore(tmp_path / "specs")
     spec = _reviewable(open_questions=[OpenQuestion(id="q1", text="?", answer=None)])
@@ -43,6 +71,34 @@ def test_approve_blocked_by_open_questions_does_not_write(tmp_path):
     assert "q1" in "; ".join(e.value.blockers)
     assert store.find_by_id("s1").status == "needs_review"
 
+
+
+def test_request_changes_does_not_restore_a_snapshot_stale_after_apply(tmp_path):
+    store = SpecStore(tmp_path / "specs")
+    store.save(_reviewable())
+    stale = store.find_by_id("s1")
+    assert stale is not None
+    log = LogManager(tmp_path / "logs")
+
+    apply_draft_transaction(
+        store,
+        "s1",
+        SpecDraft(
+            problem="New problem",
+            user_story="New story",
+            approach="New approach",
+            acceptance_criteria=["replacement"],
+        ),
+        bypass_status_gate=True,
+        discard_review=True,
+    )
+    request_changes_spec(stale, store, "tighten scope", log_manager=log, actor="alice")
+
+    persisted = store.find_by_id("s1")
+    assert persisted is not None
+    assert persisted.status == "draft"
+    assert persisted.acceptance_criteria[0].text == "replacement"
+    assert "New approach" in persisted.body
 
 def test_request_changes_sends_to_draft_with_reason(tmp_path):
     store = SpecStore(tmp_path / "specs")

--- a/tests/core/test_workitem_migrate.py
+++ b/tests/core/test_workitem_migrate.py
@@ -39,6 +39,33 @@ def test_spec_with_task_becomes_one_feature_item(tmp_path):
     assert state.load().tasks["alpha"].work_item_id == wi.id
 
 
+def test_migration_preserves_an_apply_after_listing(tmp_path, monkeypatch):
+    from mship.core.spec_draft import SpecDraft, apply_draft_transaction
+
+    specs, state, msgs, items = _setup(tmp_path)
+    specs.save(Spec(id="alpha", title="Alpha", status="draft",
+                    created_at=_now(), updated_at=_now(), body="Old draft"))
+    original_list = specs.list
+
+    def list_before_apply():
+        snapshot = original_list()
+        monkeypatch.setattr(specs, "list", original_list)
+        apply_draft_transaction(
+            specs, "alpha",
+            SpecDraft(problem="Updated problem", user_story="Updated story",
+                      approach="Updated approach"),
+        )
+        return snapshot
+
+    monkeypatch.setattr(specs, "list", list_before_apply)
+    created = wrap_existing(items, specs, state, msgs, now=_now(), workspace="testws")
+
+    persisted = specs.find_by_id("alpha")
+    assert persisted.status == "needs_review"
+    assert "Updated approach" in persisted.body
+    assert persisted.work_item_id == created[0]
+
+
 def test_orphan_task_becomes_chore_item(tmp_path):
     specs, state, msgs, items = _setup(tmp_path)
     state.save(WorkspaceState(tasks={"bugfix": Task(


### PR DESCRIPTION
## Summary
- refuse `mship spec apply` when AC or prose verdict state would be discarded
- require explicit `--discard-review` and report the redacted reviewed-unit count
- preserve unchanged unreviewed criterion evidence and leave refused specs/activity untouched

Closes #425

## Test plan
- `uv run pytest -q tests/cli/test_spec.py`
- `task lint`
- `mship test --repos mothership` (iteration 1: pass)
