### PR TITLE
Detect in-progress git operations

### DIFF
--- a/src/mship/core/remote_preflight.py
+++ b/src/mship/core/remote_preflight.py
@@ -276,7 +276,12 @@ def _operation_in_progress(
 ) -> tuple[str, tuple[str, ...], tuple[str, ...]] | None:
     """Description and complete recovery commands for a suspended git operation."""
     for marker, description, continue_commands, abort_commands in _OPERATIONS:
-        if (git_dir / marker).exists():
+        marker_path = git_dir / marker
+        if (
+            marker == "BISECT_START"
+            and marker_path.is_file()
+            and marker_path.stat().st_size > 0
+        ) or (marker != "BISECT_START" and marker_path.exists()):
             return description, continue_commands, abort_commands
     return None
 
@@ -368,7 +373,7 @@ def _inspect_repo(
                 ]
             )
         if unmerged:
-            detail = f"{detail}; unresolved: {', '.join(sorted(unmerged)[:5])}"
+            detail = f"{detail}\nunresolved: {', '.join(sorted(unmerged)[:5])}"
         return state(blocked=IN_PROGRESS, detail=detail)
 
     # WHAT is being inspected, before WHAT STATE it is in: every verdict below

--- a/src/mship/core/remote_preflight.py
+++ b/src/mship/core/remote_preflight.py
@@ -263,7 +263,7 @@ _OPERATIONS = (
     ),
     ("REVERT_HEAD", "a revert is in progress", ("revert --continue",), ("revert --abort",)),
     (
-        "BISECT_LOG",
+        "BISECT_START",
         "a bisect is in progress",
         ("bisect skip",),
         ("bisect reset",),

--- a/src/mship/core/remote_preflight.py
+++ b/src/mship/core/remote_preflight.py
@@ -159,9 +159,8 @@ _WHY = {
 # collapsing into a command the operator has to rewrite five times by hand.
 _FIX = {
     IN_PROGRESS: [
-        "Finish it or abandon it, then re-run:",
+        "Inspect and finish or abandon the operation Git identifies, then re-run:",
         '  git -C "{path}" status                 # what git is in the middle of',
-        '  git -C "{path}" rebase --abort         # ...or merge/cherry-pick/revert --abort',
     ],
     WRONG_BRANCH: [
         "Check the task's branch back out, then re-run:",
@@ -237,29 +236,48 @@ _UNMERGED_CODES = ("DD", "AU", "UD", "UA", "DU", "AA", "UU")
 # suspended. A `--no-commit` merge leaves MERGE_HEAD with NOTHING unmerged, so
 # the porcelain alone cannot see it — hence the extra look.
 _OPERATIONS = (
-    ("rebase-merge", "a rebase is in progress", "rebase --continue", "rebase --abort"),
+    (
+        "rebase-merge",
+        "a rebase is in progress",
+        ("rebase --continue",),
+        ("rebase --abort",),
+    ),
     (
         "rebase-apply",
         "a rebase or `git am` is in progress",
-        "rebase --continue  # or git am --continue",
-        "rebase --abort     # or git am --abort",
+        ("rebase --continue", "am --continue"),
+        ("rebase --abort", "am --abort"),
     ),
-    ("MERGE_HEAD", "a merge is in progress", "merge --continue", "merge --abort"),
+    (
+        "sequencer",
+        "a cherry-pick or revert sequence is in progress",
+        ("cherry-pick --continue", "revert --continue"),
+        ("cherry-pick --abort", "revert --abort"),
+    ),
+    ("MERGE_HEAD", "a merge is in progress", ("merge --continue",), ("merge --abort",)),
     (
         "CHERRY_PICK_HEAD",
         "a cherry-pick is in progress",
-        "cherry-pick --continue",
-        "cherry-pick --abort",
+        ("cherry-pick --continue",),
+        ("cherry-pick --abort",),
     ),
-    ("REVERT_HEAD", "a revert is in progress", "revert --continue", "revert --abort"),
+    ("REVERT_HEAD", "a revert is in progress", ("revert --continue",), ("revert --abort",)),
+    (
+        "BISECT_LOG",
+        "a bisect is in progress",
+        ("bisect good", "bisect bad"),
+        ("bisect reset",),
+    ),
 )
 
 
-def _operation_in_progress(git_dir: Path) -> tuple[str, str, str] | None:
-    """Description and recovery commands for a suspended git operation."""
-    for marker, description, continue_command, abort_command in _OPERATIONS:
+def _operation_in_progress(
+    git_dir: Path,
+) -> tuple[str, tuple[str, ...], tuple[str, ...]] | None:
+    """Description and complete recovery commands for a suspended git operation."""
+    for marker, description, continue_commands, abort_commands in _OPERATIONS:
         if (git_dir / marker).exists():
-            return description, continue_command, abort_command
+            return description, continue_commands, abort_commands
     return None
 
 
@@ -337,11 +355,17 @@ def _inspect_repo(
     if operation is not None or unmerged:
         detail = "unmerged paths"
         if operation is not None:
-            description, continue_command, abort_command = operation
-            detail = (
-                f"{description}\n"
-                f'continue: git -C "{path}" {continue_command}\n'
-                f'abort: git -C "{path}" {abort_command}'
+            description, continue_commands, abort_commands = operation
+            detail = "\n".join(
+                [description]
+                + [
+                    f'continue: git -C "{path}" {command}'
+                    for command in continue_commands
+                ]
+                + [
+                    f'abort: git -C "{path}" {command}'
+                    for command in abort_commands
+                ]
             )
         if unmerged:
             detail = f"{detail}; unresolved: {', '.join(sorted(unmerged)[:5])}"

--- a/src/mship/core/remote_preflight.py
+++ b/src/mship/core/remote_preflight.py
@@ -237,19 +237,29 @@ _UNMERGED_CODES = ("DD", "AU", "UD", "UA", "DU", "AA", "UU")
 # suspended. A `--no-commit` merge leaves MERGE_HEAD with NOTHING unmerged, so
 # the porcelain alone cannot see it — hence the extra look.
 _OPERATIONS = (
-    ("rebase-merge", "a rebase is in progress"),
-    ("rebase-apply", "a rebase or `git am` is in progress"),
-    ("MERGE_HEAD", "a merge is in progress"),
-    ("CHERRY_PICK_HEAD", "a cherry-pick is in progress"),
-    ("REVERT_HEAD", "a revert is in progress"),
+    ("rebase-merge", "a rebase is in progress", "rebase --continue", "rebase --abort"),
+    (
+        "rebase-apply",
+        "a rebase or `git am` is in progress",
+        "rebase --continue  # or git am --continue",
+        "rebase --abort     # or git am --abort",
+    ),
+    ("MERGE_HEAD", "a merge is in progress", "merge --continue", "merge --abort"),
+    (
+        "CHERRY_PICK_HEAD",
+        "a cherry-pick is in progress",
+        "cherry-pick --continue",
+        "cherry-pick --abort",
+    ),
+    ("REVERT_HEAD", "a revert is in progress", "revert --continue", "revert --abort"),
 )
 
 
-def _operation_in_progress(git_dir: Path) -> str | None:
-    """Which suspended git operation this worktree is in, if any."""
-    for marker, description in _OPERATIONS:
+def _operation_in_progress(git_dir: Path) -> tuple[str, str, str] | None:
+    """Description and recovery commands for a suspended git operation."""
+    for marker, description, continue_command, abort_command in _OPERATIONS:
         if (git_dir / marker).exists():
-            return description
+            return description, continue_command, abort_command
     return None
 
 
@@ -325,7 +335,14 @@ def _inspect_repo(
         git_dir = path / git_dir
     operation = _operation_in_progress(git_dir)
     if operation is not None or unmerged:
-        detail = operation or "unmerged paths"
+        detail = "unmerged paths"
+        if operation is not None:
+            description, continue_command, abort_command = operation
+            detail = (
+                f"{description}\n"
+                f'continue: git -C "{path}" {continue_command}\n'
+                f'abort: git -C "{path}" {abort_command}'
+            )
         if unmerged:
             detail = f"{detail}; unresolved: {', '.join(sorted(unmerged)[:5])}"
         return state(blocked=IN_PROGRESS, detail=detail)

--- a/src/mship/core/remote_preflight.py
+++ b/src/mship/core/remote_preflight.py
@@ -382,45 +382,29 @@ def _inspect_repo(
     # published. Asked after `git status` because a path that is not a git
     # worktree at all is UNREADABLE, not "on the wrong branch".
     #
-    # Branch identity and the sha to carry forward used to be two separate git
-    # invocations — a `symbolic-ref` to name the checked-out branch, then a
-    # `rev-parse HEAD` to capture the sha — with a window between them: a `git
-    # checkout` landing in that window verifies branch A and then captures a
-    # sha that belongs to branch B, so every check past this point reasons
-    # about a commit that was never on the branch it validated. Two subprocess
-    # calls cannot be made atomic against an outside writer, so instead they
-    # are made self-verifying: a SINGLE `git rev-parse HEAD refs/heads/<branch>`
-    # reads both shas out of the same process. If they agree, HEAD was at that
-    # branch's tip at this instant — exactly the invariant every check below
-    # assumes. If they disagree (including one of them failing to resolve at
-    # all — a detached HEAD, no local ref by this name, an unborn branch),
-    # HEAD is not on the task's branch, which is already a refusal. That
-    # subsumes the old `symbolic-ref` check entirely: the two values could
-    # never come out equal without HEAD being ON refs/heads/<branch>.
-    #
-    # One process is not one instant, though: git still resolves HEAD and
-    # then refs/heads/<branch> as two sequential reads within this single
-    # command, so a ref mutating in THAT window (a concurrent commit, or a
-    # force-checkout that also moves the branch) is a torn read too, not just
-    # the two-command case above. It needs no separate handling because the
-    # same equality check already covers it: either the mutation lands
-    # outside the window and both reads see one consistent value, or it lands
-    # inside and the two reads disagree — which is the WRONG_BRANCH refusal
-    # already taken above. There is no interleaving where the two agree on a
-    # sha that was never actually the branch's tip at some consistent instant.
+    # `rev-parse HEAD refs/heads/<branch>` can certify that two names resolved
+    # to the same commit, but not that HEAD is attached to the branch: a
+    # detached HEAD at the task branch's tip returns the same pair. Establish
+    # the symbolic identity first, before any origin query or delivery command.
     ref = f"refs/heads/{branch}"
+    head_ref = shell.run("git symbolic-ref --quiet HEAD", cwd=path)
+    checked_ref = (head_ref.stdout or "").strip()
+    checked_out = checked_ref.removeprefix("refs/heads/")
+    if head_ref.returncode != 0 or checked_ref != ref:
+        return state(
+            blocked=WRONG_BRANCH,
+            detail=f"HEAD is {checked_out or 'detached'}, not {branch}",
+        )
+
+    # The symbolic name is not enough to safely carry a commit forward: a
+    # branch can move while git resolves HEAD and its direct ref. Keep the
+    # combined read and require the two shas to agree, refusing a torn read
+    # rather than pinning a commit that was not the task branch's tip.
     pair = shell.run(f"git rev-parse HEAD {shlex.quote(ref)}", cwd=path)
     out = (pair.stdout or "").splitlines()
     head_sha = out[0].strip() if out else ""
     branch_tip = out[1].strip() if len(out) > 1 else ""
     if pair.returncode != 0 or not head_sha or head_sha != branch_tip:
-        # `symbolic-ref` is asked here ONLY to name what IS checked out, for
-        # the refusal message — it plays no part in the decision above, so its
-        # being a second, unsynchronized read does not reopen the race: the
-        # run is already refused, and no `head_sha` is ever produced for this
-        # repo.
-        head_ref = shell.run("git symbolic-ref --quiet HEAD", cwd=path)
-        checked_out = (head_ref.stdout or "").strip().removeprefix("refs/heads/")
         return state(
             blocked=WRONG_BRANCH,
             detail=f"HEAD is {checked_out or 'detached'}, not {branch}",

--- a/src/mship/core/remote_preflight.py
+++ b/src/mship/core/remote_preflight.py
@@ -265,7 +265,7 @@ _OPERATIONS = (
     (
         "BISECT_LOG",
         "a bisect is in progress",
-        ("bisect good", "bisect bad"),
+        ("bisect skip",),
         ("bisect reset",),
     ),
 )

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -1306,7 +1306,7 @@ def test_a_mid_rebase_repo_is_refused_before_anything_is_sent(tmp_path, monkeypa
             ),
         ),
         (
-            "BISECT_LOG",
+            "BISECT_START",
             "a bisect is in progress",
             ("bisect skip", "bisect reset"),
         ),
@@ -1316,7 +1316,7 @@ def test_a_mid_rebase_repo_is_refused_before_anything_is_sent(tmp_path, monkeypa
 @pytest.mark.parametrize(
     "head_ref",
     ["refs/heads/other", ""],
-    ids=["wrong-branch", "detached"],
+    ids=["wrong-branch", "no-checkout"],
 )
 def test_clean_operation_marker_outranks_detached_or_wrong_branch(
     tmp_path, monkeypatch, marker, description, recovery_commands,
@@ -1336,6 +1336,8 @@ def test_clean_operation_marker_outranks_detached_or_wrong_branch(
         marker_path.mkdir()
     else:
         marker_path.touch()
+    if marker == "BISECT_START":
+        assert not (git_dir / "BISECT_LOG").exists()
     _configure(tmp_path)
     shell = _git_shell(
         _repo_git(head_ref=head_ref),
@@ -1353,9 +1355,14 @@ def test_clean_operation_marker_outranks_detached_or_wrong_branch(
         assert description in result.output
         for command in recovery_commands:
             assert f'git -C "{wts["api"]}" {command}' in result.output
-        if marker == "BISECT_LOG":
+        if marker == "BISECT_START":
             assert f'git -C "{wts["api"]}" bisect good' not in result.output
             assert f'git -C "{wts["api"]}" bisect bad' not in result.output
+        commands = [call.args[0] for call in shell.run.call_args_list]
+        assert not any(
+            command.startswith(("git rev-parse HEAD", "git symbolic-ref", "git ls-remote", "git merge-base"))
+            for command in commands
+        ), commands
         assert "# or git" not in result.output
         assert "checkout" not in result.output
         assert shell.pushes == []

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -1308,7 +1308,7 @@ def test_a_mid_rebase_repo_is_refused_before_anything_is_sent(tmp_path, monkeypa
         (
             "BISECT_LOG",
             "a bisect is in progress",
-            ("bisect good", "bisect bad", "bisect reset"),
+            ("bisect skip", "bisect reset"),
         ),
     ],
 )
@@ -1353,6 +1353,9 @@ def test_clean_operation_marker_outranks_detached_or_wrong_branch(
         assert description in result.output
         for command in recovery_commands:
             assert f'git -C "{wts["api"]}" {command}' in result.output
+        if marker == "BISECT_LOG":
+            assert f'git -C "{wts["api"]}" bisect good' not in result.output
+            assert f'git -C "{wts["api"]}" bisect bad' not in result.output
         assert "# or git" not in result.output
         assert "checkout" not in result.output
         assert shell.pushes == []

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -1263,21 +1263,52 @@ def test_a_mid_rebase_repo_is_refused_before_anything_is_sent(tmp_path, monkeypa
 
 
 @pytest.mark.parametrize(
-    ("marker", "description", "continue_command", "abort_command"),
+    ("marker", "description", "recovery_commands"),
     [
-        ("rebase-merge", "a rebase is in progress", "rebase --continue", "rebase --abort"),
+        (
+            "rebase-merge",
+            "a rebase is in progress",
+            ("rebase --continue", "rebase --abort"),
+        ),
         (
             "rebase-apply",
             "a rebase or `git am` is in progress",
-            "rebase --continue",
-            "rebase --abort",
+            (
+                "rebase --continue",
+                "am --continue",
+                "rebase --abort",
+                "am --abort",
+            ),
         ),
-        ("MERGE_HEAD", "a merge is in progress", "merge --continue", "merge --abort"),
+        (
+            "MERGE_HEAD",
+            "a merge is in progress",
+            ("merge --continue", "merge --abort"),
+        ),
         (
             "CHERRY_PICK_HEAD",
             "a cherry-pick is in progress",
-            "cherry-pick --continue",
-            "cherry-pick --abort",
+            ("cherry-pick --continue", "cherry-pick --abort"),
+        ),
+        (
+            "REVERT_HEAD",
+            "a revert is in progress",
+            ("revert --continue", "revert --abort"),
+        ),
+        (
+            "sequencer",
+            "a cherry-pick or revert sequence is in progress",
+            (
+                "cherry-pick --continue",
+                "revert --continue",
+                "cherry-pick --abort",
+                "revert --abort",
+            ),
+        ),
+        (
+            "BISECT_LOG",
+            "a bisect is in progress",
+            ("bisect good", "bisect bad", "bisect reset"),
         ),
     ],
 )
@@ -1288,7 +1319,7 @@ def test_a_mid_rebase_repo_is_refused_before_anything_is_sent(tmp_path, monkeypa
     ids=["wrong-branch", "detached"],
 )
 def test_clean_operation_marker_outranks_detached_or_wrong_branch(
-    tmp_path, monkeypatch, marker, description, continue_command, abort_command,
+    tmp_path, monkeypatch, marker, description, recovery_commands,
     linked_worktree, head_ref,
 ):
     """A suspended operation wins over a detached/wrong-branch HEAD, even clean."""
@@ -1301,7 +1332,7 @@ def test_clean_operation_marker_outranks_detached_or_wrong_branch(
     )
     marker_path = git_dir / marker
     marker_path.parent.mkdir(parents=True, exist_ok=True)
-    if marker.startswith("rebase-"):
+    if marker in {"rebase-merge", "rebase-apply", "sequencer"}:
         marker_path.mkdir()
     else:
         marker_path.touch()
@@ -1320,8 +1351,9 @@ def test_clean_operation_marker_outranks_detached_or_wrong_branch(
             result = runner.invoke(app, ["run", "--task", "t1", "--remote=role-x"])
         assert result.exit_code == 1, result.output
         assert description in result.output
-        assert f'git -C "{wts["api"]}" {continue_command}' in result.output
-        assert f'git -C "{wts["api"]}" {abort_command}' in result.output
+        for command in recovery_commands:
+            assert f'git -C "{wts["api"]}" {command}' in result.output
+        assert "# or git" not in result.output
         assert "checkout" not in result.output
         assert shell.pushes == []
         assert recorder == {}

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -1014,7 +1014,10 @@ def _repo_git(porcelain: str = "", *, origin: str | None = "headsha",
     }
 
 
-def _git_shell(spec: dict | dict[str, dict], *, push_rc: int = 0):
+def _git_shell(
+    spec: dict | dict[str, dict], *, push_rc: int = 0,
+    git_dirs: dict[str, Path] | None = None,
+):
     """A shell whose git answers are scripted per repo (keyed by the worktree
     directory name), with everything else passing. A bare spec applies to `api`."""
     if "status" in spec:
@@ -1023,6 +1026,7 @@ def _git_shell(spec: dict | dict[str, dict], *, push_rc: int = 0):
     pushes: list[str] = []
     push_envs: list[dict] = []
     touched: set[str] = set()
+    git_dirs = git_dirs or {}
 
     def _run(cmd, cwd=None, env=None, **kw):
         touched.add(Path(cwd).name)
@@ -1034,7 +1038,11 @@ def _git_shell(spec: dict | dict[str, dict], *, push_rc: int = 0):
         if "rev-parse --git-dir" in cmd:
             # `_inspect_repo` looks here for MERGE_HEAD / rebase-merge — a test
             # that wants the in-progress refusal creates the marker itself.
-            return ShellResult(returncode=0, stdout=str(Path(cwd) / ".git"), stderr="")
+            git_dir = git_dirs.get(Path(cwd).name)
+            return ShellResult(
+                returncode=0, stdout=str(git_dir) if git_dir is not None else ".git",
+                stderr="",
+            )
         if "symbolic-ref" in cmd:
             return ShellResult(
                 returncode=0 if s["head_ref"] else 1, stdout=s["head_ref"], stderr="",
@@ -1247,6 +1255,74 @@ def test_a_mid_rebase_repo_is_refused_before_anything_is_sent(tmp_path, monkeypa
         assert result.exit_code == 1, result.output
         assert "merge or rebase in progress in api" in result.output
         assert "--abort" in result.output
+        assert shell.pushes == []
+        assert recorder == {}
+    finally:
+        container.shell.reset_override()
+        _reset()
+
+
+@pytest.mark.parametrize(
+    ("marker", "description", "continue_command", "abort_command"),
+    [
+        ("rebase-merge", "a rebase is in progress", "rebase --continue", "rebase --abort"),
+        (
+            "rebase-apply",
+            "a rebase or `git am` is in progress",
+            "rebase --continue",
+            "rebase --abort",
+        ),
+        ("MERGE_HEAD", "a merge is in progress", "merge --continue", "merge --abort"),
+        (
+            "CHERRY_PICK_HEAD",
+            "a cherry-pick is in progress",
+            "cherry-pick --continue",
+            "cherry-pick --abort",
+        ),
+    ],
+)
+@pytest.mark.parametrize("linked_worktree", [False, True], ids=["normal", "linked"])
+@pytest.mark.parametrize(
+    "head_ref",
+    ["refs/heads/other", ""],
+    ids=["wrong-branch", "detached"],
+)
+def test_clean_operation_marker_outranks_detached_or_wrong_branch(
+    tmp_path, monkeypatch, marker, description, continue_command, abort_command,
+    linked_worktree, head_ref,
+):
+    """A suspended operation wins over a detached/wrong-branch HEAD, even clean."""
+    _write_run_workspace(tmp_path, run_hosts=["role-x"])
+    wts = _seed_task_with_worktree(tmp_path, "t1", "api")
+    git_dir = (
+        tmp_path / ".git-worktrees" / "api"
+        if linked_worktree
+        else wts["api"] / ".git"
+    )
+    marker_path = git_dir / marker
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    if marker.startswith("rebase-"):
+        marker_path.mkdir()
+    else:
+        marker_path.touch()
+    _configure(tmp_path)
+    shell = _git_shell(
+        _repo_git(head_ref=head_ref),
+        git_dirs={"api": git_dir} if linked_worktree else None,
+    )
+    container.shell.override(shell)
+    RunHostStore(tmp_path / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+    recorder: dict = {}
+    try:
+        with _ClientPatch(monkeypatch, _recording_handler(recorder, _frame([], exit_code=0))):
+            result = runner.invoke(app, ["run", "--task", "t1", "--remote=role-x"])
+        assert result.exit_code == 1, result.output
+        assert description in result.output
+        assert f'git -C "{wts["api"]}" {continue_command}' in result.output
+        assert f'git -C "{wts["api"]}" {abort_command}' in result.output
+        assert "checkout" not in result.output
         assert shell.pushes == []
         assert recorder == {}
     finally:

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -1334,6 +1334,8 @@ def test_clean_operation_marker_outranks_detached_or_wrong_branch(
     marker_path.parent.mkdir(parents=True, exist_ok=True)
     if marker in {"rebase-merge", "rebase-apply", "sequencer"}:
         marker_path.mkdir()
+    elif marker == "BISECT_START":
+        marker_path.write_text("start\n")
     else:
         marker_path.touch()
     if marker == "BISECT_START":

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -1003,14 +1003,15 @@ def _seed_task_with_worktree(ws: Path, slug: str, *repos: str) -> dict[str, Path
 def _repo_git(porcelain: str = "", *, origin: str | None = "headsha",
               head: str = "headsha", contains: list[str] = [],
               status_rc: int = 0, status_err: str = "",
-              head_ref: str = "refs/heads/feat/t1") -> dict:
+              head_ref: str = "refs/heads/feat/t1",
+              pair_output: str | None = None) -> dict:
     """One repo's scripted git answers. Defaults to clean, on the task's branch,
     and in sync with origin (`origin` None = the branch is not on origin at
     all; `head_ref` "" = a detached HEAD)."""
     return {
         "status": porcelain, "status_rc": status_rc, "status_err": status_err,
         "origin": origin, "head": head, "contains": contains,
-        "head_ref": head_ref,
+        "head_ref": head_ref, "pair_output": pair_output,
     }
 
 
@@ -1051,12 +1052,14 @@ def _git_shell(
             out = "" if s["origin"] is None else f"{s['origin']}\trefs/heads/feat/t1\n"
             return ShellResult(returncode=0, stdout=out, stderr="")
         if "rev-parse HEAD" in cmd and "refs/heads/" in cmd:
-            # The atomic branch-identity + sha read `_inspect_repo` makes: one
-            # call answering both "which branch is HEAD on" and "what sha is
-            # it at" from the same process. `head_ref` decides whether the
-            # branch-ref half of the pair agrees with `head` (HEAD really is
-            # on the named branch) or reports a distinct sha (it is not).
+            # `_inspect_repo` separately verifies symbolic attachment, then
+            # compares HEAD and the task ref in one combined read. `head_ref`
+            # decides whether the branch-ref half agrees with `head`; a test
+            # can override that pair to model a torn read or detached HEAD at
+            # the branch tip.
             target_ref = cmd.rsplit("refs/heads/", 1)[-1].strip("'\"")
+            if s["pair_output"] is not None:
+                return ShellResult(returncode=0, stdout=s["pair_output"], stderr="")
             branch_sha = (
                 s["head"] if s["head_ref"] == f"refs/heads/{target_ref}"
                 else "otherbranchsha"
@@ -1537,6 +1540,35 @@ def test_a_worktree_not_on_the_task_branch_is_not_dispatched(tmp_path, monkeypat
         assert "worktree is not on the task's branch in api" in result.output
         assert "HEAD is main, not feat/t1" in result.output
         assert shell.pushes == []        # nothing published for an unverified HEAD
+        assert recorder == {}
+    finally:
+        container.shell.reset_override()
+        _reset()
+
+
+def test_a_detached_worktree_at_the_task_tip_is_not_dispatched(tmp_path, monkeypatch):
+    """A matching SHA does not establish that the worktree is on task t1's branch."""
+    _write_run_workspace(tmp_path, run_hosts=["role-x"])
+    _seed_task_with_worktree(tmp_path, "t1", "api")
+    _configure(tmp_path)
+    shell = _git_shell(_repo_git(
+        head_ref="",
+        pair_output="headsha\nheadsha\n",
+    ))
+    container.shell.override(shell)
+    RunHostStore(tmp_path / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+    recorder: dict = {}
+    try:
+        with _ClientPatch(monkeypatch, _recording_handler(recorder, _frame([], exit_code=0))):
+            result = runner.invoke(app, ["run", "--task", "t1", "--remote=role-x"])
+        assert result.exit_code == 1, result.output
+        assert "worktree is not on the task's branch in api" in result.output
+        assert "HEAD is detached, not feat/t1" in result.output
+        commands = [call.args[0] for call in shell.run.call_args_list]
+        assert not any("ls-remote" in command for command in commands)
+        assert shell.pushes == []
         assert recorder == {}
     finally:
         container.shell.reset_override()

--- a/tests/cli/test_resolve.py
+++ b/tests/cli/test_resolve.py
@@ -7,8 +7,15 @@ import pytest
 import typer
 
 from mship.cli._resolve import resolve_for_command
-from mship.cli.output import Output
+from mship.cli.output import Output, reset_output_settings
 from mship.core.state import Task, WorkspaceState
+
+
+@pytest.fixture(autouse=True)
+def _isolate_output_settings():
+    reset_output_settings()
+    yield
+    reset_output_settings()
 
 
 def _task(slug: str, worktree: Path | None = None) -> Task:

--- a/tests/core/test_remote_preflight.py
+++ b/tests/core/test_remote_preflight.py
@@ -602,18 +602,22 @@ def test_clean_sequencer_is_refused_before_wrong_branch_with_both_recoveries(tmp
     assert f'git -C "{api}" rebase --abort' not in msg
 
 
-def test_active_bisect_log_is_refused_before_wrong_branch_with_recovery(tmp_path):
+def test_custom_term_bisect_is_refused_before_wrong_branch_with_recovery(tmp_path):
     api = _repo(tmp_path, "api")
     (api / ".git").mkdir(parents=True, exist_ok=True)
-    (api / ".git" / "BISECT_LOG").write_text("git bisect start\n")
+    (api / ".git" / "BISECT_LOG").write_text(
+        "git bisect start --term-old=stable --term-new=broken\n"
+    )
     shell = FakeShell({"api": _clean(status="", head_ref="refs/heads/other")})
 
     pre = inspect(FakeTask({"api": api}), shell)
 
     assert [s.blocked_reason for s in pre.blocked] == [IN_PROGRESS]
     msg = blocked_message(pre)
-    for command in ("bisect good", "bisect bad", "bisect reset"):
+    for command in ("bisect skip", "bisect reset"):
         assert f'git -C "{api}" {command}' in msg
+    assert f'git -C "{api}" bisect good' not in msg
+    assert f'git -C "{api}" bisect bad' not in msg
     assert "checkout" not in msg
     assert f'git -C "{api}" rebase --abort' not in msg
 

--- a/tests/core/test_remote_preflight.py
+++ b/tests/core/test_remote_preflight.py
@@ -620,6 +620,37 @@ def test_bisect_is_refused_before_wrong_branch_with_term_agnostic_recovery(tmp_p
     assert f'git -C "{api}" rebase --abort' not in msg
 
 
+def test_bisect_start_is_active_only_when_nonempty(tmp_path):
+    api = _repo(tmp_path, "api")
+    (api / ".git").mkdir(parents=True, exist_ok=True)
+    shell = FakeShell({"api": _clean(status="")})
+
+    (api / ".git" / "BISECT_START").touch()
+    empty = inspect(FakeTask({"api": api}), shell)
+
+    (api / ".git" / "BISECT_START").write_text("start\n")
+    active = inspect(FakeTask({"api": api}), shell)
+
+    assert empty.ok
+    assert empty.blocked == []
+    assert [s.blocked_reason for s in active.blocked] == [IN_PROGRESS]
+
+
+def test_bisect_recovery_commands_remain_copyable_with_unmerged_paths(tmp_path):
+    api = _repo(tmp_path, "api")
+    (api / ".git").mkdir(parents=True, exist_ok=True)
+    (api / ".git" / "BISECT_START").write_text("start\n")
+    shell = FakeShell({"api": _clean(status="UU src/app.py\n")})
+
+    lines = blocked_message(inspect(FakeTask({"api": api}), shell)).splitlines()
+    skip = f'continue: git -C "{api}" bisect skip'
+    reset = f'abort: git -C "{api}" bisect reset'
+
+    assert skip in lines
+    assert reset in lines
+    assert lines[lines.index(reset) + 1] == "unresolved: src/app.py"
+
+
 def test_historical_bisect_log_without_active_state_is_not_refused(tmp_path):
     api = _repo(tmp_path, "api")
     (api / ".git").mkdir(parents=True, exist_ok=True)

--- a/tests/core/test_remote_preflight.py
+++ b/tests/core/test_remote_preflight.py
@@ -602,12 +602,10 @@ def test_clean_sequencer_is_refused_before_wrong_branch_with_both_recoveries(tmp
     assert f'git -C "{api}" rebase --abort' not in msg
 
 
-def test_custom_term_bisect_is_refused_before_wrong_branch_with_recovery(tmp_path):
+def test_bisect_is_refused_before_wrong_branch_with_term_agnostic_recovery(tmp_path):
     api = _repo(tmp_path, "api")
     (api / ".git").mkdir(parents=True, exist_ok=True)
-    (api / ".git" / "BISECT_LOG").write_text(
-        "git bisect start --term-old=stable --term-new=broken\n"
-    )
+    (api / ".git" / "BISECT_START").write_text("start\n")
     shell = FakeShell({"api": _clean(status="", head_ref="refs/heads/other")})
 
     pre = inspect(FakeTask({"api": api}), shell)
@@ -620,6 +618,18 @@ def test_custom_term_bisect_is_refused_before_wrong_branch_with_recovery(tmp_pat
     assert f'git -C "{api}" bisect bad' not in msg
     assert "checkout" not in msg
     assert f'git -C "{api}" rebase --abort' not in msg
+
+
+def test_historical_bisect_log_without_active_state_is_not_refused(tmp_path):
+    api = _repo(tmp_path, "api")
+    (api / ".git").mkdir(parents=True, exist_ok=True)
+    (api / ".git" / "BISECT_LOG").write_text("git bisect start --term-old=stable --term-new=broken\n")
+    shell = FakeShell({"api": _clean(status="")})
+
+    pre = inspect(FakeTask({"api": api}), shell)
+
+    assert pre.ok
+    assert pre.blocked == []
 
 
 def test_a_revert_in_progress_does_not_offer_a_rebase_abort(tmp_path):

--- a/tests/core/test_remote_preflight.py
+++ b/tests/core/test_remote_preflight.py
@@ -431,6 +431,22 @@ def test_one_ref_failing_to_resolve_mid_command_is_refused_not_pinned(tmp_path):
     assert pre.states[0].head_sha is None
 
 
+def test_a_detached_worktree_at_the_task_tip_is_refused_before_origin(tmp_path):
+    """SHA equality cannot substitute for being attached to the task branch."""
+    api = _repo(tmp_path, "api")
+    shell = FakeShell({"api": _clean(
+        head_ref="",
+        pair_output="headsha\nheadsha\n",
+    )})
+    pre = inspect(FakeTask({"api": api}), shell)
+
+    assert not pre.ok
+    assert [s.blocked_reason for s in pre.blocked] == [WRONG_BRANCH]
+    assert "HEAD is detached, not feat/x" in blocked_message(pre)
+    assert not any("ls-remote" in command for command in shell.commands)
+    assert shell.pushes == []
+
+
 def test_a_detached_worktree_is_refused_and_says_so(tmp_path):
     """Detached is the same finding with no branch name to report: `symbolic-ref
     --quiet` exits non-zero with empty output, which must not read as a match."""

--- a/tests/core/test_remote_preflight.py
+++ b/tests/core/test_remote_preflight.py
@@ -511,11 +511,8 @@ def test_a_conflicted_repo_is_refused(tmp_path):
     msg = blocked_message(pre)
     assert "merge or rebase in progress in api" in msg
     assert "src/app.py" in msg          # which file, exactly
-    assert "--abort" in msg             # the way out
-    assert (
-        f'git -C "{api}" rebase --abort         '
-        "# ...or merge/cherry-pick/revert --abort"
-    ) in msg
+    assert f'git -C "{api}" status' in msg
+    assert f'git -C "{api}" rebase --abort' not in msg
 
 
 def test_a_mid_rebase_repo_is_refused_ahead_of_the_branch_check(tmp_path):
@@ -551,6 +548,8 @@ def test_a_mid_merge_repo_is_refused_even_with_a_clean_tree(tmp_path):
     assert f'continue: git -C "{api}" merge --continue' in msg
     assert f'abort: git -C "{api}" merge --abort' in msg
 
+    assert f'git -C "{api}" rebase --abort' not in msg
+
 
 def test_a_cherry_pick_in_progress_is_refused(tmp_path):
     api = _repo(tmp_path, "api")
@@ -564,8 +563,10 @@ def test_a_cherry_pick_in_progress_is_refused(tmp_path):
     assert f'continue: git -C "{api}" cherry-pick --continue' in msg
     assert f'abort: git -C "{api}" cherry-pick --abort' in msg
 
+    assert f'git -C "{api}" rebase --abort' not in msg
 
-def test_a_mid_rebase_apply_repo_names_its_precise_recovery_commands(tmp_path):
+
+def test_a_mid_rebase_apply_repo_lists_rebase_and_git_am_recovery_separately(tmp_path):
     api = _repo(tmp_path, "api")
     (api / ".git" / "rebase-apply").mkdir(parents=True)
     shell = FakeShell({"api": _clean(status="", head_ref="")})
@@ -574,8 +575,62 @@ def test_a_mid_rebase_apply_repo_names_its_precise_recovery_commands(tmp_path):
 
     assert [s.blocked_reason for s in pre.blocked] == [IN_PROGRESS]
     msg = blocked_message(pre)
-    assert f'continue: git -C "{api}" rebase --continue  # or git am --continue' in msg
-    assert f'abort: git -C "{api}" rebase --abort     # or git am --abort' in msg
+    assert f'continue: git -C "{api}" rebase --continue' in msg
+    assert f'continue: git -C "{api}" am --continue' in msg
+    assert f'abort: git -C "{api}" rebase --abort' in msg
+    assert f'abort: git -C "{api}" am --abort' in msg
+    assert "# or git am" not in msg
+
+
+def test_clean_sequencer_is_refused_before_wrong_branch_with_both_recoveries(tmp_path):
+    api = _repo(tmp_path, "api")
+    (api / ".git" / "sequencer").mkdir(parents=True)
+    shell = FakeShell({"api": _clean(status="", head_ref="refs/heads/other")})
+
+    pre = inspect(FakeTask({"api": api}), shell)
+
+    assert [s.blocked_reason for s in pre.blocked] == [IN_PROGRESS]
+    msg = blocked_message(pre)
+    for command in (
+        "cherry-pick --continue",
+        "revert --continue",
+        "cherry-pick --abort",
+        "revert --abort",
+    ):
+        assert f'git -C "{api}" {command}' in msg
+    assert "checkout" not in msg
+    assert f'git -C "{api}" rebase --abort' not in msg
+
+
+def test_active_bisect_log_is_refused_before_wrong_branch_with_recovery(tmp_path):
+    api = _repo(tmp_path, "api")
+    (api / ".git").mkdir(parents=True, exist_ok=True)
+    (api / ".git" / "BISECT_LOG").write_text("git bisect start\n")
+    shell = FakeShell({"api": _clean(status="", head_ref="refs/heads/other")})
+
+    pre = inspect(FakeTask({"api": api}), shell)
+
+    assert [s.blocked_reason for s in pre.blocked] == [IN_PROGRESS]
+    msg = blocked_message(pre)
+    for command in ("bisect good", "bisect bad", "bisect reset"):
+        assert f'git -C "{api}" {command}' in msg
+    assert "checkout" not in msg
+    assert f'git -C "{api}" rebase --abort' not in msg
+
+
+def test_a_revert_in_progress_does_not_offer_a_rebase_abort(tmp_path):
+    api = _repo(tmp_path, "api")
+    (api / ".git").mkdir(parents=True, exist_ok=True)
+    (api / ".git" / "REVERT_HEAD").write_text("abc\n")
+    shell = FakeShell({"api": _clean(status="")})
+
+    msg = blocked_message(inspect(FakeTask({"api": api}), shell))
+
+    assert f'git -C "{api}" revert --continue' in msg
+    assert f'git -C "{api}" revert --abort' in msg
+    assert f'git -C "{api}" rebase --abort' not in msg
+
+
 
 
 def test_an_unanswerable_git_dir_is_unreadable_not_transferred(tmp_path):

--- a/tests/core/test_remote_preflight.py
+++ b/tests/core/test_remote_preflight.py
@@ -512,6 +512,10 @@ def test_a_conflicted_repo_is_refused(tmp_path):
     assert "merge or rebase in progress in api" in msg
     assert "src/app.py" in msg          # which file, exactly
     assert "--abort" in msg             # the way out
+    assert (
+        f'git -C "{api}" rebase --abort         '
+        "# ...or merge/cherry-pick/revert --abort"
+    ) in msg
 
 
 def test_a_mid_rebase_repo_is_refused_ahead_of_the_branch_check(tmp_path):
@@ -528,6 +532,8 @@ def test_a_mid_rebase_repo_is_refused_ahead_of_the_branch_check(tmp_path):
     assert [s.blocked_reason for s in pre.blocked] == [IN_PROGRESS]
     msg = blocked_message(pre)
     assert "rebase" in msg
+    assert f'continue: git -C "{api}" rebase --continue' in msg
+    assert f'abort: git -C "{api}" rebase --abort' in msg
     assert "checkout" not in msg        # NOT the wrong-branch remedy
 
 
@@ -538,8 +544,12 @@ def test_a_mid_merge_repo_is_refused_even_with_a_clean_tree(tmp_path):
     (api / ".git").mkdir(parents=True, exist_ok=True)
     (api / ".git" / "MERGE_HEAD").write_text("abc\n")
     shell = FakeShell({"api": _clean(status="")})
-    assert [s.blocked_reason for s in inspect(FakeTask({"api": api}), shell).blocked] \
-        == [IN_PROGRESS]
+    pre = inspect(FakeTask({"api": api}), shell)
+
+    assert [s.blocked_reason for s in pre.blocked] == [IN_PROGRESS]
+    msg = blocked_message(pre)
+    assert f'continue: git -C "{api}" merge --continue' in msg
+    assert f'abort: git -C "{api}" merge --abort' in msg
 
 
 def test_a_cherry_pick_in_progress_is_refused(tmp_path):
@@ -547,8 +557,25 @@ def test_a_cherry_pick_in_progress_is_refused(tmp_path):
     (api / ".git").mkdir(parents=True, exist_ok=True)
     (api / ".git" / "CHERRY_PICK_HEAD").write_text("abc\n")
     shell = FakeShell({"api": _clean(status="")})
-    assert [s.blocked_reason for s in inspect(FakeTask({"api": api}), shell).blocked] \
-        == [IN_PROGRESS]
+    pre = inspect(FakeTask({"api": api}), shell)
+
+    assert [s.blocked_reason for s in pre.blocked] == [IN_PROGRESS]
+    msg = blocked_message(pre)
+    assert f'continue: git -C "{api}" cherry-pick --continue' in msg
+    assert f'abort: git -C "{api}" cherry-pick --abort' in msg
+
+
+def test_a_mid_rebase_apply_repo_names_its_precise_recovery_commands(tmp_path):
+    api = _repo(tmp_path, "api")
+    (api / ".git" / "rebase-apply").mkdir(parents=True)
+    shell = FakeShell({"api": _clean(status="", head_ref="")})
+
+    pre = inspect(FakeTask({"api": api}), shell)
+
+    assert [s.blocked_reason for s in pre.blocked] == [IN_PROGRESS]
+    msg = blocked_message(pre)
+    assert f'continue: git -C "{api}" rebase --continue  # or git am --continue' in msg
+    assert f'abort: git -C "{api}" rebase --abort     # or git am --abort' in msg
 
 
 def test_an_unanswerable_git_dir_is_unreadable_not_transferred(tmp_path):


### PR DESCRIPTION
## Summary
- detect rebase, merge, and cherry-pick markers before wrong-branch diagnosis
- emit operation-specific continue/abort guidance for normal and linked worktrees
- preserve generic conflicted-repository abort guidance

Closes #431

## Test plan
- `uv run pytest -q tests/cli/test_remote_dispatch.py tests/core/test_remote_preflight.py`
- `task lint`
- `mship test --repos mothership` (iteration 3: pass)
