### PR TITLE
Fix and verify macOS launchd daemon lifecycle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,22 @@ jobs:
           git config --global init.defaultBranch main
       - name: Run the suite
         run: task test
+
+  macos-daemon:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Verify lockfile is current
+        run: uv lock --check
+      - uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Give git an identity
+        run: |
+          git config --global user.name "mship ci"
+          git config --global user.email "ci@example.invalid"
+          git config --global init.defaultBranch main
+      - name: Exercise daemon and native launchd lifecycle
+        run: task test:daemon

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,6 +17,12 @@ tasks:
       - task: check-runtime-deps
       - uv run pytest -q -n auto --dist loadfile
 
+  test:daemon:
+    desc: Run daemon tests, including native launchd lifecycle tests on macOS
+    cmds:
+      - task: check-runtime-deps
+      - uv run pytest -q tests/core/daemon tests/cli/test_daemon.py
+
   check-runtime-deps:
     desc: Import the CLI with runtime-only deps to catch a dev-only dep used at runtime (MOS-190)
     # A `uv tool install` ships only `[project.dependencies]`, so a module-level

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -83,11 +83,30 @@ per merge).
 
 ## macOS caveats
 
-- The LaunchAgent is bootstrapped in the `user/<uid>` domain so provisioning
-  works over SSH with no GUI session (`gui/<uid>` fails there with
-  "Bootstrap failed: 5: Input/output error").
-- Reboot-survival on a headless Mac requires a login session (enable
-  auto-login); a system-domain LaunchDaemon is out of scope for v1.
+- The LaunchAgent pairs the `user/<uid>` domain with
+  `LimitLoadToSessionType=Background`. Without that plist key, launchd defaults
+  to the Aqua session type and rejects user-domain bootstrap with error 5.
+  This works from SSH without requiring the GUI domain.
+- `stop` waits for launchd to finish bootout before returning; launchctl
+  commands have a 30-second deadline. A loaded but stopped job is reported as
+  failed, not absent, so `start` and `restart` kickstart it rather than trying
+  to bootstrap a duplicate service.
+- If an earlier installation was manually bootstrapped into `gui/<uid>`,
+  unload that specific job with
+  `launchctl bootout --wait gui/$(id -u)/com.mothership.daemon`, then run the
+  updated `mship daemon install` and `mship daemon start`. Preserve the existing
+  daemon config and credentials; no re-pairing is needed.
+- This is a per-user LaunchAgent, not a system LaunchDaemon. Do not assume
+  pre-login availability after a reboot, and do not enable automatic login
+  merely to hide an untested lifecycle assumption.
+
+`task test:daemon` runs the daemon suite. On macOS it also boots real,
+uniquely named launchd services running `mshipd` with temporary homes and
+control sockets, exercises install/start/stop/restart/reinstall, crash recovery,
+and recovery after a clean exit, then unloads the services. The same target
+runs in the dedicated macOS CI job. These tests do not log out or reboot the
+machine; those disruptive transitions require a separate operator-observed
+check.
 
 ## Tunnel registration (#471)
 

--- a/src/mship/core/daemon/supervisor.py
+++ b/src/mship/core/daemon/supervisor.py
@@ -252,12 +252,12 @@ class LaunchdSupervisor(_BaseSupervisor):
         return f"user/{self._uid}/{LAUNCHD_LABEL}"
 
     def _launchctl(self, *args: str) -> subprocess.CompletedProcess:
-        return self._run(["launchctl", *args])
+        return self._run(["launchctl", *args], timeout=30)
 
     def _checked(self, *args: str) -> subprocess.CompletedProcess:
         try:
             r = self._launchctl(*args)
-        except OSError as e:
+        except (OSError, subprocess.TimeoutExpired) as e:
             raise DaemonSupervisorError(f"launchctl {' '.join(args)} failed: {e}; {_RUN_FALLBACK}") from e
         if r.returncode != 0:
             raise DaemonSupervisorError(
@@ -280,13 +280,10 @@ class LaunchdSupervisor(_BaseSupervisor):
         log_dir = daemon_log_dir(self._home)
         log_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
         plist_path.write_text(render_launchd_plist(argv, log_dir))
-        # Re-install: launchd rejects a duplicate bootstrap of a loaded label,
-        # and the running job would keep the OLD plist. Boot the label out
-        # first (tolerated when not loaded), then bootstrap the new plist.
-        try:
-            self._launchctl("bootout", self._target)
-        except OSError:
-            pass
+        # Re-install must finish unloading the old job before bootstrapping
+        # its replacement. An unloaded service needs no bootout.
+        if self.query().state != "absent":
+            self.stop()
         # user/<uid>, never gui/<uid>: bootstrap must work over SSH with no GUI
         # session (the headless provisioning path).
         self._checked("bootstrap", f"user/{self._uid}", str(plist_path))
@@ -300,7 +297,7 @@ class LaunchdSupervisor(_BaseSupervisor):
         self._checked("kickstart", self._target)
 
     def stop(self) -> None:
-        self._checked("bootout", self._target)
+        self._checked("bootout", "--wait", self._target)
 
     def restart(self) -> None:
         if self.query().state == "absent":  # same unloaded-target class as start()
@@ -310,7 +307,7 @@ class LaunchdSupervisor(_BaseSupervisor):
     def query(self) -> SupervisorState:
         try:
             r = self._launchctl("print", self._target)
-        except OSError as e:
+        except (OSError, subprocess.TimeoutExpired) as e:
             return SupervisorState("unreachable", str(e))
         if r.returncode != 0:
             err = (r.stderr or "") + (r.stdout or "")
@@ -319,7 +316,7 @@ class LaunchdSupervisor(_BaseSupervisor):
             return SupervisorState("unreachable", err.strip())
         if "state = running" in r.stdout:
             return SupervisorState("active")
-        return SupervisorState("absent", "loaded but not running")
+        return SupervisorState("failed", "loaded but not running")
 
     def linger_state(self) -> Literal["yes", "no", "unknown"]:
         return "unknown"  # not applicable on macOS

--- a/src/mship/core/daemon/units.py
+++ b/src/mship/core/daemon/units.py
@@ -123,6 +123,8 @@ def render_launchd_plist(argv: list[str], log_dir: Path) -> str:
         {
             "Label": LAUNCHD_LABEL,
             "ProgramArguments": list(argv),
+            # Match user/<uid>; the default Aqua session requires gui/<uid>.
+            "LimitLoadToSessionType": "Background",
             "RunAtLoad": True,
             "KeepAlive": {"SuccessfulExit": False},
             "ThrottleInterval": 5,

--- a/tests/core/daemon/test_launchd_integration.py
+++ b/tests/core/daemon/test_launchd_integration.py
@@ -67,6 +67,7 @@ def launchd_daemon(monkeypatch):
                 timeout=15,
             )
             _wait_for(lambda: probe_control_socket(socket) is None, supervisor)
+            assert supervisor.query().state == "absent", "test LaunchAgent was not unloaded"
 
 
 def _healthy(socket, previous_pid=None):

--- a/tests/core/daemon/test_launchd_integration.py
+++ b/tests/core/daemon/test_launchd_integration.py
@@ -1,4 +1,5 @@
 """Real macOS launchd lifecycle, isolated from the operator's daemon and home."""
+
 import os
 import subprocess
 import sys
@@ -14,7 +15,9 @@ from mship.core.daemon import units as units_mod
 from mship.core.daemon.control import probe_control_socket
 from mship.core.daemon.paths import daemon_socket_path
 
-pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS launchd")
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin", reason="requires macOS launchd"
+)
 
 
 def _wait_for(condition, supervisor):
@@ -24,8 +27,10 @@ def _wait_for(condition, supervisor):
         if result:
             return result
         time.sleep(0.1)
-    pytest.fail(f"launchd condition timed out: {supervisor.query()}\n"
-                + "\n".join(supervisor.logs_tail(30)))
+    pytest.fail(
+        f"launchd condition timed out: {supervisor.query()}\n"
+        + "\n".join(supervisor.logs_tail(30))
+    )
 
 
 @pytest.fixture
@@ -39,17 +44,28 @@ def launchd_daemon(monkeypatch):
         env = {"HOME": str(home), "XDG_RUNTIME_DIR": str(home / "runtime")}
         socket = daemon_socket_path(env, home)
         supervisor = supervisor_mod.LaunchdSupervisor(home=home)
-        assert supervisor.available(), "macOS CI must provide a reachable user launchd domain"
+        assert supervisor.available(), (
+            "macOS CI must provide a reachable user launchd domain"
+        )
         argv = [
-            "/usr/bin/env", "-i", f"HOME={home}",
-            f"XDG_RUNTIME_DIR={env['XDG_RUNTIME_DIR']}", "PATH=/usr/bin:/bin",
-            sys.executable, "-m", "mship.core.daemon",
+            "/usr/bin/env",
+            "-i",
+            f"HOME={home}",
+            f"XDG_RUNTIME_DIR={env['XDG_RUNTIME_DIR']}",
+            "PATH=/usr/bin:/bin",
+            sys.executable,
+            "-m",
+            "mship.core.daemon",
         ]
         target = f"user/{os.getuid()}/{label}"
         try:
             yield supervisor, socket, argv, target
         finally:
-            subprocess.run(["launchctl", "bootout", target], capture_output=True, timeout=15)
+            subprocess.run(
+                ["launchctl", "bootout", "--wait", target],
+                capture_output=True,
+                timeout=15,
+            )
             _wait_for(lambda: probe_control_socket(socket) is None, supervisor)
 
 

--- a/tests/core/daemon/test_launchd_integration.py
+++ b/tests/core/daemon/test_launchd_integration.py
@@ -1,0 +1,105 @@
+"""Real macOS launchd lifecycle, isolated from the operator's daemon and home."""
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from mship.core.daemon import supervisor as supervisor_mod
+from mship.core.daemon import units as units_mod
+from mship.core.daemon.control import probe_control_socket
+from mship.core.daemon.paths import daemon_socket_path
+
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS launchd")
+
+
+def _wait_for(condition, supervisor):
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        result = condition()
+        if result:
+            return result
+        time.sleep(0.1)
+    pytest.fail(f"launchd condition timed out: {supervisor.query()}\n"
+                + "\n".join(supervisor.logs_tail(30)))
+
+
+@pytest.fixture
+def launchd_daemon(monkeypatch):
+    label = f"com.mothership.test.{uuid.uuid4().hex}"
+    monkeypatch.setattr(supervisor_mod, "LAUNCHD_LABEL", label)
+    monkeypatch.setattr(units_mod, "LAUNCHD_LABEL", label)
+    # Darwin's Unix socket path limit is short; pytest's default path can exceed it.
+    with tempfile.TemporaryDirectory(prefix="mship-", dir="/tmp") as directory:
+        home = Path(directory)
+        env = {"HOME": str(home), "XDG_RUNTIME_DIR": str(home / "runtime")}
+        socket = daemon_socket_path(env, home)
+        supervisor = supervisor_mod.LaunchdSupervisor(home=home)
+        assert supervisor.available(), "macOS CI must provide a reachable user launchd domain"
+        argv = [
+            "/usr/bin/env", "-i", f"HOME={home}",
+            f"XDG_RUNTIME_DIR={env['XDG_RUNTIME_DIR']}", "PATH=/usr/bin:/bin",
+            sys.executable, "-m", "mship.core.daemon",
+        ]
+        target = f"user/{os.getuid()}/{label}"
+        try:
+            yield supervisor, socket, argv, target
+        finally:
+            subprocess.run(["launchctl", "bootout", target], capture_output=True, timeout=15)
+            _wait_for(lambda: probe_control_socket(socket) is None, supervisor)
+
+
+def _healthy(socket, previous_pid=None):
+    health = probe_control_socket(socket)
+    return health if health and health["pid"] != previous_pid else None
+
+
+def test_launchd_runs_stops_restarts_and_recovers_daemon(launchd_daemon):
+    supervisor, socket, argv, target = launchd_daemon
+    supervisor.install(argv)
+    first = _wait_for(lambda: _healthy(socket), supervisor)
+    assert supervisor.query().state == "active"
+    print(f"installed: healthy pid={first['pid']}")
+
+    supervisor.start()
+    assert _healthy(socket)["pid"] == first["pid"]
+
+    supervisor.restart()
+    restarted = _wait_for(lambda: _healthy(socket, first["pid"]), supervisor)
+    print(f"restarted: healthy pid={restarted['pid']}")
+
+    supervisor.stop()
+    _wait_for(lambda: probe_control_socket(socket) is None, supervisor)
+    assert supervisor.query().state == "absent"
+
+    supervisor.start()
+    started = _wait_for(lambda: _healthy(socket, restarted["pid"]), supervisor)
+    print(f"started after stop: healthy pid={started['pid']}")
+
+    supervisor.install(argv)
+    reinstalled = _wait_for(lambda: _healthy(socket, started["pid"]), supervisor)
+    print(f"reinstalled: healthy pid={reinstalled['pid']}")
+
+    subprocess.run(["launchctl", "kill", "SIGKILL", target], check=True, timeout=15)
+    recovered = _wait_for(lambda: _healthy(socket, reinstalled["pid"]), supervisor)
+    assert supervisor.query().state == "active"
+    print(f"recovered after crash: healthy pid={recovered['pid']}")
+
+
+def test_launchd_start_recovers_loaded_daemon_after_clean_exit(launchd_daemon):
+    supervisor, socket, argv, target = launchd_daemon
+    supervisor.install(argv)
+    first = _wait_for(lambda: _healthy(socket), supervisor)
+    # A graceful exit leaves the service loaded, but SuccessfulExit=false does
+    # not respawn it. start must kickstart that service, not bootstrap it twice.
+    subprocess.run(["launchctl", "kill", "SIGTERM", target], check=True, timeout=15)
+    _wait_for(lambda: probe_control_socket(socket) is None, supervisor)
+    _wait_for(lambda: supervisor.query().state != "active", supervisor)
+    supervisor.start()
+    recovered = _wait_for(lambda: _healthy(socket, first["pid"]), supervisor)
+    assert supervisor.query().state == "active"
+    print(f"recovered after clean exit: healthy pid={recovered['pid']}")

--- a/tests/core/daemon/test_supervisor.py
+++ b/tests/core/daemon/test_supervisor.py
@@ -148,33 +148,10 @@ def _mac(tmp_path, responses=None):
     return sup, rec
 
 
-def test_macos_install_uses_user_domain_not_gui(tmp_path):
-    """gui/<uid> bootstrap fails over SSH with no GUI session ('Bootstrap
-    failed: 5: Input/output error') — exactly the headless provisioning
-    scenario #469/#470 describe."""
-    sup, rec = _mac(tmp_path)
-    sup.install(["/venv/bin/mshipd"])
-    plist = tmp_path / "Library" / "LaunchAgents" / "com.mothership.daemon.plist"
-    assert plist.is_file()
-    cmds = [" ".join(c) for c in rec.calls]
-    assert any("bootstrap user/501" in c for c in cmds)
-    assert not any("gui/" in c for c in cmds)
-
-
 def test_macos_bootstrap_failure_is_daemon_error(tmp_path):
     sup, _ = _mac(tmp_path, {"bootstrap": _fail(stderr="Bootstrap failed: 5: Input/output error")})
     with pytest.raises(DaemonSupervisorError, match="[Bb]ootstrap"):
         sup.install(["/venv/bin/mshipd"])
-
-
-def test_macos_lifecycle_commands(tmp_path):
-    sup, rec = _mac(tmp_path)
-    sup.start()
-    sup.stop()
-    sup.restart()
-    cmds = [" ".join(c) for c in rec.calls]
-    assert any("kickstart user/501/com.mothership.daemon" in c for c in cmds)
-    assert any("bootout user/501/com.mothership.daemon" in c for c in cmds)
 
 
 def test_macos_query_unreachable_never_absent(tmp_path):
@@ -186,6 +163,16 @@ def test_macos_query_unreachable_never_absent(tmp_path):
     assert sup2.query().state == "absent"
     sup3, _ = _mac(tmp_path, {"print": _ok("state = running\npid = 4242\n")})
     assert sup3.query().state == "active"
+    sup4, _ = _mac(tmp_path, {"print": _ok("state = not running\nlast exit code = 0\n")})
+    assert sup4.query().state == "failed"
+    sup5, _ = _mac(tmp_path, {"print": subprocess.TimeoutExpired("launchctl", 30)})
+    assert sup5.query().state == "unreachable"
+
+
+def test_macos_stop_timeout_is_daemon_error(tmp_path):
+    sup, _ = _mac(tmp_path, {"bootout": subprocess.TimeoutExpired("launchctl", 30)})
+    with pytest.raises(DaemonSupervisorError, match="timed out"):
+        sup.stop()
 
 
 def test_macos_linger_not_applicable(tmp_path):
@@ -219,28 +206,6 @@ def test_macos_install_creates_log_dir(tmp_path):
     assert daemon_log_dir(tmp_path).is_dir()
 
 
-def test_macos_start_rebootstraps_after_stop(tmp_path):
-    """stop() boots the service out of the domain; start()/restart() must
-    re-bootstrap an absent service before kickstarting it."""
-    sup, rec = _mac(tmp_path, {"print": _fail(stderr="Could not find service")})
-    sup.start()
-    cmds = [" ".join(c) for c in rec.calls]
-    assert any("bootstrap user/501" in c for c in cmds)
-    assert any("kickstart user/501" in c for c in cmds)
-
-    sup2, rec2 = _mac(tmp_path, {"print": _fail(stderr="Could not find service")})
-    sup2.restart()
-    cmds2 = [" ".join(c) for c in rec2.calls]
-    assert any("bootstrap user/501" in c for c in cmds2)
-
-
-def test_macos_start_skips_bootstrap_when_loaded(tmp_path):
-    sup, rec = _mac(tmp_path, {"print": _ok("state = running\npid = 1\n")})
-    sup.start()
-    cmds = [" ".join(c) for c in rec.calls]
-    assert not any("bootstrap" in c for c in cmds)
-
-
 def test_linux_query_unit_not_found_is_absent(tmp_path):
     """A reachable manager answering 'not found' for an uninstalled unit is
     absent, not unreachable (the pre-install `daemon status` case)."""
@@ -248,21 +213,6 @@ def test_linux_query_unit_not_found_is_absent(tmp_path):
     assert sup.query().state == "absent"
 
 
-def test_macos_reinstall_unloads_first(tmp_path):
-    """launchd rejects a duplicate bootstrap of a loaded label and the running
-    job would keep the OLD plist — install boots the label out first
-    (tolerated when not loaded), then bootstraps the fresh plist."""
-    sup, rec = _mac(tmp_path)
-    sup.install(["/venv/bin/mshipd"])
-    cmds = [" ".join(c) for c in rec.calls]
-    bootout_i = next(i for i, c in enumerate(cmds) if "bootout" in c)
-    bootstrap_i = next(i for i, c in enumerate(cmds) if "bootstrap" in c)
-    assert bootout_i < bootstrap_i
-
-    # bootout failing (label not loaded — the FIRST install) must not block.
-    sup2, rec2 = _mac(tmp_path, {"launchctl bootout": _fail(stderr="Boot-out failed: 3: No such process")})
-    sup2.install(["/venv/bin/mshipd"])
-    assert any("bootstrap" in " ".join(c) for c in rec2.calls)
 
 
 def test_linux_user_defaults_to_uid_not_env(tmp_path, monkeypatch):

--- a/tests/core/daemon/test_units.py
+++ b/tests/core/daemon/test_units.py
@@ -11,7 +11,6 @@ import pytest
 
 import mship.core.daemon.units as units_mod
 from mship.core.daemon.units import (
-    LAUNCHD_LABEL,
     DaemonExecResolutionError,
     render_launchd_plist,
     render_systemd_unit,
@@ -50,20 +49,6 @@ def test_systemd_unit_has_no_working_directory():
 def test_systemd_multiarg_exec_is_joined():
     cp = _parse_unit(render_systemd_unit(["/usr/bin/python3", "-m", "mship.core.daemon"]))
     assert cp["Service"]["ExecStart"] == "/usr/bin/python3 -m mship.core.daemon"
-
-
-def test_launchd_plist_shape(tmp_path: Path):
-    log_dir = tmp_path / "logs"
-    plist = plistlib.loads(render_launchd_plist(ARGV, log_dir).encode())
-    assert plist["Label"] == LAUNCHD_LABEL == "com.mothership.daemon"
-    assert plist["KeepAlive"] == {"SuccessfulExit": False}
-    assert plist["ThrottleInterval"] == 5
-    assert plist["RunAtLoad"] is True
-    assert plist["ProgramArguments"] == ARGV
-    # launchd discards stderr otherwise — the last-resort net for output that
-    # escapes the logging tree.
-    assert plist["StandardOutPath"] == str(log_dir / "launchd.out.log")
-    assert plist["StandardErrorPath"] == str(log_dir / "launchd.err.log")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem: observed on an actual MacBook Air
The released v0.5.68 generator fails user-domain bootstrap with error5 because its LaunchAgent lacks LimitLoadToSessionType=Background. A manually loaded GUI-domain workaround ran, but normal daemon status/start/stop addressed the user domain instead.

Native launchd tests then exposed two recovery defects: bootout returns before unloading completes, and a loaded cleanly exited daemon was classified as absent, causing duplicate bootstrap.

## Fix
- Pair user/<uid> with the Background session type.
- Use bootout --wait, with launchctl commands bounded to30seconds.
- Distinguish loaded-but-stopped from absent so start/restart use kickstart appropriately.
- Replace command-string/plist-shape assertions with actual macOS launchd lifecycle tests.
- Add task test:daemon and a native macOS CI job.
- Document migration and untested reboot/login limits.

## Verification
- Released v0.5.68 fails the new native bootstrap regression.
- Background-only correction reproduces the separate stop/start race and clean-exit recovery bug.
- Final native tests on MacBook Air:2 passed in19.90s. Tests cover install, idempotent start, stop/start, restart, reinstall, SIGKILL recovery, clean-exit recovery, and complete temporary service cleanup.
- macOS CI:520 daemon tests passed. Linux focused suite:518 passed,2 native-only skips. Full Linux CI, build, CodeQL and dependency checks passed.
- Live Mac uses repair runtime ae70e7c (final40346c9 only strengthens the native-test cleanup assertion), installed in user/501: running=true, supervised=true, compatible=true, daemon/CLI0.5.68.
- Live CLI stop/start/restart/reinstall succeeded across fresh SSH sessions. Configuration, hostidentity, serve-token bytes and modes preserved.
- Devbox Mothership remote app run and capture both exited0 through the repaired daemon; app emitted QuicklyGuide6896ffd and captured the clean login UI.

## Review and limits
The automated review's claim that --wait is unsupported is contradicted by `launchctl help bootout` and actual successful calls on the Mac and macos-26-arm64 CI. Runtime evidence is recorded on the review thread; no checks are disabled and the PR is not merged.

Logout/login, reboot/pre-login availability, sleep/wake and older macOS releases were not exercised or claimed. Temporary test services/homes and Mac provisioning files were removed.