### PR TITLE
Fix default relay SSH CPU spin

### DIFF
--- a/docker/relay/.dockerignore
+++ b/docker/relay/.dockerignore
@@ -1,0 +1,5 @@
+# Only build inputs; never send keys, enrollment state, or Caddy data to Docker.
+*
+!Dockerfile
+!checks/
+!checks/ssh-close.go

--- a/docker/relay/Dockerfile
+++ b/docker/relay/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.26.8-alpine@sha256:ce864e7223ac17b1775e6fd0b4c0db580c2eb50e7953a427916379e4b92a1628 AS source
+WORKDIR /src
+# Bound compiler concurrency and heap growth on small relay hosts.
+ENV CGO_ENABLED=0 GOFLAGS=-p=1 GOMAXPROCS=2 GOMEMLIMIT=512MiB
+
+# sish v2.23.0, pinned independently of mutable upstream image tags.
+ADD --checksum=sha256:1efd323d9d5148211e4d0347d355cca2bd3b68fc89462b4af22ee4b272431a19 https://codeload.github.com/antoniomika/sish/tar.gz/7a53da3d988b809782175f9e62a7066e5a7dad31 /tmp/sish.tar.gz
+RUN tar -xzf /tmp/sish.tar.gz --strip-components=1 -C /src && mkdir /emptydir
+COPY checks/ssh-close.go /tmp/ssh-close.go
+
+FROM source AS build
+# v0.52.0 spins in SendRequest after SSH shutdown (golang/go#79717).
+# Keep the security fixes; upgrade rather than disabling keepalives or downgrading.
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
+    go get golang.org/x/crypto@v0.53.0 && \
+    go run /tmp/ssh-close.go && \
+    go build -trimpath -o /out/app \
+      -ldflags="-s -w -X github.com/antoniomika/sish/cmd.Version=v2.23.0-mship-crypto0.53.0 -X github.com/antoniomika/sish/cmd.Commit=7a53da3d988b809782175f9e62a7066e5a7dad31" .
+
+FROM scratch
+WORKDIR /app
+LABEL org.opencontainers.image.title="mship sish relay" \
+      org.opencontainers.image.version="v2.23.0-mship-crypto0.53.0" \
+      org.opencontainers.image.source="https://github.com/antoniomika/sish" \
+      org.opencontainers.image.revision="7a53da3d988b809782175f9e62a7066e5a7dad31"
+COPY --from=build /emptydir /tmp
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /src/deploy/ /app/deploy/
+COPY --from=build /src/README* /src/LICENSE* /app/
+COPY --from=build /src/templates/ /app/templates/
+COPY --from=build /out/app /app/app
+ENTRYPOINT ["/app/app"]

--- a/docker/relay/checks/ssh-close.go
+++ b/docker/relay/checks/ssh-close.go
@@ -1,0 +1,96 @@
+// Build-time regression check for golang/go#79717: a keepalive sent after
+// connection shutdown must return an error, not spin forever on a closed channel.
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"log"
+	"net"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func main() {
+	done := make(chan error, 1)
+	go func() { done <- checkClosedRequest() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("PASS: SSH keepalive after close returned an error without spinning")
+	case <-time.After(10 * time.Second):
+		log.Fatal("FAIL: SSH request did not finish; possible closed-channel CPU spin")
+	}
+}
+
+func checkClosedRequest() error {
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return err
+	}
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		return err
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return err
+	}
+	defer listener.Close()
+
+	type accepted struct {
+		conn *ssh.ServerConn
+		err  error
+	}
+	server := make(chan accepted, 1)
+	go func() {
+		raw, err := listener.Accept()
+		if err != nil {
+			server <- accepted{err: err}
+			return
+		}
+		config := &ssh.ServerConfig{NoClientAuth: true}
+		config.AddHostKey(signer)
+		conn, _, requests, err := ssh.NewServerConn(raw, config)
+		if err != nil {
+			raw.Close()
+			server <- accepted{err: err}
+			return
+		}
+		go ssh.DiscardRequests(requests)
+		server <- accepted{conn: conn}
+	}()
+
+	client, err := ssh.Dial("tcp", listener.Addr().String(), &ssh.ClientConfig{
+		User:            "regression-check",
+		HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
+		Timeout:         5 * time.Second,
+	})
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	result := <-server
+	if result.err != nil {
+		return result.err
+	}
+	defer result.conn.Close()
+
+	if _, _, err := result.conn.SendRequest("keepalive@sish", true, nil); err != nil {
+		return fmt.Errorf("live keepalive failed: %w", err)
+	}
+	if err := result.conn.Close(); err != nil {
+		return err
+	}
+	// Wait for mux.loop to close globalResponses: this is the production race's
+	// terminal state, reached deterministically without timing sleeps.
+	result.conn.Wait()
+	if _, _, err := result.conn.SendRequest("keepalive@sish", true, nil); err == nil {
+		return fmt.Errorf("closed SSH connection accepted a keepalive")
+	}
+	return nil
+}

--- a/docker/relay/docker-compose.yml
+++ b/docker/relay/docker-compose.yml
@@ -11,7 +11,9 @@
 # egress-server, like enroll-server, runs as a host process, not a compose service.
 services:
   sish:
-    image: antoniomika/sish:latest
+    # Build the pinned SSH dependency fix on fresh installs and upgrades alike.
+    build: .
+    pull_policy: build
     restart: unless-stopped
     ports:
       - "2222:2222"               # SSH (clients open reverse tunnels here)

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -63,7 +63,7 @@ but the running relay will reject it because it verifies against its own
 
 | Requirement | Notes |
 |---|---|
-| A VPS (Debian 12 or Ubuntu 22.04+) | 1 CPU / 512 MB RAM is sufficient. A $5/month cloud instance (Hetzner, DigitalOcean, Vultr, etc.) works. |
+| A VPS (Debian 12 or Ubuntu 22.04+) | Runtime needs are small, but bootstrap now compiles the relay locally. Allow additional RAM and several GB of free disk for the Go compiler, dependencies, and build cache; a 512 MB instance may need swap or a larger build host. |
 | A domain you control | Example: `relay.example.com`. You only need a subdomain — the relay does not take over the root domain. |
 | SSH access to the VPS as root (or a sudo user) | To run the bootstrap script and open ports. |
 | OpenSSH client tools on the VPS | `ssh-keygen` verifies signed host registrations. On Debian/Ubuntu: `apt install openssh-client`. |
@@ -136,12 +136,44 @@ What the script does:
 1. Installs Docker Engine if it is not already present (via `https://get.docker.com`).
 2. Creates the data directories `docker/relay/pubkeys/`, `docker/relay/keys/`, `docker/relay/caddy-data/`, and `docker/relay/caddy-config/`.
 3. Prints a reminder to add client public keys before tunnels will be accepted.
-4. Starts the sish and Caddy containers with `docker compose up -d`.
+4. Builds the pinned, patched sish image and starts it alongside Caddy with `docker compose up -d --build`. Docker provides the Go toolchain; no host Go installation is needed.
 
 The compose file (`docker/relay/docker-compose.yml`) starts two services:
 
-- **sish** — `--https=false`, HTTP on internal `127.0.0.1:8080`, SSH on `:2222`. Mounts `./pubkeys` (read-only key allowlist) and `./keys` (sish host key).
+- **sish** — built from the checked-in `docker/relay/Dockerfile`, not pulled from `antoniomika/sish:latest`. Uses `--https=false`, HTTP on internal `127.0.0.1:8080`, SSH on `:2222`. Mounts `./pubkeys` (read-only key allowlist) and `./keys` (sish host key).
 - **caddy** — `network_mode: host` so it can bind `:80`/`:443` directly and reach the sish and enroll-server loopback addresses. Mounts `./Caddyfile`, `./caddy-data`, and `./caddy-config`.
+
+### Pinned relay build and upgrades
+
+The default build uses sish **v2.23.0** at commit
+`7a53da3d988b809782175f9e62a7066e5a7dad31`, with
+`golang.org/x/crypto` upgraded to **v0.53.0**. The upstream v2.23.0 image
+contains v0.52.0, whose SSH keepalive request can spin forever after a
+connection closes ([Go issue #79717](https://github.com/golang/go/issues/79717)).
+Restarting only clears the accumulated spinning goroutines; it does not fix
+the installed binary. Do not work around this by disabling keepalives or
+idle-connection reaping.
+
+The Dockerfile pins the Go builder image and verifies the upstream source
+archive checksum. Every build runs `checks/ssh-close.go` against the selected
+dependency graph: a request on a closed SSH connection must return an error
+within a bounded time. `.dockerignore` excludes all runtime state and secrets
+from the build context. Compose's `pull_policy: build` makes this the default
+for ordinary `docker compose up` as well as the bootstrap script; there is no
+machine-local override to copy to a new relay.
+
+To upgrade an existing relay after updating this checkout, run from the
+**original deployment checkout**, retaining its `.env`, keys, and state:
+
+```bash
+docker compose -f docker/relay/docker-compose.yml up -d --build --no-deps sish
+docker compose -f docker/relay/docker-compose.yml exec sish /app/app --version
+```
+
+The version should be `v2.23.0-mship-crypto0.53.0`. Recreating sish briefly
+disconnects tunnels; clients must reconnect. Caddy and enrollment state are
+not recreated. Never deploy from an empty worktree's relay directory: that
+would use a different key allowlist and generate a different SSH host key.
 
 ### Idle-connection reaping
 

--- a/docs/relay-hosting.md
+++ b/docs/relay-hosting.md
@@ -162,18 +162,8 @@ from the build context. Compose's `pull_policy: build` makes this the default
 for ordinary `docker compose up` as well as the bootstrap script; there is no
 machine-local override to copy to a new relay.
 
-To upgrade an existing relay after updating this checkout, run from the
-**original deployment checkout**, retaining its `.env`, keys, and state:
-
-```bash
-docker compose -f docker/relay/docker-compose.yml up -d --build --no-deps sish
-docker compose -f docker/relay/docker-compose.yml exec sish /app/app --version
-```
-
-The version should be `v2.23.0-mship-crypto0.53.0`. Recreating sish briefly
-disconnects tunnels; clients must reconnect. Caddy and enrollment state are
-not recreated. Never deploy from an empty worktree's relay directory: that
-would use a different key allowlist and generate a different SSH host key.
+Use the [upgrade procedure](#upgrading) below to deploy the fixed build from
+the original checkout while preserving the relay's identity and state.
 
 ### Idle-connection reaping
 
@@ -457,7 +447,7 @@ registration (within a minute) publishes freshly derived ones.
 
 ## Configuration Reference
 
-The relay is configured entirely through environment variables passed to `docker compose`. The bootstrap script sets them; you can also export them in a `.env` file alongside `docker-compose.yml`:
+The relay is configured through environment variables passed to `docker compose`. The bootstrap script passes them to its startup invocation but **does not persist them**. For later commands, export the same values again, or save them in `docker/relay/.env` and explicitly pass `--env-file docker/relay/.env` to Compose.
 
 | Variable | Required | Example | Description |
 |---|---|---|---|
@@ -477,15 +467,35 @@ The `mship relay enroll-server` command also respects `RELAY_DOMAIN` if `--relay
 
 ## Upgrading
 
-sish and Caddy both use the `latest` tag. To update:
+sish is built from the source and dependency versions pinned in the checked-in
+Dockerfile; `docker compose pull` cannot upgrade it. Update the original
+deployment checkout, then rebuild and recreate only sish:
 
 ```bash
 cd /path/to/mothership
-docker compose -f docker/relay/docker-compose.yml pull
-docker compose -f docker/relay/docker-compose.yml up -d
+git pull --ff-only
+# Use this relay's original bootstrap values, not a new domain.
+export RELAY_DOMAIN=relay.example.com
+export ACME_EMAIL=you@example.com
+docker compose -f docker/relay/docker-compose.yml up -d --build --no-deps sish
+docker compose -f docker/relay/docker-compose.yml exec sish /app/app --version
 ```
 
-Data directories (`keys/`, `pubkeys/`, `caddy-data/`, `caddy-config/`) are mounted volumes and survive the upgrade.
+The version should be `v2.23.0-mship-crypto0.53.0`. Recreating sish briefly
+disconnects tunnels; clients must reconnect. This does not recreate Caddy or
+the enroll-server. Never deploy from an empty worktree's relay directory: it
+would use a different key allowlist and generate a different SSH host key.
+
+Caddy uses the `caddy:2` image. To update it separately, in the same shell:
+
+```bash
+docker compose -f docker/relay/docker-compose.yml pull caddy
+docker compose -f docker/relay/docker-compose.yml up -d --no-deps caddy
+```
+
+Existing `.env`, keys, allowlist, enrollment store, and Caddy data remain in
+the original deployment directory. The mounted data directories survive
+container recreation.
 
 ---
 

--- a/scripts/relay-bootstrap.sh
+++ b/scripts/relay-bootstrap.sh
@@ -16,9 +16,9 @@ fi
 HERE="$(cd "$(dirname "$0")/../docker/relay" && pwd)"
 mkdir -p "$HERE/pubkeys" "$HERE/keys" "$HERE/caddy-data" "$HERE/caddy-config"
 echo "[bootstrap] add client public keys to $HERE/pubkeys/ (one file per key), then:"
-echo "  RELAY_DOMAIN=$RELAY_DOMAIN ACME_EMAIL=$ACME_EMAIL docker compose -f $HERE/docker-compose.yml up -d"
+echo "  RELAY_DOMAIN=$RELAY_DOMAIN ACME_EMAIL=$ACME_EMAIL docker compose -f $HERE/docker-compose.yml up -d --build"
 echo "[bootstrap] DNS: point  *.$RELAY_DOMAIN  A record at this host's public IP."
-RELAY_DOMAIN="$RELAY_DOMAIN" ACME_EMAIL="$ACME_EMAIL" docker compose -f "$HERE/docker-compose.yml" up -d
+RELAY_DOMAIN="$RELAY_DOMAIN" ACME_EMAIL="$ACME_EMAIL" docker compose -f "$HERE/docker-compose.yml" up -d --build
 # Supervise the enroll-server: it backs Caddy's on-demand TLS `ask`, so it gates
 # cert issuance/renewal for EVERY relay subdomain, not just enrollment — keep it up.
 # Run it as the user who owns the relay dir (the operator who also runs


### PR DESCRIPTION
## Summary
- Make the default relay Compose service build a pinned sish v2.23.0 source revision with golang.org/x/crypto v0.53.0 instead of pulling the affected upstream image.
- Fix the SSH SendRequest-after-close busy loop tracked by golang/go#79717 without disabling keepalives, authentication, or idle-connection reaping.
- Pin the Go builder and upstream archive checksum, exclude runtime secrets from the build context, and bound compiler concurrency/heap growth for small relay hosts.
- Run a real closed-connection regression check during every image build. Update bootstrap and hosting instructions so fresh installs and upgrades use the same fixed build.

## Verification
- Original x/crypto v0.52.0: the regression check hangs and fails its deadline.
- Updated x/crypto v0.53.0: the same check passes; complete Docker Compose image build succeeds.
- Extracted image binary reports Go 1.26.8 and x/crypto v0.53.0.
- Isolated runtime smoke: authenticated SSH reverse tunnel forwards the expected HTTP body; disconnect removes the route and relay CPU returns to idle.
- Bootstrap shell syntax and Compose configuration validate; Go regression source is gofmt-clean.

## Deployment
Recreate only the sish service from the original deployment checkout after merge, preserving its existing .env, SSH host key, key allowlist, and runtime state. Caddy is not recreated. Tunnels briefly disconnect and must reconnect.
