### PR TITLE
Keep mailbox polling off the daemon event loop

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -302,6 +302,10 @@ The daemon discovers workspaces instead of being told about them: at startup
 (and on explicit refresh) it scans the configured **scan roots** for
 `mothership.yaml` and serves every healthy one.
 
+Mailbox polling reads its disk-backed snapshots outside the daemon's event
+loop so a slow inbox read does not stall host health or other workspaces.
+When no threads changed, it skips the spec/work-item index entirely.
+
 ```bash
 mship daemon install --scan-root ~/src --scan-root ~/work --serve 127.0.0.1:47190
 ```

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -1458,6 +1458,8 @@ def create_app(
 
     def _summaries(threads, now: datetime | None = None):
         threads = list(threads)
+        if not threads:
+            return []
         now = now or datetime.now(timezone.utc)
         links_by_thread = _thread_inbox_links(threads)
         summaries = []
@@ -1511,7 +1513,9 @@ def create_app(
         q: str | None = None,
     ):
         if not wait:
-            return _filtered_summaries(msgs.list(), inbox, q)
+            return await asyncio.to_thread(
+                lambda: _filtered_summaries(msgs.list(), inbox, q)
+            )
         from mship.core.message_wait import changed_since
         timeout = max(0.0, min(timeout, 30.0))  # cap for the relay idle-read timeout
         try:
@@ -1520,11 +1524,15 @@ def create_app(
             raise HTTPException(status_code=422, detail=f"invalid since value: {since!r}")
         if since_dt.tzinfo is None:
             since_dt = since_dt.replace(tzinfo=timezone.utc)
+
+        def read_updates():
+            changed, cursor = changed_since(msgs.list(), since_dt, include_inbox=True)
+            return _summaries(changed), cursor
+
         interval = 1.0
         deadline = _time.monotonic() + timeout
         while True:
-            changed, cursor = changed_since(msgs.list(), since_dt, include_inbox=True)
-            summaries = _summaries(changed)
+            summaries, cursor = await asyncio.to_thread(read_updates)
             threads = [
                 summary for summary in summaries
                 if _matches_thread_filter(summary, inbox, q)

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from threading import Event
 
 import pytest
 
@@ -183,6 +185,39 @@ def test_wait_times_out_with_empty_list(tmp_path: Path):
     body = r.json()
     assert body["timed_out"] is True
     assert body["threads"] == []
+
+
+@pytest.mark.parametrize("wait", [0, 1])
+def test_health_remains_available_during_mailbox_read(tmp_path: Path, monkeypatch, wait):
+    client, store = _client(tmp_path)
+    thread = store.create_thread("Pending question", "Help", datetime.now(timezone.utc))
+    entered = Event()
+    release = Event()
+    read_timed_out = Event()
+    original_list = MessageStore.list
+
+    def blocked_list(self):
+        entered.set()
+        if not release.wait(3):
+            read_timed_out.set()
+        return original_list(self)
+
+    monkeypatch.setattr(MessageStore, "list", blocked_list)
+    with client, ThreadPoolExecutor(max_workers=1) as executor:
+        pending = executor.submit(
+            client.get, "/threads", params={"wait": wait, "since": PAST, "timeout": 0},
+        )
+        try:
+            assert entered.wait(3)
+            health = client.get("/health")
+            assert health.status_code == 200
+            assert not read_timed_out.is_set(), "Mailbox read blocked the health endpoint"
+        finally:
+            release.set()
+        response = pending.result(timeout=3)
+        assert response.status_code == 200
+        threads = response.json()["threads"] if wait else response.json()
+        assert [summary["id"] for summary in threads] == [thread.id]
 
 
 def test_wait_requires_auth(tmp_path: Path):


### PR DESCRIPTION
## Observed problem
While verifying the daemon fleet after #494, the Linux daemon repeatedly timed out health requests and consumed98%CPU. A live SIGUSR1 stack dump showed the main asyncio thread parsing YAML specs from `_thread_inbox_links -> _summaries -> list_threads`. Even empty changed-thread polls rebuilt all spec/work-item links synchronously.

## Fix
- Skip inbox indexing when there are no thread summaries to produce.
- Read plain and long-poll mailbox snapshots via the existing asyncio.to_thread pattern, not on the event loop.
- Keep cursor, filtering, removed_ids, and inbox semantics unchanged.
- Add deterministic concurrent-health regressions for plain and waiting requests; both fail before the fix and pass afterward.

## Verification
- Focused serve+daemon suite:571 passed,2 macOS-only skips.
- Full `mship test --repos mothership`:passed.
- Ruff on changed Python files:passed.
- Actual Linux daemon installed with this fix:authenticated health for all three workspaces4ms each; publichealth2–3ms, versus the previous timeout.
- CPU fell from98% to4.8% over a10-second live sample while mailbox clients remained connected.
- Existing relay refresh credential exchange succeeds; unauthenticated directory/workspace requests remain401.
- Config, identity, tokens and modes preserved on both hosts. Temporary stack-dump systemd override removed and normal unit restarted.

This is the additional fleet-health defect found during the operator-requested merge/deployment verification. No polling is disabled and no timeouts are increased.