### PR TITLE
fix: preserve quiet remote execution streams

### DIFF
--- a/docs/remote-run.md
+++ b/docs/remote-run.md
@@ -21,6 +21,11 @@ Your local box (the operator) then treats that URL+token as a **run-host role** 
 - Output streams back live (not a final blob) and the remote task's exit code becomes your local process's exit code.
 - For `capture`, produced artifacts (`screen.png`, `layout.*`) are pulled home automatically.
 
+The execution stream has no read-idle timeout: a quiet compiler or running app
+must not be mistaken for an unreachable host. Connection establishment, writes,
+and pool acquisition retain five-second timeouts. There is no overall run
+deadline; interrupt the command when you want to stop waiting.
+
 Without `--remote`, nothing changes — `mship run/capture/build` behave exactly as before.
 
 ## Declaring roles (`mothership.yaml`)

--- a/docs/remote-run.md
+++ b/docs/remote-run.md
@@ -21,10 +21,12 @@ Your local box (the operator) then treats that URL+token as a **run-host role** 
 - Output streams back live (not a final blob) and the remote task's exit code becomes your local process's exit code.
 - For `capture`, produced artifacts (`screen.png`, `layout.*`) are pulled home automatically.
 
-The execution stream has no read-idle timeout: a quiet compiler or running app
-must not be mistaken for an unreachable host. Connection establishment, writes,
-and pool acquisition retain five-second timeouts. There is no overall run
-deadline; interrupt the command when you want to stop waiting.
+The client imposes no read-idle timeout on a valid execution response body:
+a quiet compiler or running app must not trigger HTTPX's default five-second
+read timeout. Response headers, HTTP error bodies, connection establishment,
+writes, and pool acquisition retain five-second timeouts. There is no overall
+client run deadline; interrupt the command when you want to stop waiting.
+This does not disable timeouts imposed by a proxy or relay on the route.
 
 Without `--remote`, nothing changes — `mship run/capture/build` behave exactly as before.
 

--- a/src/mship/core/remote_client.py
+++ b/src/mship/core/remote_client.py
@@ -282,11 +282,9 @@ def exec_remote(
     url = f"{conn.url}/exec/{verb}"
 
     try:
-        # Builds and live apps may be silent indefinitely; silence is not a
-        # disconnected host. Keep connection/write/pool timeouts bounded.
-        with httpx.Client(
-            transport=transport, timeout=httpx.Timeout(5.0, read=None),
-        ) as client:
+        # Keep response headers and HTTP error bodies bounded by HTTPX's
+        # default five-second timeout; only a valid execution body may be idle.
+        with httpx.Client(transport=transport) as client:
             with client.stream("POST", url, headers=headers, json=body) as resp:
                 if resp.status_code >= 400:
                     resp.read()
@@ -302,6 +300,9 @@ def exec_remote(
                         f"cannot authenticate the exit-code/artifact framing "
                         f"(is the remote running a current mship serve?)"
                     )
+                # HTTPX/httpcore consult the request's timeout extension when
+                # starting the response-body iterator, after headers arrive.
+                resp.request.extensions["timeout"]["read"] = None
                 reader = _ChunkReader(resp.iter_raw())
                 return _drive(
                     reader, nonce=nonce,

--- a/src/mship/core/remote_client.py
+++ b/src/mship/core/remote_client.py
@@ -282,7 +282,11 @@ def exec_remote(
     url = f"{conn.url}/exec/{verb}"
 
     try:
-        with httpx.Client(transport=transport) as client:
+        # Builds and live apps may be silent indefinitely; silence is not a
+        # disconnected host. Keep connection/write/pool timeouts bounded.
+        with httpx.Client(
+            transport=transport, timeout=httpx.Timeout(5.0, read=None),
+        ) as client:
             with client.stream("POST", url, headers=headers, json=body) as resp:
                 if resp.status_code >= 400:
                     resp.read()

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -23,8 +23,11 @@ from __future__ import annotations
 import io
 import json
 import tarfile
+import time
 from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from threading import Thread
 from unittest.mock import MagicMock
 
 import httpx
@@ -255,6 +258,45 @@ def test_exec_remote_503_surfaces_not_bootstrapped_message():
         )
     msg = str(exc_info.value)
     assert "not bootstrapped" in msg
+
+
+def test_exec_remote_survives_quiet_build_then_returns_remote_result():
+    """A real socket must survive more than HTTPX's default five idle seconds."""
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.rfile.read(int(self.headers["Content-Length"]))
+            self.send_response(200)
+            self.send_header(NONCE_HEADER, NONCE)
+            self.end_headers()
+            self.wfile.write(b"building\n")
+            self.wfile.flush()
+            time.sleep(6)
+            try:
+                self.wfile.write(_frame(["build failed\n"], exit_code=7))
+                self.wfile.flush()
+            except BrokenPipeError:
+                # The unfixed client disconnects before the build finishes.
+                pass
+
+        def log_message(self, *_args):
+            pass
+
+    with HTTPServer(("127.0.0.1", 0), Handler) as server:
+        worker = Thread(target=server.handle_request, daemon=True)
+        worker.start()
+        printed = []
+        try:
+            code = remote_client.exec_remote(
+                verb="run",
+                conn=RunHostConnection(
+                    url=f"http://127.0.0.1:{server.server_port}", token="test",
+                ),
+                task="quiet-build", repos=["app"], print_fn=printed.append,
+            )
+        finally:
+            worker.join(timeout=10)
+    assert code == 7
+    assert printed == ["building", "build failed"]
 
 
 def test_exec_remote_stream_without_exit_sentinel_raises():

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -27,7 +27,7 @@ import time
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from threading import Thread
+from threading import Event, Thread
 from unittest.mock import MagicMock
 
 import httpx
@@ -297,6 +297,40 @@ def test_exec_remote_survives_quiet_build_then_returns_remote_result():
             worker.join(timeout=10)
     assert code == 7
     assert printed == ["building", "build failed"]
+
+
+def test_exec_remote_bounds_stalled_error_body():
+    """An HTTP error body is not a live execution stream and must time out."""
+    release = Event()
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.rfile.read(int(self.headers["Content-Length"]))
+            self.send_response(503)
+            self.send_header("Content-Length", "100")
+            self.end_headers()
+            self.wfile.flush()
+            release.wait(timeout=7)
+
+        def log_message(self, *_args):
+            pass
+
+    with HTTPServer(("127.0.0.1", 0), Handler) as server:
+        worker = Thread(target=server.handle_request, daemon=True)
+        worker.start()
+        try:
+            with pytest.raises(remote_client.RemoteExecError) as exc_info:
+                remote_client.exec_remote(
+                    verb="run",
+                    conn=RunHostConnection(
+                        url=f"http://127.0.0.1:{server.server_port}", token="test",
+                    ),
+                    task="stalled-error", repos=["app"], print_fn=lambda _: None,
+                )
+        finally:
+            release.set()
+            worker.join(timeout=10)
+    assert isinstance(exc_info.value.__cause__, httpx.ReadTimeout)
 
 
 def test_exec_remote_stream_without_exit_sentinel_raises():


### PR DESCRIPTION
## Problem
Remote iOS builds can emit no output for longer than HTTPX's default five-second read timeout. The CLI then aborts an already-connected run and incorrectly suggests relay/pairing failure.

## Change
Disable only the execution stream's read-idle timeout. Retain five-second connection, write, and pool timeouts. Document that no overall run deadline is imposed.

## Verification
- Added a real-socket regression with six seconds of silence followed by output and remote exit code 7; it fails against the unmodified client and passes with this fix.
- Targeted remote-dispatch suite: 86 tests passed.
- Actual QuicklyGuide remote iOS run sustained a 165.2-second CocoaPods install and 675.4-second Xcode build, then launched successfully.
- Subsequent nonresident remote runs and captures succeeded.

This does not fix remote-capture provenance issue #422 or change disconnect cancellation behavior.