### PR TITLE
fix: normalize legacy task links before state migration

### DIFF
--- a/src/mship/core/persistence/migration.py
+++ b/src/mship/core/persistence/migration.py
@@ -124,6 +124,31 @@ def _normalize_timestamps(value: object) -> object:
     return value
 
 
+def _normalize_task_links(
+    state: WorkspaceState,
+    items: list[WorkItem],
+) -> list[WorkItem]:
+    """Collapse repeated links, preserving order and rejecting competing owners."""
+    owners = {
+        slug: task.work_item_id
+        for slug, task in state.tasks.items()
+        if task.work_item_id is not None
+    }
+    normalized = []
+    for item in items:
+        task_slugs = list(dict.fromkeys(item.task_slugs))
+        for slug in task_slugs:
+            owner = owners.setdefault(slug, item.id)
+            if owner != item.id:
+                raise MigrationPreflightError(
+                    f"legacy task {slug!r} has conflicting WorkItem owners "
+                    f"{owner!r} and {item.id!r}; correct the legacy task links "
+                    "before retrying migration"
+                )
+        normalized.append(item.model_copy(update={"task_slugs": task_slugs}))
+    return normalized
+
+
 def _verify_candidate(
     database: WorkspaceDatabase,
     expected_state: WorkspaceState,
@@ -242,6 +267,7 @@ def migrate_legacy_state(
                 workitems_dir,
                 include_archived=True,
             )[0]
+            legacy_items = _normalize_task_links(legacy_state, legacy_items)
             state_fingerprint, items_fingerprint = _legacy_fingerprints(state_dir)
 
             _call_stage(stage_hook, "backup")

--- a/tests/core/persistence/test_legacy_migration.py
+++ b/tests/core/persistence/test_legacy_migration.py
@@ -205,6 +205,108 @@ def test_migration_preserves_switch_source_without_dependencies(
     assert not (state_dir / "state.yaml").exists()
 
 
+@pytest.mark.parametrize(
+    ("legacy_slugs", "expected_slugs"),
+    [
+        (["upstream", "upstream"], ["upstream"]),
+        (
+            ["closed-z", "upstream", "closed-z", "upstream", "closed-a"],
+            ["closed-z", "upstream", "closed-a"],
+        ),
+    ],
+)
+def test_migration_deduplicates_same_owner_task_links(
+    legacy_workspace: LegacyWorkspace,
+    legacy_slugs: list[str],
+    expected_slugs: list[str],
+) -> None:
+    item = legacy_workspace.expected_items[0].model_copy(
+        update={"task_slugs": legacy_slugs}
+    )
+    item_path = legacy_workspace.state_dir / "workitems" / "wi-active.json"
+    original = item.model_dump_json(indent=2)
+    item_path.write_text(original)
+
+    report = migrate_legacy_state(
+        legacy_workspace.state_dir, daemon_probe=lambda: None, now=NOW
+    )
+
+    assert report.migrated is True
+    assert report.backup_path is not None
+    assert (report.backup_path / "workitems" / "wi-active.json").read_text() == original
+    store = WorkItemStore(legacy_workspace.state_dir / "workitems")
+    expected_item = item.model_copy(update={"task_slugs": expected_slugs})
+    assert store.get("wi-active") == expected_item
+    assert store.get("wi-archived") == legacy_workspace.expected_items[1]
+    assert (
+        StateManager(legacy_workspace.state_dir).load()
+        == legacy_workspace.expected_state
+    )
+
+    repeated = migrate_legacy_state(
+        legacy_workspace.state_dir, daemon_probe=lambda: None, now=NOW
+    )
+    assert repeated.migrated is False
+    assert repeated.backup_path is None
+    assert repeated.tasks == 2
+    assert repeated.work_items == 2
+    assert store.get("wi-active") == expected_item
+
+
+@pytest.mark.parametrize("conflict_source", ["workitem", "task", "historical-task"])
+def test_migration_rejects_conflicting_task_owners_before_import(
+    legacy_workspace: LegacyWorkspace,
+    conflict_source: str,
+) -> None:
+    state_dir = legacy_workspace.state_dir
+    slug = "closed-task" if conflict_source == "historical-task" else "upstream"
+    if conflict_source == "historical-task":
+        active = legacy_workspace.expected_items[0]
+        active.task_slugs.append(slug)
+        (state_dir / "workitems" / "wi-active.json").write_text(
+            active.model_dump_json()
+        )
+    if conflict_source != "task":
+        item = legacy_workspace.expected_items[1].model_copy(
+            update={"task_slugs": ["downstream", slug]}
+        )
+        source = state_dir / "workitems" / "wi-archived.json"
+        valid = source.read_bytes()
+        source.write_text(item.model_dump_json())
+    else:
+        state = legacy_workspace.expected_state.model_copy(deep=True)
+        state.tasks["upstream"].work_item_id = "wi-archived"
+        source = state_dir / "state.yaml"
+        valid = source.read_bytes()
+        source.write_text(yaml.safe_dump(state.model_dump(mode="json")))
+    originals = {
+        path: path.read_bytes()
+        for path in [
+            state_dir / "state.yaml",
+            *sorted((state_dir / "workitems").glob("*.json")),
+        ]
+    }
+
+    with pytest.raises(MigrationPreflightError) as error:
+        migrate_legacy_state(state_dir, daemon_probe=lambda: None, now=NOW)
+
+    for identifier in (slug, "wi-active", "wi-archived"):
+        assert identifier in str(error.value)
+    assert {path: path.read_bytes() for path in originals} == originals
+    assert not WorkspaceDatabase(state_dir).path.exists()
+    assert not list(state_dir.glob(".mothership.db.migrating-*"))
+    assert not (state_dir / "backups").exists()
+
+    source.write_bytes(valid)
+    report = migrate_legacy_state(state_dir, daemon_probe=lambda: None, now=NOW)
+    assert report.migrated is True
+    assert StateManager(state_dir).load() == legacy_workspace.expected_state
+    assert {
+        item.id: item
+        for item in WorkItemStore(state_dir / "workitems").list(include_archived=True)
+    } == {item.id: item for item in legacy_workspace.expected_items}
+
+
 def test_migration_accepts_semantically_equivalent_naive_timestamps(
     tmp_path: Path,
 ) -> None:
@@ -259,9 +361,7 @@ def test_migration_rejects_non_timestamp_candidate_mismatch(
             return
         candidate_path = next(
             path
-            for path in legacy_workspace.state_dir.glob(
-                ".mothership.db.migrating-*"
-            )
+            for path in legacy_workspace.state_dir.glob(".mothership.db.migrating-*")
             if not path.name.endswith(("-wal", "-shm"))
         )
         candidate = WorkspaceDatabase(


### PR DESCRIPTION
## Summary

- normalize repeated same-owner legacy WorkItem task links before SQLite import, preserving first-seen order
- reject conflicting WorkItem owners and Task reverse-owner disagreements during migration preflight, before backup or candidate creation
- preserve migration atomicity, idempotent retry, original legacy bytes, archived/historical links, and the relational uniqueness constraint

## Test plan

- [x] `uv run pytest -q tests/core/persistence/test_legacy_migration.py tests/cli/test_state_storage.py --tb=short` (30 passed)
- [x] `mship test --task state-migrate-duplicate-workitem-tasks` (iteration 5, pass)
- [x] Ruff check and format check on changed files
- [x] Pyrefly on changed files
- [x] `git diff --check`

## Root cause

Legacy `WorkItem.task_slugs` can contain the same task more than once. Migration passed that list unchanged to the SQLite child-row insert, which correctly enforces one global owner per task and raised `UNIQUE constraint failed: workitem_tasks.task_slug`. The migration boundary now collapses idempotent repeats while failing explicitly on contradictory owners.

