### PR TITLE
Keep uv lock synchronized

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -30,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
+      - name: Verify lockfile is current
+        run: uv lock --check
       - uses: arduino/setup-task@v2
         with:
           # `task test` is the entry point; the action needs a token to resolve

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -55,4 +55,21 @@ jobs:
           git commit -m "chore: bump version to v${{ steps.bump.outputs.new_version }}"
           git tag -a "v${{ steps.bump.outputs.new_version }}" -m "v${{ steps.bump.outputs.new_version }}"
           git push origin main --follow-tags
-          gh workflow run test.yml --ref "v${{ steps.bump.outputs.new_version }}"
+          TAG="v${{ steps.bump.outputs.new_version }}"
+          gh workflow run test.yml --ref "$TAG"
+
+          RUN_ID=""
+          for attempt in 1 2 3 4 5; do
+            RUN_ID="$(gh run list --workflow test.yml --branch "$TAG" --event workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
+            if [ -n "$RUN_ID" ]; then
+              break
+            fi
+            sleep "$attempt"
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "Timed out waiting for test.yml workflow_dispatch run on $TAG" >&2
+            exit 1
+          fi
+
+          gh run watch "$RUN_ID" --exit-status

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: version-bump-main
@@ -28,6 +29,8 @@ jobs:
         with:
           python-version: "3.x"
 
+      - uses: astral-sh/setup-uv@v5
+
       - name: Compute and apply version bump
         id: bump
         env:
@@ -39,11 +42,17 @@ jobs:
           NEW_VERSION="$(python -m mship.ci.version_bump --labels "$PR_LABELS")"
           echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Regenerate lockfile
+        run: uv lock
+
       - name: Commit, tag, and push
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml src/mship/__init__.py
-          git commit -m "[skip ci] chore: bump version to v${{ steps.bump.outputs.new_version }}"
+          git add pyproject.toml src/mship/__init__.py uv.lock
+          git commit -m "chore: bump version to v${{ steps.bump.outputs.new_version }}"
           git tag -a "v${{ steps.bump.outputs.new_version }}" -m "v${{ steps.bump.outputs.new_version }}"
           git push origin main --follow-tags
+          gh workflow run test.yml --ref main

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,7 +1,7 @@
 name: version-bump
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:
@@ -55,4 +55,4 @@ jobs:
           git commit -m "chore: bump version to v${{ steps.bump.outputs.new_version }}"
           git tag -a "v${{ steps.bump.outputs.new_version }}" -m "v${{ steps.bump.outputs.new_version }}"
           git push origin main --follow-tags
-          gh workflow run test.yml --ref main
+          gh workflow run test.yml --ref "v${{ steps.bump.outputs.new_version }}"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -45,6 +45,19 @@ jobs:
       - name: Regenerate lockfile
         run: uv lock
 
+      - uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Give git an identity
+        run: |
+          git config --global user.name "mship ci"
+          git config --global user.email "ci@example.invalid"
+          git config --global init.defaultBranch main
+
+      - name: Run bumped tree suite
+        run: task test
+
       - name: Commit, tag, and push
         env:
           GH_TOKEN: ${{ github.token }}
@@ -53,6 +66,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml src/mship/__init__.py uv.lock
           git commit -m "chore: bump version to v${{ steps.bump.outputs.new_version }}"
+          BUMP_SHA="$(git rev-parse HEAD)"
           git tag -a "v${{ steps.bump.outputs.new_version }}" -m "v${{ steps.bump.outputs.new_version }}"
           git push origin main --follow-tags
           TAG="v${{ steps.bump.outputs.new_version }}"
@@ -60,7 +74,7 @@ jobs:
 
           RUN_ID=""
           for attempt in 1 2 3 4 5; do
-            RUN_ID="$(gh run list --workflow test.yml --branch "$TAG" --event workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
+            RUN_ID="$(gh run list --workflow test.yml --commit "$BUMP_SHA" --event workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
             if [ -n "$RUN_ID" ]; then
               break
             fi
@@ -68,7 +82,7 @@ jobs:
           done
 
           if [ -z "$RUN_ID" ]; then
-            echo "Timed out waiting for test.yml workflow_dispatch run on $TAG" >&2
+            echo "Timed out waiting for test.yml workflow_dispatch run on $BUMP_SHA" >&2
             exit 1
           fi
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -67,10 +67,16 @@ jobs:
           git add pyproject.toml src/mship/__init__.py uv.lock
           git commit -m "chore: bump version to v${{ steps.bump.outputs.new_version }}"
           BUMP_SHA="$(git rev-parse HEAD)"
-          git tag -a "v${{ steps.bump.outputs.new_version }}" -m "v${{ steps.bump.outputs.new_version }}"
-          git push origin main --follow-tags
-          TAG="v${{ steps.bump.outputs.new_version }}"
-          gh workflow run test.yml --ref "$TAG"
+          # This non-main branch is dispatch-only: test.yml's push trigger cannot
+          # start a competing run for it.
+          VERIFY_BRANCH="mship-verify-$BUMP_SHA"
+          cleanup_verification_ref() {
+            git push origin --delete "$VERIFY_BRANCH" || echo "Warning: failed to delete $VERIFY_BRANCH" >&2
+          }
+          trap 'status=$?; cleanup_verification_ref; exit "$status"' EXIT
+
+          git push origin "$BUMP_SHA:refs/heads/$VERIFY_BRANCH"
+          gh workflow run test.yml --ref "$VERIFY_BRANCH"
 
           RUN_ID=""
           for attempt in 1 2 3 4 5; do
@@ -87,3 +93,6 @@ jobs:
           fi
 
           gh run watch "$RUN_ID" --exit-status
+          TAG="v${{ steps.bump.outputs.new_version }}"
+          git tag -a "$TAG" -m "$TAG"
+          git push --atomic origin "HEAD:main" "refs/tags/$TAG"

--- a/tests/ci/test_workflow.py
+++ b/tests/ci/test_workflow.py
@@ -81,6 +81,40 @@ def test_version_bump_regenerates_and_commits_lockfile():
     assert lock_step["run"].strip() == "uv lock"
     assert "git add pyproject.toml src/mship/__init__.py uv.lock" in commit_step["run"]
 
+def test_version_bump_runs_canonical_suite_before_publishing():
+    steps = next(iter(_load()["jobs"].values()))["steps"]
+    lock_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Regenerate lockfile"
+    )
+    task_setup_index, task_setup = next(
+        (index, step)
+        for index, step in enumerate(steps)
+        if step.get("uses") == "arduino/setup-task@v2"
+    )
+    identity_index, identity_step = next(
+        (index, step)
+        for index, step in enumerate(steps)
+        if step.get("name") == "Give git an identity"
+    )
+    suite_index, suite_step = next(
+        (index, step)
+        for index, step in enumerate(steps)
+        if step.get("name") == "Run bumped tree suite"
+    )
+    commit_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Commit, tag, and push"
+    )
+
+    assert task_setup["with"]["repo-token"] == "${{ secrets.GITHUB_TOKEN }}"
+    assert 'git config --global user.name "mship ci"' in identity_step["run"]
+    assert 'git config --global user.email "ci@example.invalid"' in identity_step["run"]
+    assert suite_step["run"].strip() == "task test"
+    assert lock_index < task_setup_index < identity_index < suite_index < commit_index
+
 
 def test_pr_workflow_checks_lockfile_before_running_suite():
     steps = next(iter(_load(TEST_WORKFLOW)["jobs"].values()))["steps"]
@@ -109,10 +143,17 @@ def test_version_bump_dispatches_tests_for_new_version_tag_after_pushing():
     commit_step = next(step for step in steps if step.get("name") == "Commit, tag, and push")
     run = commit_step["run"]
     tag = 'git tag -a "v${{ steps.bump.outputs.new_version }}"'
+    commit_sha = 'BUMP_SHA="$(git rev-parse HEAD)"'
     dispatch = 'gh workflow run test.yml --ref "$TAG"'
 
     assert commit_step["env"]["GH_TOKEN"] == "${{ github.token }}"
-    assert run.index(tag) < run.index("git push origin main --follow-tags") < run.index(dispatch)
+    assert (
+        run.index('git commit -m "chore: bump version')
+        < run.index(commit_sha)
+        < run.index(tag)
+        < run.index("git push origin main --follow-tags")
+        < run.index(dispatch)
+    )
     assert "gh workflow run test.yml --ref main" not in run
 
 
@@ -122,7 +163,7 @@ def test_version_bump_waits_for_the_dispatched_tag_ci_run():
     run = commit_step["run"]
     dispatch = 'gh workflow run test.yml --ref "$TAG"'
     lookup = (
-        'gh run list --workflow test.yml --branch "$TAG" --event workflow_dispatch '
+        'gh run list --workflow test.yml --commit "$BUMP_SHA" --event workflow_dispatch '
         "--limit 1 --json databaseId --jq '.[0].databaseId // empty'"
     )
     watch = 'gh run watch "$RUN_ID" --exit-status'
@@ -135,4 +176,5 @@ def test_version_bump_waits_for_the_dispatched_tag_ci_run():
     assert '[ -z "$RUN_ID" ]' in run
     assert "exit 1" in run
     assert watch in run
+    assert '--branch "$TAG"' not in run
     assert run.index(dispatch) < run.index(lookup) < run.index('[ -z "$RUN_ID" ]') < run.index(watch)

--- a/tests/ci/test_workflow.py
+++ b/tests/ci/test_workflow.py
@@ -15,11 +15,13 @@ def test_workflow_exists():
     assert WORKFLOW.is_file()
 
 
-def test_triggers_on_pr_closed():
+def test_triggers_on_pull_request_target_closed_not_pull_request():
     wf = _load()
     # PyYAML parses the bare `on:` key as the boolean True.
     on = wf.get("on", wf.get(True))
-    assert on["pull_request"]["types"] == ["closed"]
+
+    assert on["pull_request_target"]["types"] == ["closed"]
+    assert "pull_request" not in on
 
 
 def test_job_guarded_to_merged_into_main():
@@ -35,6 +37,13 @@ def test_has_required_permissions_and_concurrency():
     assert wf["permissions"]["contents"] == "write"
     assert wf["permissions"]["actions"] == "write"
     assert "concurrency" in wf
+
+def test_bump_job_checks_out_only_trusted_main():
+    steps = next(iter(_load()["jobs"].values()))["steps"]
+    checkout = next(step for step in steps if step["uses"] == "actions/checkout@v4")
+
+    assert checkout["with"]["ref"] == "main"
+    assert "github.event.pull_request.head" not in WORKFLOW.read_text(encoding="utf-8")
 
 
 def test_bump_commit_runs_ci_and_tags():
@@ -95,12 +104,13 @@ def test_test_workflow_supports_explicit_dispatch():
     assert "workflow_dispatch" in on
 
 
-def test_version_bump_dispatches_tests_for_main_after_pushing():
+def test_version_bump_dispatches_tests_for_new_version_tag_after_pushing():
     steps = next(iter(_load()["jobs"].values()))["steps"]
     commit_step = next(step for step in steps if step.get("name") == "Commit, tag, and push")
     run = commit_step["run"]
+    tag = 'git tag -a "v${{ steps.bump.outputs.new_version }}"'
+    dispatch = 'gh workflow run test.yml --ref "v${{ steps.bump.outputs.new_version }}"'
 
     assert commit_step["env"]["GH_TOKEN"] == "${{ github.token }}"
-    assert run.index("git push origin main --follow-tags") < run.index(
-        "gh workflow run test.yml --ref main"
-    )
+    assert run.index(tag) < run.index("git push origin main --follow-tags") < run.index(dispatch)
+    assert "gh workflow run test.yml --ref main" not in run

--- a/tests/ci/test_workflow.py
+++ b/tests/ci/test_workflow.py
@@ -109,8 +109,30 @@ def test_version_bump_dispatches_tests_for_new_version_tag_after_pushing():
     commit_step = next(step for step in steps if step.get("name") == "Commit, tag, and push")
     run = commit_step["run"]
     tag = 'git tag -a "v${{ steps.bump.outputs.new_version }}"'
-    dispatch = 'gh workflow run test.yml --ref "v${{ steps.bump.outputs.new_version }}"'
+    dispatch = 'gh workflow run test.yml --ref "$TAG"'
 
     assert commit_step["env"]["GH_TOKEN"] == "${{ github.token }}"
     assert run.index(tag) < run.index("git push origin main --follow-tags") < run.index(dispatch)
     assert "gh workflow run test.yml --ref main" not in run
+
+
+def test_version_bump_waits_for_the_dispatched_tag_ci_run():
+    steps = next(iter(_load()["jobs"].values()))["steps"]
+    commit_step = next(step for step in steps if step.get("name") == "Commit, tag, and push")
+    run = commit_step["run"]
+    dispatch = 'gh workflow run test.yml --ref "$TAG"'
+    lookup = (
+        'gh run list --workflow test.yml --branch "$TAG" --event workflow_dispatch '
+        "--limit 1 --json databaseId --jq '.[0].databaseId // empty'"
+    )
+    watch = 'gh run watch "$RUN_ID" --exit-status'
+
+    assert 'TAG="v${{ steps.bump.outputs.new_version }}"' in run
+    assert dispatch in run
+    assert lookup in run
+    assert "for attempt in 1 2 3 4 5; do" in run
+    assert 'sleep "$attempt"' in run
+    assert '[ -z "$RUN_ID" ]' in run
+    assert "exit 1" in run
+    assert watch in run
+    assert run.index(dispatch) < run.index(lookup) < run.index('[ -z "$RUN_ID" ]') < run.index(watch)

--- a/tests/ci/test_workflow.py
+++ b/tests/ci/test_workflow.py
@@ -4,10 +4,11 @@ from pathlib import Path
 import yaml
 
 WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "version-bump.yml"
+TEST_WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "test.yml"
 
 
-def _load():
-    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+def _load(workflow=WORKFLOW):
+    return yaml.safe_load(workflow.read_text(encoding="utf-8"))
 
 
 def test_workflow_exists():
@@ -29,15 +30,16 @@ def test_job_guarded_to_merged_into_main():
     assert "base.ref == 'main'" in guard
 
 
-def test_has_write_permission_and_concurrency():
+def test_has_required_permissions_and_concurrency():
     wf = _load()
     assert wf["permissions"]["contents"] == "write"
+    assert wf["permissions"]["actions"] == "write"
     assert "concurrency" in wf
 
 
-def test_bump_commit_uses_skip_ci_and_tags():
+def test_bump_commit_runs_ci_and_tags():
     raw = WORKFLOW.read_text(encoding="utf-8")
-    assert "[skip ci]" in raw
+    assert "[skip ci]" not in raw
     assert "python -m mship.ci.version_bump" in raw
     assert "git tag" in raw
 
@@ -50,3 +52,55 @@ def test_labels_passed_via_env_not_interpolated_into_shell():
     assert "PR_LABELS:" in raw
     assert '--labels "$PR_LABELS"' in raw
     assert '--labels "${{' not in raw
+
+
+def test_version_bump_regenerates_and_commits_lockfile():
+    steps = next(iter(_load()["jobs"].values()))["steps"]
+    bump_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Compute and apply version bump"
+    )
+    lock_index, lock_step = next(
+        (index, step)
+        for index, step in enumerate(steps)
+        if step.get("name") == "Regenerate lockfile"
+    )
+    commit_step = next(step for step in steps if step.get("name") == "Commit, tag, and push")
+
+    assert bump_index < lock_index
+    assert lock_step["run"].strip() == "uv lock"
+    assert "git add pyproject.toml src/mship/__init__.py uv.lock" in commit_step["run"]
+
+
+def test_pr_workflow_checks_lockfile_before_running_suite():
+    steps = next(iter(_load(TEST_WORKFLOW)["jobs"].values()))["steps"]
+    lock_index, lock_step = next(
+        (index, step)
+        for index, step in enumerate(steps)
+        if step.get("name") == "Verify lockfile is current"
+    )
+    suite_index = next(
+        index for index, step in enumerate(steps) if step.get("name") == "Run the suite"
+    )
+
+    assert lock_index < suite_index
+    assert lock_step["run"].strip() == "uv lock --check"
+
+
+def test_test_workflow_supports_explicit_dispatch():
+    wf = _load(TEST_WORKFLOW)
+    on = wf.get("on", wf.get(True))
+
+    assert "workflow_dispatch" in on
+
+
+def test_version_bump_dispatches_tests_for_main_after_pushing():
+    steps = next(iter(_load()["jobs"].values()))["steps"]
+    commit_step = next(step for step in steps if step.get("name") == "Commit, tag, and push")
+    run = commit_step["run"]
+
+    assert commit_step["env"]["GH_TOKEN"] == "${{ github.token }}"
+    assert run.index("git push origin main --follow-tags") < run.index(
+        "gh workflow run test.yml --ref main"
+    )

--- a/tests/ci/test_workflow.py
+++ b/tests/ci/test_workflow.py
@@ -138,37 +138,25 @@ def test_test_workflow_supports_explicit_dispatch():
     assert "workflow_dispatch" in on
 
 
-def test_version_bump_dispatches_tests_for_new_version_tag_after_pushing():
+def test_version_bump_verifies_exact_commit_on_temporary_ref_before_promotion():
     steps = next(iter(_load()["jobs"].values()))["steps"]
     commit_step = next(step for step in steps if step.get("name") == "Commit, tag, and push")
     run = commit_step["run"]
-    tag = 'git tag -a "v${{ steps.bump.outputs.new_version }}"'
     commit_sha = 'BUMP_SHA="$(git rev-parse HEAD)"'
-    dispatch = 'gh workflow run test.yml --ref "$TAG"'
-
-    assert commit_step["env"]["GH_TOKEN"] == "${{ github.token }}"
-    assert (
-        run.index('git commit -m "chore: bump version')
-        < run.index(commit_sha)
-        < run.index(tag)
-        < run.index("git push origin main --follow-tags")
-        < run.index(dispatch)
-    )
-    assert "gh workflow run test.yml --ref main" not in run
-
-
-def test_version_bump_waits_for_the_dispatched_tag_ci_run():
-    steps = next(iter(_load()["jobs"].values()))["steps"]
-    commit_step = next(step for step in steps if step.get("name") == "Commit, tag, and push")
-    run = commit_step["run"]
-    dispatch = 'gh workflow run test.yml --ref "$TAG"'
+    verification_branch = 'VERIFY_BRANCH="mship-verify-$BUMP_SHA"'
+    verification_push = 'git push origin "$BUMP_SHA:refs/heads/$VERIFY_BRANCH"'
+    dispatch = 'gh workflow run test.yml --ref "$VERIFY_BRANCH"'
     lookup = (
         'gh run list --workflow test.yml --commit "$BUMP_SHA" --event workflow_dispatch '
         "--limit 1 --json databaseId --jq '.[0].databaseId // empty'"
     )
     watch = 'gh run watch "$RUN_ID" --exit-status'
+    tag = 'git tag -a "$TAG" -m "$TAG"'
+    promote = 'git push --atomic origin "HEAD:main" "refs/tags/$TAG"'
 
-    assert 'TAG="v${{ steps.bump.outputs.new_version }}"' in run
+    assert commit_step["env"]["GH_TOKEN"] == "${{ github.token }}"
+    assert verification_branch in run
+    assert verification_push in run
     assert dispatch in run
     assert lookup in run
     assert "for attempt in 1 2 3 4 5; do" in run
@@ -176,5 +164,21 @@ def test_version_bump_waits_for_the_dispatched_tag_ci_run():
     assert '[ -z "$RUN_ID" ]' in run
     assert "exit 1" in run
     assert watch in run
-    assert '--branch "$TAG"' not in run
-    assert run.index(dispatch) < run.index(lookup) < run.index('[ -z "$RUN_ID" ]') < run.index(watch)
+    assert tag in run
+    assert promote in run
+    assert "git push origin main --follow-tags" not in run
+    assert 'git push origin main' not in run
+    assert "git push origin --delete \"$VERIFY_BRANCH\"" in run
+    assert "trap 'status=$?; cleanup_verification_ref; exit \"$status\"' EXIT" in run
+    assert (
+        run.index('git commit -m "chore: bump version')
+        < run.index(commit_sha)
+        < run.index(verification_branch)
+        < run.index(verification_push)
+        < run.index(dispatch)
+        < run.index(lookup)
+        < run.index('[ -z "$RUN_ID" ]')
+        < run.index(watch)
+        < run.index(tag)
+        < run.index(promote)
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -568,7 +568,7 @@ wheels = [
 
 [[package]]
 name = "mothership"
-version = "0.5.58"
+version = "0.5.62"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
- regenerate and commit `uv.lock` with every automated version bump
- reject stale locks in PR and main test workflows
- explicitly dispatch the test workflow after the GITHUB_TOKEN version push

Closes #427

## Test plan
- `uv run pytest -q tests/ci/test_workflow.py`
- `uv lock --check`
- `task lint`
- `mship test --repos mothership` (iteration 3: pass)
