### PR TITLE
Transactional SQLite core for Tasks and WorkItems

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ repair command.
 
 ## How it works
 
-Tasks live in git worktrees managed by mship and tracked in `.mothership/state.yaml`. The runtime layer (`mship run`) reads a topology from `mothership.yaml` — services, dependencies, healthchecks, `env_runner` for secret delegation, `start_mode: background` for long-running services — and brings the stack up in dependency-ordered tiers. The interface layer (`mship status`, `context`, `journal`, `dispatch`) exposes that state to agents as structured output. The coordination layer (phases, audits, the pre-commit hook, `mship finish`) keeps state consistent across sessions and across repos.
+Tasks live in git worktrees managed by mship and are tracked with WorkItems in `.mothership/mothership.db`. The runtime layer (`mship run`) reads a topology from `mothership.yaml` — services, dependencies, healthchecks, `env_runner` for secret delegation, `start_mode: background` for long-running services — and brings the stack up in dependency-ordered tiers. The interface layer (`mship status`, `context`, `journal`, `dispatch`) exposes that state to agents as structured output. The coordination layer (phases, audits, the pre-commit hook, `mship finish`) keeps state consistent across sessions and across repos. Existing workspaces keep their legacy `state.yaml` and WorkItem JSON authoritative until an explicit `mship state migrate` cutover.
 
 Agents plug into this through any MCP server or shell tool they already have. mship doesn't replace `bash`, `playwright-mcp`, or `postgres-mcp`; it tells those tools where to point and what's real.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,7 +69,8 @@ tasks:
         root = Path(sys.argv[1])
         expected_tables = {
             "storage_metadata", "tasks", "task_repos", "task_test_results",
-            "task_pr_urls", "task_switch_anchors", "task_dependencies",
+            "task_pr_urls", "task_switch_sources", "task_switch_anchors",
+            "task_dependencies",
             "work_items", "workitem_tasks", "workitem_threads",
             "workitem_external_links", "workitem_affected_repos",
             "workitem_pr_urls",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -50,6 +50,74 @@ tasks:
         uv venv "$tmp/venv" >/dev/null
         uv pip install --python "$tmp/venv/bin/python" --quiet .
         "$tmp/venv/bin/python" -c "import mship.cli"
+        "$tmp/venv/bin/python" - "$tmp" <<'PY'
+        import json
+        import subprocess
+        import sys
+        from datetime import datetime, timezone
+        from pathlib import Path
+
+        import yaml
+        from sqlalchemy import inspect
+
+        from mship.core.persistence.database import WorkspaceDatabase
+        from mship.core.persistence.migration import migrate_legacy_state
+        from mship.core.state import StateManager, Task, WorkspaceState
+        from mship.core.workitem import WorkItem
+        from mship.core.workitem_store import WorkItemStore
+
+        root = Path(sys.argv[1])
+        expected_tables = {
+            "storage_metadata", "tasks", "task_repos", "task_test_results",
+            "task_pr_urls", "task_switch_anchors", "task_dependencies",
+            "work_items", "workitem_tasks", "workitem_threads",
+            "workitem_external_links", "workitem_affected_repos",
+            "workitem_pr_urls",
+        }
+
+        fresh = root / "fresh"
+        fresh.mkdir()
+        (fresh / "mothership.yaml").write_text("workspace: installed-wheel\n")
+        fresh_database = WorkspaceDatabase(fresh / ".mothership")
+        fresh_database.initialize()
+        with fresh_database.connect() as connection:
+            assert expected_tables <= set(inspect(connection).get_table_names())
+        assert fresh_database.current_revision() == fresh_database.head_revision()
+        status = subprocess.run(
+            [str(Path(sys.executable).with_name("mship")), "--json", "state", "status"],
+            cwd=fresh, check=True, capture_output=True, text=True,
+        )
+        status_payload = json.loads(status.stdout)
+        assert status_payload["backend"] == "sqlite"
+        assert status_payload["current_revision"] == fresh_database.head_revision()
+
+        legacy = root / "legacy"
+        legacy_state_dir = legacy / ".mothership"
+        legacy_items_dir = legacy_state_dir / "workitems"
+        legacy_items_dir.mkdir(parents=True)
+        (legacy / "mothership.yaml").write_text("workspace: installed-wheel-legacy\n")
+        now = datetime(2026, 9, 7, tzinfo=timezone.utc)
+        task = Task(
+            slug="legacy-task", description="legacy", phase="dev",
+            created_at=now, affected_repos=[], branch="feat/legacy-task",
+            work_item_id="wi-legacy",
+        )
+        (legacy_state_dir / "state.yaml").write_text(
+            yaml.safe_dump(WorkspaceState(tasks={task.slug: task}).model_dump(mode="json"))
+        )
+        item = WorkItem(
+            id="wi-legacy", title="Legacy", workspace="installed-wheel-legacy",
+            kind="chore", created_at=now, updated_at=now,
+            task_slugs=[task.slug],
+        )
+        (legacy_items_dir / "wi-legacy.json").write_text(item.model_dump_json())
+        report = migrate_legacy_state(
+            legacy_state_dir, daemon_probe=lambda: None, now=now,
+        )
+        assert report.migrated is True
+        assert StateManager(legacy_state_dir).load().tasks[task.slug] == task
+        assert WorkItemStore(legacy_items_dir).get(item.id) == item
+        PY
 
   lint:
     desc: Run static analysis

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,6 +95,10 @@ mship item link-spec|link-task|link-url <id> <ref>  # attach a spec, task, or UR
 mship item link-plan <id> <path>                    # attach an implementation plan doc (feature plan-gate)
 mship item archive|unarchive <id>                   # soft-hide / restore
 
+mship state status                                  # inspect legacy/SQLite backend and schema revision
+mship state migrate                                 # explicitly cut legacy Task/WorkItem files over to SQLite
+mship state export --format json|yaml               # deterministic Task/WorkItem records on stdout
+
 mship spec new --title "title"                      # create a spec (lands in needs_review)
 mship spec draft <id> [--from-text "..."]           # emit an authoring prompt for an agent
 mship spec apply <id> --from-json <file>            # populate the spec from JSON
@@ -160,7 +164,35 @@ console exchanges that for a short-lived cookie and cleans the URL. `GET
 mship sync [--repos r]                              # fast-forward behind-only clean repos
 mship prune [--force]                               # remove orphaned worktrees
 mship export [--redacted] [--format dir|zip]        # bundle a task's journal/plan/spec/state/diffs (opt-in secret redaction)
+mship state status                                  # read-only storage backend/revision inspection
+mship state migrate                                 # validated legacy -> SQLite cutover
+mship state export --format json|yaml               # full Task/WorkItem data only
 ```
+
+### Workspace state storage
+
+`mship state status` is read-only. Its structured output contains `backend`,
+`database_path`, `current_revision`, `head_revision`, and
+`migration_required`, so operators can check compatibility before maintenance.
+
+Stop the per-user daemon before running `mship state migrate`. Migration takes
+exclusive state locks, validates every legacy Task and WorkItem, and copies the
+live legacy files to `.mothership/backups/<UTC timestamp>/`. It builds and
+verifies a candidate database before atomically activating `mothership.db`; a
+failure leaves the legacy files live and can be retried. Successful legacy
+paths are retained beside the database with a `.migrated-<UTC timestamp>`
+suffix.
+
+The cutover has no dual-write period. Once `mothership.db` is active, the
+SQLite database is authoritative and older Mothership binaries that only write
+`state.yaml` or WorkItem JSON are unsupported. A database at an unknown or
+incompatible Alembic revision is refused with the current and required
+revisions rather than being changed implicitly.
+
+`mship state export --format json` and `--format yaml` emit the same stable,
+sorted Task and WorkItem payload, including archived WorkItems. The export does
+not traverse mailbox messages, secrets, specs, journals, or artifact bytes. It
+is distinct from `mship export`, which builds a task review bundle.
 
 ## Long-running services
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -171,6 +171,11 @@ mship state export --format json|yaml               # full Task/WorkItem data on
 
 ### Workspace state storage
 
+New workspaces initialize `.mothership/mothership.db` for Task and WorkItem
+state. Existing `state.yaml` and `workitems/*.json` files remain authoritative
+legacy inputs until an explicit migration; mship never dual-writes them with
+SQLite.
+
 `mship state status` is read-only. Its structured output contains `backend`,
 `database_path`, `current_revision`, `head_revision`, and
 `migration_required`, so operators can check compatibility before maintenance.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,8 +110,9 @@ mship close
 # Closed: completed (1 prs merged): add-hello-world
 ```
 
-`close` verifies the PR state, tears down the worktrees, and clears the task
-from `.mothership/state.yaml`. The loop is complete.
+`close` verifies the PR state, tears down the worktrees, and clears the transient
+task from `.mothership/mothership.db` after retaining delivery metadata on its
+WorkItem. The loop is complete.
 
 ## Where next
 

--- a/docs/guides/agent-driven-development.md
+++ b/docs/guides/agent-driven-development.md
@@ -47,17 +47,18 @@ Two rules of thumb:
 
 - **Parallel subagents are safe to run.** Both halves are isolated: each task
   gets its own worktree and branch, so code edits never collide, and every write
-  to `state.yaml` goes through a single read-modify-write under an exclusive
-  `flock` with an atomic replace — so concurrent `journal` / `test` / `finish`
-  calls cannot lose each other's updates to it. There are multiprocessing
-  regression tests covering concurrent phase transitions and a same-slug spawn
-  race.
+  to Task and WorkItem state goes through a short SQLite transaction. WAL mode,
+  `BEGIN IMMEDIATE`, bounded busy retries, and row-targeted mutations prevent
+  concurrent `journal` / `test` / `finish` calls from losing each other's
+  updates. Lifecycle changes that touch both a Task and its WorkItem commit
+  atomically. Multiprocessing regression tests cover concurrent phase changes,
+  Task↔WorkItem linking, duplicate ownership, and same-slug spawn races.
 
-  Everything else those commands write is keyed by task, so **different tasks**
-  never contend: `mship journal` appends to `logs/<task>.md`, and a test run's
-  output, iteration JSON, and `latest.json` pointer live under
-  `.mothership/test-runs/<task>/`. Only the pass/fail status in `state.yaml` goes
-  through the lock; the run artifacts are written outside it.
+  External artifacts remain keyed by task: `mship journal` appends to
+  `logs/<task>.md`, and a test run's output, iteration JSON, and `latest.json`
+  pointer live under `.mothership/test-runs/<task>/`. Only the pass/fail status
+  is committed to `mothership.db`; file, Git, process, and network operations run
+  outside SQL transactions so a slow collaborator does not hold the writer lock.
 
   That leaves one narrow case to avoid: **two concurrent runs of the *same* task**.
   The test iteration number is chosen by scanning the run directory for its highest

--- a/docs/guides/specs-across-machines.md
+++ b/docs/guides/specs-across-machines.md
@@ -86,17 +86,21 @@ of untracked files under `specs/` is the usual cause.
 
 | State | Why it stays local |
 |---|---|
-| `state.yaml` — tasks, phases, worktrees | A task's worktrees are paths on *this* disk |
+| `mothership.db` — tasks, phases, worktrees, WorkItems | A task's worktrees and active lifecycle state belong to *this* machine |
 | `serve-token` | Each machine's serve has its own bearer |
 | `run-hosts.yaml` — role → url + token | Which machines *this* one can reach, plus their tokens |
 | `relay-runtime.json` | The tunnel this machine is running |
-| `messages/`, `workitems/` | Mailbox and work-item stores for this machine's serve |
+| `messages/` | Mailbox threads for this machine's serve |
 
 The consequence worth internalising: **tasks are machine-local**. A task you
 spawned on the devbox does not exist on the desktop — `mship status` there will
 not list it, and `mship test --task <slug>` will report an unknown task. What
 crosses machines is the *branch* (pushed to the remote) and the *spec and plan*
 (committed to the workspace repo).
+
+For an existing workspace, legacy `state.yaml` and `workitems/*.json` remain
+read-only migration inputs until `mship state migrate` atomically activates the
+database. They are not a second synchronized state store.
 
 Note what you cannot do: **`mship spawn` always derives its own branch** from the
 task slug (`branch_pattern`, e.g. `feat/<slug>`), and there is no flag to adopt an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "pyjwt[crypto]>=2.8",
     "cryptography>=50.0.0",
     "jinja2>=3.1",
+    "sqlalchemy>=2.0,<3",
+    "alembic>=1.19,<2",
 ]
 
 [project.scripts]

--- a/src/mship/cli/__init__.py
+++ b/src/mship/cli/__init__.py
@@ -118,6 +118,7 @@ from mship.cli import relay as _relay_mod
 from mship.cli import run_host as _run_host_mod
 from mship.cli import skill as _skill_mod
 from mship.cli import spec as _spec_mod
+from mship.cli import state as _state_storage_mod
 from mship.cli import status as _status_mod
 from mship.cli import switch as _switch_mod
 from mship.cli import ui as _ui_mod
@@ -188,6 +189,7 @@ _relay_mod.register(app, get_container)
 _run_host_mod.register(app, get_container)
 _skill_mod.register(app, get_container)
 _spec_mod.register(app, get_container)
+_state_storage_mod.register(app, get_container)
 _status_mod.register(app, get_container)
 _switch_mod.register(app, get_container)
 _serve_mod.register(app, get_container)

--- a/src/mship/cli/block.py
+++ b/src/mship/cli/block.py
@@ -29,11 +29,11 @@ def register(app: typer.Typer, get_container):
             )
             raise typer.Exit(code=1)
 
-        def _apply(s):
-            s.tasks[t.slug].blocked_reason = reason
-            s.tasks[t.slug].blocked_at = datetime.now(timezone.utc)
+        def _apply(task):
+            task.blocked_reason = reason
+            task.blocked_at = datetime.now(timezone.utc)
 
-        state_mgr.mutate(_apply)
+        state_mgr.mutate_task(t.slug, _apply)
 
         log_mgr = container.log_manager()
         log_mgr.append(t.slug, f"Blocked: {reason}")
@@ -65,11 +65,11 @@ def register(app: typer.Typer, get_container):
             output.error("Task is not blocked. Use `mship block \"reason\"` to mark it as blocked.")
             raise typer.Exit(code=1)
 
-        def _apply(s):
-            s.tasks[t.slug].blocked_reason = None
-            s.tasks[t.slug].blocked_at = None
+        def _apply(task):
+            task.blocked_reason = None
+            task.blocked_at = None
 
-        state_mgr.mutate(_apply)
+        state_mgr.mutate_task(t.slug, _apply)
 
         log_mgr = container.log_manager()
         log_mgr.append(t.slug, "Unblocked")

--- a/src/mship/cli/depends.py
+++ b/src/mship/cli/depends.py
@@ -64,15 +64,14 @@ def register(app: typer.Typer, get_container):
             output.error(f"Cycle detected: {' → '.join(cycle)}")
             raise typer.Exit(code=1)
 
-        def _mutate(s):
-            t = s.tasks[downstream]
+        def _mutate(t):
             if any(e.upstream_slug == upstream_slug for e in t.depends_on):
                 return  # idempotent
             t.depends_on.append(
                 DependencyEdge(upstream_slug=upstream_slug, created_at=datetime.now(timezone.utc))
             )
 
-        state_mgr.mutate(_mutate)
+        state_mgr.mutate_task(downstream, _mutate)
         if output.human_mode:
             output.success(f"{downstream} now depends on {upstream_slug}")
         else:
@@ -96,13 +95,13 @@ def register(app: typer.Typer, get_container):
             output.error(f"No edge from {downstream!r} to {upstream_slug!r}.")
             raise typer.Exit(code=1)
 
-        def _mutate(s):
-            s.tasks[downstream].depends_on = [
-                e for e in s.tasks[downstream].depends_on
+        def _mutate(task):
+            task.depends_on = [
+                e for e in task.depends_on
                 if e.upstream_slug != upstream_slug
             ]
 
-        state_mgr.mutate(_mutate)
+        state_mgr.mutate_task(downstream, _mutate)
         if output.human_mode:
             output.success(f"{downstream} no longer depends on {upstream_slug}")
         else:

--- a/src/mship/cli/exec.py
+++ b/src/mship/cli/exec.py
@@ -366,11 +366,11 @@ def register(app: typer.Typer, get_container):
         )
 
         # Persist iteration on task (read-modify-write under the lock).
-        def _record(s):
-            s.tasks[t.slug].test_iteration = new_iter
+        def _record(task):
+            task.test_iteration = new_iter
             # Agent-agnostic activity heartbeat: running tests is task work.
-            s.tasks[t.slug].last_activity_at = datetime.now(timezone.utc)
-        state_mgr.mutate(_record)
+            task.last_activity_at = datetime.now(timezone.utc)
+        state_mgr.mutate_task(t.slug, _record)
 
         prune(state_dir, t.slug, keep=20)
 

--- a/src/mship/cli/init.py
+++ b/src/mship/cli/init.py
@@ -199,6 +199,7 @@ def register(app: typer.Typer, get_container):
             raise typer.Exit(code=1)
 
         initializer.write_config(config_path, config)
+        initializer.initialize_storage(cwd / ".mothership")
 
         config = ConfigLoader.load(config_path, require_paths=False)
         # Scaffold Taskfiles
@@ -409,6 +410,7 @@ def _run_interactive(
         raise typer.Exit(code=1)
 
     initializer.write_config(config_path, config)
+    initializer.initialize_storage(cwd / ".mothership")
     config = ConfigLoader.load(config_path, require_paths=False)
 
     # Install pre-commit hooks on each effective git root

--- a/src/mship/cli/init.py
+++ b/src/mship/cli/init.py
@@ -16,6 +16,7 @@ from mship.core.codex_hooks import (
     probe_codex_hook_capability,
 )
 from mship.core.omp_extension import install_omp_extension
+from mship.core.workspace_context import _resolve_state_dir
 from mship.util.shell import ShellRunner
 
 
@@ -199,7 +200,7 @@ def register(app: typer.Typer, get_container):
             raise typer.Exit(code=1)
 
         initializer.write_config(config_path, config)
-        initializer.initialize_storage(cwd / ".mothership")
+        initializer.initialize_storage(_resolve_state_dir(config_path))
 
         config = ConfigLoader.load(config_path, require_paths=False)
         # Scaffold Taskfiles
@@ -410,7 +411,7 @@ def _run_interactive(
         raise typer.Exit(code=1)
 
     initializer.write_config(config_path, config)
-    initializer.initialize_storage(cwd / ".mothership")
+    initializer.initialize_storage(_resolve_state_dir(config_path))
     config = ConfigLoader.load(config_path, require_paths=False)
 
     # Install pre-commit hooks on each effective git root

--- a/src/mship/cli/state.py
+++ b/src/mship/cli/state.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+
+import typer
+from pydantic import ValidationError
+
+from mship.cli.output import Output
+from mship.core.persistence.database import DatabaseRevisionError
+from mship.core.persistence.export import export_state, storage_status
+from mship.core.persistence.migration import (
+    MigrationPreflightError,
+    MigrationVerificationError,
+    migrate_legacy_state,
+)
+
+
+def _state_dir(get_container):
+    container = get_container()
+    return container.state_dir()
+
+
+def _fail(out: Output, error: Exception) -> None:
+    out.error(str(error))
+    raise typer.Exit(1)
+
+
+def register(parent: typer.Typer, get_container) -> None:
+    state_app = typer.Typer(
+        help="Inspect, migrate, and export workspace state storage.",
+        no_args_is_help=True,
+    )
+
+    @state_app.command("status")
+    def status() -> None:
+        """Show the active backend and schema revision without changing state."""
+        out = Output()
+        try:
+            result = storage_status(_state_dir(get_container))
+        except (DatabaseRevisionError, OSError) as error:
+            _fail(out, error)
+        payload = result.as_dict()
+        if out.json_mode:
+            out.json(payload)
+            return
+        out.print(
+            "\n".join(
+                (
+                    f"backend: {payload['backend']}",
+                    f"database: {payload['database_path']}",
+                    f"revision: {payload['current_revision'] or '-'}",
+                    f"head revision: {payload['head_revision']}",
+                    f"migration required: {str(payload['migration_required']).lower()}",
+                )
+            )
+        )
+
+    @state_app.command("migrate")
+    def migrate() -> None:
+        """Explicitly replace validated legacy files with transactional SQLite."""
+        out = Output()
+        try:
+            report = migrate_legacy_state(_state_dir(get_container))
+        except (
+            DatabaseRevisionError,
+            MigrationPreflightError,
+            MigrationVerificationError,
+            OSError,
+            ValidationError,
+            ValueError,
+        ) as error:
+            _fail(out, error)
+        payload = asdict(report)
+        if out.json_mode:
+            out.json(payload)
+            return
+        action = "migrated" if report.migrated else "already migrated"
+        backup = str(report.backup_path) if report.backup_path else "none"
+        out.success(
+            f"{action}: {report.database_path}\n"
+            f"revision: {report.revision}\n"
+            f"tasks: {report.tasks}; work items: {report.work_items}\n"
+            f"backup: {backup}"
+        )
+
+    @state_app.command("export")
+    def export(
+        format: str = typer.Option(
+            "json",
+            "--format",
+            help="Output format: json or yaml.",
+        ),
+    ) -> None:
+        """Export deterministic Task and WorkItem records to stdout."""
+        out = Output()
+        try:
+            rendered = export_state(
+                _state_dir(get_container),
+                format=format.lower(),
+            )
+        except (DatabaseRevisionError, OSError, ValidationError, ValueError) as error:
+            _fail(out, error)
+        typer.echo(rendered, nl=False)
+
+    parent.add_typer(
+        state_app,
+        name="state",
+        rich_help_panel="Work items & specs",
+    )

--- a/src/mship/cli/switch.py
+++ b/src/mship/cli/switch.py
@@ -56,11 +56,11 @@ def register(app: typer.Typer, get_container):
                 if result.returncode == 0 and result.stdout.strip():
                     snapshot[dep_name] = result.stdout.strip()
 
-            def _apply(s):
-                s.tasks[t.slug].active_repo = target
-                s.tasks[t.slug].last_switched_at_sha[target] = snapshot
+            def _apply(task):
+                task.active_repo = target
+                task.last_switched_at_sha[target] = snapshot
 
-            state_mgr.mutate(_apply)
+            state_mgr.mutate_task(t.slug, _apply)
 
         handoff = build_handoff(config, state_mgr.load(), shell, log_mgr, repo=target, task_slug=t.slug)
 

--- a/src/mship/cli/workitem.py
+++ b/src/mship/cli/workitem.py
@@ -251,7 +251,13 @@ def register(parent: typer.Typer, get_container) -> None:
     def link_task(item_id: str, task_slug: str):
         items, _, state_manager, _, _ = _ctx()
         _guard(items, item_id)
-        items.add_task(item_id, task_slug, now=datetime.now(timezone.utc), state=state_manager)
+        from mship.core.persistence.lifecycle_repository import LifecycleRepository
+
+        LifecycleRepository(state_manager.workspace_store).link_task(
+            item_id,
+            task_slug,
+            now=datetime.now(timezone.utc),
+        )
         typer.echo(f"linked task {task_slug} -> {item_id}")
 
     @item_app.command("link-issue")

--- a/src/mship/cli/workitem.py
+++ b/src/mship/cli/workitem.py
@@ -419,13 +419,17 @@ def register(parent: typer.Typer, get_container) -> None:
 
         def mark_blocked(item, reason):
             stamp = now()
+            live_slugs = [
+                slug for slug in item.task_slugs if slug in snapshot.tasks
+            ]
 
-            def _apply(s):
-                for slug in item.task_slugs:
-                    if slug in s.tasks:
-                        s.tasks[slug].blocked_reason = reason
-                        s.tasks[slug].blocked_at = stamp
-            state_manager.mutate(_apply)
+            def _apply(tasks):
+                for task in tasks.values():
+                    task.blocked_reason = reason
+                    task.blocked_at = stamp
+
+            if live_slugs:
+                state_manager.mutate_tasks(live_slugs, _apply)
 
         def push_branch(item):
             """Push the item's task branch to origin from each existing worktree, so

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1153,13 +1153,11 @@ def register(app: typer.Typer, get_container):
             raise typer.Exit(code=1)
 
         if downstream and detach_downstream:
-            def _detach(s):
-                for d_slug in downstream:
-                    t = s.tasks.get(d_slug)
-                    if t is None:
-                        continue
+            def _detach(tasks):
+                for t in tasks.values():
                     t.depends_on = [e for e in t.depends_on if e.upstream_slug != task.slug]
-            state_mgr.mutate(_detach)
+
+            state_mgr.mutate_tasks(downstream, _detach)
         elif downstream and cascade:
             # Cascaded tasks are removed directly rather than through
             # WorktreeManager.abort, so retain their observed delivery metadata
@@ -1182,20 +1180,14 @@ def register(app: typer.Typer, get_container):
                             workitems_dir=workitems_dir,
                         )
 
-                def _cascade(s):
-                    tasks_to_remove = []
-                    for d_slug in downstream:
-                        downstream_task = s.tasks.get(d_slug)
-                        if downstream_task is None:
-                            continue
+                def _cascade(tasks):
+                    for d_slug, downstream_task in list(tasks.items()):
                         require_retained_task_metadata(
                             downstream_task, retained_by_slug.get(d_slug),
                         )
-                        tasks_to_remove.append(d_slug)
-                    for d_slug in tasks_to_remove:
-                        del s.tasks[d_slug]
+                        del tasks[d_slug]
 
-                state_mgr.mutate(_cascade)
+                state_mgr.mutate_tasks(retained_by_slug, _cascade)
             except TaskMetadataRetentionConflictError as e:
                 output.error(str(e))
                 raise typer.Exit(code=1)
@@ -1612,10 +1604,10 @@ def register(app: typer.Typer, get_container):
             if task.finished_at is None:
                 now = _dt.now(_tz.utc)
 
-                def _stamp_push_only(s):
-                    s.tasks[t.slug].finished_at = now
+                def _stamp_push_only(task):
+                    task.finished_at = now
 
-                state_mgr.mutate(_stamp_push_only)
+                state_mgr.mutate_task(t.slug, _stamp_push_only)
                 task.finished_at = now
 
             if output.is_tty:
@@ -2051,10 +2043,10 @@ def register(app: typer.Typer, get_container):
                     raise typer.Exit(code=1)
 
             # Store URL on every group member (crash-safe: single state mutation).
-            def _record_group(s, members=list(group.members), u=pr_url):
+            def _record_group(task, members=list(group.members), u=pr_url):
                 for name in members:
-                    s.tasks[t.slug].pr_urls[name] = u
-            state_mgr.mutate(_record_group)
+                    task.pr_urls[name] = u
+            state_mgr.mutate_task(t.slug, _record_group)
             for name in group.members:
                 task.pr_urls[name] = pr_url
 
@@ -2139,10 +2131,10 @@ def register(app: typer.Typer, get_container):
         if task.finished_at is None or force:
             now = _dt.now(_tz.utc)
 
-            def _stamp_finished(s):
-                s.tasks[t.slug].finished_at = now
+            def _stamp_finished(task):
+                task.finished_at = now
 
-            state_mgr.mutate(_stamp_finished)
+            state_mgr.mutate_task(t.slug, _stamp_finished)
             task.finished_at = now
 
         if output.is_tty:

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -2043,6 +2043,7 @@ def register(app: typer.Typer, get_container):
                 t.slug,
                 {name: pr_url for name in group.members},
                 now=_dt_pr.now(_tz_pr.utc),
+                allow_unreadable_workitem=hotfix,
             )
 
             pr_list.append({

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1079,7 +1079,7 @@ def register(app: typer.Typer, get_container):
             _ws_root = Path(container.config_path()).parent
             advance_workitem_on_close(
                 task=task,
-                workitems_dir=_ws_root / ".mothership" / "workitems",
+                workitems=container.workitem_store(),
                 specs_dir=_ws_root / SPECS_DIRNAME,
                 state=state,
                 merged_count=merged_count,
@@ -1095,7 +1095,7 @@ def register(app: typer.Typer, get_container):
             from mship.core.issue_close import close_linked_issues
             close_linked_issues(
                 task=task,
-                workitems_dir=Path(container.config_path()).parent / ".mothership" / "workitems",
+                workitems=container.workitem_store(),
                 pr_manager=container.pr_manager(),
                 merged_count=merged_count,
                 closed_count=closed_count,
@@ -1400,8 +1400,14 @@ def register(app: typer.Typer, get_container):
         # cleanly via output.error rather than a traceback.
         from mship.core import workitem_gate
         workspace_root = container.config_path().parent
+        canonical_workitems = container.workitem_store()
         try:
-            gate_result = workitem_gate.check_task_gate(task, workspace_root, require_plan=True)
+            gate_result = workitem_gate.check_task_gate(
+                task,
+                workspace_root,
+                require_plan=True,
+                workitems=canonical_workitems,
+            )
         except Exception as e:
             gate_result = workitem_gate.GateResult(
                 False, f"couldn't evaluate WorkItem gate (corrupt store?): {e}"
@@ -1421,8 +1427,7 @@ def register(app: typer.Typer, get_container):
         if getattr(task, "work_item_id", None):
             try:
                 from mship.core.issue_link import linked_issue_refs
-                from mship.core.workitem_store import WorkItemStore
-                _wi = WorkItemStore(workspace_root / ".mothership" / "workitems").get(task.work_item_id)
+                _wi = canonical_workitems.get(task.work_item_id)
                 if _wi is not None:
                     linked_issue_canonicals = linked_issue_refs(_wi)
             except Exception as e:
@@ -1755,7 +1760,7 @@ def register(app: typer.Typer, get_container):
         # reused by the PR-body assembly below (build_acceptance_block).
         from mship.core.workitem_gate import resolve_bound_spec
         try:
-            bound_spec = resolve_bound_spec(task, workspace_root)
+            bound_spec = resolve_bound_spec(task, workspace_root, workitems=canonical_workitems)
         except Exception as e:
             # The bound spec should exist but couldn't be resolved (ambiguous slug,
             # missing linked spec, or a corrupt store). Never SILENTLY skip a required
@@ -2095,10 +2100,9 @@ def register(app: typer.Typer, get_container):
             from datetime import datetime as _dt_ann, timezone as _tz_ann
             from mship.core.message_store import MessageStore
             from mship.core.pr_watcher import announce_prs_on_thread
-            from mship.core.workitem_store import WorkItemStore
             _md = workspace_root / ".mothership"
             announce_prs_on_thread(
-                MessageStore(_md / "messages"), WorkItemStore(_md / "workitems"),
+                MessageStore(_md / "messages"), canonical_workitems,
                 t.slug, task, pr_list, _dt_ann.now(_tz_ann.utc),
             )
         except Exception as e:

--- a/src/mship/cli/worktree.py
+++ b/src/mship/cli/worktree.py
@@ -1159,35 +1159,24 @@ def register(app: typer.Typer, get_container):
 
             state_mgr.mutate_tasks(downstream, _detach)
         elif downstream and cascade:
-            # Cascaded tasks are removed directly rather than through
-            # WorktreeManager.abort, so retain their observed delivery metadata
-            # before dropping their only live state copy. Never take item locks
-            # while StateManager.mutate holds state.lock.
-            from mship.core.workitem_lifecycle import (
-                require_retained_task_metadata,
-                retain_workitem_metadata_on_teardown,
+            from datetime import datetime as _dt_cascade, timezone as _tz_cascade
+
+            from mship.core.persistence.lifecycle_repository import (
+                LifecycleRepository,
             )
 
             try:
-                workitems_dir = Path(container.state_dir()) / "workitems"
-                retained_by_slug = {}
                 state_before_cascade = state_mgr.load()
-                for d_slug in downstream:
-                    downstream_task = state_before_cascade.tasks.get(d_slug)
-                    if downstream_task is not None:
-                        retained_by_slug[d_slug] = retain_workitem_metadata_on_teardown(
-                            task=downstream_task,
-                            workitems_dir=workitems_dir,
-                        )
-
-                def _cascade(tasks):
-                    for d_slug, downstream_task in list(tasks.items()):
-                        require_retained_task_metadata(
-                            downstream_task, retained_by_slug.get(d_slug),
-                        )
-                        del tasks[d_slug]
-
-                state_mgr.mutate_tasks(retained_by_slug, _cascade)
+                lifecycle = LifecycleRepository(state_mgr.workspace_store)
+                expected_downstream = {
+                    d_slug: state_before_cascade.tasks[d_slug]
+                    for d_slug in downstream
+                    if d_slug in state_before_cascade.tasks
+                }
+                lifecycle.retain_and_delete_tasks(
+                    expected_downstream,
+                    now=_dt_cascade.now(_tz_cascade.utc),
+                )
             except TaskMetadataRetentionConflictError as e:
                 output.error(str(e))
                 raise typer.Exit(code=1)
@@ -1381,6 +1370,10 @@ def register(app: typer.Typer, get_container):
         resolved_finish = resolve_for_command("finish", state, task, output)
         t = resolved_finish.task
         task = t
+
+        from mship.core.persistence.lifecycle_repository import LifecycleRepository
+
+        lifecycle = LifecycleRepository(state_mgr.workspace_store)
 
         # Scoped to this task only — drift on another, unrelated task must not
         # block this one's finish (#455 Part 2).
@@ -2042,13 +2035,15 @@ def register(app: typer.Typer, get_container):
                     output.error(f"{group.rep_name}: {e}")
                     raise typer.Exit(code=1)
 
-            # Store URL on every group member (crash-safe: single state mutation).
-            def _record_group(task, members=list(group.members), u=pr_url):
-                for name in members:
-                    task.pr_urls[name] = u
-            state_mgr.mutate_task(t.slug, _record_group)
-            for name in group.members:
-                task.pr_urls[name] = pr_url
+            # GitHub work is complete before SQL begins. Mirror the URL to the
+            # Task and its WorkItem in one short transaction.
+            from datetime import datetime as _dt_pr, timezone as _tz_pr
+
+            task = lifecycle.record_pr_urls(
+                t.slug,
+                {name: pr_url for name in group.members},
+                now=_dt_pr.now(_tz_pr.utc),
+            )
 
             pr_list.append({
                 "repo": group.rep_name,

--- a/src/mship/container.py
+++ b/src/mship/container.py
@@ -8,9 +8,12 @@ from mship.core.healthcheck import HealthcheckRunner
 from mship.core.graph import DependencyGraph
 from mship.core.log import LogManager
 from mship.core.phase import PhaseManager
+from mship.core.persistence.database import WorkspaceDatabase
+from mship.core.persistence.workspace_store import WorkspaceStore
 from mship.core.state import StateManager
 from mship.core.pr import PRManager
 from mship.core.prune import PruneManager
+from mship.core.workitem_store import WorkItemStore
 from mship.core.worktree import WorktreeManager
 from mship.util.git import GitRunner
 from mship.util.shell import ShellRunner
@@ -25,9 +28,29 @@ class Container(containers.DeclarativeContainer):
         path=config_path,
     )
 
+    workspace_database = providers.Singleton(
+        WorkspaceDatabase,
+        state_dir=state_dir,
+    )
+
+    workspace_store = providers.Singleton(
+        WorkspaceStore,
+        state_dir=state_dir,
+        database=workspace_database,
+    )
+
     state_manager = providers.Singleton(
         StateManager,
-        state_dir=state_dir,
+        workspace_store=workspace_store,
+    )
+
+    workitem_store = providers.Factory(
+        WorkItemStore,
+        workitems_dir=providers.Factory(
+            lambda state_dir: Path(state_dir) / "workitems",
+            state_dir,
+        ),
+        workspace_store=workspace_store,
     )
 
     git = providers.Singleton(GitRunner)

--- a/src/mship/core/daemon/status.py
+++ b/src/mship/core/daemon/status.py
@@ -7,6 +7,7 @@ supervisor state.
 """
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -36,6 +37,11 @@ def probe_daemon(*, home: Path, env: Mapping[str, str]) -> dict | None:
     if record is not None and record.socket_path:
         return probe_control_socket(record.socket_path)
     return probe_control_socket(daemon_socket_path(env, home))
+
+
+def daemon_is_running() -> bool:
+    """Return whether maintenance must treat the per-user daemon as active."""
+    return probe_daemon(home=Path.home(), env=os.environ) is not None
 
 
 _LOOP_WINDOW_S = 600

--- a/src/mship/core/executor.py
+++ b/src/mship/core/executor.py
@@ -352,14 +352,17 @@ class RepoExecutor:
                         pre_skips.append(self._make_skip_result(m, "test"))
             if pre_skips:
                 if task_slug:
-                    def _record_pre_skips(s, _results=pre_skips, _slug=task_slug):
-                        task = s.tasks.get(_slug)
-                        if task is None:
-                            return
+                    def _record_pre_skips(task, _results=pre_skips):
                         now = datetime.now(timezone.utc)
                         for rr in _results:
                             task.test_results[rr.repo] = TestResult(status="skip", at=now)
-                    self._state_manager.mutate(_record_pre_skips)
+                    try:
+                        self._state_manager.mutate_task(
+                            task_slug,
+                            _record_pre_skips,
+                        )
+                    except KeyError:
+                        pass
                 result.results.extend(pre_skips)
             repos = run_repos
 
@@ -456,10 +459,7 @@ class RepoExecutor:
 
             # Batch-save test results for this tier
             if task_slug and canonical_task == "test":
-                def _apply_test_results(s, _results=tier_results, _slug=task_slug):
-                    task = s.tasks.get(_slug)
-                    if task is None:
-                        return
+                def _apply_test_results(task, _results=tier_results):
                     now = datetime.now(timezone.utc)
                     for repo_result in _results:
                         if repo_result.skipped:
@@ -472,7 +472,13 @@ class RepoExecutor:
                             status=status,
                             at=now,
                         )
-                self._state_manager.mutate(_apply_test_results)
+                try:
+                    self._state_manager.mutate_task(
+                        task_slug,
+                        _apply_test_results,
+                    )
+                except KeyError:
+                    pass
 
             # Fail-fast between tiers
             tier_success = all(r.success for r in tier_results)

--- a/src/mship/core/export.py
+++ b/src/mship/core/export.py
@@ -379,9 +379,11 @@ def _render_journal(task_slug: str, entries: list) -> str:
 
 
 def _task_state_data(task: "Task") -> dict:
-    """A task's state slice as a plain JSON-serializable dict, the same shape
-    StateManager persists to state.yaml (worktrees as plain strings,
-    passive_repos sorted)."""
+    """Return a stable JSON-serializable task slice for review exports.
+
+    Paths become plain strings and ``passive_repos`` is sorted independently
+    of the normalized SQLite persistence representation.
+    """
     data = task.model_dump(mode="json")
     data["worktrees"] = {k: str(v) for k, v in task.worktrees.items()}
     if "passive_repos" in data:

--- a/src/mship/core/init.py
+++ b/src/mship/core/init.py
@@ -6,6 +6,7 @@ import yaml
 
 from mship.core.config import RepoConfig, WorkspaceConfig, resolve_go_task_files
 from mship.core.persistence.workspace_store import WorkspaceStore
+from mship.util.git import GitRunner
 
 
 REPO_MARKERS = [
@@ -243,6 +244,7 @@ tasks:
 
     def initialize_storage(self, state_dir: Path) -> bool:
         """Initialize SQLite only when the workspace has no active storage."""
+        GitRunner().add_to_gitignore(state_dir.parent, ".mothership/")
         return WorkspaceStore(state_dir).initialize_if_empty()
 
     def write_taskfile(self, repo_path: Path) -> TaskfileWriteResult:

--- a/src/mship/core/init.py
+++ b/src/mship/core/init.py
@@ -5,6 +5,7 @@ from typing import Literal
 import yaml
 
 from mship.core.config import RepoConfig, WorkspaceConfig, resolve_go_task_files
+from mship.core.persistence.workspace_store import WorkspaceStore
 
 
 REPO_MARKERS = [
@@ -239,6 +240,10 @@ tasks:
 
         with open(path, "w") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+    def initialize_storage(self, state_dir: Path) -> bool:
+        """Initialize SQLite only when the workspace has no active storage."""
+        return WorkspaceStore(state_dir).initialize_if_empty()
 
     def write_taskfile(self, repo_path: Path) -> TaskfileWriteResult:
         """Write a starter Taskfile.yml only when NO go-task file already resolves

--- a/src/mship/core/issue_close.py
+++ b/src/mship/core/issue_close.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from mship.core.workitem_store import WorkItemStore
+
 _PR_URL = re.compile(r"https?://github\.com/([\w.-]+)/([\w.-]+)/pull/(\d+)")
 
 
@@ -20,7 +22,8 @@ def _shipped_comment(pr_url: str) -> str:
     return "Shipped (PR merged)."
 
 
-def close_linked_issues(*, task, workitems_dir, pr_manager,
+def close_linked_issues(*, task, workitems_dir: Path | None = None,
+                        workitems: WorkItemStore | None = None, pr_manager,
                         merged_count: int, closed_count: int, warn,
                         open_count: int = 0) -> dict:
     """Close every still-open GitHub issue linked to the task's WorkItem.
@@ -39,9 +42,13 @@ def close_linked_issues(*, task, workitems_dir, pr_manager,
     try:
         from mship.core.issue_link import linked_issue_refs
         from mship.core.issue_refs import issue_slug_and_number
-        from mship.core.workitem_store import WorkItemStore
-
-        item = WorkItemStore(Path(workitems_dir)).get(task.work_item_id)
+        if workitems is not None:
+            store = workitems
+        elif workitems_dir is not None:
+            store = WorkItemStore(workitems_dir)
+        else:
+            raise TypeError("workitems or workitems_dir is required")
+        item = store.get(task.work_item_id)
         if item is None:
             return result
         refs = linked_issue_refs(item)

--- a/src/mship/core/persistence/__init__.py
+++ b/src/mship/core/persistence/__init__.py
@@ -1,0 +1,19 @@
+"""Transactional persistence primitives for workspace state."""
+
+from mship.core.persistence.database import (
+    BUSY_TIMEOUT_MS,
+    DB_FILENAME,
+    DatabaseBusyError,
+    DatabaseRevisionError,
+    WorkspaceDatabase,
+    make_alembic_config,
+)
+
+__all__ = [
+    "BUSY_TIMEOUT_MS",
+    "DB_FILENAME",
+    "DatabaseBusyError",
+    "DatabaseRevisionError",
+    "WorkspaceDatabase",
+    "make_alembic_config",
+]

--- a/src/mship/core/persistence/alembic/__init__.py
+++ b/src/mship/core/persistence/alembic/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged Alembic environment for Mothership workspace state."""

--- a/src/mship/core/persistence/alembic/env.py
+++ b/src/mship/core/persistence/alembic/env.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import Connection, create_engine
+from sqlalchemy.engine import Engine
+
+from mship.core.persistence.database import (
+    BUSY_TIMEOUT_MS,
+    install_sqlite_policy,
+)
+from mship.core.persistence.schema import metadata
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=config.get_main_option("sqlalchemy.url"),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_with_connection(connection: Connection) -> None:
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        compare_type=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    supplied = config.attributes.get("connection")
+    if supplied is not None:
+        run_with_connection(supplied)
+        return
+
+    engine: Engine = create_engine(
+        config.get_main_option("sqlalchemy.url"),
+        connect_args={
+            "autocommit": False,
+            "timeout": BUSY_TIMEOUT_MS / 1_000,
+        },
+    )
+    install_sqlite_policy(engine)
+    try:
+        with engine.connect() as connection:
+            run_with_connection(connection)
+    finally:
+        engine.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/src/mship/core/persistence/alembic/script.py.mako
+++ b/src/mship/core/persistence/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/src/mship/core/persistence/alembic/versions/0001_tasks_and_workitems.py
+++ b/src/mship/core/persistence/alembic/versions/0001_tasks_and_workitems.py
@@ -1,0 +1,342 @@
+"""Create transactional Task and WorkItem storage.
+
+Revision ID: 0001_tasks_and_workitems
+Revises:
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0001_tasks_and_workitems"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "storage_metadata",
+        sa.Column("key", sa.Text(), nullable=False),
+        sa.Column("value", sa.Text(), nullable=False),
+        sa.Column("updated_at", sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint("key", name="pk_storage_metadata"),
+    )
+    op.create_table(
+        "tasks",
+        sa.Column("slug", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("phase", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.Column("branch", sa.Text(), nullable=False),
+        sa.Column("blocked_reason", sa.Text()),
+        sa.Column("blocked_at", sa.Text()),
+        sa.Column("finished_at", sa.Text()),
+        sa.Column("phase_entered_at", sa.Text()),
+        sa.Column("last_activity_at", sa.Text()),
+        sa.Column("active_repo", sa.Text()),
+        sa.Column("test_iteration", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("base_branch", sa.Text()),
+        sa.Column("base_override", sa.Text()),
+        sa.Column("spec_id", sa.Text()),
+        sa.Column("work_item_id", sa.Text()),
+        sa.Column("revision", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.CheckConstraint(
+            "phase IN ('plan', 'dev', 'review', 'run')",
+            name="ck_tasks_phase",
+        ),
+        sa.CheckConstraint(
+            "test_iteration >= 0",
+            name="ck_tasks_test_iteration_non_negative",
+        ),
+        sa.CheckConstraint(
+            "revision >= 0",
+            name="ck_tasks_revision_non_negative",
+        ),
+        sa.PrimaryKeyConstraint("slug", name="pk_tasks"),
+    )
+    op.create_table(
+        "task_repos",
+        sa.Column("task_slug", sa.Text(), nullable=False),
+        sa.Column("repo_name", sa.Text(), nullable=False),
+        sa.Column("affected_ordinal", sa.Integer()),
+        sa.Column("passive", sa.Boolean(), server_default=sa.text("0"), nullable=False),
+        sa.Column("worktree_path", sa.Text()),
+        sa.CheckConstraint(
+            "affected_ordinal IS NULL OR affected_ordinal >= 0",
+            name="ck_task_repos_affected_ordinal_non_negative",
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_slug"],
+            ["tasks.slug"],
+            name="fk_task_repos_task_slug_tasks",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("task_slug", "repo_name", name="pk_task_repos"),
+        sa.UniqueConstraint(
+            "task_slug",
+            "affected_ordinal",
+            name="uq_task_repos_task_slug",
+        ),
+    )
+    op.create_table(
+        "task_test_results",
+        sa.Column("task_slug", sa.Text(), nullable=False),
+        sa.Column("repo_name", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("at", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('pass', 'fail', 'skip')",
+            name="ck_task_test_results_status",
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_slug"],
+            ["tasks.slug"],
+            name="fk_task_test_results_task_slug_tasks",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "task_slug",
+            "repo_name",
+            name="pk_task_test_results",
+        ),
+    )
+    op.create_table(
+        "task_pr_urls",
+        sa.Column("task_slug", sa.Text(), nullable=False),
+        sa.Column("repo_name", sa.Text(), nullable=False),
+        sa.Column("url", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["task_slug"],
+            ["tasks.slug"],
+            name="fk_task_pr_urls_task_slug_tasks",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("task_slug", "repo_name", name="pk_task_pr_urls"),
+    )
+    op.create_table(
+        "task_switch_anchors",
+        sa.Column("task_slug", sa.Text(), nullable=False),
+        sa.Column("source_repo", sa.Text(), nullable=False),
+        sa.Column("dependency_repo", sa.Text(), nullable=False),
+        sa.Column("sha", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["task_slug"],
+            ["tasks.slug"],
+            name="fk_task_switch_anchors_task_slug_tasks",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "task_slug",
+            "source_repo",
+            "dependency_repo",
+            name="pk_task_switch_anchors",
+        ),
+    )
+    op.create_table(
+        "task_dependencies",
+        sa.Column("task_slug", sa.Text(), nullable=False),
+        sa.Column("upstream_slug", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "task_slug <> upstream_slug",
+            name="ck_task_dependencies_not_self",
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_slug"],
+            ["tasks.slug"],
+            name="fk_task_dependencies_task_slug_tasks",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["upstream_slug"],
+            ["tasks.slug"],
+            name="fk_task_dependencies_upstream_slug_tasks",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "task_slug",
+            "upstream_slug",
+            name="pk_task_dependencies",
+        ),
+    )
+    op.create_table(
+        "work_items",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("workspace", sa.Text(), nullable=False),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.Column("updated_at", sa.Text(), nullable=False),
+        sa.Column("spec_id", sa.Text()),
+        sa.Column("plan_path", sa.Text()),
+        sa.Column("phase_override", sa.Text()),
+        sa.Column("unattended", sa.Boolean(), server_default=sa.text("0"), nullable=False),
+        sa.Column("archived", sa.Boolean(), server_default=sa.text("0"), nullable=False),
+        sa.Column("revision", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("extras_json", sa.Text(), server_default=sa.text("'{}'"), nullable=False),
+        sa.CheckConstraint(
+            "kind IN ('feature', 'bug', 'chore', 'question')",
+            name="ck_work_items_kind",
+        ),
+        sa.CheckConstraint(
+            "phase_override IS NULL OR "
+            "phase_override IN ('inbox', 'shaping', 'ready', 'in_flight', 'review', 'done')",
+            name="ck_work_items_phase_override",
+        ),
+        sa.CheckConstraint(
+            "revision >= 0",
+            name="ck_work_items_revision_non_negative",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_work_items"),
+    )
+    op.create_table(
+        "workitem_tasks",
+        sa.Column("work_item_id", sa.Text(), nullable=False),
+        sa.Column("task_slug", sa.Text(), nullable=False),
+        sa.Column("ordinal", sa.Integer(), nullable=False),
+        sa.CheckConstraint(
+            "ordinal >= 0",
+            name="ck_workitem_tasks_ordinal_non_negative",
+        ),
+        sa.ForeignKeyConstraint(
+            ["work_item_id"],
+            ["work_items.id"],
+            name="fk_workitem_tasks_work_item_id_work_items",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "work_item_id",
+            "task_slug",
+            name="pk_workitem_tasks",
+        ),
+        sa.UniqueConstraint(
+            "work_item_id",
+            "ordinal",
+            name="uq_workitem_tasks_work_item_id",
+        ),
+        sa.UniqueConstraint("task_slug", name="uq_workitem_tasks_task_slug"),
+    )
+    op.create_table(
+        "workitem_threads",
+        sa.Column("work_item_id", sa.Text(), nullable=False),
+        sa.Column("thread_id", sa.Text(), nullable=False),
+        sa.Column("ordinal", sa.Integer(), nullable=False),
+        sa.CheckConstraint(
+            "ordinal >= 0",
+            name="ck_workitem_threads_ordinal_non_negative",
+        ),
+        sa.ForeignKeyConstraint(
+            ["work_item_id"],
+            ["work_items.id"],
+            name="fk_workitem_threads_work_item_id_work_items",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "work_item_id",
+            "thread_id",
+            name="pk_workitem_threads",
+        ),
+        sa.UniqueConstraint(
+            "work_item_id",
+            "ordinal",
+            name="uq_workitem_threads_work_item_id",
+        ),
+        sa.UniqueConstraint("thread_id", name="uq_workitem_threads_thread_id"),
+    )
+    op.create_table(
+        "workitem_external_links",
+        sa.Column("work_item_id", sa.Text(), nullable=False),
+        sa.Column("ordinal", sa.Integer(), nullable=False),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("url", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), server_default=sa.text("''"), nullable=False),
+        sa.CheckConstraint(
+            "ordinal >= 0",
+            name="ck_workitem_external_links_ordinal_non_negative",
+        ),
+        sa.CheckConstraint(
+            "provider IN ('github', 'linear', 'notion', 'jira', 'url')",
+            name="ck_workitem_external_links_provider",
+        ),
+        sa.ForeignKeyConstraint(
+            ["work_item_id"],
+            ["work_items.id"],
+            name="fk_workitem_external_links_work_item_id_work_items",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "work_item_id",
+            "ordinal",
+            name="pk_workitem_external_links",
+        ),
+    )
+    op.create_table(
+        "workitem_affected_repos",
+        sa.Column("work_item_id", sa.Text(), nullable=False),
+        sa.Column("repo_name", sa.Text(), nullable=False),
+        sa.Column("ordinal", sa.Integer(), nullable=False),
+        sa.CheckConstraint(
+            "ordinal >= 0",
+            name="ck_workitem_affected_repos_ordinal_non_negative",
+        ),
+        sa.ForeignKeyConstraint(
+            ["work_item_id"],
+            ["work_items.id"],
+            name="fk_workitem_affected_repos_work_item_id_work_items",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "work_item_id",
+            "repo_name",
+            name="pk_workitem_affected_repos",
+        ),
+        sa.UniqueConstraint(
+            "work_item_id",
+            "ordinal",
+            name="uq_workitem_affected_repos_work_item_id",
+        ),
+    )
+    op.create_table(
+        "workitem_pr_urls",
+        sa.Column("work_item_id", sa.Text(), nullable=False),
+        sa.Column("url", sa.Text(), nullable=False),
+        sa.Column("ordinal", sa.Integer(), nullable=False),
+        sa.CheckConstraint(
+            "ordinal >= 0",
+            name="ck_workitem_pr_urls_ordinal_non_negative",
+        ),
+        sa.ForeignKeyConstraint(
+            ["work_item_id"],
+            ["work_items.id"],
+            name="fk_workitem_pr_urls_work_item_id_work_items",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "work_item_id",
+            "url",
+            name="pk_workitem_pr_urls",
+        ),
+        sa.UniqueConstraint(
+            "work_item_id",
+            "ordinal",
+            name="uq_workitem_pr_urls_work_item_id",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("workitem_pr_urls")
+    op.drop_table("workitem_affected_repos")
+    op.drop_table("workitem_external_links")
+    op.drop_table("workitem_threads")
+    op.drop_table("workitem_tasks")
+    op.drop_table("work_items")
+    op.drop_table("task_dependencies")
+    op.drop_table("task_switch_anchors")
+    op.drop_table("task_pr_urls")
+    op.drop_table("task_test_results")
+    op.drop_table("task_repos")
+    op.drop_table("tasks")
+    op.drop_table("storage_metadata")

--- a/src/mship/core/persistence/alembic/versions/0001_tasks_and_workitems.py
+++ b/src/mship/core/persistence/alembic/versions/0001_tasks_and_workitems.py
@@ -116,6 +116,22 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("task_slug", "repo_name", name="pk_task_pr_urls"),
     )
     op.create_table(
+        "task_switch_sources",
+        sa.Column("task_slug", sa.Text(), nullable=False),
+        sa.Column("source_repo", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["task_slug"],
+            ["tasks.slug"],
+            name="fk_task_switch_sources_task_slug_tasks",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "task_slug",
+            "source_repo",
+            name="pk_task_switch_sources",
+        ),
+    )
+    op.create_table(
         "task_switch_anchors",
         sa.Column("task_slug", sa.Text(), nullable=False),
         sa.Column("source_repo", sa.Text(), nullable=False),
@@ -335,6 +351,7 @@ def downgrade() -> None:
     op.drop_table("work_items")
     op.drop_table("task_dependencies")
     op.drop_table("task_switch_anchors")
+    op.drop_table("task_switch_sources")
     op.drop_table("task_pr_urls")
     op.drop_table("task_test_results")
     op.drop_table("task_repos")

--- a/src/mship/core/persistence/alembic/versions/__init__.py
+++ b/src/mship/core/persistence/alembic/versions/__init__.py
@@ -1,0 +1,1 @@
+"""Alembic revisions for Mothership workspace state."""

--- a/src/mship/core/persistence/backend.py
+++ b/src/mship/core/persistence/backend.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import timezone
+from enum import StrEnum
+from pathlib import Path
+
+import yaml
+
+from mship.core.persistence.database import DB_FILENAME
+from mship.core.state import WorkspaceState
+from mship.core.workitem import WorkItem
+
+LEGACY_STATE_FILENAME = "state.yaml"
+LEGACY_WORKITEMS_DIRNAME = "workitems"
+
+
+class StorageBackend(StrEnum):
+    EMPTY = "empty"
+    LEGACY = "legacy"
+    SQLITE = "sqlite"
+
+
+def detect_backend(state_dir: Path) -> StorageBackend:
+    state_dir = Path(state_dir)
+    if (state_dir / DB_FILENAME).is_file():
+        return StorageBackend.SQLITE
+    if (state_dir / LEGACY_STATE_FILENAME).is_file():
+        return StorageBackend.LEGACY
+    workitems_dir = state_dir / LEGACY_WORKITEMS_DIRNAME
+    if workitems_dir.is_dir() and next(workitems_dir.glob("*.json"), None) is not None:
+        return StorageBackend.LEGACY
+    return StorageBackend.EMPTY
+
+
+def load_legacy_state(state_dir: Path) -> WorkspaceState:
+    state_file = Path(state_dir) / LEGACY_STATE_FILENAME
+    if not state_file.is_file():
+        return WorkspaceState()
+    with state_file.open() as stream:
+        raw = yaml.safe_load(stream)
+    if raw is None:
+        return WorkspaceState()
+    return WorkspaceState.model_validate(raw)
+
+
+def get_legacy_workitem(workitems_dir: Path, item_id: str) -> WorkItem | None:
+    path = Path(workitems_dir) / f"{item_id}.json"
+    if not path.is_file():
+        return None
+    return WorkItem.model_validate_json(path.read_text())
+
+
+def list_legacy_workitems(
+    workitems_dir: Path,
+    *,
+    include_archived: bool = False,
+    tolerant: bool = False,
+) -> tuple[list[WorkItem], bool]:
+    directory = Path(workitems_dir)
+    if not directory.is_dir():
+        return [], False
+    items: list[WorkItem] = []
+    uncertain = False
+    for path in directory.glob("*.json"):
+        try:
+            items.append(WorkItem.model_validate_json(path.read_text()))
+        except Exception:
+            if not tolerant:
+                raise
+            uncertain = True
+    if not include_archived:
+        items = [item for item in items if not item.archived]
+    return (
+        sorted(
+            items,
+            key=lambda item: (
+                item.updated_at.replace(tzinfo=timezone.utc)
+                if item.updated_at.tzinfo is None
+                else item.updated_at
+            ),
+            reverse=True,
+        ),
+        uncertain,
+    )

--- a/src/mship/core/persistence/backend.py
+++ b/src/mship/core/persistence/backend.py
@@ -43,7 +43,7 @@ def load_legacy_state(state_dir: Path) -> WorkspaceState:
     return WorkspaceState.model_validate(raw)
 
 
-def _legacy_workitem_path(workitems_dir: Path, item_id: str) -> Path:
+def _validate_legacy_workitem_id(item_id: str) -> None:
     if (
         not item_id
         or "/" in item_id
@@ -52,18 +52,42 @@ def _legacy_workitem_path(workitems_dir: Path, item_id: str) -> Path:
         or item_id.startswith(".")
     ):
         raise ValueError(f"unsafe work item id: {item_id!r}")
+
+
+def _contained_legacy_workitem_path(
+    workitems_dir: Path,
+    discovered: Path,
+) -> Path:
     directory = Path(workitems_dir).resolve()
-    path = (directory / f"{item_id}.json").resolve()
+    path = discovered.resolve()
     if path.parent != directory:
-        raise ValueError(f"unsafe work item id: {item_id!r}")
+        raise ValueError(f"unsafe work item id: {discovered.stem!r}")
     return path
 
 
+def _legacy_workitem_entries(workitems_dir: Path) -> list[tuple[str, Path]]:
+    directory = Path(workitems_dir)
+    if not directory.is_dir():
+        return []
+    return [
+        (discovered.stem, _contained_legacy_workitem_path(directory, discovered))
+        for discovered in directory.glob("*.json")
+    ]
+
+
 def get_legacy_workitem(workitems_dir: Path, item_id: str) -> WorkItem | None:
-    path = _legacy_workitem_path(workitems_dir, item_id)
-    if not path.is_file():
+    _validate_legacy_workitem_id(item_id)
+    directory = Path(workitems_dir)
+    if not directory.is_dir():
         return None
-    return WorkItem.model_validate_json(path.read_text())
+    for discovered in directory.glob("*.json"):
+        if discovered.stem != item_id:
+            continue
+        path = _contained_legacy_workitem_path(directory, discovered)
+        if path.is_file():
+            return WorkItem.model_validate_json(path.read_text())
+        return None
+    return None
 
 
 def list_legacy_workitems(
@@ -77,10 +101,13 @@ def list_legacy_workitems(
         return [], False
     items: list[WorkItem] = []
     uncertain = False
-    for path in directory.glob("*.json"):
+    for discovered in directory.glob("*.json"):
         try:
-            contained_path = _legacy_workitem_path(directory, path.stem)
-            items.append(WorkItem.model_validate_json(contained_path.read_text()))
+            path = _contained_legacy_workitem_path(
+                directory,
+                discovered,
+            )
+            items.append(WorkItem.model_validate_json(path.read_text()))
         except Exception:
             if not tolerant:
                 raise

--- a/src/mship/core/persistence/backend.py
+++ b/src/mship/core/persistence/backend.py
@@ -43,8 +43,24 @@ def load_legacy_state(state_dir: Path) -> WorkspaceState:
     return WorkspaceState.model_validate(raw)
 
 
+def _legacy_workitem_path(workitems_dir: Path, item_id: str) -> Path:
+    if (
+        not item_id
+        or "/" in item_id
+        or "\\" in item_id
+        or item_id in (".", "..")
+        or item_id.startswith(".")
+    ):
+        raise ValueError(f"unsafe work item id: {item_id!r}")
+    directory = Path(workitems_dir).resolve()
+    path = (directory / f"{item_id}.json").resolve()
+    if path.parent != directory:
+        raise ValueError(f"unsafe work item id: {item_id!r}")
+    return path
+
+
 def get_legacy_workitem(workitems_dir: Path, item_id: str) -> WorkItem | None:
-    path = Path(workitems_dir) / f"{item_id}.json"
+    path = _legacy_workitem_path(workitems_dir, item_id)
     if not path.is_file():
         return None
     return WorkItem.model_validate_json(path.read_text())

--- a/src/mship/core/persistence/backend.py
+++ b/src/mship/core/persistence/backend.py
@@ -79,7 +79,8 @@ def list_legacy_workitems(
     uncertain = False
     for path in directory.glob("*.json"):
         try:
-            items.append(WorkItem.model_validate_json(path.read_text()))
+            contained_path = _legacy_workitem_path(directory, path.stem)
+            items.append(WorkItem.model_validate_json(contained_path.read_text()))
         except Exception:
             if not tolerant:
                 raise

--- a/src/mship/core/persistence/database.py
+++ b/src/mship/core/persistence/database.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from importlib import resources
+from pathlib import Path
+from sqlite3 import Connection as SQLiteConnection
+
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import Connection, Engine, create_engine, event, inspect, text
+from sqlalchemy.exc import OperationalError
+
+DB_FILENAME = "mothership.db"
+BUSY_TIMEOUT_MS = 5_000
+
+
+class DatabaseRevisionError(RuntimeError):
+    """The workspace database revision cannot be used by this binary."""
+
+
+class DatabaseBusyError(RuntimeError):
+    """The workspace database remained locked past the bounded busy timeout."""
+
+
+def install_sqlite_policy(engine: Engine) -> None:
+    """Apply Mothership's required SQLite policy to every engine connection."""
+
+    @event.listens_for(engine, "connect")
+    def configure_sqlite(
+        dbapi_connection: SQLiteConnection,
+        _connection_record: object,
+    ) -> None:
+        previous_autocommit = dbapi_connection.autocommit
+        dbapi_connection.autocommit = True
+        try:
+            cursor = dbapi_connection.cursor()
+            try:
+                cursor.execute("PRAGMA journal_mode=WAL")
+                cursor.execute("PRAGMA foreign_keys=ON")
+                cursor.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+            finally:
+                cursor.close()
+        finally:
+            dbapi_connection.autocommit = previous_autocommit
+
+
+def make_alembic_config(database_path: Path) -> Config:
+    """Build an Alembic config whose scripts come from this installed package."""
+    script_location = resources.files("mship.core.persistence.alembic")
+    config = Config()
+    config.set_main_option("script_location", str(script_location))
+    config.set_main_option(
+        "sqlalchemy.url",
+        f"sqlite+pysqlite:///{database_path.absolute()}",
+    )
+    return config
+
+
+class WorkspaceDatabase:
+    """Own the SQLite engine and its transaction policy for one workspace."""
+
+    def __init__(self, state_dir: Path) -> None:
+        self._state_dir = state_dir
+        self._engine = self._create_engine()
+
+    @property
+    def path(self) -> Path:
+        return self._state_dir / DB_FILENAME
+
+    def _create_engine(self) -> Engine:
+        engine = create_engine(
+            f"sqlite+pysqlite:///{self.path}",
+            connect_args={
+                "autocommit": False,
+                "timeout": BUSY_TIMEOUT_MS / 1_000,
+            },
+        )
+        install_sqlite_policy(engine)
+        return engine
+
+    def initialize(self) -> None:
+        self._state_dir.mkdir(parents=True, exist_ok=True)
+        current = self.current_revision()
+        head = self.head_revision()
+        if current is not None and current != head:
+            raise DatabaseRevisionError(
+                f"workspace database {self.path} is at revision {current!r}; "
+                f"this binary requires {head!r}. Stop active writers and run "
+                "mship state migrate with a compatible binary"
+            )
+        if current == head:
+            return
+        with self.connect() as connection:
+            config = make_alembic_config(self.path)
+            config.attributes["connection"] = connection
+            command.upgrade(config, "head")
+
+    def current_revision(self) -> str | None:
+        if not self.path.exists():
+            return None
+        with self.connect() as connection:
+            if not inspect(connection).has_table("alembic_version"):
+                return None
+            return connection.execute(
+                text("SELECT version_num FROM alembic_version")
+            ).scalar_one_or_none()
+
+    def head_revision(self) -> str:
+        head = ScriptDirectory.from_config(make_alembic_config(self.path)).get_current_head()
+        if head is None:
+            raise DatabaseRevisionError("the packaged Alembic history has no head revision")
+        return head
+
+    @contextmanager
+    def connect(self) -> Iterator[Connection]:
+        self._state_dir.mkdir(parents=True, exist_ok=True)
+        with self._engine.connect() as connection:
+            yield connection
+
+    @contextmanager
+    def read(self) -> Iterator[Connection]:
+        with self.connect() as connection:
+            yield connection
+
+    @contextmanager
+    def write(self, *, immediate: bool = False) -> Iterator[Connection]:
+        try:
+            with self.connect() as connection:
+                if immediate:
+                    connection.exec_driver_sql("BEGIN IMMEDIATE")
+                    try:
+                        yield connection
+                    except BaseException:
+                        connection.rollback()
+                        raise
+                    else:
+                        connection.commit()
+                else:
+                    with connection.begin():
+                        yield connection
+        except OperationalError as error:
+            if "database is locked" not in str(error).lower():
+                raise
+            raise DatabaseBusyError(
+                f"workspace database {self.path} remained locked for "
+                f"{BUSY_TIMEOUT_MS}ms; retry the operation"
+            ) from error

--- a/src/mship/core/persistence/database.py
+++ b/src/mship/core/persistence/database.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fcntl
 from collections.abc import Iterator
 from contextlib import contextmanager
 from importlib import resources
@@ -14,6 +15,7 @@ from sqlalchemy.exc import OperationalError
 
 DB_FILENAME = "mothership.db"
 BUSY_TIMEOUT_MS = 5_000
+INITIALIZE_LOCK_FILENAME = "mothership.db.initialize.lock"
 
 
 class DatabaseRevisionError(RuntimeError):
@@ -22,6 +24,19 @@ class DatabaseRevisionError(RuntimeError):
 
 class DatabaseBusyError(RuntimeError):
     """The workspace database remained locked past the bounded busy timeout."""
+
+
+@contextmanager
+def _initialization_lock(state_dir: Path) -> Iterator[None]:
+    """Serialize first-time Alembic setup across workspace processes."""
+    lock_path = state_dir / INITIALIZE_LOCK_FILENAME
+    lock_path.touch(exist_ok=True)
+    with lock_path.open("r+") as stream:
+        fcntl.flock(stream, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(stream, fcntl.LOCK_UN)
 
 
 def install_sqlite_policy(engine: Engine) -> None:
@@ -116,10 +131,20 @@ class WorkspaceDatabase:
             )
         if current == head:
             return
-        with self.connect() as connection:
-            config = make_alembic_config(self.path)
-            config.attributes["connection"] = connection
-            command.upgrade(config, "head")
+        with _initialization_lock(self._state_dir):
+            current = self.current_revision()
+            if current is not None and current != head:
+                raise DatabaseRevisionError(
+                    f"workspace database {self.path} is at revision {current!r}; "
+                    f"this binary requires {head!r}. Stop active writers and run "
+                    "mship state migrate with a compatible binary"
+                )
+            if current == head:
+                return
+            with self.connect() as connection:
+                config = make_alembic_config(self.path)
+                config.attributes["connection"] = connection
+                command.upgrade(config, "head")
 
     def current_revision(self) -> str | None:
         if not self.path.exists():

--- a/src/mship/core/persistence/database.py
+++ b/src/mship/core/persistence/database.py
@@ -129,6 +129,11 @@ class WorkspaceDatabase:
         try:
             with self.connect() as connection:
                 if immediate:
+                    # Python 3.14's PEP 249 mode keeps a transaction open while
+                    # autocommit is False. End that empty transaction with SQL
+                    # (Connection.commit would immediately open another one)
+                    # before acquiring the reserved writer lock.
+                    connection.exec_driver_sql("COMMIT")
                     connection.exec_driver_sql("BEGIN IMMEDIATE")
                     try:
                         yield connection

--- a/src/mship/core/persistence/database.py
+++ b/src/mship/core/persistence/database.py
@@ -158,7 +158,16 @@ class WorkspaceDatabase:
                     # (Connection.commit would immediately open another one)
                     # before acquiring the reserved writer lock.
                     connection.exec_driver_sql("COMMIT")
-                    connection.exec_driver_sql("BEGIN IMMEDIATE")
+                    try:
+                        connection.exec_driver_sql("BEGIN IMMEDIATE")
+                    except OperationalError as error:
+                        # The raw COMMIT above ends SQLite's transaction while
+                        # SQLAlchemy still tracks its autobegin transaction. If
+                        # BEGIN fails (normally at the busy deadline), discard
+                        # the divergent connection so context cleanup cannot
+                        # mask the real error by rolling back no transaction.
+                        connection.invalidate(error)
+                        raise
                     try:
                         yield connection
                     except BaseException:

--- a/src/mship/core/persistence/database.py
+++ b/src/mship/core/persistence/database.py
@@ -61,13 +61,37 @@ def make_alembic_config(database_path: Path) -> Config:
 class WorkspaceDatabase:
     """Own the SQLite engine and its transaction policy for one workspace."""
 
-    def __init__(self, state_dir: Path) -> None:
+    def __init__(
+        self,
+        state_dir: Path,
+        *,
+        database_path: Path | None = None,
+    ) -> None:
         self._state_dir = state_dir
+        self._database_path = database_path
         self._engine = self._create_engine()
 
     @property
     def path(self) -> Path:
-        return self._state_dir / DB_FILENAME
+        return self._database_path or self._state_dir / DB_FILENAME
+
+    def dispose(self) -> None:
+        self._engine.dispose()
+
+    def checkpoint(self) -> None:
+        """Move committed WAL content into the database before file activation."""
+        with self.connect() as connection:
+            dbapi_connection = connection.connection.driver_connection
+            previous_autocommit = dbapi_connection.autocommit
+            dbapi_connection.autocommit = True
+            try:
+                cursor = dbapi_connection.cursor()
+                try:
+                    cursor.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                finally:
+                    cursor.close()
+            finally:
+                dbapi_connection.autocommit = previous_autocommit
 
     def _create_engine(self) -> Engine:
         engine = create_engine(

--- a/src/mship/core/persistence/errors.py
+++ b/src/mship/core/persistence/errors.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class LegacyMigrationRequired(RuntimeError):
+    """A legacy Task/WorkItem store must be migrated before it can be written."""
+
+    def __init__(self, state_dir: Path) -> None:
+        self.state_dir = state_dir
+        super().__init__(
+            f"legacy Task/WorkItem storage detected at {state_dir}; "
+            "stop active writers and run mship state migrate before writing"
+        )

--- a/src/mship/core/persistence/export.py
+++ b/src/mship/core/persistence/export.py
@@ -55,10 +55,13 @@ def storage_status(state_dir: Path) -> StorageStatus:
 def _export_payload(state_dir: Path) -> dict[str, list[dict[str, object]]]:
     state = StateManager(state_dir).load()
     items = WorkItemStore(state_dir / "workitems").list(include_archived=True)
+    tasks = []
+    for slug in sorted(state.tasks):
+        task = state.tasks[slug].model_dump(mode="json")
+        task["passive_repos"] = sorted(task["passive_repos"])
+        tasks.append(task)
     return {
-        "tasks": [
-            state.tasks[slug].model_dump(mode="json") for slug in sorted(state.tasks)
-        ],
+        "tasks": tasks,
         "work_items": [
             item.model_dump(mode="json")
             for item in sorted(items, key=lambda value: value.id)

--- a/src/mship/core/persistence/export.py
+++ b/src/mship/core/persistence/export.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import yaml
+
+from mship.core.persistence.backend import StorageBackend, detect_backend
+from mship.core.persistence.database import WorkspaceDatabase
+from mship.core.state import StateManager
+from mship.core.workitem_store import WorkItemStore
+
+
+@dataclass(frozen=True)
+class StorageStatus:
+    backend: StorageBackend
+    database_path: Path
+    current_revision: str | None
+    head_revision: str
+    migration_required: bool
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "backend": self.backend.value,
+            "database_path": str(self.database_path),
+            "current_revision": self.current_revision,
+            "head_revision": self.head_revision,
+            "migration_required": self.migration_required,
+        }
+
+
+def storage_status(state_dir: Path) -> StorageStatus:
+    """Inspect the selected state backend without creating or migrating it."""
+    state_dir = Path(state_dir)
+    backend = detect_backend(state_dir)
+    database = WorkspaceDatabase(state_dir)
+    current_revision = (
+        database.current_revision() if backend is StorageBackend.SQLITE else None
+    )
+    head_revision = database.head_revision()
+    return StorageStatus(
+        backend=backend,
+        database_path=database.path,
+        current_revision=current_revision,
+        head_revision=head_revision,
+        migration_required=(
+            backend is StorageBackend.LEGACY
+            or (backend is StorageBackend.SQLITE and current_revision != head_revision)
+        ),
+    )
+
+
+def _export_payload(state_dir: Path) -> dict[str, list[dict[str, object]]]:
+    state = StateManager(state_dir).load()
+    items = WorkItemStore(state_dir / "workitems").list(include_archived=True)
+    return {
+        "tasks": [
+            state.tasks[slug].model_dump(mode="json") for slug in sorted(state.tasks)
+        ],
+        "work_items": [
+            item.model_dump(mode="json")
+            for item in sorted(items, key=lambda value: value.id)
+        ],
+    }
+
+
+def export_state(
+    state_dir: Path,
+    *,
+    format: Literal["json", "yaml"] | str = "json",
+) -> str:
+    """Render only Task and WorkItem records in a deterministic text format."""
+    if format not in {"json", "yaml"}:
+        raise ValueError("unsupported state export format; use json or yaml")
+    payload = _export_payload(Path(state_dir))
+    if format == "json":
+        return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    return yaml.safe_dump(payload, allow_unicode=True, sort_keys=True)

--- a/src/mship/core/persistence/lifecycle_repository.py
+++ b/src/mship/core/persistence/lifecycle_repository.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from sqlalchemy import Connection
 
 from mship.core.persistence.workspace_store import WorkspaceStore
+from mship.core.persistence.serialization import PersistenceDecodeError
 from mship.core.state import Task
 from mship.core.workitem import WorkItem
 from mship.core.workitem_lifecycle import TaskMetadataRetentionConflictError
@@ -291,8 +292,14 @@ class LifecycleRepository:
         pr_urls: Mapping[str, str],
         *,
         now: datetime,
+        allow_unreadable_workitem: bool = False,
     ) -> Task:
-        """Record Task PRs and mirror retained WorkItem URLs in one short write."""
+        """Record Task PRs and mirror retained WorkItem URLs in one short write.
+
+        A hotfix finish may explicitly preserve the Task result even when a
+        corrupt WorkItem payload cannot be decoded. Normal calls remain atomic:
+        any WorkItem read or update failure rolls the Task write back.
+        """
         with self._store.write(immediate=True) as transaction:
             task = transaction.tasks.get(transaction.connection, task_slug)
             if task is None:
@@ -300,5 +307,9 @@ class LifecycleRepository:
             task.pr_urls.update(pr_urls)
             transaction.tasks.replace(transaction.connection, task)
             self._checkpoint("after_task_replace")
-            self._retain_loaded(transaction.connection, task, now=now)
+            try:
+                self._retain_loaded(transaction.connection, task, now=now)
+            except PersistenceDecodeError:
+                if not allow_unreadable_workitem:
+                    raise
             return task

--- a/src/mship/core/persistence/lifecycle_repository.py
+++ b/src/mship/core/persistence/lifecycle_repository.py
@@ -172,6 +172,8 @@ class LifecycleRepository:
         self,
         connection: Connection,
         task: Task,
+        *,
+        allow_missing_workitem: bool = False,
     ) -> WorkItem | None:
         owners = self._owner_ids(connection, task.slug)
         if len(owners) > 1:
@@ -184,6 +186,8 @@ class LifecycleRepository:
             return None
         item = self._store.workitems.get(connection, item_id)
         if item is None:
+            if allow_missing_workitem:
+                return None
             raise TaskMetadataRetentionConflictError(
                 task.slug,
                 f"linked work item {item_id!r} is unavailable",
@@ -196,8 +200,13 @@ class LifecycleRepository:
         task: Task,
         *,
         now: datetime,
+        allow_missing_workitem: bool = False,
     ) -> None:
-        item = self._resolve_owner_item(connection, task)
+        item = self._resolve_owner_item(
+            connection,
+            task,
+            allow_missing_workitem=allow_missing_workitem,
+        )
         if item is None:
             return
         repos = list(dict.fromkeys([*item.affected_repos, *task.affected_repos]))
@@ -297,7 +306,7 @@ class LifecycleRepository:
         """Record Task PRs and mirror retained WorkItem URLs in one short write.
 
         A hotfix finish may explicitly preserve the Task result even when a
-        corrupt WorkItem payload cannot be decoded. Normal calls remain atomic:
+        linked WorkItem is unreadable or has gone stale/missing. Normal calls remain atomic:
         any WorkItem read or update failure rolls the Task write back.
         """
         with self._store.write(immediate=True) as transaction:
@@ -308,7 +317,12 @@ class LifecycleRepository:
             transaction.tasks.replace(transaction.connection, task)
             self._checkpoint("after_task_replace")
             try:
-                self._retain_loaded(transaction.connection, task, now=now)
+                self._retain_loaded(
+                    transaction.connection,
+                    task,
+                    now=now,
+                    allow_missing_workitem=allow_unreadable_workitem,
+                )
             except PersistenceDecodeError:
                 if not allow_unreadable_workitem:
                     raise

--- a/src/mship/core/persistence/lifecycle_repository.py
+++ b/src/mship/core/persistence/lifecycle_repository.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping
+from datetime import datetime
+
+from sqlalchemy import Connection
+
+from mship.core.persistence.workspace_store import WorkspaceStore
+from mship.core.state import Task
+from mship.core.workitem import WorkItem
+from mship.core.workitem_lifecycle import TaskMetadataRetentionConflictError
+from mship.core.workitem_store import TaskLinkAmbiguousError
+
+
+class LifecycleRepository:
+    """Atomic Task↔WorkItem ownership and delivery-metadata operations."""
+
+    def __init__(self, store: WorkspaceStore) -> None:
+        self._store = store
+
+    def _checkpoint(self, _stage: str) -> None:
+        """Private fault-injection seam used by transaction rollback tests."""
+
+    def _owner_ids(self, connection: Connection, task_slug: str) -> list[str]:
+        return sorted(
+            item.id
+            for item in self._store.workitems.list(
+                connection,
+                include_archived=True,
+            )
+            if task_slug in item.task_slugs
+        )
+
+    def _require_owner_available(
+        self,
+        connection: Connection,
+        task_slug: str,
+        work_item_id: str,
+    ) -> WorkItem:
+        item = self._store.workitems.get(connection, work_item_id)
+        if item is None:
+            raise KeyError(work_item_id)
+        owners = self._owner_ids(connection, task_slug)
+        conflicting = [owner for owner in owners if owner != work_item_id]
+        if conflicting:
+            raise TaskLinkAmbiguousError(
+                task_slug,
+                sorted([*conflicting, work_item_id]),
+            )
+        return item
+
+    def _link_loaded(
+        self,
+        connection: Connection,
+        task: Task,
+        item: WorkItem,
+        *,
+        now: datetime,
+        spec_id: str | None = None,
+    ) -> None:
+        task_changed = task.work_item_id != item.id
+        task.work_item_id = item.id
+        if spec_id is not None and task.spec_id != spec_id:
+            task.spec_id = spec_id
+            task_changed = True
+
+        item_changed = False
+        if task.slug not in item.task_slugs:
+            item.task_slugs.append(task.slug)
+            item_changed = True
+        if spec_id is not None and item.spec_id != spec_id:
+            item.spec_id = spec_id
+            item_changed = True
+
+        if task_changed:
+            self._store.tasks.replace(connection, task)
+            self._checkpoint("after_task_link")
+        if item_changed:
+            item.updated_at = now
+            self._store.workitems.replace(connection, item)
+
+    def register_task(
+        self,
+        task: Task,
+        work_item_id: str,
+        *,
+        now: datetime,
+    ) -> None:
+        """Insert a Task and establish its durable WorkItem owner atomically."""
+        registered = task.model_copy(deep=True)
+        registered.work_item_id = work_item_id
+        with self._store.write(immediate=True) as transaction:
+            if transaction.tasks.get(transaction.connection, registered.slug):
+                raise KeyError(registered.slug)
+            transaction.tasks.insert(transaction.connection, registered)
+            self._checkpoint("after_task_insert")
+            item = self._require_owner_available(
+                transaction.connection,
+                registered.slug,
+                work_item_id,
+            )
+            self._link_loaded(
+                transaction.connection,
+                registered,
+                item,
+                now=now,
+            )
+
+    def link_task(
+        self,
+        work_item_id: str,
+        task_slug: str,
+        *,
+        now: datetime,
+    ) -> None:
+        """Set both sides of an existing Task↔WorkItem link atomically."""
+        with self._store.write(immediate=True) as transaction:
+            task = transaction.tasks.get(transaction.connection, task_slug)
+            if task is None:
+                raise KeyError(task_slug)
+            item = self._require_owner_available(
+                transaction.connection,
+                task_slug,
+                work_item_id,
+            )
+            self._link_loaded(
+                transaction.connection,
+                task,
+                item,
+                now=now,
+            )
+
+    def bind_spec(
+        self,
+        task_slug: str,
+        work_item_id: str,
+        spec_id: str,
+        *,
+        now: datetime,
+    ) -> None:
+        """Bind Task, WorkItem ownership, and their shared spec id atomically."""
+        with self._store.write(immediate=True) as transaction:
+            task = transaction.tasks.get(transaction.connection, task_slug)
+            if task is None:
+                raise KeyError(task_slug)
+            item = self._require_owner_available(
+                transaction.connection,
+                task_slug,
+                work_item_id,
+            )
+            self._link_loaded(
+                transaction.connection,
+                task,
+                item,
+                now=now,
+                spec_id=spec_id,
+            )
+
+    @staticmethod
+    def _validate_expected_task(
+        task: Task,
+        expected_task: Task | None,
+    ) -> None:
+        if expected_task is not None and task != expected_task:
+            raise TaskMetadataRetentionConflictError(
+                task.slug,
+                "its Task revision changed after external checks",
+            )
+
+    def _resolve_owner_item(
+        self,
+        connection: Connection,
+        task: Task,
+    ) -> WorkItem | None:
+        owners = self._owner_ids(connection, task.slug)
+        if len(owners) > 1:
+            raise TaskMetadataRetentionConflictError(
+                task.slug,
+                f"forward WorkItem link is ambiguous ({', '.join(owners)})",
+            )
+        item_id = owners[0] if owners else task.work_item_id
+        if item_id is None:
+            return None
+        item = self._store.workitems.get(connection, item_id)
+        if item is None:
+            raise TaskMetadataRetentionConflictError(
+                task.slug,
+                f"linked work item {item_id!r} is unavailable",
+            )
+        return item
+
+    def _retain_loaded(
+        self,
+        connection: Connection,
+        task: Task,
+        *,
+        now: datetime,
+    ) -> None:
+        item = self._resolve_owner_item(connection, task)
+        if item is None:
+            return
+        repos = list(dict.fromkeys([*item.affected_repos, *task.affected_repos]))
+        urls = list(dict.fromkeys([*item.pr_urls, *task.pr_urls.values()]))
+        if repos == item.affected_repos and urls == item.pr_urls:
+            return
+        item.affected_repos = repos
+        item.pr_urls = urls
+        item.updated_at = now
+        self._store.workitems.replace(connection, item)
+
+    def retain_and_delete_task(
+        self,
+        task_slug: str,
+        *,
+        now: datetime,
+        expected_task: Task | None = None,
+    ) -> bool:
+        """Retain delivery metadata and delete transient Task state atomically."""
+        with self._store.write(immediate=True) as transaction:
+            task = transaction.tasks.get(transaction.connection, task_slug)
+            if task is None:
+                if expected_task is not None:
+                    raise TaskMetadataRetentionConflictError(
+                        task_slug,
+                        "its Task revision changed after external checks",
+                    )
+                return False
+            self._validate_expected_task(task, expected_task)
+            self._retain_loaded(transaction.connection, task, now=now)
+            self._checkpoint("before_task_delete")
+            return transaction.tasks.delete(transaction.connection, task_slug)
+
+    def retain_and_delete_tasks(
+        self,
+        expected_tasks: Mapping[str, Task],
+        *,
+        now: datetime,
+    ) -> set[str]:
+        """Atomically retain and delete a snapshot of several Tasks."""
+        with self._store.write(immediate=True) as transaction:
+            loaded: dict[str, Task] = {}
+            for task_slug, expected_task in expected_tasks.items():
+                task = transaction.tasks.get(transaction.connection, task_slug)
+                if task is None:
+                    raise TaskMetadataRetentionConflictError(
+                        task_slug,
+                        "its Task revision changed after external checks",
+                    )
+                self._validate_expected_task(task, expected_task)
+                loaded[task_slug] = task
+
+            for task in loaded.values():
+                self._retain_loaded(transaction.connection, task, now=now)
+            self._checkpoint("before_tasks_delete")
+            for task_slug in loaded:
+                transaction.tasks.delete(transaction.connection, task_slug)
+            return set(loaded)
+
+    def retain_and_prune_task_repos(
+        self,
+        task_slug: str,
+        repos: Collection[str],
+        *,
+        now: datetime,
+        expected_task: Task | None = None,
+    ) -> bool:
+        """Prune worktree mappings; retain and delete if the final mapping leaves."""
+        with self._store.write(immediate=True) as transaction:
+            task = transaction.tasks.get(transaction.connection, task_slug)
+            if task is None:
+                if expected_task is not None:
+                    raise TaskMetadataRetentionConflictError(
+                        task_slug,
+                        "its Task revision changed after external checks",
+                    )
+                return False
+            self._validate_expected_task(task, expected_task)
+            for repo in set(repos):
+                task.worktrees.pop(repo, None)
+            if task.worktrees:
+                transaction.tasks.replace(transaction.connection, task)
+                return False
+            self._retain_loaded(transaction.connection, task, now=now)
+            self._checkpoint("before_task_delete")
+            transaction.tasks.delete(transaction.connection, task_slug)
+            return True
+
+    def record_pr_urls(
+        self,
+        task_slug: str,
+        pr_urls: Mapping[str, str],
+        *,
+        now: datetime,
+    ) -> Task:
+        """Record Task PRs and mirror retained WorkItem URLs in one short write."""
+        with self._store.write(immediate=True) as transaction:
+            task = transaction.tasks.get(transaction.connection, task_slug)
+            if task is None:
+                raise KeyError(task_slug)
+            task.pr_urls.update(pr_urls)
+            transaction.tasks.replace(transaction.connection, task)
+            self._checkpoint("after_task_replace")
+            self._retain_loaded(transaction.connection, task, now=now)
+            return task

--- a/src/mship/core/persistence/migration.py
+++ b/src/mship/core/persistence/migration.py
@@ -109,6 +109,20 @@ def _backup_legacy(state_dir: Path, now: datetime) -> Path:
     return backup
 
 
+def _normalize_timestamps(value: object) -> object:
+    if isinstance(value, datetime):
+        return encode_datetime(value)
+    if isinstance(value, dict):
+        return {key: _normalize_timestamps(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_timestamps(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_normalize_timestamps(item) for item in value)
+    if isinstance(value, set):
+        return {_normalize_timestamps(item) for item in value}
+    return value
+
+
 def _verify_candidate(
     database: WorkspaceDatabase,
     expected_state: WorkspaceState,
@@ -122,13 +136,17 @@ def _verify_candidate(
         foreign_key_errors = connection.exec_driver_sql(
             "PRAGMA foreign_key_check"
         ).all()
-    if actual_state != expected_state:
+    if _normalize_timestamps(actual_state.model_dump(mode="python")) != (
+        _normalize_timestamps(expected_state.model_dump(mode="python"))
+    ):
         raise MigrationVerificationError(
             "candidate Task state does not match legacy state"
         )
-    if {item.id: item for item in actual_items} != {
-        item.id: item for item in expected_items
-    }:
+    if _normalize_timestamps(
+        {item.id: item.model_dump(mode="python") for item in actual_items}
+    ) != _normalize_timestamps(
+        {item.id: item.model_dump(mode="python") for item in expected_items}
+    ):
         raise MigrationVerificationError(
             "candidate WorkItem state does not match legacy state"
         )

--- a/src/mship/core/persistence/migration.py
+++ b/src/mship/core/persistence/migration.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from mship.core.daemon.status import daemon_is_running
 from mship.core.persistence.backend import (
     StorageBackend,
-    _legacy_workitem_path,
+    _legacy_workitem_entries,
     detect_backend,
     list_legacy_workitems,
     load_legacy_state,
@@ -85,9 +85,8 @@ def _legacy_fingerprints(state_dir: Path) -> tuple[str, str]:
     items_digest = hashlib.sha256()
     workitems_dir = state_dir / "workitems"
     if workitems_dir.is_dir():
-        for discovered in sorted(workitems_dir.glob("*.json")):
-            path = _legacy_workitem_path(workitems_dir, discovered.stem)
-            items_digest.update(path.name.encode())
+        for item_id, path in sorted(_legacy_workitem_entries(workitems_dir)):
+            items_digest.update(f"{item_id}.json".encode())
             items_digest.update(b"\0")
             items_digest.update(hashlib.sha256(path.read_bytes()).digest())
     return state_digest, items_digest.hexdigest()
@@ -106,9 +105,8 @@ def _backup_legacy(state_dir: Path, now: datetime) -> Path:
     if workitems_dir.is_dir():
         backup_items = backup / "workitems"
         backup_items.mkdir()
-        for discovered in sorted(workitems_dir.glob("*.json")):
-            path = _legacy_workitem_path(workitems_dir, discovered.stem)
-            shutil.copy2(path, backup_items / discovered.name)
+        for item_id, path in sorted(_legacy_workitem_entries(workitems_dir)):
+            shutil.copy2(path, backup_items / f"{item_id}.json")
     return backup
 
 
@@ -227,14 +225,9 @@ def migrate_legacy_state(
             )
 
         workitems_dir = state_dir / "workitems"
-        item_paths = (
-            [
-                _legacy_workitem_path(workitems_dir, path.stem)
-                for path in sorted(workitems_dir.glob("*.json"))
-            ]
-            if workitems_dir.is_dir()
-            else []
-        )
+        item_paths = [
+            path for _, path in sorted(_legacy_workitem_entries(workitems_dir))
+        ]
         with ExitStack() as locks:
             locks.enter_context(_exclusive_lock(state_dir / "state.lock"))
             locks.enter_context(_exclusive_lock(workitems_dir / ".thread-link.lock"))

--- a/src/mship/core/persistence/migration.py
+++ b/src/mship/core/persistence/migration.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from mship.core.daemon.status import daemon_is_running
 from mship.core.persistence.backend import (
     StorageBackend,
+    _legacy_workitem_path,
     detect_backend,
     list_legacy_workitems,
     load_legacy_state,
@@ -84,7 +85,8 @@ def _legacy_fingerprints(state_dir: Path) -> tuple[str, str]:
     items_digest = hashlib.sha256()
     workitems_dir = state_dir / "workitems"
     if workitems_dir.is_dir():
-        for path in sorted(workitems_dir.glob("*.json")):
+        for discovered in sorted(workitems_dir.glob("*.json")):
+            path = _legacy_workitem_path(workitems_dir, discovered.stem)
             items_digest.update(path.name.encode())
             items_digest.update(b"\0")
             items_digest.update(hashlib.sha256(path.read_bytes()).digest())
@@ -104,8 +106,9 @@ def _backup_legacy(state_dir: Path, now: datetime) -> Path:
     if workitems_dir.is_dir():
         backup_items = backup / "workitems"
         backup_items.mkdir()
-        for path in sorted(workitems_dir.glob("*.json")):
-            shutil.copy2(path, backup_items / path.name)
+        for discovered in sorted(workitems_dir.glob("*.json")):
+            path = _legacy_workitem_path(workitems_dir, discovered.stem)
+            shutil.copy2(path, backup_items / discovered.name)
     return backup
 
 
@@ -225,7 +228,12 @@ def migrate_legacy_state(
 
         workitems_dir = state_dir / "workitems"
         item_paths = (
-            sorted(workitems_dir.glob("*.json")) if workitems_dir.is_dir() else []
+            [
+                _legacy_workitem_path(workitems_dir, path.stem)
+                for path in sorted(workitems_dir.glob("*.json"))
+            ]
+            if workitems_dir.is_dir()
+            else []
         )
         with ExitStack() as locks:
             locks.enter_context(_exclusive_lock(state_dir / "state.lock"))

--- a/src/mship/core/persistence/migration.py
+++ b/src/mship/core/persistence/migration.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import os
+import shutil
+import uuid
+from collections.abc import Callable, Iterator
+from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from mship.core.daemon.status import daemon_is_running
+from mship.core.persistence.backend import (
+    StorageBackend,
+    detect_backend,
+    list_legacy_workitems,
+    load_legacy_state,
+)
+from mship.core.persistence.database import WorkspaceDatabase
+from mship.core.persistence.schema import storage_metadata
+from mship.core.persistence.serialization import encode_datetime
+from mship.core.persistence.task_repository import TaskRepository
+from mship.core.persistence.workitem_repository import WorkItemRepository
+from mship.core.state import StateManager, WorkspaceState
+from mship.core.workitem import WorkItem
+
+
+class MigrationPreflightError(RuntimeError):
+    """The workspace cannot be migrated safely in its current state."""
+
+
+class MigrationVerificationError(RuntimeError):
+    """The candidate database did not reproduce the legacy state exactly."""
+
+
+@dataclass(frozen=True)
+class MigrationReport:
+    migrated: bool
+    database_path: Path
+    backup_path: Path | None
+    revision: str
+    tasks: int
+    work_items: int
+
+
+@contextmanager
+def _exclusive_lock(path: Path) -> Iterator[None]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch(exist_ok=True)
+    with path.open("r+") as stream:
+        fcntl.flock(stream, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(stream, fcntl.LOCK_UN)
+
+
+def _call_stage(
+    stage_hook: Callable[[str], None] | None,
+    stage: str,
+) -> None:
+    if stage_hook is not None:
+        stage_hook(stage)
+
+
+def _timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+
+
+def _unique_path(parent: Path, stem: str) -> Path:
+    candidate = parent / stem
+    if not candidate.exists():
+        return candidate
+    return parent / f"{stem}-{uuid.uuid4().hex[:8]}"
+
+
+def _legacy_fingerprints(state_dir: Path) -> tuple[str, str]:
+    state_path = state_dir / "state.yaml"
+    state_bytes = state_path.read_bytes() if state_path.is_file() else b""
+    state_digest = hashlib.sha256(state_bytes).hexdigest()
+
+    items_digest = hashlib.sha256()
+    workitems_dir = state_dir / "workitems"
+    if workitems_dir.is_dir():
+        for path in sorted(workitems_dir.glob("*.json")):
+            items_digest.update(path.name.encode())
+            items_digest.update(b"\0")
+            items_digest.update(hashlib.sha256(path.read_bytes()).digest())
+    return state_digest, items_digest.hexdigest()
+
+
+def _backup_legacy(state_dir: Path, now: datetime) -> Path:
+    backup = _unique_path(
+        state_dir / "backups",
+        _timestamp(now),
+    )
+    backup.mkdir(parents=True)
+    state_path = state_dir / "state.yaml"
+    if state_path.is_file():
+        shutil.copy2(state_path, backup / "state.yaml")
+    workitems_dir = state_dir / "workitems"
+    if workitems_dir.is_dir():
+        backup_items = backup / "workitems"
+        backup_items.mkdir()
+        for path in sorted(workitems_dir.glob("*.json")):
+            shutil.copy2(path, backup_items / path.name)
+    return backup
+
+
+def _verify_candidate(
+    database: WorkspaceDatabase,
+    expected_state: WorkspaceState,
+    expected_items: list[WorkItem],
+) -> None:
+    tasks_repo = TaskRepository()
+    items_repo = WorkItemRepository()
+    with database.read() as connection:
+        actual_state = WorkspaceState(tasks=tasks_repo.list(connection))
+        actual_items = items_repo.list(connection, include_archived=True)
+        foreign_key_errors = connection.exec_driver_sql(
+            "PRAGMA foreign_key_check"
+        ).all()
+    if actual_state != expected_state:
+        raise MigrationVerificationError(
+            "candidate Task state does not match legacy state"
+        )
+    if {item.id: item for item in actual_items} != {
+        item.id: item for item in expected_items
+    }:
+        raise MigrationVerificationError(
+            "candidate WorkItem state does not match legacy state"
+        )
+    if foreign_key_errors:
+        raise MigrationVerificationError(
+            f"candidate database has foreign-key errors: {foreign_key_errors}"
+        )
+
+
+def _write_migration_metadata(
+    database: WorkspaceDatabase,
+    *,
+    migrated_at: datetime,
+    state_fingerprint: str,
+    workitems_fingerprint: str,
+) -> None:
+    stamp = encode_datetime(migrated_at)
+    values = {
+        "migrated_at": stamp,
+        "legacy_state_sha256": state_fingerprint,
+        "legacy_workitems_sha256": workitems_fingerprint,
+    }
+    with database.write() as connection:
+        connection.execute(
+            storage_metadata.insert(),
+            [
+                {"key": key, "value": value, "updated_at": stamp}
+                for key, value in values.items()
+            ],
+        )
+
+
+def _existing_report(database: WorkspaceDatabase) -> MigrationReport:
+    database.initialize()
+    with database.read() as connection:
+        task_count = len(TaskRepository().list(connection))
+        item_count = len(WorkItemRepository().list(connection, include_archived=True))
+    return MigrationReport(
+        migrated=False,
+        database_path=database.path,
+        backup_path=None,
+        revision=database.head_revision(),
+        tasks=task_count,
+        work_items=item_count,
+    )
+
+
+def migrate_legacy_state(
+    state_dir: Path,
+    *,
+    daemon_probe: Callable[[], object | None] | None = None,
+    now: datetime | None = None,
+    stage_hook: Callable[[str], None] | None = None,
+) -> MigrationReport:
+    """Validate, back up, import, verify, and atomically activate legacy state."""
+    state_dir = Path(state_dir)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    final_database = WorkspaceDatabase(state_dir)
+    migration_time = now or datetime.now(timezone.utc)
+    probe = daemon_probe or daemon_is_running
+
+    with _exclusive_lock(state_dir / "state-migration.lock"):
+        if final_database.path.is_file():
+            return _existing_report(final_database)
+        if probe():
+            raise MigrationPreflightError(
+                "the Mothership daemon is running; stop it before migration"
+            )
+        backend = detect_backend(state_dir)
+        if backend is StorageBackend.EMPTY:
+            return _existing_report(final_database)
+        if backend is not StorageBackend.LEGACY:
+            raise MigrationPreflightError(
+                f"cannot migrate storage backend {backend.value!r}"
+            )
+
+        workitems_dir = state_dir / "workitems"
+        item_paths = (
+            sorted(workitems_dir.glob("*.json")) if workitems_dir.is_dir() else []
+        )
+        with ExitStack() as locks:
+            locks.enter_context(_exclusive_lock(state_dir / "state.lock"))
+            locks.enter_context(_exclusive_lock(workitems_dir / ".thread-link.lock"))
+            for path in item_paths:
+                locks.enter_context(
+                    _exclusive_lock(path.with_name(path.name + ".lock"))
+                )
+
+            _call_stage(stage_hook, "validate")
+            legacy_state = load_legacy_state(state_dir)
+            legacy_items = list_legacy_workitems(
+                workitems_dir,
+                include_archived=True,
+            )[0]
+            state_fingerprint, items_fingerprint = _legacy_fingerprints(state_dir)
+
+            _call_stage(stage_hook, "backup")
+            backup_path = _backup_legacy(state_dir, migration_time)
+
+            candidate_path = state_dir / (
+                f".mothership.db.migrating-{uuid.uuid4().hex}"
+            )
+            candidate = WorkspaceDatabase(
+                state_dir,
+                database_path=candidate_path,
+            )
+            activated = False
+            retired: list[tuple[Path, Path]] = []
+            try:
+                _call_stage(stage_hook, "alembic")
+                candidate.initialize()
+
+                _call_stage(stage_hook, "import")
+                tasks_repo = TaskRepository()
+                items_repo = WorkItemRepository()
+                with candidate.write(immediate=True) as connection:
+                    for slug in StateManager._dependency_order(legacy_state.tasks):
+                        tasks_repo.insert(
+                            connection,
+                            legacy_state.tasks[slug],
+                        )
+                    for item in sorted(legacy_items, key=lambda value: value.id):
+                        items_repo.insert(connection, item)
+
+                _call_stage(stage_hook, "verify")
+                _verify_candidate(candidate, legacy_state, legacy_items)
+                _write_migration_metadata(
+                    candidate,
+                    migrated_at=migration_time,
+                    state_fingerprint=state_fingerprint,
+                    workitems_fingerprint=items_fingerprint,
+                )
+                revision = candidate.head_revision()
+                candidate.checkpoint()
+                candidate.dispose()
+
+                _call_stage(stage_hook, "activate")
+                os.replace(candidate_path, final_database.path)
+                activated = True
+                suffix = f".migrated-{_timestamp(migration_time)}"
+                for source in (state_dir / "state.yaml", workitems_dir):
+                    if not source.exists():
+                        continue
+                    destination = _unique_path(
+                        source.parent,
+                        source.name + suffix,
+                    )
+                    source.rename(destination)
+                    retired.append((source, destination))
+            except BaseException:
+                for source, destination in reversed(retired):
+                    if destination.exists():
+                        destination.rename(source)
+                if activated and final_database.path.exists():
+                    os.replace(final_database.path, candidate_path)
+                    activated = False
+                raise
+            finally:
+                candidate.dispose()
+                for path in (
+                    candidate_path,
+                    Path(str(candidate_path) + "-wal"),
+                    Path(str(candidate_path) + "-shm"),
+                ):
+                    path.unlink(missing_ok=True)
+
+    return MigrationReport(
+        migrated=True,
+        database_path=final_database.path,
+        backup_path=backup_path,
+        revision=revision,
+        tasks=len(legacy_state.tasks),
+        work_items=len(legacy_items),
+    )

--- a/src/mship/core/persistence/schema.py
+++ b/src/mship/core/persistence/schema.py
@@ -113,6 +113,20 @@ task_pr_urls = Table(
     PrimaryKeyConstraint("task_slug", "repo_name"),
 )
 
+
+task_switch_sources = Table(
+    "task_switch_sources",
+    metadata,
+    Column(
+        "task_slug",
+        Text,
+        ForeignKey("tasks.slug", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("source_repo", Text, nullable=False),
+    PrimaryKeyConstraint("task_slug", "source_repo"),
+)
+
 task_switch_anchors = Table(
     "task_switch_anchors",
     metadata,

--- a/src/mship/core/persistence/schema.py
+++ b/src/mship/core/persistence/schema.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Integer,
+    MetaData,
+    PrimaryKeyConstraint,
+    Table,
+    Text,
+    UniqueConstraint,
+    text,
+)
+
+NAMING_CONVENTION = {
+    "ix": "ix_%(table_name)s_%(column_0_name)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+metadata = MetaData(naming_convention=NAMING_CONVENTION)
+
+
+storage_metadata = Table(
+    "storage_metadata",
+    metadata,
+    Column("key", Text, primary_key=True),
+    Column("value", Text, nullable=False),
+    Column("updated_at", Text, nullable=False),
+)
+
+tasks = Table(
+    "tasks",
+    metadata,
+    Column("slug", Text, primary_key=True),
+    Column("description", Text, nullable=False),
+    Column("phase", Text, nullable=False),
+    Column("created_at", Text, nullable=False),
+    Column("branch", Text, nullable=False),
+    Column("blocked_reason", Text),
+    Column("blocked_at", Text),
+    Column("finished_at", Text),
+    Column("phase_entered_at", Text),
+    Column("last_activity_at", Text),
+    Column("active_repo", Text),
+    Column("test_iteration", Integer, nullable=False, server_default=text("0")),
+    Column("base_branch", Text),
+    Column("base_override", Text),
+    Column("spec_id", Text),
+    Column("work_item_id", Text),
+    Column("revision", Integer, nullable=False, server_default=text("0")),
+    CheckConstraint(
+        "phase IN ('plan', 'dev', 'review', 'run')",
+        name="phase",
+    ),
+    CheckConstraint("test_iteration >= 0", name="test_iteration_non_negative"),
+    CheckConstraint("revision >= 0", name="revision_non_negative"),
+)
+
+task_repos = Table(
+    "task_repos",
+    metadata,
+    Column(
+        "task_slug",
+        Text,
+        ForeignKey("tasks.slug", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("repo_name", Text, nullable=False),
+    Column("affected_ordinal", Integer),
+    Column("passive", Boolean, nullable=False, server_default=text("0")),
+    Column("worktree_path", Text),
+    PrimaryKeyConstraint("task_slug", "repo_name"),
+    UniqueConstraint("task_slug", "affected_ordinal"),
+    CheckConstraint(
+        "affected_ordinal IS NULL OR affected_ordinal >= 0",
+        name="affected_ordinal_non_negative",
+    ),
+)
+
+task_test_results = Table(
+    "task_test_results",
+    metadata,
+    Column(
+        "task_slug",
+        Text,
+        ForeignKey("tasks.slug", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("repo_name", Text, nullable=False),
+    Column("status", Text, nullable=False),
+    Column("at", Text, nullable=False),
+    PrimaryKeyConstraint("task_slug", "repo_name"),
+    CheckConstraint("status IN ('pass', 'fail', 'skip')", name="status"),
+)
+
+task_pr_urls = Table(
+    "task_pr_urls",
+    metadata,
+    Column(
+        "task_slug",
+        Text,
+        ForeignKey("tasks.slug", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("repo_name", Text, nullable=False),
+    Column("url", Text, nullable=False),
+    PrimaryKeyConstraint("task_slug", "repo_name"),
+)
+
+task_switch_anchors = Table(
+    "task_switch_anchors",
+    metadata,
+    Column(
+        "task_slug",
+        Text,
+        ForeignKey("tasks.slug", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("source_repo", Text, nullable=False),
+    Column("dependency_repo", Text, nullable=False),
+    Column("sha", Text, nullable=False),
+    PrimaryKeyConstraint("task_slug", "source_repo", "dependency_repo"),
+)
+
+task_dependencies = Table(
+    "task_dependencies",
+    metadata,
+    Column("task_slug", Text, nullable=False),
+    Column("upstream_slug", Text, nullable=False),
+    Column("created_at", Text, nullable=False),
+    PrimaryKeyConstraint("task_slug", "upstream_slug"),
+    ForeignKeyConstraint(["task_slug"], ["tasks.slug"], ondelete="CASCADE"),
+    ForeignKeyConstraint(["upstream_slug"], ["tasks.slug"], ondelete="CASCADE"),
+    CheckConstraint("task_slug <> upstream_slug", name="not_self"),
+)
+
+work_items = Table(
+    "work_items",
+    metadata,
+    Column("id", Text, primary_key=True),
+    Column("title", Text, nullable=False),
+    Column("workspace", Text, nullable=False),
+    Column("kind", Text, nullable=False),
+    Column("created_at", Text, nullable=False),
+    Column("updated_at", Text, nullable=False),
+    Column("spec_id", Text),
+    Column("plan_path", Text),
+    Column("phase_override", Text),
+    Column("unattended", Boolean, nullable=False, server_default=text("0")),
+    Column("archived", Boolean, nullable=False, server_default=text("0")),
+    Column("revision", Integer, nullable=False, server_default=text("0")),
+    Column("extras_json", Text, nullable=False, server_default=text("'{}'")),
+    CheckConstraint(
+        "kind IN ('feature', 'bug', 'chore', 'question')",
+        name="kind",
+    ),
+    CheckConstraint(
+        "phase_override IS NULL OR "
+        "phase_override IN ('inbox', 'shaping', 'ready', 'in_flight', 'review', 'done')",
+        name="phase_override",
+    ),
+    CheckConstraint("revision >= 0", name="revision_non_negative"),
+)
+
+workitem_tasks = Table(
+    "workitem_tasks",
+    metadata,
+    Column(
+        "work_item_id",
+        Text,
+        ForeignKey("work_items.id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("task_slug", Text, nullable=False, unique=True),
+    Column("ordinal", Integer, nullable=False),
+    PrimaryKeyConstraint("work_item_id", "task_slug"),
+    UniqueConstraint("work_item_id", "ordinal"),
+    CheckConstraint("ordinal >= 0", name="ordinal_non_negative"),
+)
+
+workitem_threads = Table(
+    "workitem_threads",
+    metadata,
+    Column(
+        "work_item_id",
+        Text,
+        ForeignKey("work_items.id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("thread_id", Text, nullable=False, unique=True),
+    Column("ordinal", Integer, nullable=False),
+    PrimaryKeyConstraint("work_item_id", "thread_id"),
+    UniqueConstraint("work_item_id", "ordinal"),
+    CheckConstraint("ordinal >= 0", name="ordinal_non_negative"),
+)
+
+workitem_external_links = Table(
+    "workitem_external_links",
+    metadata,
+    Column(
+        "work_item_id",
+        Text,
+        ForeignKey("work_items.id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("ordinal", Integer, nullable=False),
+    Column("provider", Text, nullable=False),
+    Column("url", Text, nullable=False),
+    Column("title", Text, nullable=False, server_default=text("''")),
+    PrimaryKeyConstraint("work_item_id", "ordinal"),
+    CheckConstraint("ordinal >= 0", name="ordinal_non_negative"),
+    CheckConstraint(
+        "provider IN ('github', 'linear', 'notion', 'jira', 'url')",
+        name="provider",
+    ),
+)
+
+workitem_affected_repos = Table(
+    "workitem_affected_repos",
+    metadata,
+    Column(
+        "work_item_id",
+        Text,
+        ForeignKey("work_items.id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("repo_name", Text, nullable=False),
+    Column("ordinal", Integer, nullable=False),
+    PrimaryKeyConstraint("work_item_id", "repo_name"),
+    UniqueConstraint("work_item_id", "ordinal"),
+    CheckConstraint("ordinal >= 0", name="ordinal_non_negative"),
+)
+
+workitem_pr_urls = Table(
+    "workitem_pr_urls",
+    metadata,
+    Column(
+        "work_item_id",
+        Text,
+        ForeignKey("work_items.id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("url", Text, nullable=False),
+    Column("ordinal", Integer, nullable=False),
+    PrimaryKeyConstraint("work_item_id", "url"),
+    UniqueConstraint("work_item_id", "ordinal"),
+    CheckConstraint("ordinal >= 0", name="ordinal_non_negative"),
+)

--- a/src/mship/core/persistence/serialization.py
+++ b/src/mship/core/persistence/serialization.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pydantic_core import to_jsonable_python
+
+from mship.core.workitem import WorkItem
+
+
+class PersistenceError(RuntimeError):
+    """Base class for stable persistence-boundary failures."""
+
+
+class PersistenceDecodeError(PersistenceError):
+    """A stored entity could not be restored through its Pydantic contract."""
+
+    def __init__(self, table: str, entity_id: str, cause: Exception) -> None:
+        self.table = table
+        self.entity_id = entity_id
+        super().__init__(
+            f"could not decode {table} entity {entity_id!r}: {cause}"
+        )
+
+
+class ConcurrentUpdateError(PersistenceError):
+    """An optimistic revision no longer matches the persisted entity."""
+
+    def __init__(
+        self,
+        table: str,
+        entity_id: str,
+        expected_revision: int,
+    ) -> None:
+        self.table = table
+        self.entity_id = entity_id
+        self.expected_revision = expected_revision
+        super().__init__(
+            f"concurrent update for {table} entity {entity_id!r}: "
+            f"expected revision {expected_revision}"
+        )
+
+
+def encode_datetime(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def decode_datetime(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    decoded = datetime.fromisoformat(value)
+    if decoded.tzinfo is None:
+        decoded = decoded.replace(tzinfo=timezone.utc)
+    return decoded.astimezone(timezone.utc)
+
+
+def encode_path(value: Path | None) -> str | None:
+    return None if value is None else str(value)
+
+
+def encode_json(value: object) -> str:
+    return json.dumps(
+        to_jsonable_python(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def decode_json(value: str) -> object:
+    return json.loads(value)
+
+
+def workitem_extras(item: WorkItem) -> dict[str, object]:
+    return dict(item.__pydantic_extra__ or {})

--- a/src/mship/core/persistence/task_repository.py
+++ b/src/mship/core/persistence/task_repository.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from pydantic import ValidationError
+from sqlalchemy import Connection, delete, select
+
+from mship.core.persistence.schema import (
+    task_dependencies,
+    task_pr_urls,
+    task_repos,
+    task_switch_anchors,
+    task_test_results,
+    tasks,
+)
+from mship.core.persistence.serialization import (
+    ConcurrentUpdateError,
+    PersistenceDecodeError,
+    decode_datetime,
+    encode_datetime,
+    encode_path,
+)
+from mship.core.state import DependencyEdge, Task, TestResult
+
+_TASK_CHILD_TABLES = (
+    task_dependencies,
+    task_switch_anchors,
+    task_pr_urls,
+    task_test_results,
+    task_repos,
+)
+
+
+class TaskRepository:
+    def list(self, conn: Connection) -> dict[str, Task]:
+        slugs = conn.execute(select(tasks.c.slug).order_by(tasks.c.slug)).scalars()
+        return {slug: self._load(conn, slug) for slug in slugs}
+
+    def get(self, conn: Connection, slug: str) -> Task | None:
+        row = conn.execute(
+            select(tasks).where(tasks.c.slug == slug)
+        ).mappings().one_or_none()
+        if row is None:
+            return None
+        return self._decode(conn, row)
+
+    def insert(self, conn: Connection, task: Task) -> None:
+        conn.execute(tasks.insert().values(**self._scalar_values(task)))
+        self._insert_children(conn, task)
+
+    def replace(
+        self,
+        conn: Connection,
+        task: Task,
+        *,
+        expected_revision: int | None = None,
+    ) -> int:
+        predicate = tasks.c.slug == task.slug
+        if expected_revision is not None:
+            predicate &= tasks.c.revision == expected_revision
+        statement = (
+            tasks.update()
+            .where(predicate)
+            .values(
+                **self._scalar_values(task),
+                revision=tasks.c.revision + 1,
+            )
+            .returning(tasks.c.revision)
+        )
+        new_revision = conn.execute(statement).scalar_one_or_none()
+        if new_revision is None:
+            if expected_revision is not None:
+                raise ConcurrentUpdateError("tasks", task.slug, expected_revision)
+            raise KeyError(task.slug)
+        self._delete_children(conn, task.slug)
+        self._insert_children(conn, task)
+        return int(new_revision)
+
+    def delete(self, conn: Connection, slug: str) -> bool:
+        result = conn.execute(delete(tasks).where(tasks.c.slug == slug))
+        return bool(result.rowcount)
+
+    def _load(self, conn: Connection, slug: str) -> Task:
+        task = self.get(conn, slug)
+        if task is None:
+            raise KeyError(slug)
+        return task
+
+    def _scalar_values(self, task: Task) -> dict[str, object]:
+        return {
+            "slug": task.slug,
+            "description": task.description,
+            "phase": task.phase,
+            "created_at": encode_datetime(task.created_at),
+            "branch": task.branch,
+            "blocked_reason": task.blocked_reason,
+            "blocked_at": encode_datetime(task.blocked_at),
+            "finished_at": encode_datetime(task.finished_at),
+            "phase_entered_at": encode_datetime(task.phase_entered_at),
+            "last_activity_at": encode_datetime(task.last_activity_at),
+            "active_repo": task.active_repo,
+            "test_iteration": task.test_iteration,
+            "base_branch": task.base_branch,
+            "base_override": task.base_override,
+            "spec_id": task.spec_id,
+            "work_item_id": task.work_item_id,
+        }
+
+    def _delete_children(self, conn: Connection, slug: str) -> None:
+        for table in _TASK_CHILD_TABLES:
+            conn.execute(delete(table).where(table.c.task_slug == slug))
+
+    def _insert_children(self, conn: Connection, task: Task) -> None:
+        repo_names = list(dict.fromkeys(task.affected_repos))
+        repo_names.extend(name for name in task.worktrees if name not in repo_names)
+        repo_names.extend(name for name in sorted(task.passive_repos) if name not in repo_names)
+        affected_ordinals = {
+            repo_name: ordinal
+            for ordinal, repo_name in enumerate(task.affected_repos)
+        }
+        self._insert_many(
+            conn,
+            task_repos,
+            (
+                {
+                    "task_slug": task.slug,
+                    "repo_name": repo_name,
+                    "affected_ordinal": affected_ordinals.get(repo_name),
+                    "passive": repo_name in task.passive_repos,
+                    "worktree_path": encode_path(task.worktrees.get(repo_name)),
+                }
+                for repo_name in repo_names
+            ),
+        )
+        self._insert_many(
+            conn,
+            task_test_results,
+            (
+                {
+                    "task_slug": task.slug,
+                    "repo_name": repo_name,
+                    "status": result.status,
+                    "at": encode_datetime(result.at),
+                }
+                for repo_name, result in task.test_results.items()
+            ),
+        )
+        self._insert_many(
+            conn,
+            task_pr_urls,
+            (
+                {
+                    "task_slug": task.slug,
+                    "repo_name": repo_name,
+                    "url": url,
+                }
+                for repo_name, url in task.pr_urls.items()
+            ),
+        )
+        self._insert_many(
+            conn,
+            task_switch_anchors,
+            (
+                {
+                    "task_slug": task.slug,
+                    "source_repo": source_repo,
+                    "dependency_repo": dependency_repo,
+                    "sha": sha,
+                }
+                for source_repo, dependencies in task.last_switched_at_sha.items()
+                for dependency_repo, sha in dependencies.items()
+            ),
+        )
+        self._insert_many(
+            conn,
+            task_dependencies,
+            (
+                {
+                    "task_slug": task.slug,
+                    "upstream_slug": edge.upstream_slug,
+                    "created_at": encode_datetime(edge.created_at),
+                }
+                for edge in task.depends_on
+            ),
+        )
+
+    def _insert_many(
+        self,
+        conn: Connection,
+        table,
+        rows: Iterable[dict[str, object]],
+    ) -> None:
+        values = list(rows)
+        if values:
+            conn.execute(table.insert(), values)
+
+    def _decode(self, conn: Connection, row) -> Task:
+        slug = str(row["slug"])
+        try:
+            repo_rows = conn.execute(
+                select(task_repos)
+                .where(task_repos.c.task_slug == slug)
+                .order_by(task_repos.c.repo_name)
+            ).mappings().all()
+            affected_repos = [
+                str(repo["repo_name"])
+                for repo in sorted(
+                    (repo for repo in repo_rows if repo["affected_ordinal"] is not None),
+                    key=lambda repo: int(repo["affected_ordinal"]),
+                )
+            ]
+            worktrees = {
+                str(repo["repo_name"]): Path(str(repo["worktree_path"]))
+                for repo in repo_rows
+                if repo["worktree_path"] is not None
+            }
+            passive_repos = {
+                str(repo["repo_name"]) for repo in repo_rows if repo["passive"]
+            }
+            test_results = {
+                str(result["repo_name"]): TestResult(
+                    status=result["status"],
+                    at=decode_datetime(result["at"]),
+                )
+                for result in conn.execute(
+                    select(task_test_results)
+                    .where(task_test_results.c.task_slug == slug)
+                    .order_by(task_test_results.c.repo_name)
+                ).mappings()
+            }
+            pr_urls = {
+                str(pr["repo_name"]): str(pr["url"])
+                for pr in conn.execute(
+                    select(task_pr_urls)
+                    .where(task_pr_urls.c.task_slug == slug)
+                    .order_by(task_pr_urls.c.repo_name)
+                ).mappings()
+            }
+            switched: dict[str, dict[str, str]] = {}
+            for anchor in conn.execute(
+                select(task_switch_anchors)
+                .where(task_switch_anchors.c.task_slug == slug)
+                .order_by(
+                    task_switch_anchors.c.source_repo,
+                    task_switch_anchors.c.dependency_repo,
+                )
+            ).mappings():
+                switched.setdefault(str(anchor["source_repo"]), {})[
+                    str(anchor["dependency_repo"])
+                ] = str(anchor["sha"])
+            depends_on = [
+                DependencyEdge(
+                    upstream_slug=dependency["upstream_slug"],
+                    created_at=decode_datetime(dependency["created_at"]),
+                )
+                for dependency in conn.execute(
+                    select(task_dependencies)
+                    .where(task_dependencies.c.task_slug == slug)
+                    .order_by(
+                        task_dependencies.c.created_at,
+                        task_dependencies.c.upstream_slug,
+                    )
+                ).mappings()
+            ]
+            return Task.model_validate(
+                {
+                    "slug": slug,
+                    "description": row["description"],
+                    "phase": row["phase"],
+                    "created_at": decode_datetime(row["created_at"]),
+                    "affected_repos": affected_repos,
+                    "worktrees": worktrees,
+                    "branch": row["branch"],
+                    "test_results": test_results,
+                    "blocked_reason": row["blocked_reason"],
+                    "blocked_at": decode_datetime(row["blocked_at"]),
+                    "pr_urls": pr_urls,
+                    "finished_at": decode_datetime(row["finished_at"]),
+                    "phase_entered_at": decode_datetime(row["phase_entered_at"]),
+                    "last_activity_at": decode_datetime(row["last_activity_at"]),
+                    "active_repo": row["active_repo"],
+                    "last_switched_at_sha": switched,
+                    "test_iteration": row["test_iteration"],
+                    "base_branch": row["base_branch"],
+                    "base_override": row["base_override"],
+                    "passive_repos": passive_repos,
+                    "spec_id": row["spec_id"],
+                    "depends_on": depends_on,
+                    "work_item_id": row["work_item_id"],
+                }
+            )
+        except (TypeError, ValueError, ValidationError) as error:
+            raise PersistenceDecodeError("tasks", slug, error) from error

--- a/src/mship/core/persistence/task_repository.py
+++ b/src/mship/core/persistence/task_repository.py
@@ -11,6 +11,7 @@ from mship.core.persistence.schema import (
     task_pr_urls,
     task_repos,
     task_switch_anchors,
+    task_switch_sources,
     task_test_results,
     tasks,
 )
@@ -26,6 +27,7 @@ from mship.core.state import DependencyEdge, Task, TestResult
 _TASK_CHILD_TABLES = (
     task_dependencies,
     task_switch_anchors,
+    task_switch_sources,
     task_pr_urls,
     task_test_results,
     task_repos,
@@ -160,6 +162,17 @@ class TaskRepository:
         )
         self._insert_many(
             conn,
+            task_switch_sources,
+            (
+                {
+                    "task_slug": task.slug,
+                    "source_repo": source_repo,
+                }
+                for source_repo in task.last_switched_at_sha
+            ),
+        )
+        self._insert_many(
+            conn,
             task_switch_anchors,
             (
                 {
@@ -237,7 +250,14 @@ class TaskRepository:
                     .order_by(task_pr_urls.c.repo_name)
                 ).mappings()
             }
-            switched: dict[str, dict[str, str]] = {}
+            switched = {
+                str(source["source_repo"]): {}
+                for source in conn.execute(
+                    select(task_switch_sources)
+                    .where(task_switch_sources.c.task_slug == slug)
+                    .order_by(task_switch_sources.c.source_repo)
+                ).mappings()
+            }
             for anchor in conn.execute(
                 select(task_switch_anchors)
                 .where(task_switch_anchors.c.task_slug == slug)

--- a/src/mship/core/persistence/workitem_repository.py
+++ b/src/mship/core/persistence/workitem_repository.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from pydantic import ValidationError
+from sqlalchemy import Connection, delete, select
+
+from mship.core.persistence.schema import (
+    work_items,
+    workitem_affected_repos,
+    workitem_external_links,
+    workitem_pr_urls,
+    workitem_tasks,
+    workitem_threads,
+)
+from mship.core.persistence.serialization import (
+    ConcurrentUpdateError,
+    PersistenceDecodeError,
+    decode_datetime,
+    decode_json,
+    encode_datetime,
+    encode_json,
+    workitem_extras,
+)
+from mship.core.workitem import WorkItem
+
+_WORKITEM_CHILD_TABLES = (
+    workitem_pr_urls,
+    workitem_affected_repos,
+    workitem_external_links,
+    workitem_threads,
+    workitem_tasks,
+)
+
+
+class WorkItemRepository:
+    def list(
+        self,
+        conn: Connection,
+        *,
+        include_archived: bool = False,
+    ) -> list[WorkItem]:
+        statement = select(work_items).order_by(
+            work_items.c.updated_at.desc(),
+            work_items.c.id,
+        )
+        if not include_archived:
+            statement = statement.where(work_items.c.archived.is_(False))
+        return [self._decode(conn, row) for row in conn.execute(statement).mappings()]
+
+    def list_tolerant_with_uncertainty(
+        self,
+        conn: Connection,
+        *,
+        include_archived: bool = False,
+    ) -> tuple[list[WorkItem], bool]:
+        statement = select(work_items).order_by(
+            work_items.c.updated_at.desc(),
+            work_items.c.id,
+        )
+        if not include_archived:
+            statement = statement.where(work_items.c.archived.is_(False))
+        items: list[WorkItem] = []
+        uncertain = False
+        for row in conn.execute(statement).mappings():
+            try:
+                items.append(self._decode(conn, row))
+            except PersistenceDecodeError:
+                uncertain = True
+        return items, uncertain
+
+    def list_tolerant(
+        self,
+        conn: Connection,
+        *,
+        include_archived: bool = False,
+    ) -> list[WorkItem]:
+        return self.list_tolerant_with_uncertainty(
+            conn,
+            include_archived=include_archived,
+        )[0]
+
+    def get(self, conn: Connection, item_id: str) -> WorkItem | None:
+        row = conn.execute(
+            select(work_items).where(work_items.c.id == item_id)
+        ).mappings().one_or_none()
+        if row is None:
+            return None
+        return self._decode(conn, row)
+
+    def insert(self, conn: Connection, item: WorkItem) -> None:
+        conn.execute(work_items.insert().values(**self._scalar_values(item)))
+        self._insert_children(conn, item)
+
+    def replace(
+        self,
+        conn: Connection,
+        item: WorkItem,
+        *,
+        expected_revision: int | None = None,
+    ) -> int:
+        predicate = work_items.c.id == item.id
+        if expected_revision is not None:
+            predicate &= work_items.c.revision == expected_revision
+        statement = (
+            work_items.update()
+            .where(predicate)
+            .values(
+                **self._scalar_values(item),
+                revision=work_items.c.revision + 1,
+            )
+            .returning(work_items.c.revision)
+        )
+        new_revision = conn.execute(statement).scalar_one_or_none()
+        if new_revision is None:
+            if expected_revision is not None:
+                raise ConcurrentUpdateError("work_items", item.id, expected_revision)
+            raise KeyError(item.id)
+        self._delete_children(conn, item.id)
+        self._insert_children(conn, item)
+        return int(new_revision)
+
+    def delete(self, conn: Connection, item_id: str) -> bool:
+        result = conn.execute(delete(work_items).where(work_items.c.id == item_id))
+        return bool(result.rowcount)
+
+    def _scalar_values(self, item: WorkItem) -> dict[str, object]:
+        return {
+            "id": item.id,
+            "title": item.title,
+            "workspace": item.workspace,
+            "kind": item.kind,
+            "created_at": encode_datetime(item.created_at),
+            "updated_at": encode_datetime(item.updated_at),
+            "spec_id": item.spec_id,
+            "plan_path": item.plan_path,
+            "phase_override": item.phase_override,
+            "unattended": item.unattended,
+            "archived": item.archived,
+            "extras_json": encode_json(workitem_extras(item)),
+        }
+
+    def _delete_children(self, conn: Connection, item_id: str) -> None:
+        for table in _WORKITEM_CHILD_TABLES:
+            conn.execute(delete(table).where(table.c.work_item_id == item_id))
+
+    def _insert_children(self, conn: Connection, item: WorkItem) -> None:
+        self._insert_many(
+            conn,
+            workitem_tasks,
+            (
+                {
+                    "work_item_id": item.id,
+                    "task_slug": task_slug,
+                    "ordinal": ordinal,
+                }
+                for ordinal, task_slug in enumerate(item.task_slugs)
+            ),
+        )
+        self._insert_many(
+            conn,
+            workitem_threads,
+            (
+                {
+                    "work_item_id": item.id,
+                    "thread_id": thread_id,
+                    "ordinal": ordinal,
+                }
+                for ordinal, thread_id in enumerate(item.thread_ids)
+            ),
+        )
+        self._insert_many(
+            conn,
+            workitem_external_links,
+            (
+                {
+                    "work_item_id": item.id,
+                    "ordinal": ordinal,
+                    "provider": link.provider,
+                    "url": link.url,
+                    "title": link.title,
+                }
+                for ordinal, link in enumerate(item.external_links)
+            ),
+        )
+        self._insert_many(
+            conn,
+            workitem_affected_repos,
+            (
+                {
+                    "work_item_id": item.id,
+                    "repo_name": repo_name,
+                    "ordinal": ordinal,
+                }
+                for ordinal, repo_name in enumerate(item.affected_repos)
+            ),
+        )
+        self._insert_many(
+            conn,
+            workitem_pr_urls,
+            (
+                {
+                    "work_item_id": item.id,
+                    "url": url,
+                    "ordinal": ordinal,
+                }
+                for ordinal, url in enumerate(item.pr_urls)
+            ),
+        )
+
+    def _insert_many(
+        self,
+        conn: Connection,
+        table,
+        rows: Iterable[dict[str, object]],
+    ) -> None:
+        values = list(rows)
+        if values:
+            conn.execute(table.insert(), values)
+
+    def _decode(self, conn: Connection, row) -> WorkItem:
+        item_id = str(row["id"])
+        try:
+            extras = decode_json(row["extras_json"])
+            if not isinstance(extras, dict):
+                raise TypeError("extras_json must decode to an object")
+            payload = dict(extras)
+            payload.update(
+                {
+                    "id": item_id,
+                    "title": row["title"],
+                    "workspace": row["workspace"],
+                    "kind": row["kind"],
+                    "created_at": decode_datetime(row["created_at"]),
+                    "updated_at": decode_datetime(row["updated_at"]),
+                    "spec_id": row["spec_id"],
+                    "plan_path": row["plan_path"],
+                    "task_slugs": list(
+                        conn.execute(
+                            select(workitem_tasks.c.task_slug)
+                            .where(workitem_tasks.c.work_item_id == item_id)
+                            .order_by(workitem_tasks.c.ordinal)
+                        ).scalars()
+                    ),
+                    "thread_ids": list(
+                        conn.execute(
+                            select(workitem_threads.c.thread_id)
+                            .where(workitem_threads.c.work_item_id == item_id)
+                            .order_by(workitem_threads.c.ordinal)
+                        ).scalars()
+                    ),
+                    "external_links": [
+                        {
+                            "provider": link["provider"],
+                            "url": link["url"],
+                            "title": link["title"],
+                        }
+                        for link in conn.execute(
+                            select(workitem_external_links)
+                            .where(workitem_external_links.c.work_item_id == item_id)
+                            .order_by(workitem_external_links.c.ordinal)
+                        ).mappings()
+                    ],
+                    "phase_override": row["phase_override"],
+                    "unattended": row["unattended"],
+                    "archived": row["archived"],
+                    "affected_repos": list(
+                        conn.execute(
+                            select(workitem_affected_repos.c.repo_name)
+                            .where(workitem_affected_repos.c.work_item_id == item_id)
+                            .order_by(workitem_affected_repos.c.ordinal)
+                        ).scalars()
+                    ),
+                    "pr_urls": list(
+                        conn.execute(
+                            select(workitem_pr_urls.c.url)
+                            .where(workitem_pr_urls.c.work_item_id == item_id)
+                            .order_by(workitem_pr_urls.c.ordinal)
+                        ).scalars()
+                    ),
+                }
+            )
+            return WorkItem.model_validate(payload)
+        except (TypeError, ValueError, ValidationError) as error:
+            raise PersistenceDecodeError("work_items", item_id, error) from error

--- a/src/mship/core/persistence/workspace_store.py
+++ b/src/mship/core/persistence/workspace_store.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from sqlalchemy import Connection
+
+from mship.core.persistence.backend import (
+    StorageBackend,
+    detect_backend,
+    load_legacy_state,
+)
+from mship.core.persistence.database import WorkspaceDatabase
+from mship.core.persistence.errors import LegacyMigrationRequired
+from mship.core.persistence.task_repository import TaskRepository
+from mship.core.persistence.workitem_repository import WorkItemRepository
+from mship.core.state import WorkspaceState
+
+
+@dataclass(frozen=True)
+class WorkspaceTransaction:
+    connection: Connection
+    tasks: TaskRepository
+    workitems: WorkItemRepository
+
+
+class WorkspaceStore:
+    """Select storage and provide one transaction boundary for domain repositories."""
+
+    def __init__(
+        self,
+        state_dir: Path,
+        database: WorkspaceDatabase | None = None,
+    ) -> None:
+        self.state_dir = Path(state_dir)
+        self.database = database or WorkspaceDatabase(self.state_dir)
+        self.tasks = TaskRepository()
+        self.workitems = WorkItemRepository()
+
+    @property
+    def backend(self) -> StorageBackend:
+        return detect_backend(self.state_dir)
+
+    def load_state(self) -> WorkspaceState:
+        backend = self.backend
+        if backend is StorageBackend.EMPTY:
+            return WorkspaceState()
+        if backend is StorageBackend.LEGACY:
+            return load_legacy_state(self.state_dir)
+        self.database.initialize()
+        with self.database.read() as connection:
+            return WorkspaceState(tasks=self.tasks.list(connection))
+
+    def initialize_if_empty(self) -> bool:
+        if self.backend is not StorageBackend.EMPTY:
+            return False
+        self.database.initialize()
+        return True
+
+    @contextmanager
+    def read(self) -> Iterator[WorkspaceTransaction]:
+        if self.backend is not StorageBackend.SQLITE:
+            raise RuntimeError("SQLite workspace transaction requested without a database")
+        self.database.initialize()
+        with self.database.read() as connection:
+            yield WorkspaceTransaction(connection, self.tasks, self.workitems)
+
+    @contextmanager
+    def write(self, *, immediate: bool = False) -> Iterator[WorkspaceTransaction]:
+        backend = self.backend
+        if backend is StorageBackend.LEGACY:
+            raise LegacyMigrationRequired(self.state_dir)
+        self.database.initialize()
+        with self.database.write(immediate=immediate) as connection:
+            yield WorkspaceTransaction(connection, self.tasks, self.workitems)

--- a/src/mship/core/phase.py
+++ b/src/mship/core/phase.py
@@ -189,8 +189,7 @@ class PhaseManager:
                         f"failed: {hr.error}"
                     )
 
-        def _apply(s):
-            t = s.tasks[task_slug]
+        def _apply(t):
             if blocked_force_unblock:
                 t.blocked_reason = None
                 t.blocked_at = None
@@ -200,7 +199,7 @@ class PhaseManager:
             # Agent-agnostic activity heartbeat: a phase transition is task work.
             t.last_activity_at = now
 
-        self._state_manager.mutate(_apply)
+        self._state_manager.mutate_task(task_slug, _apply)
 
         # Journal entries happen outside the mutate — LogManager writes a
         # separate file, not mship state.

--- a/src/mship/core/pr_watcher.py
+++ b/src/mship/core/pr_watcher.py
@@ -243,14 +243,13 @@ class PrWatcher:
             self._auto_closed_slugs.add(slug)
 
             specs_dir = self.workspace_root / SPECS_DIRNAME
-            workitems_dir = self.workspace_root / ".mothership" / "workitems"
             snapshot = self.state_manager.load()  # still contains the closing task
             advance_spec_on_close(
                 task=task, specs_dir=specs_dir,
                 merged_count=merged_count, closed_count=closed_count,
             )
             advance_workitem_on_close(
-                task=task, workitems_dir=workitems_dir, specs_dir=specs_dir,
+                task=task, workitems=self.workitems, specs_dir=specs_dir,
                 state=snapshot, merged_count=merged_count, closed_count=closed_count,
             )
 
@@ -262,7 +261,7 @@ class PrWatcher:
                 from mship.core.pr import PRManager
                 close_linked_issues(
                     task=task,
-                    workitems_dir=workitems_dir,
+                    workitems=self.workitems,
                     pr_manager=PRManager(self.shell),
                     merged_count=merged_count,
                     closed_count=closed_count,

--- a/src/mship/core/prune.py
+++ b/src/mship/core/prune.py
@@ -1,5 +1,6 @@
 import shutil
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 from mship.core.config import WorkspaceConfig
@@ -123,68 +124,39 @@ class PruneManager:
                         shutil.rmtree(orphan.path, ignore_errors=True)
                 pruned += 1
 
-        # Retain metadata before entering the state lock. WorkItemStore's item
-        # lock must never be taken while holding state.lock, and a persistence
-        # failure must leave state (the last copy) untouched.
-        from mship.core.workitem_lifecycle import (
-            require_retained_task_metadata,
-            retain_workitem_metadata_on_teardown,
-        )
-
+        # Filesystem observations remain outside SQL. Each Task snapshot is
+        # compared after the write transaction begins, so a concurrent update
+        # is rejected instead of being overwritten by stale prune results.
         state_before_cleanup = self._state_manager.load()
-        retained_by_slug = {}
-        workitems_dir = self._state_manager.state_dir / "workitems"
+        missing_by_slug: dict[str, list[str]] = {}
         for task in state_before_cleanup.tasks.values():
-            remaining = {
-                repo: path
+            missing = [
+                repo
                 for repo, path in task.worktrees.items()
-                if not any(
+                if any(
                     orphan.reason == "not_on_disk"
                     and orphan.repo == repo
                     and not Path(path).exists()
                     for orphan in orphans
                 )
-            }
-            if task.worktrees and not remaining:
-                retained_by_slug[task.slug] = retain_workitem_metadata_on_teardown(
-                    task=task, workitems_dir=workitems_dir,
-                )
+            ]
+            if missing:
+                missing_by_slug[task.slug] = missing
 
-        # Phase 2: clean up state entries pointing to nonexistent worktrees.
-        # Validate every task that will be deleted before mutating state, so a
-        # concurrent metadata update leaves the entire source snapshot intact.
-        def _cleanup(state):
-            nonlocal pruned
-            cleanup_actions = []
-            for task_slug, task in state.tasks.items():
-                missing_repos = [
-                    repo
-                    for repo, path in task.worktrees.items()
-                    if any(
-                        orphan.reason == "not_on_disk"
-                        and orphan.repo == repo
-                        and not Path(path).exists()
-                        for orphan in orphans
-                    )
-                ]
-                if not missing_repos:
-                    continue
-                removes_task = len(missing_repos) == len(task.worktrees)
-                if removes_task:
-                    require_retained_task_metadata(
-                        task, retained_by_slug.get(task_slug),
-                    )
-                cleanup_actions.append((task_slug, missing_repos, removes_task))
+        # Phase 2: remove stale mappings and, when the final mapping leaves,
+        # retain delivery metadata on the WorkItem in the same transaction that
+        # deletes the transient Task row.
+        from mship.core.persistence.lifecycle_repository import LifecycleRepository
 
-            for task_slug, missing_repos, removes_task in cleanup_actions:
-                task = state.tasks[task_slug]
-                for repo in missing_repos:
-                    del task.worktrees[repo]
-                    pruned += 1
-                if removes_task:
-                    del state.tasks[task_slug]
-
-        self._state_manager.mutate(_cleanup)
+        lifecycle = LifecycleRepository(self._state_manager.workspace_store)
+        for task_slug, missing_repos in missing_by_slug.items():
+            lifecycle.retain_and_prune_task_repos(
+                task_slug,
+                missing_repos,
+                now=datetime.now(timezone.utc),
+                expected_task=state_before_cleanup.tasks[task_slug],
+            )
+            pruned += len(missing_repos)
 
         # Run git worktree prune per repo
         for repo_config in self._config.repos.values():

--- a/src/mship/core/serve.py
+++ b/src/mship/core/serve.py
@@ -371,7 +371,16 @@ def create_app(
     # otherwise both create a thread (orphaning one message) or lose the
     # add_thread update. threading.Lock is the right primitive for that pool.
     msgs = MessageStore(workspace_root / ".mothership" / "messages")
-    workitems = WorkItemStore(workspace_root / ".mothership" / "workitems")
+    if hasattr(state_manager, "state_dir") and hasattr(
+        state_manager,
+        "workspace_store",
+    ):
+        workitems = WorkItemStore(
+            state_manager.state_dir / "workitems",
+            workspace_store=state_manager.workspace_store,
+        )
+    else:
+        workitems = WorkItemStore(workspace_root / ".mothership" / "workitems")
     _item_msg_lock = threading.Lock()
 
     @asynccontextmanager

--- a/src/mship/core/spec_dispatch.py
+++ b/src/mship/core/spec_dispatch.py
@@ -246,18 +246,35 @@ def _dispatch_current(
     # same as workitem_migrate.wrap_existing pass 1 — so the spawned/bound task
     # carries a work_item_id and clears the enforcement gate.
     if spec.work_item_id:
-        workitems.add_task(spec.work_item_id, chosen_slug, now=now, state=state_manager)
+        work_item_id = spec.work_item_id
     else:
-        wi = workitems.create(title=spec.title, kind="feature", workspace=workspace, now=now)
-        workitems.link_spec(wi.id, spec.id, now=now)
-        spec.work_item_id = wi.id
-        workitems.add_task(wi.id, chosen_slug, now=now, state=state_manager)
+        # A prior dispatch may have created and spec-linked the WorkItem before
+        # its spec-file save failed. Reuse that durable identity on retry rather
+        # than minting a second item that would conflict with task ownership.
+        candidates = [item for item in workitems.list() if item.spec_id == spec.id]
+        if len(candidates) > 1:
+            raise DispatchError(
+                f"spec {spec.id!r} is linked to multiple work items: "
+                f"{[item.id for item in candidates]}"
+            )
+        if candidates:
+            work_item_id = candidates[0].id
+        else:
+            wi = workitems.create(title=spec.title, kind="feature", workspace=workspace, now=now)
+            workitems.link_spec(wi.id, spec.id, now=now)
+            work_item_id = wi.id
+        spec.work_item_id = work_item_id
+        spec.updated_at = now
+        store.save_while_locked(spec, artifact)
 
-    def _bind(s):
-        if chosen_slug in s.tasks:
-            s.tasks[chosen_slug].spec_id = spec.id
+    from mship.core.persistence.lifecycle_repository import LifecycleRepository
 
-    state_manager.mutate(_bind)
+    LifecycleRepository(state_manager.workspace_store).bind_spec(
+        chosen_slug,
+        work_item_id,
+        spec.id,
+        now=now,
+    )
 
     spec.status = "dispatched"
     spec.task_slug = chosen_slug

--- a/src/mship/core/state.py
+++ b/src/mship/core/state.py
@@ -85,6 +85,11 @@ class StateManager:
         """Canonical state directory shared by this workspace's stores."""
         return self._store.state_dir
 
+    @property
+    def workspace_store(self) -> WorkspaceStore:
+        """Shared transaction boundary for cross-entity lifecycle operations."""
+        return self._store
+
     def load(self) -> WorkspaceState:
         return self._store.load_state()
 

--- a/src/mship/core/state.py
+++ b/src/mship/core/state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Literal
@@ -7,6 +8,8 @@ from typing import TYPE_CHECKING, Callable, Literal
 from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
+    from sqlalchemy import Connection
+
     from mship.core.persistence.workspace_store import WorkspaceStore
 
 
@@ -97,6 +100,124 @@ class StateManager:
             self._persist_state(transaction, state)
             return state
 
+    def insert_task(
+        self,
+        task: Task,
+        *,
+        connection: Connection | None = None,
+    ) -> None:
+        """Insert one Task, optionally joining an existing workspace transaction."""
+        if connection is not None:
+            self._store.tasks.insert(connection, task)
+            return
+        with self._store.write(immediate=True) as transaction:
+            transaction.tasks.insert(transaction.connection, task)
+
+    def mutate_task(
+        self,
+        slug: str,
+        fn: Callable[[Task], None],
+        *,
+        connection: Connection | None = None,
+    ) -> Task:
+        """Mutate one named Task without rewriting any other Task row."""
+        if connection is not None:
+            return self._mutate_task(connection, slug, fn)
+        with self._store.write(immediate=True) as transaction:
+            return self._mutate_task(transaction.connection, slug, fn)
+
+    def _mutate_task(
+        self,
+        connection: Connection,
+        slug: str,
+        fn: Callable[[Task], None],
+    ) -> Task:
+        task = self._store.tasks.get(connection, slug)
+        if task is None:
+            raise KeyError(slug)
+        before = task.model_copy(deep=True)
+        fn(task)
+        if task.slug != slug:
+            raise ValueError(
+                f"task mutation changed slug from {slug!r} to {task.slug!r}"
+            )
+        if task != before:
+            self._store.tasks.replace(connection, task)
+        return task
+
+    def mutate_tasks(
+        self,
+        slugs: Iterable[str],
+        fn: Callable[[dict[str, Task]], None],
+        *,
+        connection: Connection | None = None,
+    ) -> dict[str, Task]:
+        """Atomically mutate only the requested Task rows."""
+        requested = sorted(set(slugs))
+        if connection is not None:
+            return self._mutate_tasks(connection, requested, fn)
+        with self._store.write(immediate=True) as transaction:
+            return self._mutate_tasks(transaction.connection, requested, fn)
+
+    def _mutate_tasks(
+        self,
+        connection: Connection,
+        slugs: list[str],
+        fn: Callable[[dict[str, Task]], None],
+    ) -> dict[str, Task]:
+        selected: dict[str, Task] = {}
+        before: dict[str, Task] = {}
+        for slug in slugs:
+            task = self._store.tasks.get(connection, slug)
+            if task is None:
+                raise KeyError(slug)
+            selected[slug] = task
+            before[slug] = task.model_copy(deep=True)
+
+        fn(selected)
+        unexpected = set(selected) - set(slugs)
+        if unexpected:
+            raise ValueError(
+                "task mutation added unrequested slug(s): "
+                + ", ".join(sorted(unexpected))
+            )
+        for slug, task in selected.items():
+            if task.slug != slug:
+                raise ValueError(
+                    f"task mutation changed slug from {slug!r} to {task.slug!r}"
+                )
+
+        removed = set(slugs) - set(selected)
+        dependencies_changed = bool(removed) or any(
+            selected[slug].depends_on != before[slug].depends_on
+            for slug in selected
+        )
+        if dependencies_changed:
+            all_tasks = self._store.tasks.list(connection)
+            for slug in removed:
+                all_tasks.pop(slug, None)
+            all_tasks.update(selected)
+            self._dependency_order(all_tasks)
+
+        for slug in sorted(removed):
+            self._store.tasks.delete(connection, slug)
+        for slug in sorted(selected):
+            if selected[slug] != before[slug]:
+                self._store.tasks.replace(connection, selected[slug])
+        return selected
+
+    def delete_task(
+        self,
+        slug: str,
+        *,
+        connection: Connection | None = None,
+    ) -> bool:
+        """Delete one Task, optionally joining an existing workspace transaction."""
+        if connection is not None:
+            return self._store.tasks.delete(connection, slug)
+        with self._store.write(immediate=True) as transaction:
+            return transaction.tasks.delete(transaction.connection, slug)
+
     @staticmethod
     def _persist_state(transaction, state: WorkspaceState) -> None:
         existing = transaction.tasks.list(transaction.connection)
@@ -147,9 +268,10 @@ class StateManager:
         """
         stamp = now or datetime.now(timezone.utc)
 
-        def _apply(state: WorkspaceState) -> None:
-            task = state.tasks.get(slug)
-            if task is not None:
-                task.last_activity_at = stamp
-
-        self.mutate(_apply)
+        try:
+            self.mutate_task(
+                slug,
+                lambda task: setattr(task, "last_activity_at", stamp),
+            )
+        except KeyError:
+            pass

--- a/src/mship/core/state.py
+++ b/src/mship/core/state.py
@@ -1,14 +1,13 @@
-import tempfile
+from __future__ import annotations
+
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Callable, Literal
 
-import yaml
 from pydantic import BaseModel, ConfigDict
 
-import fcntl
-from contextlib import contextmanager
-from typing import Callable
+if TYPE_CHECKING:
+    from mship.core.persistence.workspace_store import WorkspaceStore
 
 
 class TestResult(BaseModel):
@@ -61,82 +60,84 @@ class WorkspaceState(BaseModel):
     tasks: dict[str, Task] = {}
 
 
-@contextmanager
-def _locked(state_dir: Path, mode: int):
-    """Advisory lock on `<state_dir>/state.lock`.
-
-    mode: fcntl.LOCK_SH (shared read) or fcntl.LOCK_EX (exclusive write).
-    Released when the context exits.
-    """
-    lock_path = state_dir / "state.lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path.touch(exist_ok=True)
-    with open(lock_path, "r+") as lf:
-        fcntl.flock(lf, mode)
-        try:
-            yield
-        finally:
-            fcntl.flock(lf, fcntl.LOCK_UN)
-
-
 class StateManager:
-    """Read/write .mothership/state.yaml with atomic writes + flock."""
+    """Compatibility facade over legacy state.yaml and transactional SQLite."""
 
-    def __init__(self, state_dir: Path) -> None:
-        self._state_dir = state_dir
-        self._state_file = state_dir / "state.yaml"
+    def __init__(
+        self,
+        state_dir: Path | None = None,
+        *,
+        workspace_store: WorkspaceStore | None = None,
+    ) -> None:
+        if workspace_store is None:
+            if state_dir is None:
+                raise TypeError("state_dir is required when workspace_store is omitted")
+            from mship.core.persistence.workspace_store import WorkspaceStore
+
+            workspace_store = WorkspaceStore(state_dir)
+        self._store = workspace_store
 
     @property
     def state_dir(self) -> Path:
         """Canonical state directory shared by this workspace's stores."""
-        return self._state_dir
-
-    def _load_nolock(self) -> WorkspaceState:
-        if not self._state_file.exists():
-            return WorkspaceState()
-        with open(self._state_file) as f:
-            raw = yaml.safe_load(f)
-        if raw is None:
-            return WorkspaceState()
-        return WorkspaceState(**raw)
-
-    def _save_nolock(self, state: WorkspaceState) -> None:
-        self._state_dir.mkdir(parents=True, exist_ok=True)
-        data = state.model_dump(mode="json")
-        for task in data.get("tasks", {}).values():
-            task["worktrees"] = {
-                k: str(v) for k, v in task.get("worktrees", {}).items()
-            }
-            if "passive_repos" in task:
-                task["passive_repos"] = sorted(task["passive_repos"])
-        fd, tmp_path = tempfile.mkstemp(
-            dir=self._state_dir, suffix=".yaml.tmp"
-        )
-        try:
-            with open(fd, "w") as f:
-                yaml.dump(data, f, default_flow_style=False, sort_keys=False)
-            Path(tmp_path).replace(self._state_file)
-        except Exception:
-            Path(tmp_path).unlink(missing_ok=True)
-            raise
+        return self._store.state_dir
 
     def load(self) -> WorkspaceState:
-        with _locked(self._state_dir, fcntl.LOCK_SH):
-            return self._load_nolock()
+        return self._store.load_state()
 
     def save(self, state: WorkspaceState) -> None:
-        with _locked(self._state_dir, fcntl.LOCK_EX):
-            self._save_nolock(state)
+        with self._store.write(immediate=True) as transaction:
+            self._persist_state(transaction, state)
 
-    def mutate(self, fn: "Callable[[WorkspaceState], None]") -> WorkspaceState:
-        """Read-modify-write under one exclusive lock. No lost updates."""
-        with _locked(self._state_dir, fcntl.LOCK_EX):
-            state = self._load_nolock()
+    def mutate(self, fn: Callable[[WorkspaceState], None]) -> WorkspaceState:
+        """Read-modify-write in one immediate transaction. No lost updates."""
+        with self._store.write(immediate=True) as transaction:
+            state = WorkspaceState(tasks=transaction.tasks.list(transaction.connection))
             fn(state)
-            self._save_nolock(state)
+            self._persist_state(transaction, state)
             return state
 
-    def record_activity(self, slug: str, now: "datetime | None" = None) -> None:
+    @staticmethod
+    def _persist_state(transaction, state: WorkspaceState) -> None:
+        existing = transaction.tasks.list(transaction.connection)
+        for slug in existing.keys() - state.tasks.keys():
+            transaction.tasks.delete(transaction.connection, slug)
+        for slug in StateManager._dependency_order(state.tasks):
+            task = state.tasks[slug]
+            previous = existing.get(slug)
+            if previous is None:
+                transaction.tasks.insert(transaction.connection, task)
+            elif previous != task:
+                transaction.tasks.replace(transaction.connection, task)
+
+    @staticmethod
+    def _dependency_order(tasks: dict[str, Task]) -> list[str]:
+        for key, task in tasks.items():
+            if key != task.slug:
+                raise ValueError(
+                    f"task mapping key {key!r} does not match slug {task.slug!r}"
+                )
+
+        pending = set(tasks)
+        ordered: list[str] = []
+        while pending:
+            ready = sorted(
+                slug
+                for slug in pending
+                if all(
+                    edge.upstream_slug not in pending
+                    for edge in tasks[slug].depends_on
+                )
+            )
+            if not ready:
+                raise ValueError(
+                    "task dependency cycle: " + ", ".join(sorted(pending))
+                )
+            ordered.extend(ready)
+            pending.difference_update(ready)
+        return ordered
+
+    def record_activity(self, slug: str, now: datetime | None = None) -> None:
         """Stamp `last_activity_at` on a task — the agent-agnostic activity heartbeat.
 
         Cheap: one field write under the same exclusive lock as any other

--- a/src/mship/core/workitem_gate.py
+++ b/src/mship/core/workitem_gate.py
@@ -24,7 +24,12 @@ class GateResult:
 
 
 def check_task_gate(
-    task, workspace_root: Path, require_plan: bool = False, require_assumption_gate: bool = False
+    task,
+    workspace_root: Path,
+    require_plan: bool = False,
+    require_assumption_gate: bool = False,
+    *,
+    workitems: WorkItemStore | None = None,
 ) -> GateResult:
     """Universal: a task must have a WorkItem. Kind-gated: a feature WorkItem
     must have an approved spec. When `require_plan` is set — only at phase
@@ -36,11 +41,13 @@ def check_task_gate(
     if getattr(task, "work_item_id", None) is None:
         return GateResult(False, "no WorkItem — create one with `mship item new --kind <kind>` "
                                  "and spawn with `--work-item <id>` (or pass `--hotfix` to override)")
-    items = WorkItemStore(Path(workspace_root) / ".mothership" / "workitems")
+    items = workitems or WorkItemStore(Path(workspace_root) / ".mothership" / "workitems")
     wi = items.get(task.work_item_id)
     if wi is None:
         return GateResult(False, f"work_item_id {task.work_item_id!r} not found")
-    if wi.kind == "feature" and not _feature_has_approved_spec(wi, task, workspace_root):
+    if wi.kind == "feature" and not _feature_has_approved_spec(
+        wi, task, workspace_root, workitems=items,
+    ):
         return GateResult(False, "feature WorkItem requires an approved spec before dev/finish "
                                  "(approve it in Ground Control, or `--hotfix` to override)")
     if require_plan and wi.kind == "feature" and not _feature_has_plan(wi, task, workspace_root):
@@ -56,14 +63,20 @@ def check_task_gate(
     return GateResult(True)
 
 
-def _feature_has_approved_spec(wi: WorkItem, task, workspace_root: Path) -> bool:
+def _feature_has_approved_spec(
+    wi: WorkItem,
+    task,
+    workspace_root: Path,
+    *,
+    workitems: WorkItemStore | None = None,
+) -> bool:
     """Feature gate: satisfied iff the task resolves to an APPROVED spec, using the
     SAME resolution rules as `resolve_bound_spec` (single source of truth) — the
     explicit `spec_id` link is terminal, and an unresolvable binding (a deleted
     linked spec, or several approved specs tying on the slug) is NOT satisfied rather
     than silently falling back to a possibly-unrelated slug match."""
     try:
-        spec = resolve_bound_spec(task, workspace_root)
+        spec = resolve_bound_spec(task, workspace_root, workitems=workitems)
     except BoundSpecUnresolved:
         return False
     return spec is not None and spec.status in APPROVED_STATUSES
@@ -77,7 +90,12 @@ class BoundSpecUnresolved(Exception):
     (phase review, default finish) warn/skip."""
 
 
-def resolve_bound_spec(task, workspace_root: Path):
+def resolve_bound_spec(
+    task,
+    workspace_root: Path,
+    *,
+    workitems: WorkItemStore | None = None,
+):
     """Return the Spec bound to `task`, or None when the task genuinely has NO spec.
 
     The three outcomes are distinct on purpose:
@@ -106,7 +124,8 @@ def resolve_bound_spec(task, workspace_root: Path):
     wi = None
     wi_id = getattr(task, "work_item_id", None)
     if wi_id is not None:
-        wi = WorkItemStore(Path(workspace_root) / ".mothership" / "workitems").get(wi_id)
+        items = workitems or WorkItemStore(Path(workspace_root) / ".mothership" / "workitems")
+        wi = items.get(wi_id)
         if wi is not None and wi.spec_id:
             bound = specs.read_strict(wi.spec_id)
             if bound is None:

--- a/src/mship/core/workitem_lifecycle.py
+++ b/src/mship/core/workitem_lifecycle.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
+from mship.core.workitem_store import WorkItemStore
+
 
 @dataclass(frozen=True)
 class RetainedTaskMetadata:
@@ -101,7 +103,8 @@ def require_retained_task_metadata(
 def advance_workitem_on_close(
     *,
     task,
-    workitems_dir: Path,
+    workitems_dir: Path | None = None,
+    workitems: WorkItemStore | None = None,
     specs_dir: Path,
     state,
     merged_count: int,
@@ -144,9 +147,12 @@ def advance_workitem_on_close(
     if not completed_without_prs and (merged_count == 0 or closed_count > 0):
         return
 
-    from mship.core.workitem_store import WorkItemStore
-
-    store = WorkItemStore(workitems_dir)
+    if workitems is not None:
+        store = workitems
+    elif workitems_dir is not None:
+        store = WorkItemStore(workitems_dir)
+    else:
+        raise TypeError("workitems or workitems_dir is required")
     item = store.get(wid)
     if item is None:
         return

--- a/src/mship/core/workitem_migrate.py
+++ b/src/mship/core/workitem_migrate.py
@@ -30,12 +30,12 @@ def wrap_existing(items: WorkItemStore, specs: SpecStore, state: StateManager,
             spec.work_item_id = wi.id
             specs.save_while_locked(spec, artifact)
             if spec.task_slug and spec.task_slug in task_by_slug:
-                items.add_task(wi.id, spec.task_slug, now=now)
-
-                def _set(s, _slug=spec.task_slug, _wid=wi.id):
-                    if _slug in s.tasks:
-                        s.tasks[_slug].work_item_id = _wid
-                state.mutate(_set)
+                items.add_task(
+                    wi.id,
+                    spec.task_slug,
+                    now=now,
+                    state=state,
+                )
 
     # 2) Orphan tasks (no work_item_id yet) -> attach to an existing item, or
     # else get a feature/chore item of their own. A task's spec_id (or a
@@ -70,12 +70,7 @@ def wrap_existing(items: WorkItemStore, specs: SpecStore, state: StateManager,
                               workspace=workspace, now=now)
             created.append(wi.id)
             wi_id = wi.id
-        items.add_task(wi_id, slug, now=now)
-
-        def _set(s, _slug=slug, _wid=wi_id):
-            if _slug in s.tasks:
-                s.tasks[_slug].work_item_id = _wid
-        state.mutate(_set)
+        items.add_task(wi_id, slug, now=now, state=state)
 
     # 3) Threads -> attach to the item their spec/task already belongs to.
     all_items = items.list()

--- a/src/mship/core/workitem_store.py
+++ b/src/mship/core/workitem_store.py
@@ -229,6 +229,21 @@ class WorkItemStore:
         state: StateManager | None = None,
     ) -> None:
         self._path(item_id)
+        if state is not None:
+            if state.state_dir.resolve() != self._store.state_dir.resolve():
+                raise ValueError(
+                    "Task and WorkItem stores belong to different workspaces"
+                )
+            from mship.core.persistence.lifecycle_repository import (
+                LifecycleRepository,
+            )
+
+            LifecycleRepository(self._store).link_task(
+                item_id,
+                task_slug,
+                now=now or datetime.now(timezone.utc),
+            )
+            return
         with self._store.write(immediate=True) as transaction:
             item = transaction.workitems.get(transaction.connection, item_id)
             if item is None:
@@ -252,12 +267,6 @@ class WorkItemStore:
             if now is not None:
                 item.updated_at = now
             transaction.workitems.replace(transaction.connection, item)
-        if state is not None:
-            def _set(current, slug=task_slug, work_item_id=item_id):
-                if slug in current.tasks:
-                    current.tasks[slug].work_item_id = work_item_id
-
-            state.mutate(_set)
 
     def resolve_task_workitem_id(
         self,

--- a/src/mship/core/workitem_store.py
+++ b/src/mship/core/workitem_store.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-import fcntl
-import tempfile
 import uuid
-from contextlib import contextmanager
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 
+from mship.core.persistence.backend import (
+    StorageBackend,
+    get_legacy_workitem,
+    list_legacy_workitems,
+)
+from mship.core.persistence.workspace_store import WorkspaceStore
 from mship.core.state import StateManager
 from mship.core.workitem import ExternalLink, Kind, Phase, WorkItem
 
@@ -15,24 +19,6 @@ __all__ = ["TaskLinkAmbiguousError", "ThreadAlreadyLinkedError", "WorkItemStore"
 
 def _new_id(now: datetime) -> str:
     return f"wi-{now:%Y%m%d%H%M%S}-{uuid.uuid4().hex[:8]}"
-
-
-@contextmanager
-def _locked(lock_path: Path, mode: int):
-    """Advisory flock on `lock_path` (mirrors state.py's `_locked`).
-
-    mode: fcntl.LOCK_SH (shared read) or fcntl.LOCK_EX (exclusive write).
-    Released when the context exits. A per-item lock file lets writers to
-    DIFFERENT items proceed in parallel; only same-item writers serialize.
-    """
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path.touch(exist_ok=True)
-    with open(lock_path, "r+") as lf:
-        fcntl.flock(lf, mode)
-        try:
-            yield
-        finally:
-            fcntl.flock(lf, fcntl.LOCK_UN)
 
 
 class TaskLinkAmbiguousError(RuntimeError):
@@ -47,149 +33,237 @@ class TaskLinkAmbiguousError(RuntimeError):
 
 
 class ThreadAlreadyLinkedError(Exception):
-    """Raised when linking a thread to a WorkItem that another WorkItem already owns.
-
-    Threads are single-owner: the thread->WorkItem resolver (view/thread_links) assumes a thread
-    appears in at most one item's `thread_ids`, so the write side refuses dual membership rather than
-    silently creating an ambiguous link.
-    """
+    """Raised when a thread already belongs to another WorkItem."""
 
     def __init__(self, thread_id: str, owner_id: str) -> None:
         self.thread_id = thread_id
         self.owner_id = owner_id
-        super().__init__(f"thread {thread_id!r} is already linked to work item {owner_id!r}")
+        super().__init__(
+            f"thread {thread_id!r} is already linked to work item {owner_id!r}"
+        )
 
 
 class WorkItemStore:
-    """Filesystem registry for work items: one JSON file per item."""
+    """Compatibility facade over legacy JSON and transactional SQLite."""
 
-    def __init__(self, workitems_dir: Path) -> None:
+    def __init__(
+        self,
+        workitems_dir: Path,
+        *,
+        workspace_store: WorkspaceStore | None = None,
+    ) -> None:
         self._dir = Path(workitems_dir)
+        self._store = workspace_store or WorkspaceStore(self._dir.parent)
 
     def _path(self, item_id: str) -> Path:
-        if (not item_id or "/" in item_id or "\\" in item_id
-                or item_id in (".", "..") or item_id.startswith(".")):
+        if (
+            not item_id
+            or "/" in item_id
+            or "\\" in item_id
+            or item_id in (".", "..")
+            or item_id.startswith(".")
+        ):
             raise ValueError(f"unsafe work item id: {item_id!r}")
         return self._dir / f"{item_id}.json"
 
-    def _lock_path(self, item_id: str) -> Path:
-        """Per-item lock file (`<id>.json.lock`). Reuses `_path`'s id validation.
-        Not matched by `list()`'s `*.json` glob, so it stays invisible to reads."""
-        p = self._path(item_id)
-        return p.with_name(p.name + ".lock")
-
     def save(self, item: WorkItem) -> Path:
-        self._dir.mkdir(parents=True, exist_ok=True)
-        path = self._path(item.id)
-        fd, tmp = tempfile.mkstemp(dir=self._dir, suffix=".json.tmp")
-        try:
-            with open(fd, "w") as f:
-                f.write(item.model_dump_json(indent=2))
-            Path(tmp).replace(path)
-        except Exception:
-            Path(tmp).unlink(missing_ok=True)
-            raise
-        return path
+        self._path(item.id)
+        with self._store.write(immediate=True) as transaction:
+            existing = transaction.workitems.get(transaction.connection, item.id)
+            self._validate_ownership(
+                item,
+                transaction.workitems.list(
+                    transaction.connection,
+                    include_archived=True,
+                ),
+            )
+            if existing is None:
+                transaction.workitems.insert(transaction.connection, item)
+            else:
+                transaction.workitems.replace(transaction.connection, item)
+        return self._store.database.path
+
+    @staticmethod
+    def _validate_ownership(
+        item: WorkItem,
+        candidates: list[WorkItem],
+    ) -> None:
+        others = [candidate for candidate in candidates if candidate.id != item.id]
+        for task_slug in item.task_slugs:
+            owner = next(
+                (
+                    candidate.id
+                    for candidate in others
+                    if task_slug in candidate.task_slugs
+                ),
+                None,
+            )
+            if owner is not None:
+                raise TaskLinkAmbiguousError(
+                    task_slug,
+                    sorted([owner, item.id]),
+                )
+        for thread_id in item.thread_ids:
+            owner = next(
+                (
+                    candidate.id
+                    for candidate in others
+                    if thread_id in candidate.thread_ids
+                ),
+                None,
+            )
+            if owner is not None:
+                raise ThreadAlreadyLinkedError(thread_id, owner)
 
     def get(self, item_id: str) -> WorkItem | None:
-        path = self._path(item_id)
-        if not path.is_file():
+        self._path(item_id)
+        backend = self._store.backend
+        if backend is StorageBackend.EMPTY:
             return None
-        return WorkItem.model_validate_json(path.read_text())
+        if backend is StorageBackend.LEGACY:
+            return get_legacy_workitem(self._dir, item_id)
+        with self._store.read() as transaction:
+            return transaction.workitems.get(transaction.connection, item_id)
 
     def list(self, include_archived: bool = False) -> list[WorkItem]:
-        if not self._dir.is_dir():
+        backend = self._store.backend
+        if backend is StorageBackend.EMPTY:
             return []
-        items = [WorkItem.model_validate_json(p.read_text()) for p in self._dir.glob("*.json")]
-        if not include_archived:
-            items = [item for item in items if not item.archived]
-        return sorted(items, key=lambda w: w.updated_at, reverse=True)
+        if backend is StorageBackend.LEGACY:
+            return list_legacy_workitems(
+                self._dir,
+                include_archived=include_archived,
+            )[0]
+        with self._store.read() as transaction:
+            return transaction.workitems.list(
+                transaction.connection,
+                include_archived=include_archived,
+            )
 
     def list_tolerant_with_uncertainty(
-        self, include_archived: bool = False,
+        self,
+        include_archived: bool = False,
     ) -> tuple[list[WorkItem], bool]:
-        """Read healthy items and report whether any artifact was unreadable."""
-        if not self._dir.is_dir():
+        backend = self._store.backend
+        if backend is StorageBackend.EMPTY:
             return [], False
-        items: list[WorkItem] = []
-        uncertain = False
-        for path in self._dir.glob("*.json"):
-            try:
-                items.append(WorkItem.model_validate_json(path.read_text()))
-            except Exception:
-                uncertain = True
-        if not include_archived:
-            items = [item for item in items if not item.archived]
-        return sorted(
-            items,
-            key=lambda item: item.updated_at.replace(tzinfo=timezone.utc)
-            if item.updated_at.tzinfo is None else item.updated_at,
-            reverse=True,
-        ), uncertain
+        if backend is StorageBackend.LEGACY:
+            return list_legacy_workitems(
+                self._dir,
+                include_archived=include_archived,
+                tolerant=True,
+            )
+        with self._store.read() as transaction:
+            return transaction.workitems.list_tolerant_with_uncertainty(
+                transaction.connection,
+                include_archived=include_archived,
+            )
 
     def list_tolerant(self, include_archived: bool = False) -> list[WorkItem]:
         return self.list_tolerant_with_uncertainty(include_archived)[0]
 
-    def create(self, title: str, kind: Kind, workspace: str, now: datetime) -> WorkItem:
-        item = WorkItem(id=_new_id(now), title=title, workspace=workspace, kind=kind,
-                        created_at=now, updated_at=now)
+    def create(
+        self,
+        title: str,
+        kind: Kind,
+        workspace: str,
+        now: datetime,
+    ) -> WorkItem:
+        item = WorkItem(
+            id=_new_id(now),
+            title=title,
+            workspace=workspace,
+            kind=kind,
+            created_at=now,
+            updated_at=now,
+        )
         self.save(item)
         return item
 
-    def _mutate(self, item_id: str, now: datetime | None) -> WorkItem:
-        item = self.get(item_id)
-        if item is None:
-            raise KeyError(item_id)
-        if now is not None:
-            item.updated_at = now
-        return item
+    def _mutate_item(
+        self,
+        item_id: str,
+        now: datetime | None,
+        fn: Callable[[WorkItem], None],
+    ) -> WorkItem:
+        self._path(item_id)
+        with self._store.write(immediate=True) as transaction:
+            item = transaction.workitems.get(transaction.connection, item_id)
+            if item is None:
+                raise KeyError(item_id)
+            fn(item)
+            if now is not None:
+                item.updated_at = now
+            transaction.workitems.replace(transaction.connection, item)
+            return item
 
-    def link_spec(self, item_id: str, spec_id: str, now: datetime | None = None) -> None:
-        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
-            item = self._mutate(item_id, now)
-            item.spec_id = spec_id
-            self.save(item)
+    def link_spec(
+        self,
+        item_id: str,
+        spec_id: str,
+        now: datetime | None = None,
+    ) -> None:
+        self._mutate_item(
+            item_id,
+            now,
+            lambda item: setattr(item, "spec_id", spec_id),
+        )
 
-    def link_plan(self, item_id: str, plan_path: str, now: datetime | None = None) -> None:
-        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
-            item = self._mutate(item_id, now)
-            item.plan_path = plan_path
-            self.save(item)
+    def link_plan(
+        self,
+        item_id: str,
+        plan_path: str,
+        now: datetime | None = None,
+    ) -> None:
+        self._mutate_item(
+            item_id,
+            now,
+            lambda item: setattr(item, "plan_path", plan_path),
+        )
 
-    def add_task(self, item_id: str, task_slug: str, now: datetime | None = None,
-                state: StateManager | None = None) -> None:
-        # Exclusive lock spans get+append+save so concurrent add_task calls to the
-        # same item can't clobber each other's task_slugs (MOS-233).
-        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
-            item = self.get(item_id)
+    def add_task(
+        self,
+        item_id: str,
+        task_slug: str,
+        now: datetime | None = None,
+        state: StateManager | None = None,
+    ) -> None:
+        self._path(item_id)
+        with self._store.write(immediate=True) as transaction:
+            item = transaction.workitems.get(transaction.connection, item_id)
             if item is None:
                 raise KeyError(item_id)
             if task_slug in item.task_slugs:
                 return
+            owner_ids = [
+                candidate.id
+                for candidate in transaction.workitems.list(
+                    transaction.connection,
+                    include_archived=True,
+                )
+                if task_slug in candidate.task_slugs
+            ]
+            if owner_ids:
+                raise TaskLinkAmbiguousError(
+                    task_slug,
+                    sorted([*owner_ids, item_id]),
+                )
             item.task_slugs.append(task_slug)
             if now is not None:
                 item.updated_at = now
-            self.save(item)
+            transaction.workitems.replace(transaction.connection, item)
         if state is not None:
-            # Reverse link: task.work_item_id, mirroring workitem_migrate.wrap_existing's
-            # pass-2 mutation (workitem_migrate.py:46-49). StateManager.mutate takes its
-            # own state.lock, so keep it outside this item lock to avoid lock coupling.
-            def _set(s, _slug=task_slug, _wid=item_id):
-                if _slug in s.tasks:
-                    s.tasks[_slug].work_item_id = _wid
+            def _set(current, slug=task_slug, work_item_id=item_id):
+                if slug in current.tasks:
+                    current.tasks[slug].work_item_id = work_item_id
+
             state.mutate(_set)
 
     def resolve_task_workitem_id(
-        self, task_slug: str, reverse_item_id: str | None,
+        self,
+        task_slug: str,
+        reverse_item_id: str | None,
     ) -> str | None:
-        """Return a task's authoritative WorkItem id, preferring its forward link.
-
-        WorkItem.task_slugs is the durable association used by archive guards.
-        A unique forward link therefore repairs a missing or stale task-side
-        work_item_id. Archived items participate too: archiving hides an item
-        from the default list, but must not discard its retained delivery data.
-        Multiple forward owners are unsafe to choose between and fail closed.
-        """
         forward_ids = sorted(
             item.id
             for item in self.list(include_archived=True)
@@ -199,104 +273,114 @@ class WorkItemStore:
             raise TaskLinkAmbiguousError(task_slug, forward_ids)
         return forward_ids[0] if forward_ids else reverse_item_id
 
-
     def retain_task_metadata(self, task, *, item_id: str | None = None) -> bool:
-        """Persist a linked task's observed repos and PR URLs before task removal.
-
-        The exclusive item lock makes repeated close/prune paths merge rather
-        than overwrite retained metadata. Any write failure propagates so the
-        caller can keep the task state, which remains the last source of truth.
-        Returns False only when the linked WorkItem no longer exists.
-        """
         item_id = item_id if item_id is not None else getattr(task, "work_item_id", None)
         if not item_id:
             return True
+        self._path(item_id)
         repos = list(getattr(task, "affected_repos", []) or [])
         pr_urls = list((getattr(task, "pr_urls", {}) or {}).values())
-        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
-            item = self.get(item_id)
+        with self._store.write(immediate=True) as transaction:
+            item = transaction.workitems.get(transaction.connection, item_id)
             if item is None:
                 return False
             retained_repos = list(dict.fromkeys([*item.affected_repos, *repos]))
             retained_pr_urls = list(dict.fromkeys([*item.pr_urls, *pr_urls]))
-            if retained_repos == item.affected_repos and retained_pr_urls == item.pr_urls:
+            if (
+                retained_repos == item.affected_repos
+                and retained_pr_urls == item.pr_urls
+            ):
                 return True
             item.affected_repos = retained_repos
             item.pr_urls = retained_pr_urls
             item.updated_at = datetime.now(timezone.utc)
-            self.save(item)
+            transaction.workitems.replace(transaction.connection, item)
             return True
 
     def _thread_owner(self, thread_id: str, exclude: str) -> str | None:
-        """Id of a WorkItem (other than `exclude`) whose thread_ids contains `thread_id`, else None.
-        Scans archived items too — an archived item still holds its threads in stored data, so it
-        still counts as the thread's owner for the single-owner invariant."""
-        for w in self.list(include_archived=True):
-            if w.id != exclude and thread_id in w.thread_ids:
-                return w.id
+        for item in self.list(include_archived=True):
+            if item.id != exclude and thread_id in item.thread_ids:
+                return item.id
         return None
 
-    def _thread_link_lock_path(self) -> Path:
-        """Store-wide lock serializing all `add_thread` calls. The per-item locks let writers to
-        DIFFERENT items run in parallel, so the cross-item ownership scan + append would otherwise
-        race (two concurrent adds of the same thread to different items could both see "no owner"
-        and both save → dual membership). Held around the scan+append so the exclusivity check is
-        atomic. Starts with '.', so `list()`'s `*.json` glob never reads it."""
-        return self._dir / ".thread-link.lock"
+    def add_thread(
+        self,
+        item_id: str,
+        thread_id: str,
+        now: datetime | None = None,
+    ) -> None:
+        self._path(item_id)
+        with self._store.write(immediate=True) as transaction:
+            item = transaction.workitems.get(transaction.connection, item_id)
+            if item is None:
+                raise KeyError(item_id)
+            if thread_id in item.thread_ids:
+                return
+            owner = next(
+                (
+                    candidate.id
+                    for candidate in transaction.workitems.list(
+                        transaction.connection,
+                        include_archived=True,
+                    )
+                    if candidate.id != item_id
+                    and thread_id in candidate.thread_ids
+                ),
+                None,
+            )
+            if owner is not None:
+                raise ThreadAlreadyLinkedError(thread_id, owner)
+            item.thread_ids.append(thread_id)
+            if now is not None:
+                item.updated_at = now
+            transaction.workitems.replace(transaction.connection, item)
 
-    def add_thread(self, item_id: str, thread_id: str, now: datetime | None = None) -> None:
-        # Outer store-wide lock makes the ownership scan + append atomic ACROSS items; inner per-item
-        # lock keeps this item's read-modify-write atomic against other same-item writers. Ordering is
-        # always store-lock → item-lock (other methods take only the item lock), so no deadlock cycle.
-        with _locked(self._thread_link_lock_path(), fcntl.LOCK_EX):
-            with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
-                item = self.get(item_id)
-                if item is None:
-                    raise KeyError(item_id)
-                if thread_id in item.thread_ids:
-                    return  # already ours — idempotent no-op
-                # Exclusive membership: a thread belongs to at most one WorkItem (the resolver assumes
-                # a single owner). If another item holds it, refuse rather than create dual membership.
-                owner = self._thread_owner(thread_id, exclude=item_id)
-                if owner is not None:
-                    raise ThreadAlreadyLinkedError(thread_id, owner)
-                item.thread_ids.append(thread_id)
-                if now is not None:
-                    item.updated_at = now
-                self.save(item)
+    def add_external_link(
+        self,
+        item_id: str,
+        link: ExternalLink,
+        now: datetime | None = None,
+    ) -> None:
+        self._mutate_item(
+            item_id,
+            now,
+            lambda item: item.external_links.append(link),
+        )
 
-    def add_external_link(self, item_id: str, link: ExternalLink, now: datetime | None = None) -> None:
-        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
-            item = self._mutate(item_id, now)
-            item.external_links.append(link)
-            self.save(item)
+    def set_phase_override(
+        self,
+        item_id: str,
+        phase: Phase | None,
+        now: datetime | None = None,
+    ) -> None:
+        self._mutate_item(
+            item_id,
+            now,
+            lambda item: setattr(item, "phase_override", phase),
+        )
 
-    def set_phase_override(self, item_id: str, phase: Phase | None, now: datetime | None = None) -> None:
-        """Set the manual phase override, or clear it (return to derived phase) when
-        `phase` is None. Raises KeyError if the item does not exist."""
-        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
-            item = self._mutate(item_id, now)
-            item.phase_override = phase
-            self.save(item)
-
-    def set_unattended(self, item_id: str, on: bool, now: datetime | None = None) -> None:
-        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
-            item = self._mutate(item_id, now)
-            item.unattended = on
-            self.save(item)
+    def set_unattended(
+        self,
+        item_id: str,
+        on: bool,
+        now: datetime | None = None,
+    ) -> None:
+        self._mutate_item(
+            item_id,
+            now,
+            lambda item: setattr(item, "unattended", on),
+        )
 
     def archive(self, item_id: str, now: datetime | None = None) -> None:
-        """Soft-delete: mark the item archived so it's excluded from list() by
-        default. Raises KeyError if the item does not exist."""
-        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
-            item = self._mutate(item_id, now)
-            item.archived = True
-            self.save(item)
+        self._mutate_item(
+            item_id,
+            now,
+            lambda item: setattr(item, "archived", True),
+        )
 
     def unarchive(self, item_id: str, now: datetime | None = None) -> None:
-        """Reverse of archive(): clear the archived flag. Raises KeyError if the
-        item does not exist."""
-        with _locked(self._lock_path(item_id), fcntl.LOCK_EX):
-            item = self._mutate(item_id, now)
-            item.archived = False
-            self.save(item)
+        self._mutate_item(
+            item_id,
+            now,
+            lambda item: setattr(item, "archived", False),
+        )

--- a/src/mship/core/workspace_meta.py
+++ b/src/mship/core/workspace_meta.py
@@ -1,8 +1,8 @@
-"""Tiny key/value store for workspace-level metadata that doesn't fit in state.yaml.
+"""Tiny key/value store for metadata outside normalized Task/WorkItem state.
 
 Currently holds only `last_sync_at` (written by `mship sync`, read by
-`mship context`). Kept as a separate JSON file so a corrupt write here can
-never wedge `state.yaml`.
+`mship context`). Kept as a separate JSON file so a corrupt write here cannot
+wedge the authoritative Task and WorkItem database.
 """
 from __future__ import annotations
 

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -730,26 +730,24 @@ class WorktreeManager:
             work_item_id=work_item_id,
         )
 
-        def _apply(s: WorkspaceState) -> None:
-            # Atomic check-and-set: re-check under the exclusive lock so two
-            # concurrent spawns with the same slug cannot both register. The
-            # caller-facing error matches the preflight message.
-            if slug in s.tasks:
-                raise ValueError(
-                    f"Task '{slug}' already exists. "
-                    f"Run `mship close --yes --abandon --task {slug}` to remove it first, or use a different description."
+        try:
+            if work_item_id is None:
+                self._state_manager.insert_task(task)
+            else:
+                from mship.core.persistence.lifecycle_repository import (
+                    LifecycleRepository,
                 )
-            s.tasks[slug] = task
-        self._state_manager.mutate(_apply)
 
-        if work_item_id is not None:
-            # Forward link (task_slugs) on the WorkItem. The reverse link
-            # (task.work_item_id) is already set atomically on the Task above;
-            # add_task's state=... mutate is a harmless no-op re-set of the
-            # same value (see WorkItemStore.add_task).
-            from mship.core.workitem_store import WorkItemStore
-            items = WorkItemStore(workspace_root / ".mothership" / "workitems")
-            items.add_task(work_item_id, slug, now=now, state=self._state_manager)
+                LifecycleRepository(self._state_manager.workspace_store).register_task(
+                    task, work_item_id, now=now
+                )
+        except KeyError as error:
+            if error.args != (slug,):
+                raise
+            raise ValueError(
+                f"Task '{slug}' already exists. "
+                f"Run `mship close --yes --abandon --task {slug}` to remove it first, or use a different description."
+            ) from error
 
         self._log.create(slug)
         log_msg = f"Task spawned. Repos: {', '.join(ordered)}. Branch: {branch}"
@@ -842,29 +840,13 @@ class WorktreeManager:
             except Exception:
                 pass
 
-        # State is the final copy of task delivery metadata. Persist it before
-        # removing the task so a failed WorkItem write cannot silently lose it.
-        # Item locks stay outside StateManager.mutate's state.lock.
-        from mship.core.workitem_lifecycle import (
-            require_retained_task_metadata,
-            retain_workitem_metadata_on_teardown,
+        from mship.core.persistence.lifecycle_repository import LifecycleRepository
+
+        LifecycleRepository(self._state_manager.workspace_store).retain_and_delete_task(
+            task_slug,
+            now=datetime.now(timezone.utc),
+            expected_task=task,
         )
-
-        retained = retain_workitem_metadata_on_teardown(
-            task=task,
-            workitems_dir=self._state_manager.state_dir / "workitems",
-        )
-
-        # Only update state after all cleanup attempts. A task metadata update
-        # that raced the retention write must remain available for a retry.
-        def _abort(s):
-            live_task = s.tasks.get(task_slug)
-            if live_task is None:
-                return
-            require_retained_task_metadata(live_task, retained)
-            del s.tasks[task_slug]
-
-        self._state_manager.mutate(_abort)
 
     def list_worktrees(self) -> dict[str, dict[str, Path]]:
         state = self._state_manager.load()

--- a/src/mship/core/worktree.py
+++ b/src/mship/core/worktree.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 
+from sqlalchemy.exc import IntegrityError
+
 from mship.core.config import WorkspaceConfig
 from mship.core.graph import DependencyGraph
 from mship.core.log import LogManager
@@ -741,8 +743,11 @@ class WorktreeManager:
                 LifecycleRepository(self._state_manager.workspace_store).register_task(
                     task, work_item_id, now=now
                 )
-        except KeyError as error:
-            if error.args != (slug,):
+        except (IntegrityError, KeyError) as error:
+            if isinstance(error, KeyError):
+                if error.args != (slug,):
+                    raise
+            elif "UNIQUE constraint failed: tasks.slug" not in str(error.orig):
                 raise
             raise ValueError(
                 f"Task '{slug}' already exists. "

--- a/src/mship/skills/working-with-mothership/SKILL.md
+++ b/src/mship/skills/working-with-mothership/SKILL.md
@@ -495,7 +495,7 @@ mship journal           # full narrative of what was done
 mship journal --last 5  # only the recent entries
 ```
 
-The state file lives in `<git-main-repo>/.mothership/state.yaml` (anchored to the main repo's `.git`, so it works correctly when you `cd` into a worktree).
+Task and WorkItem state lives in `<git-main-repo>/.mothership/mothership.db` (anchored to the main repo's `.git`, so it works correctly when you `cd` into a worktree). In an unmigrated workspace, legacy `state.yaml` and `workitems/*.json` remain authoritative until `mship state migrate` performs the explicit cutover.
 
 **Always log progress before:**
 - Ending a session
@@ -625,7 +625,7 @@ Then `mship test --tag mobile` runs both.
 - **Don't ship a PR with a placeholder body.** If you didn't pass `--body-file`/`--body` to `mship finish`, the PR body is just the task description — not a Summary + Test plan. Follow up with `gh pr edit <url> --body-file <path>` before declaring done. Reviewers (human or agent) need to know what changed and how it was verified.
 - **Don't paste test output into `mship journal`** — after every `mship test`, mship auto-logs a structured entry with iteration, test_state, and action. The iteration file under `.mothership/test-runs/` has stderr for failures.
 - **Don't keep editing a worktree after `mship finish` without using `mship commit`** — once `finish` stamps the task as done, phase transitions are blocked (except `run`). For small post-finish changes (reviewer feedback, CI fixes, doc tweaks), stage your changes and run `mship commit "<msg>"` — it commits and pushes to the existing PR across all affected repos. For larger changes, open a new task with `mship spawn`.
-- **Don't manually edit `.mothership/state.yaml`** — use the CLI commands instead.
+- **Don't manually edit `.mothership/mothership.db` or legacy state files** — use the CLI, including `mship state status`, `migrate`, and `export`.
 - **Don't assume `mship` knows what's running outside of it** — if you started services manually, mothership won't track them. Use `mship run` or accept that `mship status` won't reflect them.
 - **Don't `--force-audit` without reading the drift** — the gate is there to stop you from starting work on a dirty/wrong-branch repo. If you bypass, know why; the task log records the bypass.
 - **Don't `cd` between worktrees without `mship switch`** — you'll miss cross-repo changes and lose the "since your last switch" anchor. Always call `mship switch <repo>` before starting work in a different repo.

--- a/tests/cli/test_cli_help_improvements.py
+++ b/tests/cli/test_cli_help_improvements.py
@@ -48,6 +48,12 @@ def test_view_no_args_shows_help(workspace: Path):
         container.state_manager.reset()
 
 
+def test_state_no_args_shows_help():
+    result = runner.invoke(app, ["state"])
+    assert result.exit_code in (0, 2)
+    assert "Inspect, migrate, and export workspace state storage" in result.output
+
+
 # ---------------------------------------------------------------------------
 # 2. _resolve_repos error lists available repos
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_commit.py
+++ b/tests/cli/test_commit.py
@@ -15,13 +15,14 @@ runner = CliRunner()
 
 def _set_finished(workspace: Path, slug: str, pr_urls: dict[str, str]) -> None:
     """Mark a spawned task as finished with given pr_urls."""
-    import yaml
     from datetime import datetime, timezone
-    state_path = workspace / ".mothership" / "state.yaml"
-    data = yaml.safe_load(state_path.read_text())
-    data["tasks"][slug]["finished_at"] = datetime.now(timezone.utc).isoformat()
-    data["tasks"][slug]["pr_urls"] = pr_urls
-    state_path.write_text(yaml.safe_dump(data))
+    manager = StateManager(workspace / ".mothership")
+
+    def _update(state):
+        state.tasks[slug].finished_at = datetime.now(timezone.utc)
+        state.tasks[slug].pr_urls = pr_urls
+
+    manager.mutate(_update)
 
 
 def test_commit_pre_finish_single_repo(configured_git_app: Path):

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -40,6 +40,7 @@ def test_init_non_interactive_with_cwd(init_workspace: Path, monkeypatch):
     assert data["repos"]["shared"]["type"] == "library"
     assert data["repos"]["auth-service"]["type"] == "service"
     assert data["repos"]["auth-service"]["depends_on"] == ["shared"]
+    assert (init_workspace / ".mothership" / "mothership.db").is_file()
 
 
 def test_init_detect(init_workspace: Path, monkeypatch):
@@ -81,6 +82,7 @@ def test_init_detect_emits_git_root_for_single_git_monorepo(tmp_path: Path, monk
     for sub in ("web", "infra"):
         assert data["repos"][sub]["path"] == sub
         assert data["repos"][sub]["git_root"] == root_name
+    assert (tmp_path / ".mothership" / "mothership.db").is_file()
     for repo in data["repos"].values():          # ac2
         assert not str(repo["path"]).startswith("/")
 

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -22,6 +22,28 @@ def init_workspace(tmp_path: Path) -> Path:
     return tmp_path
 
 
+def _linked_worktree(tmp_path: Path, *, with_project: bool = False) -> tuple[Path, Path]:
+    main = tmp_path / "main"
+    main.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=main, check=True)
+    if with_project:
+        (main / "pyproject.toml").write_text("[project]\nname='root'\n")
+        subprocess.run(["git", "add", "pyproject.toml"], cwd=main, check=True)
+    subprocess.run(
+        ["git", "-c", "user.name=Test", "-c", "user.email=test@example.com",
+         "commit", "--allow-empty", "-m", "initial"],
+        cwd=main,
+        check=True,
+    )
+    worktree = tmp_path / "linked"
+    subprocess.run(
+        ["git", "worktree", "add", "-q", "-b", "linked", str(worktree)],
+        cwd=main,
+        check=True,
+    )
+    return main, worktree
+
+
 def test_init_non_interactive_with_cwd(init_workspace: Path, monkeypatch):
     monkeypatch.chdir(init_workspace)
     result = runner.invoke(app, [
@@ -41,6 +63,23 @@ def test_init_non_interactive_with_cwd(init_workspace: Path, monkeypatch):
     assert data["repos"]["auth-service"]["type"] == "service"
     assert data["repos"]["auth-service"]["depends_on"] == ["shared"]
     assert (init_workspace / ".mothership" / "mothership.db").is_file()
+
+
+def test_init_non_interactive_in_linked_worktree_uses_git_common_state(
+    tmp_path: Path,
+    monkeypatch,
+):
+    main, worktree = _linked_worktree(tmp_path)
+    monkeypatch.chdir(worktree)
+
+    result = runner.invoke(
+        app,
+        ["init", "--name", "linked", "--repo", ".:service"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (main / ".mothership" / "mothership.db").is_file()
+    assert not (worktree / ".mothership").exists()
 
 
 def test_init_detect(init_workspace: Path, monkeypatch):
@@ -624,3 +663,90 @@ def test_interactive_wizard_emits_git_root_for_single_git_monorepo(tmp_path: Pat
     for sub in ("web", "infra"):
         assert data["repos"][sub]["path"] == sub
         assert data["repos"][sub]["git_root"] == root_name
+
+
+def test_init_interactive_in_linked_worktree_uses_git_common_state(
+    tmp_path: Path,
+    monkeypatch,
+):
+    import InquirerPy.inquirer  # noqa: F401
+    from mship.cli.init import _run_interactive
+    from mship.cli.output import Output
+    from mship.core.init import WorkspaceInitializer
+
+    main, worktree = _linked_worktree(tmp_path, with_project=True)
+    monkeypatch.chdir(worktree)
+
+    class _Prompt:
+        def __init__(self, value):
+            self.value = value
+
+        def execute(self):
+            return self.value
+
+    class _FakeInquirer:
+        def text(self, message="", default="", **_kwargs):
+            return _Prompt("linked") if "Workspace name" in message else _Prompt("")
+
+        def checkbox(self, message="", choices=None, **_kwargs):
+            if "Select repos" in message:
+                return _Prompt([choice["value"] for choice in choices or []])
+            return _Prompt([])
+
+        def select(self, message="", choices=None, default=None, **_kwargs):
+            return _Prompt("service") if "type is" in message else _Prompt(None)
+
+        def confirm(self, message="", default=True, **_kwargs):
+            return _Prompt(False)
+
+    monkeypatch.setattr("InquirerPy.inquirer", _FakeInquirer())
+
+    _run_interactive(
+        WorkspaceInitializer(),
+        Output(),
+        worktree,
+        worktree / "mothership.yaml",
+        None,
+        False,
+    )
+
+    assert (main / ".mothership" / "mothership.db").is_file()
+    assert not (worktree / ".mothership").exists()
+
+
+def test_init_ignores_state_before_creating_database(
+    tmp_path: Path,
+    monkeypatch,
+):
+    from mship.core.persistence.workspace_store import WorkspaceStore
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    assert not (workspace / ".gitignore").exists()
+
+    initialize_if_empty = WorkspaceStore.initialize_if_empty
+    observed_order = False
+
+    def initialize_after_ignore(self):
+        nonlocal observed_order
+        ignore_path = self.state_dir.parent / ".gitignore"
+        assert ignore_path.is_file()
+        assert ".mothership/" in ignore_path.read_text().splitlines()
+        assert not (self.state_dir / "mothership.db").exists()
+        observed_order = True
+        return initialize_if_empty(self)
+
+    monkeypatch.setattr(
+        WorkspaceStore,
+        "initialize_if_empty",
+        initialize_after_ignore,
+    )
+    monkeypatch.chdir(workspace)
+
+    result = runner.invoke(
+        app,
+        ["init", "--name", "ignored", "--repo", ".:service"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert observed_order

--- a/tests/cli/test_internal.py
+++ b/tests/cli/test_internal.py
@@ -164,12 +164,14 @@ _TASK_YAML_NO_WORKITEM = (
 def _seed_bug_workitem(state_dir, item_id: str = _KNOWN_WORK_ITEM_ID) -> None:
     from datetime import datetime, timezone
     from mship.core.workitem import WorkItem
-    from mship.core.workitem_store import WorkItemStore
     now = datetime.now(timezone.utc)
-    WorkItemStore(state_dir / "workitems").save(
-        WorkItem(id=item_id, title="t", workspace="w", kind="bug",
-                 created_at=now, updated_at=now)
+    workitems_dir = state_dir / "workitems"
+    workitems_dir.mkdir(parents=True, exist_ok=True)
+    item = WorkItem(
+        id=item_id, title="t", workspace="w", kind="bug",
+        created_at=now, updated_at=now,
     )
+    (workitems_dir / f"{item_id}.json").write_text(item.model_dump_json())
 
 
 def test_check_push_rejects_unregistered_feat_branch(tmp_path, monkeypatch):

--- a/tests/cli/test_pr.py
+++ b/tests/cli/test_pr.py
@@ -4,10 +4,10 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-import yaml
 from typer.testing import CliRunner
 
 from mship.cli import app, container
+from mship.core.state import StateManager
 from mship.util.shell import ShellResult, ShellRunner
 
 runner = CliRunner()
@@ -15,11 +15,13 @@ runner = CliRunner()
 
 def _set_pr_urls(workspace: Path, slug: str, pr_urls: dict[str, str]) -> None:
     from datetime import datetime, timezone
-    state_path = workspace / ".mothership" / "state.yaml"
-    data = yaml.safe_load(state_path.read_text())
-    data["tasks"][slug]["pr_urls"] = pr_urls
-    data["tasks"][slug]["finished_at"] = datetime.now(timezone.utc).isoformat()
-    state_path.write_text(yaml.safe_dump(data))
+    manager = StateManager(workspace / ".mothership")
+
+    def _update(state):
+        state.tasks[slug].pr_urls = pr_urls
+        state.tasks[slug].finished_at = datetime.now(timezone.utc)
+
+    manager.mutate(_update)
 
 
 def _pr_view_shell(mapping: dict[str, tuple[str, int, str]]):

--- a/tests/cli/test_prune.py
+++ b/tests/cli/test_prune.py
@@ -71,11 +71,12 @@ def test_prune_retention_conflict_is_clean_error(
         ),
     }))
 
-    def reject_retention(*, task, workitems_dir):
-        raise TaskMetadataRetentionConflictError(task.slug, "metadata retention failed")
+    def reject_retention(self, task_slug, repos, *, now, expected_task=None):
+        raise TaskMetadataRetentionConflictError(task_slug, "metadata retention failed")
 
     monkeypatch.setattr(
-        "mship.core.workitem_lifecycle.retain_workitem_metadata_on_teardown",
+        "mship.core.persistence.lifecycle_repository."
+        "LifecycleRepository.retain_and_prune_task_repos",
         reject_retention,
     )
 

--- a/tests/cli/test_state_storage.py
+++ b/tests/cli/test_state_storage.py
@@ -1,0 +1,133 @@
+import json
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.persistence.database import WorkspaceDatabase
+
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def state_cli(workspace: Path):
+    state_dir = workspace / ".mothership"
+    state_dir.mkdir(exist_ok=True)
+    container.config_path.override(workspace / "mothership.yaml")
+    container.state_dir.override(state_dir)
+    try:
+        yield state_dir
+    finally:
+        container.config_path.reset_override()
+        container.state_dir.reset_override()
+        container.config.reset()
+        container.state_manager.reset()
+        container.workspace_store.reset()
+        container.workspace_database.reset()
+
+
+def test_state_status_reports_stable_legacy_payload(state_cli: Path) -> None:
+    (state_cli / "state.yaml").write_text("tasks: {}\n")
+
+    result = runner.invoke(app, ["--json", "state", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {
+        "backend": "legacy",
+        "database_path": str(state_cli / "mothership.db"),
+        "current_revision": None,
+        "head_revision": "0001_tasks_and_workitems",
+        "migration_required": True,
+    }
+    assert not (state_cli / "mothership.db").exists()
+
+
+def test_state_export_emits_machine_readable_json(state_cli: Path) -> None:
+    (state_cli / "state.yaml").write_text("tasks: {}\n")
+
+    result = runner.invoke(app, ["state", "export", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {"tasks": [], "work_items": []}
+
+
+def test_state_export_rejects_unsupported_format(state_cli: Path) -> None:
+    result = runner.invoke(app, ["state", "export", "--format", "toml"])
+
+    assert result.exit_code == 1
+    assert "json or yaml" in result.output
+
+
+def test_state_migrate_refuses_running_daemon(
+    state_cli: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (state_cli / "state.yaml").write_text("tasks: {}\n")
+    monkeypatch.setattr(
+        "mship.core.persistence.migration.daemon_is_running",
+        lambda: True,
+    )
+
+    result = runner.invoke(app, ["state", "migrate"])
+
+    assert result.exit_code == 1
+    assert "daemon is running" in result.output
+
+
+def test_state_migrate_rejects_invalid_legacy_data(
+    state_cli: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (state_cli / "state.yaml").write_text("tasks: [not-a-mapping]\n")
+    monkeypatch.setattr(
+        "mship.core.persistence.migration.daemon_is_running",
+        lambda: False,
+    )
+
+    result = runner.invoke(app, ["state", "migrate"])
+
+    assert result.exit_code == 1
+    assert "validation" in result.output.lower()
+    assert not (state_cli / "mothership.db").exists()
+
+
+def test_state_migrate_is_idempotent(
+    state_cli: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (state_cli / "state.yaml").write_text("tasks: {}\n")
+    monkeypatch.setattr(
+        "mship.core.persistence.migration.daemon_is_running",
+        lambda: False,
+    )
+
+    first = runner.invoke(app, ["--json", "state", "migrate"])
+    second = runner.invoke(app, ["--json", "state", "migrate"])
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    assert json.loads(first.output)["migrated"] is True
+    assert json.loads(second.output)["migrated"] is False
+
+
+@pytest.mark.parametrize("revision", ["behind_revision", "future_revision"])
+def test_state_commands_explain_incompatible_revision(
+    state_cli: Path,
+    revision: str,
+) -> None:
+    database = WorkspaceDatabase(state_cli)
+    database.initialize()
+    with database.write() as connection:
+        connection.execute(
+            text("UPDATE alembic_version SET version_num = :revision"),
+            {"revision": revision},
+        )
+
+    result = runner.invoke(app, ["state", "migrate"])
+
+    assert result.exit_code == 1
+    assert revision in result.output
+    assert "requires '0001_tasks_and_workitems'" in result.output

--- a/tests/cli/test_state_storage.py
+++ b/tests/cli/test_state_storage.py
@@ -113,6 +113,34 @@ def test_state_migrate_is_idempotent(
     assert json.loads(second.output)["migrated"] is False
 
 
+def test_state_status_and_export_use_sqlite_after_migration(
+    state_cli: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (state_cli / "state.yaml").write_text("tasks: {}\n")
+    monkeypatch.setattr(
+        "mship.core.persistence.migration.daemon_is_running",
+        lambda: False,
+    )
+
+    migrated = runner.invoke(app, ["--json", "state", "migrate"])
+    status = runner.invoke(app, ["--json", "state", "status"])
+    exported = runner.invoke(app, ["state", "export", "--format", "json"])
+
+    assert migrated.exit_code == 0, migrated.output
+    assert status.exit_code == 0, status.output
+    status_payload = json.loads(status.output)
+    assert status_payload == {
+        "backend": "sqlite",
+        "database_path": str(state_cli / "mothership.db"),
+        "current_revision": "0001_tasks_and_workitems",
+        "head_revision": "0001_tasks_and_workitems",
+        "migration_required": False,
+    }
+    assert exported.exit_code == 0, exported.output
+    assert json.loads(exported.output) == {"tasks": [], "work_items": []}
+
+
 @pytest.mark.parametrize("revision", ["behind_revision", "future_revision"])
 def test_state_commands_explain_incompatible_revision(
     state_cli: Path,

--- a/tests/cli/test_workitem.py
+++ b/tests/cli/test_workitem.py
@@ -41,6 +41,8 @@ def _isolate(tmp_path):
     # state_manager/log_manager are Singletons keyed off state_dir; drop any
     # instance a prior test bound to its own tmp so they rebind to this one.
     container.state_manager.reset()
+    container.workspace_store.reset()
+    container.workspace_database.reset()
     container.log_manager.reset()
 
 
@@ -49,6 +51,8 @@ def _reset():
     container.state_dir.reset_override()
     container.config.reset()
     container.state_manager.reset()
+    container.workspace_store.reset()
+    container.workspace_database.reset()
     container.log_manager.reset()
 
 

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -769,10 +769,20 @@ def test_finish_handoff(configured_git_app: Path):
 
 
 def test_finish_creates_prs(configured_git_app: Path):
+    from datetime import datetime, timezone
+
     from mship.cli import container as cli_container
+    from mship.core.persistence.lifecycle_repository import LifecycleRepository
+    from mship.core.workitem_store import WorkItemStore
 
     # Spawn a task first
     runner.invoke(app, ["spawn", "--hotfix", "test prs", "--repos", "shared"])
+    state_dir = configured_git_app / ".mothership"
+    items = WorkItemStore(state_dir / "workitems")
+    item = items.create("Test PRs", "chore", "test", datetime.now(timezone.utc))
+    LifecycleRepository(StateManager(state_dir).workspace_store).link_task(
+        item.id, "test-prs", now=datetime.now(timezone.utc),
+    )
 
     # Mock shell for finish operations
     def mock_run(cmd, cwd, env=None):
@@ -801,11 +811,11 @@ def test_finish_creates_prs(configured_git_app: Path):
     assert result.exit_code == 0, result.output
 
     # Verify PR URL stored in state
-    from mship.core.state import StateManager
     mgr = StateManager(configured_git_app / ".mothership")
     state = mgr.load()
     assert "test-prs" in state.tasks
     assert state.tasks["test-prs"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
+    assert items.get(item.id).pr_urls == ["https://github.com/org/shared/pull/1"]
 
     cli_container.shell.reset_override()
 
@@ -2379,7 +2389,7 @@ def test_close_cascade_refuses_metadata_changed_after_retention(
     configured_git_app: Path, monkeypatch,
 ):
     from datetime import datetime, timezone
-    from mship.core.workitem_lifecycle import retain_workitem_metadata_on_teardown
+    from mship.core.persistence.lifecycle_repository import LifecycleRepository
     from mship.core.workitem_store import WorkItemStore
 
     state = _seed_ab_tasks(configured_git_app)
@@ -2395,24 +2405,25 @@ def test_close_cascade_refuses_metadata_changed_after_retention(
         ),
     )
 
-    def retain_then_update(*, task, workitems_dir):
-        retained = retain_workitem_metadata_on_teardown(
-            task=task, workitems_dir=workitems_dir,
-        )
-        if task.slug == "b":
-            state.mutate(
-                lambda s: (
-                    s.tasks["b"].affected_repos.append("api-gateway"),
-                    s.tasks["b"].pr_urls.update(
+    original = LifecycleRepository.retain_and_delete_tasks
+
+    def update_then_retain(self, expected_tasks, *, now):
+        if "b" in expected_tasks:
+            state.mutate_task(
+                "b",
+                lambda task: (
+                    task.affected_repos.append("api-gateway"),
+                    task.pr_urls.update(
                         {"api-gateway": "https://github.example/api/pull/3"},
                     ),
                 ),
             )
-        return retained
+        return original(self, expected_tasks, now=now)
 
     monkeypatch.setattr(
-        "mship.core.workitem_lifecycle.retain_workitem_metadata_on_teardown",
-        retain_then_update,
+        LifecycleRepository,
+        "retain_and_delete_tasks",
+        update_then_retain,
     )
 
     result = runner.invoke(app, ["close", "a", "--yes", "--skip-pr-check", "--cascade"])

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -768,10 +768,12 @@ def test_finish_handoff(configured_git_app: Path):
     assert handoff_file.exists()
 
 
-def test_finish_creates_prs(configured_git_app: Path):
+def test_finish_creates_prs(configured_git_app: Path, monkeypatch):
+    from contextlib import contextmanager
     from datetime import datetime, timezone
 
     from mship.cli import container as cli_container
+    from mship.core.persistence.database import WorkspaceDatabase
     from mship.core.persistence.lifecycle_repository import LifecycleRepository
     from mship.core.workitem_store import WorkItemStore
 
@@ -783,9 +785,28 @@ def test_finish_creates_prs(configured_git_app: Path):
     LifecycleRepository(StateManager(state_dir).workspace_store).link_task(
         item.id, "test-prs", now=datetime.now(timezone.utc),
     )
+    active_connections = []
+    observations = []
+    original_write = WorkspaceDatabase.write
+
+    @contextmanager
+    def tracked_write(database, *, immediate=False):
+        with original_write(database, immediate=immediate) as connection:
+            active_connections.append(connection)
+            try:
+                yield connection
+            finally:
+                active_connections.remove(connection)
+
+    def assert_outside_sql(name):
+        assert all(not connection.in_transaction() for connection in active_connections)
+        observations.append(name)
+
+    monkeypatch.setattr(WorkspaceDatabase, "write", tracked_write)
 
     # Mock shell for finish operations
     def mock_run(cmd, cwd, env=None):
+        assert_outside_sql("git_or_github")
         if "gh auth status" in cmd:
             return ShellResult(returncode=0, stdout="Logged in", stderr="")
         if "ls-remote" in cmd:
@@ -807,6 +828,14 @@ def test_finish_creates_prs(configured_git_app: Path):
     mock_shell.run_task.return_value = ShellResult(returncode=0, stdout="ok", stderr="")
     cli_container.shell.override(mock_shell)
 
+    def observed_announce(*args, **kwargs):
+        assert_outside_sql("message_store")
+
+    monkeypatch.setattr(
+        "mship.core.pr_watcher.announce_prs_on_thread",
+        observed_announce,
+    )
+
     result = runner.invoke(app, ["finish", "--hotfix", "--task", "test-prs", "--no-require-tests"])
     assert result.exit_code == 0, result.output
 
@@ -816,6 +845,7 @@ def test_finish_creates_prs(configured_git_app: Path):
     assert "test-prs" in state.tasks
     assert state.tasks["test-prs"].pr_urls.get("shared") == "https://github.com/org/shared/pull/1"
     assert items.get(item.id).pr_urls == ["https://github.com/org/shared/pull/1"]
+    assert {"git_or_github", "message_store"} <= set(observations)
 
     cli_container.shell.reset_override()
 

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -2008,20 +2008,19 @@ def test_finish_does_not_capture_diagnostic_when_main_is_clean(configured_git_ap
 
 def test_close_logs_rate_limit_reason_when_pr_state_unknown(configured_git_app: Path):
     """When gh pr view fails with rate-limit stderr, close surfaces the reason. See #73."""
+    from datetime import datetime, timezone
     from mship.cli import container as cli_container
     from mship.util.shell import ShellResult, ShellRunner
     from unittest.mock import MagicMock
 
     runner.invoke(app, ["spawn", "--hotfix", "rate-limit close", "--repos", "shared"])
     # Set a pr_url manually so close actually calls gh pr view.
-    import yaml
-    state_path = configured_git_app / ".mothership" / "state.yaml"
-    data = yaml.safe_load(state_path.read_text())
-    data["tasks"]["rate-limit-close"]["pr_urls"] = {
-        "shared": "https://github.com/org/repo/pull/1"
-    }
-    data["tasks"]["rate-limit-close"]["finished_at"] = "2026-04-22T00:00:00Z"
-    state_path.write_text(yaml.safe_dump(data))
+    def _mark_finished(state):
+        task = state.tasks["rate-limit-close"]
+        task.pr_urls = {"shared": "https://github.com/org/repo/pull/1"}
+        task.finished_at = datetime(2026, 4, 22, tzinfo=timezone.utc)
+
+    StateManager(configured_git_app / ".mothership").mutate(_mark_finished)
 
     def mock_run(cmd, cwd, env=None):
         if "gh pr view" in cmd and "--json state" in cmd:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,25 @@ def _isolate_runtime_dir(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(status, "probe_control_socket", sandboxed_probe)
 
 
+@pytest.fixture(autouse=True)
+def _reset_global_workspace_storage():
+    """Keep process-wide storage singletons isolated between test workspaces."""
+    from mship.cli import container
+
+    providers = (
+        container.state_manager,
+        container.workspace_store,
+        container.workspace_database,
+    )
+    for provider in providers:
+        provider.reset()
+    try:
+        yield
+    finally:
+        for provider in providers:
+            provider.reset()
+
+
 @pytest.fixture
 def workspace(tmp_path: Path) -> Path:
     """Create a minimal workspace with repos that have Taskfile.yml files."""

--- a/tests/core/persistence/test_alembic_package.py
+++ b/tests/core/persistence/test_alembic_package.py
@@ -1,0 +1,70 @@
+from importlib import resources
+from pathlib import Path
+import sqlite3
+
+from alembic import command
+from sqlalchemy import inspect
+
+from mship.core.persistence.database import WorkspaceDatabase, make_alembic_config
+
+EXPECTED_DOMAIN_TABLES = {
+    "storage_metadata",
+    "tasks",
+    "task_repos",
+    "task_test_results",
+    "task_pr_urls",
+    "task_switch_anchors",
+    "task_dependencies",
+    "work_items",
+    "workitem_tasks",
+    "workitem_threads",
+    "workitem_external_links",
+    "workitem_affected_repos",
+    "workitem_pr_urls",
+}
+
+
+def test_initialize_upgrades_an_empty_database_to_alembic_head(tmp_path: Path) -> None:
+    database = WorkspaceDatabase(tmp_path / ".mothership")
+
+    database.initialize()
+
+    assert database.current_revision() == database.head_revision()
+    with database.connect() as connection:
+        assert EXPECTED_DOMAIN_TABLES <= set(inspect(connection).get_table_names())
+
+
+def test_alembic_downgrade_upgrade_round_trip(tmp_path: Path) -> None:
+    database = WorkspaceDatabase(tmp_path / ".mothership")
+    database.initialize()
+    config = make_alembic_config(database.path)
+
+    with database.connect() as connection:
+        config.attributes["connection"] = connection
+        command.downgrade(config, "base")
+    assert database.current_revision() is None
+
+    with database.connect() as connection:
+        config.attributes["connection"] = connection
+        command.upgrade(config, "head")
+    assert database.current_revision() == database.head_revision()
+
+
+def test_initial_revision_is_a_package_resource() -> None:
+    migration = resources.files("mship.core.persistence.alembic").joinpath(
+        "versions",
+        "0001_tasks_and_workitems.py",
+    )
+
+    assert migration.is_file()
+
+
+def test_standalone_alembic_upgrade_enables_wal(tmp_path: Path) -> None:
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    database_path = state_dir / "mothership.db"
+
+    command.upgrade(make_alembic_config(database_path), "head")
+
+    with sqlite3.connect(database_path, autocommit=False) as connection:
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"

--- a/tests/core/persistence/test_alembic_package.py
+++ b/tests/core/persistence/test_alembic_package.py
@@ -59,6 +59,15 @@ def test_initial_revision_is_a_package_resource() -> None:
     assert migration.is_file()
 
 
+def test_packaged_alembic_environment_contains_every_runtime_resource() -> None:
+    package = resources.files("mship.core.persistence.alembic")
+
+    assert package.joinpath("env.py").is_file()
+    assert package.joinpath("script.py.mako").is_file()
+    assert package.joinpath("versions", "__init__.py").is_file()
+    assert package.joinpath("versions", "0001_tasks_and_workitems.py").is_file()
+
+
 def test_standalone_alembic_upgrade_enables_wal(tmp_path: Path) -> None:
     state_dir = tmp_path / ".mothership"
     state_dir.mkdir()

--- a/tests/core/persistence/test_alembic_package.py
+++ b/tests/core/persistence/test_alembic_package.py
@@ -13,6 +13,7 @@ EXPECTED_DOMAIN_TABLES = {
     "task_repos",
     "task_test_results",
     "task_pr_urls",
+    "task_switch_sources",
     "task_switch_anchors",
     "task_dependencies",
     "work_items",

--- a/tests/core/persistence/test_atomic_lifecycle.py
+++ b/tests/core/persistence/test_atomic_lifecycle.py
@@ -1,0 +1,335 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from mship.core.persistence.lifecycle_repository import LifecycleRepository
+from mship.core.persistence.workspace_store import WorkspaceStore
+from mship.core.state import StateManager, Task
+from mship.core.workitem import WorkItem
+from mship.core.workitem_lifecycle import TaskMetadataRetentionConflictError
+from mship.core.workitem_store import TaskLinkAmbiguousError, WorkItemStore
+
+
+NOW = datetime(2026, 9, 7, 20, 0, tzinfo=timezone.utc)
+
+
+class InjectedFailure(RuntimeError):
+    pass
+
+
+def _task(slug: str = "task-a", *, work_item_id: str | None = None) -> Task:
+    return Task(
+        slug=slug,
+        description="Atomic lifecycle",
+        phase="dev",
+        created_at=NOW,
+        affected_repos=["api", "web"],
+        worktrees={
+            "api": Path("/tmp/api"),
+            "web": Path("/tmp/web"),
+        },
+        branch=f"feat/{slug}",
+        pr_urls={
+            "api": "https://example.test/pr/1",
+            "web": "https://example.test/pr/2",
+            "mirror": "https://example.test/pr/1",
+        },
+        work_item_id=work_item_id,
+    )
+
+
+@pytest.fixture
+def lifecycle_stores(tmp_path: Path):
+    state_dir = tmp_path / ".mothership"
+    workspace = WorkspaceStore(state_dir)
+    state = StateManager(workspace_store=workspace)
+    items = WorkItemStore(
+        state_dir / "workitems",
+        workspace_store=workspace,
+    )
+    lifecycle = LifecycleRepository(workspace)
+    return lifecycle, state, items
+
+
+def _item(items: WorkItemStore, title: str = "Owner") -> WorkItem:
+    return items.create(title, "feature", "test", NOW)
+
+
+def test_register_task_and_owner_roll_back_together(
+    lifecycle_stores,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lifecycle, state, items = lifecycle_stores
+    item = _item(items)
+    monkeypatch.setattr(
+        lifecycle,
+        "_checkpoint",
+        lambda stage: (
+            (_ for _ in ()).throw(InjectedFailure("after task insert"))
+            if stage == "after_task_insert"
+            else None
+        ),
+    )
+
+    with pytest.raises(InjectedFailure, match="after task insert"):
+        lifecycle.register_task(_task(), item.id, now=NOW)
+
+    assert state.load().tasks.get("task-a") is None
+    assert items.get(item.id).task_slugs == []
+
+
+def test_register_missing_workitem_rolls_back_task(lifecycle_stores) -> None:
+    lifecycle, state, _items = lifecycle_stores
+
+    with pytest.raises(KeyError, match="missing-item"):
+        lifecycle.register_task(_task(), "missing-item", now=NOW)
+
+    assert state.load().tasks == {}
+
+
+def test_retain_and_delete_is_atomic(
+    lifecycle_stores,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lifecycle, state, items = lifecycle_stores
+    item = _item(items)
+    task = _task(work_item_id=item.id)
+    lifecycle.register_task(task, item.id, now=NOW)
+    before_item = items.get(item.id)
+    monkeypatch.setattr(
+        lifecycle,
+        "_checkpoint",
+        lambda stage: (
+            (_ for _ in ()).throw(InjectedFailure("before task delete"))
+            if stage == "before_task_delete"
+            else None
+        ),
+    )
+
+    with pytest.raises(InjectedFailure, match="before task delete"):
+        lifecycle.retain_and_delete_task(task.slug, now=NOW)
+
+    assert state.load().tasks[task.slug] == task
+    assert items.get(item.id) == before_item
+
+
+def test_historical_owner_is_authoritative_and_duplicate_is_refused(
+    lifecycle_stores,
+) -> None:
+    lifecycle, state, items = lifecycle_stores
+    first = _item(items, "First")
+    second = _item(items, "Second")
+    lifecycle.register_task(_task(work_item_id=first.id), first.id, now=NOW)
+    assert lifecycle.retain_and_delete_task("task-a", now=NOW) is True
+
+    with pytest.raises(TaskLinkAmbiguousError) as error:
+        lifecycle.register_task(
+            _task(work_item_id=second.id),
+            second.id,
+            now=NOW,
+        )
+
+    assert error.value.item_ids == sorted([first.id, second.id])
+    assert state.load().tasks == {}
+    assert items.get(first.id).task_slugs == ["task-a"]
+    assert items.get(second.id).task_slugs == []
+
+
+def test_retention_deduplicates_repositories_and_pr_urls(
+    lifecycle_stores,
+) -> None:
+    lifecycle, state, items = lifecycle_stores
+    item = _item(items)
+    item.affected_repos = ["api"]
+    item.pr_urls = ["https://example.test/pr/1"]
+    items.save(item)
+    lifecycle.register_task(_task(work_item_id=item.id), item.id, now=NOW)
+
+    assert lifecycle.retain_and_delete_task("task-a", now=NOW) is True
+
+    assert state.load().tasks == {}
+    retained = items.get(item.id)
+    assert retained.affected_repos == ["api", "web"]
+    assert retained.pr_urls == [
+        "https://example.test/pr/1",
+        "https://example.test/pr/2",
+    ]
+
+
+def test_bind_spec_updates_both_sides_in_one_transaction(
+    lifecycle_stores,
+) -> None:
+    lifecycle, state, items = lifecycle_stores
+    item = _item(items)
+    state.insert_task(_task())
+
+    lifecycle.bind_spec("task-a", item.id, "spec-1", now=NOW)
+
+    task = state.load().tasks["task-a"]
+    assert task.work_item_id == item.id
+    assert task.spec_id == "spec-1"
+    linked = items.get(item.id)
+    assert linked.task_slugs == ["task-a"]
+    assert linked.spec_id == "spec-1"
+
+
+def test_bind_spec_rolls_back_task_when_workitem_update_fails(
+    lifecycle_stores,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lifecycle, state, items = lifecycle_stores
+    item = _item(items)
+    state.insert_task(_task())
+    monkeypatch.setattr(
+        lifecycle,
+        "_checkpoint",
+        lambda stage: (
+            (_ for _ in ()).throw(InjectedFailure("after task link"))
+            if stage == "after_task_link"
+            else None
+        ),
+    )
+
+    with pytest.raises(InjectedFailure, match="after task link"):
+        lifecycle.bind_spec("task-a", item.id, "spec-1", now=NOW)
+
+    task = state.load().tasks["task-a"]
+    assert task.work_item_id is None
+    assert task.spec_id is None
+    assert items.get(item.id).task_slugs == []
+
+
+def test_partial_prune_keeps_task_then_final_prune_retains_and_deletes(
+    lifecycle_stores,
+) -> None:
+    lifecycle, state, items = lifecycle_stores
+    item = _item(items)
+    lifecycle.register_task(_task(work_item_id=item.id), item.id, now=NOW)
+
+    assert (
+        lifecycle.retain_and_prune_task_repos(
+            "task-a",
+            ["api"],
+            now=NOW,
+        )
+        is False
+    )
+    current = state.load().tasks["task-a"]
+    assert current.worktrees == {"web": Path("/tmp/web")}
+    assert items.get(item.id).affected_repos == []
+
+    assert (
+        lifecycle.retain_and_prune_task_repos(
+            "task-a",
+            ["web"],
+            now=NOW,
+            expected_task=current,
+        )
+        is True
+    )
+    assert state.load().tasks == {}
+    assert items.get(item.id).affected_repos == ["api", "web"]
+
+
+def test_external_snapshot_change_refuses_delete(lifecycle_stores) -> None:
+    lifecycle, state, items = lifecycle_stores
+    item = _item(items)
+    task = _task(work_item_id=item.id)
+    lifecycle.register_task(task, item.id, now=NOW)
+    expected = state.load().tasks[task.slug]
+    state.mutate_task(
+        task.slug,
+        lambda live: live.pr_urls.update({"new": "https://example.test/pr/new"}),
+    )
+
+    with pytest.raises(TaskMetadataRetentionConflictError, match="changed"):
+        lifecycle.retain_and_delete_task(
+            task.slug,
+            now=NOW,
+            expected_task=expected,
+        )
+
+    assert task.slug in state.load().tasks
+    assert "https://example.test/pr/new" not in items.get(item.id).pr_urls
+
+
+def test_batch_delete_rolls_back_every_task_on_snapshot_conflict(
+    lifecycle_stores,
+) -> None:
+    lifecycle, state, items = lifecycle_stores
+    first_item = _item(items, "First")
+    second_item = _item(items, "Second")
+    first = _task("first", work_item_id=first_item.id)
+    second = _task("second", work_item_id=second_item.id)
+    lifecycle.register_task(first, first_item.id, now=NOW)
+    lifecycle.register_task(second, second_item.id, now=NOW)
+    expected = state.load().tasks
+    state.mutate_task(
+        "second",
+        lambda task: task.pr_urls.update({"new": "https://example.test/pr/new"}),
+    )
+
+    with pytest.raises(TaskMetadataRetentionConflictError, match="changed"):
+        lifecycle.retain_and_delete_tasks(expected, now=NOW)
+
+    assert set(state.load().tasks) == {"first", "second"}
+    assert items.get(first_item.id).affected_repos == []
+    assert items.get(second_item.id).affected_repos == []
+
+
+def test_record_pr_urls_updates_both_sides_and_deduplicates(
+    lifecycle_stores,
+) -> None:
+    lifecycle, state, items = lifecycle_stores
+    item = _item(items)
+    task = _task(work_item_id=item.id)
+    task.pr_urls = {}
+    lifecycle.register_task(task, item.id, now=NOW)
+
+    url = "https://example.test/pr/3"
+    lifecycle.record_pr_urls("task-a", {"api": url}, now=NOW)
+    lifecycle.record_pr_urls(
+        "task-a",
+        {"api": url, "web": url},
+        now=NOW,
+    )
+
+    assert state.load().tasks["task-a"].pr_urls == {
+        "api": url,
+        "web": url,
+    }
+    retained = items.get(item.id)
+    assert retained.affected_repos == ["api", "web"]
+    assert retained.pr_urls == [url]
+
+
+def test_record_pr_urls_rolls_back_task_when_workitem_update_fails(
+    lifecycle_stores,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lifecycle, state, items = lifecycle_stores
+    item = _item(items)
+    task = _task(work_item_id=item.id)
+    task.pr_urls = {}
+    lifecycle.register_task(task, item.id, now=NOW)
+    before_item = items.get(item.id)
+    monkeypatch.setattr(
+        lifecycle,
+        "_checkpoint",
+        lambda stage: (
+            (_ for _ in ()).throw(InjectedFailure("after task replace"))
+            if stage == "after_task_replace"
+            else None
+        ),
+    )
+
+    with pytest.raises(InjectedFailure, match="after task replace"):
+        lifecycle.record_pr_urls(
+            "task-a",
+            {"api": "https://example.test/pr/3"},
+            now=NOW,
+        )
+
+    assert state.load().tasks["task-a"].pr_urls == {}
+    assert items.get(item.id) == before_item

--- a/tests/core/persistence/test_atomic_lifecycle.py
+++ b/tests/core/persistence/test_atomic_lifecycle.py
@@ -9,6 +9,7 @@ from mship.core.state import StateManager, Task
 from mship.core.workitem import WorkItem
 from mship.core.workitem_lifecycle import TaskMetadataRetentionConflictError
 from mship.core.workitem_store import TaskLinkAmbiguousError, WorkItemStore
+from tests.persistence_helpers import corrupt_workitem
 
 
 NOW = datetime(2026, 9, 7, 20, 0, tzinfo=timezone.utc)
@@ -333,3 +334,25 @@ def test_record_pr_urls_rolls_back_task_when_workitem_update_fails(
 
     assert state.load().tasks["task-a"].pr_urls == {}
     assert items.get(item.id) == before_item
+
+
+def test_record_pr_urls_hotfix_preserves_task_when_workitem_is_unreadable(
+    lifecycle_stores,
+) -> None:
+    lifecycle, state, items = lifecycle_stores
+    item = _item(items)
+    task = _task(work_item_id=item.id)
+    task.pr_urls = {}
+    lifecycle.register_task(task, item.id, now=NOW)
+    corrupt_workitem(state.state_dir, item.id)
+
+    url = "https://example.test/pr/3"
+    recorded = lifecycle.record_pr_urls(
+        task.slug,
+        {"api": url},
+        now=NOW,
+        allow_unreadable_workitem=True,
+    )
+
+    assert recorded.pr_urls == {"api": url}
+    assert state.load().tasks[task.slug].pr_urls == {"api": url}

--- a/tests/core/persistence/test_atomic_lifecycle.py
+++ b/tests/core/persistence/test_atomic_lifecycle.py
@@ -356,3 +356,79 @@ def test_record_pr_urls_hotfix_preserves_task_when_workitem_is_unreadable(
 
     assert recorded.pr_urls == {"api": url}
     assert state.load().tasks[task.slug].pr_urls == {"api": url}
+
+
+def test_record_pr_urls_hotfix_preserves_task_when_linked_workitem_is_missing(
+    lifecycle_stores,
+) -> None:
+    lifecycle, state, items = lifecycle_stores
+    item = _item(items)
+    task = _task(work_item_id=item.id)
+    task.pr_urls = {}
+    lifecycle.register_task(task, item.id, now=NOW)
+    with state.workspace_store.write(immediate=True) as transaction:
+        transaction.workitems.delete(transaction.connection, item.id)
+
+    url = "https://example.test/pr/3"
+    recorded = lifecycle.record_pr_urls(
+        task.slug,
+        {"api": url},
+        now=NOW,
+        allow_unreadable_workitem=True,
+    )
+
+    assert recorded.pr_urls == {"api": url}
+    assert state.load().tasks[task.slug].pr_urls == {"api": url}
+
+
+def test_record_pr_urls_missing_workitem_rolls_back_without_hotfix(
+    lifecycle_stores,
+) -> None:
+    lifecycle, state, items = lifecycle_stores
+    item = _item(items)
+    task = _task(work_item_id=item.id)
+    task.pr_urls = {}
+    lifecycle.register_task(task, item.id, now=NOW)
+    with state.workspace_store.write(immediate=True) as transaction:
+        transaction.workitems.delete(transaction.connection, item.id)
+
+    with pytest.raises(
+        TaskMetadataRetentionConflictError,
+        match="linked work item.*unavailable",
+    ):
+        lifecycle.record_pr_urls(
+            task.slug,
+            {"api": "https://example.test/pr/3"},
+            now=NOW,
+        )
+
+    assert state.load().tasks[task.slug].pr_urls == {}
+
+
+def test_record_pr_urls_hotfix_keeps_ambiguous_workitem_atomic(
+    lifecycle_stores,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lifecycle, state, items = lifecycle_stores
+    item = _item(items)
+    task = _task(work_item_id=item.id)
+    task.pr_urls = {}
+    lifecycle.register_task(task, item.id, now=NOW)
+    monkeypatch.setattr(
+        lifecycle,
+        "_owner_ids",
+        lambda connection, task_slug: ["wi-first", "wi-second"],
+    )
+
+    with pytest.raises(
+        TaskMetadataRetentionConflictError,
+        match="ambiguous",
+    ):
+        lifecycle.record_pr_urls(
+            task.slug,
+            {"api": "https://example.test/pr/3"},
+            now=NOW,
+            allow_unreadable_workitem=True,
+        )
+
+    assert state.load().tasks[task.slug].pr_urls == {}

--- a/tests/core/persistence/test_backend.py
+++ b/tests/core/persistence/test_backend.py
@@ -105,6 +105,13 @@ def test_legacy_workitems_are_readable_but_mutations_require_migration(
         store.create("new", "feature", "test", NOW)
 
 
+def test_legacy_backend_returns_none_for_missing_workitem(tmp_path: Path) -> None:
+    items_dir = tmp_path / ".mothership" / "workitems"
+    items_dir.mkdir(parents=True)
+
+    assert get_legacy_workitem(items_dir, "wi-missing") is None
+
+
 def test_legacy_backend_rejects_workitem_id_traversal(tmp_path: Path) -> None:
     state_dir = tmp_path / ".mothership"
     items_dir = state_dir / "workitems"
@@ -114,6 +121,21 @@ def test_legacy_backend_rejects_workitem_id_traversal(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="unsafe work item id"):
         get_legacy_workitem(items_dir, "../outside")
+
+
+def test_legacy_backend_get_rejects_symlink_outside_directory(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    items_dir = state_dir / "workitems"
+    items_dir.mkdir(parents=True)
+    outside = _item("outside")
+    outside_path = state_dir / "outside.json"
+    outside_path.write_text(outside.model_dump_json())
+    (items_dir / "linked.json").symlink_to(outside_path)
+
+    with pytest.raises(ValueError, match="unsafe work item id"):
+        get_legacy_workitem(items_dir, "linked")
 
 
 def test_legacy_workitem_list_rejects_symlink_outside_directory(
@@ -129,6 +151,27 @@ def test_legacy_workitem_list_rejects_symlink_outside_directory(
 
     with pytest.raises(ValueError, match="unsafe work item id"):
         WorkItemStore(items_dir).list()
+
+
+def test_legacy_workitem_tolerant_list_skips_symlink_outside_directory(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    items_dir = state_dir / "workitems"
+    items_dir.mkdir(parents=True)
+    valid = _item("valid")
+    (items_dir / "valid.json").write_text(valid.model_dump_json())
+    outside = _item("outside")
+    outside_path = state_dir / "outside.json"
+    outside_path.write_text(outside.model_dump_json())
+    (items_dir / "linked.json").symlink_to(outside_path)
+
+    items, uncertain = WorkItemStore(
+        items_dir
+    ).list_tolerant_with_uncertainty()
+
+    assert items == [valid]
+    assert uncertain is True
 
 
 def test_empty_state_store_initializes_sqlite_on_first_write(tmp_path: Path) -> None:

--- a/tests/core/persistence/test_backend.py
+++ b/tests/core/persistence/test_backend.py
@@ -1,0 +1,147 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mship.core.persistence.backend import StorageBackend, detect_backend
+from mship.core.persistence.database import WorkspaceDatabase
+from mship.core.persistence.errors import LegacyMigrationRequired
+from mship.core.persistence.task_repository import TaskRepository
+from mship.core.persistence.workitem_repository import WorkItemRepository
+from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.workitem import WorkItem
+from mship.core.workitem_store import WorkItemStore
+
+NOW = datetime(2026, 9, 7, 14, 0, tzinfo=timezone.utc)
+
+
+def _task(slug: str) -> Task:
+    return Task(
+        slug=slug,
+        description=slug,
+        phase="plan",
+        created_at=NOW,
+        affected_repos=[],
+        branch=f"feat/{slug}",
+    )
+
+
+def _item(item_id: str) -> WorkItem:
+    return WorkItem(
+        id=item_id,
+        title=item_id,
+        workspace="test",
+        kind="feature",
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+@pytest.mark.parametrize(
+    ("legacy_state", "legacy_items", "database", "expected"),
+    [
+        (False, False, False, StorageBackend.EMPTY),
+        (True, False, False, StorageBackend.LEGACY),
+        (False, True, False, StorageBackend.LEGACY),
+        (True, True, True, StorageBackend.SQLITE),
+    ],
+)
+def test_detect_backend(
+    tmp_path: Path,
+    legacy_state: bool,
+    legacy_items: bool,
+    database: bool,
+    expected: StorageBackend,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    if legacy_state:
+        (state_dir / "state.yaml").write_text("tasks: {}\n")
+    if legacy_items:
+        items_dir = state_dir / "workitems"
+        items_dir.mkdir()
+        (items_dir / "wi-a.json").write_text(_item("wi-a").model_dump_json())
+    if database:
+        WorkspaceDatabase(state_dir).initialize()
+
+    assert detect_backend(state_dir) is expected
+
+
+def test_legacy_state_is_readable_but_writes_require_migration(tmp_path: Path) -> None:
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    state = WorkspaceState(tasks={"legacy": _task("legacy")})
+    (state_dir / "state.yaml").write_text(
+        yaml.safe_dump(state.model_dump(mode="json"))
+    )
+    manager = StateManager(state_dir)
+
+    assert manager.load() == state
+    with pytest.raises(LegacyMigrationRequired, match="mship state migrate"):
+        manager.save(state)
+    with pytest.raises(LegacyMigrationRequired, match="mship state migrate"):
+        manager.mutate(lambda current: current.tasks.clear())
+
+
+def test_legacy_workitems_are_readable_but_mutations_require_migration(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    items_dir = state_dir / "workitems"
+    items_dir.mkdir(parents=True)
+    item = _item("wi-legacy")
+    (items_dir / "wi-legacy.json").write_text(item.model_dump_json())
+    store = WorkItemStore(items_dir)
+
+    assert store.get(item.id) == item
+    with pytest.raises(LegacyMigrationRequired, match="mship state migrate"):
+        store.link_spec(item.id, "spec-a", now=NOW)
+    with pytest.raises(LegacyMigrationRequired, match="mship state migrate"):
+        store.create("new", "feature", "test", NOW)
+
+
+def test_empty_state_store_initializes_sqlite_on_first_write(tmp_path: Path) -> None:
+    state_dir = tmp_path / ".mothership"
+    manager = StateManager(state_dir)
+    state = WorkspaceState(tasks={"task-a": _task("task-a")})
+
+    manager.save(state)
+
+    assert manager.load() == state
+    assert (state_dir / "mothership.db").is_file()
+    assert not (state_dir / "state.yaml").exists()
+
+
+def test_empty_workitem_store_initializes_sqlite_on_first_write(tmp_path: Path) -> None:
+    state_dir = tmp_path / ".mothership"
+    store = WorkItemStore(state_dir / "workitems")
+
+    item = store.create("new", "feature", "test", NOW)
+
+    assert store.get(item.id) == item
+    assert (state_dir / "mothership.db").is_file()
+    assert not (state_dir / "workitems").exists()
+
+
+def test_activated_database_wins_over_stale_legacy_files(tmp_path: Path) -> None:
+    state_dir = tmp_path / ".mothership"
+    database = WorkspaceDatabase(state_dir)
+    database.initialize()
+    with database.write() as connection:
+        TaskRepository().insert(connection, _task("database-task"))
+        WorkItemRepository().insert(connection, _item("wi-database"))
+
+    (state_dir / "state.yaml").write_text(
+        yaml.safe_dump(
+            WorkspaceState(
+                tasks={"stale-legacy-task": _task("stale-legacy-task")}
+            ).model_dump(mode="json")
+        )
+    )
+    items_dir = state_dir / "workitems"
+    items_dir.mkdir()
+    (items_dir / "wi-stale.json").write_text(_item("wi-stale").model_dump_json())
+
+    assert list(StateManager(state_dir).load().tasks) == ["database-task"]
+    assert [item.id for item in WorkItemStore(items_dir).list()] == ["wi-database"]

--- a/tests/core/persistence/test_backend.py
+++ b/tests/core/persistence/test_backend.py
@@ -4,7 +4,11 @@ from pathlib import Path
 import pytest
 import yaml
 
-from mship.core.persistence.backend import StorageBackend, detect_backend
+from mship.core.persistence.backend import (
+    StorageBackend,
+    detect_backend,
+    get_legacy_workitem,
+)
 from mship.core.persistence.database import WorkspaceDatabase
 from mship.core.persistence.errors import LegacyMigrationRequired
 from mship.core.persistence.task_repository import TaskRepository
@@ -99,6 +103,17 @@ def test_legacy_workitems_are_readable_but_mutations_require_migration(
         store.link_spec(item.id, "spec-a", now=NOW)
     with pytest.raises(LegacyMigrationRequired, match="mship state migrate"):
         store.create("new", "feature", "test", NOW)
+
+
+def test_legacy_backend_rejects_workitem_id_traversal(tmp_path: Path) -> None:
+    state_dir = tmp_path / ".mothership"
+    items_dir = state_dir / "workitems"
+    items_dir.mkdir(parents=True)
+    outside = _item("outside")
+    (state_dir / "outside.json").write_text(outside.model_dump_json())
+
+    with pytest.raises(ValueError, match="unsafe work item id"):
+        get_legacy_workitem(items_dir, "../outside")
 
 
 def test_empty_state_store_initializes_sqlite_on_first_write(tmp_path: Path) -> None:

--- a/tests/core/persistence/test_backend.py
+++ b/tests/core/persistence/test_backend.py
@@ -116,6 +116,21 @@ def test_legacy_backend_rejects_workitem_id_traversal(tmp_path: Path) -> None:
         get_legacy_workitem(items_dir, "../outside")
 
 
+def test_legacy_workitem_list_rejects_symlink_outside_directory(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    items_dir = state_dir / "workitems"
+    items_dir.mkdir(parents=True)
+    outside = _item("outside")
+    outside_path = state_dir / "outside.json"
+    outside_path.write_text(outside.model_dump_json())
+    (items_dir / "linked.json").symlink_to(outside_path)
+
+    with pytest.raises(ValueError, match="unsafe work item id"):
+        WorkItemStore(items_dir).list()
+
+
 def test_empty_state_store_initializes_sqlite_on_first_write(tmp_path: Path) -> None:
     state_dir = tmp_path / ".mothership"
     manager = StateManager(state_dir)

--- a/tests/core/persistence/test_database.py
+++ b/tests/core/persistence/test_database.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import pytest
+
+from mship.core.persistence.database import (
+    BUSY_TIMEOUT_MS,
+    DB_FILENAME,
+    DatabaseRevisionError,
+    WorkspaceDatabase,
+)
+
+
+def test_database_path_is_state_dir_mothership_db(tmp_path: Path) -> None:
+    state_dir = tmp_path / ".mothership"
+
+    database = WorkspaceDatabase(state_dir)
+
+    assert database.path == state_dir / DB_FILENAME
+    assert database.path.name == "mothership.db"
+
+
+def test_workspace_database_configures_required_sqlite_policy(tmp_path: Path) -> None:
+    database = WorkspaceDatabase(tmp_path / ".mothership")
+    database.initialize()
+
+    with database.connect() as connection:
+        assert connection.exec_driver_sql("PRAGMA journal_mode").scalar_one().lower() == "wal"
+        assert connection.exec_driver_sql("PRAGMA foreign_keys").scalar_one() == 1
+        assert connection.exec_driver_sql("PRAGMA busy_timeout").scalar_one() == BUSY_TIMEOUT_MS
+        assert connection.connection.driver_connection.autocommit is False
+
+
+def test_explicit_write_rolls_back_on_exception(tmp_path: Path) -> None:
+    database = WorkspaceDatabase(tmp_path / ".mothership")
+    database.initialize()
+    with database.write() as connection:
+        connection.exec_driver_sql("CREATE TABLE rollback_probe (value INTEGER NOT NULL)")
+
+    with pytest.raises(RuntimeError, match="abort transaction"):
+        with database.write() as connection:
+            connection.exec_driver_sql("INSERT INTO rollback_probe (value) VALUES (1)")
+            raise RuntimeError("abort transaction")
+
+    with database.read() as connection:
+        count = connection.exec_driver_sql("SELECT COUNT(*) FROM rollback_probe").scalar_one()
+
+    assert count == 0
+
+
+def test_initialize_rejects_an_unknown_existing_revision(tmp_path: Path) -> None:
+    database = WorkspaceDatabase(tmp_path / ".mothership")
+    database.initialize()
+    with database.write() as connection:
+        connection.exec_driver_sql(
+            "UPDATE alembic_version SET version_num = 'future_revision'"
+        )
+
+    with pytest.raises(DatabaseRevisionError, match="future_revision"):
+        database.initialize()

--- a/tests/core/persistence/test_database.py
+++ b/tests/core/persistence/test_database.py
@@ -47,6 +47,28 @@ def test_explicit_write_rolls_back_on_exception(tmp_path: Path) -> None:
     assert count == 0
 
 
+def test_immediate_write_works_with_pep249_autocommit_disabled(
+    tmp_path: Path,
+) -> None:
+    database = WorkspaceDatabase(tmp_path / ".mothership")
+    database.initialize()
+
+    with database.write(immediate=True) as connection:
+        connection.exec_driver_sql(
+            "CREATE TABLE immediate_probe (value INTEGER NOT NULL)"
+        )
+        connection.exec_driver_sql(
+            "INSERT INTO immediate_probe (value) VALUES (1)"
+        )
+
+    with database.read() as connection:
+        count = connection.exec_driver_sql(
+            "SELECT COUNT(*) FROM immediate_probe"
+        ).scalar_one()
+
+    assert count == 1
+
+
 def test_initialize_rejects_an_unknown_existing_revision(tmp_path: Path) -> None:
     database = WorkspaceDatabase(tmp_path / ".mothership")
     database.initialize()

--- a/tests/core/persistence/test_export.py
+++ b/tests/core/persistence/test_export.py
@@ -1,4 +1,7 @@
 import json
+import os
+import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -72,6 +75,43 @@ def test_export_json_is_deterministic_sorted_and_scoped(tmp_path: Path) -> None:
     assert payload["work_items"][1]["archived"] is True
     assert "MESSAGE_SENTINEL" not in first
     assert "ARTIFACT_SENTINEL" not in first
+
+
+def test_export_json_is_stable_across_python_hash_seeds(tmp_path: Path) -> None:
+    state_dir = tmp_path / ".mothership"
+    _seed_sqlite_state(state_dir)
+    state = StateManager(state_dir).load()
+    state.tasks["alpha"].passive_repos = {
+        "analytics",
+        "billing",
+        "catalog",
+        "delivery",
+        "events",
+    }
+    StateManager(state_dir).save(state)
+    command = [
+        sys.executable,
+        "-c",
+        (
+            "from pathlib import Path; "
+            "from mship.core.persistence.export import export_state; "
+            "print(export_state(Path(__import__('sys').argv[1])), end='')"
+        ),
+        str(state_dir),
+    ]
+
+    rendered = [
+        subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PYTHONHASHSEED": seed},
+        ).stdout
+        for seed in ("1", "2")
+    ]
+
+    assert rendered[0] == rendered[1]
 
 
 def test_export_yaml_has_same_payload_as_json(tmp_path: Path) -> None:

--- a/tests/core/persistence/test_export.py
+++ b/tests/core/persistence/test_export.py
@@ -1,0 +1,89 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mship.core.persistence.export import export_state
+from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.workitem import WorkItem
+from mship.core.workitem_store import WorkItemStore
+
+
+NOW = datetime(2026, 9, 7, 18, 0, tzinfo=timezone.utc)
+
+
+def _seed_sqlite_state(state_dir: Path) -> None:
+    tasks = {
+        slug: Task(
+            slug=slug,
+            description=f"Task {slug}",
+            phase="dev",
+            created_at=NOW,
+            affected_repos=["mothership"],
+            branch=f"feat/{slug}",
+        )
+        for slug in ("zeta", "alpha")
+    }
+    StateManager(state_dir).save(WorkspaceState(tasks=tasks))
+    store = WorkItemStore(state_dir / "workitems")
+    store.save(
+        WorkItem(
+            id="wi-zeta",
+            title="Zeta",
+            workspace="test",
+            kind="chore",
+            created_at=NOW,
+            updated_at=NOW,
+            archived=True,
+        )
+    )
+    store.save(
+        WorkItem(
+            id="wi-alpha",
+            title="Alpha",
+            workspace="test",
+            kind="feature",
+            created_at=NOW,
+            updated_at=NOW,
+        )
+    )
+
+
+def test_export_json_is_deterministic_sorted_and_scoped(tmp_path: Path) -> None:
+    state_dir = tmp_path / ".mothership"
+    _seed_sqlite_state(state_dir)
+    (state_dir / "messages").mkdir()
+    (state_dir / "messages" / "private.json").write_text("MESSAGE_SENTINEL")
+    (state_dir / "artifacts").mkdir()
+    (state_dir / "artifacts" / "secret.bin").write_bytes(b"ARTIFACT_SENTINEL")
+
+    first = export_state(state_dir, format="json")
+    second = export_state(state_dir, format="json")
+    payload = json.loads(first)
+
+    assert first == second
+    assert [task["slug"] for task in payload["tasks"]] == ["alpha", "zeta"]
+    assert [item["id"] for item in payload["work_items"]] == [
+        "wi-alpha",
+        "wi-zeta",
+    ]
+    assert payload["work_items"][1]["archived"] is True
+    assert "MESSAGE_SENTINEL" not in first
+    assert "ARTIFACT_SENTINEL" not in first
+
+
+def test_export_yaml_has_same_payload_as_json(tmp_path: Path) -> None:
+    state_dir = tmp_path / ".mothership"
+    _seed_sqlite_state(state_dir)
+
+    json_payload = json.loads(export_state(state_dir, format="json"))
+    yaml_payload = yaml.safe_load(export_state(state_dir, format="yaml"))
+
+    assert yaml_payload == json_payload
+
+
+def test_export_rejects_unsupported_format(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="json or yaml"):
+        export_state(tmp_path / ".mothership", format="toml")

--- a/tests/core/persistence/test_legacy_migration.py
+++ b/tests/core/persistence/test_legacy_migration.py
@@ -172,6 +172,52 @@ def test_migration_activates_only_after_verified_import(
     assert len(metadata["legacy_workitems_sha256"]) == 64
 
 
+def test_migration_accepts_semantically_equivalent_naive_timestamps(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    workitems_dir = state_dir / "workitems"
+    workitems_dir.mkdir(parents=True)
+    naive = datetime(2026, 9, 7, 20, 0)
+    task = Task(
+        slug="naive-task",
+        description="legacy naive timestamps",
+        phase="dev",
+        created_at=naive,
+        affected_repos=["mothership"],
+        branch="feat/naive-task",
+        test_results={"mothership": TestResult(status="pass", at=naive)},
+        phase_entered_at=naive,
+        work_item_id="wi-naive",
+    )
+    item = WorkItem(
+        id="wi-naive",
+        title="Naive timestamps",
+        workspace="test",
+        kind="chore",
+        created_at=naive,
+        updated_at=naive,
+        task_slugs=[task.slug],
+    )
+    (state_dir / "state.yaml").write_text(
+        yaml.safe_dump(WorkspaceState(tasks={task.slug: task}).model_dump(mode="json"))
+    )
+    (workitems_dir / f"{item.id}.json").write_text(item.model_dump_json(indent=2))
+
+    report = migrate_legacy_state(
+        state_dir,
+        daemon_probe=lambda: None,
+        now=NOW,
+    )
+
+    assert report.migrated is True
+    restored = StateManager(state_dir).load().tasks[task.slug]
+    assert restored.created_at == naive.replace(tzinfo=timezone.utc)
+    restored_item = WorkItemStore(state_dir / "workitems").get(item.id)
+    assert restored_item is not None
+    assert restored_item.updated_at == naive.replace(tzinfo=timezone.utc)
+
+
 @pytest.mark.parametrize(
     "stage",
     ["validate", "backup", "alembic", "import", "verify", "activate"],

--- a/tests/core/persistence/test_legacy_migration.py
+++ b/tests/core/persistence/test_legacy_migration.py
@@ -236,3 +236,43 @@ def test_migration_rejects_invalid_legacy_data(
 
     assert not WorkspaceDatabase(legacy_workspace.state_dir).path.exists()
     assert (legacy_workspace.state_dir / "state.yaml").is_file()
+
+
+def test_retirement_failure_restores_legacy_authority_and_is_retryable(
+    legacy_workspace: LegacyWorkspace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_rename = Path.rename
+    failed = False
+
+    def fail_workitems_retirement(path: Path, target: Path):
+        nonlocal failed
+        if path.name == "workitems" and not failed:
+            failed = True
+            raise OSError("injected retirement failure")
+        return original_rename(path, target)
+
+    monkeypatch.setattr(Path, "rename", fail_workitems_retirement)
+
+    with pytest.raises(OSError, match="retirement failure"):
+        migrate_legacy_state(
+            legacy_workspace.state_dir,
+            daemon_probe=lambda: None,
+            now=NOW,
+        )
+
+    assert not WorkspaceDatabase(legacy_workspace.state_dir).path.exists()
+    assert (legacy_workspace.state_dir / "state.yaml").is_file()
+    assert (legacy_workspace.state_dir / "workitems").is_dir()
+    assert not list(legacy_workspace.state_dir.glob("state.yaml.migrated-*"))
+    assert not list(legacy_workspace.state_dir.glob("workitems.migrated-*"))
+
+    report = migrate_legacy_state(
+        legacy_workspace.state_dir,
+        daemon_probe=lambda: None,
+        now=NOW,
+    )
+    assert report.migrated is True
+    assert StateManager(legacy_workspace.state_dir).load() == (
+        legacy_workspace.expected_state
+    )

--- a/tests/core/persistence/test_legacy_migration.py
+++ b/tests/core/persistence/test_legacy_migration.py
@@ -11,11 +11,12 @@ from sqlalchemy import select
 from mship.core.persistence.database import WorkspaceDatabase
 from mship.core.persistence.migration import (
     MigrationPreflightError,
+    MigrationVerificationError,
     _backup_legacy,
     _legacy_fingerprints,
     migrate_legacy_state,
 )
-from mship.core.persistence.schema import storage_metadata
+from mship.core.persistence.schema import storage_metadata, tasks
 from mship.core.state import (
     DependencyEdge,
     StateManager,
@@ -174,6 +175,36 @@ def test_migration_activates_only_after_verified_import(
     assert len(metadata["legacy_workitems_sha256"]) == 64
 
 
+def test_migration_preserves_switch_source_without_dependencies(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    task = Task(
+        slug="no-dependencies",
+        description="switch source without usable dependencies",
+        phase="dev",
+        created_at=NOW,
+        affected_repos=["mothership"],
+        branch="feat/no-dependencies",
+        last_switched_at_sha={"mothership": {}},
+    )
+    expected = WorkspaceState(tasks={task.slug: task})
+    (state_dir / "state.yaml").write_text(
+        yaml.safe_dump(expected.model_dump(mode="json"))
+    )
+
+    report = migrate_legacy_state(
+        state_dir,
+        daemon_probe=lambda: None,
+        now=NOW,
+    )
+
+    assert report.migrated is True
+    assert StateManager(state_dir).load() == expected
+    assert not (state_dir / "state.yaml").exists()
+
+
 def test_migration_accepts_semantically_equivalent_naive_timestamps(
     tmp_path: Path,
 ) -> None:
@@ -218,6 +249,43 @@ def test_migration_accepts_semantically_equivalent_naive_timestamps(
     restored_item = WorkItemStore(state_dir / "workitems").get(item.id)
     assert restored_item is not None
     assert restored_item.updated_at == naive.replace(tzinfo=timezone.utc)
+
+
+def test_migration_rejects_non_timestamp_candidate_mismatch(
+    legacy_workspace: LegacyWorkspace,
+) -> None:
+    def corrupt_candidate(stage: str) -> None:
+        if stage != "verify":
+            return
+        candidate_path = next(
+            path
+            for path in legacy_workspace.state_dir.glob(
+                ".mothership.db.migrating-*"
+            )
+            if not path.name.endswith(("-wal", "-shm"))
+        )
+        candidate = WorkspaceDatabase(
+            legacy_workspace.state_dir,
+            database_path=candidate_path,
+        )
+        with candidate.write() as connection:
+            connection.execute(
+                tasks.update()
+                .where(tasks.c.slug == "upstream")
+                .values(description="corrupted")
+            )
+
+    with pytest.raises(MigrationVerificationError, match="does not match"):
+        migrate_legacy_state(
+            legacy_workspace.state_dir,
+            daemon_probe=lambda: None,
+            now=NOW,
+            stage_hook=corrupt_candidate,
+        )
+
+    assert (legacy_workspace.state_dir / "state.yaml").is_file()
+    assert (legacy_workspace.state_dir / "workitems").is_dir()
+    assert not WorkspaceDatabase(legacy_workspace.state_dir).path.exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/core/persistence/test_legacy_migration.py
+++ b/tests/core/persistence/test_legacy_migration.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+from sqlalchemy import select
+
+from mship.core.persistence.database import WorkspaceDatabase
+from mship.core.persistence.migration import (
+    MigrationPreflightError,
+    migrate_legacy_state,
+)
+from mship.core.persistence.schema import storage_metadata
+from mship.core.state import (
+    DependencyEdge,
+    StateManager,
+    Task,
+    TestResult,
+    WorkspaceState,
+)
+from mship.core.workitem import ExternalLink, WorkItem
+from mship.core.workitem_store import WorkItemStore
+
+NOW = datetime(2026, 9, 7, 20, 0, tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class LegacyWorkspace:
+    state_dir: Path
+    expected_state: WorkspaceState
+    expected_items: list[WorkItem]
+    message_sentinel: Path
+    spec_sentinel: Path
+
+
+@pytest.fixture
+def legacy_workspace(tmp_path: Path) -> LegacyWorkspace:
+    state_dir = tmp_path / ".mothership"
+    workitems_dir = state_dir / "workitems"
+    workitems_dir.mkdir(parents=True)
+
+    upstream = Task(
+        slug="upstream",
+        description="library",
+        phase="review",
+        created_at=NOW,
+        affected_repos=["shared"],
+        worktrees={"shared": tmp_path / "upstream-shared"},
+        branch="feat/upstream",
+        test_results={"shared": TestResult(status="pass", at=NOW)},
+        pr_urls={"shared": "https://github.example/shared/pull/1"},
+        active_repo="shared",
+        last_switched_at_sha={"shared": {"api": "abc123"}},
+        test_iteration=3,
+        base_branch="main",
+        passive_repos={"docs"},
+        spec_id="spec-upstream",
+        work_item_id="wi-active",
+    )
+    downstream = Task(
+        slug="downstream",
+        description="service",
+        phase="dev",
+        created_at=NOW,
+        affected_repos=["api"],
+        branch="feat/downstream",
+        depends_on=[DependencyEdge(upstream_slug="upstream", created_at=NOW)],
+        work_item_id="wi-archived",
+    )
+    expected_state = WorkspaceState(
+        tasks={"downstream": downstream, "upstream": upstream}
+    )
+    (state_dir / "state.yaml").write_text(
+        yaml.safe_dump(expected_state.model_dump(mode="json"))
+    )
+
+    active = WorkItem.model_validate(
+        {
+            "id": "wi-active",
+            "title": "Active",
+            "workspace": "test",
+            "kind": "feature",
+            "created_at": NOW,
+            "updated_at": NOW,
+            "spec_id": "spec-upstream",
+            "plan_path": "docs/plans/upstream.md",
+            "task_slugs": ["upstream"],
+            "thread_ids": ["thread-active"],
+            "external_links": [
+                ExternalLink(
+                    provider="github",
+                    url="https://github.example/issues/1",
+                    title="Issue 1",
+                )
+            ],
+            "affected_repos": ["shared"],
+            "pr_urls": ["https://github.example/shared/pull/1"],
+            "future_field": {"preserve": True},
+        }
+    )
+    archived = WorkItem(
+        id="wi-archived",
+        title="Archived",
+        workspace="test",
+        kind="chore",
+        created_at=NOW,
+        updated_at=NOW,
+        task_slugs=["downstream"],
+        thread_ids=["thread-archived"],
+        archived=True,
+    )
+    for item in (active, archived):
+        (workitems_dir / f"{item.id}.json").write_text(item.model_dump_json(indent=2))
+
+    message_sentinel = state_dir / "messages" / "thread.json"
+    message_sentinel.parent.mkdir()
+    message_sentinel.write_text('{"unchanged": true}\n')
+    spec_sentinel = tmp_path / "specs" / "spec-upstream.md"
+    spec_sentinel.parent.mkdir()
+    spec_sentinel.write_text("# unchanged\n")
+    return LegacyWorkspace(
+        state_dir=state_dir,
+        expected_state=expected_state,
+        expected_items=[active, archived],
+        message_sentinel=message_sentinel,
+        spec_sentinel=spec_sentinel,
+    )
+
+
+def test_migration_activates_only_after_verified_import(
+    legacy_workspace: LegacyWorkspace,
+) -> None:
+    report = migrate_legacy_state(
+        legacy_workspace.state_dir,
+        daemon_probe=lambda: None,
+        now=NOW,
+    )
+
+    assert report.migrated is True
+    assert report.tasks == 2
+    assert report.work_items == 2
+    assert report.database_path.is_file()
+    assert report.backup_path is not None
+    assert (report.backup_path / "state.yaml").is_file()
+    assert (report.backup_path / "workitems" / "wi-active.json").is_file()
+    assert not (legacy_workspace.state_dir / "state.yaml").exists()
+    assert not (legacy_workspace.state_dir / "workitems").exists()
+    assert StateManager(legacy_workspace.state_dir).load() == (
+        legacy_workspace.expected_state
+    )
+    actual_items = WorkItemStore(legacy_workspace.state_dir / "workitems").list(
+        include_archived=True
+    )
+    assert {item.id: item for item in actual_items} == {
+        item.id: item for item in legacy_workspace.expected_items
+    }
+    assert legacy_workspace.message_sentinel.read_text() == ('{"unchanged": true}\n')
+    assert legacy_workspace.spec_sentinel.read_text() == "# unchanged\n"
+
+    database = WorkspaceDatabase(legacy_workspace.state_dir)
+    with database.read() as connection:
+        metadata = dict(
+            connection.execute(select(storage_metadata.c.key, storage_metadata.c.value))
+            .tuples()
+            .all()
+        )
+    assert metadata["migrated_at"] == NOW.isoformat()
+    assert len(metadata["legacy_state_sha256"]) == 64
+    assert len(metadata["legacy_workitems_sha256"]) == 64
+
+
+@pytest.mark.parametrize(
+    "stage",
+    ["validate", "backup", "alembic", "import", "verify", "activate"],
+)
+def test_migration_fault_leaves_legacy_live_and_retryable(
+    legacy_workspace: LegacyWorkspace,
+    stage: str,
+) -> None:
+    def fail_at(current: str) -> None:
+        if current == stage:
+            raise RuntimeError(f"injected {stage} failure")
+
+    with pytest.raises(RuntimeError, match=f"injected {stage} failure"):
+        migrate_legacy_state(
+            legacy_workspace.state_dir,
+            daemon_probe=lambda: None,
+            now=NOW,
+            stage_hook=fail_at,
+        )
+
+    assert not WorkspaceDatabase(legacy_workspace.state_dir).path.exists()
+    assert (legacy_workspace.state_dir / "state.yaml").is_file()
+    assert (legacy_workspace.state_dir / "workitems").is_dir()
+    assert not list(legacy_workspace.state_dir.glob("*.migrating-*"))
+    assert legacy_workspace.message_sentinel.read_text() == ('{"unchanged": true}\n')
+    assert legacy_workspace.spec_sentinel.read_text() == "# unchanged\n"
+
+    report = migrate_legacy_state(
+        legacy_workspace.state_dir,
+        daemon_probe=lambda: None,
+        now=NOW,
+    )
+    assert report.migrated is True
+    assert report.database_path.is_file()
+
+
+def test_migration_refuses_while_daemon_is_running(
+    legacy_workspace: LegacyWorkspace,
+) -> None:
+    with pytest.raises(MigrationPreflightError, match="daemon"):
+        migrate_legacy_state(
+            legacy_workspace.state_dir,
+            daemon_probe=lambda: {"pid": 42},
+            now=NOW,
+        )
+
+    assert not WorkspaceDatabase(legacy_workspace.state_dir).path.exists()
+    assert (legacy_workspace.state_dir / "state.yaml").is_file()
+
+
+def test_migration_rejects_invalid_legacy_data(
+    legacy_workspace: LegacyWorkspace,
+) -> None:
+    (legacy_workspace.state_dir / "workitems" / "wi-active.json").write_text("{")
+
+    with pytest.raises(Exception):
+        migrate_legacy_state(
+            legacy_workspace.state_dir,
+            daemon_probe=lambda: None,
+            now=NOW,
+        )
+
+    assert not WorkspaceDatabase(legacy_workspace.state_dir).path.exists()
+    assert (legacy_workspace.state_dir / "state.yaml").is_file()

--- a/tests/core/persistence/test_legacy_migration.py
+++ b/tests/core/persistence/test_legacy_migration.py
@@ -11,6 +11,8 @@ from sqlalchemy import select
 from mship.core.persistence.database import WorkspaceDatabase
 from mship.core.persistence.migration import (
     MigrationPreflightError,
+    _backup_legacy,
+    _legacy_fingerprints,
     migrate_legacy_state,
 )
 from mship.core.persistence.schema import storage_metadata
@@ -282,6 +284,85 @@ def test_migration_rejects_invalid_legacy_data(
 
     assert not WorkspaceDatabase(legacy_workspace.state_dir).path.exists()
     assert (legacy_workspace.state_dir / "state.yaml").is_file()
+
+
+def test_legacy_fingerprints_reject_external_workitem_symlink(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    workitems_dir = state_dir / "workitems"
+    workitems_dir.mkdir(parents=True)
+    outside = WorkItem(
+        id="outside",
+        title="Outside",
+        workspace="test",
+        kind="chore",
+        created_at=NOW,
+        updated_at=NOW,
+    )
+    outside_path = state_dir / "outside.json"
+    outside_path.write_text(outside.model_dump_json())
+    (workitems_dir / "linked.json").symlink_to(outside_path)
+
+    with pytest.raises(ValueError, match="unsafe work item id"):
+        _legacy_fingerprints(state_dir)
+
+
+def test_legacy_backup_rejects_external_workitem_symlink(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    workitems_dir = state_dir / "workitems"
+    workitems_dir.mkdir(parents=True)
+    outside = WorkItem(
+        id="outside",
+        title="Outside",
+        workspace="test",
+        kind="chore",
+        created_at=NOW,
+        updated_at=NOW,
+    )
+    outside_path = state_dir / "outside.json"
+    outside_path.write_text(outside.model_dump_json())
+    (workitems_dir / "linked.json").symlink_to(outside_path)
+
+    with pytest.raises(ValueError, match="unsafe work item id"):
+        _backup_legacy(state_dir, NOW)
+
+
+def test_migration_rejects_external_workitem_symlink_before_loading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    workitems_dir = state_dir / "workitems"
+    workitems_dir.mkdir(parents=True)
+    (state_dir / "state.yaml").write_text("tasks: {}\n")
+    outside = WorkItem(
+        id="outside",
+        title="Outside",
+        workspace="test",
+        kind="chore",
+        created_at=NOW,
+        updated_at=NOW,
+    )
+    outside_path = state_dir / "outside.json"
+    outside_path.write_text(outside.model_dump_json())
+    (workitems_dir / "linked.json").symlink_to(outside_path)
+    monkeypatch.setattr(
+        "mship.core.persistence.migration.list_legacy_workitems",
+        lambda *_args, **_kwargs: ([], False),
+    )
+
+    with pytest.raises(ValueError, match="unsafe work item id"):
+        migrate_legacy_state(
+            state_dir,
+            daemon_probe=lambda: None,
+            now=NOW,
+        )
+
+    assert (state_dir / "state.yaml").is_file()
+    assert not WorkspaceDatabase(state_dir).path.exists()
 
 
 def test_retirement_failure_restores_legacy_authority_and_is_retryable(

--- a/tests/core/persistence/test_multiprocess_contracts.py
+++ b/tests/core/persistence/test_multiprocess_contracts.py
@@ -113,6 +113,34 @@ def _registration_worker(
     Path(result_path).write_text(json.dumps(outcomes))
 
 
+def _first_write_worker(
+    state_dir: str,
+    slug: str,
+    result_path: str,
+    barrier,
+) -> None:
+    current_revision = WorkspaceDatabase.current_revision
+    first_check = True
+
+    def synchronized_revision(database):
+        nonlocal first_check
+        current = current_revision(database)
+        if first_check:
+            first_check = False
+            barrier.wait(timeout=PROCESS_TIMEOUT_SECONDS)
+        return current
+
+    WorkspaceDatabase.current_revision = synchronized_revision
+    try:
+        manager = StateManager(Path(state_dir))
+        manager.insert_task(_task(slug))
+    except Exception as error:
+        outcome = f"{type(error).__name__}: {error}"
+    else:
+        outcome = "ok"
+    Path(result_path).write_text(outcome)
+
+
 def _run_pair(ctx, target, args_a: tuple, args_b: tuple) -> None:
     barrier = ctx.Barrier(2)
     processes = [
@@ -128,6 +156,28 @@ def _run_pair(ctx, target, args_a: tuple, args_b: tuple) -> None:
             process.join(timeout=PROCESS_TIMEOUT_SECONDS)
             pytest.fail(f"multiprocess worker exceeded {PROCESS_TIMEOUT_SECONDS}s")
         assert process.exitcode == 0, f"worker exited with {process.exitcode}"
+
+
+def test_concurrent_first_writes_initialize_alembic_once_without_leaking_errors(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    first_result = tmp_path / "first-result"
+    second_result = tmp_path / "second-result"
+    ctx = multiprocessing.get_context("spawn")
+
+    _run_pair(
+        ctx,
+        _first_write_worker,
+        (str(state_dir), "first", str(first_result)),
+        (str(state_dir), "second", str(second_result)),
+    )
+
+    assert first_result.read_text() == "ok"
+    assert second_result.read_text() == "ok"
+
+    state = StateManager(state_dir).load()
+    assert set(state.tasks) == {"first", "second"}
 
 
 def test_concurrent_different_task_mutations_never_lose_updates(

--- a/tests/core/persistence/test_multiprocess_contracts.py
+++ b/tests/core/persistence/test_multiprocess_contracts.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import json
+import multiprocessing
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from mship.core.persistence import database as database_module
+from mship.core.persistence.database import DatabaseBusyError, WorkspaceDatabase
+from mship.core.persistence.lifecycle_repository import LifecycleRepository
+from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.workitem_store import TaskLinkAmbiguousError, WorkItemStore
+
+
+NOW = datetime(2026, 9, 7, 22, 0, tzinfo=timezone.utc)
+ROUNDS = 20
+MUTATIONS_PER_WORKER = 50
+PROCESS_TIMEOUT_SECONDS = 10
+
+
+def _task(slug: str) -> Task:
+    return Task(
+        slug=slug,
+        description=slug,
+        phase="dev",
+        created_at=NOW,
+        affected_repos=[],
+        branch=f"feat/{slug}",
+    )
+
+
+def _round_mutations(round_index: int) -> int:
+    return 3 if round_index < 10 else 2
+
+
+def _mutate_task_worker(state_dir: str, slug: str, barrier) -> None:
+    manager = StateManager(Path(state_dir))
+    for round_index in range(ROUNDS):
+        barrier.wait(timeout=PROCESS_TIMEOUT_SECONDS)
+        for _ in range(_round_mutations(round_index)):
+            manager.mutate_task(
+                slug,
+                lambda task: setattr(
+                    task,
+                    "test_iteration",
+                    task.test_iteration + 1,
+                ),
+            )
+
+
+def _mutate_whole_snapshot_worker(state_dir: str, slug: str, barrier) -> None:
+    manager = StateManager(Path(state_dir))
+    for round_index in range(ROUNDS):
+        barrier.wait(timeout=PROCESS_TIMEOUT_SECONDS)
+        for _ in range(_round_mutations(round_index)):
+            manager.mutate(
+                lambda state: setattr(
+                    state.tasks[slug],
+                    "test_iteration",
+                    state.tasks[slug].test_iteration + 1,
+                ),
+            )
+
+
+def _link_worker(
+    state_dir: str,
+    task_item_pairs: list[tuple[str, str]],
+    barrier,
+) -> None:
+    lifecycle = LifecycleRepository(StateManager(Path(state_dir)).workspace_store)
+    for task_slug, item_id in task_item_pairs:
+        barrier.wait(timeout=PROCESS_TIMEOUT_SECONDS)
+        lifecycle.link_task(item_id, task_slug, now=NOW)
+
+
+def _duplicate_link_worker(
+    state_dir: str,
+    item_id: str,
+    result_path: str,
+    barrier,
+) -> None:
+    lifecycle = LifecycleRepository(StateManager(Path(state_dir)).workspace_store)
+    barrier.wait(timeout=PROCESS_TIMEOUT_SECONDS)
+    try:
+        lifecycle.link_task(item_id, "shared-task", now=NOW)
+    except TaskLinkAmbiguousError:
+        outcome = "duplicate"
+    else:
+        outcome = "linked"
+    Path(result_path).write_text(outcome)
+
+
+def _registration_worker(
+    state_dir: str,
+    item_ids: list[str],
+    result_path: str,
+    barrier,
+) -> None:
+    lifecycle = LifecycleRepository(StateManager(Path(state_dir)).workspace_store)
+    outcomes: list[str] = []
+    for round_index, item_id in enumerate(item_ids):
+        barrier.wait(timeout=PROCESS_TIMEOUT_SECONDS)
+        task = _task(f"registration-{round_index}")
+        try:
+            lifecycle.register_task(task, item_id, now=NOW)
+        except KeyError, TaskLinkAmbiguousError:
+            outcomes.append("duplicate")
+        else:
+            outcomes.append("registered")
+    Path(result_path).write_text(json.dumps(outcomes))
+
+
+def _run_pair(ctx, target, args_a: tuple, args_b: tuple) -> None:
+    barrier = ctx.Barrier(2)
+    processes = [
+        ctx.Process(target=target, args=(*args_a, barrier)),
+        ctx.Process(target=target, args=(*args_b, barrier)),
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=PROCESS_TIMEOUT_SECONDS)
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=PROCESS_TIMEOUT_SECONDS)
+            pytest.fail(f"multiprocess worker exceeded {PROCESS_TIMEOUT_SECONDS}s")
+        assert process.exitcode == 0, f"worker exited with {process.exitcode}"
+
+
+def test_concurrent_different_task_mutations_never_lose_updates(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    manager = StateManager(state_dir)
+    manager.save(
+        WorkspaceState(tasks={"task-a": _task("task-a"), "task-b": _task("task-b")})
+    )
+    ctx = multiprocessing.get_context("spawn")
+
+    _run_pair(
+        ctx,
+        _mutate_task_worker,
+        (str(state_dir), "task-a"),
+        (str(state_dir), "task-b"),
+    )
+
+    state = manager.load()
+    assert state.tasks["task-a"].test_iteration == MUTATIONS_PER_WORKER
+    assert state.tasks["task-b"].test_iteration == MUTATIONS_PER_WORKER
+
+
+def test_concurrent_same_task_mutations_serialize_without_loss(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    manager = StateManager(state_dir)
+    manager.save(WorkspaceState(tasks={"shared-task": _task("shared-task")}))
+    ctx = multiprocessing.get_context("spawn")
+
+    _run_pair(
+        ctx,
+        _mutate_task_worker,
+        (str(state_dir), "shared-task"),
+        (str(state_dir), "shared-task"),
+    )
+
+    assert manager.load().tasks["shared-task"].test_iteration == (
+        MUTATIONS_PER_WORKER * 2
+    )
+
+
+def test_concurrent_whole_snapshot_mutations_remain_compatible(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    manager = StateManager(state_dir)
+    manager.save(
+        WorkspaceState(tasks={"task-a": _task("task-a"), "task-b": _task("task-b")})
+    )
+    ctx = multiprocessing.get_context("spawn")
+
+    _run_pair(
+        ctx,
+        _mutate_whole_snapshot_worker,
+        (str(state_dir), "task-a"),
+        (str(state_dir), "task-b"),
+    )
+
+    state = manager.load()
+    assert state.tasks["task-a"].test_iteration == MUTATIONS_PER_WORKER
+    assert state.tasks["task-b"].test_iteration == MUTATIONS_PER_WORKER
+
+
+def test_concurrent_workitem_links_commit_both_sides(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    manager = StateManager(state_dir)
+    tasks = {
+        f"task-{worker}-{round_index}": _task(f"task-{worker}-{round_index}")
+        for worker in ("a", "b")
+        for round_index in range(ROUNDS)
+    }
+    manager.save(WorkspaceState(tasks=tasks))
+    items = WorkItemStore(state_dir / "workitems")
+    pairs: dict[str, list[tuple[str, str]]] = {"a": [], "b": []}
+    for worker in ("a", "b"):
+        for round_index in range(ROUNDS):
+            task_slug = f"task-{worker}-{round_index}"
+            item = items.create(task_slug, "chore", "test", NOW)
+            pairs[worker].append((task_slug, item.id))
+    ctx = multiprocessing.get_context("spawn")
+
+    _run_pair(
+        ctx,
+        _link_worker,
+        (str(state_dir), pairs["a"]),
+        (str(state_dir), pairs["b"]),
+    )
+
+    state = manager.load()
+    for task_slug, item_id in [*pairs["a"], *pairs["b"]]:
+        assert state.tasks[task_slug].work_item_id == item_id
+        assert items.get(item_id).task_slugs == [task_slug]
+
+
+def test_concurrent_duplicate_task_ownership_has_exactly_one_winner(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    manager = StateManager(state_dir)
+    manager.save(WorkspaceState(tasks={"shared-task": _task("shared-task")}))
+    items = WorkItemStore(state_dir / "workitems")
+    first = items.create("First", "chore", "test", NOW)
+    second = items.create("Second", "chore", "test", NOW)
+    first_result = tmp_path / "first-result"
+    second_result = tmp_path / "second-result"
+    ctx = multiprocessing.get_context("spawn")
+
+    _run_pair(
+        ctx,
+        _duplicate_link_worker,
+        (str(state_dir), first.id, str(first_result)),
+        (str(state_dir), second.id, str(second_result)),
+    )
+
+    assert sorted([first_result.read_text(), second_result.read_text()]) == [
+        "duplicate",
+        "linked",
+    ]
+    linked = [item for item in items.list() if item.task_slugs]
+    assert len(linked) == 1
+    assert linked[0].task_slugs == ["shared-task"]
+    assert manager.load().tasks["shared-task"].work_item_id == linked[0].id
+
+
+def test_concurrent_task_workitem_registration_is_atomic_for_twenty_rounds(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    manager = StateManager(state_dir)
+    manager.save(WorkspaceState())
+    items = WorkItemStore(state_dir / "workitems")
+    first_items = [
+        items.create(f"First {index}", "chore", "test", NOW).id
+        for index in range(ROUNDS)
+    ]
+    second_items = [
+        items.create(f"Second {index}", "chore", "test", NOW).id
+        for index in range(ROUNDS)
+    ]
+    first_result = tmp_path / "first-registrations.json"
+    second_result = tmp_path / "second-registrations.json"
+    ctx = multiprocessing.get_context("spawn")
+
+    _run_pair(
+        ctx,
+        _registration_worker,
+        (str(state_dir), first_items, str(first_result)),
+        (str(state_dir), second_items, str(second_result)),
+    )
+
+    first_outcomes = json.loads(first_result.read_text())
+    second_outcomes = json.loads(second_result.read_text())
+    state = manager.load()
+    assert len(state.tasks) == ROUNDS
+    for round_index in range(ROUNDS):
+        assert sorted([first_outcomes[round_index], second_outcomes[round_index]]) == [
+            "duplicate",
+            "registered",
+        ]
+        task = state.tasks[f"registration-{round_index}"]
+        owners = [
+            item
+            for item in items.list()
+            if f"registration-{round_index}" in item.task_slugs
+        ]
+        assert len(owners) == 1
+        assert task.work_item_id == owners[0].id
+
+
+def test_busy_contention_ends_at_bounded_deadline_with_recovery_guidance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(database_module, "BUSY_TIMEOUT_MS", 100)
+    state_dir = tmp_path / ".mothership"
+    holder = WorkspaceDatabase(state_dir)
+    contender = WorkspaceDatabase(state_dir)
+    holder.initialize()
+    contender.initialize()
+
+    with holder.write(immediate=True):
+        started = time.monotonic()
+        with pytest.raises(DatabaseBusyError) as error:
+            with contender.write(immediate=True):
+                pass
+        elapsed = time.monotonic() - started
+
+    message = str(error.value)
+    assert str(holder.path) in message
+    assert "retry the operation" in message
+    assert 0.05 <= elapsed < 1.0

--- a/tests/core/persistence/test_schema.py
+++ b/tests/core/persistence/test_schema.py
@@ -1,0 +1,189 @@
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy import Connection
+from sqlalchemy.exc import IntegrityError
+
+from mship.core.persistence.database import WorkspaceDatabase
+from mship.core.persistence.schema import (
+    metadata,
+    task_dependencies,
+    task_repos,
+    tasks,
+    work_items,
+    workitem_external_links,
+    workitem_tasks,
+    workitem_threads,
+)
+
+
+@pytest.fixture
+def connection(tmp_path: Path) -> Iterator[Connection]:
+    database = WorkspaceDatabase(tmp_path / ".mothership")
+    database.initialize()
+    with database.write() as conn:
+        metadata.create_all(conn)
+    with database.write() as conn:
+        yield conn
+
+
+def _seed_work_items(connection: Connection) -> None:
+    connection.execute(
+        work_items.insert(),
+        [
+            {
+                "id": "wi-a",
+                "title": "A",
+                "workspace": "test",
+                "kind": "feature",
+                "created_at": "2026-09-07T00:00:00+00:00",
+                "updated_at": "2026-09-07T00:00:00+00:00",
+            },
+            {
+                "id": "wi-b",
+                "title": "B",
+                "workspace": "test",
+                "kind": "bug",
+                "created_at": "2026-09-07T00:00:00+00:00",
+                "updated_at": "2026-09-07T00:00:00+00:00",
+            },
+        ],
+    )
+
+
+def _task_row(slug: str = "task-a", **updates: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "slug": slug,
+        "description": "Task",
+        "phase": "dev",
+        "created_at": "2026-09-07T00:00:00+00:00",
+        "branch": f"feat/{slug}",
+    }
+    row.update(updates)
+    return row
+
+
+def test_one_task_slug_has_one_workitem_owner(connection: Connection) -> None:
+    _seed_work_items(connection)
+    connection.execute(
+        workitem_tasks.insert().values(work_item_id="wi-a", task_slug="task-a", ordinal=0)
+    )
+
+    with pytest.raises(IntegrityError):
+        connection.execute(
+            workitem_tasks.insert().values(
+                work_item_id="wi-b",
+                task_slug="task-a",
+                ordinal=0,
+            )
+        )
+
+
+def test_thread_has_one_workitem_owner(connection: Connection) -> None:
+    _seed_work_items(connection)
+    connection.execute(
+        workitem_threads.insert().values(
+            work_item_id="wi-a",
+            thread_id="thread-a",
+            ordinal=0,
+        )
+    )
+
+    with pytest.raises(IntegrityError):
+        connection.execute(
+            workitem_threads.insert().values(
+                work_item_id="wi-b",
+                thread_id="thread-a",
+                ordinal=0,
+            )
+        )
+
+
+def test_workitem_children_require_an_existing_parent(connection: Connection) -> None:
+    with pytest.raises(IntegrityError):
+        connection.execute(
+            workitem_tasks.insert().values(
+                work_item_id="missing",
+                task_slug="task-a",
+                ordinal=0,
+            )
+        )
+
+
+@pytest.mark.parametrize("phase", ["inbox", "finished", ""])
+def test_task_phase_is_constrained(connection: Connection, phase: str) -> None:
+    with pytest.raises(IntegrityError):
+        connection.execute(tasks.insert().values(**_task_row(phase=phase)))
+
+
+@pytest.mark.parametrize(
+    ("column", "value"),
+    [("revision", -1), ("test_iteration", -1)],
+)
+def test_task_counters_are_non_negative(
+    connection: Connection,
+    column: str,
+    value: int,
+) -> None:
+    with pytest.raises(IntegrityError):
+        connection.execute(tasks.insert().values(**_task_row(**{column: value})))
+
+
+def test_child_ordinals_are_unique_per_parent(connection: Connection) -> None:
+    _seed_work_items(connection)
+    connection.execute(
+        workitem_external_links.insert().values(
+            work_item_id="wi-a",
+            ordinal=0,
+            provider="github",
+            url="https://example.test/one",
+            title="One",
+        )
+    )
+
+    with pytest.raises(IntegrityError):
+        connection.execute(
+            workitem_external_links.insert().values(
+                work_item_id="wi-a",
+                ordinal=0,
+                provider="url",
+                url="https://example.test/two",
+                title="Two",
+            )
+        )
+
+
+def test_affected_repo_ordinals_are_unique_per_task(connection: Connection) -> None:
+    connection.execute(tasks.insert().values(**_task_row()))
+    connection.execute(
+        task_repos.insert().values(
+            task_slug="task-a",
+            repo_name="repo-a",
+            affected_ordinal=0,
+            passive=False,
+        )
+    )
+
+    with pytest.raises(IntegrityError):
+        connection.execute(
+            task_repos.insert().values(
+                task_slug="task-a",
+                repo_name="repo-b",
+                affected_ordinal=0,
+                passive=False,
+            )
+        )
+
+
+def test_task_cannot_depend_on_itself(connection: Connection) -> None:
+    connection.execute(tasks.insert().values(**_task_row()))
+
+    with pytest.raises(IntegrityError):
+        connection.execute(
+            task_dependencies.insert().values(
+                task_slug="task-a",
+                upstream_slug="task-a",
+                created_at="2026-09-07T00:00:00+00:00",
+            )
+        )

--- a/tests/core/persistence/test_targeted_mutations.py
+++ b/tests/core/persistence/test_targeted_mutations.py
@@ -1,0 +1,144 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import event
+
+from mship.core.persistence.database import WorkspaceDatabase
+from mship.core.persistence.workspace_store import WorkspaceStore
+from mship.core.state import StateManager, Task, WorkspaceState
+
+
+NOW = datetime(2026, 9, 7, 19, 0, tzinfo=timezone.utc)
+
+
+def _task(slug: str) -> Task:
+    return Task(
+        slug=slug,
+        description=f"Task {slug}",
+        phase="dev",
+        created_at=NOW,
+        affected_repos=[f"repo-{slug}"],
+        worktrees={f"repo-{slug}": Path(f"/tmp/{slug}")},
+        branch=f"feat/{slug}",
+    )
+
+
+@pytest.fixture
+def manager(tmp_path: Path) -> StateManager:
+    return StateManager(tmp_path / ".mothership")
+
+
+@pytest.fixture
+def two_tasks(manager: StateManager) -> WorkspaceState:
+    state = WorkspaceState(tasks={slug: _task(slug) for slug in ("a", "b")})
+    manager.save(state)
+    return state
+
+
+def test_mutate_task_updates_only_named_task(
+    manager: StateManager,
+    two_tasks: WorkspaceState,
+) -> None:
+    before_other = manager.load().tasks["b"].model_dump(mode="json")
+
+    result = manager.mutate_task(
+        "a",
+        lambda task: setattr(task, "blocked_reason", "wait"),
+    )
+
+    assert result.blocked_reason == "wait"
+    assert manager.load().tasks["a"].blocked_reason == "wait"
+    assert manager.load().tasks["b"].model_dump(mode="json") == before_other
+
+
+def test_mutate_tasks_is_atomic_on_callback_failure(
+    manager: StateManager,
+    two_tasks: WorkspaceState,
+) -> None:
+    before = manager.load()
+
+    def fail(tasks: dict[str, Task]) -> None:
+        tasks["a"].blocked_reason = "changed"
+        tasks["b"].blocked_reason = "changed"
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        manager.mutate_tasks(["a", "b"], fail)
+
+    assert manager.load() == before
+
+
+def test_mutate_tasks_updates_and_deletes_only_requested_rows(
+    manager: StateManager,
+) -> None:
+    initial = WorkspaceState(tasks={slug: _task(slug) for slug in ("a", "b", "other")})
+    manager.save(initial)
+    before_other = manager.load().tasks["other"]
+
+    def apply(tasks: dict[str, Task]) -> None:
+        tasks["a"].blocked_reason = "wait"
+        del tasks["b"]
+
+    result = manager.mutate_tasks(["a", "b"], apply)
+    state = manager.load()
+
+    assert result == {"a": state.tasks["a"]}
+    assert state.tasks["a"].blocked_reason == "wait"
+    assert "b" not in state.tasks
+    assert state.tasks["other"] == before_other
+
+
+def test_mutate_task_does_not_rewrite_another_tasks_children(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / ".mothership"
+    database = WorkspaceDatabase(state_dir)
+    store = WorkspaceStore(state_dir, database=database)
+    manager = StateManager(workspace_store=store)
+    manager.save(WorkspaceState(tasks={slug: _task(slug) for slug in ("a", "b")}))
+    writes: list[tuple[str, object]] = []
+
+    @event.listens_for(database._engine, "before_cursor_execute")
+    def capture_statement(
+        _connection,
+        _cursor,
+        statement,
+        parameters,
+        _context,
+        _executemany,
+    ) -> None:
+        if statement.lstrip().upper().startswith(("DELETE", "INSERT", "UPDATE")):
+            writes.append((statement, parameters))
+
+    manager.mutate_task("a", lambda task: setattr(task, "active_repo", "repo-a"))
+
+    assert writes
+    assert all("b" not in repr(parameters) for _, parameters in writes)
+
+
+def test_insert_and_delete_task_are_targeted(manager: StateManager) -> None:
+    manager.insert_task(_task("a"))
+
+    assert manager.load().tasks == {"a": _task("a")}
+    assert manager.delete_task("missing") is False
+    assert manager.delete_task("a") is True
+    assert manager.load().tasks == {}
+
+
+def test_targeted_mutations_can_join_a_caller_transaction(tmp_path: Path) -> None:
+    state_dir = tmp_path / ".mothership"
+    store = WorkspaceStore(state_dir)
+    manager = StateManager(workspace_store=store)
+
+    with pytest.raises(RuntimeError, match="rollback"):
+        with store.write(immediate=True) as transaction:
+            manager.insert_task(_task("a"), connection=transaction.connection)
+            manager.mutate_task(
+                "a",
+                lambda task: setattr(task, "blocked_reason", "wait"),
+                connection=transaction.connection,
+            )
+            raise RuntimeError("rollback")
+
+    assert manager.load().tasks == {}

--- a/tests/core/persistence/test_task_repository.py
+++ b/tests/core/persistence/test_task_repository.py
@@ -1,0 +1,154 @@
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import Connection
+
+from mship.core.persistence.database import WorkspaceDatabase
+from mship.core.persistence.serialization import (
+    ConcurrentUpdateError,
+    PersistenceDecodeError,
+)
+from mship.core.persistence.task_repository import TaskRepository
+from mship.core.persistence.schema import tasks
+from mship.core.state import DependencyEdge, Task, TestResult
+
+NOW = datetime(2026, 9, 7, 12, 30, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def connection(tmp_path: Path) -> Iterator[Connection]:
+    database = WorkspaceDatabase(tmp_path / ".mothership")
+    database.initialize()
+    with database.write() as conn:
+        yield conn
+
+
+def _full_task(slug: str = "task-a", *, with_dependencies: bool = False) -> Task:
+    return Task(
+        slug=slug,
+        description="Persist every Task field",
+        phase="review",
+        created_at=NOW,
+        affected_repos=["api", "web"],
+        worktrees={
+            "api": Path("/worktrees/api"),
+            "tooling": Path("/worktrees/tooling"),
+        },
+        branch=f"feat/{slug}",
+        test_results={
+            "api": TestResult(status="pass", at=NOW + timedelta(minutes=1)),
+            "web": TestResult(status="skip", at=NOW + timedelta(minutes=2)),
+        },
+        blocked_reason="waiting for review",
+        blocked_at=NOW + timedelta(minutes=3),
+        pr_urls={
+            "api": "https://github.com/o/api/pull/1",
+            "web": "https://github.com/o/web/pull/2",
+        },
+        finished_at=NOW + timedelta(minutes=4),
+        phase_entered_at=NOW + timedelta(minutes=5),
+        last_activity_at=NOW + timedelta(minutes=6),
+        active_repo="api",
+        last_switched_at_sha={
+            "api": {"web": "abc123", "tooling": "def456"},
+            "web": {"api": "987fed"},
+        },
+        test_iteration=4,
+        base_branch="main",
+        base_override="stack/base",
+        passive_repos={"api", "docs"},
+        spec_id="spec-a",
+        depends_on=(
+            [
+                DependencyEdge(upstream_slug="up-a", created_at=NOW),
+                DependencyEdge(
+                    upstream_slug="up-b",
+                    created_at=NOW + timedelta(seconds=1),
+                ),
+            ]
+            if with_dependencies
+            else []
+        ),
+        work_item_id="wi-a",
+    )
+
+
+def test_task_round_trips_every_model_field(connection: Connection) -> None:
+    repository = TaskRepository()
+    repository.insert(connection, _full_task("up-a"))
+    repository.insert(connection, _full_task("up-b"))
+    task = _full_task(with_dependencies=True)
+
+    repository.insert(connection, task)
+    restored = repository.get(connection, task.slug)
+
+    assert restored is not None
+    assert restored.model_dump(mode="json") == task.model_dump(mode="json")
+
+
+def test_task_list_order_is_stable_by_slug(connection: Connection) -> None:
+    repository = TaskRepository()
+    repository.insert(connection, _full_task("task-b"))
+    repository.insert(connection, _full_task("task-a"))
+
+    assert list(repository.list(connection)) == ["task-a", "task-b"]
+
+
+def test_replace_uses_optimistic_revision(connection: Connection) -> None:
+    repository = TaskRepository()
+    task = _full_task()
+    repository.insert(connection, task)
+    changed = task.model_copy(update={"description": "Changed"})
+
+    assert repository.replace(connection, changed, expected_revision=0) == 1
+    assert repository.get(connection, task.slug).description == "Changed"
+
+    with pytest.raises(ConcurrentUpdateError, match="task-a"):
+        repository.replace(connection, task, expected_revision=0)
+
+
+def test_replace_changes_only_the_target_tasks_children(connection: Connection) -> None:
+    repository = TaskRepository()
+    task_a = _full_task("task-a")
+    task_b = _full_task("task-b")
+    repository.insert(connection, task_a)
+    repository.insert(connection, task_b)
+
+    changed_a = task_a.model_copy(
+        update={
+            "affected_repos": ["cli"],
+            "worktrees": {"cli": Path("/worktrees/cli")},
+            "test_results": {},
+            "pr_urls": {},
+            "depends_on": [],
+        }
+    )
+    repository.replace(connection, changed_a)
+
+    assert repository.get(connection, "task-a").model_dump(mode="json") == (
+        changed_a.model_dump(mode="json")
+    )
+    assert repository.get(connection, "task-b").model_dump(mode="json") == (
+        task_b.model_dump(mode="json")
+    )
+
+
+def test_malformed_task_row_names_table_and_entity(connection: Connection) -> None:
+    repository = TaskRepository()
+    repository.insert(connection, _full_task())
+    connection.execute(
+        tasks.update().where(tasks.c.slug == "task-a").values(created_at="not-a-datetime")
+    )
+
+    with pytest.raises(PersistenceDecodeError, match=r"tasks.*task-a"):
+        repository.get(connection, "task-a")
+
+
+def test_delete_reports_whether_task_existed(connection: Connection) -> None:
+    repository = TaskRepository()
+    repository.insert(connection, _full_task())
+
+    assert repository.delete(connection, "task-a") is True
+    assert repository.delete(connection, "task-a") is False

--- a/tests/core/persistence/test_task_repository.py
+++ b/tests/core/persistence/test_task_repository.py
@@ -88,6 +88,21 @@ def test_task_round_trips_every_model_field(connection: Connection) -> None:
     assert restored.model_dump(mode="json") == task.model_dump(mode="json")
 
 
+def test_task_round_trips_switch_source_without_dependencies(
+    connection: Connection,
+) -> None:
+    repository = TaskRepository()
+    task = _full_task().model_copy(
+        update={"last_switched_at_sha": {"mothership": {}}}
+    )
+
+    repository.insert(connection, task)
+    restored = repository.get(connection, task.slug)
+
+    assert restored is not None
+    assert restored.last_switched_at_sha == {"mothership": {}}
+
+
 def test_task_list_order_is_stable_by_slug(connection: Connection) -> None:
     repository = TaskRepository()
     repository.insert(connection, _full_task("task-b"))

--- a/tests/core/persistence/test_workitem_repository.py
+++ b/tests/core/persistence/test_workitem_repository.py
@@ -1,0 +1,150 @@
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import Connection
+
+from mship.core.persistence.database import WorkspaceDatabase
+from mship.core.persistence.schema import work_items
+from mship.core.persistence.serialization import (
+    ConcurrentUpdateError,
+    PersistenceDecodeError,
+)
+from mship.core.persistence.workitem_repository import WorkItemRepository
+from mship.core.workitem import WorkItem
+
+NOW = datetime(2026, 9, 7, 13, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def connection(tmp_path: Path) -> Iterator[Connection]:
+    database = WorkspaceDatabase(tmp_path / ".mothership")
+    database.initialize()
+    with database.write() as conn:
+        yield conn
+
+
+def _full_item(
+    item_id: str = "wi-a",
+    *,
+    updated_at: datetime = NOW,
+    archived: bool = False,
+) -> WorkItem:
+    return WorkItem.model_validate(
+        {
+            "id": item_id,
+            "title": f"Item {item_id}",
+            "workspace": "ws",
+            "kind": "feature",
+            "created_at": NOW,
+            "updated_at": updated_at,
+            "spec_id": "spec-a",
+            "plan_path": "docs/plans/a.md",
+            "task_slugs": ["task-b", "task-a"],
+            "thread_ids": ["thread-b", "thread-a"],
+            "external_links": [
+                {
+                    "provider": "github",
+                    "url": "https://github.com/o/r/issues/1",
+                    "title": "#1",
+                },
+                {
+                    "provider": "url",
+                    "url": "https://example.test/context",
+                    "title": "Context",
+                },
+            ],
+            "phase_override": "in_flight",
+            "unattended": True,
+            "archived": archived,
+            "affected_repos": ["web", "api"],
+            "pr_urls": [
+                "https://github.com/o/web/pull/2",
+                "https://github.com/o/api/pull/1",
+            ],
+            "future_field": {"preserve": True},
+        }
+    )
+
+
+def test_workitem_round_trips_every_field_and_unknown_extras(
+    connection: Connection,
+) -> None:
+    repository = WorkItemRepository()
+    item = _full_item()
+
+    repository.insert(connection, item)
+    restored = repository.get(connection, item.id)
+
+    assert restored is not None
+    assert restored.model_dump(mode="json") == item.model_dump(mode="json")
+
+
+def test_list_filters_archived_and_orders_newest_first(connection: Connection) -> None:
+    repository = WorkItemRepository()
+    old = _full_item("wi-old", updated_at=NOW)
+    archived = _full_item(
+        "wi-archived",
+        updated_at=NOW + timedelta(minutes=2),
+        archived=True,
+    )
+    new = _full_item("wi-new", updated_at=NOW + timedelta(minutes=1))
+    for item in (old, archived, new):
+        item.task_slugs = [f"{item.id}-task"]
+        item.thread_ids = [f"{item.id}-thread"]
+        repository.insert(connection, item)
+
+    assert [item.id for item in repository.list(connection)] == ["wi-new", "wi-old"]
+    assert [item.id for item in repository.list(connection, include_archived=True)] == [
+        "wi-archived",
+        "wi-new",
+        "wi-old",
+    ]
+
+
+def test_replace_uses_optimistic_revision(connection: Connection) -> None:
+    repository = WorkItemRepository()
+    item = _full_item()
+    repository.insert(connection, item)
+    changed = item.model_copy(update={"title": "Changed"})
+
+    assert repository.replace(connection, changed, expected_revision=0) == 1
+    assert repository.get(connection, item.id).title == "Changed"
+
+    with pytest.raises(ConcurrentUpdateError, match="wi-a"):
+        repository.replace(connection, item, expected_revision=0)
+
+
+def test_tolerant_list_skips_malformed_rows_and_reports_uncertainty(
+    connection: Connection,
+) -> None:
+    repository = WorkItemRepository()
+    good = _full_item("wi-good")
+    good.task_slugs = ["good-task"]
+    good.thread_ids = ["good-thread"]
+    bad = _full_item("wi-bad")
+    bad.task_slugs = ["bad-task"]
+    bad.thread_ids = ["bad-thread"]
+    repository.insert(connection, good)
+    repository.insert(connection, bad)
+    connection.execute(
+        work_items.update()
+        .where(work_items.c.id == "wi-bad")
+        .values(extras_json="{malformed")
+    )
+
+    items, uncertain = repository.list_tolerant_with_uncertainty(connection)
+
+    assert [item.id for item in items] == ["wi-good"]
+    assert uncertain is True
+    with pytest.raises(PersistenceDecodeError, match=r"work_items.*wi-bad"):
+        repository.get(connection, "wi-bad")
+
+
+def test_delete_reports_whether_workitem_existed(connection: Connection) -> None:
+    repository = WorkItemRepository()
+    repository.insert(connection, _full_item())
+
+    assert repository.delete(connection, "wi-a") is True
+    assert repository.delete(connection, "wi-a") is False

--- a/tests/core/test_concurrent_mutations.py
+++ b/tests/core/test_concurrent_mutations.py
@@ -1,9 +1,9 @@
 """Concurrency tests proving lost-update prevention across tasks.
 
-These target the four `mutate()` migrations (executor batch save, phase
-transition, task abort, spawn TOCTOU). They use multiprocessing so each
-worker has its own process and therefore its own flock — the exact scenario
-two concurrent `mship` invocations create.
+These retain the original command-level race coverage alongside the normalized
+repository contracts. They use spawn-context multiprocessing so every worker
+opens its own SQLite connection — the exact scenario concurrent `mship`
+invocations create on every supported platform.
 """
 from __future__ import annotations
 
@@ -24,6 +24,18 @@ from mship.core.state import StateManager, Task, WorkspaceState
 from mship.core.worktree import WorktreeManager
 from mship.util.git import GitRunner
 from mship.util.shell import ShellRunner, ShellResult
+
+
+PROCESS_TIMEOUT_SECONDS = 10
+
+
+def _join_or_terminate(process) -> None:
+    process.join(timeout=PROCESS_TIMEOUT_SECONDS)
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=PROCESS_TIMEOUT_SECONDS)
+        pytest.fail(f"worker exceeded {PROCESS_TIMEOUT_SECONDS}s")
+    assert process.exitcode == 0, f"worker crashed (exitcode={process.exitcode})"
 
 
 # ---------------------------------------------------------------------------
@@ -55,20 +67,20 @@ def test_concurrent_phase_transitions_do_not_lose_updates(tmp_path: Path):
     sm.save(state)
 
     # Fire a reasonable number of pairs to amplify any lost-update race.
+    ctx = multiprocessing.get_context("spawn")
     pairs = 8
     procs = []
     for i in range(pairs):
-        procs.append(multiprocessing.Process(
+        procs.append(ctx.Process(
             target=_phase_worker, args=(str(state_dir), "a", "dev"),
         ))
-        procs.append(multiprocessing.Process(
+        procs.append(ctx.Process(
             target=_phase_worker, args=(str(state_dir), "b", "review"),
         ))
     for p in procs:
         p.start()
     for p in procs:
-        p.join(timeout=60)
-        assert p.exitcode == 0, f"worker crashed (exitcode={p.exitcode})"
+        _join_or_terminate(p)
 
     final = sm.load()
     # Without mutate(), one task's update could have been clobbered by the
@@ -129,18 +141,17 @@ def test_concurrent_same_slug_spawns_exactly_one_wins(tmp_path: Path):
     r1 = tmp_path / "r1.txt"
     r2 = tmp_path / "r2.txt"
 
-    p1 = multiprocessing.Process(
+    ctx = multiprocessing.get_context("spawn")
+    p1 = ctx.Process(
         target=_spawn_worker, args=(str(state_dir), str(r1), "same desc"),
     )
-    p2 = multiprocessing.Process(
+    p2 = ctx.Process(
         target=_spawn_worker, args=(str(state_dir), str(r2), "same desc"),
     )
     p1.start()
     p2.start()
-    p1.join(timeout=30)
-    p2.join(timeout=30)
-    assert p1.exitcode == 0
-    assert p2.exitcode == 0
+    _join_or_terminate(p1)
+    _join_or_terminate(p2)
 
     outcomes = sorted([r1.read_text(), r2.read_text()])
     assert outcomes == ["duplicate", "ok"], f"expected one ok + one duplicate, got {outcomes}"
@@ -196,25 +207,24 @@ def test_real_spawn_concurrent_same_slug(workspace_with_git: Path):
     r1 = workspace_with_git / "r1.txt"
     r2 = workspace_with_git / "r2.txt"
 
-    p1 = multiprocessing.Process(
+    ctx = multiprocessing.get_context("spawn")
+    p1 = ctx.Process(
         target=_real_spawn_worker,
         args=(str(workspace_with_git), str(r1), "race me"),
     )
-    p2 = multiprocessing.Process(
+    p2 = ctx.Process(
         target=_real_spawn_worker,
         args=(str(workspace_with_git), str(r2), "race me"),
     )
     p1.start()
     p2.start()
-    p1.join(timeout=60)
-    p2.join(timeout=60)
-    assert p1.exitcode == 0, f"p1 crashed: exitcode={p1.exitcode}"
-    assert p2.exitcode == 0, f"p2 crashed: exitcode={p2.exitcode}"
+    _join_or_terminate(p1)
+    _join_or_terminate(p2)
 
     outcomes = sorted([r1.read_text(), r2.read_text()])
     # At least one spawn must succeed (otherwise something else is broken),
     # and we must NOT see two "ok" outcomes (which would indicate a
-    # lost-update race past the in-mutate check-and-set).
+    # lost-update race past the transactional check-and-set).
     ok_count = sum(1 for o in outcomes if o == "ok")
     assert ok_count >= 1, f"neither spawn succeeded: {outcomes}"
     assert ok_count == 1, (

--- a/tests/core/test_issue_close.py
+++ b/tests/core/test_issue_close.py
@@ -59,6 +59,25 @@ def test_closes_open_issue_with_shipped_comment(tmp_path):
     assert warnings == []
 
 
+def test_issue_close_uses_injected_canonical_workitem_store(tmp_path):
+    store, wi_id = _item_with_issue(
+        tmp_path / "main-checkout" / ".mothership",
+        ["acme/widgets#12"],
+    )
+    pm = FakePRManager({"acme/widgets#12": "open"})
+
+    result = close_linked_issues(
+        task=_task(wi_id),
+        workitems=store,
+        pr_manager=pm,
+        merged_count=1,
+        closed_count=0,
+        warn=lambda message: None,
+    )
+
+    assert result["closed"] == ["acme/widgets#12"]
+
+
 def test_already_closed_issue_is_skipped_without_comment(tmp_path):
     store, wi_id = _item_with_issue(tmp_path, ["acme/widgets#12"])
     pm = FakePRManager({"acme/widgets#12": "closed"})

--- a/tests/core/test_phase.py
+++ b/tests/core/test_phase.py
@@ -8,6 +8,7 @@ from mship.core.log import LogManager
 from mship.core.phase import FinishedTaskError, PhaseManager, PhaseTransition, SpecGateError
 from mship.core.state import StateManager, Task, TestResult, WorkspaceState
 from mship.core.workitem_store import WorkItemStore
+from tests.persistence_helpers import corrupt_workitem
 
 
 @pytest.fixture
@@ -560,9 +561,7 @@ def test_plan_to_dev_corrupt_workitem_store_raises_clean_spec_gate_error(tmp_pat
         title="add thing", kind="feature", workspace="test",
         now=datetime(2026, 4, 10, tzinfo=timezone.utc),
     )
-    # Corrupt the WorkItem's JSON file on disk after it's been created.
-    wi_path = tmp_path / ".mothership" / "workitems" / f"{wi.id}.json"
-    wi_path.write_text("{not valid json")
+    corrupt_workitem(tmp_path / ".mothership", wi.id)
 
     sm, pm = _workitem_gate_env(tmp_path)
     sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))
@@ -580,8 +579,7 @@ def test_plan_to_dev_bypass_spec_gate_skips_corrupt_workitem_store(tmp_path: Pat
         title="add thing", kind="feature", workspace="test",
         now=datetime(2026, 4, 10, tzinfo=timezone.utc),
     )
-    wi_path = tmp_path / ".mothership" / "workitems" / f"{wi.id}.json"
-    wi_path.write_text("{not valid json")
+    corrupt_workitem(tmp_path / ".mothership", wi.id)
 
     sm, pm = _workitem_gate_env(tmp_path)
     sm.save(WorkspaceState(tasks={"wi-task": _plan_task(work_item_id=wi.id)}))

--- a/tests/core/test_pr_watcher.py
+++ b/tests/core/test_pr_watcher.py
@@ -867,6 +867,38 @@ def test_merge_auto_advances_spec_and_workitem_then_tears_down(tmp_path):
     assert any(c["kind"] == "event" and "merged" in c["text"] for c in msgs.append_calls)
 
 
+def test_merge_auto_close_uses_injected_canonical_workitem_store(tmp_path):
+    from mship.core.workitem_store import WorkItemStore
+
+    linked_root = tmp_path / "linked-worktree"
+    linked_root.mkdir()
+    canonical_state = tmp_path / "main-checkout" / ".mothership"
+    wstore = WorkItemStore(canonical_state / "workitems")
+    wi = wstore.create(
+        title="Canonical lifecycle",
+        kind="chore",
+        workspace="ws",
+        now=NOW,
+    )
+    wstore.add_task(wi.id, "task-m", now=NOW)
+    url = "https://github.com/org/repo1/pull/1"
+    task = SimpleNamespace(
+        slug="task-m",
+        pr_urls={"repo1": url},
+        work_item_id=wi.id,
+        spec_id=None,
+        worktrees={"repo1": str(linked_root / "wt")},
+    )
+    tasks = {"task-m": task}
+
+    PrWatcher(
+        FakeMessageStore(), wstore, FakeStateManager(tasks), lambda u: "merged", now_fn,
+        worktree_manager=FakeWorktreeManager(tasks), workspace_root=linked_root,
+    ).check_once()
+
+    assert wstore.get(wi.id).phase_override == "done"
+
+
 def test_merge_auto_close_removes_sdd_records(tmp_path):
     from mship.core.sdd_store import SddStore, DispatchRecord
     from datetime import datetime, timezone

--- a/tests/core/test_prune.py
+++ b/tests/core/test_prune.py
@@ -154,10 +154,10 @@ def test_prune_retains_metadata_for_forward_only_workitem_link(prune_deps):
 
 
 def test_prune_refuses_metadata_changed_after_retention(prune_deps, monkeypatch):
-    from mship.core.workitem_lifecycle import (
-        TaskMetadataRetentionConflictError,
-        retain_workitem_metadata_on_teardown,
+    from mship.core.persistence.lifecycle_repository import (
+        LifecycleRepository,
     )
+    from mship.core.workitem_lifecycle import TaskMetadataRetentionConflictError
     from mship.core.workitem_store import WorkItemStore
 
     config, state_mgr, git, _workspace = prune_deps
@@ -173,23 +173,37 @@ def test_prune_refuses_metadata_changed_after_retention(prune_deps, monkeypatch)
     state_mgr.save(WorkspaceState(tasks={task.slug: task}))
     manager = PruneManager(config, state_mgr, git)
 
-    def retain_then_update(*, task, workitems_dir):
-        retained = retain_workitem_metadata_on_teardown(
-            task=task, workitems_dir=workitems_dir,
-        )
-        state_mgr.mutate(
-            lambda state: (
-                state.tasks[task.slug].affected_repos.append("api-gateway"),
-                state.tasks[task.slug].pr_urls.update(
+    original = LifecycleRepository.retain_and_prune_task_repos
+
+    def update_then_prune(
+        self,
+        task_slug,
+        repos,
+        *,
+        now,
+        expected_task=None,
+    ):
+        state_mgr.mutate_task(
+            task_slug,
+            lambda task: (
+                task.affected_repos.append("api-gateway"),
+                task.pr_urls.update(
                     {"api-gateway": "https://github.example/api/pull/2"},
                 ),
             ),
         )
-        return retained
+        return original(
+            self,
+            task_slug,
+            repos,
+            now=now,
+            expected_task=expected_task,
+        )
 
     monkeypatch.setattr(
-        "mship.core.workitem_lifecycle.retain_workitem_metadata_on_teardown",
-        retain_then_update,
+        LifecycleRepository,
+        "retain_and_prune_task_repos",
+        update_then_prune,
     )
 
     with pytest.raises(TaskMetadataRetentionConflictError, match="Retry"):

--- a/tests/core/test_serve.py
+++ b/tests/core/test_serve.py
@@ -16,6 +16,7 @@ from mship.core.spec_storage import SpecStorage
 from mship.core.state import StateManager, Task, WorkspaceState
 from mship.core.log import LogManager
 from mship.core.workitem_store import WorkItemStore
+from tests.persistence_helpers import corrupt_workitem
 
 
 def _app(tmp_path: Path):
@@ -1323,7 +1324,8 @@ def test_threads_keep_healthy_terminal_link_with_corrupt_work_item(tmp_path):
     item = items.create("Implemented", "feature", "test-ws", now)
     items.link_spec(item.id, "implemented", now)
     items.add_thread(item.id, thread.id, now)
-    (tmp_path / ".mothership" / "workitems" / "corrupt.json").write_text("{")
+    corrupt = items.create("Corrupt", "chore", "test-ws", now)
+    corrupt_workitem(tmp_path / ".mothership", corrupt.id)
 
     response = TestClient(_app(tmp_path)).get("/threads", params={"inbox": "all"})
 
@@ -1677,5 +1679,4 @@ def test_get_task_serializes_activity_fields(tmp_path):
     body = TestClient(_app(tmp_path)).get("/tasks/dq").json()
     assert body["last_activity_at"].startswith("2026-07-13T12:00:00")
     assert body["phase_entered_at"].startswith("2026-07-13T12:00:00")
-
 

--- a/tests/core/test_serve_items.py
+++ b/tests/core/test_serve_items.py
@@ -45,6 +45,36 @@ def test_list_and_get_item_with_derived_phase(tmp_path):
     assert client.get("/items/nope").status_code == 404
 
 
+def test_serve_uses_state_managers_canonical_workitem_store_from_linked_worktree(
+    tmp_path,
+):
+    linked_root = tmp_path / "linked-worktree"
+    linked_root.mkdir()
+    specs_dir = linked_root / "specs"
+    SpecStore(specs_dir)
+    state_manager = StateManager(tmp_path / "main-checkout" / ".mothership")
+    items = WorkItemStore(
+        state_manager.state_dir / "workitems",
+        workspace_store=state_manager.workspace_store,
+    )
+    wi = items.create(
+        title="Canonical item",
+        kind="question",
+        workspace="testws",
+        now=_now(),
+    )
+
+    app = create_app(
+        specs_dir=specs_dir,
+        state_manager=state_manager,
+        log_manager=None,
+        workspace_root=linked_root,
+        workspace_name="testws",
+    )
+
+    assert [item["id"] for item in TestClient(app).get("/items").json()] == [wi.id]
+
+
 # --- MOS-228 T3: GET /items archived filter; GET /items/{id} stays unfiltered ---
 
 def test_list_items_excludes_archived_by_default(tmp_path):

--- a/tests/core/test_spec_dispatch.py
+++ b/tests/core/test_spec_dispatch.py
@@ -39,7 +39,7 @@ def _sm(tmp_path) -> StateManager:
 
 
 def _items(tmp_path) -> WorkItemStore:
-    return WorkItemStore(tmp_path / "workitems")
+    return WorkItemStore(tmp_path / ".mothership" / "workitems")
 
 
 def _task(slug="dq", repos=("mothership",)) -> Task:
@@ -102,6 +102,81 @@ def test_dispatch_spec_handoff_reminds_write_plan_when_none(tmp_path):
         workitems=items, workspace=WORKSPACE, workspace_root=tmp_path,
     )
     assert "writing-plans" in result.handoff
+
+
+def test_dispatch_spec_retry_reuses_workitem_after_final_spec_save_failure(
+    tmp_path, monkeypatch,
+):
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
+    sm.save(WorkspaceState(tasks={"dq": _task()}))
+    store.save(_approved_spec())
+    original_save = store.save_while_locked
+
+    def fail_final_save(spec, artifact):
+        if spec.status == "dispatched":
+            raise OSError("injected final save failure")
+        return original_save(spec, artifact)
+
+    monkeypatch.setattr(store, "save_while_locked", fail_final_save)
+    with pytest.raises(OSError, match="final save failure"):
+        dispatch_spec(
+            store.find_by_id("dq"), state_manager=sm, store=store,
+            spawn_fn=lambda s: None, now=NOW, workitems=items,
+            workspace=WORKSPACE,
+        )
+
+    persisted = store.find_by_id("dq")
+    assert persisted.status == "approved"
+    assert persisted.work_item_id is not None
+    assert sm.load().tasks["dq"].work_item_id == persisted.work_item_id
+    assert len(items.list()) == 1
+
+    monkeypatch.setattr(store, "save_while_locked", original_save)
+    result = dispatch_spec(
+        persisted, state_manager=sm, store=store,
+        spawn_fn=lambda s: None, now=NOW, workitems=items,
+        workspace=WORKSPACE,
+    )
+
+    assert result.spec.status == "dispatched"
+    assert len(items.list()) == 1
+
+
+def test_dispatch_spec_retry_recovers_workitem_after_first_spec_save_failure(
+    tmp_path, monkeypatch,
+):
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
+    sm.save(WorkspaceState(tasks={"dq": _task()}))
+    store.save(_approved_spec())
+    original_save = store.save_while_locked
+
+    def fail_first_save(spec, artifact):
+        monkeypatch.setattr(store, "save_while_locked", original_save)
+        raise OSError("injected first save failure")
+
+    monkeypatch.setattr(store, "save_while_locked", fail_first_save)
+    with pytest.raises(OSError, match="first save failure"):
+        dispatch_spec(
+            store.find_by_id("dq"), state_manager=sm, store=store,
+            spawn_fn=lambda s: None, now=NOW, workitems=items,
+            workspace=WORKSPACE,
+        )
+
+    persisted = store.find_by_id("dq")
+    assert persisted.work_item_id is None
+    assert sm.load().tasks["dq"].work_item_id is None
+    orphan = items.list()[0]
+    assert orphan.spec_id == "dq"
+
+    result = dispatch_spec(
+        persisted, state_manager=sm, store=store,
+        spawn_fn=lambda s: None, now=NOW, workitems=items,
+        workspace=WORKSPACE,
+    )
+
+    assert result.spec.status == "dispatched"
+    assert result.spec.work_item_id == orphan.id
+    assert len(items.list()) == 1
 
 
 def test_dispatch_spec_binds_existing_task_without_spawning(tmp_path):

--- a/tests/core/test_spec_dispatch.py
+++ b/tests/core/test_spec_dispatch.py
@@ -179,6 +179,47 @@ def test_dispatch_spec_retry_recovers_workitem_after_first_spec_save_failure(
     assert len(items.list()) == 1
 
 
+def test_dispatch_spec_file_writes_run_outside_sql_transaction(
+    tmp_path, monkeypatch,
+):
+    from contextlib import contextmanager
+
+    sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
+    sm.save(WorkspaceState(tasks={"dq": _task()}))
+    store.save(_approved_spec())
+    database = sm.workspace_store.database
+    active_connections = []
+    save_observations = []
+    original_write = database.write
+    original_save = store.save_while_locked
+
+    @contextmanager
+    def tracked_write(*, immediate=False):
+        with original_write(immediate=immediate) as connection:
+            active_connections.append(connection)
+            try:
+                yield connection
+            finally:
+                active_connections.remove(connection)
+
+    def observed_save(spec, artifact):
+        assert all(not connection.in_transaction() for connection in active_connections)
+        save_observations.append(spec.status)
+        return original_save(spec, artifact)
+
+    monkeypatch.setattr(database, "write", tracked_write)
+    monkeypatch.setattr(store, "save_while_locked", observed_save)
+
+    result = dispatch_spec(
+        store.find_by_id("dq"), state_manager=sm, store=store,
+        spawn_fn=lambda s: None, now=NOW, workitems=items,
+        workspace=WORKSPACE,
+    )
+
+    assert result.spec.status == "dispatched"
+    assert save_observations == ["approved", "dispatched"]
+
+
 def test_dispatch_spec_binds_existing_task_without_spawning(tmp_path):
     sm, store, items = _sm(tmp_path), _store(tmp_path), _items(tmp_path)
     sm.save(WorkspaceState(tasks={"dq": _task()}))

--- a/tests/core/test_state.py
+++ b/tests/core/test_state.py
@@ -319,7 +319,7 @@ def test_task_depends_on_defaults_empty(tmp_path):
 
 
 def test_dependency_edge_roundtrip(tmp_path):
-    """DependencyEdge serializes and deserializes through state.yaml."""
+    """DependencyEdge serializes and deserializes through active storage."""
     from mship.core.state import StateManager, Task, WorkspaceState, DependencyEdge
     from datetime import datetime, timezone
 
@@ -331,13 +331,39 @@ def test_dependency_edge_roundtrip(tmp_path):
         affected_repos=["r"], branch="feat/b",
         depends_on=[DependencyEdge(upstream_slug="a", created_at=now)],
     )
-    sm.save(WorkspaceState(tasks={"b": t}))
+    upstream = Task(
+        slug="a", description="upstream", phase="dev",
+        created_at=now,
+        affected_repos=["r"], branch="feat/a",
+    )
+    sm.save(WorkspaceState(tasks={"a": upstream, "b": t}))
 
     loaded = sm.load()
     assert "b" in loaded.tasks
     edges = loaded.tasks["b"].depends_on
     assert len(edges) == 1
     assert edges[0].upstream_slug == "a"
+
+
+def test_save_orders_dependency_upstreams_before_downstreams(tmp_path):
+    from mship.core.state import StateManager, Task, WorkspaceState, DependencyEdge
+    from datetime import datetime, timezone
+
+    manager = StateManager(tmp_path / ".mothership")
+    now = datetime.now(timezone.utc)
+    upstream = Task(
+        slug="a", description="upstream", phase="dev", created_at=now,
+        affected_repos=["r"], branch="feat/a",
+    )
+    downstream = Task(
+        slug="b", description="downstream", phase="dev", created_at=now,
+        affected_repos=["r"], branch="feat/b",
+        depends_on=[DependencyEdge(upstream_slug="a", created_at=now)],
+    )
+
+    manager.save(WorkspaceState(tasks={"b": downstream, "a": upstream}))
+
+    assert list(manager.load().tasks) == ["a", "b"]
 
 
 def test_legacy_state_without_depends_on_loads_clean(tmp_path):

--- a/tests/core/test_workitem_lifecycle.py
+++ b/tests/core/test_workitem_lifecycle.py
@@ -25,6 +25,7 @@ from mship.core.workitem_lifecycle import (
     retain_workitem_metadata_on_teardown,
 )
 from mship.core.workitem_store import WorkItemStore
+from mship.core.workitem import WorkItem
 
 
 def _now():
@@ -301,10 +302,19 @@ def test_teardown_retains_metadata_from_authoritative_forward_link(
 
 
 def test_teardown_refuses_ambiguous_forward_links(tmp_path):
-    store, first = _store_with_item(tmp_path)
-    second = store.create(title="other", kind="chore", workspace="ws", now=_now())
-    store.add_task(first.id, "task-a", now=_now())
-    store.add_task(second.id, "task-a", now=_now())
+    workitems_dir = tmp_path / "workitems"
+    workitems_dir.mkdir()
+    first = WorkItem(
+        id="wi-first", title="first", kind="chore", workspace="ws",
+        created_at=_now(), updated_at=_now(), task_slugs=["task-a"],
+    )
+    second = WorkItem(
+        id="wi-second", title="second", kind="chore", workspace="ws",
+        created_at=_now(), updated_at=_now(), task_slugs=["task-a"],
+    )
+    for item in (first, second):
+        (workitems_dir / f"{item.id}.json").write_text(item.model_dump_json())
+    store = WorkItemStore(workitems_dir)
     task = _task("task-a", None)
     task.affected_repos = ["api"]
 

--- a/tests/core/test_workitem_lifecycle.py
+++ b/tests/core/test_workitem_lifecycle.py
@@ -140,6 +140,25 @@ def test_no_op_when_no_work_item_id(tmp_path):
     assert store.get(wi.id).phase_override is None
 
 
+def test_close_advance_uses_injected_canonical_workitem_store(tmp_path):
+    state_dir = tmp_path / "main-checkout" / ".mothership"
+    store = WorkItemStore(state_dir / "workitems")
+    wi = store.create(title="t", kind="chore", workspace="ws", now=_now())
+    store.add_task(wi.id, "task-a", now=_now())
+    task = _task("task-a", wi.id)
+
+    advance_workitem_on_close(
+        task=task,
+        workitems=store,
+        specs_dir=tmp_path / "linked-worktree" / "specs",
+        state=WorkspaceState(tasks={"task-a": task}),
+        merged_count=1,
+        closed_count=0,
+    )
+
+    assert store.get(wi.id).phase_override == "done"
+
+
 def test_no_op_when_workitem_missing(tmp_path):
     # Dangling work_item_id (item deleted) must not raise.
     t = _task("task-a", "wi-does-not-exist")

--- a/tests/core/test_workitem_store.py
+++ b/tests/core/test_workitem_store.py
@@ -2,7 +2,11 @@ from datetime import datetime, timezone
 
 import pytest
 
-from mship.core.workitem_store import ThreadAlreadyLinkedError, WorkItemStore
+from mship.core.workitem_store import (
+    TaskLinkAmbiguousError,
+    ThreadAlreadyLinkedError,
+    WorkItemStore,
+)
 
 
 def _now():
@@ -137,6 +141,36 @@ def test_add_thread_refuses_when_owner_is_archived(tmp_path):
     with pytest.raises(ThreadAlreadyLinkedError) as exc:
         store.add_thread(b.id, "thread-x", now=_now())
     assert exc.value.owner_id == a.id
+
+
+def test_save_translates_duplicate_task_owner(tmp_path):
+    store = WorkItemStore(tmp_path / "workitems")
+    first = store.create(title="a", kind="feature", workspace="ws", now=_now())
+    second = store.create(title="b", kind="feature", workspace="ws", now=_now())
+    first.task_slugs.append("task-x")
+    store.save(first)
+    second.task_slugs.append("task-x")
+
+    with pytest.raises(TaskLinkAmbiguousError) as exc:
+        store.save(second)
+
+    assert exc.value.task_slug == "task-x"
+    assert exc.value.item_ids == sorted([first.id, second.id])
+
+
+def test_save_translates_duplicate_thread_owner(tmp_path):
+    store = WorkItemStore(tmp_path / "workitems")
+    first = store.create(title="a", kind="feature", workspace="ws", now=_now())
+    second = store.create(title="b", kind="feature", workspace="ws", now=_now())
+    first.thread_ids.append("thread-x")
+    store.save(first)
+    second.thread_ids.append("thread-x")
+
+    with pytest.raises(ThreadAlreadyLinkedError) as exc:
+        store.save(second)
+
+    assert exc.value.thread_id == "thread-x"
+    assert exc.value.owner_id == first.id
 
 
 def test_unarchive_clears_flag(tmp_path):

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -201,10 +201,10 @@ def test_abort_retains_metadata_for_forward_only_workitem_link(worktree_deps):
 
 
 def test_abort_refuses_metadata_changed_after_retention(worktree_deps, monkeypatch):
-    from mship.core.workitem_lifecycle import (
-        TaskMetadataRetentionConflictError,
-        retain_workitem_metadata_on_teardown,
+    from mship.core.persistence.lifecycle_repository import (
+        LifecycleRepository,
     )
+    from mship.core.workitem_lifecycle import TaskMetadataRetentionConflictError
     from mship.core.workitem_store import WorkItemStore
 
     config, graph, state_mgr, git, shell, workspace, log = worktree_deps
@@ -215,24 +215,30 @@ def test_abort_refuses_metadata_changed_after_retention(worktree_deps, monkeypat
     manager.spawn("racing delivery", repos=["shared"], workspace_root=workspace,
                   work_item_id=item.id)
 
-    def retain_then_update(*, task, workitems_dir):
-        retained = retain_workitem_metadata_on_teardown(
-            task=task, workitems_dir=workitems_dir,
-        )
-        state_mgr.mutate(
-            lambda state: (
-                setattr(state.tasks[task.slug], "work_item_id", updated_item.id),
-                state.tasks[task.slug].affected_repos.append("api-gateway"),
-                state.tasks[task.slug].pr_urls.update(
+    original = LifecycleRepository.retain_and_delete_task
+
+    def update_then_retain(self, task_slug, *, now, expected_task=None):
+        state_mgr.mutate_task(
+            task_slug,
+            lambda task: (
+                setattr(task, "work_item_id", updated_item.id),
+                task.affected_repos.append("api-gateway"),
+                task.pr_urls.update(
                     {"api-gateway": "https://github.example/api/pull/2"},
                 ),
             ),
         )
-        return retained
+        return original(
+            self,
+            task_slug,
+            now=now,
+            expected_task=expected_task,
+        )
 
     monkeypatch.setattr(
-        "mship.core.workitem_lifecycle.retain_workitem_metadata_on_teardown",
-        retain_then_update,
+        LifecycleRepository,
+        "retain_and_delete_task",
+        update_then_retain,
     )
 
     with pytest.raises(TaskMetadataRetentionConflictError, match="Retry"):

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -338,6 +338,38 @@ def test_spawn_duplicate_slug_raises(worktree_deps):
         mgr.spawn("duplicate test", repos=["shared"], workspace_root=workspace)
 
 
+def test_spawn_duplicate_slug_insert_race_is_actionable(
+    worktree_deps,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    state_mgr.insert_task(
+        Task(
+            slug="duplicate-race",
+            description="already registered by another process",
+            phase="plan",
+            created_at=datetime(2026, 9, 7, tzinfo=timezone.utc),
+            affected_repos=[],
+            branch="feat/duplicate-race",
+        )
+    )
+    monkeypatch.setattr(state_mgr, "load", lambda: WorkspaceState())
+    manager = WorktreeManager(config, graph, state_mgr, git, shell, log)
+
+    with pytest.raises(ValueError) as error:
+        manager.spawn(
+            "duplicate race",
+            repos=["shared"],
+            workspace_root=workspace,
+        )
+
+    assert str(error.value) == (
+        "Task 'duplicate-race' already exists. "
+        "Run `mship close --yes --abandon --task duplicate-race` to remove it "
+        "first, or use a different description."
+    )
+
+
 # ---------------------------------------------------------------------------
 # spawn --base: cut the new worktree from another branch (stacked PRs, #42)
 # ---------------------------------------------------------------------------

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from mship.core.config import ConfigLoader, WorkspaceConfig
 from mship.core.graph import DependencyGraph
@@ -368,6 +369,29 @@ def test_spawn_duplicate_slug_insert_race_is_actionable(
         "Run `mship close --yes --abandon --task duplicate-race` to remove it "
         "first, or use a different description."
     )
+
+
+def test_spawn_propagates_unrelated_integrity_error(
+    worktree_deps,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    error = IntegrityError(
+        "INSERT INTO task_dependencies",
+        {},
+        RuntimeError("FOREIGN KEY constraint failed"),
+    )
+    monkeypatch.setattr(
+        state_mgr,
+        "insert_task",
+        MagicMock(side_effect=error),
+    )
+    manager = WorktreeManager(config, graph, state_mgr, git, shell, log)
+
+    with pytest.raises(IntegrityError) as raised:
+        manager.spawn("unrelated integrity", repos=["shared"], workspace_root=workspace)
+
+    assert raised.value is error
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -136,6 +136,56 @@ def test_abort_removes_worktrees(worktree_deps):
     state = state_mgr.load()
     assert "to-abort" not in state.tasks
 
+
+def test_spawn_and_abort_run_external_collaborators_outside_sql(
+    worktree_deps, monkeypatch,
+):
+    from contextlib import contextmanager
+
+    config, graph, state_mgr, git, shell, workspace, log = worktree_deps
+    database = state_mgr.workspace_store.database
+    active_connections = []
+    observations = []
+    original_write = database.write
+    original_add = git.worktree_add
+    original_remove = git.worktree_remove
+
+    @contextmanager
+    def tracked_write(*, immediate=False):
+        with original_write(immediate=immediate) as connection:
+            active_connections.append(connection)
+            try:
+                yield connection
+            finally:
+                active_connections.remove(connection)
+
+    def assert_outside_sql(name):
+        assert all(not connection.in_transaction() for connection in active_connections)
+        observations.append(name)
+
+    def observed_add(*args, **kwargs):
+        assert_outside_sql("worktree_add")
+        return original_add(*args, **kwargs)
+
+    def observed_remove(*args, **kwargs):
+        assert_outside_sql("worktree_remove")
+        return original_remove(*args, **kwargs)
+
+    def observed_task(*args, **kwargs):
+        assert_outside_sql("subprocess")
+        return ShellResult(returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(database, "write", tracked_write)
+    monkeypatch.setattr(git, "worktree_add", observed_add)
+    monkeypatch.setattr(git, "worktree_remove", observed_remove)
+    shell.run_task.side_effect = observed_task
+    manager = WorktreeManager(config, graph, state_mgr, git, shell, log)
+
+    manager.spawn("transaction boundary", repos=["shared"], workspace_root=workspace)
+    manager.abort("transaction-boundary")
+
+    assert {"worktree_add", "worktree_remove", "subprocess"} <= set(observations)
+
 def test_abort_retains_linked_delivery_metadata_for_item_summary(worktree_deps):
     from mship.core.view.workitem_index import build_workitem_index
     from mship.core.workitem_store import WorkItemStore

--- a/tests/persistence_helpers.py
+++ b/tests/persistence_helpers.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from mship.core.persistence.database import WorkspaceDatabase
+
+
+def corrupt_workitem(state_dir: Path, item_id: str) -> None:
+    """Fault-inject an unreadable WorkItem payload into an active SQLite store."""
+    database = WorkspaceDatabase(state_dir)
+    with database.write() as connection:
+        connection.exec_driver_sql(
+            "UPDATE work_items SET extras_json = ? WHERE id = ?",
+            ("{", item_id),
+        )

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -7,7 +7,10 @@ from mship.core.config import WorkspaceConfig
 from mship.core.executor import RepoExecutor
 from mship.core.graph import DependencyGraph
 from mship.core.phase import PhaseManager
+from mship.core.persistence.database import WorkspaceDatabase
+from mship.core.persistence.workspace_store import WorkspaceStore
 from mship.core.state import StateManager
+from mship.core.workitem_store import WorkItemStore
 from mship.core.worktree import WorktreeManager
 
 
@@ -34,6 +37,24 @@ def test_container_wires_state_manager(workspace: Path):
     container.state_dir.override(workspace / ".mothership")
     mgr = container.state_manager()
     assert isinstance(mgr, StateManager)
+
+
+def test_container_shares_one_workspace_store(workspace: Path):
+    container = Container()
+    container.config_path.override(workspace / "mothership.yaml")
+    container.state_dir.override(workspace / ".mothership")
+
+    database = container.workspace_database()
+    store = container.workspace_store()
+    state = container.state_manager()
+    items = container.workitem_store()
+
+    assert isinstance(database, WorkspaceDatabase)
+    assert isinstance(store, WorkspaceStore)
+    assert isinstance(items, WorkItemStore)
+    assert store.database is database
+    assert state._store is store
+    assert items._store is store
 
 
 def test_container_wires_executor(workspace: Path):

--- a/tests/test_finish_gate.py
+++ b/tests/test_finish_gate.py
@@ -18,6 +18,7 @@ from mship.core.spec import Spec
 from mship.core.spec_store import SpecStore
 from mship.core.state import StateManager
 from mship.core.workitem_store import WorkItemStore
+from tests.persistence_helpers import corrupt_workitem
 from mship.util.shell import ShellResult, ShellRunner
 
 runner = CliRunner()
@@ -237,10 +238,8 @@ def test_finish_blocks_cleanly_on_corrupt_workitem_store(finish_gate_workspace):
     )
     assert result.exit_code == 0, result.output
 
-    # Corrupt the WorkItem's JSON file on disk (spawn already validated it
-    # while it was still well-formed).
-    wi_path = workspace / ".mothership" / "workitems" / f"{wi.id}.json"
-    wi_path.write_text("{not valid json")
+    # Corrupt the persisted payload after spawn already validated it.
+    corrupt_workitem(workspace / ".mothership", wi.id)
 
     result = runner.invoke(app, ["finish", "--task", "corrupt-store-task"])
     assert result.exit_code == 1, result.output
@@ -265,8 +264,7 @@ def test_finish_hotfix_survives_corrupt_workitem_store(finish_gate_workspace):
     )
     assert result.exit_code == 0, result.output
 
-    wi_path = workspace / ".mothership" / "workitems" / f"{wi.id}.json"
-    wi_path.write_text("{not valid json")
+    corrupt_workitem(workspace / ".mothership", wi.id)
 
     result = runner.invoke(app, ["finish", "--hotfix", "--task", "corrupt-store-hotfix-task", "--no-require-tests"])
     assert result.exit_code == 0, result.output

--- a/tests/test_finish_integration.py
+++ b/tests/test_finish_integration.py
@@ -206,14 +206,14 @@ def test_finish_not_blocked_by_own_worktree(finish_workspace):
 
     # Point the state's worktree entry at /tmp/shared-wt so the exclusion matches
     # what the mocked `git worktree list` reports.
-    state_path = workspace / ".mothership" / "state.yaml"
-    import yaml
-    data = yaml.safe_load(state_path.read_text())
     slug = "own-wt"
-    data["tasks"][slug]["worktrees"] = {"shared": "/tmp/shared-wt"}
-    state_path.write_text(yaml.safe_dump(data))
-    from mship.cli import container
-    container.state_manager.reset()
+    StateManager(workspace / ".mothership").mutate(
+        lambda state: setattr(
+            state.tasks[slug],
+            "worktrees",
+            {"shared": Path("/tmp/shared-wt")},
+        )
+    )
 
     result = runner.invoke(app, ["finish", "--hotfix", "--task", slug, "--no-require-tests"])
     assert result.exit_code == 0, result.output

--- a/tests/test_workitem_gate.py
+++ b/tests/test_workitem_gate.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 
 from mship.core.spec import Spec
 from mship.core.spec_store import SpecStore
+from mship.core.persistence.workspace_store import WorkspaceStore
 from mship.core.state import StateManager, Task, WorkspaceState
 from mship.core.workitem_gate import GateResult, check_task_gate, log_hotfix, resolve_bound_spec
 from mship.core.workitem_store import WorkItemStore
@@ -35,6 +36,22 @@ def test_bug_work_item_ok_without_spec(tmp_path):
     result = check_task_gate(_task(work_item_id=wi.id), tmp_path)
     assert result.ok
     assert result.reason is None
+
+
+def test_gate_uses_injected_canonical_workitem_store_from_linked_worktree(tmp_path):
+    checkout_root = tmp_path / "linked-worktree"
+    checkout_root.mkdir()
+    state_dir = tmp_path / "main-checkout" / ".mothership"
+    workspace_store = WorkspaceStore(state_dir)
+    items = WorkItemStore(
+        state_dir / "workitems",
+        workspace_store=workspace_store,
+    )
+    wi = items.create(title="fix it", kind="bug", workspace="ws", now=_now())
+
+    result = check_task_gate(_task(work_item_id=wi.id), checkout_root, workitems=items)
+
+    assert result.ok
 
 
 def test_feature_work_item_without_approved_spec_is_not_ok(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,20 @@ revision = 3
 requires-python = ">=3.14"
 
 [[package]]
+name = "alembic"
+version = "1.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/10/181eecdd552217d0342492bd6f3b8a96e973083379aace3d3402830ddc03/alembic-1.19.2.tar.gz", hash = "sha256:297950a8a91f6770eb82bfbce9bea55c728b90a5386c6e81430191a319d138b0", size = 2082643, upload-time = "2026-09-04T17:10:11.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/cb/9014784dcb0585977ae23b6f43331d0a33c51ac0d692506d12b4f5ee9f3b/alembic-1.19.2-py3-none-any.whl", hash = "sha256:32d553dcd577e6fe5c3c63e91468526d35e4dcecafe865d7db4e9b328fa93cb2", size = 267399, upload-time = "2026-09-04T17:10:12.796Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -320,6 +334,45 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/8c/080e881fa2be95ff1ddbd6994b2bab3b1a78df3b3fcab39306011764fcc7/greenlet-3.5.5-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d4a389a852e392a6366058651a20fa5ba40d979865aa81bea2ccbdc44805070d", size = 295309, upload-time = "2026-08-10T13:26:03.032Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cc/0ac614e6586c0e42d4cc281a5819150f4f43685744a4c5ff77139286409d/greenlet-3.5.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70b157cd319873e8b544ddc2de158f55bbd0a9b0218c8ce9332039801518e328", size = 661185, upload-time = "2026-08-10T14:14:37.867Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b9/6808725354be8ad305dfe5172377664fc9642d4fc043be246b3314cf4482/greenlet-3.5.5-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8bdfd1424abcf26832961e766570cae79efdb9599d709088c9cb6ef82b194926", size = 673419, upload-time = "2026-08-10T14:27:28.652Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2e/40c509967da7f254680826a2fa0dd22138ec79946c70b97542d74cde8b43/greenlet-3.5.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:182de51c6b572a705f2fafaab2e783bcf7d2760940229dfe73086cbae037af3e", size = 670822, upload-time = "2026-08-10T13:40:51.833Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/22/c3c2eee4a8fe191d6d1d183086c56133d646024e3d70bfd414829f64560b/greenlet-3.5.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8fec3f165dfe332e490c3247c0f6c23b0bfc45f06496ad7f00ddb00e3d35e4dc", size = 1628469, upload-time = "2026-08-10T14:15:08.11Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/87/25babd09b94cb1f03e71db815fde463f0262e40cfbd953d58a8d77311351/greenlet-3.5.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c6ce25fee6cabc8bf22cb8b52e642cbb821be5b9aec8094d07ff03378141b8e9", size = 1691952, upload-time = "2026-08-10T13:40:33.502Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/5cc9701117ea4dc0eb7bf1f4f9b7888a6e2e5277ddfae095805ace50f2b6/greenlet-3.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:7dffc5c859fe6059974df1e37d7923d654a83e2ae18fdd616994270e001115e1", size = 327458, upload-time = "2026-08-10T13:27:02.868Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/594fa2de7fae7629168a404a4305d7d7e31a5742c50a801b1839543cb93d/greenlet-3.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:5e2afcfc4d4305dd715809b03da5cbe437c8984f61d8917751eb5fe4aefa3e07", size = 311146, upload-time = "2026-08-10T13:27:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e0/50cd600b469e5734c72709b6b1838b6bc63f307b573c772c3132d6ecfe92/greenlet-3.5.5-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:0e5a7de979d764aea1f5b6e95cf92b5b37741b9823702041f34b126e7f690277", size = 305471, upload-time = "2026-08-10T13:26:20.568Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a3/77acd66dfc6387b5219b2080806c0cabb73c10eb1bb44b413c40a62015ba/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fef01bd457f11fc158b130ca0027a3c365693280e8e231b65bdaf57999f39f5b", size = 672470, upload-time = "2026-08-10T14:14:39.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/71/0d178142dca3ec19f46fb2212ae73d30ad53b9d548dc64804086033a7089/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5173a72310725a74afc82c164f0e52cb8ad0de62f2bb623f24f6c0cc07d80272", size = 679973, upload-time = "2026-08-10T14:27:30.072Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/46eb8567302eaf787abf88d09df014e14ae3baf460af1b8b0efdbd3efcd5/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44f08341873200ba8a60a8bc14ace3d91f1754f7fa7bc66157714a8cd420a476", size = 676634, upload-time = "2026-08-10T13:40:53.004Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e9/b88bbf5b29970cb84172dc2c32aa3e5e579ceb94c808e81c826454138850/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d246c0db9a2513cd45f019ba178ea4d4d4705bd210ee465e2c15d76a1ab13874", size = 1637320, upload-time = "2026-08-10T14:15:09.317Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/8c/7631ed29cc6f0392f11830076e172ce4885e70b0bc2c1bce1731176d4b4e/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:72507285b5caa1d17904a3f7c322ca780823a54170a0e04ec3f37bcc60d4db71", size = 1697412, upload-time = "2026-08-10T13:40:34.924Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0f/f7dd935f9c4cb1be49098770587f54d8a78518e55c89bce86c4fb4109057/greenlet-3.5.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7805655781fb8f28a55d05fe57ed61f5f10f1892fb587673e3bb5264f28041f0", size = 331514, upload-time = "2026-08-10T13:29:20.611Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e5/681b01f8fbc1b55232822f99e8f8afeb78a55a7c76a7bf9dbdc7ccb03a6d/greenlet-3.5.5-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:c0db80fcd5b8aece93f66c64f78a786bbb6b96c5fe63ef5a5a4581ecf8bab206", size = 295975, upload-time = "2026-08-10T13:28:45.985Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f2/69b488cd9e7267bf4b0fe8cdebf25d8d6df680d21bdf41150d23e23d6652/greenlet-3.5.5-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b241c32f912ada659808d68e308c568baf577eebf757d15471472de0c18cfad", size = 666823, upload-time = "2026-08-10T14:14:40.222Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d4/d5bc2fdebbdda0c94555925ba79948b8395d75a7f6a36cc85dce5bab9f11/greenlet-3.5.5-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ef6a08349401d8eaf3cb12688ac8557de95788556b8631ef17555a4a173022c0", size = 677613, upload-time = "2026-08-10T14:27:31.543Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/93/542d8a3a90f3b35c6ad8bf7e56a03010287f2cafa289a5b7985b5207db39/greenlet-3.5.5-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2e3d061b8e13aec2f0441689b3c71b244a20e5d274a52cb0f7e31bd1d139552", size = 675930, upload-time = "2026-08-10T13:40:54.205Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/89c9f2e8460d71101037d47a1feed11928615a5edd42370be290e0657eeb/greenlet-3.5.5-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:9ab5f5b93655e77fe0d6c2dfd22b5eac751bb1f876d8ec21761b7c1fb9266007", size = 1633878, upload-time = "2026-08-10T14:15:10.693Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/60/297de93f3b02ac78a5e04d32bb8bbe3080f4a73d8ed95016561463b70618/greenlet-3.5.5-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f0e5a21bd4452a88cf032fc43c4a5b307ab1380eacb63b5988f9c0317885e773", size = 1696597, upload-time = "2026-08-10T13:40:36.252Z" },
+    { url = "https://files.pythonhosted.org/packages/18/25/54c6eaff4f337fb670215e89eb2d00d9499487b658e709d4b477be4a342e/greenlet-3.5.5-cp315-cp315-win_amd64.whl", hash = "sha256:469dbb0a78625642f4a626cfd0c6e8bccc0385b5e49189b6308bbe849ec88a8e", size = 327700, upload-time = "2026-08-10T13:28:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/67/67/857e88a36301caa0e029870132c2478bd55d896630321432afab03a3115f/greenlet-3.5.5-cp315-cp315-win_arm64.whl", hash = "sha256:2d57406c3efd32d7a81e17a674314e8bd00792cdab49ea3228a49aa1bfb2e769", size = 311750, upload-time = "2026-08-10T13:34:08.815Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e2/3144c0a116067ac1e30457b0139a94d60d1d36a86e015de68e9ac87cb3bc/greenlet-3.5.5-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:68184dfcf50ccaa8e864770fe0633a7e27250ea9329f8192ef47ee9ecfd78e1c", size = 306387, upload-time = "2026-08-10T13:27:00.897Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a1/cb4223a7e9b9f43b8807e8eb212358bfe2dfaa174a9ea2889eb1714dcba2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ec0dc0e59dc9c61af5c47348365ccbbd7addfafe0a93b00336ff3da2907bdc6", size = 676472, upload-time = "2026-08-10T14:14:41.417Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cd/a154b4498e5d8f12ada291cfb3b8d596eadde2177f5bf09a9be699d2a446/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e604f58e35833fc46ef20302bcb314dddbfd3fcf33a4f936216d51dd678d63ae", size = 684238, upload-time = "2026-08-10T14:27:32.946Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/bb/b0031d260c2968a3c87deebc51d80c64e499377f993aafe06ee3b7488cc2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40239b5384f96da3963585cc6d7eaa9b56f8ae67e8d92cc82dd9e202fc847de3", size = 681246, upload-time = "2026-08-10T13:40:55.402Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/07/da554b71ab88e649da146e1065d86a48a5c5d92e50ab74ef41b504aa7f56/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:a1eaccf5c3a1d3e46dead602c72e6836731e8e245c9de6a27764567b6b62d4c0", size = 1642735, upload-time = "2026-08-10T14:15:11.92Z" },
+    { url = "https://files.pythonhosted.org/packages/78/76/26a3782a051677668af9d92beaa47cd87ba9dd5072f762961144a03dd4c6/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:19e4e026fe20691f333b8eb1a3bc9625eceba8c3f9d62ec5a6f8581afbc6b5a5", size = 1700925, upload-time = "2026-08-10T13:40:37.656Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d9/fe7baf4190c2ae71f267efb9de21b3172bb35bc0ed1ef53dd6027d658e33/greenlet-3.5.5-cp315-cp315t-win_amd64.whl", hash = "sha256:712aee154f648bde84634654bb38bb78c69ac640c37a45c9effed800735049d8", size = 331829, upload-time = "2026-08-10T13:26:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/df/af/419a4e383bd600858a9b67e9b280a60fdc383ee3f2fe5b6c0c1ef04e74d1/greenlet-3.5.5-cp315-cp315t-win_arm64.whl", hash = "sha256:7f049911ee81a16a03c33d5450d8d5867d27f596ca5fb201b86f4524e874468b", size = 315093, upload-time = "2026-08-10T13:29:34.949Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -409,6 +462,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/12/b5fa2353e2754cd67fb9f83793fa48ff42c213a5da7e719869d2301f6ab8/mako-1.4.1.tar.gz", hash = "sha256:d7904710b662996425a21627710c4777c45053146942cf8a7aebf757c92b8c27", size = 410165, upload-time = "2026-08-05T06:10:56.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl", hash = "sha256:a359d9a94a541213958742b2698d0a7757bb83551767bc468a74b9905aba9617", size = 80010, upload-time = "2026-08-05T06:10:58.248Z" },
 ]
 
 [[package]]
@@ -571,6 +636,7 @@ name = "mothership"
 version = "0.5.73"
 source = { editable = "." }
 dependencies = [
+    { name = "alembic" },
     { name = "cryptography" },
     { name = "dependency-injector" },
     { name = "fastapi" },
@@ -582,6 +648,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "segno" },
+    { name = "sqlalchemy" },
     { name = "textual" },
     { name = "typer" },
     { name = "uvicorn" },
@@ -603,6 +670,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.19,<2" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "dependency-injector", specifier = ">=4.0" },
     { name = "fastapi", specifier = ">=0.110" },
@@ -614,6 +682,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "segno", specifier = ">=1.6.6" },
+    { name = "sqlalchemy", specifier = ">=2.0,<3" },
     { name = "textual", specifier = ">=0.80" },
     { name = "typer", specifier = ">=0.15" },
     { name = "uvicorn", specifier = ">=0.27" },
@@ -999,6 +1068,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/21/77b4c147963073040dc3c3a5cb7a8c3001a1893c0209432cb77f9df836aa/sqlalchemy-2.0.52.tar.gz", hash = "sha256:5e2d46356ac2ccb7d268ab6c2319ac6a2b42f1b8d5fd8bd3d46855cd82abee97", size = 9945637, upload-time = "2026-08-11T19:07:09.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/f5/71cb30af58c9b80a4e1fac0b73bb48f86d497a774a6a2eb6d2f1e657bb73/sqlalchemy-2.0.52-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:410d52be41d17f1a236d19520fbe776257dc16516ed06bd16d433311842aefd9", size = 2169537, upload-time = "2026-08-11T20:58:13.855Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/93/d07ebd645d1b07b6b5ed63450a70f063a346a7e0f2c8810daf2e532400cb/sqlalchemy-2.0.52-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfe9ce533dbe4d0a2ae1486546619bd30b76bcd670539a44d910361376175f5e", size = 3319606, upload-time = "2026-08-11T21:02:45.829Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/5c/290c84c7c2566ecd3b65baaae0fddec9bc33b033b398a06123bb86fbfc6e/sqlalchemy-2.0.52-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:812bae5138bfc0aa46fb0686da0fc7f581f68e2bbb05bc24c3713bebaedd1437", size = 3323642, upload-time = "2026-08-11T21:17:05.675Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f5/2cc160590ca49173359557880b92a0572293ccb899e8f6cedf150c5a3ddf/sqlalchemy-2.0.52-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:50bff43b632a56fbf5ed9afdd76307e1512b62051bcd5afb341ae67205bbb6c8", size = 3268125, upload-time = "2026-08-11T21:02:47.649Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f3/ea8933fc9f7d1353e9c2ff9965eae687c4cef181120574591ed2fa0633e1/sqlalchemy-2.0.52-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:49565daf5af554f538e23aef1fc81a95a4e49658f152285e45c02f5fc44f04cd", size = 3289516, upload-time = "2026-08-11T21:17:07.267Z" },
+    { url = "https://files.pythonhosted.org/packages/45/67/05cf86541c1e1716fca1e4a996954a439cd74501707cda607fb7cb02ef50/sqlalchemy-2.0.52-cp314-cp314-win32.whl", hash = "sha256:ab9da41e61b9979b910499d633b241df20c51ee5037e5405b11c2faac3cbe1a2", size = 2130249, upload-time = "2026-08-11T21:14:57.273Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d7/8ac6ffa1e36169e762ef65bd835046abb2251b1bc17f8f6708e14ed8d31f/sqlalchemy-2.0.52-cp314-cp314-win_amd64.whl", hash = "sha256:a593db51b3bae75db17a5738ad5f992244b3a03863f83c28117ee482c6a3f76d", size = 2156718, upload-time = "2026-08-11T21:14:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4b/e01a737eef378e734cc6394a82248a6ce13b167dfa36c731075ce9fc9c64/sqlalchemy-2.0.52-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1e61d08bdf4ee2f41024569e3400de7d6734ba498144766b11260936ccfa582", size = 2190344, upload-time = "2026-08-11T19:53:21.393Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/3f/3582293d1e185e71d19d7c731c3e2ee20ba21981c4a1115c0806c1f62120/sqlalchemy-2.0.52-py3-none-any.whl", hash = "sha256:3b81b8363a919ce53453591cdb93702e6bd54ade6c4fa2f468fc053baee5ed89", size = 1950700, upload-time = "2026-08-11T20:47:21.603Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- replace Task and WorkItem file persistence with SQLAlchemy Core, SQLite WAL, and Alembic-managed schema state
- add explicit legacy migration/status/export workflows and atomic Task↔WorkItem lifecycle operations
- prove concurrency, rollback, transaction-boundary, and installed-wheel behavior with multiprocess and fault-injection coverage

## Test plan

- [x] `mship test --repos mothership --task transactional-sqlite-core-for-tasks-and` (recorded iteration 23)
- [x] `task lint`
- [x] `task check-runtime-deps`
- [x] `mship plan check-assumptions --plan docs/plans/2026-09-07-transactional-sqlite-core-for-tasks-and.md`

Closes #363
---

## Acceptance criteria

- [x] `ac1` A fresh workspace creates .mothership/mothership.db at the packaged Alembic head, and every connection demonstrably uses WAL, foreign_keys=ON, a bounded busy timeout, and sqlite3 autocommit=False transaction control. — test:test-runs/23.mothership
- [x] `ac2` When legacy state.yaml or WorkItem JSON exists without an activated database, reads remain available but Task and WorkItem writes fail with instructions to stop active writers and run mship state migrate. — test:test-runs/23.mothership
- [x] `ac3` mship state migrate validates all legacy Tasks and WorkItems through their Pydantic models, preserves a timestamped recovery backup, imports through a temporary database, verifies counts, ownership constraints, unknown WorkItem fields, and model round-trips, then atomically activates the database and can be rerun safely. — test:test-runs/23.mothership
- [x] `ac4` Any validation, migration, import, verification, or activation failure leaves legacy data authoritative and does not expose a partially imported database. — test:test-runs/23.mothership
- [x] `ac5` Task and WorkItem data round-trips through the existing Pydantic WorkspaceState, Task, TestResult, DependencyEdge, WorkItem, and ExternalLink contracts, while uniqueness, ownership, foreign-key, revision, and idempotency invariants supported by the design are enforced by database constraints. — test:test-runs/23.mothership
- [x] `ac6` Creating or linking a Task and its WorkItem ownership/history commits atomically, and closing a Task atomically retains its affected repositories and PR URLs on the WorkItem while removing it from active Task state; injected failures produce neither one-sided links nor partially retained metadata. — test:test-runs/23.mothership
- [x] `ac7` Multiprocess tests prove there are no lost updates when writers concurrently mutate different Tasks, the same Task, WorkItem links, and Task-to-WorkItem associations, including the StateManager.mutate compatibility path. — test:test-runs/23.mothership
- [x] `ac8` Git, GitHub and other network calls, subprocesses, worktree copies or removals, and message/spec file writes occur outside database transactions; targeted repository transactions remain short. — test:test-runs/23.mothership
- [x] `ac9` mship state status reports the active backend, database path, current and head Alembic revisions, and migration readiness, while mship state export emits deterministic JSON or YAML for Tasks and WorkItems. — test:test-runs/23.mothership
- [x] `ac10` Messages, specs, daemon registry files, secrets, and artifacts keep their current storage and behavior, and the existing StateManager, WorkItemStore, CLI, serve/API, and lifecycle test suites remain green. — test:test-runs/23.mothership