### PR TITLE
Scope spawn drift gate

### DIFF
--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -433,25 +433,15 @@ def register(app: typer.Typer, get_container):
                 f"Run `mship close --yes --abandon --task {effective_slug}` to remove it first, or use a different description."
             )
 
-        _run_gate(
-            get_container,
-            command="spawn",
-            bypass=bypass_reconcile,
-            output=output,
-            only_repos=set(effective_scope),
-        )
-
-        # --- WorkItem gate: every task must be linked to a WorkItem, unless
-        #     --hotfix explicitly overrides it (logged to the bypass log).
+        # --- WorkItem validation: every task must be linked to a WorkItem,
+        #     unless --hotfix explicitly overrides that requirement. Keep these
+        #     deterministic local errors ahead of remote reconciliation.
         #     See spec workitem-mandatory-kind-gated-approval.
-        from mship.core.workitem_gate import log_hotfix
         from mship.core.workitem_store import WorkItemStore
 
         workspace_root = container.config_path().parent
         if work_item is None:
-            if hotfix:
-                log_hotfix(workspace_root, "spawn", effective_slug)
-            else:
+            if not hotfix:
                 output.error(
                     "mship spawn requires a WorkItem: create one with "
                     "`mship item new` and pass --work-item <id> (or --hotfix)"
@@ -462,6 +452,20 @@ def register(app: typer.Typer, get_container):
             if items.get(work_item) is None:
                 output.error(f"WorkItem {work_item!r} not found")
                 raise typer.Exit(code=1)
+
+        _run_gate(
+            get_container,
+            command="spawn",
+            bypass=bypass_reconcile,
+            output=output,
+            only_repos=set(effective_scope),
+        )
+
+        # Record a hotfix bypass only after reconciliation accepts the spawn.
+        if work_item is None:
+            from mship.core.workitem_gate import log_hotfix
+
+            log_hotfix(workspace_root, "spawn", effective_slug)
 
         # Validate --closes refs BEFORE any side effects (#386): a bad ref must
         # fail the spawn while nothing has been created yet.

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -30,14 +30,15 @@ def _run_gate(
     bypass: bool,
     output,
     only_slug: str | None = None,
+    only_repos: set[str] | None = None,
     cli_base: str | None = None,
     base_map: dict[str, str] | None = None,
 ) -> None:
     """Run the upstream reconciler; exit(1) on block, print warnings on warn.
 
-    `only_slug`, when given, scopes the gate to that single task — drift on
-    an unrelated task must not block this one (#455 Part 2; mirrors the
-    per-task scoping the precommit gate in cli/internal.py already does).
+    `only_slug`, when given, scopes the gate to that single task. `only_repos`
+    scopes it to persisted tasks that touch any requested repository, which is
+    how spawn excludes unrelated task drift without inventing a future slug.
     """
     if bypass:
         return
@@ -58,25 +59,63 @@ def _run_gate(
             collect_git_snapshots(worktrees_by_branch),
         )
 
-    try:
-        base_inputs = (
-            {only_slug: (cli_base, base_map or {})}
-            if only_slug is not None
-            else None
-        )
-        decisions = reconcile_now(
-            state,
-            cache=cache,
-            fetcher=_fetcher,
-            config=config,
-            base_inputs_by_slug=base_inputs,
-        )
-    except Exception as e:  # noqa: BLE001 — never fail closed
-        output.warning(f"reconcile unavailable: {e}; proceeding")
-        return
+    if only_repos is not None:
+        scoped_slugs = {
+            task.slug
+            for task in state.tasks.values()
+            if any(repo in only_repos for repo in task.affected_repos)
+        }
+        if only_slug is not None:
+            scoped_slugs.intersection_update({only_slug})
+        if not scoped_slugs:
+            return
+        try:
+            decisions = reconcile_now(
+                state,
+                cache=cache,
+                fetcher=_fetcher,
+                config=config,
+                only_slugs=scoped_slugs,
+            )
+        except Exception as e:  # noqa: BLE001 — scoped spawns fail closed
+            output.error(f"reconcile unavailable: {e}")
+            raise typer.Exit(code=1)
 
-    if only_slug is not None:
-        decisions = {slug: d for slug, d in decisions.items() if slug == only_slug}
+        decisions = {
+            slug: decision
+            for slug, decision in decisions.items()
+            if slug in scoped_slugs
+        }
+        unavailable = scoped_slugs.difference(decisions)
+        if unavailable:
+            output.error(
+                "reconcile unavailable for: " + ", ".join(sorted(unavailable))
+            )
+            raise typer.Exit(code=1)
+    else:
+        try:
+            base_inputs = (
+                {only_slug: (cli_base, base_map or {})}
+                if only_slug is not None
+                else None
+            )
+            decisions = reconcile_now(
+                state,
+                cache=cache,
+                fetcher=_fetcher,
+                config=config,
+                base_inputs_by_slug=base_inputs,
+            )
+        except Exception as e:  # noqa: BLE001 — preserve fail-open callers
+            output.warning(f"reconcile unavailable: {e}; proceeding")
+            return
+
+        if only_slug is not None:
+            decisions = {
+                slug: decision
+                for slug, decision in decisions.items()
+                if slug == only_slug
+            }
 
     ignored = cache.read_ignores()
     blockers: list[str] = []
@@ -322,52 +361,7 @@ def register(app: typer.Typer, get_container):
                 )
                 raise typer.Exit(code=1)
 
-        _run_gate(get_container, command="spawn", bypass=bypass_reconcile, output=output)
-
-        # --- WorkItem gate: every task must be linked to a WorkItem, unless
-        #     --hotfix explicitly overrides it (logged to the bypass log).
-        #     See spec workitem-mandatory-kind-gated-approval.
-        from mship.core.workitem_gate import log_hotfix
-        from mship.core.workitem_store import WorkItemStore
-        from mship.util.slug import slugify as _slugify
-
-        workspace_root = container.config_path().parent
-        if work_item is None:
-            if hotfix:
-                effective_slug = slug if slug is not None else _slugify(description)
-                log_hotfix(workspace_root, "spawn", effective_slug)
-            else:
-                output.error(
-                    "mship spawn requires a WorkItem: create one with "
-                    "`mship item new` and pass --work-item <id> (or --hotfix)"
-                )
-                raise typer.Exit(code=1)
-        else:
-            items = WorkItemStore(workspace_root / ".mothership" / "workitems")
-            if items.get(work_item) is None:
-                output.error(f"WorkItem {work_item!r} not found")
-                raise typer.Exit(code=1)
-
-        # Validate --closes refs BEFORE any side effects (#386): a bad ref must
-        # fail the spawn while nothing has been created yet.
-        closes_canonical: list[str] = []
-        if closes:
-            if work_item is None:
-                output.error("--closes requires --work-item (issues are linked to the WorkItem)")
-                raise typer.Exit(code=1)
-            from mship.core.issue_link import default_issue_slug
-            from mship.core.issue_refs import IssueRefError, normalize_issue_ref
-            _slug_default = default_issue_slug(container.config().repos.values())
-            try:
-                closes_canonical = [normalize_issue_ref(c, default_slug=_slug_default)
-                                    for c in closes]
-            except IssueRefError as e:
-                output.error(str(e))
-                raise typer.Exit(code=1)
-
-        wt_mgr = container.worktree_manager()
         config = container.config()
-        shell = container.shell()
 
         user_passed_repos = repos is not None
         repo_list = repos.split(",") if repos else None
@@ -426,7 +420,70 @@ def register(app: typer.Typer, get_container):
                 )
                 raise typer.Exit(code=1)
 
-        audit_names = repo_list if repo_list else list(config.repos.keys())
+        # A duplicate task slug is a deterministic local error. Preserve its
+        # precedence over reconciliation, which may require unavailable remote
+        # repository decisions; WorktreeManager.spawn repeats this check under
+        # its state lock to prevent concurrent spawns from racing.
+        from mship.util.slug import slugify
+
+        effective_slug = slug if slug is not None else slugify(description)
+        if effective_slug in container.state_manager().load().tasks:
+            raise ValueError(
+                f"Task '{effective_slug}' already exists. "
+                f"Run `mship close --yes --abandon --task {effective_slug}` to remove it first, or use a different description."
+            )
+
+        _run_gate(
+            get_container,
+            command="spawn",
+            bypass=bypass_reconcile,
+            output=output,
+            only_repos=set(effective_scope),
+        )
+
+        # --- WorkItem gate: every task must be linked to a WorkItem, unless
+        #     --hotfix explicitly overrides it (logged to the bypass log).
+        #     See spec workitem-mandatory-kind-gated-approval.
+        from mship.core.workitem_gate import log_hotfix
+        from mship.core.workitem_store import WorkItemStore
+
+        workspace_root = container.config_path().parent
+        if work_item is None:
+            if hotfix:
+                log_hotfix(workspace_root, "spawn", effective_slug)
+            else:
+                output.error(
+                    "mship spawn requires a WorkItem: create one with "
+                    "`mship item new` and pass --work-item <id> (or --hotfix)"
+                )
+                raise typer.Exit(code=1)
+        else:
+            items = WorkItemStore(workspace_root / ".mothership" / "workitems")
+            if items.get(work_item) is None:
+                output.error(f"WorkItem {work_item!r} not found")
+                raise typer.Exit(code=1)
+
+        # Validate --closes refs BEFORE any side effects (#386): a bad ref must
+        # fail the spawn while nothing has been created yet.
+        closes_canonical: list[str] = []
+        if closes:
+            if work_item is None:
+                output.error("--closes requires --work-item (issues are linked to the WorkItem)")
+                raise typer.Exit(code=1)
+            from mship.core.issue_link import default_issue_slug
+            from mship.core.issue_refs import IssueRefError, normalize_issue_ref
+            _slug_default = default_issue_slug(config.repos.values())
+            try:
+                closes_canonical = [normalize_issue_ref(c, default_slug=_slug_default)
+                                    for c in closes]
+            except IssueRefError as e:
+                output.error(str(e))
+                raise typer.Exit(code=1)
+
+        wt_mgr = container.worktree_manager()
+        shell = container.shell()
+
+        audit_names = effective_scope
 
         from mship.core.audit_gate import collect_known_worktree_paths
         try:
@@ -506,7 +563,6 @@ def register(app: typer.Typer, get_container):
         from datetime import datetime, timezone
         from mship.core.state import DependencyEdge
         from mship.core.task_graph import find_cycle
-        from mship.util.slug import slugify
 
         dep_edges: list[DependencyEdge] = []
         if depends_on:

--- a/src/mship/core/reconcile/cache.py
+++ b/src/mship/core/reconcile/cache.py
@@ -108,16 +108,27 @@ class ReconcileCache:
         payload: CachePayload | None,
         *,
         base_context: dict[str, list[str] | None],
+        only_slugs: set[str] | None = None,
     ) -> CachePayload | None:
         """Drop results produced under another schema or resolved-base context.
 
         This is deliberately not a TTL gate: fetch failures may fall back to a
         TTL-stale entry, but only when its schema and base context are compatible.
+        Scoped reconciliation only requires matching context for selected tasks.
         """
-        if (
-            payload is None
-            or payload.schema_version != SCHEMA_VERSION
-            or payload.base_context != base_context
+        if payload is None or payload.schema_version != SCHEMA_VERSION:
+            return None
+        if only_slugs is None:
+            if payload.base_context != base_context:
+                return None
+            return payload
+        if payload.base_context is None:
+            return None
+        if any(
+            slug not in payload.base_context
+            or slug not in base_context
+            or payload.base_context[slug] != base_context[slug]
+            for slug in only_slugs
         ):
             return None
         return payload

--- a/src/mship/core/reconcile/cache.py
+++ b/src/mship/core/reconcile/cache.py
@@ -114,7 +114,8 @@ class ReconcileCache:
 
         This is deliberately not a TTL gate: fetch failures may fall back to a
         TTL-stale entry, but only when its schema and base context are compatible.
-        Scoped reconciliation only requires matching context for selected tasks.
+        Scoped reconciliation requires matching context and results for the
+        selected tasks and their dependency closure.
         """
         if payload is None or payload.schema_version != SCHEMA_VERSION:
             return None
@@ -126,6 +127,7 @@ class ReconcileCache:
             return None
         if any(
             slug not in payload.base_context
+            or slug not in payload.results
             or slug not in base_context
             or payload.base_context[slug] != base_context[slug]
             for slug in only_slugs

--- a/src/mship/core/reconcile/cache.py
+++ b/src/mship/core/reconcile/cache.py
@@ -21,7 +21,7 @@ SCHEMA_VERSION = 2
 class CachePayload:
     fetched_at: float
     ttl_seconds: int
-    results: dict[str, dict]
+    results: dict[str, object]
     ignored: list[str] = field(default_factory=list)
     schema_version: int = SCHEMA_VERSION
     base_context: dict[str, list[str] | None] | None = None

--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -161,7 +161,12 @@ def _decision_from_cache_entry(slug: str, raw: dict, state: WorkspaceState) -> D
         return None
 
 
-def _decisions_from_cache(state: WorkspaceState, payload: CachePayload) -> dict[str, Decision]:
+def _decisions_from_cache(
+    state: WorkspaceState,
+    payload: CachePayload,
+    *,
+    only_slugs: set[str] | None = None,
+) -> dict[str, Decision]:
     out: dict[str, Decision] = {}
     for slug in state.tasks:
         raw = payload.results.get(slug)
@@ -177,7 +182,10 @@ def _decisions_from_cache(state: WorkspaceState, payload: CachePayload) -> dict[
     # cache — the common case, since reconcile shares one 300s cache across spawn/finish/close/
     # precommit — silently drops it and a dependency-stale task reverts to in_sync (finish stops
     # blocking on the stale base).
-    return apply_dependency_stale(state, out)
+    decisions = apply_dependency_stale(state, out)
+    if only_slugs is None:
+        return decisions
+    return {slug: decision for slug, decision in decisions.items() if slug in only_slugs}
 
 
 def reconcile_now(
@@ -190,8 +198,9 @@ def reconcile_now(
     base_inputs_by_slug: dict[
         str, tuple[str | None, dict[str, str]]
     ] | None = None,
+    only_slugs: set[str] | None = None,
 ) -> dict[str, Decision]:
-    """Cache-first; fetch on stale; fall back on error. Never raises."""
+    """Cache-first; fetch on stale; fall back on error for selected tasks."""
     resolved_bases = resolve_task_bases(
         state, config, base_inputs_by_slug=base_inputs_by_slug,
     )
@@ -205,23 +214,29 @@ def reconcile_now(
     payload = cache.read()
     current_payload = cache.current(payload, base_context=base_context)
     if current_payload is not None and cache.is_fresh(current_payload):
-        return _decisions_from_cache(state, current_payload)
+        return _decisions_from_cache(
+            state, current_payload, only_slugs=only_slugs,
+        )
 
-    branches = [t.branch for t in state.tasks.values()]
+    tasks = list(state.tasks.values())
+    branches = [task.branch for task in tasks]
     worktrees_by_branch: dict[str, Path] = {}
-    for t in state.tasks.values():
-        if t.worktrees:
-            worktrees_by_branch[t.branch] = next(iter(t.worktrees.values()))
+    for task in tasks:
+        if task.worktrees:
+            worktrees_by_branch[task.branch] = next(iter(task.worktrees.values()))
 
     try:
         pr_by_head, git_by_branch = fetcher(branches, worktrees_by_branch)
     except FetchError:
         if current_payload is not None:
-            return _decisions_from_cache(state, current_payload)
+            return _decisions_from_cache(
+                state, current_payload, only_slugs=only_slugs,
+            )
         return {}
 
     tasks_tuples = [
-        (t.slug, t.branch, resolved_bases[t.slug]) for t in state.tasks.values()
+        (task.slug, task.branch, resolved_bases[task.slug])
+        for task in tasks
     ]
     detections = detect_many(tasks_tuples, pr_by_head, git_by_branch)
 
@@ -241,5 +256,11 @@ def reconcile_now(
         ignored=(payload.ignored if payload else []),
         base_context=base_context,
     ))
-    decisions = {slug: _decision_from_detection(slug, d, state) for slug, d in detections.items()}
-    return apply_dependency_stale(state, decisions)
+    decisions = {
+        slug: _decision_from_detection(slug, d, state)
+        for slug, d in detections.items()
+    }
+    decisions = apply_dependency_stale(state, decisions)
+    if only_slugs is None:
+        return decisions
+    return {slug: decision for slug, decision in decisions.items() if slug in only_slugs}

--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -6,8 +6,10 @@ each Decision via should_block() to choose block/warn/allow per command.
 from __future__ import annotations
 
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
+
 from pathlib import Path
 from typing import Callable, Literal
 
@@ -145,7 +147,13 @@ def _decision_from_detection(slug: str, det: Detection, state: WorkspaceState) -
     )
 
 
-def _decision_from_cache_entry(slug: str, raw: dict, state: WorkspaceState) -> Decision | None:
+def _decision_from_cache_entry(
+    slug: str,
+    raw: object,
+    state: WorkspaceState,
+) -> Decision | None:
+    if not isinstance(raw, Mapping):
+        return None
     try:
         return Decision(
             slug=slug,
@@ -157,7 +165,7 @@ def _decision_from_cache_entry(slug: str, raw: dict, state: WorkspaceState) -> D
             updated_at=raw.get("updated_at"),
             finished_at=_finished_at_for(slug, state),
         )
-    except (KeyError, ValueError):
+    except (KeyError, TypeError, ValueError):
         return None
 
 
@@ -168,7 +176,8 @@ def _decisions_from_cache(
     only_slugs: set[str] | None = None,
 ) -> dict[str, Decision]:
     out: dict[str, Decision] = {}
-    for slug in state.tasks:
+    slugs = state.tasks if only_slugs is None else only_slugs
+    for slug in slugs:
         raw = payload.results.get(slug)
         if raw is None:
             continue
@@ -226,17 +235,39 @@ def reconcile_now(
     ]
 
     # Keep the raw payload only to preserve its ignore list on a fresh write.
-    # Every results-consuming path uses the schema/context-compatible payload.
+    # Every results-consuming path validates the schema/context-compatible closure.
     payload = cache.read()
     current_payload = cache.current(
         payload,
         base_context=base_context,
         only_slugs=reconciliation_slugs,
     )
-    if current_payload is not None and cache.is_fresh(current_payload):
-        return _decisions_from_cache(
-            state, current_payload, only_slugs=only_slugs,
+    cached_decisions = (
+        _decisions_from_cache(
+            state, current_payload, only_slugs=reconciliation_slugs,
         )
+        if current_payload is not None
+        else None
+    )
+    cache_complete = (
+        reconciliation_slugs is None
+        or (
+            cached_decisions is not None
+            and reconciliation_slugs <= cached_decisions.keys()
+        )
+    )
+    if (
+        current_payload is not None
+        and cache.is_fresh(current_payload)
+        and cache_complete
+    ):
+        if only_slugs is None:
+            return cached_decisions
+        return {
+            slug: decision
+            for slug, decision in cached_decisions.items()
+            if slug in only_slugs
+        }
 
     branches = [task.branch for task in tasks]
     worktrees_by_branch: dict[str, Path] = {}
@@ -247,10 +278,14 @@ def reconcile_now(
     try:
         pr_by_head, git_by_branch = fetcher(branches, worktrees_by_branch)
     except FetchError:
-        if current_payload is not None:
-            return _decisions_from_cache(
-                state, current_payload, only_slugs=only_slugs,
-            )
+        if cached_decisions is not None and cache_complete:
+            if only_slugs is None:
+                return cached_decisions
+            return {
+                slug: decision
+                for slug, decision in cached_decisions.items()
+                if slug in only_slugs
+            }
         return {}
 
     tasks_tuples = [
@@ -280,8 +315,7 @@ def reconcile_now(
         slug: _decision_from_detection(slug, d, state)
         for slug, d in detections.items()
     }
-    if current_payload is not None and only_slugs is not None:
-        cached_decisions = _decisions_from_cache(state, current_payload)
+    if cached_decisions is not None and only_slugs is not None:
         cached_decisions.update(decisions)
         decisions = cached_decisions
     decisions = apply_dependency_stale(state, decisions)

--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
-
 from pathlib import Path
 from typing import Callable, Literal
 
@@ -147,6 +147,19 @@ def _decision_from_detection(slug: str, det: Detection, state: WorkspaceState) -
     )
 
 
+def _valid_merged_timestamp(value: object) -> str | None:
+    """Return an aware ISO-8601 merge timestamp, or None for malformed input."""
+    if not isinstance(value, str):
+        return None
+    try:
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+        return None
+    return value
+
+
 def _decision_from_cache_entry(
     slug: str,
     raw: object,
@@ -155,18 +168,25 @@ def _decision_from_cache_entry(
     if not isinstance(raw, Mapping):
         return None
     try:
-        return Decision(
-            slug=slug,
-            state=UpstreamState(raw["state"]),
-            pr_url=raw.get("pr_url"),
-            pr_number=raw.get("pr_number"),
-            base=raw.get("base"),
-            merge_commit=raw.get("merge_commit"),
-            updated_at=raw.get("updated_at"),
-            finished_at=_finished_at_for(slug, state),
-        )
+        upstream_state = UpstreamState(raw["state"])
     except (KeyError, TypeError, ValueError):
         return None
+    updated_at = raw.get("updated_at")
+    if (
+        upstream_state is UpstreamState.merged
+        and _valid_merged_timestamp(updated_at) is None
+    ):
+        return None
+    return Decision(
+        slug=slug,
+        state=upstream_state,
+        pr_url=raw.get("pr_url"),
+        pr_number=raw.get("pr_number"),
+        base=raw.get("base"),
+        merge_commit=raw.get("merge_commit"),
+        updated_at=updated_at,
+        finished_at=_finished_at_for(slug, state),
+    )
 
 
 def _decisions_from_cache(

--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -208,17 +208,36 @@ def reconcile_now(
         slug: sorted(bases) if bases is not None else None
         for slug, bases in resolved_bases.items()
     }
+    reconciliation_slugs = only_slugs
+    if only_slugs is not None:
+        reconciliation_slugs = set(only_slugs)
+        pending = list(only_slugs)
+        while pending:
+            task = state.tasks.get(pending.pop())
+            if task is None:
+                continue
+            for edge in task.depends_on:
+                if edge.upstream_slug not in reconciliation_slugs:
+                    reconciliation_slugs.add(edge.upstream_slug)
+                    pending.append(edge.upstream_slug)
+    tasks = [
+        task for task in state.tasks.values()
+        if reconciliation_slugs is None or task.slug in reconciliation_slugs
+    ]
 
     # Keep the raw payload only to preserve its ignore list on a fresh write.
     # Every results-consuming path uses the schema/context-compatible payload.
     payload = cache.read()
-    current_payload = cache.current(payload, base_context=base_context)
+    current_payload = cache.current(
+        payload,
+        base_context=base_context,
+        only_slugs=reconciliation_slugs,
+    )
     if current_payload is not None and cache.is_fresh(current_payload):
         return _decisions_from_cache(
             state, current_payload, only_slugs=only_slugs,
         )
 
-    tasks = list(state.tasks.values())
     branches = [task.branch for task in tasks]
     worktrees_by_branch: dict[str, Path] = {}
     for task in tasks:
@@ -249,17 +268,22 @@ def reconcile_now(
         }
         for slug, d in detections.items()
     }
-    cache.write(CachePayload(
-        fetched_at=time.time(),
-        ttl_seconds=ttl_seconds,
-        results=results,
-        ignored=(payload.ignored if payload else []),
-        base_context=base_context,
-    ))
+    if only_slugs is None:
+        cache.write(CachePayload(
+            fetched_at=time.time(),
+            ttl_seconds=ttl_seconds,
+            results=results,
+            ignored=(payload.ignored if payload else []),
+            base_context=base_context,
+        ))
     decisions = {
         slug: _decision_from_detection(slug, d, state)
         for slug, d in detections.items()
     }
+    if current_payload is not None and only_slugs is not None:
+        cached_decisions = _decisions_from_cache(state, current_payload)
+        cached_decisions.update(decisions)
+        decisions = cached_decisions
     decisions = apply_dependency_stale(state, decisions)
     if only_slugs is None:
         return decisions

--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -249,12 +249,14 @@ def reconcile_now(
         if current_payload is not None
         else None
     )
+    required_slugs = (
+        state.tasks.keys()
+        if reconciliation_slugs is None
+        else reconciliation_slugs
+    )
     cache_complete = (
-        reconciliation_slugs is None
-        or (
-            cached_decisions is not None
-            and reconciliation_slugs <= cached_decisions.keys()
-        )
+        cached_decisions is not None
+        and required_slugs <= cached_decisions.keys()
     )
     if (
         current_payload is not None

--- a/tests/cli/test_breadcrumb.py
+++ b/tests/cli/test_breadcrumb.py
@@ -25,7 +25,7 @@ def ws_with_task(workspace_with_git: Path):
     mock_shell.run.return_value = ShellResult(returncode=0, stdout="", stderr="")
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
     container.shell.override(mock_shell)
-    runner.invoke(app, ["spawn", "--hotfix", "breadcrumb test", "--repos", "shared", "--force-audit"])
+    runner.invoke(app, ["spawn", "--hotfix", "breadcrumb test", "--repos", "shared", "--force-audit", "--bypass-reconcile"])
     yield workspace_with_git
     container.config_path.reset_override()
     container.state_dir.reset_override()
@@ -94,7 +94,7 @@ def test_ambiguity_lists_candidates(ws_with_task: Path):
     """Second task + running from outside both worktrees → ambiguity error with
     `--task <slug>` hints for BOTH tasks."""
     runner.invoke(
-        app, ["spawn", "--hotfix", "second task", "--repos", "shared", "--force-audit"],
+        app, ["spawn", "--hotfix", "second task", "--repos", "shared", "--force-audit", "--bypass-reconcile"],
     )
     import os
     prev = os.getcwd()

--- a/tests/cli/test_pr.py
+++ b/tests/cli/test_pr.py
@@ -51,8 +51,8 @@ def test_pr_empty_when_no_tasks(configured_git_app: Path):
 
 
 def test_pr_lists_tasks_with_pr_urls(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "--hotfix", "first", "--repos", "shared", "--skip-setup"])
-    runner.invoke(app, ["spawn", "--hotfix", "second", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "first", "--repos", "shared", "--skip-setup", "--bypass-reconcile"])
+    runner.invoke(app, ["spawn", "--hotfix", "second", "--repos", "shared", "--skip-setup", "--bypass-reconcile"])
     _set_pr_urls(configured_git_app, "first", {"shared": "https://github.com/o/r/pull/1"})
     _set_pr_urls(configured_git_app, "second", {"shared": "https://github.com/o/r/pull/2"})
 
@@ -77,7 +77,7 @@ def test_pr_lists_tasks_with_pr_urls(configured_git_app: Path):
 
 
 def test_pr_skips_tasks_without_pr_urls(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "--hotfix", "no pr", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "no pr", "--repos", "shared", "--skip-setup", "--bypass-reconcile"])
     # Don't set pr_urls.
     result = runner.invoke(app, ["pr"])
     assert result.exit_code == 0, result.output
@@ -86,7 +86,7 @@ def test_pr_skips_tasks_without_pr_urls(configured_git_app: Path):
 
 
 def test_pr_gh_failure_shows_unknown(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "--hotfix", "fail", "--repos", "shared", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "fail", "--repos", "shared", "--skip-setup", "--bypass-reconcile"])
     _set_pr_urls(configured_git_app, "fail", {"shared": "https://github.com/o/r/pull/9"})
 
     mock_shell = MagicMock(spec=ShellRunner)
@@ -110,7 +110,7 @@ def test_pr_gh_failure_shows_unknown(configured_git_app: Path):
 
 
 def test_pr_multiple_repos_per_task(configured_git_app: Path):
-    runner.invoke(app, ["spawn", "--hotfix", "multi", "--repos", "shared,auth-service", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "multi", "--repos", "shared,auth-service", "--skip-setup", "--bypass-reconcile"])
     _set_pr_urls(configured_git_app, "multi", {
         "shared": "https://github.com/o/r/pull/1",
         "auth-service": "https://github.com/o/r/pull/2",

--- a/tests/cli/test_reconcile.py
+++ b/tests/cli/test_reconcile.py
@@ -131,7 +131,7 @@ def _seed_merged_cache(
                 "pr_number": 1,
                 "base": "main",
                 "merge_commit": "abc123",
-                "updated_at": None,
+                "updated_at": "2026-05-10T00:00:00Z",
             }
         },
         ignored=[],

--- a/tests/cli/test_resolve.py
+++ b/tests/cli/test_resolve.py
@@ -7,8 +7,15 @@ import pytest
 import typer
 
 from mship.cli._resolve import resolve_for_command
-from mship.cli.output import Output
+from mship.cli.output import Output, reset_output_settings
 from mship.core.state import Task, WorkspaceState
+
+
+@pytest.fixture(autouse=True)
+def _isolate_output_settings():
+    reset_output_settings()
+    yield
+    reset_output_settings()
 
 
 def _task(slug: str, worktree: Path | None = None) -> Task:

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -40,6 +40,142 @@ def test_spawn(configured_git_app: Path):
     assert "add-labels-to-tasks" in state.tasks
 
 
+
+def test_spawn_gate_ignores_merged_drift_on_disjoint_repo(
+    configured_git_app: Path, monkeypatch,
+):
+    """A merged task in another repo does not block a scoped spawn."""
+    from datetime import datetime, timezone
+    from mship.core.reconcile.detect import UpstreamState
+    from mship.core.reconcile.gate import Decision
+
+    now = datetime.now(timezone.utc)
+    StateManager(configured_git_app / ".mothership").save(WorkspaceState(tasks={
+        "unrelated": Task(
+            slug="unrelated", description="unrelated", phase="dev",
+            created_at=now, affected_repos=["auth-service"], branch="feat/unrelated",
+        ),
+        "shared-task": Task(
+            slug="shared-task", description="shared", phase="dev",
+            created_at=now, affected_repos=["shared"], branch="feat/shared-task",
+        ),
+    }))
+    observed: dict[str, set[str]] = {}
+
+    def reconcile_for_scope(state, **kwargs):
+        observed["only_slugs"] = kwargs["only_slugs"]
+        return {
+            "unrelated": Decision(
+                slug="unrelated", state=UpstreamState.merged,
+                pr_url=None, pr_number=None, base=None,
+                merge_commit=None, updated_at=None,
+            ),
+            "shared-task": Decision(
+                slug="shared-task", state=UpstreamState.in_sync,
+                pr_url=None, pr_number=None, base=None,
+                merge_commit=None, updated_at=None,
+            ),
+        }
+
+    monkeypatch.setattr("mship.core.reconcile.gate.reconcile_now", reconcile_for_scope)
+
+    result = runner.invoke(
+        app, ["spawn", "--hotfix", "scoped spawn", "--repos", "shared"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert observed["only_slugs"] == {"shared-task"}
+
+
+def test_spawn_gate_blocks_merged_drift_on_requested_repo(
+    configured_git_app: Path, monkeypatch,
+):
+    """A merged task in the requested repo still blocks the spawn."""
+    from datetime import datetime, timezone
+    from mship.core.reconcile.detect import UpstreamState
+    from mship.core.reconcile.gate import Decision
+
+    now = datetime.now(timezone.utc)
+    StateManager(configured_git_app / ".mothership").save(WorkspaceState(tasks={
+        "relevant": Task(
+            slug="relevant", description="relevant", phase="dev",
+            created_at=now, affected_repos=["shared"], branch="feat/relevant",
+        ),
+    }))
+
+    def reconcile_for_scope(state, **kwargs):
+        assert kwargs["only_slugs"] == {"relevant"}
+        return {
+            "relevant": Decision(
+                slug="relevant", state=UpstreamState.merged,
+                pr_url=None, pr_number=None, base=None,
+                merge_commit=None, updated_at=None,
+            ),
+        }
+
+    monkeypatch.setattr("mship.core.reconcile.gate.reconcile_now", reconcile_for_scope)
+
+    result = runner.invoke(
+        app, ["spawn", "--hotfix", "blocked spawn", "--repos", "shared"],
+    )
+
+    assert result.exit_code != 0
+    assert "relevant" in result.output
+    assert not (configured_git_app / ".mothership" / "bypass-log.jsonl").exists()
+
+
+def test_spawn_gate_blocks_when_relevant_decision_is_unavailable(
+    configured_git_app: Path, monkeypatch,
+):
+    """A scoped spawn fails closed when it cannot decide a relevant task."""
+    from datetime import datetime, timezone
+
+    StateManager(configured_git_app / ".mothership").save(WorkspaceState(tasks={
+        "relevant": Task(
+            slug="relevant", description="relevant", phase="dev",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/relevant",
+        ),
+    }))
+
+    def reconcile_for_scope(state, **kwargs):
+        assert kwargs["only_slugs"] == {"relevant"}
+        return {}
+
+    monkeypatch.setattr("mship.core.reconcile.gate.reconcile_now", reconcile_for_scope)
+
+    result = runner.invoke(
+        app, ["spawn", "--hotfix", "unavailable spawn", "--repos", "shared"],
+    )
+
+    assert result.exit_code != 0
+    assert "reconcile unavailable for: relevant" in result.output
+
+
+def test_finish_gate_allows_empty_decision_map(
+    configured_git_app: Path, monkeypatch,
+):
+    """A finished task proceeds when reconciliation returns no decision."""
+    spawned = runner.invoke(
+        app, ["spawn", "--hotfix", "empty decision", "--repos", "shared"],
+    )
+    assert spawned.exit_code == 0, spawned.output
+
+    monkeypatch.setattr(
+        "mship.core.reconcile.gate.reconcile_now",
+        lambda state, **kwargs: {},
+    )
+
+    result = runner.invoke(
+        app, ["finish", "--hotfix", "--handoff", "--task", "empty-decision"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (
+        configured_git_app / ".mothership" / "handoffs" / "empty-decision.yaml"
+    ).exists()
+
+
 def test_spawn_slug_override(configured_git_app: Path):
     """--slug overrides auto-generated slug. See #59."""
     result = runner.invoke(
@@ -64,12 +200,19 @@ def test_spawn_slug_rejects_invalid_chars(configured_git_app: Path):
         assert result.exit_code != 0, f"expected rejection for slug={bad!r}: {result.output}"
 
 
-def test_spawn_slug_collision_errors(configured_git_app: Path):
-    """Two spawns with the same --slug → second fails with a clear error."""
+def test_spawn_slug_collision_precedes_unavailable_reconciliation(
+    configured_git_app: Path, monkeypatch,
+):
+    """A duplicate slug stays a local error even if reconciliation cannot decide."""
     first = runner.invoke(
         app, ["spawn", "--hotfix", "first", "--repos", "shared", "--slug", "dupe"],
     )
     assert first.exit_code == 0, first.output
+
+    monkeypatch.setattr(
+        "mship.core.reconcile.gate.reconcile_now",
+        lambda state, **kwargs: {},
+    )
     second = runner.invoke(
         app, ["spawn", "--hotfix", "second", "--repos", "shared", "--slug", "dupe"],
     )
@@ -198,7 +341,7 @@ def test_spawn_with_depends_on_persists_edges(configured_git_app: Path):
     result = runner.invoke(
         app,
         ["spawn", "--hotfix", "downstream task", "--repos", "shared", "--slug", "down",
-         "--depends-on", "a", "--skip-setup"],
+         "--depends-on", "a", "--skip-setup", "--bypass-reconcile"],
     )
     assert result.exit_code == 0, result.stderr or result.output
     state = StateManager(configured_git_app / ".mothership").load()
@@ -244,6 +387,33 @@ def test_close_with_no_prs_cancelled_before_finish(configured_git_app):
     # Task was never finished → must use --abandon to close without PRs
     result = r.invoke(_app, ["close", "--yes", "--abandon", "--task", "t"])
     assert result.exit_code == 0, result.output
+    assert "t" not in sm.load().tasks
+
+
+def test_close_gate_warns_and_proceeds_when_reconciler_raises(
+    configured_git_app: Path, monkeypatch,
+):
+    """Unscoped close remains fail-open when reconciliation is unavailable."""
+    from datetime import datetime, timezone
+
+    sm = StateManager(configured_git_app / ".mothership")
+    sm.save(WorkspaceState(tasks={
+        "t": Task(
+            slug="t", description="d", phase="dev",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/t",
+        ),
+    }))
+
+    def unavailable(state, **kwargs):
+        raise RuntimeError("network unavailable")
+
+    monkeypatch.setattr("mship.core.reconcile.gate.reconcile_now", unavailable)
+
+    result = runner.invoke(app, ["close", "--yes", "--abandon", "--task", "t"])
+
+    assert result.exit_code == 0, result.output
+    assert "reconcile unavailable: network unavailable; proceeding" in result.output
     assert "t" not in sm.load().tasks
 
 
@@ -802,7 +972,9 @@ def test_close_accepts_positional_slug(configured_git_app: Path):
 def test_close_positional_and_task_flag_conflict(configured_git_app: Path):
     """Conflicting positional + --task values fail loudly."""
     runner.invoke(app, ["spawn", "--hotfix", "conflict a", "--repos", "shared"])
-    runner.invoke(app, ["spawn", "--hotfix", "conflict b", "--repos", "shared"])
+    runner.invoke(
+        app, ["spawn", "--hotfix", "conflict b", "--repos", "shared", "--bypass-reconcile"],
+    )
     result = runner.invoke(
         app, ["close", "conflict-a", "--task", "conflict-b", "-y", "--abandon"],
     )

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -152,6 +152,69 @@ def test_spawn_gate_blocks_when_relevant_decision_is_unavailable(
     assert "reconcile unavailable for: relevant" in result.output
 
 
+def test_spawn_requires_work_item_before_reconciling_relevant_tasks(
+    configured_git_app: Path, monkeypatch,
+):
+    """A missing local WorkItem must not be masked by unavailable reconciliation."""
+    from datetime import datetime, timezone
+
+    StateManager(configured_git_app / ".mothership").save(WorkspaceState(tasks={
+        "relevant": Task(
+            slug="relevant", description="relevant", phase="dev",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/relevant",
+        ),
+    }))
+
+    reconciled = False
+
+    def reconcile_for_scope(*args, **kwargs):
+        nonlocal reconciled
+        reconciled = True
+        raise RuntimeError("remote unavailable")
+
+    monkeypatch.setattr("mship.core.reconcile.gate.reconcile_now", reconcile_for_scope)
+
+    result = runner.invoke(app, ["spawn", "missing WorkItem", "--repos", "shared"])
+
+    assert result.exit_code != 0
+    assert "spawn requires a WorkItem" in result.output
+    assert not reconciled
+
+
+def test_spawn_rejects_unknown_work_item_before_reconciling_relevant_tasks(
+    configured_git_app: Path, monkeypatch,
+):
+    """An unknown local WorkItem must not be masked by unavailable reconciliation."""
+    from datetime import datetime, timezone
+
+    StateManager(configured_git_app / ".mothership").save(WorkspaceState(tasks={
+        "relevant": Task(
+            slug="relevant", description="relevant", phase="dev",
+            created_at=datetime.now(timezone.utc),
+            affected_repos=["shared"], branch="feat/relevant",
+        ),
+    }))
+
+    reconciled = False
+
+    def reconcile_for_scope(*args, **kwargs):
+        nonlocal reconciled
+        reconciled = True
+        raise RuntimeError("remote unavailable")
+
+    monkeypatch.setattr("mship.core.reconcile.gate.reconcile_now", reconcile_for_scope)
+
+    result = runner.invoke(
+        app,
+        ["spawn", "unknown WorkItem", "--repos", "shared", "--work-item", "missing"],
+    )
+
+    assert result.exit_code != 0
+    assert "WorkItem 'missing' not found" in result.output
+    assert not reconciled
+
+
 def test_finish_gate_allows_empty_decision_map(
     configured_git_app: Path, monkeypatch,
 ):

--- a/tests/core/reconcile/test_cache.py
+++ b/tests/core/reconcile/test_cache.py
@@ -171,3 +171,20 @@ def test_current_scoped_context_requires_each_requested_entry(tmp_path: Path):
         base_context={"selected": ["release"]},
         only_slugs={"selected"},
     ) is None
+
+
+def test_current_scoped_context_requires_results_for_every_requested_entry(tmp_path: Path):
+    cache = ReconcileCache(tmp_path / ".mothership")
+    payload = CachePayload(
+        fetched_at=time.time(),
+        ttl_seconds=300,
+        results={"selected": {"state": "in_sync"}},
+        ignored=[],
+        base_context={"selected": ["main"], "dependency": ["main"]},
+    )
+
+    assert cache.current(
+        payload,
+        base_context={"selected": ["main"], "dependency": ["main"]},
+        only_slugs={"selected", "dependency"},
+    ) is None

--- a/tests/core/reconcile/test_cache.py
+++ b/tests/core/reconcile/test_cache.py
@@ -132,3 +132,42 @@ def test_write_stamps_current_schema_version_for_freshly_computed_results(tmp_pa
     got = c.read()
     assert got is not None
     assert c.is_fresh(got) is True
+
+
+def test_current_scoped_context_ignores_unrequested_entries(tmp_path: Path):
+    cache = ReconcileCache(tmp_path / ".mothership")
+    payload = CachePayload(
+        fetched_at=time.time(),
+        ttl_seconds=300,
+        results={"selected": {"state": "in_sync"}, "unrelated": {"state": "merged"}},
+        ignored=[],
+        base_context={"selected": ["main"], "unrelated": ["old-base"]},
+    )
+
+    assert cache.current(
+        payload,
+        base_context={"selected": ["main"], "unrelated": ["new-base"]},
+        only_slugs={"selected"},
+    ) is payload
+
+
+def test_current_scoped_context_requires_each_requested_entry(tmp_path: Path):
+    cache = ReconcileCache(tmp_path / ".mothership")
+    payload = CachePayload(
+        fetched_at=time.time(),
+        ttl_seconds=300,
+        results={"selected": {"state": "in_sync"}},
+        ignored=[],
+        base_context={"selected": ["main"]},
+    )
+
+    assert cache.current(
+        payload,
+        base_context={"selected": ["main"], "missing": ["main"]},
+        only_slugs={"missing"},
+    ) is None
+    assert cache.current(
+        payload,
+        base_context={"selected": ["release"]},
+        only_slugs={"selected"},
+    ) is None

--- a/tests/core/reconcile/test_cache.py
+++ b/tests/core/reconcile/test_cache.py
@@ -134,12 +134,12 @@ def test_write_stamps_current_schema_version_for_freshly_computed_results(tmp_pa
     assert c.is_fresh(got) is True
 
 
-def test_current_scoped_context_ignores_unrequested_entries(tmp_path: Path):
+def test_current_scoped_context_ignores_malformed_unrequested_entries(tmp_path: Path):
     cache = ReconcileCache(tmp_path / ".mothership")
     payload = CachePayload(
         fetched_at=time.time(),
         ttl_seconds=300,
-        results={"selected": {"state": "in_sync"}, "unrelated": {"state": "merged"}},
+        results={"selected": {"state": "in_sync"}, "unrelated": []},
         ignored=[],
         base_context={"selected": ["main"], "unrelated": ["old-base"]},
     )

--- a/tests/core/reconcile/test_gate.py
+++ b/tests/core/reconcile/test_gate.py
@@ -59,11 +59,14 @@ def test_reconcile_now_applies_dependency_stale_from_fresh_cache(tmp_path: Path)
         "b": _task("b", created_at=t0,
                    depends_on=[DependencyEdge(upstream_slug="a", created_at=t0)]),
     })
-    # Fresh cache → fetcher must NOT be called; the override still has to apply.
+    # A scoped cache hit still needs the cached upstream to derive b's state,
+    # while returning only the selected task.
     decisions = reconcile_now(
         state, cache=cache,
         fetcher=lambda *_: (_ for _ in ()).throw(AssertionError("should not fetch")),
+        only_slugs={"b"},
     )
+    assert set(decisions) == {"b"}
     assert decisions["b"].state == UpstreamState.dependency_stale
 
 
@@ -296,6 +299,192 @@ def test_reconcile_now_returns_unavailable_on_error_without_cache(tmp_path: Path
         raise FetchError("offline")
     decisions = reconcile_now(state, cache=cache, fetcher=bad_fetcher)
     assert decisions == {}
+
+
+def test_reconcile_now_scoped_fetch_error_uses_selected_compatible_cache(
+    tmp_path: Path,
+):
+    cache = ReconcileCache(tmp_path)
+    cache.write(CachePayload(
+        fetched_at=time.time() - 9999,
+        ttl_seconds=300,
+        results={"a": {"state": "merged", "pr_url": "u", "pr_number": 1, "base": "main"}},
+        ignored=[],
+        base_context={"a": ["main"], "b": ["old-base"]},
+    ))
+    state = WorkspaceState(tasks={"a": _task("a"), "b": _task("b", base_branch="new-base")})
+
+    def bad_fetcher(*_):
+        from mship.core.reconcile.fetch import FetchError
+        raise FetchError("offline")
+
+    decisions = reconcile_now(
+        state,
+        cache=cache,
+        fetcher=bad_fetcher,
+        only_slugs={"a"},
+    )
+
+    assert decisions["a"].state == UpstreamState.merged
+
+
+def test_reconcile_now_scoped_fetches_only_selected_task_snapshots(tmp_path: Path):
+    cache = ReconcileCache(tmp_path)
+    state = WorkspaceState(tasks={"a": _task("a"), "b": _task("b")})
+    calls: list[tuple[list[str], dict[str, Path]]] = []
+
+    def fetcher(branches, worktrees):
+        calls.append((list(branches), dict(worktrees)))
+        return (
+            {"feat/a": PRSnapshot(head_ref="feat/a", state="OPEN", base_ref="main",
+                                  merge_commit=None, url="u", updated_at="z")},
+            {"feat/a": GitSnapshot(has_upstream=True, behind=0, ahead=0)},
+        )
+
+    decisions = reconcile_now(
+        state,
+        cache=cache,
+        fetcher=fetcher,
+        only_slugs={"a"},
+    )
+
+    assert calls == [(["feat/a"], {"feat/a": Path("/tmp/fake/a")})]
+    assert set(decisions) == {"a"}
+
+
+def test_reconcile_now_scoped_context_miss_fetches_transitive_dependencies(
+    tmp_path: Path,
+):
+    """A selected context miss must still retain dependency-stale detection."""
+    from mship.core.state import DependencyEdge
+
+    created = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    merged = datetime(2026, 5, 10, tzinfo=timezone.utc)
+    cache = ReconcileCache(tmp_path)
+    cache.write(CachePayload(
+        fetched_at=time.time(),
+        ttl_seconds=300,
+        results={
+            "root": {"state": "in_sync"},
+            "a": {"state": "merged", "updated_at": merged.isoformat()},
+            "b": {"state": "in_sync"},
+            "unrelated": {"state": "merged"},
+        },
+        ignored=[],
+        base_context={
+            "root": ["main"],
+            "a": ["main"],
+            "b": ["old-base"],
+            "unrelated": ["main"],
+        },
+    ))
+    state = WorkspaceState(tasks={
+        "root": _task("root", created_at=created),
+        "a": _task(
+            "a",
+            created_at=created,
+            finished_at=created,
+            depends_on=[
+                DependencyEdge(upstream_slug="root", created_at=created),
+            ],
+        ),
+        "b": _task(
+            "b",
+            created_at=created,
+            base_branch="new-base",
+            depends_on=[
+                DependencyEdge(upstream_slug="a", created_at=created),
+            ],
+        ),
+        "unrelated": _task("unrelated"),
+    })
+    calls: list[list[str]] = []
+
+    def fetcher(branches, worktrees):
+        calls.append(list(branches))
+        return (
+            {
+                "feat/root": PRSnapshot(
+                    head_ref="feat/root",
+                    state="OPEN",
+                    base_ref="main",
+                    merge_commit=None,
+                    url="https://x/pr/root",
+                    updated_at=created.isoformat(),
+                ),
+                "feat/a": PRSnapshot(
+                    head_ref="feat/a",
+                    state="MERGED",
+                    base_ref="main",
+                    merge_commit="a-merge",
+                    url="https://x/pr/a",
+                    updated_at=merged.isoformat(),
+                ),
+                "feat/b": PRSnapshot(
+                    head_ref="feat/b",
+                    state="OPEN",
+                    base_ref="new-base",
+                    merge_commit=None,
+                    url="https://x/pr/b",
+                    updated_at=created.isoformat(),
+                ),
+            },
+            {
+                "feat/root": GitSnapshot(
+                    has_upstream=True,
+                    behind=0,
+                    ahead=0,
+                ),
+                "feat/a": GitSnapshot(has_upstream=True, behind=0, ahead=0),
+                "feat/b": GitSnapshot(has_upstream=True, behind=0, ahead=0),
+            },
+        )
+
+    decisions = reconcile_now(
+        state,
+        cache=cache,
+        fetcher=fetcher,
+        only_slugs={"b"},
+    )
+
+    assert calls == [["feat/root", "feat/a", "feat/b"]]
+    assert set(decisions) == {"b"}
+    assert decisions["b"].state == UpstreamState.dependency_stale
+
+
+def test_reconcile_now_scoped_fetch_does_not_refresh_unrelated_cache(
+    tmp_path: Path,
+):
+    cache = ReconcileCache(tmp_path)
+    original = CachePayload(
+        fetched_at=time.time() - 9999,
+        ttl_seconds=300,
+        results={
+            "a": {"state": "merged", "pr_url": "u", "pr_number": 1, "base": "main"},
+            "b": {"state": "merged", "pr_url": "u", "pr_number": 2, "base": "main"},
+        },
+        ignored=["b"],
+        base_context={"a": ["main"], "b": ["main"]},
+    )
+    cache.write(original)
+    state = WorkspaceState(tasks={"a": _task("a"), "b": _task("b")})
+
+    decisions = reconcile_now(
+        state,
+        cache=cache,
+        fetcher=lambda *_: (
+            {"feat/a": PRSnapshot(head_ref="feat/a", state="OPEN", base_ref="main",
+                                  merge_commit=None, url="u", updated_at="z")},
+            {"feat/a": GitSnapshot(has_upstream=True, behind=0, ahead=0)},
+        ),
+        only_slugs={"a"},
+    )
+
+    cached = cache.read()
+    assert decisions["a"].state == UpstreamState.in_sync
+    assert cached is not None
+    assert cached.fetched_at == original.fetched_at
+    assert cached.results == original.results
 
 
 def test_should_block_merged_on_finish():

--- a/tests/core/reconcile/test_gate.py
+++ b/tests/core/reconcile/test_gate.py
@@ -352,10 +352,10 @@ def test_reconcile_now_scoped_fetches_only_selected_task_snapshots(tmp_path: Pat
     assert set(decisions) == {"a"}
 
 
-def test_reconcile_now_scoped_missing_dependency_cache_result_fetches_dependencies(
+def test_reconcile_now_scoped_malformed_dependency_cache_result_fetches_dependencies(
     tmp_path: Path,
 ):
-    """A scoped cache hit needs results for the full dependency closure."""
+    """A malformed closure entry cannot bypass fresh reconciliation."""
     from mship.core.state import DependencyEdge
 
     created = datetime(2026, 5, 1, tzinfo=timezone.utc)
@@ -364,7 +364,7 @@ def test_reconcile_now_scoped_missing_dependency_cache_result_fetches_dependenci
     cache.write(CachePayload(
         fetched_at=time.time(),
         ttl_seconds=300,
-        results={"b": {"state": "in_sync"}},
+        results={"a": [], "b": {"state": "in_sync"}},
         ignored=[],
         base_context={"a": ["main"], "b": ["main"]},
     ))
@@ -417,6 +417,62 @@ def test_reconcile_now_scoped_missing_dependency_cache_result_fetches_dependenci
     assert calls == [["feat/a", "feat/b"]]
     assert set(decisions) == {"b"}
     assert decisions["b"].state == UpstreamState.dependency_stale
+
+
+def test_reconcile_now_scoped_fresh_cache_ignores_malformed_unrelated_result(
+    tmp_path: Path,
+):
+    cache = ReconcileCache(tmp_path)
+    cache.write(CachePayload(
+        fetched_at=time.time(),
+        ttl_seconds=300,
+        results={
+            "a": {"state": "merged", "pr_url": "u", "pr_number": 1, "base": "main"},
+            "b": [],
+        },
+        ignored=[],
+        base_context={"a": ["main"], "b": ["main"]},
+    ))
+    state = WorkspaceState(tasks={"a": _task("a"), "b": _task("b")})
+
+    decisions = reconcile_now(
+        state,
+        cache=cache,
+        fetcher=lambda *_: (_ for _ in ()).throw(AssertionError("should not fetch")),
+        only_slugs={"a"},
+    )
+
+    assert decisions["a"].state == UpstreamState.merged
+
+
+def test_reconcile_now_scoped_malformed_cache_fails_closed_after_fetch_error(
+    tmp_path: Path,
+):
+    from mship.core.reconcile.fetch import FetchError
+
+    cache = ReconcileCache(tmp_path)
+    cache.write(CachePayload(
+        fetched_at=time.time(),
+        ttl_seconds=300,
+        results={"a": []},
+        ignored=[],
+        base_context={"a": ["main"]},
+    ))
+    calls: list[list[str]] = []
+
+    def fetcher(branches, worktrees):
+        calls.append(list(branches))
+        raise FetchError("offline")
+
+    decisions = reconcile_now(
+        WorkspaceState(tasks={"a": _task("a")}),
+        cache=cache,
+        fetcher=fetcher,
+        only_slugs={"a"},
+    )
+
+    assert calls == [["feat/a"]]
+    assert decisions == {}
 
 
 def test_reconcile_now_scoped_fetch_does_not_refresh_unrelated_cache(

--- a/tests/core/reconcile/test_gate.py
+++ b/tests/core/reconcile/test_gate.py
@@ -34,6 +34,54 @@ def test_reconcile_now_uses_fresh_cache(tmp_path: Path):
     assert decisions["a"].state == UpstreamState.merged
 
 
+def test_reconcile_now_refetches_when_fresh_full_cache_entry_is_missing(
+    tmp_path: Path,
+):
+    cache = ReconcileCache(tmp_path)
+    cache.write(CachePayload(
+        fetched_at=time.time(), ttl_seconds=300,
+        results={"a": {"state": "merged"}},
+        ignored=[],
+        base_context={"a": ["main"], "b": ["main"]},
+    ))
+    state = WorkspaceState(tasks={"a": _task("a"), "b": _task("b")})
+    calls: list[list[str]] = []
+
+    def bad_fetcher(branches, _):
+        calls.append(list(branches))
+        from mship.core.reconcile.fetch import FetchError
+        raise FetchError("offline")
+
+    decisions = reconcile_now(state, cache=cache, fetcher=bad_fetcher)
+
+    assert calls == [["feat/a", "feat/b"]]
+    assert decisions == {}
+
+
+def test_reconcile_now_refetches_when_fresh_full_cache_entry_is_malformed(
+    tmp_path: Path,
+):
+    cache = ReconcileCache(tmp_path)
+    cache.write(CachePayload(
+        fetched_at=time.time(), ttl_seconds=300,
+        results={"a": {"state": "merged"}, "b": []},
+        ignored=[],
+        base_context={"a": ["main"], "b": ["main"]},
+    ))
+    state = WorkspaceState(tasks={"a": _task("a"), "b": _task("b")})
+    calls: list[list[str]] = []
+
+    def bad_fetcher(branches, _):
+        calls.append(list(branches))
+        from mship.core.reconcile.fetch import FetchError
+        raise FetchError("offline")
+
+    decisions = reconcile_now(state, cache=cache, fetcher=bad_fetcher)
+
+    assert calls == [["feat/a", "feat/b"]]
+    assert decisions == {}
+
+
 def test_reconcile_now_applies_dependency_stale_from_fresh_cache(tmp_path: Path):
     # #104 regression: dependency_stale is derived from LIVE task state (depends_on edges + the
     # upstream's merge state), so it must apply on the cache-hit path too — not only the fresh fetch.

--- a/tests/core/reconcile/test_gate.py
+++ b/tests/core/reconcile/test_gate.py
@@ -25,7 +25,12 @@ def test_reconcile_now_uses_fresh_cache(tmp_path: Path):
     cache = ReconcileCache(tmp_path)
     cache.write(CachePayload(
         fetched_at=time.time(), ttl_seconds=300,
-        results={"a": {"state": "merged", "pr_url": "u", "pr_number": 1, "base": "main"}},
+        results={
+            "a": {
+                "state": "merged", "pr_url": "u", "pr_number": 1,
+                "base": "main", "updated_at": "2026-05-10T00:00:00Z",
+            },
+        },
         ignored=[],
         base_context={"a": ["main"]},
     ))
@@ -252,13 +257,14 @@ def test_reconcile_now_recomputes_when_cache_schema_is_stale(tmp_path: Path):
     assert decisions["a"].state == UpstreamState.in_sync
 
 
-def test_reconcile_now_uses_fresh_cache_with_current_schema_version(tmp_path: Path):
-    """A cache entry written under the CURRENT schema version is still used as-is
-    (caching must not be broken by the version check)."""
-    cache = ReconcileCache(tmp_path)
     cache.write(CachePayload(
         fetched_at=time.time(), ttl_seconds=300,
-        results={"a": {"state": "merged", "pr_url": "u", "pr_number": 1, "base": "main"}},
+        results={
+            "a": {
+                "state": "merged", "pr_url": "u", "pr_number": 1,
+                "base": "main", "updated_at": "2026-05-10T00:00:00Z",
+            },
+        },
         ignored=[],
         base_context={"a": ["main"]},
     ))
@@ -291,11 +297,14 @@ def test_reconcile_now_refetches_when_stale(tmp_path: Path):
     assert decisions["a"].state == UpstreamState.merged
 
 
-def test_reconcile_now_falls_back_to_cache_on_fetcher_error(tmp_path: Path):
-    cache = ReconcileCache(tmp_path)
     cache.write(CachePayload(
         fetched_at=time.time() - 9999, ttl_seconds=300,
-        results={"a": {"state": "merged", "pr_url": "u", "pr_number": 1, "base": "main"}},
+        results={
+            "a": {
+                "state": "merged", "pr_url": "u", "pr_number": 1,
+                "base": "main", "updated_at": "2026-05-10T00:00:00Z",
+            },
+        },
         ignored=[],
         base_context={"a": ["main"]},
     ))
@@ -356,7 +365,12 @@ def test_reconcile_now_scoped_fetch_error_uses_selected_compatible_cache(
     cache.write(CachePayload(
         fetched_at=time.time() - 9999,
         ttl_seconds=300,
-        results={"a": {"state": "merged", "pr_url": "u", "pr_number": 1, "base": "main"}},
+        results={
+            "a": {
+                "state": "merged", "pr_url": "u", "pr_number": 1,
+                "base": "main", "updated_at": "2026-05-10T00:00:00Z",
+            },
+        },
         ignored=[],
         base_context={"a": ["main"], "b": ["old-base"]},
     ))
@@ -467,6 +481,78 @@ def test_reconcile_now_scoped_malformed_dependency_cache_result_fetches_dependen
     assert decisions["b"].state == UpstreamState.dependency_stale
 
 
+def test_reconcile_now_refetches_malformed_merged_dependency_timestamps(
+    tmp_path: Path,
+):
+    """A merged dependency without an aware timestamp cannot suppress stale detection."""
+    from mship.core.state import DependencyEdge
+
+    created = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    merged = datetime(2026, 5, 10, tzinfo=timezone.utc)
+    state = WorkspaceState(tasks={
+        "a": _task("a", created_at=created, finished_at=created),
+        "b": _task(
+            "b",
+            created_at=created,
+            depends_on=[
+                DependencyEdge(upstream_slug="a", created_at=created),
+            ],
+        ),
+    })
+    malformed_timestamps = (None, "not-a-timestamp", "2026-05-10T00:00:00")
+
+    for index, updated_at in enumerate(malformed_timestamps):
+        cache = ReconcileCache(tmp_path / str(index))
+        cache.write(CachePayload(
+            fetched_at=time.time(),
+            ttl_seconds=300,
+            results={
+                "a": {"state": "merged", "updated_at": updated_at},
+                "b": {"state": "in_sync"},
+            },
+            ignored=[],
+            base_context={"a": ["main"], "b": ["main"]},
+        ))
+        calls: list[list[str]] = []
+
+        def fetcher(branches, worktrees):
+            calls.append(list(branches))
+            return (
+                {
+                    "feat/a": PRSnapshot(
+                        head_ref="feat/a",
+                        state="MERGED",
+                        base_ref="main",
+                        merge_commit="a-merge",
+                        url="https://x/pr/a",
+                        updated_at=merged.isoformat(),
+                    ),
+                    "feat/b": PRSnapshot(
+                        head_ref="feat/b",
+                        state="OPEN",
+                        base_ref="main",
+                        merge_commit=None,
+                        url="https://x/pr/b",
+                        updated_at=created.isoformat(),
+                    ),
+                },
+                {
+                    "feat/a": GitSnapshot(has_upstream=True, behind=0, ahead=0),
+                    "feat/b": GitSnapshot(has_upstream=True, behind=0, ahead=0),
+                },
+            )
+
+        decisions = reconcile_now(
+            state,
+            cache=cache,
+            fetcher=fetcher,
+            only_slugs={"b"},
+        )
+
+        assert calls == [["feat/a", "feat/b"]]
+        assert decisions["b"].state == UpstreamState.dependency_stale
+
+
 def test_reconcile_now_scoped_fresh_cache_ignores_malformed_unrelated_result(
     tmp_path: Path,
 ):
@@ -475,7 +561,10 @@ def test_reconcile_now_scoped_fresh_cache_ignores_malformed_unrelated_result(
         fetched_at=time.time(),
         ttl_seconds=300,
         results={
-            "a": {"state": "merged", "pr_url": "u", "pr_number": 1, "base": "main"},
+            "a": {
+                "state": "merged", "pr_url": "u", "pr_number": 1,
+                "base": "main", "updated_at": "2026-05-10T00:00:00Z",
+            },
             "b": [],
         },
         ignored=[],
@@ -615,7 +704,12 @@ def test_decision_finished_at_populated_from_cache_hit(tmp_path: Path):
     cache = ReconcileCache(tmp_path)
     cache.write(CachePayload(
         fetched_at=time.time(), ttl_seconds=300,
-        results={"a": {"state": "merged", "pr_url": "u", "pr_number": 1, "base": "main"}},
+        results={
+            "a": {
+                "state": "merged", "pr_url": "u", "pr_number": 1,
+                "base": "main", "updated_at": "2026-05-10T00:00:00Z",
+            },
+        },
         ignored=[],
         base_context={"a": ["main"]},
     ))

--- a/tests/core/reconcile/test_gate.py
+++ b/tests/core/reconcile/test_gate.py
@@ -352,10 +352,10 @@ def test_reconcile_now_scoped_fetches_only_selected_task_snapshots(tmp_path: Pat
     assert set(decisions) == {"a"}
 
 
-def test_reconcile_now_scoped_context_miss_fetches_transitive_dependencies(
+def test_reconcile_now_scoped_missing_dependency_cache_result_fetches_dependencies(
     tmp_path: Path,
 ):
-    """A selected context miss must still retain dependency-stale detection."""
+    """A scoped cache hit needs results for the full dependency closure."""
     from mship.core.state import DependencyEdge
 
     created = datetime(2026, 5, 1, tzinfo=timezone.utc)
@@ -364,39 +364,19 @@ def test_reconcile_now_scoped_context_miss_fetches_transitive_dependencies(
     cache.write(CachePayload(
         fetched_at=time.time(),
         ttl_seconds=300,
-        results={
-            "root": {"state": "in_sync"},
-            "a": {"state": "merged", "updated_at": merged.isoformat()},
-            "b": {"state": "in_sync"},
-            "unrelated": {"state": "merged"},
-        },
+        results={"b": {"state": "in_sync"}},
         ignored=[],
-        base_context={
-            "root": ["main"],
-            "a": ["main"],
-            "b": ["old-base"],
-            "unrelated": ["main"],
-        },
+        base_context={"a": ["main"], "b": ["main"]},
     ))
     state = WorkspaceState(tasks={
-        "root": _task("root", created_at=created),
-        "a": _task(
-            "a",
-            created_at=created,
-            finished_at=created,
-            depends_on=[
-                DependencyEdge(upstream_slug="root", created_at=created),
-            ],
-        ),
+        "a": _task("a", created_at=created, finished_at=created),
         "b": _task(
             "b",
             created_at=created,
-            base_branch="new-base",
             depends_on=[
                 DependencyEdge(upstream_slug="a", created_at=created),
             ],
         ),
-        "unrelated": _task("unrelated"),
     })
     calls: list[list[str]] = []
 
@@ -404,14 +384,6 @@ def test_reconcile_now_scoped_context_miss_fetches_transitive_dependencies(
         calls.append(list(branches))
         return (
             {
-                "feat/root": PRSnapshot(
-                    head_ref="feat/root",
-                    state="OPEN",
-                    base_ref="main",
-                    merge_commit=None,
-                    url="https://x/pr/root",
-                    updated_at=created.isoformat(),
-                ),
                 "feat/a": PRSnapshot(
                     head_ref="feat/a",
                     state="MERGED",
@@ -423,18 +395,13 @@ def test_reconcile_now_scoped_context_miss_fetches_transitive_dependencies(
                 "feat/b": PRSnapshot(
                     head_ref="feat/b",
                     state="OPEN",
-                    base_ref="new-base",
+                    base_ref="main",
                     merge_commit=None,
                     url="https://x/pr/b",
                     updated_at=created.isoformat(),
                 ),
             },
             {
-                "feat/root": GitSnapshot(
-                    has_upstream=True,
-                    behind=0,
-                    ahead=0,
-                ),
                 "feat/a": GitSnapshot(has_upstream=True, behind=0, ahead=0),
                 "feat/b": GitSnapshot(has_upstream=True, behind=0, ahead=0),
             },
@@ -447,7 +414,7 @@ def test_reconcile_now_scoped_context_miss_fetches_transitive_dependencies(
         only_slugs={"b"},
     )
 
-    assert calls == [["feat/root", "feat/a", "feat/b"]]
+    assert calls == [["feat/a", "feat/b"]]
     assert set(decisions) == {"b"}
     assert decisions["b"].state == UpstreamState.dependency_stale
 

--- a/tests/test_dependency_integration.py
+++ b/tests/test_dependency_integration.py
@@ -64,13 +64,13 @@ def test_dependency_flow(dep_workspace):
     workspace_root = dep_workspace
 
     # 1. Spawn task-a (no deps).
-    r1 = runner.invoke(app, ["spawn", "--hotfix", "task a", "--slug", "a", "--skip-setup", "--force-audit"])
+    r1 = runner.invoke(app, ["spawn", "--hotfix", "task a", "--slug", "a", "--skip-setup", "--force-audit", "--bypass-reconcile"])
     assert r1.exit_code == 0, r1.output
 
     # 2. Spawn task-b depending on a.
     r2 = runner.invoke(
         app,
-        ["spawn", "--hotfix", "task b", "--slug", "b", "--depends-on", "a", "--skip-setup", "--force-audit"],
+        ["spawn", "--hotfix", "task b", "--slug", "b", "--depends-on", "a", "--skip-setup", "--force-audit", "--bypass-reconcile"],
     )
     assert r2.exit_code == 0, r2.output
 

--- a/tests/test_hook_integration.py
+++ b/tests/test_hook_integration.py
@@ -66,7 +66,7 @@ def test_commit_outside_task_worktree_refused(workspace_for_hooks):
     """End-to-end: spawn creates a worktree; a commit in the main checkout is refused."""
     tmp_path, repo = workspace_for_hooks
     runner.invoke(app, ["init", "--install-hooks"])
-    r = runner.invoke(app, ["spawn", "--hotfix", "add avatars", "--repos", "cli", "--force-audit", "--skip-setup"])
+    r = runner.invoke(app, ["spawn", "--hotfix", "add avatars", "--repos", "cli", "--force-audit", "--skip-setup", "--bypass-reconcile"])
     assert r.exit_code == 0, r.output
 
     # Make a change in the main checkout (wrong place)
@@ -88,7 +88,7 @@ def test_commit_outside_task_worktree_refused(workspace_for_hooks):
 def test_commit_inside_worktree_succeeds(workspace_for_hooks):
     tmp_path, repo = workspace_for_hooks
     runner.invoke(app, ["init", "--install-hooks"])
-    r = runner.invoke(app, ["spawn", "--hotfix", "inside ok", "--repos", "cli", "--force-audit", "--skip-setup"])
+    r = runner.invoke(app, ["spawn", "--hotfix", "inside ok", "--repos", "cli", "--force-audit", "--skip-setup", "--bypass-reconcile"])
     assert r.exit_code == 0, r.output
 
     from mship.core.state import StateManager
@@ -115,7 +115,7 @@ def test_commit_inside_worktree_succeeds(workspace_for_hooks):
 def test_no_verify_bypasses_hook(workspace_for_hooks):
     tmp_path, repo = workspace_for_hooks
     runner.invoke(app, ["init", "--install-hooks"])
-    runner.invoke(app, ["spawn", "--hotfix", "bypass test", "--repos", "cli", "--force-audit", "--skip-setup"])
+    runner.invoke(app, ["spawn", "--hotfix", "bypass test", "--repos", "cli", "--force-audit", "--skip-setup", "--bypass-reconcile"])
 
     (repo / "new.py").write_text("x\n")
     env = {**os.environ,
@@ -161,7 +161,7 @@ def test_post_commit_auto_logs_in_worktree(workspace_for_hooks):
     tmp_path, repo = workspace_for_hooks
     runner.invoke(app, ["init", "--install-hooks"])
     spawn_result = runner.invoke(
-        app, ["spawn", "--hotfix", "auto log test", "--repos", "cli", "--force-audit", "--skip-setup"],
+        app, ["spawn", "--hotfix", "auto log test", "--repos", "cli", "--force-audit", "--skip-setup", "--bypass-reconcile"],
     )
     assert spawn_result.exit_code == 0, spawn_result.output
 
@@ -200,11 +200,11 @@ def _spawn_two_tasks(tmp_path: Path, repo: Path):
 
     runner.invoke(app, ["init", "--install-hooks"])
     r1 = runner.invoke(
-        app, ["spawn", "--hotfix", "task a", "--repos", "cli", "--force-audit", "--skip-setup"],
+        app, ["spawn", "--hotfix", "task a", "--repos", "cli", "--force-audit", "--skip-setup", "--bypass-reconcile"],
     )
     assert r1.exit_code == 0, r1.output
     r2 = runner.invoke(
-        app, ["spawn", "--hotfix", "task b", "--repos", "cli", "--force-audit", "--skip-setup"],
+        app, ["spawn", "--hotfix", "task b", "--repos", "cli", "--force-audit", "--skip-setup", "--bypass-reconcile"],
     )
     assert r2.exit_code == 0, r2.output
 


### PR DESCRIPTION
## Summary
- scope spawn reconciliation to existing tasks touching requested repositories
- ignore disjoint drift while failing closed for unavailable or blocking relevant decisions
- preserve finish/close behavior, validation precedence, and hotfix bypass logging semantics

Closes #460

## Test plan
- focused spawn/worktree/integration suites (131 passed)
- `task lint`
- `mship test --repos mothership` (iteration 3: pass)
