### PR TITLE
Fix completed threads stuck in Needs you

### DIFF
--- a/docs/guides/phone-control.md
+++ b/docs/guides/phone-control.md
@@ -18,6 +18,21 @@ and coffee-shop Wi-Fi don't matter. You can use a self-hosted relay
 ([Relay hosting](../relay-hosting.md)); serving over a tailnet works too
 ([Serve over Tailscale](../mship-serve-tailscale.md)).
 
+### Upgrading mailbox writers
+
+Mailbox thread files are read-modify-written. Before using a release that adds
+phone-visible mailbox fields such as **Done**, install the new `mship` version
+and restart every long-lived mailbox writer for that workspace — including
+`mship serve` and any running agent, worker, or inbox process that can write
+`.mothership/messages`. Fresh CLI invocations started after the upgrade use the
+new version.
+
+Do not leave an older mailbox-writing process running during the rollout: its
+older `Thread` model ignores fields it does not know, so a later write can
+discard a newer resolution cursor. A configuration change in the new binary
+cannot protect data from an already-running older binary; upgrade and restart
+all writers first.
+
 ## 2. Pair the phone
 
 ```bash

--- a/docs/guides/phone-control.md
+++ b/docs/guides/phone-control.md
@@ -43,6 +43,10 @@ per workspace — the app is multi-workspace.
 - **Chat with the agent.** Every work item has its threads; messages are
   durable, so the agent answers when it wakes even if it wasn't running when
   you wrote.
+- **Close completed conversations.** Mark a finished thread **Done** to clear
+  its older action and decision cards without sending a message or waking an
+  agent. Opening a thread marks it read but does not resolve its requests.
+  Any later request still returns to your attention.
 - **Watch progress.** Work items show their phase (inbox → shaping → ready →
   in flight → review → done) as the linked spec, tasks, and PRs advance.
 - **Review and merge PRs.** Merged PRs flow back as events — the agent sees the

--- a/src/mship/core/message.py
+++ b/src/mship/core/message.py
@@ -55,6 +55,12 @@ class Thread(BaseModel):
     # Symmetric to `seen_at`; drives Ground Control's "Read" indicator (#345). A human message
     # reads as Read iff `agent_seen_at is not None and agent_seen_at >= message.created_at`.
     agent_seen_at: datetime | None = None
+    # Explicit operator completion cursor. It identifies a message by append order,
+    # never by timestamp, so equal-timestamp messages remain unambiguous.
+    resolved_through_message_id: str | None = None
+    # Separate durable change time for long-poll clients. Completion changes attention
+    # state but deliberately must not reorder the thread by changing `updated_at`.
+    resolved_at: datetime | None = None
     inbox: InboxMetadata = Field(default_factory=InboxMetadata)
     messages: list[Message] = []
 
@@ -64,32 +70,33 @@ class Thread(BaseModel):
         """A thread needs an agent iff its latest message is from a human."""
         return bool(self.messages) and self.messages[-1].role == "human"
 
+    def _unanswered_after(self) -> int:
+        """Return the append index after both human and explicit resolution cursors."""
+        last_human = -1
+        resolved = -1
+        for i, message in enumerate(self.messages):
+            if message.role == "human":
+                last_human = i
+            if message.id == self.resolved_through_message_id:
+                resolved = i
+        return max(last_human, resolved)
+
     @computed_field
     @property
     def needs_you(self) -> bool:
-        """True iff an agent message marked needs_you is unanswered — i.e. newer
-        than the operator's last human message. Survives a follow-up plain note."""
-        last_human = -1
-        for i, m in enumerate(self.messages):
-            if m.role == "human":
-                last_human = i
+        """True iff a needs-you message remains after either resolution cursor."""
         return any(
-            m.role == "agent" and m.kind == "needs_you"
-            for m in self.messages[last_human + 1:]
+            message.role == "agent" and message.kind == "needs_you"
+            for message in self.messages[self._unanswered_after() + 1:]
         )
 
     @computed_field
     @property
     def needs_decision(self) -> bool:
-        """True iff an unanswered agent message with kind=decision exists after the
-        operator's last human message (mirrors needs_you)."""
-        last_human = -1
-        for i, m in enumerate(self.messages):
-            if m.role == "human":
-                last_human = i
+        """True iff a decision remains after either resolution cursor."""
         return any(
-            m.role == "agent" and m.kind == "decision"
-            for m in self.messages[last_human + 1:]
+            message.role == "agent" and message.kind == "decision"
+            for message in self.messages[self._unanswered_after() + 1:]
         )
 
     @computed_field

--- a/src/mship/core/message_store.py
+++ b/src/mship/core/message_store.py
@@ -19,6 +19,22 @@ def _new_id(now: datetime) -> str:
     return f"{now:%Y%m%d%H%M%S}-{uuid.uuid4().hex[:8]}"
 
 
+def _utc(timestamp: datetime) -> datetime:
+    """Normalize legacy naive timestamps before comparing mailbox cursors."""
+    return timestamp.replace(tzinfo=timezone.utc) if timestamp.tzinfo is None else timestamp
+
+
+def _phone_visible_at(thread: Thread) -> datetime:
+    """Match the high-water timestamp used by phone long-polling."""
+    timestamps = (
+        thread.updated_at,
+        thread.inbox.last_mutated_at,
+        thread.resolved_at,
+    )
+    return max(_utc(timestamp) for timestamp in timestamps if timestamp is not None)
+
+
+
 @contextmanager
 def _locked(lock_path: Path, mode: int):
     """Advisory flock on `lock_path` (mirrors state.py's `_locked`).
@@ -187,10 +203,12 @@ class MessageStore:
             )
             if target_index > current_index:
                 thread.resolved_through_message_id = through_message_id
+                # A resolve can arrive behind a content or inbox mutation the phone
+                # already observed. Advance beyond that entire long-poll high-water
+                # mark so its strictly-greater cursor sees this attention update.
                 thread.resolved_at = max(
-                    now,
-                    thread.resolved_at + timedelta(microseconds=1)
-                    if thread.resolved_at is not None else now,
+                    _utc(now),
+                    _phone_visible_at(thread) + timedelta(microseconds=1),
                 )
                 self.save(thread)
             return thread

--- a/src/mship/core/message_store.py
+++ b/src/mship/core/message_store.py
@@ -203,12 +203,15 @@ class MessageStore:
             )
             if target_index > current_index:
                 thread.resolved_through_message_id = through_message_id
-                # A resolve can arrive behind a content or inbox mutation the phone
-                # already observed. Advance beyond that entire long-poll high-water
-                # mark so its strictly-greater cursor sees this attention update.
+                # Phone polling has one mailbox-wide cursor: a previously observed
+                # change on another thread must not hide this acknowledgement.
+                phone_high_water = max(
+                    (_phone_visible_at(candidate) for candidate in self.list()),
+                    default=_phone_visible_at(thread),
+                )
                 thread.resolved_at = max(
                     _utc(now),
-                    _phone_visible_at(thread) + timedelta(microseconds=1),
+                    phone_high_water + timedelta(microseconds=1),
                 )
                 self.save(thread)
             return thread

--- a/src/mship/core/message_store.py
+++ b/src/mship/core/message_store.py
@@ -4,7 +4,7 @@ import fcntl
 import tempfile
 import uuid
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Literal
 
@@ -155,6 +155,43 @@ class MessageStore:
                 raise KeyError(thread_id)
             if thread.seen_at is None or seen_at > thread.seen_at:
                 thread.seen_at = seen_at
+                self.save(thread)
+            return thread
+
+    def resolve_through(self, thread_id: str, through_message_id: str, now: datetime) -> Thread:
+        """Durably advance the explicit operator completion cursor by append order.
+
+        Resolution is intentionally not a content update: it neither appends a
+        message nor changes `updated_at`. `resolved_at` exists solely to make this
+        attention-state mutation visible to serve-side long polling.
+        """
+        with _locked(self._lock_path(thread_id), fcntl.LOCK_EX):
+            thread = self.get(thread_id)
+            if thread is None:
+                raise KeyError(thread_id)
+            try:
+                target_index = next(
+                    index for index, message in enumerate(thread.messages)
+                    if message.id == through_message_id
+                )
+            except StopIteration as exc:
+                raise ValueError(
+                    f"message {through_message_id!r} does not belong to thread {thread_id!r}"
+                ) from exc
+            current_index = next(
+                (
+                    index for index, message in enumerate(thread.messages)
+                    if message.id == thread.resolved_through_message_id
+                ),
+                -1,
+            )
+            if target_index > current_index:
+                thread.resolved_through_message_id = through_message_id
+                thread.resolved_at = max(
+                    now,
+                    thread.resolved_at + timedelta(microseconds=1)
+                    if thread.resolved_at is not None else now,
+                )
                 self.save(thread)
             return thread
 

--- a/src/mship/core/message_wait.py
+++ b/src/mship/core/message_wait.py
@@ -19,19 +19,24 @@ def _utc(dt: datetime) -> datetime:
 
 
 def _change_at(thread, include_inbox: bool) -> datetime:
-    """Content time, or inbox time when a caller explicitly opts in."""
+    """Content time, or a durable phone-visible metadata mutation when enabled."""
     content_at = _utc(thread.updated_at)
     if not include_inbox:
         return content_at
     inbox_mutation = getattr(getattr(thread, "inbox", None), "last_mutated_at", None)
-    return max(content_at, _utc(inbox_mutation) if inbox_mutation else content_at)
+    resolution = getattr(thread, "resolved_at", None)
+    return max(
+        content_at,
+        _utc(inbox_mutation) if inbox_mutation else content_at,
+        _utc(resolution) if resolution else content_at,
+    )
 
 
 def changed_since(threads, since: datetime, *, include_inbox: bool = False):
     """Return changed threads and the monotonic high-water change cursor.
 
     Agent mailbox waits retain content-only semantics by default. The serve
-    inbox surface opts into durable inbox mutations explicitly.
+    inbox surface opts into durable inbox and completion mutations explicitly.
     """
     since = _utc(since)
     change_times = [(thread, _change_at(thread, include_inbox)) for thread in threads]

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -118,6 +118,18 @@ class SeenBody(BaseModel):
     seen_at: str | None = None
 
 
+class ResolveThreadBody(BaseModel):
+    through_message_id: str
+
+    @field_validator("through_message_id")
+    @classmethod
+    def validate_through_message_id(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("through_message_id must not be blank")
+        return value
+
+
+
 class InboxMutationBody(BaseModel):
     mutation_id: str
 
@@ -1412,6 +1424,17 @@ def create_app(
         except (KeyError, ValueError):
             raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
         return _thread_payload(thread)
+
+    @app.post("/threads/{thread_id}/resolve")
+    def post_resolve_thread(thread_id: str, body: ResolveThreadBody):
+        now = datetime.now(timezone.utc)
+        try:
+            thread = msgs.resolve_through(thread_id, body.through_message_id, now)
+        except KeyError:
+            raise HTTPException(status_code=404, detail=f"no thread {thread_id!r}")
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
+        return _thread_payload(thread, now)
 
     def _thread_inbox_links(threads, all_items=None):
         if all_items is None:

--- a/tests/core/test_message_model.py
+++ b/tests/core/test_message_model.py
@@ -52,6 +52,31 @@ def test_needs_you_clears_after_human_reply():
     t = _thread(_m("human", 0), _m("agent", 1, kind="needs_you"), _m("human", 2))
     assert t.needs_you is False
 
+def test_explicit_resolution_clears_actionable_prefix_only():
+    t = _thread(
+        _m("human", 0),
+        _m("agent", 1, kind="needs_you"),
+        _dm(
+            "agent", "decision", "m2", DecisionPayload(options=["Approve", "Wait"]),
+            t=(BASE + timedelta(minutes=2)).isoformat(),
+        ),
+        _m("agent", 3, kind="needs_you"),
+    )
+    t.resolved_through_message_id = "m2"
+
+    assert t.needs_decision is False
+    assert t.needs_you is True
+
+
+def test_legacy_thread_preserves_unresolved_attention():
+    legacy = _thread(_m("human", 0), _m("agent", 1, kind="needs_you")).model_dump()
+    legacy.pop("resolved_through_message_id")
+    legacy.pop("resolved_at")
+
+    restored = Thread.model_validate(legacy)
+
+    assert restored.needs_you is True
+
 
 def test_unseen_true_when_agent_newer_than_seen_cursor():
     t = _thread(_m("human", 0), _m("agent", 1), seen_at=None)

--- a/tests/core/test_message_store.py
+++ b/tests/core/test_message_store.py
@@ -186,6 +186,33 @@ def test_later_resolution_remains_poll_visible_when_request_clocks_reorder(tmp_p
     assert cursor > prior.resolved_at
 
 
+
+def test_resolution_advances_past_phone_visible_high_water_without_agent_wake(tmp_path):
+    from mship.core.message_wait import changed_since
+
+    base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    content_at = base + timedelta(minutes=3)
+    inbox_at = base + timedelta(minutes=4)
+    store = _store(tmp_path)
+    thread = store.create_thread("requests", "start", base)
+    prompt = store.append(thread.id, "agent", "review this", content_at, kind="needs_you")
+    store.mutate_inbox(thread.id, "pin", "pin-1", inbox_at)
+
+    resolved = store.resolve_through(thread.id, prompt.id, base + timedelta(minutes=1))
+    retried = store.resolve_through(thread.id, prompt.id, base + timedelta(minutes=5))
+    agent_changed, agent_cursor = changed_since(store.list(), content_at)
+    phone_changed, phone_cursor = changed_since(store.list(), inbox_at, include_inbox=True)
+
+    assert resolved.updated_at == content_at
+    assert resolved.inbox.last_mutated_at == inbox_at
+    assert [message.id for message in resolved.messages] == [thread.messages[0].id, prompt.id]
+    assert resolved.needs_you is False
+    assert retried.model_dump(mode="json") == resolved.model_dump(mode="json")
+    assert agent_changed == []
+    assert agent_cursor == content_at
+    assert [item.id for item in phone_changed] == [thread.id]
+    assert phone_cursor == resolved.resolved_at
+
 def test_mark_seen_advances_cursor_and_clears_unseen(tmp_path):
     from datetime import timedelta
     base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)

--- a/tests/core/test_message_store.py
+++ b/tests/core/test_message_store.py
@@ -130,6 +130,61 @@ def test_append_needs_you_kind_flags_thread(tmp_path):
     assert got.messages[-1].kind == "needs_you"
     assert got.needs_you is True
 
+def test_resolve_through_completed_closeout_is_idempotent_and_keeps_content_time(tmp_path):
+    base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    store = _store(tmp_path)
+    thread = store.create_thread("closeout", "start", base)
+    store.append(thread.id, "agent", "please review", base, kind="needs_you")
+    closeout = store.append(thread.id, "agent", "PR merged", base, kind="event")
+
+    resolved = store.resolve_through(thread.id, closeout.id, base + timedelta(minutes=1))
+    persisted = store.get(thread.id)
+    retried = store.resolve_through(thread.id, closeout.id, base + timedelta(minutes=2))
+
+    assert persisted.resolved_through_message_id == closeout.id
+    assert persisted.resolved_at == base + timedelta(minutes=1)
+    assert persisted.updated_at == base
+    assert persisted.needs_you is False
+    assert persisted.awaiting_agent_event is True
+    assert [message.id for message in persisted.messages] == [message.id for message in resolved.messages]
+    assert retried.model_dump(mode="json") == persisted.model_dump(mode="json")
+
+
+def test_stale_resolve_does_not_clear_newer_equal_timestamp_prompt(tmp_path):
+    base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    store = _store(tmp_path)
+    thread = store.create_thread("closeout", "start", base)
+    store.append(thread.id, "agent", "old request", base, kind="needs_you")
+    loaded_through = store.append(thread.id, "agent", "merged", base, kind="event")
+    newer_prompt = store.append(thread.id, "agent", "new request", base, kind="needs_you")
+
+    resolved = store.resolve_through(thread.id, loaded_through.id, base + timedelta(minutes=1))
+
+    assert resolved.resolved_through_message_id == loaded_through.id
+    assert resolved.needs_you is True
+    assert resolved.messages[-1].id == newer_prompt.id
+    with pytest.raises(ValueError):
+        other = store.create_thread("other", "body", base)
+        store.resolve_through(thread.id, other.messages[0].id, base + timedelta(minutes=2))
+
+
+def test_later_resolution_remains_poll_visible_when_request_clocks_reorder(tmp_path):
+    from mship.core.message_wait import changed_since
+
+    base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    store = _store(tmp_path)
+    thread = store.create_thread("requests", "start", base)
+    first = store.append(thread.id, "agent", "first", base, kind="needs_you")
+    second = store.append(thread.id, "agent", "second", base, kind="needs_you")
+    prior = store.resolve_through(thread.id, first.id, base + timedelta(minutes=2))
+
+    store.resolve_through(thread.id, second.id, base + timedelta(minutes=1))
+    changed, cursor = changed_since(store.list(), prior.resolved_at, include_inbox=True)
+
+    assert [item.id for item in changed] == [thread.id]
+    assert changed[0].needs_you is False
+    assert cursor > prior.resolved_at
+
 
 def test_mark_seen_advances_cursor_and_clears_unseen(tmp_path):
     from datetime import timedelta

--- a/tests/core/test_message_wait.py
+++ b/tests/core/test_message_wait.py
@@ -34,6 +34,17 @@ def test_changed_since_can_include_newer_inbox_mutation_without_reordering_conte
     assert thread.updated_at == T0
 
 
+def test_changed_since_can_include_resolution_without_reordering_content():
+    thread = _thread("a", T0)
+    thread.resolved_at = T0 + timedelta(seconds=5)
+
+    changed, cursor = changed_since([thread], T0, include_inbox=True)
+
+    assert changed == [thread]
+    assert cursor == T0 + timedelta(seconds=5)
+    assert thread.updated_at == T0
+
+
 def test_changed_since_ignores_inbox_only_change_by_default():
     thread = _thread("a", T0)
     thread.inbox.last_mutated_at = T0 + timedelta(seconds=5)

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -1514,6 +1514,48 @@ def test_post_seen_marks_thread_and_clears_unseen(tmp_path):
     assert r.status_code == 200
     assert next(x for x in client.get("/threads").json() if x["id"] == t.id)["unseen"] is False
 
+def test_post_resolve_is_distinct_from_seen_and_returns_authoritative_thread(tmp_path):
+    base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    store = MessageStore(tmp_path / ".mothership" / "messages")
+    thread = store.create_thread("closeout", "start", base)
+    prompt = store.append(thread.id, "agent", "please review", base, kind="needs_you")
+    client = TestClient(_app(tmp_path))
+
+    read = client.post(
+        f"/threads/{thread.id}/seen",
+        json={"seen_at": (base + timedelta(minutes=1)).isoformat()},
+    )
+    done = client.post(f"/threads/{thread.id}/resolve", json={"through_message_id": prompt.id})
+
+    assert read.status_code == done.status_code == 200
+    assert read.json()["needs_you"] is True
+    assert done.json()["resolved_through_message_id"] == prompt.id
+    assert done.json()["needs_you"] is False
+    assert done.json()["needs_decision"] is False
+    assert datetime.fromisoformat(done.json()["updated_at"]) == base
+    assert len(done.json()["messages"]) == 2
+    assert store.get(thread.id).resolved_through_message_id == prompt.id
+
+
+def test_post_resolve_rejects_unknown_message_and_missing_thread(tmp_path):
+    base = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+    store = MessageStore(tmp_path / ".mothership" / "messages")
+    first = store.create_thread("first", "start", base)
+    second = store.create_thread("second", "other", base)
+    client = TestClient(_app(tmp_path))
+
+    assert client.post(
+        f"/threads/{first.id}/resolve", json={"through_message_id": "missing"},
+    ).status_code == 422
+    assert client.post(
+        f"/threads/{first.id}/resolve",
+        json={"through_message_id": second.messages[0].id},
+    ).status_code == 422
+    assert client.post(
+        "/threads/missing/resolve", json={"through_message_id": first.messages[0].id},
+    ).status_code == 404
+    assert client.post(f"/threads/{first.id}/resolve", json={"through_message_id": " "}).status_code == 422
+
 
 def test_post_seen_unknown_thread_404(tmp_path):
     client = TestClient(_app(tmp_path))

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -178,6 +178,32 @@ def test_wait_reports_removed_ids_when_an_inbox_mutation_leaves_the_filter(
     assert response.json()["threads"] == []
     assert response.json()["removed_ids"] == [thread.id]
 
+
+def test_resolve_moves_old_attention_thread_to_archived_and_wakes_active_wait(tmp_path: Path):
+    client, store = _client(tmp_path)
+    created_at = datetime.now(timezone.utc) - timedelta(days=8)
+    thread = store.create_thread("completed", "body", created_at)
+    prompt = store.append(thread.id, "agent", "review this", created_at, kind="needs_you")
+    assert [summary["id"] for summary in client.get("/threads", params={"inbox": "active"}).json()] == [thread.id]
+    since = datetime.now(timezone.utc)
+
+    resolved = client.post(
+        f"/threads/{thread.id}/resolve", json={"through_message_id": prompt.id},
+    )
+    woke = client.get("/threads", params={
+        "wait": 1, "since": since.isoformat(), "timeout": 0, "inbox": "active",
+    })
+
+    assert resolved.status_code == 200
+    assert resolved.json()["inbox_state"] == "archived"
+    assert resolved.json()["archive_reason"] == "inactive_unlinked"
+    assert client.get("/threads", params={"inbox": "active"}).json() == []
+    assert [summary["id"] for summary in client.get("/threads", params={"inbox": "archived"}).json()] == [thread.id]
+    assert woke.status_code == 200
+    assert woke.json()["timed_out"] is False
+    assert woke.json()["threads"] == []
+    assert woke.json()["removed_ids"] == [thread.id]
+
 def test_wait_times_out_with_empty_list(tmp_path: Path):
     client, _ = _client(tmp_path)
     r = client.get("/threads", params={"wait": 1, "timeout": 0.1})  # since defaults to now

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -205,14 +205,21 @@ def test_resolve_moves_old_attention_thread_to_archived_and_wakes_active_wait(tm
     assert woke.json()["removed_ids"] == [thread.id]
 
 
-def test_resolve_with_reordered_clock_wakes_after_prior_phone_cursor(tmp_path: Path):
+@pytest.mark.parametrize("cursor_on_other_thread", [False, True])
+def test_resolve_with_reordered_clock_wakes_after_prior_phone_cursor(
+    tmp_path: Path, cursor_on_other_thread: bool,
+):
     client, store = _client(tmp_path)
     base = datetime.now(timezone.utc) - timedelta(days=1)
     content_at = datetime.now(timezone.utc) + timedelta(hours=1)
     inbox_at = content_at + timedelta(minutes=1)
     thread = store.create_thread("completed", "body", base)
     prompt = store.append(thread.id, "agent", "review this", content_at, kind="needs_you")
-    store.mutate_inbox(thread.id, "pin", "pin-1", inbox_at)
+    cursor_thread = (
+        store.create_thread("other conversation", "body", base)
+        if cursor_on_other_thread else thread
+    )
+    store.mutate_inbox(cursor_thread.id, "pin", "pin-1", inbox_at)
 
     resolved = client.post(
         f"/threads/{thread.id}/resolve", json={"through_message_id": prompt.id},

--- a/tests/core/test_serve_threads_wait.py
+++ b/tests/core/test_serve_threads_wait.py
@@ -204,6 +204,29 @@ def test_resolve_moves_old_attention_thread_to_archived_and_wakes_active_wait(tm
     assert woke.json()["threads"] == []
     assert woke.json()["removed_ids"] == [thread.id]
 
+
+def test_resolve_with_reordered_clock_wakes_after_prior_phone_cursor(tmp_path: Path):
+    client, store = _client(tmp_path)
+    base = datetime.now(timezone.utc) - timedelta(days=1)
+    content_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    inbox_at = content_at + timedelta(minutes=1)
+    thread = store.create_thread("completed", "body", base)
+    prompt = store.append(thread.id, "agent", "review this", content_at, kind="needs_you")
+    store.mutate_inbox(thread.id, "pin", "pin-1", inbox_at)
+
+    resolved = client.post(
+        f"/threads/{thread.id}/resolve", json={"through_message_id": prompt.id},
+    )
+    woke = client.get("/threads", params={
+        "wait": 1, "since": inbox_at.isoformat(), "timeout": 0,
+    })
+
+    assert resolved.status_code == 200
+    assert store.get(thread.id).updated_at == content_at
+    assert woke.status_code == 200
+    assert woke.json()["timed_out"] is False
+    assert [summary["id"] for summary in woke.json()["threads"]] == [thread.id]
+
 def test_wait_times_out_with_empty_list(tmp_path: Path):
     client, _ = _client(tmp_path)
     r = client.get("/threads", params={"wait": 1, "timeout": 0.1})  # since defaults to now


### PR DESCRIPTION
## Problem
Completed conversations remain in Needs you because an older needs_you/decision prompt is still unresolved. Opening a conversation already marks it read; a later close-out note does not resolve the older prompt.

## Changes
- Add an explicit Done acknowledgement, separate from reading, replying, and archiving.
- Resolve only through the last message the operator loaded, using an append-order message ID cursor. Newer requests (including equal-timestamp messages) remain actionable.
- Persist resolution without posting a human reply, waking an agent, or changing content ordering. Expose resolution changes to phone long-poll clients.
- Refresh Home when returning from a conversation; apply the same resolution boundary to conversation, Queue, Console, and notification decision actions.
- Preserve drafts, report failures, prevent duplicate mutations, and fence responses from replaced connections. Do not consume a poll delta that was skipped during Done.

## Verification
- Task-native checks on current main: mship test --task thread-attention-done --all — Android: 899 passed; Mothership: 5,328 passed, 2 skipped.
- Focused server regressions: 230 passed; Ruff passed.
- Android unit suite, lintDebug, and assembleDebug passed locally.
- Real Android emulator against an isolated real Mothership server: opening marked read without resolving; Done changed Needs you from 2 to 1 while preserving the unanswered question; state survived app and server restarts; a new prompt reactivated the resolved thread.
- Screenshots retained locally at .mothership/captures/thread-attention-done. Isolated app, server, mailbox, and tunnel were removed; existing live threads were not modified.

## Deployment
This is a coordinated Mothership + Ground Control change. Deploy the new server endpoint before releasing the Android Done action. A merge or a message containing "Closed out" is not automatically treated as permission to discard genuine follow-up requests.

Task: `thread-attention-done` · Work item: `wi-20260906125112-35919dd8`.

## Pre-merge review remediation
- Advance Done beyond the mailbox-wide phone cursor, including another thread's newer inbox mutation; regression reproduced before the fix and confirmed after it.
- Refresh both Home feed and sticky unread-thread state on resume.
- Retire stale direct-reply capabilities through the existing notification coordinator, preserving newer notifications and connection fencing.
- Both complete on-device notification regression classes passed: 47 tests. Final Android build and lint passed on an isolated Studio copy.
- Real emulator recheck: opening alone kept Needs you at 2 while unread dropped to 1; Done then reduced Needs you to 1 without posting a reply.
- Rollout requires upgrading and restarting every mailbox-writing mship process. An old binary cannot be made to retain unknown schema fields by configuration in the new binary.

Companion PR: https://github.com/atomikpanda/ground-control/pull/88
