### PR TITLE
Fix verified merged-PR metadata recovery without teardown

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -136,6 +136,7 @@ mship dispatch --task <slug> -i "<instruction>"     # emit self-contained subage
 mship dispatch --task <slug> --mode standalone -i "<instruction>"  # standalone framing — subagent finishes and opens its own PR
 mship audit [--repos r] [--json]
 mship reconcile [--json] [--ignore SLUG] [--clear-ignores] [--refresh]
+mship reconcile --adopt-merged SLUG                  # verify merged PRs and recover missing task PR URLs/finish time; no teardown
 mship pr                                            # PR state for every active task with recorded PR URLs
 mship debug hypothesis "..." | rule-out "..." | resolved  # structured debugging journal entries (#30)
 mship view status|journal|diff|spec [--watch]

--- a/src/mship/cli/reconcile.py
+++ b/src/mship/cli/reconcile.py
@@ -91,6 +91,7 @@ def register(app: typer.Typer, get_container):
                         "url": entry.url,
                         "merge_commit": entry.merge_commit,
                         "merged_at": entry.merged_at.isoformat(),
+                        "base": entry.base,
                     }
                     for entry in verified
                 ],
@@ -135,10 +136,7 @@ def register(app: typer.Typer, get_container):
         config = ConfigLoader.load(container.config_path(), require_paths=False)
 
         if refresh:
-            payload = cache.read()
-            if payload is not None:
-                payload.fetched_at = 0.0
-                cache.write(payload)
+            cache.invalidate()
 
         def _fetcher(branches, worktrees_by_branch):
             return (

--- a/src/mship/cli/reconcile.py
+++ b/src/mship/cli/reconcile.py
@@ -1,4 +1,5 @@
 """`mship reconcile` — detect upstream PR drift."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -8,22 +9,24 @@ import typer
 
 from mship.cli.output import Output
 from mship.core.config import ConfigLoader
+from mship.core.reconcile.adopt import AdoptionError, adopt_merged_task
 from mship.core.reconcile.cache import ReconcileCache
 from mship.core.reconcile.detect import UpstreamState
 from mship.core.reconcile.fetch import (
-    collect_git_snapshots, fetch_pr_snapshots,
+    collect_git_snapshots,
+    fetch_pr_snapshots,
 )
 from mship.core.reconcile.gate import Decision, reconcile_now
 
 
 _ACTION_HINTS = {
-    UpstreamState.merged:            "run `mship close`",
-    UpstreamState.closed:            "run `mship close --abandon`",
-    UpstreamState.diverged:          "pull and rebase",
-    UpstreamState.base_changed:      "rebase onto new base",
-    UpstreamState.missing:           "—",
-    UpstreamState.in_sync:           "—",
-    UpstreamState.dependency_stale:  "rebase onto upstream's merge",
+    UpstreamState.merged: "run `mship close`",
+    UpstreamState.closed: "run `mship close --abandon`",
+    UpstreamState.diverged: "pull and rebase",
+    UpstreamState.base_changed: "rebase onto new base",
+    UpstreamState.missing: "—",
+    UpstreamState.in_sync: "—",
+    UpstreamState.dependency_stale: "rebase onto upstream's merge",
 }
 
 
@@ -34,16 +37,81 @@ def _glyph(state: UpstreamState) -> str:
 def register(app: typer.Typer, get_container):
     @app.command(rich_help_panel="Inspection")
     def reconcile(
-        json_out: bool = typer.Option(False, "--json", help="Emit JSON instead of a table"),
-        ignore: Optional[str] = typer.Option(None, "--ignore", help="Persistently ignore drift for this slug"),
-        clear_ignores: bool = typer.Option(False, "--clear-ignores", help="Reset the ignore list"),
+        json_out: bool = typer.Option(
+            False, "--json", help="Emit JSON instead of a table"
+        ),
+        ignore: Optional[str] = typer.Option(
+            None, "--ignore", help="Persistently ignore drift for this slug"
+        ),
+        clear_ignores: bool = typer.Option(
+            False, "--clear-ignores", help="Reset the ignore list"
+        ),
         refresh: bool = typer.Option(False, "--refresh", help="Skip cache, refetch"),
+        adopt_merged: Optional[str] = typer.Option(
+            None,
+            "--adopt-merged",
+            metavar="TASK",
+            help="Recover missing metadata for a verified merged task PR.",
+        ),
     ):
         """Detect upstream PR drift across every task in the workspace."""
         output = Output()
         container = get_container()
-        state = container.state_manager().load()
         cache = ReconcileCache(container.state_dir())
+
+        if adopt_merged is not None:
+            if ignore is not None or clear_ignores:
+                output.error(
+                    "--adopt-merged cannot be combined with --ignore or --clear-ignores."
+                )
+                raise typer.Exit(code=1)
+            try:
+                config = ConfigLoader.load(container.config_path(), require_paths=False)
+                adopted, verified = adopt_merged_task(
+                    adopt_merged,
+                    state_manager=container.state_manager(),
+                    config=config,
+                    shell=container.shell(),
+                    pr_manager=container.pr_manager(),
+                    cache=cache,
+                    log=container.log_manager(),
+                )
+            except AdoptionError as exc:
+                output.error(str(exc))
+                raise typer.Exit(code=1)
+            except Exception as exc:  # Explicit recovery must fail closed.
+                output.error(f"Could not adopt merged PR metadata: {exc}")
+                raise typer.Exit(code=1)
+            result = {
+                "task": adopt_merged,
+                "adopted": adopted,
+                "prs": [
+                    {
+                        "repo": entry.repo,
+                        "url": entry.url,
+                        "merge_commit": entry.merge_commit,
+                        "merged_at": entry.merged_at.isoformat(),
+                    }
+                    for entry in verified
+                ],
+            }
+            if json_out or not output.human_mode:
+                output.json(result)
+            elif adopted:
+                output.success(f"Adopted merged PR metadata for: {adopt_merged}")
+            else:
+                output.success(
+                    f"Merged PR metadata is already adopted for: {adopt_merged}"
+                )
+            if output.human_mode and not json_out:
+                for entry in verified:
+                    output.print(
+                        f"  {entry.repo}: {entry.url} "
+                        f"(merge {entry.merge_commit}, merged {entry.merged_at.isoformat()})"
+                    )
+            return
+
+        state = container.state_manager().load()
 
         if clear_ignores:
             cache.clear_ignores()
@@ -79,7 +147,9 @@ def register(app: typer.Typer, get_container):
             )
 
         try:
-            decisions = reconcile_now(state, cache=cache, fetcher=_fetcher, config=config)
+            decisions = reconcile_now(
+                state, cache=cache, fetcher=_fetcher, config=config
+            )
         except Exception as e:  # noqa: BLE001 — never fail closed
             output.warning(f"reconcile unavailable: {e}")
             decisions = {}
@@ -87,23 +157,27 @@ def register(app: typer.Typer, get_container):
         _emit(output, decisions, json_out, cache.read_ignores())
 
 
-def _emit(output: Output, decisions: dict[str, Decision], json_out: bool, ignored: list[str]) -> None:
+def _emit(
+    output: Output, decisions: dict[str, Decision], json_out: bool, ignored: list[str]
+) -> None:
     if json_out or not output.human_mode:
-        output.json({
-            "tasks": [
-                {
-                    "slug": d.slug,
-                    "state": d.state.value,
-                    "pr_url": d.pr_url,
-                    "pr_number": d.pr_number,
-                    "base": d.base,
-                    "merge_commit": d.merge_commit,
-                    "ignored": d.slug in ignored,
-                }
-                for d in decisions.values()
-            ],
-            "ignored": ignored,
-        })
+        output.json(
+            {
+                "tasks": [
+                    {
+                        "slug": d.slug,
+                        "state": d.state.value,
+                        "pr_url": d.pr_url,
+                        "pr_number": d.pr_number,
+                        "base": d.base,
+                        "merge_commit": d.merge_commit,
+                        "ignored": d.slug in ignored,
+                    }
+                    for d in decisions.values()
+                ],
+                "ignored": ignored,
+            }
+        )
         return
     if not decisions:
         output.print("No tasks to reconcile.")

--- a/src/mship/core/persistence/lifecycle_repository.py
+++ b/src/mship/core/persistence/lifecycle_repository.py
@@ -201,22 +201,62 @@ class LifecycleRepository:
         *,
         now: datetime,
         allow_missing_workitem: bool = False,
-    ) -> None:
+    ) -> bool:
         item = self._resolve_owner_item(
             connection,
             task,
             allow_missing_workitem=allow_missing_workitem,
         )
         if item is None:
-            return
+            return False
         repos = list(dict.fromkeys([*item.affected_repos, *task.affected_repos]))
         urls = list(dict.fromkeys([*item.pr_urls, *task.pr_urls.values()]))
         if repos == item.affected_repos and urls == item.pr_urls:
-            return
+            return False
         item.affected_repos = repos
         item.pr_urls = urls
         item.updated_at = now
         self._store.workitems.replace(connection, item)
+        return True
+
+    def adopt_merged_metadata(
+        self,
+        expected_task: Task,
+        pr_urls: Mapping[str, str],
+        *,
+        finished_at: datetime,
+        discovered_base: str | None,
+        now: datetime,
+    ) -> bool:
+        """Fill verified missing delivery metadata and repair its durable mirror."""
+        with self._store.write(immediate=True) as transaction:
+            task = transaction.tasks.get(transaction.connection, expected_task.slug)
+            if task is None:
+                raise TaskMetadataRetentionConflictError(
+                    expected_task.slug, "its Task disappeared after external checks"
+                )
+            self._validate_expected_task(task, expected_task)
+            for repo, url in pr_urls.items():
+                recorded = task.pr_urls.get(repo)
+                if recorded is not None and recorded != url:
+                    raise TaskMetadataRetentionConflictError(
+                        task.slug,
+                        f"{repo}: recorded PR URL {recorded!r} does not match verified URL {url!r}",
+                    )
+            task.pr_urls.update(pr_urls)
+            if task.finished_at is None:
+                task.finished_at = finished_at
+            if not task.base_branch and discovered_base is not None:
+                task.base_branch = discovered_base
+            task_changed = task != expected_task
+            if task_changed:
+                transaction.tasks.replace(transaction.connection, task)
+                self._checkpoint("after_task_replace")
+            item_changed = self._retain_loaded(
+                transaction.connection, task, now=now, allow_missing_workitem=True
+            )
+            self._checkpoint("after_adoption_retention")
+            return task_changed or item_changed
 
     def retain_and_delete_task(
         self,

--- a/src/mship/core/reconcile/adopt.py
+++ b/src/mship/core/reconcile/adopt.py
@@ -6,12 +6,13 @@ import json
 import re
 import shlex
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from mship.core.base_resolver import resolve_base
 from mship.core.log import LogManager
+from mship.core.persistence.lifecycle_repository import LifecycleRepository
 from mship.core.pr import PRManager
 from mship.core.reconcile.cache import ReconcileCache
 from mship.core.state import StateManager, Task
@@ -34,6 +35,7 @@ class VerifiedMergedPR:
     url: str
     merge_commit: str
     merged_at: datetime
+    base: str
 
 
 def adopt_merged_task(
@@ -56,7 +58,6 @@ def adopt_merged_task(
     task = state.tasks.get(task_slug)
     if task is None:
         raise AdoptionError(f"Unknown task: {task_slug!r}.")
-    expected = task.model_dump(mode="json")
     if not task.affected_repos:
         raise AdoptionError(f"Task {task_slug!r} has no affected repositories.")
 
@@ -71,37 +72,23 @@ def adopt_merged_task(
     ]
     recovered_urls = {entry.repo: entry.url for entry in verified}
     completed_at = max(entry.merged_at for entry in verified)
+    discovered_bases = {
+        entry.base for entry in verified
+        if not _effective_base(task, entry.repo, config)
+    }
+    if len(discovered_bases) > 1:
+        raise AdoptionError("Discovered PR bases cannot be represented by one Task base branch.")
+    discovered_base = next(iter(discovered_bases), None)
 
-    changed = False
-
-    def apply(current_state) -> None:
-        nonlocal changed
-        current = current_state.tasks.get(task_slug)
-        if current is None or current.model_dump(mode="json") != expected:
-            raise AdoptionError(
-                f"Task {task_slug!r} changed while PR recovery was being verified; retry it."
-            )
-        for repo, url in recovered_urls.items():
-            recorded = current.pr_urls.get(repo)
-            if recorded is not None and recorded != url:
-                raise AdoptionError(
-                    f"{repo}: recorded PR URL {recorded!r} does not match verified URL {url!r}."
-                )
-        missing_urls = {
-            repo: url
-            for repo, url in recovered_urls.items()
-            if repo not in current.pr_urls
-        }
-        if missing_urls:
-            current.pr_urls.update(missing_urls)
-            changed = True
-        if current.finished_at is None:
-            current.finished_at = completed_at
-            changed = True
-
-    state_manager.mutate(apply)
-    _invalidate(cache)
+    changed = LifecycleRepository(state_manager.workspace_store).adopt_merged_metadata(
+        task,
+        recovered_urls,
+        finished_at=completed_at,
+        discovered_base=discovered_base,
+        now=datetime.now(timezone.utc),
+    )
     if changed:
+        cache.invalidate()
         details = "; ".join(
             f"{entry.repo}: {entry.url} (merge {entry.merge_commit}, merged {entry.merged_at.isoformat()})"
             for entry in verified
@@ -131,31 +118,15 @@ def _verify_repo(
     if not worktree.is_dir():
         raise AdoptionError(f"{repo_name}: task worktree does not exist: {worktree}")
 
-    base = (
-        resolve_base(
-            repo_name,
-            repo_config,
-            cli_base=None,
-            base_map={},
-            known_repos=getattr(config, "repos", {}).keys(),
-            task_base=task.base_override,
-        )
-        or task.base_branch
-    )
-    if not base:
-        raise AdoptionError(f"{repo_name}: no effective base branch is recorded.")
+    base = _effective_base(task, repo_name, config)
 
     _require_clean_worktree(repo_name, worktree, shell)
     head_sha = _git_value(repo_name, worktree, shell, "git rev-parse HEAD")
     if not _SHA_RE.fullmatch(head_sha):
         raise AdoptionError(f"{repo_name}: git returned an invalid HEAD SHA.")
-    if not pr_manager.check_pushed_to_origin(worktree, task.branch):
-        raise AdoptionError(
-            f"{repo_name}: task branch {task.branch!r} is not pushed at its current commit."
-        )
-
     github_repo = _github_repo(repo_name, worktree, shell)
     pr = _fetch_exact_pr(repo_name, worktree, shell, github_repo, task.branch, base)
+    base = pr["baseRefName"]
     pr_head = pr["headRefOid"]
     if pr_head != head_sha:
         raise AdoptionError(
@@ -179,7 +150,19 @@ def _verify_repo(
         url=pr["url"],
         merge_commit=pr["mergeCommit"]["oid"],
         merged_at=_parse_merged_at(repo_name, pr["mergedAt"]),
+        base=base,
     )
+
+
+def _effective_base(task: Task, repo_name: str, config: Any) -> str | None:
+    return resolve_base(
+        repo_name,
+        config.repos[repo_name],
+        cli_base=None,
+        base_map={},
+        known_repos=config.repos.keys(),
+        task_base=task.base_override,
+    ) or task.base_branch or None
 
 
 def _require_clean_worktree(repo_name: str, worktree: Path, shell: ShellRunner) -> None:
@@ -211,7 +194,7 @@ def _fetch_exact_pr(
     shell: ShellRunner,
     github_repo: str,
     branch: str,
-    base: str,
+    base: str | None,
 ) -> dict[str, Any]:
     command = (
         "gh pr list "
@@ -246,7 +229,10 @@ def _fetch_exact_pr(
         raise AdoptionError(
             f"{repo_name}: GitHub returned a PR with the wrong head branch."
         )
-    if pr.get("baseRefName") != base:
+    actual_base = pr.get("baseRefName")
+    if not isinstance(actual_base, str) or not actual_base.strip():
+        raise AdoptionError(f"{repo_name}: merged PR has no valid base branch.")
+    if base is not None and actual_base != base:
         raise AdoptionError(
             f"{repo_name}: GitHub returned a PR with the wrong base branch."
         )
@@ -277,10 +263,3 @@ def _parse_merged_at(repo_name: str, raw: object) -> datetime:
     if value.tzinfo is None or value.utcoffset() is None:
         raise AdoptionError(f"{repo_name}: merged PR timestamp lacks a timezone.")
     return value
-
-
-def _invalidate(cache: ReconcileCache) -> None:
-    payload = cache.read()
-    if payload is not None:
-        payload.fetched_at = 0.0
-        cache.write(payload)

--- a/src/mship/core/reconcile/adopt.py
+++ b/src/mship/core/reconcile/adopt.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from mship.core.base_resolver import resolve_base
 from mship.core.log import LogManager
@@ -67,7 +68,7 @@ def adopt_merged_task(
         raise AdoptionError(str(exc)) from exc
 
     verified = [
-        _verify_repo(task, repo, config, shell, pr_manager)
+        _verify_repo(task, repo, config, shell)
         for repo in task.affected_repos
     ]
     recovered_urls = {entry.repo: entry.url for entry in verified}
@@ -106,7 +107,6 @@ def _verify_repo(
     repo_name: str,
     config: Any,
     shell: ShellRunner,
-    pr_manager: PRManager,
 ) -> VerifiedMergedPR:
     repo_config = getattr(config, "repos", {}).get(repo_name)
     if repo_config is None:
@@ -133,17 +133,35 @@ def _verify_repo(
             f"{repo_name}: worktree HEAD does not match the merged PR head commit."
         )
 
-    if not pr_manager.fetch_remote_branch(worktree, base):
-        raise AdoptionError(f"{repo_name}: could not fetch origin/{base}.")
-    reachability = shell.run(
-        "git merge-base --is-ancestor "
-        f"{shlex.quote(pr['mergeCommit']['oid'])} {shlex.quote(f'origin/{base}')}",
-        cwd=worktree,
-    )
-    if reachability.returncode != 0:
-        raise AdoptionError(
-            f"{repo_name}: merge commit is not reachable from origin/{base}."
+    # An explicit destination bypasses narrowed remote fetch mappings. A unique
+    # ref isolates simultaneous recoveries; neither tracking refs nor FETCH_HEAD
+    # provide that guarantee. Pin ancestry to the commit fetched by this check.
+    recovery_ref = f"refs/mship/adopt-merged/{uuid4().hex}"
+    try:
+        fetched = shell.run(
+            "git fetch --no-tags --no-write-fetch-head origin "
+            f"{shlex.quote(f'+refs/heads/{base}:{recovery_ref}')}",
+            cwd=worktree,
         )
+        if fetched.returncode != 0:
+            raise AdoptionError(f"{repo_name}: could not fetch origin/{base}.")
+        base_commit = _git_value(
+            repo_name, worktree, shell,
+            f"git rev-parse --verify {shlex.quote(recovery_ref + '^{commit}')}",
+        )
+        if not _SHA_RE.fullmatch(base_commit):
+            raise AdoptionError(f"{repo_name}: fetched base has an invalid commit SHA.")
+        reachability = shell.run(
+            "git merge-base --is-ancestor "
+            f"{shlex.quote(pr['mergeCommit']['oid'])} {shlex.quote(base_commit)}",
+            cwd=worktree,
+        )
+        if reachability.returncode != 0:
+            raise AdoptionError(
+                f"{repo_name}: merge commit is not reachable from fetched origin/{base}."
+            )
+    finally:
+        shell.run(f"git update-ref -d {shlex.quote(recovery_ref)}", cwd=worktree)
 
     return VerifiedMergedPR(
         repo=repo_name,

--- a/src/mship/core/reconcile/adopt.py
+++ b/src/mship/core/reconcile/adopt.py
@@ -1,0 +1,286 @@
+"""Explicit, fail-closed recovery of missing metadata for merged task PRs."""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from mship.core.base_resolver import resolve_base
+from mship.core.log import LogManager
+from mship.core.pr import PRManager
+from mship.core.reconcile.cache import ReconcileCache
+from mship.core.state import StateManager, Task
+from mship.util.shell import ShellRunner
+
+
+class AdoptionError(RuntimeError):
+    """A requested merged-PR metadata recovery could not be proven safe."""
+
+
+_GITHUB_REMOTE_RE = re.compile(
+    r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/\s]+?)(?:\.git)?/?$"
+)
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
+
+
+@dataclass(frozen=True)
+class VerifiedMergedPR:
+    repo: str
+    url: str
+    merge_commit: str
+    merged_at: datetime
+
+
+def adopt_merged_task(
+    task_slug: str,
+    *,
+    state_manager: StateManager,
+    config: Any,
+    shell: ShellRunner,
+    pr_manager: PRManager,
+    cache: ReconcileCache,
+    log: LogManager,
+) -> tuple[bool, list[VerifiedMergedPR]]:
+    """Recover one task's PR URLs and finish time after proving all deliveries.
+
+    GitHub and git checks are deliberately complete before the one state
+    mutation.  The mutation compares the task with the snapshot used for those
+    checks, so a concurrent task change cannot be overwritten.
+    """
+    state = state_manager.load()
+    task = state.tasks.get(task_slug)
+    if task is None:
+        raise AdoptionError(f"Unknown task: {task_slug!r}.")
+    expected = task.model_dump(mode="json")
+    if not task.affected_repos:
+        raise AdoptionError(f"Task {task_slug!r} has no affected repositories.")
+
+    try:
+        pr_manager.check_gh_available()
+    except RuntimeError as exc:
+        raise AdoptionError(str(exc)) from exc
+
+    verified = [
+        _verify_repo(task, repo, config, shell, pr_manager)
+        for repo in task.affected_repos
+    ]
+    recovered_urls = {entry.repo: entry.url for entry in verified}
+    completed_at = max(entry.merged_at for entry in verified)
+
+    changed = False
+
+    def apply(current_state) -> None:
+        nonlocal changed
+        current = current_state.tasks.get(task_slug)
+        if current is None or current.model_dump(mode="json") != expected:
+            raise AdoptionError(
+                f"Task {task_slug!r} changed while PR recovery was being verified; retry it."
+            )
+        for repo, url in recovered_urls.items():
+            recorded = current.pr_urls.get(repo)
+            if recorded is not None and recorded != url:
+                raise AdoptionError(
+                    f"{repo}: recorded PR URL {recorded!r} does not match verified URL {url!r}."
+                )
+        missing_urls = {
+            repo: url
+            for repo, url in recovered_urls.items()
+            if repo not in current.pr_urls
+        }
+        if missing_urls:
+            current.pr_urls.update(missing_urls)
+            changed = True
+        if current.finished_at is None:
+            current.finished_at = completed_at
+            changed = True
+
+    state_manager.mutate(apply)
+    _invalidate(cache)
+    if changed:
+        details = "; ".join(
+            f"{entry.repo}: {entry.url} (merge {entry.merge_commit}, merged {entry.merged_at.isoformat()})"
+            for entry in verified
+        )
+        log.append(
+            task_slug,
+            f"adopted merged PR metadata: {details}",
+            action="adopt_merged",
+        )
+    return changed, verified
+
+
+def _verify_repo(
+    task: Task,
+    repo_name: str,
+    config: Any,
+    shell: ShellRunner,
+    pr_manager: PRManager,
+) -> VerifiedMergedPR:
+    repo_config = getattr(config, "repos", {}).get(repo_name)
+    if repo_config is None:
+        raise AdoptionError(f"{repo_name}: repository is not configured.")
+    worktree = task.worktrees.get(repo_name)
+    if worktree is None:
+        raise AdoptionError(f"{repo_name}: task worktree is missing.")
+    worktree = Path(worktree)
+    if not worktree.is_dir():
+        raise AdoptionError(f"{repo_name}: task worktree does not exist: {worktree}")
+
+    base = (
+        resolve_base(
+            repo_name,
+            repo_config,
+            cli_base=None,
+            base_map={},
+            known_repos=getattr(config, "repos", {}).keys(),
+            task_base=task.base_override,
+        )
+        or task.base_branch
+    )
+    if not base:
+        raise AdoptionError(f"{repo_name}: no effective base branch is recorded.")
+
+    _require_clean_worktree(repo_name, worktree, shell)
+    head_sha = _git_value(repo_name, worktree, shell, "git rev-parse HEAD")
+    if not _SHA_RE.fullmatch(head_sha):
+        raise AdoptionError(f"{repo_name}: git returned an invalid HEAD SHA.")
+    if not pr_manager.check_pushed_to_origin(worktree, task.branch):
+        raise AdoptionError(
+            f"{repo_name}: task branch {task.branch!r} is not pushed at its current commit."
+        )
+
+    github_repo = _github_repo(repo_name, worktree, shell)
+    pr = _fetch_exact_pr(repo_name, worktree, shell, github_repo, task.branch, base)
+    pr_head = pr["headRefOid"]
+    if pr_head != head_sha:
+        raise AdoptionError(
+            f"{repo_name}: worktree HEAD does not match the merged PR head commit."
+        )
+
+    if not pr_manager.fetch_remote_branch(worktree, base):
+        raise AdoptionError(f"{repo_name}: could not fetch origin/{base}.")
+    reachability = shell.run(
+        "git merge-base --is-ancestor "
+        f"{shlex.quote(pr['mergeCommit']['oid'])} {shlex.quote(f'origin/{base}')}",
+        cwd=worktree,
+    )
+    if reachability.returncode != 0:
+        raise AdoptionError(
+            f"{repo_name}: merge commit is not reachable from origin/{base}."
+        )
+
+    return VerifiedMergedPR(
+        repo=repo_name,
+        url=pr["url"],
+        merge_commit=pr["mergeCommit"]["oid"],
+        merged_at=_parse_merged_at(repo_name, pr["mergedAt"]),
+    )
+
+
+def _require_clean_worktree(repo_name: str, worktree: Path, shell: ShellRunner) -> None:
+    result = shell.run("git status --porcelain --untracked-files=all", cwd=worktree)
+    if result.returncode != 0:
+        raise AdoptionError(f"{repo_name}: could not determine worktree status.")
+    if result.stdout.strip():
+        raise AdoptionError(f"{repo_name}: worktree has uncommitted changes.")
+
+
+def _git_value(repo_name: str, worktree: Path, shell: ShellRunner, command: str) -> str:
+    result = shell.run(command, cwd=worktree)
+    if result.returncode != 0:
+        raise AdoptionError(f"{repo_name}: {command} failed.")
+    return result.stdout.strip()
+
+
+def _github_repo(repo_name: str, worktree: Path, shell: ShellRunner) -> str:
+    remote = _git_value(repo_name, worktree, shell, "git remote get-url origin")
+    match = _GITHUB_REMOTE_RE.search(remote)
+    if match is None:
+        raise AdoptionError(f"{repo_name}: origin is not a GitHub repository.")
+    return f"{match.group('owner')}/{match.group('repo')}"
+
+
+def _fetch_exact_pr(
+    repo_name: str,
+    worktree: Path,
+    shell: ShellRunner,
+    github_repo: str,
+    branch: str,
+    base: str,
+) -> dict[str, Any]:
+    command = (
+        "gh pr list "
+        f"--repo {shlex.quote(github_repo)} --head {shlex.quote(branch)} --state all "
+        "--json url,state,mergedAt,mergeCommit,headRefName,headRefOid,baseRefName --limit 100"
+    )
+    result = shell.run(command, cwd=worktree)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"gh exited {result.returncode}"
+        raise AdoptionError(f"{repo_name}: GitHub PR query failed: {detail}")
+    try:
+        entries = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AdoptionError(f"{repo_name}: GitHub returned invalid PR JSON.") from exc
+    if (
+        not isinstance(entries, list)
+        or len(entries) != 1
+        or not isinstance(entries[0], dict)
+    ):
+        raise AdoptionError(
+            f"{repo_name}: expected exactly one PR for branch {branch!r}."
+        )
+    pr = entries[0]
+    expected_url_prefix = f"https://github.com/{github_repo}/pull/"
+    if not isinstance(pr.get("url"), str) or not pr["url"].startswith(
+        expected_url_prefix
+    ):
+        raise AdoptionError(
+            f"{repo_name}: GitHub returned a PR from the wrong repository."
+        )
+    if pr.get("headRefName") != branch:
+        raise AdoptionError(
+            f"{repo_name}: GitHub returned a PR with the wrong head branch."
+        )
+    if pr.get("baseRefName") != base:
+        raise AdoptionError(
+            f"{repo_name}: GitHub returned a PR with the wrong base branch."
+        )
+    if pr.get("state") != "MERGED":
+        raise AdoptionError(f"{repo_name}: PR is not merged.")
+    merge_commit = pr.get("mergeCommit")
+    if not isinstance(merge_commit, dict) or not isinstance(
+        merge_commit.get("oid"), str
+    ):
+        raise AdoptionError(f"{repo_name}: merged PR has no merge commit.")
+    if not _SHA_RE.fullmatch(merge_commit["oid"]):
+        raise AdoptionError(f"{repo_name}: merged PR returned an invalid merge commit.")
+    if not isinstance(pr.get("headRefOid"), str) or not _SHA_RE.fullmatch(
+        pr["headRefOid"]
+    ):
+        raise AdoptionError(f"{repo_name}: merged PR has no valid head commit.")
+    _parse_merged_at(repo_name, pr.get("mergedAt"))
+    return pr
+
+
+def _parse_merged_at(repo_name: str, raw: object) -> datetime:
+    if not isinstance(raw, str) or not raw:
+        raise AdoptionError(f"{repo_name}: merged PR has no merge timestamp.")
+    try:
+        value = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise AdoptionError(f"{repo_name}: merged PR timestamp is invalid.") from exc
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise AdoptionError(f"{repo_name}: merged PR timestamp lacks a timezone.")
+    return value
+
+
+def _invalidate(cache: ReconcileCache) -> None:
+    payload = cache.read()
+    if payload is not None:
+        payload.fetched_at = 0.0
+        cache.write(payload)

--- a/src/mship/core/reconcile/cache.py
+++ b/src/mship/core/reconcile/cache.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import json
 import time
-from dataclasses import dataclass, field
+import fcntl
+from contextlib import contextmanager
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 
@@ -31,6 +33,18 @@ class ReconcileCache:
     def __init__(self, state_dir: Path) -> None:
         self._state_dir = Path(state_dir)
         self._path = self._state_dir / CACHE_FILENAME
+        self._lock_path = self._path.with_name(self._path.name + ".lock")
+
+    @contextmanager
+    def _locked(self):
+        # Lock a stable adjacent inode: the payload itself is atomically replaced.
+        self._state_dir.mkdir(parents=True, exist_ok=True)
+        with self._lock_path.open("a") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock, fcntl.LOCK_UN)
 
     # --- payload ---
 
@@ -74,8 +88,14 @@ class ReconcileCache:
         except (KeyError, TypeError, ValueError):
             return None
 
-    def write(self, payload: CachePayload) -> None:
-        self._state_dir.mkdir(parents=True, exist_ok=True)
+    def write(self, payload: CachePayload, *, preserve_ignores: bool = False) -> None:
+        with self._locked():
+            if preserve_ignores:
+                current = self.read()
+                payload = replace(payload, ignored=current.ignored if current else [])
+            self._write_unlocked(payload)
+
+    def _write_unlocked(self, payload: CachePayload) -> None:
         body = {
             "fetched_at": payload.fetched_at,
             "ttl_seconds": payload.ttl_seconds,
@@ -97,6 +117,14 @@ class ReconcileCache:
         tmp = self._path.with_suffix(".tmp")
         tmp.write_text(json.dumps(body, indent=2))
         tmp.replace(self._path)
+
+    def invalidate(self) -> None:
+        """Expire the latest results without losing concurrent cache changes."""
+        with self._locked():
+            payload = self.read()
+            if payload is not None:
+                payload.fetched_at = 0.0
+                self._write_unlocked(payload)
 
     def is_fresh(self, payload: CachePayload) -> bool:
         if payload.schema_version != SCHEMA_VERSION:
@@ -142,23 +170,26 @@ class ReconcileCache:
         return list(payload.ignored) if payload else []
 
     def add_ignore(self, slug: str) -> None:
-        payload = self.read() or CachePayload(
-            fetched_at=0.0, ttl_seconds=DEFAULT_TTL_SECONDS, results={}, ignored=[],
-        )
-        if slug not in payload.ignored:
-            payload.ignored.append(slug)
-        self.write(payload)
+        with self._locked():
+            payload = self.read() or CachePayload(
+                fetched_at=0.0, ttl_seconds=DEFAULT_TTL_SECONDS, results={}, ignored=[],
+            )
+            if slug not in payload.ignored:
+                payload.ignored.append(slug)
+            self._write_unlocked(payload)
 
     def remove_ignore(self, slug: str) -> None:
-        payload = self.read()
-        if payload is None or slug not in payload.ignored:
-            return
-        payload.ignored = [s for s in payload.ignored if s != slug]
-        self.write(payload)
+        with self._locked():
+            payload = self.read()
+            if payload is None or slug not in payload.ignored:
+                return
+            payload.ignored = [s for s in payload.ignored if s != slug]
+            self._write_unlocked(payload)
 
     def clear_ignores(self) -> None:
-        payload = self.read()
-        if payload is None:
-            return
-        payload.ignored = []
-        self.write(payload)
+        with self._locked():
+            payload = self.read()
+            if payload is None:
+                return
+            payload.ignored = []
+            self._write_unlocked(payload)

--- a/src/mship/core/reconcile/gate.py
+++ b/src/mship/core/reconcile/gate.py
@@ -330,9 +330,8 @@ def reconcile_now(
             fetched_at=time.time(),
             ttl_seconds=ttl_seconds,
             results=results,
-            ignored=(payload.ignored if payload else []),
             base_context=base_context,
-        ))
+        ), preserve_ignores=True)
     decisions = {
         slug: _decision_from_detection(slug, d, state)
         for slug, d in detections.items()

--- a/tests/cli/test_reconcile_adopt.py
+++ b/tests/cli/test_reconcile_adopt.py
@@ -1,0 +1,436 @@
+"""Behavioral regression coverage for explicit merged-PR metadata adoption."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from mship.cli import app, container
+from mship.core.reconcile.cache import CachePayload, ReconcileCache
+from mship.core.state import StateManager, Task, WorkspaceState
+from mship.util.shell import ShellResult, ShellRunner
+
+
+_BRANCH = "feat/adopt"
+_MERGED_AT = "2026-09-08T12:34:56Z"
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "Test User",
+    "GIT_AUTHOR_EMAIL": "test@example.invalid",
+    "GIT_COMMITTER_NAME": "Test User",
+    "GIT_COMMITTER_EMAIL": "test@example.invalid",
+}
+
+
+@dataclass(frozen=True)
+class RepoFixture:
+    name: str
+    worktree: Path
+    head: str
+    merge: str
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env=_GIT_ENV,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _merged_repo(tmp_path: Path, name: str) -> RepoFixture:
+    """Create a clean, pushed feature branch merged into a local bare origin."""
+    bare = tmp_path / "origins" / f"{name}.git"
+    bare.parent.mkdir(exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-q", "--bare", "-b", "main", str(bare)],
+        env=_GIT_ENV,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    worktree = tmp_path / name
+    subprocess.run(
+        ["git", "clone", "-q", str(bare), str(worktree)],
+        env=_GIT_ENV,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    _git(worktree, "config", "user.name", "Test User")
+    _git(worktree, "config", "user.email", "test@example.invalid")
+    (worktree / "Taskfile.yml").write_text("version: '3'\ntasks: {}\n")
+    (worktree / "README.md").write_text(f"{name}\n")
+    _git(worktree, "add", ".")
+    _git(worktree, "commit", "-qm", "base")
+    _git(worktree, "push", "-q", "origin", "main")
+    _git(worktree, "checkout", "-q", "-b", _BRANCH)
+    (worktree / "README.md").write_text(f"{name} feature\n")
+    _git(worktree, "commit", "-qam", "feature")
+    head = _git(worktree, "rev-parse", "HEAD")
+    _git(worktree, "push", "-q", "-u", "origin", _BRANCH)
+    _git(worktree, "checkout", "-q", "main")
+    _git(worktree, "merge", "--no-ff", "-qm", "merge", _BRANCH)
+    merge = _git(worktree, "rev-parse", "HEAD")
+    _git(worktree, "push", "-q", "origin", "main")
+    _git(worktree, "checkout", "-q", _BRANCH)
+    return RepoFixture(name=name, worktree=worktree, head=head, merge=merge)
+
+
+def _pr(repo: RepoFixture, **changes: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "url": f"https://github.com/acme/{repo.name}/pull/7",
+        "state": "MERGED",
+        "mergedAt": _MERGED_AT,
+        "mergeCommit": {"oid": repo.merge},
+        "headRefName": _BRANCH,
+        "headRefOid": repo.head,
+        "baseRefName": "main",
+    }
+    value.update(changes)
+    return value
+
+
+class _GitHubFixtureShell(ShellRunner):
+    """Runs fixture git commands for real and intercepts only GitHub-facing I/O."""
+
+    def __init__(
+        self,
+        prs: dict[str, list[dict[str, object]]],
+        *,
+        after_reachability=None,
+    ) -> None:
+        super().__init__()
+        self.prs = prs
+        self.commands: list[str] = []
+        self._after_reachability = after_reachability
+        self._reached = False
+
+    def run(self, command, cwd, env=None, timeout=None) -> ShellResult:
+        self.commands.append(command)
+        if command == "gh auth status":
+            return ShellResult(returncode=0, stdout="", stderr="")
+        if command == "git remote get-url origin":
+            return ShellResult(
+                returncode=0,
+                stdout=f"https://github.com/acme/{Path(cwd).name}.git\n",
+                stderr="",
+            )
+        if command.startswith("gh pr list "):
+            return ShellResult(
+                returncode=0,
+                stdout=json.dumps(self.prs[Path(cwd).name]),
+                stderr="",
+            )
+        result = super().run(command, cwd=cwd, env=env, timeout=timeout)
+        if (
+            command.startswith("git merge-base --is-ancestor")
+            and self._after_reachability is not None
+            and not self._reached
+        ):
+            self._reached = True
+            self._after_reachability()
+        return result
+
+
+def _task(repos: list[RepoFixture], *, pr_urls: dict[str, str] | None = None) -> Task:
+    return Task(
+        slug="adopt",
+        description="recover merged metadata",
+        phase="dev",
+        created_at=datetime(2026, 9, 8, tzinfo=timezone.utc),
+        affected_repos=[repo.name for repo in repos],
+        worktrees={repo.name: repo.worktree for repo in repos},
+        branch=_BRANCH,
+        base_branch="main",
+        blocked_reason="waiting for operator",
+        active_repo=repos[0].name,
+        spec_id="spec-adopt",
+        work_item_id="wi-adopt",
+        test_iteration=4,
+        pr_urls=pr_urls or {},
+    )
+
+
+def _workspace(
+    tmp_path: Path, names: tuple[str, ...] = ("api",)
+) -> tuple[Path, Path, list[RepoFixture], StateManager]:
+    repos = [_merged_repo(tmp_path, name) for name in names]
+    cfg = tmp_path / "mothership.yaml"
+    cfg.write_text(
+        "workspace: reconcile-adopt\nrepos:\n"
+        + "".join(
+            f"  {repo.name}:\n    path: ./{repo.name}\n    type: service\n    base_branch: main\n"
+            for repo in repos
+        )
+    )
+    state_dir = tmp_path / ".mothership"
+    state_dir.mkdir()
+    manager = StateManager(state_dir)
+    manager.save(
+        WorkspaceState(
+            tasks={
+                "adopt": _task(repos),
+                "untouched": Task(
+                    slug="untouched",
+                    description="unrelated",
+                    phase="review",
+                    created_at=datetime(2026, 9, 8, tzinfo=timezone.utc),
+                    affected_repos=[],
+                    worktrees={},
+                    branch="feat/untouched",
+                    spec_id="other-spec",
+                    work_item_id="wi-other",
+                ),
+            }
+        )
+    )
+    return cfg, state_dir, repos, manager
+
+
+def _configure(cfg: Path, state_dir: Path, shell: ShellRunner) -> None:
+    container.config.reset()
+    container.log_manager.reset()
+    container.config_path.override(cfg)
+    container.state_dir.override(state_dir)
+    container.shell.override(shell)
+
+
+def _reset_container() -> None:
+    container.shell.reset_override()
+    container.config_path.reset_override()
+    container.state_dir.reset_override()
+    container.config.reset_override()
+    container.config.reset()
+    container.log_manager.reset()
+    container.state_manager.reset()
+
+
+def _invoke_adoption() -> tuple[object, dict[str, object]]:
+    result = CliRunner().invoke(app, ["reconcile", "--adopt-merged", "adopt", "--json"])
+    return result, json.loads(result.output) if result.exit_code == 0 else {}
+
+
+def test_adopt_merged_recovers_only_lifecycle_metadata_and_invalidates_cache(
+    tmp_path: Path,
+):
+    cfg, state_dir, repos, manager = _workspace(tmp_path)
+    cache = ReconcileCache(state_dir)
+    cache.write(
+        CachePayload(
+            fetched_at=time.time(),
+            ttl_seconds=300,
+            results={"adopt": {"state": "missing"}},
+        )
+    )
+    shell = _GitHubFixtureShell({repo.name: [_pr(repo)] for repo in repos})
+    before = manager.load().tasks["adopt"].model_dump(mode="json")
+    _configure(cfg, state_dir, shell)
+    try:
+        result, payload = _invoke_adoption()
+        assert result.exit_code == 0, result.output
+        assert payload["adopted"] is True
+        assert payload["prs"] == [
+            {
+                "repo": repos[0].name,
+                "url": _pr(repos[0])["url"],
+                "merge_commit": repos[0].merge,
+                "merged_at": "2026-09-08T12:34:56+00:00",
+            }
+        ]
+        task = manager.load().tasks["adopt"]
+        assert task.pr_urls == {repos[0].name: _pr(repos[0])["url"]}
+        assert task.finished_at == datetime(2026, 9, 8, 12, 34, 56, tzinfo=timezone.utc)
+        after = task.model_dump(mode="json")
+        for key in (
+            "branch",
+            "worktrees",
+            "phase",
+            "blocked_reason",
+            "active_repo",
+            "spec_id",
+            "work_item_id",
+            "test_iteration",
+        ):
+            assert after[key] == before[key]
+        assert _git(repos[0].worktree, "branch", "--show-current") == _BRANCH
+        assert repos[0].worktree.is_dir()
+        assert cache.read() is not None and cache.read().fetched_at == 0.0
+        assert any(
+            command.startswith("gh pr list --repo acme/api")
+            for command in shell.commands
+        )
+        assert [entry.action for entry in container.log_manager().read("adopt")] == [
+            "adopt_merged"
+        ]
+    finally:
+        _reset_container()
+
+
+def test_adopt_merged_is_idempotent_without_timestamp_churn(tmp_path: Path):
+    cfg, state_dir, repos, manager = _workspace(tmp_path)
+    shell = _GitHubFixtureShell({repo.name: [_pr(repo)] for repo in repos})
+    _configure(cfg, state_dir, shell)
+    try:
+        first, first_payload = _invoke_adoption()
+        first_state = manager.load().tasks["adopt"].model_dump(mode="json")
+        first_journal_entries = container.log_manager().read("adopt")
+        second, second_payload = _invoke_adoption()
+        assert first.exit_code == second.exit_code == 0
+        assert first_payload["adopted"] is True
+        assert second_payload["adopted"] is False
+        assert manager.load().tasks["adopt"].model_dump(mode="json") == first_state
+        assert [entry.action for entry in first_journal_entries] == ["adopt_merged"]
+        assert container.log_manager().read("adopt") == first_journal_entries
+    finally:
+        _reset_container()
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"state": "OPEN", "mergeCommit": None},
+        {"baseRefName": "release"},
+        {"headRefName": "feat/someone-else"},
+        {"url": "https://github.com/acme/other/pull/7"},
+        {"mergeCommit": {"oid": "a" * 40}},
+    ],
+    ids=["open", "wrong-base", "wrong-head", "wrong-repository", "unreachable-merge"],
+)
+def test_adopt_merged_refuses_unverified_pr_proofs_without_mutation(
+    tmp_path: Path, change: dict[str, object]
+):
+    cfg, state_dir, repos, manager = _workspace(tmp_path)
+    shell = _GitHubFixtureShell({repos[0].name: [_pr(repos[0], **change)]})
+    before = manager.load().model_dump(mode="json")
+    _configure(cfg, state_dir, shell)
+    try:
+        result, _ = _invoke_adoption()
+        assert result.exit_code != 0
+        assert manager.load().model_dump(mode="json") == before
+    finally:
+        _reset_container()
+
+
+def test_adopt_merged_rejects_mismatched_recorded_url_without_mutation(tmp_path: Path):
+    cfg, state_dir, repos, manager = _workspace(tmp_path)
+    manager.mutate(
+        lambda state: setattr(
+            state.tasks["adopt"],
+            "pr_urls",
+            {repos[0].name: "https://github.com/acme/api/pull/99"},
+        )
+    )
+    shell = _GitHubFixtureShell({repos[0].name: [_pr(repos[0])]})
+    before = manager.load().model_dump(mode="json")
+    _configure(cfg, state_dir, shell)
+    try:
+        result, _ = _invoke_adoption()
+        assert result.exit_code != 0
+        assert manager.load().model_dump(mode="json") == before
+    finally:
+        _reset_container()
+
+
+def test_adopt_merged_verifies_every_repo_before_multi_repo_mutation(tmp_path: Path):
+    cfg, state_dir, repos, manager = _workspace(tmp_path, ("api", "worker"))
+    shell = _GitHubFixtureShell(
+        {
+            "api": [_pr(repos[0])],
+            "worker": [_pr(repos[1], state="CLOSED", mergeCommit=None)],
+        }
+    )
+    before = manager.load().model_dump(mode="json")
+    _configure(cfg, state_dir, shell)
+    try:
+        result, _ = _invoke_adoption()
+        assert result.exit_code != 0
+        assert manager.load().model_dump(mode="json") == before
+    finally:
+        _reset_container()
+
+
+def test_adopt_merged_aborts_if_task_changes_during_verification(tmp_path: Path):
+    cfg, state_dir, repos, manager = _workspace(tmp_path)
+
+    def concurrent_change() -> None:
+        manager.mutate(
+            lambda state: setattr(
+                state.tasks["adopt"], "blocked_reason", "concurrent update"
+            )
+        )
+
+    shell = _GitHubFixtureShell(
+        {repos[0].name: [_pr(repos[0])]},
+        after_reachability=concurrent_change,
+    )
+    _configure(cfg, state_dir, shell)
+    try:
+        result, _ = _invoke_adoption()
+        assert result.exit_code != 0
+        task = manager.load().tasks["adopt"]
+        assert task.blocked_reason == "concurrent update"
+        assert task.pr_urls == {}
+        assert task.finished_at is None
+    finally:
+        _reset_container()
+
+
+@pytest.mark.parametrize("case", ["dirty", "unpushed", "head-mismatch"])
+def test_adopt_merged_refuses_worktree_or_head_proof_failures(
+    tmp_path: Path,
+    case: str,
+):
+    cfg, state_dir, repos, manager = _workspace(tmp_path)
+    repo = repos[0]
+    pr = _pr(repo)
+    if case == "dirty":
+        (repo.worktree / "pending.txt").write_text("uncommitted\n")
+    elif case == "unpushed":
+        (repo.worktree / "README.md").write_text("local-only\n")
+        _git(repo.worktree, "commit", "-qam", "local-only")
+    else:
+        pr["headRefOid"] = "b" * 40
+
+    shell = _GitHubFixtureShell({repo.name: [pr]})
+    before = manager.load().model_dump(mode="json")
+    _configure(cfg, state_dir, shell)
+    try:
+        result, _ = _invoke_adoption()
+        assert result.exit_code != 0
+        assert manager.load().model_dump(mode="json") == before
+    finally:
+        _reset_container()
+
+
+def test_adopt_merged_rejects_unknown_tasks_and_conflicting_cache_actions(
+    tmp_path: Path,
+):
+    cfg, state_dir, repos, manager = _workspace(tmp_path)
+    shell = _GitHubFixtureShell({repos[0].name: [_pr(repos[0])]})
+    before = manager.load().model_dump(mode="json")
+    _configure(cfg, state_dir, shell)
+    try:
+        unknown = CliRunner().invoke(
+            app,
+            ["reconcile", "--adopt-merged", "missing", "--json"],
+        )
+        conflicting = CliRunner().invoke(
+            app,
+            ["reconcile", "--adopt-merged", "adopt", "--ignore", "adopt", "--json"],
+        )
+        assert unknown.exit_code != 0
+        assert conflicting.exit_code != 0
+        assert manager.load().model_dump(mode="json") == before
+    finally:
+        _reset_container()

--- a/tests/cli/test_reconcile_adopt.py
+++ b/tests/cli/test_reconcile_adopt.py
@@ -317,6 +317,41 @@ def test_adopt_merged_succeeds_after_origin_deletes_head(tmp_path: Path):
         _reset_container()
 
 
+@pytest.mark.parametrize("tracking_ref", ["stale", "missing"])
+def test_adopt_uses_actual_base_with_narrowed_fetch_mapping(tmp_path: Path, tracking_ref):
+    cfg, state_dir, repos, manager = _workspace(tmp_path)
+    repo = repos[0]
+    _git(repo.worktree, "config", "remote.origin.fetch",
+         "+refs/heads/feat/adopt:refs/remotes/origin/feat/adopt")
+    if tracking_ref == "stale":
+        # Change the bare remote directly: the local tracking ref must retain
+        # the old merge while the actual remote base no longer contains it.
+        bare = tmp_path / "origins" / "api.git"
+        old_base = _git(repo.worktree, "rev-parse", f"{repo.merge}^1")
+        _git(bare, "update-ref", "refs/heads/main", old_base)
+        assert _git(repo.worktree, "rev-parse", "origin/main") == repo.merge
+    else:
+        _git(repo.worktree, "update-ref", "-d", "refs/remotes/origin/main")
+    before = manager.load()
+    shell = _GitHubFixtureShell({repo.name: [_pr(repo)]})
+    _configure(cfg, state_dir, shell)
+    try:
+        result, payload = _invoke_adoption()
+        if tracking_ref == "stale":
+            assert result.exit_code != 0, result.output
+            assert "not reachable" in result.output
+            assert manager.load() == before
+        else:
+            assert result.exit_code == 0, result.output
+            assert payload["adopted"] is True
+            assert manager.load().tasks["adopt"].pr_urls == {
+                "api": "https://github.com/acme/api/pull/7"
+            }
+        assert _git(repo.worktree, "for-each-ref", "refs/mship/adopt-merged") == ""
+    finally:
+        _reset_container()
+
+
 @pytest.mark.parametrize("names", [("api",), ("api", "worker")])
 @pytest.mark.parametrize("recorded_base", [None, ""])
 def test_adopt_discovers_actual_default_base_and_persists_it(tmp_path: Path, names, recorded_base):
@@ -333,10 +368,8 @@ def test_adopt_discovers_actual_default_base_and_persists_it(tmp_path: Path, nam
         assert result.exit_code == 0, result.output
         assert manager.load().tasks["adopt"].base_branch == "release"
         assert all(pr["base"] == "release" for pr in payload["prs"])
-        assert all(
-            command.endswith("origin/release")
-            for command in shell.commands if command.startswith("git merge-base")
-        )
+        for repo in repos:
+            assert f"git merge-base --is-ancestor {repo.merge} {repo.merge}" in shell.commands
     finally:
         _reset_container()
 

--- a/tests/cli/test_reconcile_adopt.py
+++ b/tests/cli/test_reconcile_adopt.py
@@ -13,9 +13,12 @@ import pytest
 from typer.testing import CliRunner
 
 from mship.cli import app, container
+from mship.core.persistence.lifecycle_repository import LifecycleRepository
 from mship.core.reconcile.cache import CachePayload, ReconcileCache
 from mship.core.state import StateManager, Task, WorkspaceState
+from mship.core.workitem_store import WorkItemStore
 from mship.util.shell import ShellResult, ShellRunner
+from tests.persistence_helpers import corrupt_workitem
 
 
 _BRANCH = "feat/adopt"
@@ -246,6 +249,7 @@ def test_adopt_merged_recovers_only_lifecycle_metadata_and_invalidates_cache(
                 "url": _pr(repos[0])["url"],
                 "merge_commit": repos[0].merge,
                 "merged_at": "2026-09-08T12:34:56+00:00",
+                "base": "main",
             }
         ]
         task = manager.load().tasks["adopt"]
@@ -292,6 +296,151 @@ def test_adopt_merged_is_idempotent_without_timestamp_churn(tmp_path: Path):
         assert manager.load().tasks["adopt"].model_dump(mode="json") == first_state
         assert [entry.action for entry in first_journal_entries] == ["adopt_merged"]
         assert container.log_manager().read("adopt") == first_journal_entries
+    finally:
+        _reset_container()
+
+
+def test_adopt_merged_succeeds_after_origin_deletes_head(tmp_path: Path):
+    cfg, state_dir, repos, manager = _workspace(tmp_path)
+    repo = repos[0]
+    _git(repo.worktree, "push", "origin", "--delete", _BRANCH)
+    shell = _GitHubFixtureShell({repo.name: [_pr(repo)]})
+    _configure(cfg, state_dir, shell)
+    try:
+        result, payload = _invoke_adoption()
+        assert result.exit_code == 0, result.output
+        assert payload["adopted"] is True
+        assert manager.load().tasks["adopt"].pr_urls == {
+            "api": "https://github.com/acme/api/pull/7"
+        }
+    finally:
+        _reset_container()
+
+
+@pytest.mark.parametrize("names", [("api",), ("api", "worker")])
+@pytest.mark.parametrize("recorded_base", [None, ""])
+def test_adopt_discovers_actual_default_base_and_persists_it(tmp_path: Path, names, recorded_base):
+    cfg, state_dir, repos, manager = _workspace(tmp_path, names)
+    cfg.write_text(cfg.read_text().replace("    base_branch: main\n", ""))
+    manager.mutate(lambda state: setattr(state.tasks["adopt"], "base_branch", recorded_base))
+    for repo in repos:
+        _git(repo.worktree, "push", "origin", "main:refs/heads/release")
+        _git(repo.worktree, "update-ref", "-d", "refs/remotes/origin/main")
+    shell = _GitHubFixtureShell({repo.name: [_pr(repo, baseRefName="release")] for repo in repos})
+    _configure(cfg, state_dir, shell)
+    try:
+        result, payload = _invoke_adoption()
+        assert result.exit_code == 0, result.output
+        assert manager.load().tasks["adopt"].base_branch == "release"
+        assert all(pr["base"] == "release" for pr in payload["prs"])
+        assert all(
+            command.endswith("origin/release")
+            for command in shell.commands if command.startswith("git merge-base")
+        )
+    finally:
+        _reset_container()
+
+
+@pytest.mark.parametrize("bases", [("main", "release"), ("", ""), (None, None)])
+def test_adopt_refuses_unrepresentable_or_missing_discovered_bases(tmp_path: Path, bases):
+    cfg, state_dir, repos, manager = _workspace(tmp_path, ("api", "worker"))
+    cfg.write_text(cfg.read_text().replace("    base_branch: main\n", ""))
+    manager.mutate(lambda state: setattr(state.tasks["adopt"], "base_branch", None))
+    _git(repos[1].worktree, "push", "origin", "main:refs/heads/release")
+    before = manager.load()
+    shell = _GitHubFixtureShell({repo.name: [_pr(repo, baseRefName=base)] for repo, base in zip(repos, bases)})
+    _configure(cfg, state_dir, shell)
+    try:
+        result, _ = _invoke_adoption()
+        assert result.exit_code != 0
+        assert manager.load() == before
+    finally:
+        _reset_container()
+
+
+def _owner(state_dir, manager):
+    items = WorkItemStore(state_dir / "workitems", workspace_store=manager.workspace_store)
+    item = items.create("Owner", "bug", "test", datetime(2026, 9, 8, tzinfo=timezone.utc))
+    item.task_slugs = ["adopt"]
+    item.affected_repos = ["historical"]
+    item.pr_urls = ["https://github.com/acme/historical/pull/1"]
+    items.save(item)
+    manager.mutate(lambda state: setattr(state.tasks["adopt"], "work_item_id", item.id))
+    return items, item
+
+
+@pytest.mark.parametrize("task_complete", [False, True])
+def test_adopt_mirrors_and_repairs_workitem_metadata(tmp_path: Path, task_complete):
+    cfg, state_dir, repos, manager = _workspace(tmp_path)
+    items, owner = _owner(state_dir, manager)
+    if task_complete:
+        manager.mutate(lambda state: (
+            setattr(state.tasks["adopt"], "pr_urls", {"api": "https://github.com/acme/api/pull/7"}),
+            setattr(state.tasks["adopt"], "finished_at", datetime(2026, 9, 8, tzinfo=timezone.utc)),
+        ))
+    shell = _GitHubFixtureShell({repo.name: [_pr(repo)] for repo in repos})
+    _configure(cfg, state_dir, shell)
+    try:
+        result, payload = _invoke_adoption()
+        assert result.exit_code == 0, result.output
+        assert payload["adopted"] is True
+        saved = items.get(owner.id)
+        assert saved.affected_repos == ["historical", "api"]
+        assert saved.pr_urls == ["https://github.com/acme/historical/pull/1", "https://github.com/acme/api/pull/7"]
+        assert saved.task_slugs == ["adopt"]
+        before_task = manager.load().tasks["adopt"]
+        cache = ReconcileCache(state_dir)
+        cache.write(CachePayload(fetched_at=12345, ttl_seconds=300, results={"sentinel": {}}))
+        second, second_payload = _invoke_adoption()
+        assert second.exit_code == 0, second.output
+        assert second_payload["adopted"] is False
+        assert items.get(owner.id) == saved
+        assert manager.load().tasks["adopt"] == before_task
+        assert cache.read().fetched_at == 12345
+    finally:
+        _reset_container()
+
+
+@pytest.mark.parametrize("stage", ["after_task_replace", "after_adoption_retention"])
+def test_adopt_rolls_back_task_and_workitem_on_write_failure(tmp_path: Path, monkeypatch, stage):
+    cfg, state_dir, repos, manager = _workspace(tmp_path)
+    items, owner = _owner(state_dir, manager)
+    before = manager.load()
+    def fail(self, checkpoint):
+        if checkpoint == stage:
+            raise RuntimeError("injected adoption failure")
+    monkeypatch.setattr(LifecycleRepository, "_checkpoint", fail)
+    shell = _GitHubFixtureShell({repo.name: [_pr(repo)] for repo in repos})
+    _configure(cfg, state_dir, shell)
+    try:
+        result, _ = _invoke_adoption()
+        assert result.exit_code != 0
+        assert "injected adoption failure" in result.output
+        assert manager.load() == before
+        assert items.get(owner.id) == owner
+    finally:
+        _reset_container()
+
+
+@pytest.mark.parametrize("case", ["corrupt", "ambiguous"])
+def test_adopt_refuses_corrupt_or_ambiguous_owner_atomically(tmp_path: Path, monkeypatch, case):
+    cfg, state_dir, repos, manager = _workspace(tmp_path)
+    items, owner = _owner(state_dir, manager)
+    if case == "corrupt":
+        corrupt_workitem(state_dir, owner.id)
+    else:
+        # SQLite forbids duplicate forward links; inject the malformed lookup
+        # at the ownership boundary to exercise adoption's fail-closed path.
+        monkeypatch.setattr(LifecycleRepository, "_owner_ids", lambda *args: [owner.id, "wi-duplicate"])
+    before = manager.load()
+    shell = _GitHubFixtureShell({repo.name: [_pr(repo)] for repo in repos})
+    _configure(cfg, state_dir, shell)
+    try:
+        result, _ = _invoke_adoption()
+        assert result.exit_code != 0
+        assert manager.load() == before
+        if case == "ambiguous":
+            assert items.get(owner.id) == owner
     finally:
         _reset_container()
 

--- a/tests/core/reconcile/test_cache.py
+++ b/tests/core/reconcile/test_cache.py
@@ -1,7 +1,11 @@
 import json
 import time
+import fcntl
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import pytest
 from mship.core.reconcile.cache import ReconcileCache, CachePayload
 
 
@@ -64,6 +68,104 @@ def test_clear_ignores(tmp_path: Path):
     c.add_ignore("slug-b")
     c.clear_ignores()
     assert c.read_ignores() == []
+
+
+@pytest.mark.parametrize("operation", ["add", "remove", "clear", "invalidate", "write"])
+def test_cache_mutations_serialize_with_concurrent_result_writer(tmp_path, monkeypatch, operation):
+    first = ReconcileCache(tmp_path)
+    second = ReconcileCache(tmp_path)
+    first.write(CachePayload(fetched_at=10, ttl_seconds=300, results={"old": {}}, ignored=["a"]))
+    paused = threading.Event()
+    release = threading.Event()
+    contender = threading.Event()
+    first_ident = []
+    second_ident = []
+    original_read = Path.read_text
+    original_write = Path.write_text
+    original_flock = fcntl.flock
+
+    def pause():
+        paused.set()
+        assert release.wait(5), "interleaving did not release first writer"
+
+    def read(path, *args, **kwargs):
+        value = original_read(path, *args, **kwargs)
+        if threading.get_ident() in first_ident and operation != "write":
+            pause()
+        return value
+
+    def write(path, *args, **kwargs):
+        value = original_write(path, *args, **kwargs)
+        if threading.get_ident() in first_ident and operation == "write":
+            pause()
+        return value
+
+    def flock(fd, mode):
+        if threading.get_ident() in second_ident and mode == fcntl.LOCK_EX:
+            contender.set()
+        return original_flock(fd, mode)
+
+    monkeypatch.setattr(Path, "read_text", read)
+    monkeypatch.setattr(Path, "write_text", write)
+    monkeypatch.setattr(fcntl, "flock", flock)
+
+    def mutate():
+        first_ident.append(threading.get_ident())
+        try:
+            if operation == "add":
+                first.add_ignore("b")
+            elif operation == "remove":
+                first.remove_ignore("a")
+            elif operation == "clear":
+                first.clear_ignores()
+            elif operation == "invalidate":
+                first.invalidate()
+            else:
+                first.write(CachePayload(fetched_at=20, ttl_seconds=300, results={"first": {}}))
+        finally:
+            paused.set()
+
+    def replace_results():
+        second_ident.append(threading.get_ident())
+        try:
+            second.write(CachePayload(fetched_at=30, ttl_seconds=300, results={"new": {}}, ignored=["new-ignore"]))
+        finally:
+            # Without a lock the second write completes before resuming the
+            # first; with a lock its acquisition attempt releases the barrier.
+            contender.set()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        one = pool.submit(mutate)
+        try:
+            assert paused.wait(5)
+            if one.done():
+                one.result()
+            two = pool.submit(replace_results)
+            assert contender.wait(5)
+        finally:
+            release.set()
+        one.result(timeout=5)
+        two.result(timeout=5)
+    saved = first.read()
+    assert saved.results == {"new": {}}
+    assert saved.ignored == ["new-ignore"]
+    assert saved.fetched_at == 30
+
+
+def test_invalidate_preserves_payload_and_ignores(tmp_path):
+    cache = ReconcileCache(tmp_path)
+    cache.invalidate()
+    assert cache.read() is None
+    payload = CachePayload(fetched_at=50, ttl_seconds=123, results={"a": {}}, ignored=["keep"], schema_version=0, base_context={"a": ["release"]})
+    cache.write(payload)
+    cache.invalidate()
+    saved = cache.read()
+    assert saved.fetched_at == 0
+    assert saved.results == {"a": {}}
+    assert saved.ignored == ["keep"]
+    assert saved.schema_version == 0
+    assert saved.base_context == {"a": ["release"]}
+    assert saved.ttl_seconds == 123
 
 
 def test_corrupt_cache_returns_none(tmp_path: Path):

--- a/tests/core/reconcile/test_gate.py
+++ b/tests/core/reconcile/test_gate.py
@@ -39,6 +39,22 @@ def test_reconcile_now_uses_fresh_cache(tmp_path: Path):
     assert decisions["a"].state == UpstreamState.merged
 
 
+def test_reconcile_result_write_preserves_ignore_changes_during_fetch(tmp_path):
+    cache = ReconcileCache(tmp_path)
+    cache.add_ignore("old")
+    state = WorkspaceState(tasks={"a": _task("a")})
+
+    def fetcher(*_):
+        other = ReconcileCache(tmp_path)
+        other.remove_ignore("old")
+        other.add_ignore("new")
+        return {}, {}
+
+    reconcile_now(state, cache=cache, fetcher=fetcher)
+    assert cache.read_ignores() == ["new"]
+    assert "a" in cache.read().results
+
+
 def test_reconcile_now_refetches_when_fresh_full_cache_entry_is_missing(
     tmp_path: Path,
 ):


### PR DESCRIPTION
## Summary
- Add opt-in mship reconcile --adopt-merged TASK for the merged-PR/unfinished-task recovery deadlock.
- Verify fresh repository-scoped PR identity, merge status/timestamps, clean and pushed HEAD, and merge ancestry before atomic metadata adoption.
- Preserve task phase, block state, worktrees and branches; recover missing URLs/finish time idempotently; invalidate cache and journal adoption.

## Test plan
- Full mship test iterations 1 and 2 passed, including committed revision 2618110.
- Project ruff and pyrefly checks passed.
- 26 targeted reconciliation tests passed; 14 recovery tests passed against isolated installed 0.5.73 APIs without SQLite migration.
- Actual authorized QuicklyGuide recovery adopted verified PR #51 and its merge timestamp; Git lock preserved the old worktree through normal close.
- No daemon/runtime upgrade, gate bypass or manual task-state editing.