### PR TITLE
Fix remote capture integrity and Ground Control daily-use workflows

### DIFF
--- a/docs/remote-run.md
+++ b/docs/remote-run.md
@@ -109,9 +109,11 @@ These are deliberately out of scope for the first cut. Know them before you lean
 
 ## What travels to the run host
 
-`--remote` runs the code you are looking at, **including work you have not
-committed**. Before dispatching, mship reads every repo the task touches and
-takes one of three paths per repo:
+`run --remote` and `build --remote` prepare the source you are looking at,
+**including work you have not committed**. `capture --remote` shares their
+source preflight and transfer path, but observes an already-running app.
+Before dispatching, mship inspects each selected repo and takes one of three
+paths:
 
 - **Working tree differs from HEAD** — tracked edits, untracked files, or both →
   mship builds a commit from your working tree and pushes it **straight to the
@@ -182,6 +184,22 @@ need the run host to materialize an immutable revision instead of resolving a
 branch at fetch time. The **dirty path already does exactly that**: it
 materializes a specific commit from a ref nothing else writes, with no fetch at
 all. The clean path does not.
+
+### Capture provenance
+
+Remote capture uses the same repo-scoped preflight as remote run/build.
+An unsafe checkout or failed source transfer stops the command before capture
+is dispatched; a `git_root` child uses its canonical repository for transfer.
+
+Capture does **not** rebuild or relaunch the app. Preparing source therefore
+does not prove which binary is visible on the device. Run the app first when
+you need a fresh build.
+
+Attached remote evidence records source preparation separately from device
+provenance. For dirty trees it names the synthesized snapshot SHA and throwaway
+ref, not the parent HEAD. It explicitly states that the remote checkout and
+running binary provenance were not verified; it does not label a remote image
+as a local clean-HEAD capture.
 
 ### Dependencies are derived there, not copied
 

--- a/docs/remote-run.md
+++ b/docs/remote-run.md
@@ -18,7 +18,7 @@ Your local box (the operator) then treats that URL+token as a **run-host role** 
 
 - The remote **materializes the task's branch** — `git fetch` + a worktree at `.worktrees/<task>/<repo>`, mirroring the local worktree layout. Remote execution always operates on a task's branch; there's no ad-hoc remote run (the remote needs a branch to check out).
 - The remote runs the repo's go-task target (`run`/`capture`/`build`) with the **same env-var contract** as a local run.
-- Output streams back live (not a final blob) and the remote task's exit code becomes your local process's exit code.
+- Output streams back live on stderr (not a final blob), leaving structured command results on stdout parseable. `--quiet` suppresses progress; the remote task's exit code becomes your local process's exit code.
 - For `capture`, produced artifacts (`screen.png`, `layout.*`) are pulled home automatically.
 
 The client imposes no read-idle timeout on a valid execution response body:

--- a/src/mship/cli/capture.py
+++ b/src/mship/cli/capture.py
@@ -42,7 +42,8 @@ class _RemoteFlagCommand(TyperCommand):
 
 
 def _attach_evidence(
-    *, artifacts, evidence: str, container, output, worktree: Path, platform: str | None
+    *, artifacts, evidence: str, container, output, worktree: Path, platform: str | None,
+    provenance: str | None = None,
 ) -> None:
     """Promote captured artifacts into acceptance-criterion evidence.
 
@@ -76,7 +77,7 @@ def _attach_evidence(
                     f"{target.criterion_id!r}"
                 )
                 return
-            note_where = provenance_note(worktree, container.shell())
+            note_where = provenance or provenance_note(worktree, container.shell())
             for a in artifacts:
                 ref = store_artifact(workspace_root, target.spec_id, a.path, mode=mode)
                 crit.evidence.append(
@@ -207,8 +208,8 @@ def register(app: typer.Typer, get_container):
             out_dir = workspace_root / ".mothership" / "captures" / out_bucket / f"{ts}-{label}"
 
         if remote is not None:
-            from mship.core.remote_client import RemoteExecError, exec_remote
-            from mship.core.run_host import RunHostError, RunHostStore, resolve_run_host
+            from mship.cli.exec import _run_remote
+            from mship.core.evidence_attach import remote_provenance_note
 
             # Remote execution always materializes the task's branch on the
             # remote — there's no ad-hoc remote capture (an ad-hoc capture
@@ -222,22 +223,18 @@ def register(app: typer.Typer, get_container):
                 )
                 raise typer.Exit(code=1)
 
-            role = remote or None
-            store = RunHostStore(container.state_dir())
-            try:
-                conn = resolve_run_host(role, repo=repo_cfg, config=config, store=store)
-            except RunHostError as e:
-                output.error(str(e))
-                raise typer.Exit(code=1)
+            remote_note: str | None = None
 
-            try:
-                code = exec_remote(
-                    verb="capture", conn=conn, task=t.slug, repos=[resolved_repo],
-                    platform=resolved_platform, kind=kind, captures_dir_for=out_dir,
-                )
-            except RemoteExecError as e:
-                output.error(str(e))
-                raise typer.Exit(code=1)
+            def record_preparation(source_preparation: str) -> None:
+                nonlocal remote_note
+                remote_note = remote_provenance_note(source_preparation)
+
+            code = _run_remote(
+                verb="capture", remote_role=remote, task_obj=t,
+                target_repos=[resolved_repo], config=config, container=container,
+                output=output, platform=resolved_platform, kind=kind,
+                captures_dir_for=out_dir, on_prepared=record_preparation,
+            )
 
             # On success, emit the SAME confirmation a local capture does
             # (respecting --json), pointing at the local landing path where
@@ -272,6 +269,9 @@ def register(app: typer.Typer, get_container):
                     _attach_evidence(
                         artifacts=landed, evidence=evidence, container=container,
                         output=output, worktree=worktree, platform=resolved_platform,
+                        provenance=remote_note or remote_provenance_note(
+                            "source preparation was not recorded"
+                        ),
                     )
             raise typer.Exit(code=code)
 

--- a/src/mship/cli/exec.py
+++ b/src/mship/cli/exec.py
@@ -1,4 +1,6 @@
 import os
+from collections.abc import Callable
+from pathlib import Path
 from typing import Optional
 
 import typer
@@ -83,10 +85,14 @@ def _run_remote(
     config,
     container,
     output: Output,
+    platform: str | None = None,
+    kind: str = "all",
+    captures_dir_for: Path | None = None,
+    on_prepared: Callable[[str], None] | None = None,
 ) -> int:
-    """Shared `--remote` dispatch for `run`/`build`: resolve the run-host
-    role to a connection, POST to the remote's `/exec/{verb}`, and return the
-    remote task's exit code (mirrored by the caller as `raise
+    """Shared `--remote` dispatch for `run`/`build`/`capture`: resolve the
+    run-host role to a connection, POST to the remote's `/exec/{verb}`, and
+    return the remote task's exit code (mirrored by the caller as `raise
     typer.Exit(code)`).
 
     `task_obj` is the caller's already-resolved `Task` (`None` when nothing
@@ -108,6 +114,12 @@ def _run_remote(
     task is active, but that fallback has no branch for the remote to check out,
     so `--remote` without a resolvable task is a clean, actionable CLI error
     rather than a confusing remote-side failure.
+
+    A caller may supply capture-specific `platform`, `kind`, and
+    `captures_dir_for` arguments, plus `on_prepared` to receive a conservative
+    description of the source preflight completed before dispatch. This keeps
+    capture on the same preparation path as run/build without making it infer
+    source provenance from the local worktree after a remote capture.
 
     A `RunHostError` (unknown/ambiguous/unmapped role) or `RemoteExecError`
     (remote unreachable) surfaces as `output.error(...)` + `typer.Exit(1)` —
@@ -165,6 +177,12 @@ def _run_remote(
     # re-read of HEAD: it is the same guarantee `remote_preflight.push` makes
     # for the origin path, applied to the snapshot's parent.
     run_ref_repos: list[str] = []
+    # Only capture asks for source-preparation provenance. Keep the snapshot
+    # identities only in that case so run/build retain their existing work.
+    prepared_snapshots: list[tuple[str, str, str]] | None = (
+        [] if on_prepared is not None else None
+    )
+
     for state in pre.dirty:
         try:
             sha = run_transfer.synthesize_commit(
@@ -178,6 +196,11 @@ def _run_remote(
             output.error(str(e))
             raise typer.Exit(code=1)
         run_ref_repos.append(state.git_repo)
+        if prepared_snapshots is not None:
+            # This is deliberately recorded only after `push_run_ref` succeeds:
+            # it identifies the snapshot actually sent, rather than its parent
+            # HEAD or an unverified attempted transfer.
+            prepared_snapshots.append((state.git_repo, sha, ref))
         # Name it as throwaway (spec ac13): an operator who sees a bare sha will
         # reasonably try to `git show` it and find it attached to nothing.
         output.breadcrumb(
@@ -201,9 +224,26 @@ def _run_remote(
             f"pushed {repo_name}{suffix} so the run host sees your commits"
         )
 
+    if on_prepared is not None:
+        if prepared_snapshots:
+            snapshots = ", ".join(
+                f"{repo}@{sha[:12]} via {ref} (a throwaway run ref)"
+                for repo, sha, ref in prepared_snapshots
+            )
+            on_prepared(
+                f"an exact working-tree snapshot ({snapshots}) was sent to the run host"
+            )
+        else:
+            states = [s for s in pre.states if s.repo in target_repos]
+            commits = ", ".join(
+                f"{s.repo}@{(s.head_sha or 'unknown')[:12]}" for s in states
+            )
+            on_prepared(f"task source {commits} was verified before remote dispatch")
+
     try:
         return exec_remote(
             verb=verb, conn=conn, task=task_obj.slug, repos=target_repos,
+            platform=platform, kind=kind, captures_dir_for=captures_dir_for,
             run_ref_repos=run_ref_repos,
         )
     except RemoteExecError as e:

--- a/src/mship/cli/exec.py
+++ b/src/mship/cli/exec.py
@@ -244,7 +244,7 @@ def _run_remote(
         return exec_remote(
             verb=verb, conn=conn, task=task_obj.slug, repos=target_repos,
             platform=platform, kind=kind, captures_dir_for=captures_dir_for,
-            run_ref_repos=run_ref_repos,
+            run_ref_repos=run_ref_repos, print_fn=output.progress,
         )
     except RemoteExecError as e:
         output.error(str(e))

--- a/src/mship/cli/output.py
+++ b/src/mship/cli/output.py
@@ -189,6 +189,15 @@ class Output:
             # payload's `warnings` field. (MOS-177)
             self._err_stream.write(f"WARNING: {message}\n")
 
+    def progress(self, message: str) -> None:
+        """Render live task progress without contaminating structured stdout."""
+        if self.quiet:
+            return
+        if self.human_mode:
+            self._err_console.print(message, markup=False, highlight=False)
+        else:
+            self._err_stream.write(f"{message}\n")
+
     def error(self, message: str) -> None:
         # Errors are never suppressed by --quiet.
         if self.human_mode:

--- a/src/mship/cli/prune.py
+++ b/src/mship/cli/prune.py
@@ -38,7 +38,13 @@ def register(app: typer.Typer, get_container):
                 })
             return
 
-        count = prune_mgr.prune(orphans)
+        from mship.core.workitem_lifecycle import TaskMetadataRetentionConflictError
+
+        try:
+            count = prune_mgr.prune(orphans)
+        except TaskMetadataRetentionConflictError as e:
+            output.error(str(e))
+            raise typer.Exit(code=1)
         if output.human_mode:
             output.success(f"Pruned {count} item(s)")
         else:

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1140,12 +1140,16 @@ def register(app: typer.Typer, get_container):
             pass
 
         wt_mgr = container.worktree_manager()
+        from mship.core.workitem_lifecycle import TaskMetadataRetentionConflictError
         from mship.core.worktree import WorktreeDirtyError
         try:
             wt_mgr.abort(task_slug, force=force)  # core method retains the name; only CLI verb changed
         except WorktreeDirtyError as e:
             output.error(str(e))
             output.error("Resolve the changes (commit/push), or re-run `mship close --force` to discard them.")
+            raise typer.Exit(code=1)
+        except TaskMetadataRetentionConflictError as e:
+            output.error(str(e))
             raise typer.Exit(code=1)
 
         if downstream and detach_downstream:
@@ -1157,10 +1161,44 @@ def register(app: typer.Typer, get_container):
                     t.depends_on = [e for e in t.depends_on if e.upstream_slug != task.slug]
             state_mgr.mutate(_detach)
         elif downstream and cascade:
+            # Cascaded tasks are removed directly rather than through
+            # WorktreeManager.abort, so retain their observed delivery metadata
+            # before dropping their only live state copy. Never take item locks
+            # while StateManager.mutate holds state.lock.
+            from mship.core.workitem_lifecycle import (
+                require_retained_task_metadata,
+                retain_workitem_metadata_on_teardown,
+            )
+
+            workitems_dir = Path(container.state_dir()) / "workitems"
+            retained_by_slug = {}
+            state_before_cascade = state_mgr.load()
+            for d_slug in downstream:
+                downstream_task = state_before_cascade.tasks.get(d_slug)
+                if downstream_task is not None:
+                    retained_by_slug[d_slug] = retain_workitem_metadata_on_teardown(
+                        task=downstream_task,
+                        workitems_dir=workitems_dir,
+                    )
+
             def _cascade(s):
+                tasks_to_remove = []
                 for d_slug in downstream:
-                    s.tasks.pop(d_slug, None)
-            state_mgr.mutate(_cascade)
+                    downstream_task = s.tasks.get(d_slug)
+                    if downstream_task is None:
+                        continue
+                    require_retained_task_metadata(
+                        downstream_task, retained_by_slug.get(d_slug),
+                    )
+                    tasks_to_remove.append(d_slug)
+                for d_slug in tasks_to_remove:
+                    del s.tasks[d_slug]
+
+            try:
+                state_mgr.mutate(_cascade)
+            except TaskMetadataRetentionConflictError as e:
+                output.error(str(e))
+                raise typer.Exit(code=1)
 
         log_mgr.append(task_slug, log_msg)
         try:

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1170,31 +1170,31 @@ def register(app: typer.Typer, get_container):
                 retain_workitem_metadata_on_teardown,
             )
 
-            workitems_dir = Path(container.state_dir()) / "workitems"
-            retained_by_slug = {}
-            state_before_cascade = state_mgr.load()
-            for d_slug in downstream:
-                downstream_task = state_before_cascade.tasks.get(d_slug)
-                if downstream_task is not None:
-                    retained_by_slug[d_slug] = retain_workitem_metadata_on_teardown(
-                        task=downstream_task,
-                        workitems_dir=workitems_dir,
-                    )
-
-            def _cascade(s):
-                tasks_to_remove = []
-                for d_slug in downstream:
-                    downstream_task = s.tasks.get(d_slug)
-                    if downstream_task is None:
-                        continue
-                    require_retained_task_metadata(
-                        downstream_task, retained_by_slug.get(d_slug),
-                    )
-                    tasks_to_remove.append(d_slug)
-                for d_slug in tasks_to_remove:
-                    del s.tasks[d_slug]
-
             try:
+                workitems_dir = Path(container.state_dir()) / "workitems"
+                retained_by_slug = {}
+                state_before_cascade = state_mgr.load()
+                for d_slug in downstream:
+                    downstream_task = state_before_cascade.tasks.get(d_slug)
+                    if downstream_task is not None:
+                        retained_by_slug[d_slug] = retain_workitem_metadata_on_teardown(
+                            task=downstream_task,
+                            workitems_dir=workitems_dir,
+                        )
+
+                def _cascade(s):
+                    tasks_to_remove = []
+                    for d_slug in downstream:
+                        downstream_task = s.tasks.get(d_slug)
+                        if downstream_task is None:
+                            continue
+                        require_retained_task_metadata(
+                            downstream_task, retained_by_slug.get(d_slug),
+                        )
+                        tasks_to_remove.append(d_slug)
+                    for d_slug in tasks_to_remove:
+                        del s.tasks[d_slug]
+
                 state_mgr.mutate(_cascade)
             except TaskMetadataRetentionConflictError as e:
                 output.error(str(e))

--- a/src/mship/core/evidence_attach.py
+++ b/src/mship/core/evidence_attach.py
@@ -70,3 +70,17 @@ def provenance_note(worktree: Path, shell) -> str:
     if markers:
         return f"at {sha} ({', '.join(markers)})"
     return f"at {sha}"
+
+
+def remote_provenance_note(source_preparation: str) -> str:
+    """Describe a remote capture without claiming the image ran local HEAD.
+
+    The client can prove only that source preparation completed before it sent
+    the capture request. A capture target may observe an already-running app,
+    so neither source transfer nor a remote checkout proves that binary was
+    rebuilt from the prepared source.
+    """
+    return (
+        f"captured on remote run host; {source_preparation}; "
+        "remote checkout and running binary provenance not verified"
+    )

--- a/src/mship/core/prune.py
+++ b/src/mship/core/prune.py
@@ -123,23 +123,66 @@ class PruneManager:
                         shutil.rmtree(orphan.path, ignore_errors=True)
                 pruned += 1
 
-        # Phase 2: clean up state entries pointing to nonexistent worktrees
+        # Retain metadata before entering the state lock. WorkItemStore's item
+        # lock must never be taken while holding state.lock, and a persistence
+        # failure must leave state (the last copy) untouched.
+        from mship.core.workitem_lifecycle import (
+            require_retained_task_metadata,
+            retain_workitem_metadata_on_teardown,
+        )
+
+        state_before_cleanup = self._state_manager.load()
+        retained_by_slug = {}
+        workitems_dir = self._state_manager.state_dir / "workitems"
+        for task in state_before_cleanup.tasks.values():
+            remaining = {
+                repo: path
+                for repo, path in task.worktrees.items()
+                if not any(
+                    orphan.reason == "not_on_disk"
+                    and orphan.repo == repo
+                    and not Path(path).exists()
+                    for orphan in orphans
+                )
+            }
+            if task.worktrees and not remaining:
+                retained_by_slug[task.slug] = retain_workitem_metadata_on_teardown(
+                    task=task, workitems_dir=workitems_dir,
+                )
+
+        # Phase 2: clean up state entries pointing to nonexistent worktrees.
+        # Validate every task that will be deleted before mutating state, so a
+        # concurrent metadata update leaves the entire source snapshot intact.
         def _cleanup(state):
             nonlocal pruned
-            for orphan in orphans:
-                if orphan.reason != "not_on_disk":
+            cleanup_actions = []
+            for task_slug, task in state.tasks.items():
+                missing_repos = [
+                    repo
+                    for repo, path in task.worktrees.items()
+                    if any(
+                        orphan.reason == "not_on_disk"
+                        and orphan.repo == repo
+                        and not Path(path).exists()
+                        for orphan in orphans
+                    )
+                ]
+                if not missing_repos:
                     continue
-                for task_slug, task in list(state.tasks.items()):
-                    if orphan.repo in task.worktrees:
-                        wt_path = task.worktrees[orphan.repo]
-                        if not Path(wt_path).exists():
-                            # Remove just the worktree entry, not the entire task
-                            del task.worktrees[orphan.repo]
-                            pruned += 1
-                            # If task has no worktrees left, remove the task
-                            if not task.worktrees:
-                                del state.tasks[task_slug]
-                            break
+                removes_task = len(missing_repos) == len(task.worktrees)
+                if removes_task:
+                    require_retained_task_metadata(
+                        task, retained_by_slug.get(task_slug),
+                    )
+                cleanup_actions.append((task_slug, missing_repos, removes_task))
+
+            for task_slug, missing_repos, removes_task in cleanup_actions:
+                task = state.tasks[task_slug]
+                for repo in missing_repos:
+                    del task.worktrees[repo]
+                    pruned += 1
+                if removes_task:
+                    del state.tasks[task_slug]
 
         self._state_manager.mutate(_cleanup)
 

--- a/src/mship/core/spec_review.py
+++ b/src/mship/core/spec_review.py
@@ -25,6 +25,7 @@ def build_review(spec: Spec) -> dict:
     return {
         "id": spec.id,
         "status": spec.status,
+        "updated_at": spec.updated_at.isoformat(),
         "clarification_reason": spec.clarification_reason,
         "acceptance_criteria": [
             {

--- a/src/mship/core/state.py
+++ b/src/mship/core/state.py
@@ -86,6 +86,11 @@ class StateManager:
         self._state_dir = state_dir
         self._state_file = state_dir / "state.yaml"
 
+    @property
+    def state_dir(self) -> Path:
+        """Canonical state directory shared by this workspace's stores."""
+        return self._state_dir
+
     def _load_nolock(self) -> WorkspaceState:
         if not self._state_file.exists():
             return WorkspaceState()

--- a/src/mship/core/view/workitem_index.py
+++ b/src/mship/core/view/workitem_index.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Iterable
 
 from mship.core.message import Thread
 from mship.core.spec import Spec
@@ -100,6 +101,13 @@ class WorkItemSummary:
     unattended: bool = False
     active_phase: str | None = None
     active_last_activity_at: datetime | None = None
+    affected_repos: list[str] = field(default_factory=list)
+    pr_urls: list[str] = field(default_factory=list)
+
+
+def _distinct(values: Iterable[str]) -> list[str]:
+    """Preserve linked-task order while dropping repeated metadata values."""
+    return list(dict.fromkeys(values))
 
 
 def _active_task(tasks: list[Task]) -> Task | None:
@@ -136,6 +144,14 @@ def _summarize(
         unattended=item.unattended,
         active_phase=active.phase if active else None,
         active_last_activity_at=active.last_activity_at if active else None,
+        affected_repos=_distinct([
+            *item.affected_repos,
+            *(repo for task in tasks for repo in task.affected_repos),
+        ]),
+        pr_urls=_distinct([
+            *item.pr_urls,
+            *(url for task in tasks for url in task.pr_urls.values()),
+        ]),
     )
 
 

--- a/src/mship/core/workitem.py
+++ b/src/mship/core/workitem.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 Kind = Literal["feature", "bug", "chore", "question"]
 Phase = Literal["inbox", "shaping", "ready", "in_flight", "review", "done"]
@@ -45,3 +45,7 @@ class WorkItem(BaseModel):
     # Soft, reversible archive: excluded from list() by default. Missing on legacy
     # (pre-archive) JSON files, which pydantic defaults to False on load.
     archived: bool = False
+    # Task state is transient and is removed on close/prune. Retain only the
+    # observed delivery metadata needed to keep a completed item's summary useful.
+    affected_repos: list[str] = Field(default_factory=list)
+    pr_urls: list[str] = Field(default_factory=list)

--- a/src/mship/core/workitem_lifecycle.py
+++ b/src/mship/core/workitem_lifecycle.py
@@ -9,8 +9,72 @@ case a spec can't cover at all.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RetainedTaskMetadata:
+    """Delivery metadata persisted before transient task teardown."""
+
+    work_item_id: str | None
+    affected_repos: frozenset[str]
+    pr_urls: frozenset[str]
+
+
+class TaskMetadataRetentionConflictError(RuntimeError):
+    """Raised when task delivery metadata changes after retention."""
+
+    def __init__(self, task_slug: str, reason: str) -> None:
+        super().__init__(
+            f"Refusing to remove task '{task_slug}': {reason}. "
+            "Retry the operation so the latest delivery metadata is retained."
+        )
+
+
+def _task_metadata(task) -> RetainedTaskMetadata:
+    return RetainedTaskMetadata(
+        work_item_id=getattr(task, "work_item_id", None),
+        affected_repos=frozenset(getattr(task, "affected_repos", []) or []),
+        pr_urls=frozenset((getattr(task, "pr_urls", {}) or {}).values()),
+    )
+
+
+def retain_workitem_metadata_on_teardown(*, task, workitems_dir: Path) -> RetainedTaskMetadata:
+    """Persist a task's delivery metadata before it leaves transient state."""
+    retained = _task_metadata(task)
+    if not retained.work_item_id:
+        return retained
+
+    from mship.core.workitem_store import WorkItemStore
+
+    if not WorkItemStore(workitems_dir).retain_task_metadata(task):
+        raise TaskMetadataRetentionConflictError(
+            task.slug, f"linked work item {retained.work_item_id!r} is unavailable",
+        )
+    return retained
+
+
+def require_retained_task_metadata(
+    task, retained: RetainedTaskMetadata | None,
+) -> None:
+    """Refuse teardown unless the live task's delivery metadata was retained."""
+    if retained is None:
+        raise TaskMetadataRetentionConflictError(
+            task.slug, "no durable metadata snapshot was recorded",
+        )
+
+    current = _task_metadata(task)
+    if (
+        current.work_item_id != retained.work_item_id
+        or not current.affected_repos.issubset(retained.affected_repos)
+        or not current.pr_urls.issubset(retained.pr_urls)
+    ):
+        raise TaskMetadataRetentionConflictError(
+            task.slug,
+            "its delivery metadata changed after it was retained",
+        )
 
 
 def advance_workitem_on_close(

--- a/src/mship/core/workitem_lifecycle.py
+++ b/src/mship/core/workitem_lifecycle.py
@@ -42,16 +42,37 @@ def _task_metadata(task) -> RetainedTaskMetadata:
 
 
 def retain_workitem_metadata_on_teardown(*, task, workitems_dir: Path) -> RetainedTaskMetadata:
-    """Persist a task's delivery metadata before it leaves transient state."""
+    """Persist a task's delivery metadata before it leaves transient state.
+
+    A WorkItem's forward ``task_slugs`` link is durable enough to guard archive,
+    so it is authoritative when the task-side link is absent or stale. Resolve
+    that relationship before taking an item lock; state mutation callers invoke
+    this helper before acquiring state.lock.
+    """
     retained = _task_metadata(task)
-    if not retained.work_item_id:
+
+    from mship.core.workitem_store import TaskLinkAmbiguousError, WorkItemStore
+
+    store = WorkItemStore(workitems_dir)
+    try:
+        item_id = store.resolve_task_workitem_id(task.slug, retained.work_item_id)
+    except TaskLinkAmbiguousError as exc:
+        raise TaskMetadataRetentionConflictError(
+            task.slug, f"forward WorkItem link is ambiguous ({', '.join(exc.item_ids)})",
+        ) from exc
+
+    if not item_id:
         return retained
 
-    from mship.core.workitem_store import WorkItemStore
-
-    if not WorkItemStore(workitems_dir).retain_task_metadata(task):
+    try:
+        retained_successfully = store.retain_task_metadata(task, item_id=item_id)
+    except ValueError as exc:
         raise TaskMetadataRetentionConflictError(
-            task.slug, f"linked work item {retained.work_item_id!r} is unavailable",
+            task.slug, f"linked work item {item_id!r} is unavailable",
+        ) from exc
+    if not retained_successfully:
+        raise TaskMetadataRetentionConflictError(
+            task.slug, f"linked work item {item_id!r} is unavailable",
         )
     return retained
 

--- a/src/mship/core/workitem_store.py
+++ b/src/mship/core/workitem_store.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from mship.core.state import StateManager
 from mship.core.workitem import ExternalLink, Kind, Phase, WorkItem
 
-__all__ = ["WorkItemStore", "ThreadAlreadyLinkedError"]
+__all__ = ["TaskLinkAmbiguousError", "ThreadAlreadyLinkedError", "WorkItemStore"]
 
 
 def _new_id(now: datetime) -> str:
@@ -33,6 +33,17 @@ def _locked(lock_path: Path, mode: int):
             yield
         finally:
             fcntl.flock(lf, fcntl.LOCK_UN)
+
+
+class TaskLinkAmbiguousError(RuntimeError):
+    """Raised when a task's forward link belongs to multiple WorkItems."""
+
+    def __init__(self, task_slug: str, item_ids: list[str]) -> None:
+        self.task_slug = task_slug
+        self.item_ids = item_ids
+        super().__init__(
+            f"task {task_slug!r} is linked to multiple work items: {', '.join(item_ids)}",
+        )
 
 
 class ThreadAlreadyLinkedError(Exception):
@@ -168,7 +179,28 @@ class WorkItemStore:
                     s.tasks[_slug].work_item_id = _wid
             state.mutate(_set)
 
-    def retain_task_metadata(self, task) -> bool:
+    def resolve_task_workitem_id(
+        self, task_slug: str, reverse_item_id: str | None,
+    ) -> str | None:
+        """Return a task's authoritative WorkItem id, preferring its forward link.
+
+        WorkItem.task_slugs is the durable association used by archive guards.
+        A unique forward link therefore repairs a missing or stale task-side
+        work_item_id. Archived items participate too: archiving hides an item
+        from the default list, but must not discard its retained delivery data.
+        Multiple forward owners are unsafe to choose between and fail closed.
+        """
+        forward_ids = sorted(
+            item.id
+            for item in self.list(include_archived=True)
+            if task_slug in item.task_slugs
+        )
+        if len(forward_ids) > 1:
+            raise TaskLinkAmbiguousError(task_slug, forward_ids)
+        return forward_ids[0] if forward_ids else reverse_item_id
+
+
+    def retain_task_metadata(self, task, *, item_id: str | None = None) -> bool:
         """Persist a linked task's observed repos and PR URLs before task removal.
 
         The exclusive item lock makes repeated close/prune paths merge rather
@@ -176,7 +208,7 @@ class WorkItemStore:
         caller can keep the task state, which remains the last source of truth.
         Returns False only when the linked WorkItem no longer exists.
         """
-        item_id = getattr(task, "work_item_id", None)
+        item_id = item_id if item_id is not None else getattr(task, "work_item_id", None)
         if not item_id:
             return True
         repos = list(getattr(task, "affected_repos", []) or [])

--- a/src/mship/core/workitem_store.py
+++ b/src/mship/core/workitem_store.py
@@ -168,6 +168,33 @@ class WorkItemStore:
                     s.tasks[_slug].work_item_id = _wid
             state.mutate(_set)
 
+    def retain_task_metadata(self, task) -> bool:
+        """Persist a linked task's observed repos and PR URLs before task removal.
+
+        The exclusive item lock makes repeated close/prune paths merge rather
+        than overwrite retained metadata. Any write failure propagates so the
+        caller can keep the task state, which remains the last source of truth.
+        Returns False only when the linked WorkItem no longer exists.
+        """
+        item_id = getattr(task, "work_item_id", None)
+        if not item_id:
+            return True
+        repos = list(getattr(task, "affected_repos", []) or [])
+        pr_urls = list((getattr(task, "pr_urls", {}) or {}).values())
+        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
+            item = self.get(item_id)
+            if item is None:
+                return False
+            retained_repos = list(dict.fromkeys([*item.affected_repos, *repos]))
+            retained_pr_urls = list(dict.fromkeys([*item.pr_urls, *pr_urls]))
+            if retained_repos == item.affected_repos and retained_pr_urls == item.pr_urls:
+                return True
+            item.affected_repos = retained_repos
+            item.pr_urls = retained_pr_urls
+            item.updated_at = datetime.now(timezone.utc)
+            self.save(item)
+            return True
+
     def _thread_owner(self, thread_id: str, exclude: str) -> str | None:
         """Id of a WorkItem (other than `exclude`) whose thread_ids contains `thread_id`, else None.
         Scans archived items too — an archived item still holds its threads in stored data, so it

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -842,9 +842,28 @@ class WorktreeManager:
             except Exception:
                 pass
 
-        # Only update state after all cleanup attempts
+        # State is the final copy of task delivery metadata. Persist it before
+        # removing the task so a failed WorkItem write cannot silently lose it.
+        # Item locks stay outside StateManager.mutate's state.lock.
+        from mship.core.workitem_lifecycle import (
+            require_retained_task_metadata,
+            retain_workitem_metadata_on_teardown,
+        )
+
+        retained = retain_workitem_metadata_on_teardown(
+            task=task,
+            workitems_dir=self._state_manager.state_dir / "workitems",
+        )
+
+        # Only update state after all cleanup attempts. A task metadata update
+        # that raced the retention write must remain available for a retry.
         def _abort(s):
-            s.tasks.pop(task_slug, None)
+            live_task = s.tasks.get(task_slug)
+            if live_task is None:
+                return
+            require_retained_task_metadata(live_task, retained)
+            del s.tasks[task_slug]
+
         self._state_manager.mutate(_abort)
 
     def list_worktrees(self) -> dict[str, dict[str, Path]]:

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -99,3 +99,15 @@ def test_breadcrumb_suppressed_on_non_tty():
     output.breadcrumb("→ task: foo")
     assert out.getvalue() == ""
     assert err.getvalue() == ""
+
+
+def test_progress_preserves_literal_remote_output_on_stderr():
+    out, err = _TTYStream(), _TTYStream()
+    output = Output(
+        stream=out, err_stream=err,
+        force_json=False, force_quiet=False, force_no_color=True,
+    )
+    line = "capture [/not-markup] [bold]raw[/bold]"
+    output.progress(line)
+    assert err.getvalue() == line + "\n"
+    assert out.getvalue() == ""

--- a/tests/cli/test_prune.py
+++ b/tests/cli/test_prune.py
@@ -50,3 +50,39 @@ def test_prune_force_removes_orphan(configured_prune_app: Path):
     result = runner.invoke(app, ["prune", "--force"])
     assert result.exit_code == 0
     assert not wt_path.exists()
+
+
+def test_prune_retention_conflict_is_clean_error(
+    configured_prune_app: Path, monkeypatch,
+):
+    from datetime import datetime, timezone
+
+    from mship.core.state import StateManager, Task, WorkspaceState
+    from mship.core.workitem_lifecycle import TaskMetadataRetentionConflictError
+
+    state_dir = configured_prune_app / ".mothership"
+    state = StateManager(state_dir)
+    state.save(WorkspaceState(tasks={
+        "ghost": Task(
+            slug="ghost", description="Ghost task", phase="dev",
+            created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            affected_repos=["shared"], branch="feat/ghost",
+            worktrees={"shared": Path("/tmp/nonexistent/worktree")},
+        ),
+    }))
+
+    def reject_retention(*, task, workitems_dir):
+        raise TaskMetadataRetentionConflictError(task.slug, "metadata retention failed")
+
+    monkeypatch.setattr(
+        "mship.core.workitem_lifecycle.retain_workitem_metadata_on_teardown",
+        reject_retention,
+    )
+
+    result = runner.invoke(app, ["prune", "--force"])
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, SystemExit)
+    assert "Retry the operation" in result.output
+    assert "Traceback" not in result.output
+    assert "ghost" in state.load().tasks

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -504,8 +504,13 @@ def _write_capture_workspace(ws: Path, *, run_hosts: list[str], platforms: list[
         "    type: service\n"
         f"    capture:\n      platforms: {plat}\n"
     )
-    wt = ws / "wt"
-    wt.mkdir(exist_ok=True)
+    # Shared remote preflight addresses its shell calls to the task worktree,
+    # whose basename must match this fixture's scripted repository key.
+    wt = ws / ".worktrees" / "t1" / "app"
+    wt.mkdir(parents=True)
+    (wt / "Taskfile.yml").write_text(
+        "version: '3'\ntasks:\n  capture:\n    cmds:\n      - echo ok\n"
+    )
     return wt
 
 
@@ -689,7 +694,9 @@ def test_cli_capture_remote_extracts_artifacts_into_exact_local_captures_path(tm
     counterpart's `/captures/t/` assertion."""
     wt = _write_capture_workspace(tmp_path, run_hosts=["role-x"], platforms=["android"])
     _seed_task(tmp_path, slug="t1", repos=["app"], worktrees={"app": str(wt)})
-    mock_shell = _configure(tmp_path)
+    _configure(tmp_path)
+    shell = _git_shell({"app": _repo_git()})
+    container.shell.override(shell)
     RunHostStore(tmp_path / ".mothership").set(
         "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
     )
@@ -725,40 +732,26 @@ def test_cli_capture_remote_extracts_artifacts_into_exact_local_captures_path(tm
         assert '"resolved_task"' in result.output
 
         # The local capture target never ran.
-        mock_shell.run_task.assert_not_called()
+        shell.run_task.assert_not_called()
     finally:
         _reset()
 
 
-def test_cli_capture_remote_with_evidence_attaches_artifact_indistinguishably_from_local(
+def test_cli_capture_remote_with_evidence_attaches_artifact_with_remote_provenance(
     tmp_path, monkeypatch,
 ):
-    """ac15 (specs/2026-07-26-artifact-evidence-on-phone.md): `mship capture --remote
-    --evidence` must attach evidence from artifacts produced on the mapped run
-    host indistinguishably from a local capture. `_attach_evidence`
-    (cli/capture.py) is wired into the `--remote` branch AFTER `exec_remote`
-    returns, once the extracted artifacts are re-discovered locally as
-    `landed` — this proves that wiring actually runs and produces the same
-    criterion.evidence shape (kind=artifact, content-hashed `.png` ref, a
-    provenance note) that
-    test_capture_evidence.py::test_evidence_attaches_to_the_named_criterion
-    asserts for the LOCAL path."""
+    """Remote evidence records the sent snapshot, not its parent or binary.
+
+    The attachment happens after the extracted artifacts are rediscovered
+    locally. Its provenance identifies the exact throwaway ref sent before
+    capture, while retaining the disclaimer that neither a remote checkout nor
+    source transfer proves the running image came from that source.
+    """
     wt = _write_capture_workspace(tmp_path, run_hosts=["role-x"], platforms=["android"])
     _seed_task(tmp_path, slug="t1", repos=["app"], worktrees={"app": str(wt)})
-    mock_shell = _configure(tmp_path)
-
-    # provenance_note() shells out through the same container.shell() the
-    # remote path already uses — always against the LOCAL, task-bound
-    # worktree `wt` (the remote only supplies the artifact bytes).
-    def _fake_run(command, cwd=None, **kwargs):
-        assert isinstance(command, str), "ShellRunner.run takes a command string"
-        if command.startswith("git rev-parse"):
-            return ShellResult(returncode=0, stdout="abc1234\n", stderr="")
-        if command.startswith("git branch"):
-            return ShellResult(returncode=0, stdout="* main\n", stderr="")
-        return ShellResult(returncode=0, stdout="", stderr="")  # git status: clean
-
-    mock_shell.run.side_effect = _fake_run
+    _configure(tmp_path)
+    shell = _git_shell({"app": _repo_git(" M screen.dart\n?? scratch.txt\n")})
+    container.shell.override(shell)
 
     now = datetime(2026, 7, 25, tzinfo=timezone.utc)
     SpecStore(tmp_path / "specs").save(Spec(
@@ -787,15 +780,24 @@ def test_cli_capture_remote_with_evidence_attaches_artifact_indistinguishably_fr
         crit = spec.acceptance_criteria[0]
         assert len(crit.evidence) == 1
         ev = crit.evidence[0]
-        # Same shape a LOCAL --evidence capture produces.
+        # A remote image is not silently labeled as the local worktree HEAD:
+        # source preparation and the running binary have separate guarantees.
         assert ev.kind == "artifact"
         assert ev.ref.endswith(".png")
-        assert "at " in (ev.note or "")
-
+        note = ev.note or ""
+        assert "captured on remote run host" in note
+        assert (
+            "exact working-tree snapshot "
+            "(app@synth2222 via refs/mship/run/t1/app (a throwaway run ref)) "
+            "was sent to the run host"
+        ) in note
+        assert "headsha" not in note
+        assert "running binary provenance not verified" in note
+        assert "· at " not in note
         stored = tmp_path / ".mothership" / "evidence" / "dq" / ev.ref
         assert stored.read_bytes() == b"PNGDATA"
 
-        mock_shell.run_task.assert_not_called()  # the local capture target never ran
+        shell.run_task.assert_not_called()  # the local capture target never ran
     finally:
         _reset()
 
@@ -809,7 +811,9 @@ def test_cli_capture_remote_exit0_but_no_artifact_is_hard_error(tmp_path, monkey
     same no-artifact message."""
     wt = _write_capture_workspace(tmp_path, run_hosts=["role-x"], platforms=["android"])
     _seed_task(tmp_path, slug="t1", repos=["app"], worktrees={"app": str(wt)})
-    mock_shell = _configure(tmp_path)
+    _configure(tmp_path)
+    shell = _git_shell({"app": _repo_git()})
+    container.shell.override(shell)
     RunHostStore(tmp_path / ".mothership").set(
         "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
     )
@@ -823,7 +827,168 @@ def test_cli_capture_remote_exit0_but_no_artifact_is_hard_error(tmp_path, monkey
         assert result.exit_code != 0, result.output
         assert "no recognized artifact" in result.output.lower()
         assert "Traceback" not in (result.output or "")
-        mock_shell.run_task.assert_not_called()
+        shell.run_task.assert_not_called()
+    finally:
+        _reset()
+
+@pytest.mark.parametrize(
+    ("case", "remove_worktree", "diagnostic"),
+    [
+        ("wrong-branch", False, "worktree is not on the task's branch"),
+        ("missing-worktree", True, "missing worktree"),
+        ("origin-ahead", False, "unpulled commits on origin"),
+    ],
+)
+def test_cli_capture_remote_refuses_unprepared_source(
+    tmp_path, monkeypatch, case, remove_worktree, diagnostic,
+):
+    """Capture shares run/build's refusal path and never reaches the host."""
+    wt = _write_capture_workspace(tmp_path, run_hosts=["role-x"], platforms=["android"])
+    _seed_task(tmp_path, slug="t1", repos=["app"], worktrees={"app": str(wt)})
+    if remove_worktree:
+        (wt / "Taskfile.yml").unlink()
+        wt.rmdir()
+    repo_state = {
+        "wrong-branch": _repo_git(head_ref="refs/heads/main"),
+        "missing-worktree": _repo_git(),
+        "origin-ahead": _repo_git(origin="newer", head="old"),
+    }[case]
+    _configure(tmp_path)
+    container.shell.override(_git_shell({"app": repo_state}))
+    RunHostStore(tmp_path / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+    recorder: dict = {}
+
+    try:
+        with _ClientPatch(monkeypatch, _recording_handler(recorder, _frame([], exit_code=0))):
+            result = runner.invoke(
+                app, ["capture", "--task", "t1", "--repo", "app", "--remote=role-x"]
+            )
+        assert result.exit_code == 1, result.output
+        assert diagnostic in result.output
+        assert recorder == {}
+    finally:
+        _reset()
+
+
+def test_cli_capture_remote_transfers_dirty_snapshot_before_dispatch(tmp_path, monkeypatch):
+    """Dirty capture sends the exact snapshot to the run host, never origin."""
+    wt = _write_capture_workspace(tmp_path, run_hosts=["role-x"], platforms=["android"])
+    _seed_task(tmp_path, slug="t1", repos=["app"], worktrees={"app": str(wt)})
+    _configure(tmp_path)
+    shell = _git_shell({"app": _repo_git(" M screen.dart\n?? scratch.txt\n")})
+    container.shell.override(shell)
+    RunHostStore(tmp_path / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+    recorder: dict = {}
+    body = _frame([], exit_code=0, artifact_tar=_make_tar({"screen.png": b"PNGDATA"}))
+
+    try:
+        with _ClientPatch(monkeypatch, _recording_handler(recorder, body)):
+            result = runner.invoke(
+                app, ["capture", "--task", "t1", "--repo", "app", "--remote=role-x"]
+            )
+        assert result.exit_code == 0, result.output
+        assert len(shell.pushes) == 1
+        assert "synth2222:refs/mship/run/t1/app" in shell.pushes[0]
+        assert "http://remote.example/git/app" in shell.pushes[0]
+        assert "origin" not in shell.pushes[0]
+        assert recorder["json"]["run_ref_repos"] == ["app"]
+    finally:
+        _reset()
+
+def test_cli_capture_remote_aborts_when_dirty_snapshot_transfer_fails(tmp_path, monkeypatch):
+    """A failed scratch-ref push must not capture against an older remote tree."""
+    wt = _write_capture_workspace(tmp_path, run_hosts=["role-x"], platforms=["android"])
+    _seed_task(tmp_path, slug="t1", repos=["app"], worktrees={"app": str(wt)})
+    _configure(tmp_path)
+    container.shell.override(
+        _git_shell({"app": _repo_git(" M screen.dart\n")}, push_rc=1)
+    )
+    RunHostStore(tmp_path / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+    recorder: dict = {}
+
+    try:
+        with _ClientPatch(monkeypatch, _recording_handler(recorder, _frame([], exit_code=0))):
+            result = runner.invoke(
+                app, ["capture", "--task", "t1", "--repo", "app", "--remote=role-x"]
+            )
+        assert result.exit_code == 1, result.output
+        assert "run host" in result.output and "denied" in result.output
+        assert recorder == {}
+    finally:
+        _reset()
+
+def test_cli_capture_remote_uses_git_root_for_dirty_child(tmp_path, monkeypatch):
+    """A capture of a git-root child transfers its parent tree under the parent."""
+    taskfile = "version: '3'\ntasks:\n  capture:\n    cmds:\n      - echo capture\n"
+    (tmp_path / "mono" / "pkg").mkdir(parents=True)
+    (tmp_path / "mono" / "Taskfile.yml").write_text(taskfile)
+    (tmp_path / "mono" / "pkg" / "Taskfile.yml").write_text(taskfile)
+    (tmp_path / "mothership.yaml").write_text(
+        "workspace: t\n"
+        "run_hosts: [role-x]\n"
+        "repos:\n"
+        "  mono:\n    path: ./mono\n    type: service\n"
+        "  pkg:\n    path: pkg\n    type: service\n    git_root: mono\n"
+    )
+    wt_mono = tmp_path / ".worktrees" / "t1" / "mono"
+    wt_pkg = wt_mono / "pkg"
+    wt_pkg.mkdir(parents=True)
+    (wt_mono / "Taskfile.yml").write_text(taskfile)
+    (wt_pkg / "Taskfile.yml").write_text(taskfile)
+    _seed_task(
+        tmp_path, slug="t1", repos=["mono", "pkg"],
+        worktrees={"mono": str(wt_mono), "pkg": str(wt_pkg)},
+    )
+    _configure(tmp_path)
+    shell = _git_shell({"mono": _repo_git(), "pkg": _repo_git(" M screen.dart\n")})
+    container.shell.override(shell)
+    RunHostStore(tmp_path / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+    recorder: dict = {}
+    body = _frame([], exit_code=0, artifact_tar=_make_tar({"screen.png": b"PNGDATA"}))
+
+    try:
+        with _ClientPatch(monkeypatch, _recording_handler(recorder, body)):
+            result = runner.invoke(
+                app, ["capture", "--task", "t1", "--repo", "pkg", "--remote=role-x"]
+            )
+        assert result.exit_code == 0, result.output
+        assert "synth2222:refs/mship/run/t1/mono" in shell.pushes[0]
+        assert recorder["json"]["repos"] == ["pkg"]
+        assert recorder["json"]["run_ref_repos"] == ["mono"]
+    finally:
+        _reset()
+
+
+def test_cli_capture_remote_scopes_preflight_to_the_selected_repo(tmp_path, monkeypatch):
+    """A capture of api cannot inspect or transfer unrelated web work."""
+    _write_run_workspace(tmp_path, run_hosts=["role-x"], repos=["api", "web"])
+    _seed_task_with_worktree(tmp_path, "t1", "api", "web")
+    _configure(tmp_path)
+    shell = _git_shell({"api": _repo_git(), "web": _repo_git(" M unrelated.py\n")})
+    container.shell.override(shell)
+    RunHostStore(tmp_path / ".mothership").set(
+        "role-x", RunHostConnection(url="http://remote.example", token="tok-abc"),
+    )
+    recorder: dict = {}
+    body = _frame([], exit_code=0, artifact_tar=_make_tar({"screen.png": b"PNGDATA"}))
+
+    try:
+        with _ClientPatch(monkeypatch, _recording_handler(recorder, body)):
+            result = runner.invoke(
+                app, ["capture", "--task", "t1", "--repo", "api", "--remote=role-x"]
+            )
+        assert result.exit_code == 0, result.output
+        assert recorder["json"]["repos"] == ["api"]
+        assert "run_ref_repos" not in recorder["json"]
+        assert shell.touched == {"api"}
     finally:
         _reset()
 
@@ -942,9 +1107,7 @@ def test_cli_run_remote_not_bootstrapped_is_clean_error_not_traceback(tmp_path, 
 
 
 def test_cli_capture_remote_unmapped_role_is_clean_error_not_traceback(tmp_path, monkeypatch):
-    """The same RunHostError surfacing exercised for run/build above must
-    also hold for capture, which resolves the role via its own inline block
-    in cli/capture.py rather than the shared `_run_remote` helper."""
+    """Capture surfaces the shared dispatcher's role-resolution error cleanly."""
     wt = _write_capture_workspace(tmp_path, run_hosts=["role-x"], platforms=["android"])
     _seed_task(tmp_path, slug="t1", repos=["app"], worktrees={"app": str(wt)})
     _configure(tmp_path)

--- a/tests/cli/test_remote_dispatch.py
+++ b/tests/cli/test_remote_dispatch.py
@@ -11,8 +11,8 @@ Two layers:
   - The CLI wiring (`mship run/build/capture --remote[=role]`) via
     `typer.testing.CliRunner`, with `httpx.Client` monkeypatched to a
     MockTransport-backed client so no real network/relay is involved. This
-    proves: role resolution -> POST with the bearer token, live stdout
-    rendering, exit-code mirroring, the capture artifact landing at the
+    proves: role resolution -> POST with the bearer token, live progress
+    rendering on stderr, exit-code mirroring, the capture artifact landing at the
     EXACT local path `cli/capture.py` already uses, a clean (non-traceback)
     error for an unresolvable role, and — the critical regression guard —
     that OMITTING --remote never touches `remote_client`/httpx at all and
@@ -702,14 +702,21 @@ def test_cli_capture_remote_extracts_artifacts_into_exact_local_captures_path(tm
     )
     recorder: dict = {}
     tar_bytes = _make_tar({"screen.png": b"PNGDATA", "layout.json": b'{"a": 1}'})
-    body = _frame(["captured\n"], exit_code=0, artifact_tar=tar_bytes)
+    body = _frame(["remote task progress\n"], exit_code=0, artifact_tar=tar_bytes)
 
     try:
         with _ClientPatch(monkeypatch, _recording_handler(recorder, body)):
             result = runner.invoke(
-                app, ["capture", "--task", "t1", "--repo", "app", "--remote=role-x"]
+                app, [
+                    "--json", "capture", "--task", "t1", "--repo", "app",
+                    "--remote=role-x",
+                ],
             )
         assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["artifacts"][0]["kind"] == "image"
+        assert "remote task progress" not in result.stdout
+        assert "remote task progress" in result.stderr
         assert recorder["url"] == "http://remote.example/exec/capture"
         assert recorder["json"] == {
             "task": "t1", "repos": ["app"], "kind": "all", "platform": "android",
@@ -734,6 +741,9 @@ def test_cli_capture_remote_extracts_artifacts_into_exact_local_captures_path(tm
         # The local capture target never ran.
         shell.run_task.assert_not_called()
     finally:
+        from mship.cli.output import reset_output_settings
+
+        reset_output_settings()
         _reset()
 
 

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -2349,6 +2349,84 @@ def test_close_cascade_removes_downstream(configured_git_app: Path):
     state = sm.load()
     assert state.tasks == {}
 
+def test_close_cascade_retains_downstream_task_metadata(configured_git_app: Path):
+    from datetime import datetime, timezone
+    from mship.core.workitem_store import WorkItemStore
+
+    state = _seed_ab_tasks(configured_git_app)
+    store = WorkItemStore(configured_git_app / ".mothership" / "workitems")
+    item = store.create("downstream", "chore", "ws", datetime.now(timezone.utc))
+    store.set_phase_override(item.id, "review")
+    store.add_task(item.id, "b")
+    state.mutate(
+        lambda s: (
+            setattr(s.tasks["b"], "work_item_id", item.id),
+            s.tasks["b"].pr_urls.update(
+                {"shared": "https://github.example/shared/pull/2"}
+            ),
+        )
+    )
+
+    result = runner.invoke(app, ["close", "a", "--yes", "--skip-pr-check", "--cascade"])
+
+    assert result.exit_code == 0, result.output
+    retained = store.get(item.id)
+    assert retained.phase_override == "review"
+    assert retained.affected_repos == ["shared"]
+    assert retained.pr_urls == ["https://github.example/shared/pull/2"]
+
+
+def test_close_cascade_refuses_metadata_changed_after_retention(
+    configured_git_app: Path, monkeypatch,
+):
+    from datetime import datetime, timezone
+    from mship.core.workitem_lifecycle import retain_workitem_metadata_on_teardown
+    from mship.core.workitem_store import WorkItemStore
+
+    state = _seed_ab_tasks(configured_git_app)
+    store = WorkItemStore(configured_git_app / ".mothership" / "workitems")
+    item = store.create("downstream", "chore", "ws", datetime.now(timezone.utc))
+    store.add_task(item.id, "b")
+    state.mutate(
+        lambda s: (
+            setattr(s.tasks["b"], "work_item_id", item.id),
+            s.tasks["b"].pr_urls.update(
+                {"shared": "https://github.example/shared/pull/2"},
+            ),
+        ),
+    )
+
+    def retain_then_update(*, task, workitems_dir):
+        retained = retain_workitem_metadata_on_teardown(
+            task=task, workitems_dir=workitems_dir,
+        )
+        if task.slug == "b":
+            state.mutate(
+                lambda s: (
+                    s.tasks["b"].affected_repos.append("api-gateway"),
+                    s.tasks["b"].pr_urls.update(
+                        {"api-gateway": "https://github.example/api/pull/3"},
+                    ),
+                ),
+            )
+        return retained
+
+    monkeypatch.setattr(
+        "mship.core.workitem_lifecycle.retain_workitem_metadata_on_teardown",
+        retain_then_update,
+    )
+
+    result = runner.invoke(app, ["close", "a", "--yes", "--skip-pr-check", "--cascade"])
+
+    assert result.exit_code != 0
+    assert "Retry the operation" in result.output
+    live_task = state.load().tasks["b"]
+    assert live_task.affected_repos == ["shared", "api-gateway"]
+    assert live_task.pr_urls == {
+        "shared": "https://github.example/shared/pull/2",
+        "api-gateway": "https://github.example/api/pull/3",
+    }
+
 
 def test_close_cascade_removes_downstream_sdd_records(configured_git_app: Path):
     """--cascade also removes the downstream task's sdd records, not just its state."""

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -2420,12 +2420,29 @@ def test_close_cascade_refuses_metadata_changed_after_retention(
 
     assert result.exit_code != 0
     assert "Retry the operation" in result.output
+    assert isinstance(result.exception, SystemExit)
+    assert "Traceback" not in result.output
     live_task = state.load().tasks["b"]
     assert live_task.affected_repos == ["shared", "api-gateway"]
     assert live_task.pr_urls == {
         "shared": "https://github.example/shared/pull/2",
         "api-gateway": "https://github.example/api/pull/3",
     }
+
+
+def test_close_cascade_retention_conflict_is_clean_error(
+    configured_git_app: Path,
+):
+    state = _seed_ab_tasks(configured_git_app)
+    state.mutate(lambda s: setattr(s.tasks["b"], "work_item_id", "missing-item"))
+
+    result = runner.invoke(app, ["close", "a", "--yes", "--skip-pr-check", "--cascade"])
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, SystemExit)
+    assert "Retry the operation" in result.output
+    assert "Traceback" not in result.output
+    assert "b" in state.load().tasks
 
 
 def test_close_cascade_removes_downstream_sdd_records(configured_git_app: Path):

--- a/tests/core/test_evidence_attach.py
+++ b/tests/core/test_evidence_attach.py
@@ -111,3 +111,5 @@ def test_provenance_note_unknown_revision_skips_branch_check(tmp_path):
     note = provenance_note(tmp_path, shell)
     assert note == "at unknown"
     assert not any("branch" in c for c in shell.commands)
+
+

--- a/tests/core/test_prune.py
+++ b/tests/core/test_prune.py
@@ -97,6 +97,79 @@ def test_prune_removes_state_orphan(prune_deps):
     assert state.tasks == {}
 
 
+def test_prune_retains_linked_task_metadata_before_last_worktree_removal(prune_deps):
+    from mship.core.view.workitem_index import build_workitem_index
+    from mship.core.workitem_store import WorkItemStore
+
+    config, state_mgr, git, _workspace = prune_deps
+    store = WorkItemStore(state_mgr.state_dir / "workitems")
+    item = store.create("pruned", "chore", "ws", datetime.now(timezone.utc))
+    task = Task(
+        slug="ghost", description="Ghost task", phase="dev",
+        created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        affected_repos=["shared"], branch="feat/ghost",
+        worktrees={"shared": Path("/tmp/nonexistent/worktree")},
+        pr_urls={"shared": "https://github.example/shared/pull/1"},
+        work_item_id=item.id,
+    )
+    store.add_task(item.id, task.slug)
+    state_mgr.save(WorkspaceState(tasks={task.slug: task}))
+
+    manager = PruneManager(config, state_mgr, git)
+    manager.prune(manager.scan())
+
+    summary = build_workitem_index([store.get(item.id)], {}, state_mgr.load().tasks, {})[0]
+    assert summary.affected_repos == ["shared"]
+    assert summary.pr_urls == ["https://github.example/shared/pull/1"]
+
+
+
+def test_prune_refuses_metadata_changed_after_retention(prune_deps, monkeypatch):
+    from mship.core.workitem_lifecycle import (
+        TaskMetadataRetentionConflictError,
+        retain_workitem_metadata_on_teardown,
+    )
+    from mship.core.workitem_store import WorkItemStore
+
+    config, state_mgr, git, _workspace = prune_deps
+    store = WorkItemStore(state_mgr.state_dir / "workitems")
+    item = store.create("pruned", "chore", "ws", datetime.now(timezone.utc))
+    task = Task(
+        slug="ghost", description="Ghost task", phase="dev",
+        created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        affected_repos=["shared"], branch="feat/ghost",
+        worktrees={"shared": Path("/tmp/nonexistent/worktree")},
+        work_item_id=item.id,
+    )
+    state_mgr.save(WorkspaceState(tasks={task.slug: task}))
+    manager = PruneManager(config, state_mgr, git)
+
+    def retain_then_update(*, task, workitems_dir):
+        retained = retain_workitem_metadata_on_teardown(
+            task=task, workitems_dir=workitems_dir,
+        )
+        state_mgr.mutate(
+            lambda state: (
+                state.tasks[task.slug].affected_repos.append("api-gateway"),
+                state.tasks[task.slug].pr_urls.update(
+                    {"api-gateway": "https://github.example/api/pull/2"},
+                ),
+            ),
+        )
+        return retained
+
+    monkeypatch.setattr(
+        "mship.core.workitem_lifecycle.retain_workitem_metadata_on_teardown",
+        retain_then_update,
+    )
+
+    with pytest.raises(TaskMetadataRetentionConflictError, match="Retry"):
+        manager.prune(manager.scan())
+
+    live_task = state_mgr.load().tasks["ghost"]
+    assert live_task.affected_repos == ["shared", "api-gateway"]
+    assert live_task.pr_urls == {"api-gateway": "https://github.example/api/pull/2"}
+
 def test_prune_partial_missing_keeps_task(prune_deps):
     """If only one worktree is missing, remove the entry but keep the task."""
     config, state_mgr, git, workspace = prune_deps

--- a/tests/core/test_prune.py
+++ b/tests/core/test_prune.py
@@ -124,6 +124,35 @@ def test_prune_retains_linked_task_metadata_before_last_worktree_removal(prune_d
 
 
 
+
+def test_prune_retains_metadata_for_forward_only_workitem_link(prune_deps):
+    from mship.core.workitem_store import WorkItemStore
+
+    config, state_mgr, git, _workspace = prune_deps
+    store = WorkItemStore(state_mgr.state_dir / "workitems")
+    item = store.create("forward-only", "chore", "ws", datetime.now(timezone.utc))
+    task = Task(
+        slug="forward-only",
+        description="Forward-only task",
+        phase="dev",
+        created_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        affected_repos=["shared"],
+        branch="feat/forward-only",
+        worktrees={"shared": Path("/tmp/nonexistent/forward-only")},
+        pr_urls={"shared": "https://github.example/shared/pull/1"},
+    )
+    store.add_task(item.id, task.slug)
+    state_mgr.save(WorkspaceState(tasks={task.slug: task}))
+
+    manager = PruneManager(config, state_mgr, git)
+    manager.prune(manager.scan())
+
+    assert task.slug not in state_mgr.load().tasks
+    persisted = store.get(item.id)
+    assert persisted.affected_repos == ["shared"]
+    assert persisted.pr_urls == ["https://github.example/shared/pull/1"]
+
+
 def test_prune_refuses_metadata_changed_after_retention(prune_deps, monkeypatch):
     from mship.core.workitem_lifecycle import (
         TaskMetadataRetentionConflictError,

--- a/tests/core/test_workitem.py
+++ b/tests/core/test_workitem.py
@@ -14,6 +14,7 @@ def test_workitem_defaults_and_roundtrip():
                   kind="feature", created_at=_now(), updated_at=_now())
     assert wi.spec_id is None
     assert wi.task_slugs == [] and wi.thread_ids == [] and wi.external_links == []
+    assert wi.affected_repos == [] and wi.pr_urls == []
     assert wi.phase_override is None
     restored = WorkItem.model_validate_json(wi.model_dump_json())
     assert restored == wi

--- a/tests/core/test_workitem_lifecycle.py
+++ b/tests/core/test_workitem_lifecycle.py
@@ -18,7 +18,12 @@ from mship.core.spec_draft import new_spec
 from mship.core.spec_store import SpecStore
 from mship.core.spec_storage import SpecLocked, SpecStorage
 from mship.core.state import Task, WorkspaceState
-from mship.core.workitem_lifecycle import advance_workitem_on_close
+from mship.core.workitem_lifecycle import (
+    TaskMetadataRetentionConflictError,
+    advance_workitem_on_close,
+    require_retained_task_metadata,
+    retain_workitem_metadata_on_teardown,
+)
 from mship.core.workitem_store import WorkItemStore
 
 
@@ -263,3 +268,50 @@ def test_no_completion_flag_and_no_merge_stays_unadvanced(tmp_path):
     _call(tmp_path, t, state, merged_count=0)
 
     assert store.get(wi.id).phase_override is None
+
+
+# --- delivery metadata retention ----------------------------------------------
+
+@pytest.mark.parametrize(
+    ("reverse_item_id", "archived"),
+    [
+        pytest.param(None, False, id="forward-only"),
+        pytest.param("wi-stale", True, id="stale-reverse-archived-forward"),
+    ],
+)
+def test_teardown_retains_metadata_from_authoritative_forward_link(
+    tmp_path, reverse_item_id, archived,
+):
+    store, item = _store_with_item(tmp_path)
+    store.add_task(item.id, "task-a", now=_now())
+    if archived:
+        store.archive(item.id, now=_now())
+    task = _task("task-a", reverse_item_id)
+    task.affected_repos = ["api"]
+    task.pr_urls = {"api": "https://github.example/api/pull/1"}
+
+    retained = retain_workitem_metadata_on_teardown(
+        task=task, workitems_dir=tmp_path / "workitems",
+    )
+
+    require_retained_task_metadata(task, retained)
+    persisted = store.get(item.id)
+    assert persisted.affected_repos == ["api"]
+    assert persisted.pr_urls == ["https://github.example/api/pull/1"]
+
+
+def test_teardown_refuses_ambiguous_forward_links(tmp_path):
+    store, first = _store_with_item(tmp_path)
+    second = store.create(title="other", kind="chore", workspace="ws", now=_now())
+    store.add_task(first.id, "task-a", now=_now())
+    store.add_task(second.id, "task-a", now=_now())
+    task = _task("task-a", None)
+    task.affected_repos = ["api"]
+
+    with pytest.raises(TaskMetadataRetentionConflictError, match="ambiguous"):
+        retain_workitem_metadata_on_teardown(
+            task=task, workitems_dir=tmp_path / "workitems",
+        )
+
+    assert store.get(first.id).affected_repos == []
+    assert store.get(second.id).affected_repos == []

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -136,6 +136,100 @@ def test_abort_removes_worktrees(worktree_deps):
     state = state_mgr.load()
     assert "to-abort" not in state.tasks
 
+def test_abort_retains_linked_delivery_metadata_for_item_summary(worktree_deps):
+    from mship.core.view.workitem_index import build_workitem_index
+    from mship.core.workitem_store import WorkItemStore
+
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    store = WorkItemStore(state_mgr.state_dir / "workitems")
+    item = store.create("delivery", "chore", "ws", datetime.now(timezone.utc))
+    store.set_phase_override(item.id, "review")
+    manager = WorktreeManager(config, graph, state_mgr, git, shell, log)
+
+    for slug, url in (
+        ("first", "https://github.example/shared/pull/1"),
+        ("second", "https://github.example/shared/pull/2"),
+    ):
+        manager.spawn(slug, repos=["shared"], slug=slug, workspace_root=workspace,
+                      work_item_id=item.id)
+        state_mgr.mutate(
+            lambda state, slug=slug, url=url: state.tasks[slug].pr_urls.update({"shared": url})
+        )
+        manager.abort(slug)
+
+    summary = build_workitem_index([store.get(item.id)], {}, state_mgr.load().tasks, {})[0]
+
+    assert summary.phase == "review"
+    assert summary.affected_repos == ["shared"]
+    assert summary.pr_urls == [
+        "https://github.example/shared/pull/1",
+        "https://github.example/shared/pull/2",
+    ]
+
+
+
+def test_abort_refuses_metadata_changed_after_retention(worktree_deps, monkeypatch):
+    from mship.core.workitem_lifecycle import (
+        TaskMetadataRetentionConflictError,
+        retain_workitem_metadata_on_teardown,
+    )
+    from mship.core.workitem_store import WorkItemStore
+
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    store = WorkItemStore(state_mgr.state_dir / "workitems")
+    item = store.create("delivery", "chore", "ws", datetime.now(timezone.utc))
+    updated_item = store.create("updated delivery", "chore", "ws", datetime.now(timezone.utc))
+    manager = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    manager.spawn("racing delivery", repos=["shared"], workspace_root=workspace,
+                  work_item_id=item.id)
+
+    def retain_then_update(*, task, workitems_dir):
+        retained = retain_workitem_metadata_on_teardown(
+            task=task, workitems_dir=workitems_dir,
+        )
+        state_mgr.mutate(
+            lambda state: (
+                setattr(state.tasks[task.slug], "work_item_id", updated_item.id),
+                state.tasks[task.slug].affected_repos.append("api-gateway"),
+                state.tasks[task.slug].pr_urls.update(
+                    {"api-gateway": "https://github.example/api/pull/2"},
+                ),
+            ),
+        )
+        return retained
+
+    monkeypatch.setattr(
+        "mship.core.workitem_lifecycle.retain_workitem_metadata_on_teardown",
+        retain_then_update,
+    )
+
+    with pytest.raises(TaskMetadataRetentionConflictError, match="Retry"):
+        manager.abort("racing-delivery")
+
+    live_task = state_mgr.load().tasks["racing-delivery"]
+    assert live_task.affected_repos == ["shared", "api-gateway"]
+    assert live_task.pr_urls == {"api-gateway": "https://github.example/api/pull/2"}
+    assert live_task.work_item_id == updated_item.id
+
+
+def test_abort_retains_no_pr_task_without_inventing_a_pr(worktree_deps):
+    from mship.core.view.workitem_index import build_workitem_index
+    from mship.core.workitem_store import WorkItemStore
+
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    store = WorkItemStore(state_mgr.state_dir / "workitems")
+    item = store.create("no pull request", "chore", "ws", datetime.now(timezone.utc))
+    manager = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    manager.spawn("no pull request", repos=["shared"], workspace_root=workspace,
+                  work_item_id=item.id)
+
+    manager.abort("no-pull-request")
+
+    summary = build_workitem_index([store.get(item.id)], {}, state_mgr.load().tasks, {})[0]
+    assert summary.affected_repos == ["shared"]
+    assert summary.pr_urls == []
+
+
 
 def test_spawn_runs_setup_task(worktree_deps, monkeypatch):
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -168,6 +168,38 @@ def test_abort_retains_linked_delivery_metadata_for_item_summary(worktree_deps):
 
 
 
+
+def test_abort_retains_metadata_for_forward_only_workitem_link(worktree_deps):
+    from mship.core.workitem_store import WorkItemStore
+
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    store = WorkItemStore(state_mgr.state_dir / "workitems")
+    item = store.create("forward-only delivery", "chore", "ws", datetime.now(timezone.utc))
+    manager = WorktreeManager(config, graph, state_mgr, git, shell, log)
+    manager.spawn(
+        "forward-only delivery",
+        repos=["shared"],
+        slug="forward-only-delivery",
+        workspace_root=workspace,
+        work_item_id=item.id,
+    )
+    state_mgr.mutate(
+        lambda state: (
+            setattr(state.tasks["forward-only-delivery"], "work_item_id", None),
+            state.tasks["forward-only-delivery"].pr_urls.update(
+                {"shared": "https://github.example/shared/pull/1"},
+            ),
+        ),
+    )
+
+    manager.abort("forward-only-delivery")
+
+    assert "forward-only-delivery" not in state_mgr.load().tasks
+    persisted = store.get(item.id)
+    assert persisted.affected_repos == ["shared"]
+    assert persisted.pr_urls == ["https://github.example/shared/pull/1"]
+
+
 def test_abort_refuses_metadata_changed_after_retention(worktree_deps, monkeypatch):
     from mship.core.workitem_lifecycle import (
         TaskMetadataRetentionConflictError,

--- a/tests/core/view/test_workitem_index.py
+++ b/tests/core/view/test_workitem_index.py
@@ -218,6 +218,72 @@ def test_build_index_tolerates_missing_children():
     assert s.attention.total_tasks == 0
 
 
+def test_summary_aggregates_linked_task_repos_and_prs_without_mutation():
+    first_repos = ["mothership", "ground-control"]
+    first_prs = {
+        "mothership": "https://github.example/mship/pull/1",
+        "ground-control": "https://github.example/gc/pull/2",
+    }
+    second_repos = ["ground-control", "mothership"]
+    second_prs = {"mothership": "https://github.example/mship/pull/3"}
+    first = Task(
+        slug="first", description="first", phase="review", created_at=_now(),
+        affected_repos=first_repos, branch="first", pr_urls=first_prs,
+    )
+    second = Task(
+        slug="second", description="second", phase="review", created_at=_now(),
+        affected_repos=second_repos, branch="second", pr_urls=second_prs,
+    )
+
+    summary = build_workitem_index(
+        [_wi(task_slugs=["first", "second", "missing"])],
+        {}, {"first": first, "second": second}, {},
+    )[0]
+
+    assert summary.affected_repos == ["mothership", "ground-control"]
+    assert summary.pr_urls == [
+        "https://github.example/mship/pull/1",
+        "https://github.example/gc/pull/2",
+        "https://github.example/mship/pull/3",
+    ]
+    assert first_repos == ["mothership", "ground-control"]
+    assert first_prs == {
+        "mothership": "https://github.example/mship/pull/1",
+        "ground-control": "https://github.example/gc/pull/2",
+    }
+    assert second_repos == ["ground-control", "mothership"]
+    assert second_prs == {"mothership": "https://github.example/mship/pull/3"}
+
+def test_summary_merges_retained_metadata_with_live_task_urls():
+    live = Task(
+        slug="live", description="live", phase="review", created_at=_now(),
+        affected_repos=["ground-control"], branch="live",
+        pr_urls={"ground-control": "https://github.example/gc/pull/2"},
+    )
+
+    summary = build_workitem_index(
+        [_wi(
+            task_slugs=["gone", "live"],
+            affected_repos=["mothership", "ground-control"],
+            pr_urls=["https://github.example/mship/pull/1"],
+        )],
+        {}, {"live": live}, {},
+    )[0]
+
+    assert summary.affected_repos == ["mothership", "ground-control"]
+    assert summary.pr_urls == [
+        "https://github.example/mship/pull/1",
+        "https://github.example/gc/pull/2",
+    ]
+
+
+
+def test_summary_has_no_metadata_when_linked_tasks_are_missing():
+    summary = build_workitem_index([_wi(task_slugs=["missing"])], {}, {}, {})[0]
+    assert summary.affected_repos == []
+    assert summary.pr_urls == []
+
+
 def test_build_index_populates_unattended_true():
     item = _wi(id="wi-u", unattended=True)
     s = build_workitem_index([item], {}, {}, {})[0]


### PR DESCRIPTION
## Summary

- Route remote capture through the same repo-scoped source preflight and transfer path as remote run/build, including canonical `git_root` handling and abort-before-dispatch failures.
- Record the actual synthesized snapshot SHA/ref in remote evidence, not its parent HEAD. Explicitly distinguish source preparation from unverified remote checkout/running-binary provenance.
- Preserve affected repositories and PR URLs on WorkItems before task teardown; refuse deletion if concurrent metadata changes were not retained. Cover abort, prune, and cascade paths without reversing lock order.
- Expose retained/live delivery metadata in WorkItem summaries for Ground Control's Done views.
- Document the capture guarantee and its limits. Previously deleted task metadata is not reconstructed.

Coordinated with Ground Control on `feat/capture-gc-daily-use`.

## Review follow-through

- Send literal remote progress to stderr so JSON capture remains machine-readable.
- Resolve unique forward-only/archived WorkItem ownership before retention; fail closed on ambiguity. Report retention conflicts cleanly in cascade and prune.
- Include the persisted spec revision in review responses so Ground Control can distinguish stale acknowledgements from later prompts.

## Verification

- Canonical backend suite: 5,316 passed, 2 skipped. Final canonical test iteration 4 passes; current backend CI checks pass.
- Ruff and Pyrefly checks passed; runtime-only CLI dependency import passed.
- Six capture regressions failed against the original source and pass on this implementation; all 94 remote-dispatch tests pass.
- Real public-relay run installed/launched Ground Control on the Studio Pixel 9 Pro emulator; the updated remote capture returned both screen and layout artifacts.
- Live public-relay JSON capture passes: stdout parses as one JSON document, 22 progress lines stay on stderr, and screen/layout artifacts are present. Real HTTP mutation smoke verifies returned persisted revisions advance.
- Three added device scenarios fail before review fixes and pass afterward.
- Companion Android verification: 879 unit tests and lint passed; eight isolated-app UI scenarios passed, with five failures against the original UI source.
- Disposable UI harnesses/APKs were removed after preserving screenshots. No saved user connections were used for fixtures.

Closes #422
Closes #388
Closes #389
Closes #375
Closes #387

---

## Cross-repo coordination (mothership)

This PR is part of a coordinated change: `capture-gc-daily-use`

| # | Repo | PR | Merge order |
|---|------|----|-------------|
| 1 | ground-control | https://github.com/atomikpanda/ground-control/pull/86 | merge first |
| 2 | mothership | https://github.com/atomikpanda/mothership/pull/496 | this PR |

Merge in order: ground-control → mothership.
